### PR TITLE
Expose Node Events TTL Parameter in Listener Chart

### DIFF
--- a/deployments/charts/backend-operator/README.md
+++ b/deployments/charts/backend-operator/README.md
@@ -105,7 +105,8 @@ This Helm chart deploys the OSMO Backend-Operator for managing compute backend r
 | `services.backendListener.initContainers` | Init containers for backend listener | `[]` |
 | `services.backendListener.serviceAccount` | Service account name | `backend-listener` |
 | `services.backendListener.max_unacked_messages` | Maximum unacked messages | `100` |
-| `services.backendListener.podCacheTtl` | Pod cache TTL in seconds | `15` |
+| `services.backendListener.podCacheTtl` | Pod cache TTL in minutes | `15` |
+| `services.backendListener.nodeCacheTtl` | Node cache TTL in minutes | `15` |
 | `services.backendListener.extraArgs` | Additional arguments | `[]` |
 | `services.backendListener.extraEnvs` | Additional environment variables | `[]` |
 | `services.backendListener.extraPodAnnotations` | Additional pod annotations | `{}` |

--- a/deployments/charts/backend-operator/templates/backend-listener.yaml
+++ b/deployments/charts/backend-operator/templates/backend-listener.yaml
@@ -112,6 +112,8 @@ spec:
         - '{{ .Values.services.backendListener.max_unacked_messages }}'
         - --pod_event_cache_ttl
         - {{ .Values.services.backendListener.podCacheTtl | quote }}
+        - --node_event_cache_ttl
+        - {{ .Values.services.backendListener.nodeCacheTtl | quote }}
         - --include_namespace_usage
         - {{ .Values.global.includeNamespaceUsage | quote }}
         - --api_qps

--- a/deployments/charts/backend-operator/values.yaml
+++ b/deployments/charts/backend-operator/values.yaml
@@ -258,6 +258,10 @@ services:
     ##
     podCacheTtl: 15
 
+    ## Time-to-live for node cache entries (in seconds)
+    ##
+    nodeCacheTtl: 15
+
     ## Additional command line arguments to pass to the backend listener
     ##
     extraArgs: []


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
For tuning the performance of the backend listener, admins can configure the `nodeCacheTtl` parameter. In this PR, this parameter is now exposed in the helm chart, and can be configured in the values.yaml file.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
