### PR TITLE
Init configs should fetch raw value

### DIFF
--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1077,7 +1077,9 @@ class PostgresConnector:
             fetch_cmd = """
                 SELECT 1 FROM config_history WHERE config_type = %s LIMIT 1;
             """
-            data = self.execute_fetch_command(fetch_cmd, (config_type.value.lower(),))
+            data = self.execute_fetch_command(fetch_cmd,
+                                              (config_type.value.lower(),),
+                                              return_raw=True)
             if data:
                 continue
 


### PR DESCRIPTION
## Description
Init config is not using the return_raw field

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
