### PR TITLE
Fix ConfigMap name mismatch in backend test CronJob template

### DIFF
--- a/src/utils/job/test_runner_cronjob_spec/spec.yaml
+++ b/src/utils/job/test_runner_cronjob_spec/spec.yaml
@@ -209,7 +209,7 @@ spec:
           volumes:
             - name: test-config
               configMap:
-                name: "{{backend_name}}-{{test_name}}-config"
+                name: "{{configmap_name}}"
                 defaultMode: 0644
                 optional: false
 


### PR DESCRIPTION
The CronJob volume was referencing the ConfigMap as '{{backend_name}}-{{test_name}}-config' but the actual ConfigMap is created with the name '{{configmap_name}}' (which is '{test_name}-config'). This mismatch would cause the CronJob to fail to mount the ConfigMap.

Use the configmap_name template variable that is already passed to the Jinja context to ensure consistency.

## Description
The CronJob volume was referencing the ConfigMap as '{{backend_name}}-{{test_name}}-config' but the actual ConfigMap is created with the name '{{configmap_name}}' (which is '{test_name}-config'). This mismatch would cause the CronJob to fail to mount the ConfigMap.



Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
