### PR TITLE
Update Progress After Streaming Disconnect for Node and Backend Events

### DIFF
--- a/src/operator/backend_listener.py
+++ b/src/operator/backend_listener.py
@@ -1430,11 +1430,13 @@ def watch_backend_events(progress_writer: progress.ProgressWriter,
             if error.status == 410:
                 # Reset last resource version
                 last_resource_version = ''
+            progress_writer.report_progress()
         except urllib3.exceptions.ReadTimeoutError:
             helpers.send_log_through_queue(
                 backend_messages.LoggingType.WARNING,
                 'Connection timed out during watch backend events, reestablishing watch stream.',
                 event_send_queue)
+            progress_writer.report_progress()
         except (urllib3.exceptions.MaxRetryError, urllib3.exceptions.ProtocolError) as error:
             send_connection_error_count(event_type='backend')
             helpers.send_log_through_queue(
@@ -1442,6 +1444,7 @@ def watch_backend_events(progress_writer: progress.ProgressWriter,
                 f'Cluster monitor errored out during watch backend events due to {error} ' +\
                 'retrying ...',
                 event_send_queue)
+            progress_writer.report_progress()
         except KeyboardInterrupt:
             sys.exit(0)
         except Exception as error:  # pylint: disable=broad-except


### PR DESCRIPTION

## Description
When the watch stream disconnects because there are no node events for a long period of time, the listener does not write progress. This updates the logic so that even when it disconnects due to any issue or the fact that there are no events within the request_timeout period, it should still write progress to prevent liveness probe from erroneously killing the listener.

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
