### PR TITLE
#186 - Cannot collapse Tasks Filters as Guest user in Local Deployment

### DIFF
--- a/ui/src/app/datasets/components/Datasets.tsx
+++ b/ui/src/app/datasets/components/Datasets.tsx
@@ -168,14 +168,7 @@ export default function Datasets() {
   }, [isSelectAllUsersChecked, userFilter, username]);
 
   const validateFilters = useCallback(
-    ({
-      userType,
-      selectedUsers,
-      selectedBuckets,
-      dateRange,
-      createdAfter,
-      createdBefore,
-    }: DatasetsFilterDataProps): string[] => {
+    ({ selectedBuckets, dateRange, createdAfter, createdBefore }: DatasetsFilterDataProps): string[] => {
       const errors: string[] = [];
       if (selectedBuckets.length === 0) {
         errors.push("Please select at least one bucket");

--- a/ui/src/app/tasks/page.tsx
+++ b/ui/src/app/tasks/page.tsx
@@ -154,8 +154,6 @@ export default function Tasks() {
 
   const validateFilters = useCallback(
     ({
-      selectedUsers,
-      userType,
       isSelectAllPoolsChecked,
       selectedPools,
       dateRange,

--- a/ui/src/app/taskssummary/page.tsx
+++ b/ui/src/app/taskssummary/page.tsx
@@ -148,8 +148,6 @@ export default function TasksSummary() {
 
   const validateFilters = useCallback(
     ({
-      selectedUsers,
-      userType,
       isSelectAllPoolsChecked,
       selectedPools,
       dateRange,

--- a/ui/src/app/workflows/page.tsx
+++ b/ui/src/app/workflows/page.tsx
@@ -111,8 +111,6 @@ export default function Workflows() {
 
   const validateFilters = useCallback(
     ({
-      selectedUsers,
-      userType,
       isSelectAllPoolsChecked,
       selectedPools,
       dateRange,


### PR DESCRIPTION
The problem repro'd if there were no users in the system, such as in this case after a clean local deployment. 

NOTE: The infinite loop seen in this bug is triggered because updateUrl is in the dependency array of the useEffect that calls validateFilters in tasks/page.tsx. updateUrl should have been a useCallback - a problem that has already been fixed in main, as part of a different improvement. So, this issue did not repro in main. 

All the same, this fix is still warranted as the APIs all work with all_users=false and an empty user array - returning tasks/workflows/datasets for the current user in such case. So, validating that users are selected is not necessary since the APIs support that use-case. 

FYI: Users become first-class citizens after submitting a workflow. 

Issue #168

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
