### PR TITLE
Increase Backend Worker Max Message Size

### DIFF
--- a/src/operator/backend_worker.py
+++ b/src/operator/backend_worker.py
@@ -44,7 +44,7 @@ from src.utils.progress_check import progress
 UNIQUE_JOB_TTL = 5 * 24 * 60 * 60
 QUEUE_RETRY_INTERVAL = 0.05
 COMMAND_QUEUE_SIZE = 256
-MAX_MESSAGE_SIZE = 10 * 1024 * 1024
+MAX_MESSAGE_SIZE = 16 * 1024 * 1024
 
 
 class JobContext(backend_jobs.BackendJobExecutionContext):


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
The default Uvicorn websocket max message size is 16MB, so we can update the backend worker max message size to match that.

Currently, there is a benchmarking workflow that works on exactly 100 tasks, but the websocket connection starts breaking once it the workflow has 101 tasks or more. The target number of tasks is 128 for this workflow, so based on proportions, increasing from 10MB to 16MB should support this request.

The long term fix is to rearchitect communication between service and backend worker to send chunks of a big job instead of sending a big job over the connection, so we can support arbitrarily large workflows.

Issue #411 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
