### PR TITLE
Add new auto-include sections for deployment docs

### DIFF
--- a/docs/deployment_guide/getting_started/create_storage/index.rst
+++ b/docs/deployment_guide/getting_started/create_storage/index.rst
@@ -59,6 +59,11 @@ Follow the below guides to create the required buckets:
 
           Configure TOS buckets with IAM policies and user access.
 
+..
+  Optional storage sections can be included
+
+.. auto-include:: ./**.in.rst
+
 .. toctree::
    :hidden:
    :maxdepth: 1

--- a/docs/deployment_guide/index.rst
+++ b/docs/deployment_guide/index.rst
@@ -164,4 +164,8 @@ An OSMO deployment consists of two main components:
   appendix/workflow_execution
   appendix/authentication/index
 
+..
+  Optional appendix sections can be included
 
+
+.. auto-include:: appendix/*.in.rst


### PR DESCRIPTION
## Description
Add auto-include for the top level appendix section + getting_started/create_storage section

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
