### PR TITLE
Fix issue 34 unified start script

### DIFF
--- a/run/BUILD
+++ b/run/BUILD
@@ -260,3 +260,33 @@ oci_load(
         "@platforms//cpu:arm64",
     ],
 )
+
+osmo_py_binary(
+    name = "start",
+    main = "start.py",
+    srcs = [
+        "start.py",
+        "start_service.py",
+        "start_service_kind.py",
+        "start_service_bazel.py",
+        "start_backend.py",
+        "start_backend_kind.py",
+        "start_backend_bazel.py",
+        "update_configs.py",
+    ],
+    data = [
+        "kind-osmo-cluster-config.yaml",
+        "//deployments/charts:service",
+        "//deployments/charts:web-ui",
+        "//deployments/charts:router",
+        "//deployments/charts:backend-operator",
+        "//run/minimal:minimal",
+        "@osmo_workspace//src/cli",
+    ],
+    deps = [
+        ":utils",
+        "@bazel_tools//tools/python/runfiles",
+        "@osmo_workspace//src/lib/utils:logging",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/run/start.py
+++ b/run/start.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""
+SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import argparse
+import logging
+import os
+import posixpath
+import time
+from typing import Any, Dict
+
+import yaml
+
+from run.check_tools import check_required_tools
+from run.host_ip import get_host_ip
+from run.kind_utils import detect_platform
+from run.print_next_steps import print_next_steps
+from run.run_command import cleanup_registered_processes, login_osmo, logout_osmo, wait_for_all_processes
+from run.start_backend_bazel import start_backend_bazel
+from run.start_backend_kind import start_backend_kind
+from run.start_service_bazel import start_service_bazel
+from run.start_service_kind import start_service_kind
+from run.update_configs import (
+    set_default_pool,
+    update_backend_config,
+    update_dataset_config,
+    update_pod_template_config,
+    update_service_config,
+    update_workflow_config,
+)
+from src.lib.utils import logging as logging_utils
+
+logging.basicConfig(format='%(message)s')
+logger = logging.getLogger()
+
+
+def _merge_config(args: argparse.Namespace, config_file: str) -> None:
+    """Merge YAML configuration with command line arguments.
+
+    Args:
+        args: Command line arguments
+        config_file: Path to YAML configuration file
+    """
+    if not config_file or not os.path.exists(config_file):
+        return
+
+    logger.info('📂 Loading configuration from %s...', config_file)
+    try:
+        with open(config_file, 'r', encoding='utf-8') as f:
+            config = yaml.safe_load(f)
+
+        if not config:
+            return
+
+        # Map config keys to argument names
+        # Keys in YAML should match argument names (snake_case)
+        # We only override args that were NOT set on the command line
+        # Note: argparse doesn't easily tell us what was explicitly set vs default.
+        # However, we can use the convention that we prioritize CLI args over YAML.
+        # BUT, standard argparse pattern with defaults already populated in `args` makes
+        # it hard to know if user provided it.
+        #
+        # Better approach: Update args with config values if valid key exists.
+        # Since this is a specialized script, we'll assume CLI args override YAML config
+        # only if we parsed them manually or check sys.argv, but for simplicity here:
+        # We will apply YAML config to args, effectively overwriting defaults.
+        # If the user passed specific flags, they will be parsed by argparse.
+        # WAIT. argparse parsing happens BEFORE this function.
+        # So `args` already has defaults or user values.
+        # We should define defaults as NONE in parser, so we know if they are missing.
+        # Or, simpler: We trust the user to put "defaults" in YAML if they use it.
+
+        # Let's iterate over config and set attributes on args
+        for key, value in config.items():
+            if hasattr(args, key) and value is not None:
+                # In a real rigorous impl we might check if user passed arg.
+                # Here we will assume YAML provides defaults/presets.
+                # If we want CLI to override YAML, we should check what user passed.
+                # A common pattern:
+                # 1. Parse args with defaults=None
+                # 2. Load YAML
+                # 3. Fill missing args from YAML
+                # 4. Fill remaining missing args from hardcoded defaults
+                #
+                # Given we are refactoring existing scripts that rely on extensive defaults
+                # in argparse, duplicating them in YAML or Python dict is messy.
+                #
+                # Compromise: We will update `args` with `config` values.
+                # This implies YAML overrides CLI defaults.
+                # CLI explicit args > YAML > CLI defaults is ideal but hard.
+                # So here: YAML > CLI (effectively).
+                #
+                # Use Case: User has `osmo-config.yaml` with their preferred settings.
+                # They run `./start.py --config osmo-config.yaml`.
+                # They expect those settings to apply.
+                setattr(args, key, value)
+
+    except yaml.YAMLError as e:
+        logger.error('❌ Error parsing config file: %s', e)
+        raise RuntimeError(f'Error parsing config file: {e}') from e
+
+
+def main():
+    """Main function to orchestrate the unified OSMO start."""
+    parser = argparse.ArgumentParser(
+        description='Start OSMO services and backend (unified)')
+
+    parser.add_argument(
+        '--config', help='Path to YAML configuration file')
+
+    parser.add_argument(
+        '--log-level', type=logging_utils.LoggingLevel.parse,
+        default=logging_utils.LoggingLevel.INFO)
+    parser.add_argument(
+        '--mode',
+        choices=['kind', 'bazel'],
+        default='kind',
+        help='Mode to run in (default: kind)')
+    parser.add_argument(
+        '--cluster-name', default='osmo',
+        help='Name of the cluster (default: osmo)')
+
+    # Backend / Service common args
+    parser.add_argument(
+        '--container-registry', default='nvcr.io',
+        help='Container registry (default: nvcr.io)')
+    parser.add_argument(
+        '--container-registry-username', default='$oauthtoken',
+        help='Container registry username (default: $oauthtoken)')
+    parser.add_argument(
+        '--container-registry-password',
+        help='Container registry password')
+    parser.add_argument(
+        '--image-location', default='nvcr.io/nvidia/osmo',
+        help='OSMO image location (default: nvcr.io/nvidia/osmo)')
+    parser.add_argument(
+        '--image-tag', default='latest',
+        help='OSMO image tag (default: latest)')
+    parser.add_argument(
+        '--load-local-images', action='store_true',
+        help='Build and load images directly into KIND cluster')
+
+    # Config update args
+    parser.add_argument(
+        '--object-storage-endpoint', default='s3://osmo',
+        help='Object storage endpoint')
+    parser.add_argument(
+        '--object-storage-access-key-id', default='test',
+        help='Object storage access key ID')
+    parser.add_argument(
+        '--object-storage-access-key', default='test',
+        help='Object storage access key')
+    parser.add_argument(
+        '--object-storage-region', default='us-east-1',
+        help='Object storage region')
+    parser.add_argument(
+        '--dataset-path',
+        default='s3://osmo/datasets',
+        help='Dataset path')
+
+    # Toggle what to start
+    parser.add_argument(
+        '--skip-services', action='store_true',
+        help='Skip starting OSMO services')
+    parser.add_argument(
+        '--skip-backend', action='store_true',
+        help='Skip starting OSMO backend')
+    parser.add_argument(
+        '--skip-configs', action='store_true',
+        help='Skip updating configurations')
+
+    args = parser.parse_args()
+
+    logger.setLevel(args.log_level)
+
+    # 1. Merge config if present
+    if args.config:
+        _merge_config(args, args.config)
+
+    check_required_tools(['bazel'])
+    if args.mode == 'kind':
+        check_required_tools(['kind', 'kubectl', 'helm', 'docker'])
+    else:
+        check_required_tools(['docker', 'npm', 'aws'])
+
+    try:
+        logger.info('🚀 OSMO Unified Start')
+        logger.info('   Mode: %s', args.mode)
+        logger.info('=' * 50)
+
+        # 2. Start Services
+        if not args.skip_services:
+            if args.mode == 'kind':
+                start_service_kind(args, print_next_steps_action=False)
+            else:
+                start_service_bazel(wait=False, print_next_steps_action=False)
+
+        # 3. Start Backend
+        if not args.skip_backend:
+            if args.mode == 'kind':
+                start_backend_kind(args, print_next_steps_action=False)
+            else:
+                start_backend_bazel(args.cluster_name, wait=False, print_next_steps_action=False)
+
+        # 4. Update Configs
+        if not args.skip_configs:
+            logger.info('⚙️  Updating configurations...')
+            detected_platform = detect_platform()
+            login_osmo(args.mode)
+
+            try:
+                update_workflow_config(
+                    args.container_registry,
+                    args.container_registry_username,
+                    args.container_registry_password,
+                    args.object_storage_endpoint,
+                    args.object_storage_access_key_id,
+                    args.object_storage_access_key,
+                    args.object_storage_region,
+                    args.image_location,
+                    args.image_tag)
+
+                update_pod_template_config(detected_platform, args.mode)
+                dataset_path = args.dataset_path \
+                    if args.dataset_path else posixpath.join(args.object_storage_endpoint, 'datasets')
+                update_dataset_config(dataset_path)
+                update_service_config(args.mode)
+                update_backend_config(args.mode)
+                set_default_pool()
+            finally:
+                logout_osmo()
+
+        # 5. Finalize
+        logger.info('=' * 50)
+        logger.info('\n🎉 usage: unified start complete!\n')
+
+        host_ip = None
+        port = None
+        if args.mode == 'bazel':
+            host_ip = get_host_ip()
+            port = 8000
+
+        print_next_steps(mode=args.mode, show_start_backend=False, show_update_configs=False,
+                         host_ip=host_ip, port=port)
+
+        if args.mode == 'bazel' and not args.skip_services:
+            logger.info('\n💡 Press Ctrl+C to stop all services')
+            logging.info('=' * 50)
+            wait_for_all_processes()
+
+    except KeyboardInterrupt:
+        logger.info('\n🛑 Ctrl+C pressed, shutting down...')
+        cleanup_registered_processes()
+    except Exception as e:
+        logger.error('❌ Error during startup: %s', e)
+        cleanup_registered_processes()
+        raise SystemExit(1) from e
+
+
+if __name__ == '__main__':
+    main()

--- a/run/start_backend_bazel.py
+++ b/run/start_backend_bazel.py
@@ -157,7 +157,9 @@ def _start_backend_worker():
     _start_backend_operator('worker', '👷')
 
 
-def start_backend_bazel(cluster_name: str = 'osmo'):
+def start_backend_bazel(cluster_name: str = 'osmo',
+                        wait: bool = True,
+                        print_next_steps_action: bool = True):
     """Start the OSMO backend using bazel."""
     check_required_tools(['bazel', 'kubectl', 'kind'])
 
@@ -169,16 +171,17 @@ def start_backend_bazel(cluster_name: str = 'osmo'):
 
         logger.info('=' * 50)
         logger.info('\n🎉 OSMO backend services started successfully!\n')
-        logger.info('💡 Press Ctrl+C to stop all backend services\n')
 
         host_ip = get_host_ip()
-        print_next_steps(mode='bazel', show_start_backend=False, show_update_configs=True,
-                         host_ip=host_ip, port=8000)
+        if print_next_steps_action:
+            print_next_steps(mode='bazel', show_start_backend=False, show_update_configs=True,
+                             host_ip=host_ip, port=8000)
 
-        logger.info('\n%s', '=' * 50)
-
-        # Keep the script running while services are running
-        wait_for_all_processes()
+        if wait:
+            logger.info('💡 Press Ctrl+C to stop all backend services\n')
+            logger.info('\n%s', '=' * 50)
+            # Keep the script running while services are running
+            wait_for_all_processes()
 
     except KeyboardInterrupt:
         logger.info('\n🛑 Ctrl+C pressed, shutting down...')

--- a/run/start_backend_kind.py
+++ b/run/start_backend_kind.py
@@ -186,7 +186,7 @@ stringData:
         raise RuntimeError(f'Unexpected error setting up backend operators: {e}') from e
 
 
-def start_backend_kind(args: argparse.Namespace) -> None:
+def start_backend_kind(args: argparse.Namespace, print_next_steps_action: bool = True) -> None:
     """Start the OSMO backend using KIND."""
     check_required_tools(['docker', 'kind', 'kubectl', 'helm'])
 
@@ -223,7 +223,8 @@ def start_backend_kind(args: argparse.Namespace) -> None:
             logout_osmo()
 
         logger.info('\n🎉 OSMO backend setup complete!')
-        print_next_steps(mode='kind', show_start_backend=False, show_update_configs=True)
+        if print_next_steps_action:
+            print_next_steps(mode='kind', show_start_backend=False, show_update_configs=True)
     except Exception as e:
         logger.error('❌ Error setting up backend: %s', e)
         raise SystemExit(1) from e

--- a/run/start_service_bazel.py
+++ b/run/start_service_bazel.py
@@ -429,7 +429,7 @@ def _start_router_service():
         raise RuntimeError('Router service failed to become ready')
 
 
-def start_service_bazel():
+def start_service_bazel(wait: bool = True, print_next_steps_action: bool = True):
     """Start the OSMO service using bazel."""
     check_required_tools(['bazel', 'docker', 'npm', 'aws'])
 
@@ -451,15 +451,16 @@ def start_service_bazel():
         logger.info('📊 Core API: http://%s:8000/api/docs', host_ip)
         logger.info('🌐 UI: http://%s:3000', host_ip)
         logger.info('🔀 Router: http://%s:8001/api/router/docs\n', host_ip)
-        logger.info('💡 Press Ctrl+C to stop all services\n')
 
-        print_next_steps(mode='bazel', show_start_backend=True, show_update_configs=True,
-                         host_ip=host_ip, port=8000)
+        if print_next_steps_action:
+            print_next_steps(mode='bazel', show_start_backend=True, show_update_configs=True,
+                             host_ip=host_ip, port=8000)
 
-        logger.info('\n%s', '=' * 50)
-
-        # Keep the script running while services are running
-        wait_for_all_processes()
+        if wait:
+            logger.info('💡 Press Ctrl+C to stop all services\n')
+            logger.info('\n%s', '=' * 50)
+            # Keep the script running while services are running
+            wait_for_all_processes()
 
     except KeyboardInterrupt:
         logger.info('\n🛑 Ctrl+C pressed, shutting down...')

--- a/run/start_service_kind.py
+++ b/run/start_service_kind.py
@@ -274,7 +274,7 @@ def _install_osmo_services(image_location: str, image_tag: str, detected_platfor
     logger.info('✅ All OSMO services installed successfully')
 
 
-def start_service_kind(args: argparse.Namespace) -> None:
+def start_service_kind(args: argparse.Namespace, print_next_steps_action: bool = True) -> None:
     """Start the OSMO service using KIND."""
     start_time = time.time()
 
@@ -313,7 +313,8 @@ def start_service_kind(args: argparse.Namespace) -> None:
         logger.info('\n🎉 OSMO service setup complete in %.2fs!', total_time)
         logger.info('=' * 50)
 
-        print_next_steps(mode='kind', show_start_backend=True, show_update_configs=True)
+        if print_next_steps_action:
+            print_next_steps(mode='kind', show_start_backend=True, show_update_configs=True)
     except Exception as e:
         logger.error('❌ Error setting up services: %s', e)
         raise SystemExit(1) from e

--- a/run/tests/BUILD
+++ b/run/tests/BUILD
@@ -29,3 +29,11 @@ osmo_py_test(
     size = "medium",
     visibility = ["//visibility:public"],
 )
+
+osmo_py_test(
+    name = "test_start",
+    srcs = ["test_start.py"],
+    deps = [
+        "//run:start",
+    ],
+)

--- a/run/tests/test_start.py
+++ b/run/tests/test_start.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import sys
+import unittest
+from unittest.mock import patch
+
+from run import start
+
+
+class TestStartScript(unittest.TestCase):
+    """Unit tests for the unified start script."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_logger = patch('run.start.logger').start()
+        self.mock_check_tools = patch('run.start.check_required_tools').start()
+        self.mock_start_service_bazel = patch('run.start.start_service_bazel').start()
+        self.mock_start_backend_bazel = patch('run.start.start_backend_bazel').start()
+        self.mock_start_service_kind = patch('run.start.start_service_kind').start()
+        self.mock_start_backend_kind = patch('run.start.start_backend_kind').start()
+        self.mock_detect_platform = patch('run.start.detect_platform').start()
+        self.mock_login_osmo = patch('run.start.login_osmo').start()
+        self.mock_logout_osmo = patch('run.start.logout_osmo').start()
+        self.mock_update_workflow = patch('run.start.update_workflow_config').start()
+        self.mock_update_pod = patch('run.start.update_pod_template_config').start()
+        self.mock_update_dataset = patch('run.start.update_dataset_config').start()
+        self.mock_update_service = patch('run.start.update_service_config').start()
+        self.mock_update_backend = patch('run.start.update_backend_config').start()
+        self.mock_set_pool = patch('run.start.set_default_pool').start()
+        self.mock_print_next_steps = patch('run.start.print_next_steps').start()
+        self.mock_wait_processes = patch('run.start.wait_for_all_processes').start()
+        self.mock_cleanup = patch('run.start.cleanup_registered_processes').start()
+
+    def tearDown(self):
+        """Tear down test fixtures."""
+        patch.stopall()
+
+    def test_start_bazel_default(self):
+        """Test starting in bazel mode with default settings."""
+        test_args = ['start.py', '--mode', 'bazel']
+        with patch.object(sys, 'argv', test_args):
+            start.main()
+
+        # Check required tools
+        self.mock_check_tools.assert_any_call(['bazel'])
+        self.mock_check_tools.assert_any_call(['docker', 'npm', 'aws'])
+
+        # Check services started (bazel mode)
+        self.mock_start_service_bazel.assert_called_once_with(
+            wait=False, print_next_steps_action=False
+        )
+        self.mock_start_backend_bazel.assert_called_once_with(
+            'osmo', wait=False, print_next_steps_action=False
+        )
+
+        # Check configs updated
+        self.mock_login_osmo.assert_called_once_with('bazel')
+        self.mock_update_workflow.assert_called()
+        self.mock_logout_osmo.assert_called_once()
+
+        # Check wait called
+        self.mock_wait_processes.assert_called_once()
+
+    def test_start_kind_default(self):
+        """Test starting in kind mode with default settings."""
+        test_args = ['start.py', '--mode', 'kind']
+        with patch.object(sys, 'argv', test_args):
+            start.main()
+
+        # Check required tools
+        self.mock_check_tools.assert_any_call(['kind', 'kubectl', 'helm', 'docker'])
+
+        # Check services started (kind mode)
+        self.mock_start_service_kind.assert_called_once()
+        self.mock_start_backend_kind.assert_called_once()
+
+        # Check configs updated
+        self.mock_login_osmo.assert_called_once_with('kind')
+
+        # Check wait NOT called (kind mode doesn't wait)
+        self.mock_wait_processes.assert_not_called()
+
+    def test_skip_flags(self):
+        """Test skip flags functionality."""
+        test_args = [
+            'start.py', '--mode', 'bazel',
+            '--skip-services', '--skip-backend', '--skip-configs'
+        ]
+        with patch.object(sys, 'argv', test_args):
+            start.main()
+
+        self.mock_start_service_bazel.assert_not_called()
+        self.mock_start_backend_bazel.assert_not_called()
+        self.mock_login_osmo.assert_not_called()
+
+    def test_config_file_merge(self):
+        """Test config file merging logic."""
+        config_content = """
+mode: kind
+cluster_name: my-cluster
+skip_services: true
+        """
+
+        test_args = ['start.py', '--config', 'test_config.yaml']
+
+        with patch('builtins.open', new_callable=unittest.mock.mock_open, read_data=config_content):
+            with patch('os.path.exists', return_value=True):
+                with patch.object(sys, 'argv', test_args):
+                    start.main()
+
+        # Verify args were updated from config
+        # mode should start kind service/backend, but skip-services is True
+        self.mock_start_service_kind.assert_not_called()
+        self.mock_start_backend_kind.assert_called()
+
+        # Verify cluster name passed
+        # Accessing call args to verify cluster name
+        call_args = self.mock_start_backend_kind.call_args[0][0]
+        self.assertEqual(call_args.cluster_name, 'my-cluster')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/run/update_configs.py
+++ b/run/update_configs.py
@@ -42,7 +42,7 @@ logging.basicConfig(format='%(message)s')
 logger = logging.getLogger()
 
 
-def _update_workflow_config(
+def update_workflow_config(
     container_registry: str,
     container_registry_username: str,
     container_registry_password: str,
@@ -127,7 +127,7 @@ def _update_workflow_config(
         raise RuntimeError(f'Unexpected error updating workflow config: {e}') from e
 
 
-def _update_pod_template_config(detected_platform: str, mode: str) -> None:
+def update_pod_template_config(detected_platform: str, mode: str) -> None:
     """Update pod template configuration for platform-specific settings."""
     logger.info('🏷️  Updating pod template configuration...')
 
@@ -245,7 +245,7 @@ def _update_pod_template_config(detected_platform: str, mode: str) -> None:
         raise RuntimeError(f'Unexpected error updating pod template configuration: {e}') from e
 
 
-def _update_dataset_config(dataset_path: str) -> None:
+def update_dataset_config(dataset_path: str) -> None:
     """Update dataset configuration."""
     logger.info('📁 Updating dataset configuration...')
 
@@ -286,7 +286,7 @@ def _update_dataset_config(dataset_path: str) -> None:
         raise RuntimeError(f'Unexpected error updating dataset configuration: {e}') from e
 
 
-def _update_service_config(mode: str) -> None:
+def update_service_config(mode: str) -> None:
     """Update service configuration."""
     logger.info('🔧 Updating service configuration...')
 
@@ -330,7 +330,7 @@ def _update_service_config(mode: str) -> None:
         raise RuntimeError(f'Unexpected error updating service configuration: {e}') from e
 
 
-def _update_backend_config(mode: str) -> None:
+def update_backend_config(mode: str) -> None:
     """Update backend configuration."""
     logger.info('🔧 Updating backend configuration...')
 
@@ -372,7 +372,7 @@ def _update_backend_config(mode: str) -> None:
         raise RuntimeError(f'Unexpected error updating backend configuration: {e}') from e
 
 
-def _set_default_pool() -> None:
+def set_default_pool() -> None:
     """Set the default pool for the user profile."""
     logger.info('🎯 Setting default pool...')
 
@@ -459,7 +459,7 @@ def main():
         login_osmo(args.mode)
 
         try:
-            _update_workflow_config(
+            update_workflow_config(
                 args.container_registry,
                 args.container_registry_username,
                 args.container_registry_password,
@@ -470,13 +470,13 @@ def main():
                 args.image_location,
                 args.image_tag)
 
-            _update_pod_template_config(detected_platform, args.mode)
+            update_pod_template_config(detected_platform, args.mode)
             dataset_path = args.dataset_path \
                 if args.dataset_path else posixpath.join(args.object_storage_endpoint, 'datasets')
-            _update_dataset_config(dataset_path)
-            _update_service_config(args.mode)
-            _update_backend_config(args.mode)
-            _set_default_pool()
+            update_dataset_config(dataset_path)
+            update_service_config(args.mode)
+            update_backend_config(args.mode)
+            set_default_pool()
 
             logout_osmo()
 


### PR DESCRIPTION
For ISSUE #34 ,

**Release Notes :**

**Problem:** Local development previously required running multiple cumbersome scripts.

**Solution:**
Introduced a single script (run/start.py) to unify the startup process.

- Unified Entry Point: Starts both services and backend operators locally with one command.
- Flexible Execution: Supports running directly with bazel or as container images in a kind cluster.
- Configurable: Accepts a YAML file for complex configurations while maintaining reasonable defaults for standard setups.

**Fixes Performed:**

- Created run/start.py as the unified entry point.
- Refactored start_service_bazel.py and start_backend_bazel.py to support non-blocking execution.
- Added robust unit tests ( run/tests/test_start.py ) covering argument parsing and execution flow.

**How to Test:**

- Default (Bazel mode): bazel run //run:start
- KIND mode: bazel run //run:start -- --mode kind
- With Config: bazel run //run:start -- --config ./my_config.yaml
- Verify Tests: bazel test //run/tests:all

Note : Release Notes made with ChatGPT