### PR TITLE
Remove dataset version retention policy

### DIFF
--- a/src/cli/dataset.py
+++ b/src/cli/dataset.py
@@ -136,10 +136,10 @@ def _run_info_command(service_client: client.ServiceClient, args: argparse.Names
                 print(f'{table.draw()}\n')
 
             header = ['Version', 'Status', 'Created By', 'Created Date', 'Last Used',
-                      'Size', 'Checksum', 'Retention Policy']
+                      'Size', 'Checksum']
             table = common.osmo_table(header=header)
             columns = ['version', 'status', 'created_by', 'created_date', 'last_used',
-                       'size', 'checksum', 'retention_policy']
+                       'size', 'checksum']
             for version in result['versions']:
                 version['size'] = common.storage_convert(version['size'])
                 version['created_date'] = common.convert_utc_datetime_to_user_zone(

--- a/src/service/core/data/data_service.py
+++ b/src/service/core/data/data_service.py
@@ -197,7 +197,6 @@ def get_dataset_info(postgres: connectors.PostgresConnector,
             created_by=row.created_by,
             created_date=row.created_date.replace(microsecond=0),
             last_used=row.last_used.replace(microsecond=0),
-            retention_policy=row.retention_policy,
             size=row.size if row.size else 0,
             checksum=row.checksum if row.checksum else 0,
             location=storage.construct_storage_backend(row.location)\
@@ -304,9 +303,9 @@ def upload_start(bucket: objects.DatasetPattern,
                     )
                     INSERT INTO dataset_version
                     (dataset_id, version_id, location, status, created_by,
-                    created_date, last_used, metadata, retention_policy)
+                    created_date, last_used, metadata)
                     SELECT %s, updated_version.last_version,
-                    %s || updated_version.last_version || '.json', %s, %s, %s, %s, %s, %s
+                    %s || updated_version.last_version || '.json', %s, %s, %s, %s, %s
                     FROM updated_version
                     RETURNING version_id, location;
                 '''
@@ -317,7 +316,7 @@ def upload_start(bucket: objects.DatasetPattern,
                     (dataset_id, dataset_id,
                     f'{bucket_config.dataset_path}/{dataset_id}/manifests/',
                     objects.DatasetStatus.PENDING.name,
-                    user_header, current_time, current_time, json.dumps(metadata), 'P3M'))
+                    user_header, current_time, current_time, json.dumps(metadata)))
                 break
             except osmo_errors.OSMODatabaseError as err:
                 if retry >= 5:
@@ -1175,7 +1174,6 @@ def query_dataset(
                 name=row.name,
                 version=row.version_id,
                 status=row.status,
-                retention_policy=row.retention_policy,
                 created_by=row.created_by,
                 created_date=row.created_date.replace(microsecond=0),
                 last_used=row.last_used.replace(microsecond=0),

--- a/src/service/core/data/objects.py
+++ b/src/service/core/data/objects.py
@@ -110,7 +110,6 @@ class DataInfoDatasetEntry(pydantic.BaseModel, extra=pydantic.Extra.forbid):
     created_by: str
     created_date: datetime.datetime
     last_used: datetime.datetime
-    retention_policy: datetime.timedelta
     size: int
     checksum: str
     location: str

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1030,7 +1030,6 @@ class PostgresConnector:
                 size BIGINT,
                 checksum TEXT,
                 metadata JSONB,
-                retention_policy INTERVAL,
                 PRIMARY KEY (dataset_id, version_id)
             );
         '''

--- a/ui/src/app/datasets/[bucket]/[name]/components/DatasetVersionDetails.tsx
+++ b/ui/src/app/datasets/[bucket]/[name]/components/DatasetVersionDetails.tsx
@@ -56,8 +56,6 @@ export const DatasetVersionDetails = ({ datasetVersion, bucket }: DatasetVersion
         <dd>{convertToReadableTimezone(datasetVersion.last_used)}</dd>
         <dt>Size</dt>
         <dd>{convertBytes(datasetVersion.size)}</dd>
-        <dt>Retention Policy</dt>
-        <dd>{Math.floor(datasetVersion.retention_policy / (24 * 60 * 60))} days</dd>
         <dt>Tags</dt>
         <dd>
           <div className="flex flex-wrap gap-1">

--- a/ui/src/app/datasets/[bucket]/[name]/components/DatasetVersionsTable.tsx
+++ b/ui/src/app/datasets/[bucket]/[name]/components/DatasetVersionsTable.tsx
@@ -107,17 +107,6 @@ export const DatasetVersionsTable = ({ dataset, selectedVersion, visible }: Data
         enableMultiSort: true,
       },
       {
-        header: "Retention Policy",
-        accessorKey: "retention_policy",
-        cell: ({ row }) => {
-          const days = Math.floor(row.original.retention_policy / (24 * 60 * 60));
-          return `${days} days`;
-        },
-        sortingFn: "basic",
-        invertSorting: true,
-        enableMultiSort: true,
-      },
-      {
         header: "Tags",
         accessorKey: "tags",
         cell: ({ row }) => (

--- a/ui/src/models/datasets-model.ts
+++ b/ui/src/models/datasets-model.ts
@@ -77,7 +77,6 @@ const DataInfoDatasetEntrySchema = z
     created_by: z.string(),
     created_date: z.string().datetime(),
     last_used: z.string().datetime(),
-    retention_policy: z.number(),
     size: z.number().int(),
     checksum: z.string(),
     location: z.string(),


### PR DESCRIPTION
## Description
The dataset version retention policy was something we considered in the past but was never fully implemented. This PR removes the field as it only confuses users since it does nothing right now. In the future, we can add it back if we want to implement something similar

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
