### PR TITLE
fix: update extraArgs to render string properly

### DIFF
--- a/deployments/charts/backend-operator/templates/backend-listener.yaml
+++ b/deployments/charts/backend-operator/templates/backend-listener.yaml
@@ -119,7 +119,7 @@ spec:
         - --api_burst
         - {{ .Values.services.backendListener.apiBurst | quote }}
         {{- range $arg := .Values.services.backendListener.extraArgs }}
-        - {{$arg}}
+        - {{$arg | quote}}
         {{- end }}
         env:
         {{- with .Values.services.backendListener.extraEnvs }}

--- a/deployments/charts/backend-operator/templates/backend-worker.yaml
+++ b/deployments/charts/backend-operator/templates/backend-worker.yaml
@@ -115,7 +115,7 @@ spec:
         - "/tmp/backend-test-runner/spec.yaml"
         {{- end }}
         {{- range $arg := .Values.services.backendWorker.extraArgs }}
-        - {{$arg}}
+        - {{$arg | quote}}
         {{- end }}
         env:
         {{- with .Values.services.backendWorker.extraEnvs }}

--- a/deployments/charts/service/templates/_sidecar-helpers.tpl
+++ b/deployments/charts/service/templates/_sidecar-helpers.tpl
@@ -260,10 +260,10 @@ Rate limit sidecar container
     {{- if .Values.sidecars.rateLimit.extraArgs }}
     {{- if kindIs "slice" .Values.sidecars.rateLimit.extraArgs }}
     {{- range .Values.sidecars.rateLimit.extraArgs }}
-    - {{ . }}
+    - {{ . | quote }}
     {{- end }}
     {{- else }}
-    - {{ .Values.sidecars.rateLimit.extraArgs }}
+    - {{ .Values.sidecars.rateLimit.extraArgs | quote }}
     {{- end }}
     {{- end }}
     {{- end }}

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -110,9 +110,6 @@ spec:
         - --mek_file
         - {{ .Values.services.configFile.path }}
         {{- end}}
-        {{- range .Values.services.agent.extraArgs }}
-        - {{ . }}
-        {{- end }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -128,7 +125,7 @@ spec:
         - agent_service
         {{- end }}
         {{- range $arg := .Values.services.agent.extraArgs }}
-        - {{$arg}}
+        - {{ $arg | quote }}
         {{- end }}
         env:
         {{- include "osmo.extra-env" .Values.services.agent | nindent 8 }}

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -103,9 +103,6 @@ spec:
         - --mek_file
         - {{ .Values.services.configFile.path }}
         {{- end }}
-        {{- range .Values.services.service.extraArgs }}
-        - {{ . }}
-        {{- end }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -147,7 +144,7 @@ spec:
         - api_service
         {{- end }}
         {{- range $arg := .Values.services.service.extraArgs }}
-        - {{$arg}}
+        - {{ $arg | quote }}
         {{- end }}
         env:
         - name: OSMO_DISABLE_TASK_METRICS

--- a/deployments/charts/service/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/service/templates/delayed-job-monitor.yaml
@@ -92,9 +92,6 @@ spec:
         - --mek_file
         - {{ .Values.services.configFile.path }}
         {{- end}}
-        {{- range .Values.services.delayedJobMonitor.extraArgs }}
-        - {{ . }}
-        {{- end }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -113,7 +110,7 @@ spec:
         - --enable_metrics
         {{- end }}
         {{- range $arg := .Values.services.delayedJobMonitor.extraArgs }}
-        - {{$arg}}
+        - {{ $arg | quote }}
         {{- end }}
         env:
         {{- include "osmo.extra-env" .Values.services.delayedJobMonitor | nindent 8 }}

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -106,9 +106,6 @@ spec:
         - --mek_file
         - {{ .Values.services.configFile.path }}
         {{- end}}
-        {{- range .Values.services.logger.extraArgs }}
-        - {{ . }}
-        {{- end }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -124,7 +121,7 @@ spec:
         - logger_service
         {{- end }}
         {{- range $arg := .Values.services.logger.extraArgs }}
-        - {{$arg}}
+        - {{ $arg | quote }}
         {{- end }}
         env:
         {{- include "osmo.extra-env" .Values.services.logger | nindent 8 }}

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -103,9 +103,6 @@ spec:
         - --mek_file
         - {{ .Values.services.configFile.path }}
         {{- end}}
-        {{- range .Values.services.worker.extraArgs }}
-        - {{ . }}
-        {{- end }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -121,7 +118,7 @@ spec:
         - worker
         {{- end }}
         {{- range $arg := .Values.services.worker.extraArgs }}
-        - {{$arg}}
+        - {{ $arg | quote }}
         {{- end }}
         env:
         {{- include "osmo.extra-env" .Values.services.worker | nindent 8 }}


### PR DESCRIPTION
## Description
currently extraArgs in charts is not passing in string arguments properly, fix to properly include string inputs while retaining integers or boolean inputs

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
