### PR TITLE
chore: bump helm chart versions to 1.0.2

### DIFF
--- a/deployments/charts/backend-operator/Chart.yaml
+++ b/deployments/charts/backend-operator/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployments/charts/quick-start/Chart.yaml
+++ b/deployments/charts/quick-start/Chart.yaml
@@ -19,23 +19,23 @@ description: A complete OSMO deployment for local development and testing
 
 type: application
 
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
 - name: ingress-nginx
   version: 4.13.2
   repository: https://kubernetes.github.io/ingress-nginx
 - name: service
-  version: 1.0.1
+  version: 1.0.2
   repository: file://../service
 - name: web-ui
-  version: 1.0.1
+  version: 1.0.2
   repository: file://../web-ui
 - name: router
-  version: 1.0.1
+  version: 1.0.2
   repository: file://../router
 - name: backend-operator
-  version: 1.0.1
+  version: 1.0.2
   repository: file://../backend-operator
 
 appVersion: "1.0.0"

--- a/deployments/charts/router/Chart.yaml
+++ b/deployments/charts/router/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/deployments/charts/service/Chart.yaml
+++ b/deployments/charts/service/Chart.yaml
@@ -30,7 +30,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployments/charts/web-ui/Chart.yaml
+++ b/deployments/charts/web-ui/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
Bumps all Helm chart versions from 1.0.1 to 1.0.2 across the backend-operator, service, web-ui, router, and quick-start charts. This change will be cherry-picked to the release/6.1 branch as part of the 6.1 release.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
