### PR TITLE
Prevent destruction of pending async task

### DIFF
--- a/src/lib/utils/common.py
+++ b/src/lib/utils/common.py
@@ -1058,6 +1058,9 @@ async def gather_cancel(*aws, **kwargs):
         for awaitable_task in tasks:
             if not awaitable_task.done():
                 awaitable_task.cancel()
+        # Await all cancelled tasks to ensure they finish processing
+        # the CancelledError before we return
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 def load_contents_from_file(path: str) -> str:


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
This error can be seen in API calls that open a websocket connection that performs Redis operation:
```
2026-02-09T19:15:34.640+00:00 logger [ERROR] base_events: Task was destroyed but it is pending!
task: <Task pending name='Task-5586308' coro=<Redis._try_send_command_parse_response() running at /osmo_workspace+/src/service/logger/logger_binary.runfiles/rules_python++pip+osmo_python_deps_310_redis_py3_none_any_da92a39f/site-packages/redis/asyncio/client.py:498> wait_for=<Future pending cb=[Task.task_wakeup()]>>
2026-02-09T19:15:34.640+00:00 logger [ERROR] base_events: Task was destroyed but it is pending!
task: <Task pending name='Task-5591706' coro=<Redis._try_send_command_parse_response() running at /osmo_workspace+/src/service/logger/logger_binary.runfiles/rules_python++pip+osmo_python_deps_310_redis_py3_none_any_da92a39f/site-packages/redis/asyncio/client.py:498> wait_for=<Future pending cb=[Task.task_wakeup()]>>
2026-02-09T19:15:34.641+00:00 logger [ERROR] base_events: Task was destroyed but it is pending!
```

.cancel() only schedules a CancelledError to be raised in the task. It doesn't wait for the task to actually process that error and finish, so we need to wait for the task to process the cancelation before exiting.

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
