### PR TITLE
Add override_url when using default_credential

### DIFF
--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1364,6 +1364,7 @@ class PostgresConnector:
                             access_key_id=bucket.default_credential.access_key_id,
                             access_key=bucket.default_credential.access_key,
                             endpoint=bucket_info.profile,
+                            override_url=bucket.default_credential.override_url,
                         )
                     break
 
@@ -1393,7 +1394,8 @@ class PostgresConnector:
                     region=bucket.region,
                     access_key_id=bucket.default_credential.access_key_id,
                     access_key=bucket.default_credential.access_key,
-                    endpoint=bucket_info.profile
+                    endpoint=bucket_info.profile,
+                    override_url=bucket.default_credential.override_url,
                 )
         return user_creds
 


### PR DESCRIPTION
## Description
Add missing "override_url" when using "default_credential"

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
