### PR TITLE
#243: Video html element not changin when selecting different video files in the UI for OSMO dataset

### DIFF
--- a/ui/src/app/datasets/components/FilePreviewer.tsx
+++ b/ui/src/app/datasets/components/FilePreviewer.tsx
@@ -35,6 +35,7 @@ const FilePreviewer: React.FC<{ file: FileData }> = ({ file }) => {
   const windowSize = useWindowSize();
   const [height, setHeight] = useState(0);
   const { setSafeTimeout } = useSafeTimeout();
+  const videoRef = useRef<HTMLVideoElement>(null);
 
   useEffect(() => {
     if (containerRef?.current) {
@@ -72,6 +73,10 @@ const FilePreviewer: React.FC<{ file: FileData }> = ({ file }) => {
     };
   }, [fileExtension, setSafeTimeout]);
 
+  useEffect(() => {
+    videoRef.current?.load();
+  }, [file.thumbnailUrl]);
+
   const handleIframeError = () => {
     setIframeError(true);
     if (timerRef.current) {
@@ -91,6 +96,7 @@ const FilePreviewer: React.FC<{ file: FileData }> = ({ file }) => {
       case "mp4":
         return (
           <video
+            ref={videoRef}
             controls
             style={{ maxHeight: `${height}px` }}
             className="object-fit"


### PR DESCRIPTION
When changing the url of a html video element, you need to reload it. 

Issue #243

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
