### PR TITLE
make repository image from global image Location

### DIFF
--- a/deployments/charts/backend-operator/templates/backend-test-runner-config.yaml
+++ b/deployments/charts/backend-operator/templates/backend-test-runner-config.yaml
@@ -188,7 +188,8 @@ data:
               containers:
                 - name: backend-test-runner
                   {{- $imageTag := .Values.backendTestRunner.podTemplate.image.tag | default .Values.global.osmoImageTag }}
-                  image: {{ .Values.backendTestRunner.podTemplate.image.repository }}:{{ $imageTag }}
+                  {{- $imageRepository := .Values.backendTestRunner.podTemplate.image.repository | default .Values.global.osmoImageLocation }}
+                  image: {{ $imageRepository }}:{{ $imageTag }}
                   imagePullPolicy: {{ .Values.backendTestRunner.podTemplate.image.pullPolicy }}
                   command: ["backend_test_runner"]
                   args: {{ toYaml .Values.backendTestRunner.podTemplate.container.args | nindent 20 }}


### PR DESCRIPTION
## Description
Utilize global image location for test runner

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
