### PR TITLE
Add workflow to label external issues and pull requests

### DIFF
--- a/.github/workflows/label-external.yaml
+++ b/.github/workflows/label-external.yaml
@@ -18,9 +18,9 @@ name: Label external contributors
 
 on:
   issues:
-    types: [opened]
+    types: [opened, reopened]
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
 
 permissions:
   issues: write


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
This adds a GitHub workflow to add the `external` label to issues and pull requests that come from users outside of @NVIDIA/osmo-dev . This will allow us to be notified specifically for external contributions.

Tested: I flipped the logic, and verified that the workflow would add the `external` label for me when I reopened the pull request. I then reverted the logic.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
