### PR TITLE
Compress Backend Job when Service sends to Backend Worker

### DIFF
--- a/src/operator/backend_worker.py
+++ b/src/operator/backend_worker.py
@@ -23,9 +23,9 @@ import os
 import threading
 import time
 import traceback
-import zlib
 from typing import Dict, Optional
 from urllib.parse import urlparse
+import zlib
 
 import pydantic
 import websockets

--- a/src/service/agent/objects.py
+++ b/src/service/agent/objects.py
@@ -24,8 +24,8 @@ import json
 import logging
 import threading
 import time
-import zlib
 from typing import Callable, Optional, Dict, List, Set
+import zlib
 
 import fastapi
 import kombu  # type: ignore


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
By using compression (such as zlib), we can send jobs using 1/5 to 1/10 of the memory footprint as before. For a workflow that has a lot of repetition, we can use 25x less memory. This can potentially unblock us for big workflow submissions before the re-arch.

For example, for a parallel workflow that has 1 server and 99 client tasks:

Before:
```
2026-02-07T01:55:16.745+00:00 worker [INFO] backend_worker: Memory usage of value: 984017 bytes (960.95 KB, 0.94 MB)
```

After compression:
```
2026-02-07T02:12:32.895+00:00 worker [INFO] backend_worker: Value: b'x\x9c\xec\xbd[s\xe3\xc8\x92\xe7\xf9U\xc6\xce\xf3v[\xdcp[\xb...'
2026-02-07T02:12:32.896+00:00 worker [INFO] backend_worker: Memory usage of value: 46400 bytes (45.31 KB, 0.04 MB)
```

Issue #411 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
