### PR TITLE
Refactor Node Condition Updates

### DIFF
--- a/src/operator/resource_listener.go
+++ b/src/operator/resource_listener.go
@@ -513,7 +513,7 @@ func (rl *ResourceListener) buildResourceMessage(
 	hostname := utils.GetNodeHostname(node)
 
 	// Build UpdateNodeBody object
-	body := utils.BuildUpdateNodeBody(node, isDelete)
+	body := utils.BuildUpdateNodeBody(node, isDelete, rl.args.NodeConditionPrefix)
 
 	// Check if we should send (deduplication)
 	if !isDelete && !tracker.HasChanged(hostname, body) {

--- a/src/operator/resource_listener_test.go
+++ b/src/operator/resource_listener_test.go
@@ -56,7 +56,7 @@ func TestBuildResourceBody_Basic(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, false)
+	body := utils.BuildUpdateNodeBody(node, false, "")
 
 	if body.Hostname != "worker-node-1" {
 		t.Errorf("Hostname = %s, expected worker-node-1", body.Hostname)
@@ -101,7 +101,7 @@ func TestBuildResourceBody_Unschedulable(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, false)
+	body := utils.BuildUpdateNodeBody(node, false, "")
 
 	if body.Available {
 		t.Error("Expected unschedulable node to be unavailable")
@@ -128,7 +128,7 @@ func TestBuildResourceBody_NotReady(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, false)
+	body := utils.BuildUpdateNodeBody(node, false, "")
 
 	if body.Available {
 		t.Error("Expected not-ready node to be unavailable")
@@ -160,7 +160,7 @@ func TestBuildResourceBody_Conditions(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, false)
+	body := utils.BuildUpdateNodeBody(node, false, "")
 
 	// Only conditions with Status=True should be included
 	expectedConditions := map[string]bool{
@@ -200,7 +200,7 @@ func TestBuildResourceBody_LabelFiltering(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, false)
+	body := utils.BuildUpdateNodeBody(node, false, "")
 
 	// feature.node.kubernetes.io prefixed labels should now be included
 	if body.LabelFields["feature.node.kubernetes.io/cpu-cpuid"] != "AVX512" {
@@ -255,7 +255,7 @@ func TestBuildResourceBody_Taints(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, false)
+	body := utils.BuildUpdateNodeBody(node, false, "")
 
 	if len(body.Taints) != 2 {
 		t.Errorf("Expected 2 taints, got %d", len(body.Taints))
@@ -306,7 +306,7 @@ func TestBuildResourceBody_AllocatableFields(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, false)
+	body := utils.BuildUpdateNodeBody(node, false, "")
 
 	// CPU should be in cores
 	if body.AllocatableFields["cpu"] != "16" {
@@ -348,7 +348,7 @@ func TestBuildResourceBody_Delete(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, true)
+	body := utils.BuildUpdateNodeBody(node, true, "")
 
 	if !body.Delete {
 		t.Error("Expected Delete to be true")
@@ -371,7 +371,7 @@ func TestBuildResourceBody_MissingHostnameLabel(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, false)
+	body := utils.BuildUpdateNodeBody(node, false, "")
 
 	// Should fallback to "-" when hostname label is missing
 	if body.Hostname != "-" {
@@ -490,7 +490,7 @@ func TestIsNodeAvailable(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := utils.IsNodeAvailable(tt.node)
+			result := utils.IsNodeAvailable(tt.node, "")
 			if result != tt.expected {
 				t.Errorf("IsNodeAvailable() = %v, expected %v", result, tt.expected)
 			}
@@ -1139,7 +1139,7 @@ func TestNodeStateTracker(t *testing.T) {
 		},
 	}
 
-	body := utils.BuildUpdateNodeBody(node, false)
+	body := utils.BuildUpdateNodeBody(node, false, "")
 
 	// First time should indicate change
 	if !tracker.HasChanged("test-node", body) {
@@ -1156,7 +1156,7 @@ func TestNodeStateTracker(t *testing.T) {
 
 	// Change availability
 	node.Spec.Unschedulable = true
-	body2 := utils.BuildUpdateNodeBody(node, false)
+	body2 := utils.BuildUpdateNodeBody(node, false, "")
 
 	// Should indicate change
 	if !tracker.HasChanged("test-node", body2) {
@@ -1240,7 +1240,7 @@ func BenchmarkBuildResourceBody(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		utils.BuildUpdateNodeBody(node, false)
+		utils.BuildUpdateNodeBody(node, false, "")
 	}
 }
 

--- a/src/operator/tests/node_helpers_test.go
+++ b/src/operator/tests/node_helpers_test.go
@@ -170,7 +170,7 @@ func TestIsNodeAvailableFromJSON(t *testing.T) {
 				},
 			}
 
-			result := utils.IsNodeAvailable(node)
+			result := utils.IsNodeAvailable(node, "")
 			if result != tc.Expected.Available {
 				t.Errorf("IsNodeAvailable() = %v, expected %v", result, tc.Expected.Available)
 			}
@@ -211,7 +211,7 @@ func TestBuildResourceBodyFromJSON(t *testing.T) {
 				},
 			}
 
-			result := utils.BuildUpdateNodeBody(node, tc.Input.IsDelete)
+			result := utils.BuildUpdateNodeBody(node, tc.Input.IsDelete, "")
 
 			// Validate hostname
 			if tc.Expected.Hostname != "" {
@@ -382,7 +382,7 @@ func TestToKi_NegativeBytes(t *testing.T) {
 func TestBuildResourceBody_EmptyNode(t *testing.T) {
 	// Test with completely empty node
 	node := &corev1.Node{}
-	result := utils.BuildUpdateNodeBody(node, false)
+	result := utils.BuildUpdateNodeBody(node, false, "")
 
 	if result.Hostname != "-" {
 		t.Errorf("Empty node hostname = %v, expected '-'", result.Hostname)
@@ -428,7 +428,7 @@ func BenchmarkIsNodeAvailable(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		utils.IsNodeAvailable(node)
+		utils.IsNodeAvailable(node, "")
 	}
 }
 
@@ -478,6 +478,6 @@ func BenchmarkBuildResourceBody(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		utils.BuildUpdateNodeBody(node, false)
+		utils.BuildUpdateNodeBody(node, false, "")
 	}
 }

--- a/src/service/agent/agent_service.py
+++ b/src/service/agent/agent_service.py
@@ -99,13 +99,6 @@ async def backend_worker_communication(websocket: fastapi.WebSocket,
     await helpers.backend_worker_impl(websocket, name)
 
 
-@app.websocket('/api/agent/listener/control/backend/{name}')
-async def backend_listener_control_communication(websocket: fastapi.WebSocket,
-                                             name: str):
-    """ Endpoint wrapper for backend queue communication with backend listener. """
-    await helpers.backend_listener_control_impl(websocket, name)
-
-
 def main():
     config = objects.WorkflowServiceConfig.load()
     agent_service_config = BackendServiceConfig.load()

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -348,8 +348,6 @@ def configure_app(target_app: fastapi.FastAPI, config: objects.WorkflowServiceCo
                                            endpoint=backend_helpers.backend_listener_impl)
         target_app.add_api_websocket_route('/api/agent/listener/heartbeat/backend/{name}',
                                            endpoint=backend_helpers.backend_listener_impl)
-        target_app.add_api_websocket_route('/api/agent/listener/control/backend/{name}',
-                                           endpoint=backend_helpers.backend_listener_control_impl)
         target_app.add_api_websocket_route('/api/agent/worker/backend/{name}',
                                            endpoint=backend_helpers.backend_worker_impl)
 

--- a/src/utils/job/backend_job_defs.py
+++ b/src/utils/job/backend_job_defs.py
@@ -93,3 +93,14 @@ class BackendSynchronizeBackendTestMixin(pydantic.BaseModel):
     test_configs: Dict[str, Any]
     # Prefix for node conditions/labels
     node_condition_prefix: str
+
+
+class BackendUpdateNodeConditionsMixin(pydantic.BaseModel):
+    """
+    Updates node conditions by applying rules to determine node availability
+    and updating node labels in Kubernetes.
+    """
+    # Node condition rules to apply (pattern -> status regex)
+    rules: Dict[str, str]
+    # Prefix for node condition labels
+    node_condition_prefix: str


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
### Summary

Refactors node condition updates to use backend jobs instead of Redis queues and backend websocket messages. The backend worker now directly applies node condition rules and updates Kubernetes node labels, while the resource listener detects these changes via Kubernetes watch.

### Before: Redis Queue + Websocket Flow

```mermaid
graph LR
    A[Config Update] --> B[Redis Queue]
    B --> C[Agent Service]
    C --> D[Websocket Message]
    D --> E[Backend Listener]
    E --> F[Update Labels]
```

### After: Backend Job Flow

```mermaid
graph LR
    A[Config Update] --> B[Backend Job Queue]
    B --> C[Backend Worker]
    C --> D[Update Labels]
```

Issue #147 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
