### PR TITLE
Fix missing seperator in the test runner roles

### DIFF
--- a/deployments/charts/backend-operator/templates/backend-test-runner-rbac.yaml
+++ b/deployments/charts/backend-operator/templates/backend-test-runner-rbac.yaml
@@ -89,6 +89,7 @@ roleRef:
 {{- end }}
 
 {{- if .Values.backendTestRunner.extraRoles }}
+---
 {{- range $roleObj := .Values.backendTestRunner.extraRoles }}
 {{- toYaml $roleObj | nindent 0 }}
 ---


### PR DESCRIPTION

## Description
Add `---` separator before the extraRoles section in backend-test-runner-rbac.yaml
to prevent YAML document concatenation issues.

Problem:
Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
