### PR TITLE
remove router refresh filter

### DIFF
--- a/deployments/charts/router/templates/_envoy-config-helpers.tpl
+++ b/deployments/charts/router/templates/_envoy-config-helpers.tpl
@@ -277,54 +277,10 @@ listeners:
                   return cookies
                 end
 
-                -- Check if a refresh response is missing IdToken
-                -- Envoy's OAuth2 filter does not include scope in refresh requests.
-                -- Returns true if BearerToken is present but IdToken is missing or empty.
-                function is_missing_idtoken_on_refresh(set_cookie_header)
-                  local has_bearer = false
-                  local has_valid_idtoken = false
-
-                  for cookie in string.gmatch(set_cookie_header, "([^,]+)") do
-                    -- Check for BearerToken with a non-empty value
-                    local bearer_value = string.match(cookie, "^%s*BearerToken=([^;]+)")
-                    if bearer_value and bearer_value ~= "" then
-                      has_bearer = true
-                    end
-                    -- Check for IdToken with a valid JWT value (JWTs are >50 chars)
-                    local idtoken_value = string.match(cookie, "^%s*IdToken=([^;]+)")
-                    if idtoken_value and string.len(idtoken_value) > 50 then
-                      has_valid_idtoken = true
-                    end
-                  end
-
-                  -- If we got a BearerToken but no valid IdToken, this is a failed refresh
-                  return has_bearer and not has_valid_idtoken
-                end
-
                 function envoy_on_response(response_handle)
-                  local hostname = "{{ .Values.sidecars.envoy.service.hostname }}"
                   local header = response_handle:headers():get("set-cookie")
 
                   if header ~= nil then
-                    -- Check if this is a token refresh response missing IdToken.
-                    -- unless scope=openid is explicitly included (which Envoy doesn't do).
-                    if is_missing_idtoken_on_refresh(header) then
-                      response_handle:logInfo("OAuth2 refresh missing IdToken - clearing session to force re-auth")
-
-                      -- Clear all auth cookies to force full re-authentication
-                      response_handle:headers():remove("set-cookie")
-                      response_handle:headers():add("set-cookie",
-                        "IdToken=; Max-Age=0; Path=/; Domain=" .. hostname)
-                      response_handle:headers():add("set-cookie",
-                        "BearerToken=; Max-Age=0; Path=/; Domain=" .. hostname)
-                      response_handle:headers():add("set-cookie",
-                        "RefreshToken=; Max-Age=0; Path=/; Domain=" .. hostname)
-                      response_handle:headers():add("set-cookie",
-                        "OauthHMAC=; Max-Age=0; Path=/; Domain=" .. hostname)
-                      return
-                    end
-
-                    -- Normal cookie processing
                     local new_cookies = increase_refresh_age(header, {
                       RefreshToken=604800,
                       BearerToken=604800,


### PR DESCRIPTION
## Description
Router doesn't need this filter, it breaks port-forwarding when this is in place. The validate id_token filter is sufficient for router ui port-forwarding sessions
 
Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
