### PR TITLE
sync-feature-branches: fix no conflict case, allow single branch to be synced

### DIFF
--- a/.github/workflows/sync-feature-branches.yaml
+++ b/.github/workflows/sync-feature-branches.yaml
@@ -96,7 +96,7 @@ jobs:
 
             # Extract issue number from branch name (format: feature/PROJ-NNN-short-slug)
             # If no PROJ-NNN pattern is found, use "Issue - None"
-            issue_number=$(echo "$branch" | grep -oE 'PROJ-[0-9]+' || echo "")
+            issue_number=$(echo "$branch" | grep -oE 'PROJ-[0-9]+' | grep -oE '[0-9]+' || echo "")
             if [ -z "$issue_number" ]; then
               issue_ref="Issue - None"
             else


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description

`sync-feature-branches` [failed yesterday](https://github.com/NVIDIA/OSMO/actions/runs/21145957855/job/60811468906). This PR includes the following fixes:

- **Fix sync-feature-branches with no merge conflicts**: The job would fail to open the PR because the merge commit was never created when there were no conflicts.
- **Allow a single branch to be specified**: Add an optional `branch` input parameter so it's easy to open a sync PR for a specific branch without waiting for the cron.
- **Perform operations as OSMO CI Bot**: Use a PAT (`SVC_OSMO_CI_TOKEN`) instead of the default `GITHUB_TOKEN` so that PR creation triggers other workflows (checks, labeling).
- **Add external label when the PR is created**: We will receive an internal Slack notification on PR creation.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
