### PR TITLE
charts: update service hpa targets to include cpu utilization

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -104,7 +104,8 @@ This Helm chart deploys the OSMO platform with its core services and required si
 |-----------|-------------|---------|
 | `services.worker.scaling.minReplicas` | Minimum replicas | `2` |
 | `services.worker.scaling.maxReplicas` | Maximum replicas | `10` |
-| `services.worker.scaling.hpaTarget` | Target Memory utilization percentage for HPA scaling | `80` |
+| `services.worker.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA scaling | `80` |
+| `services.worker.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA scaling | `80` |
 | `services.worker.imageName` | Worker image name | `worker` |
 | `services.worker.serviceName` | Service name | `osmo-worker` |
 | `services.worker.initContainers` | Init containers for worker | `[]` |
@@ -120,7 +121,8 @@ This Helm chart deploys the OSMO platform with its core services and required si
 |-----------|-------------|---------|
 | `services.service.scaling.minReplicas` | Minimum replicas | `3` |
 | `services.service.scaling.maxReplicas` | Maximum replicas | `9` |
-| `services.service.scaling.hpaTarget` | HPA target utilization | `80` |
+| `services.service.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA scaling | `80` |
+| `services.service.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA scaling | `80` |
 | `services.service.imageName` | Service image name | `service` |
 | `services.service.serviceName` | Service name | `osmo-service` |
 | `services.service.initContainers` | Init containers for API service | `[]` |
@@ -140,7 +142,8 @@ This Helm chart deploys the OSMO platform with its core services and required si
 |-----------|-------------|---------|
 | `services.logger.scaling.minReplicas` | Minimum replicas | `3` |
 | `services.logger.scaling.maxReplicas` | Maximum replicas | `9` |
-| `services.logger.scaling.hpaTarget` | Target Memory utilization percentage for HPA scaling | `80` |
+| `services.logger.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA scaling | `80` |
+| `services.logger.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA scaling | `80` |
 | `services.logger.imageName` | Logger image name | `logger` |
 | `services.logger.serviceName` | Service name | `osmo-logger` |
 | `services.logger.initContainers` | Init containers for logger service | `[]` |
@@ -155,7 +158,8 @@ This Helm chart deploys the OSMO platform with its core services and required si
 |-----------|-------------|---------|
 | `services.agent.scaling.minReplicas` | Minimum replicas | `1` |
 | `services.agent.scaling.maxReplicas` | Maximum replicas | `9` |
-| `services.agent.scaling.hpaTarget` | HPA target utilization | `80` |
+| `services.agent.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA scaling | `80` |
+| `services.agent.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA scaling | `80` |
 | `services.agent.imageName` | Agent image name | `agent` |
 | `services.agent.serviceName` | Service name | `osmo-agent` |
 | `services.agent.initContainers` | Init containers for agent service | `[]` |

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -305,4 +305,11 @@ spec:
       container: {{ .Values.services.agent.serviceName }}
       target:
         type: Utilization
-        averageUtilization: {{ .Values.services.agent.scaling.hpaTarget }}
+        averageUtilization: {{ .Values.services.agent.scaling.hpaMemoryTarget }}
+  - type: ContainerResource
+    containerResource:
+      name: cpu
+      container: {{ .Values.services.agent.serviceName }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.services.agent.scaling.hpaCpuTarget }}

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -355,4 +355,11 @@ spec:
       container: {{ .Values.services.service.serviceName }}
       target:
         type: Utilization
-        averageUtilization: {{ .Values.services.service.scaling.hpaTarget }}
+        averageUtilization: {{ .Values.services.service.scaling.hpaMemoryTarget }}
+  - type: ContainerResource
+    containerResource:
+      name: cpu
+      container: {{ .Values.services.service.serviceName }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.services.service.scaling.hpaCpuTarget }}

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -301,4 +301,11 @@ spec:
       container: {{ .Values.services.logger.serviceName }}
       target:
         type: Utilization
-        averageUtilization: {{ .Values.services.logger.scaling.hpaTarget }}
+        averageUtilization: {{ .Values.services.logger.scaling.hpaMemoryTarget }}
+  - type: ContainerResource
+    containerResource:
+      name: cpu
+      container: {{ .Values.services.logger.serviceName }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.services.logger.scaling.hpaCpuTarget }}

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -224,4 +224,11 @@ spec:
       container: {{ .Values.services.worker.serviceName }}
       target:
         type: Utilization
-        averageUtilization: {{ .Values.services.worker.scaling.hpaTarget }}
+        averageUtilization: {{ .Values.services.worker.scaling.hpaMemoryTarget }}
+  - type: ContainerResource
+    containerResource:
+      name: cpu
+      container: {{ .Values.services.worker.serviceName }}
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.services.worker.scaling.hpaCpuTarget }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -375,7 +375,10 @@ services:
 
       ## Target Memory utilization percentage for HPA scaling
       ##
-      hpaTarget: 80
+      hpaMemoryTarget: 80
+      ## Target CPU utilization percentage for HPA scaling
+      ##
+      hpaCpuTarget: 80
 
     ## Docker image name for the worker service
     ##
@@ -478,7 +481,10 @@ services:
 
       ## Target CPU utilization percentage for HPA scaling
       ##
-      hpaTarget: 80
+      hpaMemoryTarget: 80
+      ## Target CPU utilization percentage for HPA scaling
+      ##
+      hpaCpuTarget: 80
 
     ## Docker image name for the API service
     ##
@@ -699,7 +705,10 @@ services:
 
       ## Target Memory utilization percentage for HPA scaling
       ##
-      hpaTarget: 80
+      hpaMemoryTarget: 80
+      ## Target CPU utilization percentage for HPA scaling
+      ##
+      hpaCpuTarget: 80
 
     ## Docker image name for the logger service
     ##
@@ -797,7 +806,10 @@ services:
 
       ## Target CPU utilization percentage for HPA scaling
       ##
-      hpaTarget: 80
+      hpaMemoryTarget: 80
+      ## Target CPU utilization percentage for HPA scaling
+      ##
+      hpaCpuTarget: 80
 
     ## Docker image name for the agent service
     ##


### PR DESCRIPTION
## Description
Add CPU utilization metric as a target for service HPA to scale on

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
