### PR TITLE
Remove backend name from test cronjobs

### DIFF
--- a/src/utils/job/backend_jobs.py
+++ b/src/utils/job/backend_jobs.py
@@ -748,7 +748,8 @@ class BackendSynchronizeBackendTest(backend_job_defs.BackendSynchronizeBackendTe
 
         for test_name, test_config in self.test_configs.items():
             try:
-                resource_name = f'{self.backend}-{test_name}'.lower()
+
+                resource_name = f'{test_name}'.lower()
                 configmap_name = f'{resource_name}-config'
 
                 # Load and render CronJob spec from template.


### PR DESCRIPTION
## Description
The backend Name can be set to be really long.  To avoid triggering K8s resources name lengths, I am removing the backend name from test naming. 
Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
