### PR TITLE
Grouping Pools with Shared Nodes in the Same Nodeset

### DIFF
--- a/src/service/core/workflow/workflow_service.py
+++ b/src/service/core/workflow/workflow_service.py
@@ -250,7 +250,7 @@ def get_pool_quotas(all_pools: bool = True,
     gpu_usage_by_nodeset = {
         nodeset: sum((node_gpu_usage.get(node, NodeGpuUsage()) for node in nodeset),
                      start=NodeGpuUsage())
-        for nodeset in pools_by_nodeset.keys()
+        for nodeset in pools_by_nodeset
     }
 
     # Initialize per-pool calculated sums


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
This change groups pools with a shared node in the same nodeset, which is a construct used to determine if pools are considered shared in the UI and the CLI.

This should address the scenario depicted in the attached issue.

Cases:
```                                                                                                                                                                                                      
  - Pool A {Node1, Node2}, Pool B {Node2, Node3} → share Node2 → one nodeset
  - Pool A {Node1}, Pool B {Node2} → share nothing → two nodesets
  - Transitive: Pool A {Node1}, Pool B {Node1, Node2}, Pool C {Node2} → all three in one nodeset
  - Pool A {Node1, Node3}, Pool B {Node2, Node3} → share Node3 → one nodeset
```
Issue #458 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
