### PR TITLE
Update quick start installation to always install latest version

### DIFF
--- a/deployments/brev/setup.sh
+++ b/deployments/brev/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,7 +56,6 @@ NVIDIA_CTK_INSTALL_VERSION="1.18.1-1"
 # Helm chart versions
 GPU_OPERATOR_VERSION="v25.10.0"
 KAI_SCHEDULER_VERSION="v0.8.1"
-OSMO_QUICKSTART_VERSION="1.0.0"
 
 # ============================================
 # Step 0: System Configuration
@@ -350,10 +349,10 @@ print_status "KAI Scheduler installed successfully"
 # ============================================
 print_status "Installing OSMO (this may take 5-10 minutes)..."
 
-cd ~/osmo-deployment
-helm fetch https://helm.ngc.nvidia.com/nvidia/osmo/charts/quick-start-${OSMO_QUICKSTART_VERSION}.tgz
+helm repo add osmo https://helm.ngc.nvidia.com/nvidia/osmo
+helm repo update
 
-helm upgrade --install osmo quick-start-${OSMO_QUICKSTART_VERSION}.tgz \
+helm upgrade --install osmo osmo/quick-start \
   --namespace osmo \
   --create-namespace \
   --set web-ui.services.ui.hostname="" \

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -288,8 +288,9 @@ Deploy the complete OSMO platform with a single Helm command:
 
 .. code-block:: bash
 
-   $ helm fetch https://helm.ngc.nvidia.com/nvidia/osmo/charts/quick-start-1.0.0.tgz
-   $ helm upgrade --install osmo quick-start-1.0.0.tgz \
+   $ helm repo add osmo https://helm.ngc.nvidia.com/nvidia/osmo
+   $ helm repo update
+   $ helm upgrade --install osmo osmo/quick-start \
      --namespace osmo \
      --create-namespace \
      --wait


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
Instead of pinning to a particular quick-start helm chart version, the local deployment docs and brev startup script now simply install the latest version.

Tested by deploying a brev instance with the updated startup script.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
