### PR TITLE
docs: fix doc links after multiversion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ OSMO is production-grade and proven at scale. Originally developed to power Phys
 Select one of the deployment options below depending on your needs and environment to get started
 
 <div align="center">
-  <a href="https://nvidia.github.io/OSMO/deployment_guide/introduction/whats_next.html">
+  <a href="https://nvidia.github.io/OSMO/deployment_guide/main/introduction/whats_next.html">
     <img src="./docs/deployment_options.svg" width="85%"/>
   </a>
 </div>
@@ -146,7 +146,7 @@ Select one of the deployment options below depending on your needs and environme
 
 | Resource | Description |
 |:---------|:------------|
-| 🚀 [**Local Deployment**](https://nvidia.github.io/OSMO/deployment_guide/appendix/deploy_local.html) | Run it locally on your workstation in 10 minutes |
+| 🚀 [**Local Deployment**](https://nvidia.github.io/OSMO/deployment_guide/main/appendix/deploy_local.html) | Run it locally on your workstation in 10 minutes |
 | 🛠️ [**Cloud Deployment**](https://nvidia.github.io/OSMO/deployment_guide/) | Deploy production grade on cloud providers  |
 | 📘 [**User Guide**](https://nvidia.github.io/OSMO/user_guide/) | Tutorials, workflows, and how-to guides for developers |
 | 💡 [**Workflow Examples**](./workflows/) | Robotics workflow examples

--- a/deployments/charts/quick-start/README.md
+++ b/deployments/charts/quick-start/README.md
@@ -22,7 +22,7 @@ This Helm chart provides a complete OSMO deployment for trying OSMO. If you are 
 OSMO, this is a good way to get a feel for OSMO without deploying in a CSP.
 
 It is recommended to install this chart in a KIND cluster instead of a CSP. See
-[Local Deployment](https://nvidia.github.io/OSMO/deployment_guide/appendix/deploy_local.html) for
+[Local Deployment](https://nvidia.github.io/OSMO/deployment_guide/main/appendix/deploy_local.html) for
 detailed installation instructions.
 
 ## Prerequisites

--- a/docs/user_guide/getting_started/install/index.rst
+++ b/docs/user_guide/getting_started/install/index.rst
@@ -56,7 +56,7 @@ Login
 .. important::
 
    The OSMO client can only be used to connect to already deployed OSMO web services. Please contact your administrator
-   and refer to the `Deployment Guides <https://nvidia.github.io/OSMO/deployment_guide/introduction/whats_next.html>`_ for more information.
+   and refer to the `Deployment Guides <https://nvidia.github.io/OSMO/deployment_guide/main/introduction/whats_next.html>`_ for more information.
 
 To login to the client, can use the following command:
 


### PR DESCRIPTION
## Description
Fix links to docs after #40 introduced multiversion support for docs.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
