### PR TITLE
backend test configmap name mismatch

### DIFF
--- a/src/utils/job/test_runner_cronjob_spec/spec.yaml
+++ b/src/utils/job/test_runner_cronjob_spec/spec.yaml
@@ -209,7 +209,7 @@ spec:
           volumes:
             - name: test-config
               configMap:
-                name: "{{backend_name}}-{{test_name}}-config"
+                name: "{{configmap_name}}"
                 defaultMode: 0644
                 optional: false
 


### PR DESCRIPTION
## Description
backend test configmap name mismatch

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
