### PR TITLE
Add quota field to concise resources

### DIFF
--- a/src/service/core/workflow/helpers.py
+++ b/src/service/core/workflow/helpers.py
@@ -306,7 +306,7 @@ def get_pool_resources(pools: List[str] | None = None,
         # If the quota is defined in the pool resources, use the lower of
         # the total allocatable GPU and the defined quota
         allocatable_gpu = total_allocatable['gpu', 0]
-        if pool_row.get('resources', {}) and pool_row.get('resources', {}).get('gpu', -1) != -1:
+        if pool_row.get('resources', {}) and pool_row.get('resources', {}).get('gpu', -1) > -1:
             quota = min(allocatable_gpu, pool_row.get('resources').get('gpu', -1))
         else:
             quota = allocatable_gpu


### PR DESCRIPTION
## Description
There isn't a easy way of figuring out the available quota on a pool, and this would be important for shared pools.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
