### PR TITLE
fix: remove role_arn from router cloudwatch log agent config

### DIFF
--- a/deployments/charts/router/templates/log-agent-config.yaml
+++ b/deployments/charts/router/templates/log-agent-config.yaml
@@ -123,10 +123,6 @@ data:
         log_stream_prefix   ${NODE_NAME}-flb-
         auto_create_group   true
         extra_user_agent    container-insights
-        {{- if .Values.sidecars.logAgent.cloudwatch.role }}
-        role_arn            {{ .Values.sidecars.logAgent.cloudwatch.role }}
-        {{- end }}
-
 
   parsers.conf: |
     [PARSER]


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description

Remove explicit role_arn parameter from router FluentBit CloudWatch configuration to fix IRSA authentication.

- Specifying `role_arn` explicitly causes FluentBit to bypass IRSA's automatic credential injection and attempt manual STS AssumeRole calls
- Removing `role_arn` allows IRSA to inject credentials automatically via environment variables

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
