### PR TITLE
Add prerequisite for Git LFS to develop OSMO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ If you are interested in contributing to OSMO, your contributions will fall into
 
 ### Install Prerequisites
 
+- **[Git LFS](https://git-lfs.com/)** - Source control for large files (>=3.7.1)
 - **[Bazel](https://bazel.build/install/bazelisk)** - Build tool (>=8.1.1)
 - **[Docker](https://docs.docker.com/get-docker/)** - Container runtime (>=28.3.2)
 - **[Helm](https://helm.sh/docs/intro/install/)** - Package manager for Kubernetes (>=3.17.1)


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
OSMO uses Git LFS for versioning large files, namely images. If a user tries to `git clone` the OSMO repo without Git LFS, it will fail. This explicitly adds Git LFS as a pre-req for contributing, which is before the clone step.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
