### PR TITLE
Revert "Remove auth router in agent service"

### DIFF
--- a/src/service/agent/BUILD
+++ b/src/service/agent/BUILD
@@ -34,6 +34,7 @@ osmo_py_library(
         "//src/utils:backend_messages",
         "//src/utils/metrics",
         "//src/utils/progress_check:progress_check_lib",
+        "//src/service/core/auth",
         "//src/service/core/config",
         "//src/service/core/workflow",
     ],

--- a/src/service/agent/agent_service.py
+++ b/src/service/agent/agent_service.py
@@ -27,6 +27,7 @@ import uvicorn  # type: ignore
 import src.lib.utils.logging
 from src.utils.metrics import metrics
 from src.service.agent import helpers
+from src.service.core.auth import auth_service
 from src.service.core.workflow import objects
 from src.utils import connectors, static_config
 from src.utils.progress_check import progress
@@ -43,6 +44,8 @@ class BackendServiceConfig(connectors.RedisConfig, connectors.PostgresConfig,
 
 
 app = fastapi.FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
+
+app.include_router(auth_service.router)
 
 app.add_middleware(connectors.AccessControlMiddleware)
 


### PR DESCRIPTION
Reverts NVIDIA/OSMO#371

Seems like there is something which is causing requests to be redirected to the agent service for auth. We want to fix this, but until we do so, let's revert it to keep things stable

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.