### PR TITLE
Add ci-docs step to run bazel tests on docs/ changes

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -283,9 +283,9 @@ jobs:
               io_bazel_rules_go: src/runtime/go.mod
               bazel_gazelle: src/runtime/go.sum
 
-      - name: Run Tests
+      - name: Run Build
         run: |
-          bazel test --test_output=errors -- //docs/...
+          bazel build --test_output=errors -- //docs/...
 
   #######################
   #      UI Build       #


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
The `docs-build` step does not run bazel builds, meaning any `BUILD` file issues were missed in CI. This adds a step `ci-docs` that runs `bazel build //docs/...`. 

I am purposely not running this on internal runners for now - this is a pretty light build step, so we'll start with github runners until it becomes a bottleneck.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
