### PR TITLE
Address conditional imagePullSecrets in charts

### DIFF
--- a/deployments/charts/router/templates/router-service.yaml
+++ b/deployments/charts/router/templates/router-service.yaml
@@ -63,8 +63,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}
+      {{- end }}
       serviceAccountName: {{ .Values.services.service.serviceAccountName | default "default" }}
       {{- with .Values.services.service.initContainers }}
       initContainers:

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -62,8 +62,10 @@ spec:
         {{- end}}
       tolerations:
       {{ toYaml .Values.services.agent.tolerations | nindent 8 }}
+      {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}
+      {{- end }}
       serviceAccountName: {{ include "osmo.service-account-name" (dict "serviceAccountName" .Values.services.agent.serviceAccountName "Values" .Values) }}
       {{- with .Values.services.agent.initContainers }}
       initContainers:

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -61,8 +61,10 @@ spec:
         {{- end}}
       tolerations:
       {{ toYaml .Values.services.service.tolerations | nindent 8 }}
+      {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}
+      {{- end }}
       serviceAccountName: {{ include "osmo.service-account-name" (dict "serviceAccountName" .Values.services.service.serviceAccountName "Values" .Values) }}
       {{- with .Values.services.service.initContainers }}
       initContainers:

--- a/deployments/charts/service/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/service/templates/delayed-job-monitor.yaml
@@ -43,8 +43,10 @@ spec:
         {{- end}}
       tolerations:
       {{ toYaml .Values.services.delayedJobMonitor.tolerations | nindent 8 }}
+      {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}
+      {{- end }}
       serviceAccountName: {{ include "osmo.service-account-name" (dict "serviceAccountName" .Values.services.delayedJobMonitor.serviceAccountName "Values" .Values) }}
       {{- with .Values.services.delayedJobMonitor.initContainers }}
       initContainers:

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -62,8 +62,10 @@ spec:
         {{- end}}
       tolerations:
       {{ toYaml .Values.services.logger.tolerations | nindent 8 }}
+      {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}
+      {{- end }}
       serviceAccountName: {{ include "osmo.service-account-name" (dict "serviceAccountName" .Values.services.logger.serviceAccountName "Values" .Values) }}
       {{- with .Values.services.logger.initContainers }}
       initContainers:

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -54,8 +54,10 @@ spec:
         {{- end}}
       tolerations:
       {{ toYaml .Values.services.worker.tolerations | nindent 8 }}
+      {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}
+      {{- end }}
       serviceAccountName: {{ include "osmo.service-account-name" (dict "serviceAccountName" .Values.services.worker.serviceAccountName "Values" .Values) }}
       {{- with .Values.services.worker.initContainers }}
       initContainers:

--- a/deployments/charts/web-ui/templates/ui.yaml
+++ b/deployments/charts/web-ui/templates/ui.yaml
@@ -60,8 +60,10 @@ spec:
         {{- end}}
       tolerations:
       {{ toYaml .Values.services.ui.tolerations | nindent 8 }}
+      {{- if .Values.global.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}
+      {{- end }}
       {{- if .Values.services.ui.initContainers }}
       initContainers:
         {{- toYaml .Values.services.ui.initContainers | nindent 6 }}


### PR DESCRIPTION
## Description
Handle situations where imagePullSecrets is `null` but an existing deployment has `imagePullSecrets` already. When used with `ArgoCD` with `PATCH` operation, it will fail.

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
