### PR TITLE
ci: add dependencies build to helm lint

### DIFF
--- a/.github/workflows/helm-chart-lint.yaml
+++ b/.github/workflows/helm-chart-lint.yaml
@@ -97,6 +97,16 @@ jobs:
         with:
           version: 'v3.14.0'
 
+      - name: Build Helm Dependencies
+        run: |
+          echo "Building dependencies for: ${{ matrix.chart }}"
+          helm dependency build deployments/charts/${{ matrix.chart }} || true
+          # Show what was fetched
+          if [ -d "deployments/charts/${{ matrix.chart }}/charts" ]; then
+            echo "Dependencies fetched:"
+            ls -la deployments/charts/${{ matrix.chart }}/charts/
+          fi
+
       - name: Helm Lint
         run: |
           echo "Linting chart: ${{ matrix.chart }}"


### PR DESCRIPTION
## Description
Add `helm dependency build` to helm lint ci pipeline, this was causing failures when linting the quick start chart

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
