### PR TITLE
Streaming Namespaced Pod for Backend Listener

### DIFF
--- a/src/operator/backend_listener.py
+++ b/src/operator/backend_listener.py
@@ -1136,7 +1136,9 @@ def watch_pod_events(progress_writer: progress.ProgressWriter,
                             yield pod
                     refreshed_resource_state = False
 
-                for event in watcher.stream(api.list_pod_for_all_namespaces, timeout_seconds=0,
+                for event in watcher.stream(api.list_namespaced_pod,
+                                            namespace=config.namespace,
+                                            timeout_seconds=0,
                                             _request_timeout=TIMEOUT_SEC,
                                             resource_version=last_resource_version):
                     progress_writer.report_progress()


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
In a big cluster where there are 1000+ pods in the workflow namespace, and up to 40k pods in the rest of the namespaces, workflow status updates become extremely slow. This focuses on retrieving pod events from the workflow namespace to greatly speed up the workflow status updates to the service.

A follow-up change is to have a separate process or worker to retrieve pod events from all namespaces in parallel, if necessary.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
