### PR TITLE
Fixup: fix BASE_IMAGE_URL in Build & Test guide; add imagepullsecret

### DIFF
--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -111,16 +111,11 @@ To push images to your own container registry, you need to modify the `BASE_IMAG
 1. **Update the BASE_IMAGE_URL and IMAGE_TAG**:
 
    ```bash
-   BASE_IMAGE_URL="your-registry.com/your-namespace/osmo/"
+   BASE_IMAGE_URL="your-registry.com/your-namespace/osmo"
    IMAGE_TAG="your-image-tag"
 
-   # For Linux (GNU sed)
-   sed -i "s|BASE_IMAGE_URL = \"nvcr.io/nvidia/osmo/\"|BASE_IMAGE_URL = \"${BASE_IMAGE_URL}\"|" MODULE.bazel
+   sed -i "s|BASE_IMAGE_URL = \"nvcr.io/nvidia/osmo/\"|BASE_IMAGE_URL = \"${BASE_IMAGE_URL}/\"|" MODULE.bazel
    sed -i "s|IMAGE_TAG = \"\"|IMAGE_TAG = \"${IMAGE_TAG}\"|" MODULE.bazel
-
-   # For macOS (BSD sed)
-   # sed -i "" "s|BASE_IMAGE_URL = \"nvcr.io/nvidia/osmo/\"|BASE_IMAGE_URL = \"${BASE_IMAGE_URL}\"|" MODULE.bazel
-   # sed -i "" "s|IMAGE_TAG = \"\"|IMAGE_TAG = \"${IMAGE_TAG}\"|" MODULE.bazel
    ```
 
 2. **Ensure you're authenticated** to your registry from within the builder environment.

--- a/run/minimal/osmo_values.yaml
+++ b/run/minimal/osmo_values.yaml
@@ -17,6 +17,7 @@
 global:
   osmoImageLocation: nvcr.io/nvidia/osmo
   osmoImageTag: latest
+  imagePullSecret: imagepullsecret
   nodeSelector:
     node_group: service
 

--- a/run/minimal/router_values.yaml
+++ b/run/minimal/router_values.yaml
@@ -16,6 +16,7 @@
 global:
   osmoImageLocation: nvcr.io/nvidia/osmo
   osmoImageTag: latest
+  imagePullSecret: imagepullsecret
   nodeSelector:
     node_group: service
 

--- a/run/minimal/ui_values.yaml
+++ b/run/minimal/ui_values.yaml
@@ -16,6 +16,7 @@
 global:
   osmoImageLocation: nvcr.io/nvidia/osmo
   osmoImageTag: latest
+  imagePullSecret: imagepullsecret
   nodeSelector:
     node_group: service
 


### PR DESCRIPTION
## Description

Quick fixes for the Build & Test guide:
- Remove the trailing slash from the BASE_IMAGE_URL environment variable so it can be used for both image push and `osmoImageLocation`
- Only specify GNU sed instructions since the instructions specify building in the builder container
- Specify `imagePullSecret` for minimal values files used in local dev

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
