### PR TITLE
Fix osmo config pool update payload in backend installation docs

### DIFF
--- a/docs/deployment_guide/install_backend/configure_pool.rst
+++ b/docs/deployment_guide/install_backend/configure_pool.rst
@@ -34,9 +34,11 @@ OSMO automatically creates a default pool during initial service deployment. Lin
 
   $ cat << EOF > /tmp/pool_config.json
   {
-    "default": {
-      "backend": "<backend-name>",
-      "description": "<pool-description>"
+    "pools": {
+      "default": {
+        "backend": "<backend-name>",
+        "description": "<pool-description>"
+      }
     }
   }
   EOF


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
The `osmo config update` command expects the `"pools":` key when updating all pools.


Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
