### PR TITLE
#242: Cannot select any text inside modals or slideouts

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -164,7 +164,6 @@ export const Layout = ({ children }: PropsWithChildren) => {
           </header>
           <main
             id="main-content"
-            tabIndex={-1}
             className="relative h-full w-full overflow-y-auto overflow-x-auto flex flex-row"
             aria-label="Main content"
           >


### PR DESCRIPTION
The tabIndex on main was done for WCAG Skip to Content but is not necessary. And it was the needle in the haystack that was breaking mouse capture/selection inside focus traps. 
Issue #242

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
