### PR TITLE
fix: pass node_condition_prefix to backend-worker deployment

### DIFF
--- a/deployments/charts/backend-operator/templates/backend-worker.yaml
+++ b/deployments/charts/backend-operator/templates/backend-worker.yaml
@@ -104,6 +104,8 @@ spec:
         - {{ $name }}-{{ .Values.services.backendWorker.serviceName }}
         - --metrics_otel_enable
         - {{ .Values.sidecars.OTEL.enabled | quote }}
+        - --node_condition_prefix
+        - '{{ .Values.global.nodeConditionPrefix }}'
         - --progress_iter_frequency
         - {{ .Values.services.backendWorker.progressIterFrequency | quote }}
         {{- if .Values.global.backendTestNamespace }}


### PR DESCRIPTION

## Description
The backend-worker was missing the --node_condition_prefix CLI argument,
causing it to always use the default 'osmo.nvidia.com/' prefix. When the
worker (re)connected to the service, its INIT message overwrote the
correct prefix (e.g. 'us-west-2-aws.osmo.nvidia.com/') that the
backend-listener had set in the database.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
