### PR TITLE
Add syncronize activity type and concurrency limits to PR description check

### DIFF
--- a/.github/workflows/pr-description-check.yaml
+++ b/.github/workflows/pr-description-check.yaml
@@ -21,6 +21,10 @@ on:
     types: [opened, synchronize, reopened, edited]
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   validate-pr-description:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
This adds the synchronize action type to the PR Description Check triggers. This should prevent the workflow from hanging when someone pushes to their PR.

Validated by pushing an empty commit. The PR Description Check re-ran: https://github.com/NVIDIA/OSMO/pull/86/checks

Issue - none

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
