### PR TITLE
#137 - UI: use the absolute path to support different hostnames

### DIFF
--- a/ui/src/app/workflows/components/ToolsModal.tsx
+++ b/ui/src/app/workflows/components/ToolsModal.tsx
@@ -138,7 +138,9 @@ export const ToolsModal = ({ tool, workflow, selectedTask, fullLog, lines, verbo
       const newUrl = new URL(url.origin + url.pathname);
       newUrl.search = params.toString();
 
-      return newUrl.toString();
+      // Remove the origin from the URL. Use the absolute path to support when
+      // the UI is served from a different host than the API hostname.
+      return newUrl.toString().substring(newUrl.origin.length);
     }
     return undefined;
   }, [


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
This updates the UI to use the absolute path for logs, spec, etc. instead of the fully-qualified path when displayed in iframes. By doing so, the browser uses the domain of the page and the UI can fully function regardless of the `service_base_url`, which may be another domain.

For deployments like our brev launchable, this means that the `service_base_url` can be `http://quick-start.osmo` but still use the brev secure link for the UI.

Issue #137

### Testing

1) Built images from this branch and pushed them to a private registry
2) Deployed a brev instance
3) `curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/deployments/brev/setup.sh`
4) Update the `osmo` install to use the newly-built private images
5) Add a brev secure link for port `8000`
6) Visit the secure link
7) Run any workflow from the UI, observe logs, spec, etc for the workflow

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
