### PR TITLE
docs: fix prerequisites link for build tooling

### DIFF
--- a/BUILD_AND_TEST.md
+++ b/BUILD_AND_TEST.md
@@ -29,7 +29,7 @@ similar to a deployed environment.
 
 ## Prerequisites
 
-Install the [required tools](./README.md#prerequisites) for developing OSMO.
+Install the [required tools](./CONTRIBUTING.md#prerequisites) for developing OSMO.
 
 You can push container images to your preferred container registry such as
 [NVIDIA NGC](https://www.nvidia.com/en-us/gpu-cloud/) (`nvcr.io`),

--- a/DEV.md
+++ b/DEV.md
@@ -23,7 +23,7 @@ to run OSMO using Bazel:
 
 ## Prerequisites
 
-Install the [required tools](./README.md#prerequisites) for developing OSMO.
+Install the [required tools](./CONTRIBUTING.md#prerequisites) for developing OSMO.
 
 Set the following environment variables:
 


### PR DESCRIPTION
## Description

Prerequisites link for installing build tooling in build and development and dev guide were broken, seems it was moved from README to CONTRIBUTING so updating the links.

Issue #<issue number>

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
