### PR TITLE
Allow uppercase X when checking contribution guidelines

### DIFF
--- a/.github/workflows/pr-description-check.yaml
+++ b/.github/workflows/pr-description-check.yaml
@@ -82,7 +82,7 @@ jobs:
           "
           else
             # Count checkbox items in the checklist
-            total_checkboxes=$(echo "$checklist_section" | grep -cE "^- \[[ x]\]" || true)
+            total_checkboxes=$(echo "$checklist_section" | grep -cE "^- \[[ xX]\]" || true)
             unchecked_items=$(echo "$checklist_section" | grep -cE "^- \[ \]" || true)
 
             if [ "$total_checkboxes" -eq 0 ]; then


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->

Observed in this job: https://github.com/NVIDIA/OSMO/actions/runs/20082165428/job/57611969487

The PR Description Check does not allow for uppercase X, which is a valid way to check a checklist.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
