### PR TITLE
#79 - quick-start: make apk fail fast

### DIFF
--- a/deployments/charts/quick-start/values.yaml
+++ b/deployments/charts/quick-start/values.yaml
@@ -743,6 +743,9 @@ backend-operator:
         - sh
         - -c
         - |
+          # Mostly used to fail fast if there is a transient issue with apk add.
+          # For simplicity let K8s restart and retry the container.
+          set -e
           apk add --no-cache curl jq
           echo "Waiting for backend-operator-token to be created..."
           until curl -s http://quick-start.osmo/api/auth/access_token/service | jq -e '.[] | select(.token_name == "backend-operator-token")' >/dev/null 2>&1; do
@@ -791,6 +794,9 @@ backend-operator:
         - sh
         - -c
         - |
+          # Mostly used to fail fast if there is a transient issue with apk add.
+          # For simplicity let K8s restart and retry the container.
+          set -e
           apk add --no-cache curl jq
           echo "Waiting for backend-operator-token to be created..."
           until curl -s http://quick-start.osmo/api/auth/access_token/service | jq -e '.[] | select(.token_name == "backend-operator-token")' >/dev/null 2>&1; do


### PR DESCRIPTION
## Description
apk add may fail due to things like transient upstream unavailability. Prior to this change we would get stuck in an infinite loop of trying to invoke curl. This change makes the simplest change to make it fail and let K8s handle restarting the init container.

Alternatives considered were to do a retry loop in the command or to use an alternative image that comes with `curl` and `jq` like [`netshoot`](https://hub.docker.com/r/nicolaka/netshoot), but decided for a Quick Start local deployment simplicity wins.

Before (simulated failure):

```
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
ERROR: unable to select packages:
  curl3 (no such package):
    required by: world[curl3]
Waiting for backend-operator-token to be created...
sh: curl: not found
Token backend-operator-token not found, waiting...
Token backend-operator-token not found, waiting...
sh: curl: not found
sh: curl: not found
Token backend-operator-token not found, waiting...
sh: curl: not found
Token backend-operator-token not found, waiting...
sh: curl: not found
...
```

After:

```
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.18/community/aarch64/APKINDEX.tar.gz
ERROR: unable to select packages:
  curl3 (no such package):
    required by: world[curl3]
```

and

```
$ k get po --watch
NAME   READY   STATUS              RESTARTS   AGE
test   0/1     ContainerCreating   0          4s
test   1/1     Running             0          5s
test   0/1     Error               0          6s
test   0/1     Error               1 (2s ago)   7s
test   0/1     CrashLoopBackOff    1 (1s ago)   8s
```

Issue #79 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
