### PR TITLE
Improve Concurrent Log Upload

### DIFF
--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -1390,13 +1390,6 @@ class CleanupWorkflow(WorkflowJob):
                     tmp_path,
                 )
 
-                # Ensure data is synced to disk before upload reads it
-                sync_fd = os.open(tmp_path, os.O_RDONLY)
-                try:
-                    os.fsync(sync_fd)
-                finally:
-                    os.close(sync_fd)
-
                 await progress_writer.report_progress_async()
 
                 # Wrap the call in a concrete no-arg function to avoid overload issues during lint.


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
Sometimes, log files are uploaded to cloud storage but are empty. This is because when `async with aiofiles.tempfile.NamedTemporaryFile(mode='w+') as temp_file` creates a handle, and `write_redis_to_disk()` also creates another handle for the same file. The first handle is opened in 'w+' with 0 bytes, and flushing that interferes with the second handle's writes.

With this PR, we will only have one file handler, so there will be no write and flush conflicts.

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
