### PR TITLE
Only fetch 1 config during init

### DIFF
--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1075,7 +1075,7 @@ class PostgresConnector:
             ConfigHistoryType.ROLE,
         ]:
             fetch_cmd = """
-                SELECT * FROM config_history WHERE config_type = %s;
+                SELECT 1 FROM config_history WHERE config_type = %s LIMIT 1;
             """
             data = self.execute_fetch_command(fetch_cmd, (config_type.value.lower(),))
             if data:


### PR DESCRIPTION
## Description
Config init can hang if there are too many entries for config history

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
