### PR TITLE
Fix workflow table refresh filter

### DIFF
--- a/ui/src/app/workflows/components/WorkflowsFilters.tsx
+++ b/ui/src/app/workflows/components/WorkflowsFilters.tsx
@@ -92,6 +92,10 @@ export const WorkflowsFilters = ({
   }, [userType]);
 
   useEffect(() => {
+    setLocalUsers(selectedUsers);
+  }, [selectedUsers]);
+
+  useEffect(() => {
     setLocalStatusFilterType(statusFilterType);
 
     if (statusFilterType === StatusFilterType.CUSTOM) {


### PR DESCRIPTION
When user type is custom, refreshing the page results in a "custom"... but with the current user rather than the specified user. 
This is fixed by adding a missing useEffect so that localUsers is updated
Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
