### PR TITLE
Remove auth router in agent service

### DIFF
--- a/src/service/agent/BUILD
+++ b/src/service/agent/BUILD
@@ -34,7 +34,6 @@ osmo_py_library(
         "//src/utils:backend_messages",
         "//src/utils/metrics",
         "//src/utils/progress_check:progress_check_lib",
-        "//src/service/core/auth",
         "//src/service/core/config",
         "//src/service/core/workflow",
     ],

--- a/src/service/agent/agent_service.py
+++ b/src/service/agent/agent_service.py
@@ -27,7 +27,6 @@ import uvicorn  # type: ignore
 import src.lib.utils.logging
 from src.utils.metrics import metrics
 from src.service.agent import helpers
-from src.service.core.auth import auth_service
 from src.service.core.workflow import objects
 from src.utils import connectors, static_config
 from src.utils.progress_check import progress
@@ -44,8 +43,6 @@ class BackendServiceConfig(connectors.RedisConfig, connectors.PostgresConfig,
 
 
 app = fastapi.FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
-
-app.include_router(auth_service.router)
 
 app.add_middleware(connectors.AccessControlMiddleware)
 


### PR DESCRIPTION
## Description
Auth router should just be in the core service. Not in the agent service

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
