### PR TITLE
Remove Internal Host Aliases

### DIFF
--- a/deployments/charts/backend-operator/values.yaml
+++ b/deployments/charts/backend-operator/values.yaml
@@ -116,7 +116,7 @@ global:
 
       ## Host aliases for custom DNS resolution within proxy pods
       ##
-      hostAliases: {}
+      hostAliases: []
 
   ## Kubernetes scheduler configuration
   ##


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Note: The pull request title will be included in the CHANGELOG. -->

Remove internal references in `hostAliases ` in the operators helm chart. Setting the default to empty array.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
