### PR TITLE
add envoy lua filter to refresh id_token

### DIFF
--- a/deployments/charts/router/README.md
+++ b/deployments/charts/router/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -174,6 +174,7 @@ helm upgrade my-router ./router -f my-values.yaml
 | `sidecars.envoy.oauth2Filter.secretName` | Kubernetes secret name for OIDC secrets | `oidc-secrets` |
 | `sidecars.envoy.oauth2Filter.clientSecretKey` | Key name for client secret in Kubernetes secret | `client_secret` |
 | `sidecars.envoy.oauth2Filter.hmacSecretKey` | Key name for HMAC secret in Kubernetes secret | `hmac_secret` |
+| `sidecars.envoy.oauth2Filter.forceReauthOnMissingIdToken` | Force re-auth when IdToken missing on refresh | `false` |
 
 #### JWT Authentication
 

--- a/deployments/charts/router/templates/_envoy-config-helpers.tpl
+++ b/deployments/charts/router/templates/_envoy-config-helpers.tpl
@@ -159,6 +159,7 @@ listeners:
                   end
                 end
 
+        {{- if .Values.sidecars.envoy.oauth2Filter.forceReauthOnMissingIdToken }}
         - name: envoy.filters.http.lua.validate_idtoken
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
@@ -219,6 +220,7 @@ listeners:
                     end
                   end
                 end
+        {{- end }}
 
         - name: envoy.filters.http.lua.pre_oauth2
           typed_config:

--- a/deployments/charts/router/values.yaml
+++ b/deployments/charts/router/values.yaml
@@ -396,6 +396,10 @@ sidecars:
       clientSecretKey: client_secret
       hmacSecretKey: hmac_secret
 
+      ## Force re-authentication when IdToken is missing on refresh
+      ##
+      forceReauthOnMissingIdToken: false
+
     ## JWT (JSON Web Token) authentication configuration
     ##
     jwt:

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -1,5 +1,5 @@
 <!--
-  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -238,6 +238,7 @@ Any field from `sidecars.envoy` can be overridden at the service level. Fields n
 | `sidecars.envoy.oauth2Filter.secretName` | Kubernetes secret name for OIDC secrets | `oidc-secrets` |
 | `sidecars.envoy.oauth2Filter.clientSecretKey` | Key name for client secret in Kubernetes secret | `client_secret` |
 | `sidecars.envoy.oauth2Filter.hmacSecretKey` | Key name for HMAC secret in Kubernetes secret | `hmac_secret` |
+| `sidecars.envoy.oauth2Filter.forceReauthOnMissingIdToken` | Force re-auth when IdToken missing on refresh | `false` |
 
 
 #### Log Agent Settings

--- a/deployments/charts/service/templates/_envoy-config.tpl
+++ b/deployments/charts/service/templates/_envoy-config.tpl
@@ -185,6 +185,7 @@ data:
                         end
                       end
 
+              {{- if $envoy.oauth2Filter.forceReauthOnMissingIdToken }}
               - name: envoy.filters.http.lua.validate_idtoken
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
@@ -245,6 +246,7 @@ data:
                           end
                         end
                       end
+              {{- end }}
 
               - name: envoy.filters.http.lua.pre_oauth2
                 typed_config:

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1371,6 +1371,10 @@ sidecars:
       clientSecretKey: client_secret
       hmacSecretKey: hmac_secret
 
+      ## Force re-authentication when IdToken is missing on refresh
+      ##
+      forceReauthOnMissingIdToken: false
+
     ## JWT (JSON Web Token) authentication configuration
     ##
     jwt:

--- a/deployments/charts/web-ui/README.md
+++ b/deployments/charts/web-ui/README.md
@@ -1,5 +1,5 @@
 <!--
-  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -128,6 +128,7 @@ This Helm chart deploys the OSMO UI service along with its required sidecars and
 | `sidecars.envoy.oauth2Filter.secretName` | Kubernetes secret name (when useKubernetesSecrets is true) | `oidc-secrets` |
 | `sidecars.envoy.oauth2Filter.clientSecretKey` | Secret key for OAuth2 client secret | `client_secret` |
 | `sidecars.envoy.oauth2Filter.hmacSecretKey` | Secret key for OAuth2 HMAC secret | `hmac_secret` |
+| `sidecars.envoy.oauth2Filter.forceReauthOnMissingIdToken` | Force re-auth when IdToken missing on refresh | `false` |
 
 #### Log Agent Sidecar
 

--- a/deployments/charts/web-ui/templates/_envoy-config-helpers.tpl
+++ b/deployments/charts/web-ui/templates/_envoy-config-helpers.tpl
@@ -247,6 +247,7 @@ Generate OAuth2 filter configuration
 */}}
 {{- define "envoy.oauth2-filter" -}}
 {{- $oauth := .Values.sidecars.envoy.oauth2Filter -}}
+{{- if $oauth.forceReauthOnMissingIdToken }}
 - name: envoy.filters.http.lua.validate_idtoken
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
@@ -307,6 +308,7 @@ Generate OAuth2 filter configuration
             end
           end
         end
+{{- end }}
 - name: envoy.filters.http.lua.pre_oauth2
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua

--- a/deployments/charts/web-ui/values.yaml
+++ b/deployments/charts/web-ui/values.yaml
@@ -555,6 +555,10 @@ sidecars:
       ##
       hmacSecretKey: hmac_secret
 
+      ## Force re-authentication when IdToken is missing on refresh
+      ##
+      forceReauthOnMissingIdToken: false
+
     ## SSL configuration
     ##
     ssl:


### PR DESCRIPTION
## Description

#### Problem: Token refresh missing IdToken causes "Jwt is missing" error

When using Microsoft Entra ID (Azure AD) as the OAuth2 provider, users experience a "Jwt is missing" error after approximately 5 minutes of inactivity. This issue occurs because:
* Microsoft's OAuth2 token refresh does not return id_token unless scope=openid is explicitly included in the refresh request
* Envoy's OAuth2 filter does not include scope=openid when performing token refresh
* The JWT authentication filter requires the IdToken cookie to validate reques

#### Solution: 
Added two Lua filters to the Envoy configuration for web-ui, service, and router charts:

1. Request-side filter (validate_idtoken)

  Runs before the OAuth2 filter to detect invalid auth state early:
  * Checks if BearerToken exists (proves user was previously authenticated)
  * Checks if IdToken is missing or malformed (not a valid JWT structure)
  * If detected, clears all cookies to force a full re-authentication

2. Response-side filter (is_missing_idtoken_on_refresh)

  Runs after the OAuth2 filter to catch bad refresh responses:
  * Detects when a refresh response contains BearerToken but no valid IdToken
  * Clears all auth cookies in the response to prevent persisting bad state

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
