### PR TITLE
Provide more details for supported units in resource validation rules

### DIFF
--- a/docs/deployment_guide/advanced_config/resource_validation.rst
+++ b/docs/deployment_guide/advanced_config/resource_validation.rst
@@ -137,8 +137,7 @@ Define validation rules using variables for user requests (``{{USER_*}}``) and n
     .. note::
 
       The values from the `user request variables` are the same values that are provided in the resource
-      spec of a workflow. ``{{USER_MEMORY}}`` and ``{{USER_STORAGE}}`` support units ``B``, ``KiB``,
-      ``MiB``, ``GiB`` and ``TiB``.
+      spec of a workflow.
 
     **Node Capacity Variables:**
       - ``{{K8_CPU}}`` - Available CPU on nodes
@@ -151,6 +150,11 @@ Define validation rules using variables for user requests (``{{USER_*}}``) and n
       The values from the `node capacity variables` are the same values that are reported by the Kubernetes
       API in the `allocatable` fields. ``{{K8_MEMORY}}`` and ``{{K8_STORAGE}}`` support units ``B``, ``Ki``,
       ``Mi``, ``Gi`` and ``Ti``.
+
+    .. note::
+
+      If the CPU allocatable provided by Kubernetes is in the format of ``m``,
+      ``{{K8_CPU}}`` will be an integer value after rounding down the CPU allocatable value.
 
     **Operators:**
       - EQ (equal)

--- a/docs/deployment_guide/references/configs_definitions/resource_validation.rst
+++ b/docs/deployment_guide/references/configs_definitions/resource_validation.rst
@@ -104,12 +104,15 @@ The following example shows a CPU validation rule that ensures user-requested CP
 The key here is ``default_cpu``, which is the name of the resource validation set. The value is an array of resource validation rules.
 When a pool is configured using this resource validation set, the resource validation rules will be applied to workflows submitted to the pool.
 
+Rules Breakdown
+~~~~~~~~~~~~~~~
+
 In the first rule, we are comparing the values of two dynamic variables: ``{{USER_CPU}}`` and ``{{K8_CPU}}``.
-If a variable that starts with ``K8_`` is used, this validation check will be performed against all available
+If a variable that starts with ``K8_`` is used, this validation check will be performed against **all available**
 resource nodes in the pool.
 
 In the second rule, we are comparing the values of one dynamic variable (``{{USER_CPU}}``) and a static value: ``0``.
-This static validation check will be performed once.
+This **static validation check** will be performed **once**.
 
 .. note::
 
@@ -128,6 +131,13 @@ This static validation check will be performed once.
 
   Users can pick any unit specified above for the static value, and the resource validation check will
   perform unit conversion to compare ``{{USER_STORAGE}}`` with the static value.
+
+  .. dropdown:: Does static validation support the ``m`` unit for comparing CPU?
+    :color: info
+    :icon: code
+
+    Currently, CPU validation does not support the ``m`` unit. For your static value, you will need to
+    use an integer instead.
 
 A pool can apply this resource validation set by adding the name to the ``common_resource_validations`` array,
 and a platform can apply this resource validation set by adding the name to the ``override_resource_validations`` array.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->
The documentation does not clearly specify what units can be supported in the resource validation rules. This clearly specifies what units can be interpreted for memory and storage, and what can be supported for CPU.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
