### PR TITLE
chore: remove v8 from architecture specifiers for distroless version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -288,7 +288,7 @@ oci.pull(
     digest = "sha256:9d2251565a7820224337f62ddc49ea5e5f7ee7f617da5fbb2afc7f10cb60ea9d",
     image = BASE_DISTROLESS_IMAGE_URL + "python:3.10-v4.0.2",
     platforms = [
-        "linux/arm64/v8",
+        "linux/arm64",
         "linux/amd64",
     ],
 )
@@ -319,20 +319,20 @@ oci.pull(
     image = BASE_DISTROLESS_IMAGE_URL + "node:22-v4.0.2",
     platforms = [
         "linux/amd64",
-        "linux/arm64/v8",
+        "linux/arm64",
     ],
 )
 use_repo(
     oci,
     "distroless_python3_10",
     "distroless_python3_10_linux_amd64",
-    "distroless_python3_10_linux_arm64_v8",
+    "distroless_python3_10_linux_arm64",
     # "distroless_python3_10_dev",
     # "distroless_python3_10_dev_linux_amd64",
     # "distroless_python3_10_dev_linux_arm64_v8",
     "node_22_distroless",
     "node_22_distroless_linux_amd64",
-    "node_22_distroless_linux_arm64_v8",
+    "node_22_distroless_linux_arm64",
     "ubuntu_22_04",
     "ubuntu_22_04_linux_amd64",
     "ubuntu_22_04_linux_arm64",

--- a/src/BUILD
+++ b/src/BUILD
@@ -121,7 +121,7 @@ oci_image(
 
 oci_image(
     name = "osmo_docker_distroless_image_arm64",
-    base = "@distroless_python3_10_linux_arm64_v8",
+    base = "@distroless_python3_10_linux_arm64",
     tars = [
         "//src:group_tar",
         "//src:passwd_tar",
@@ -177,7 +177,7 @@ oci_image(
 
 oci_image(
     name = "osmo_docker_client_image_arm64",
-    base = "@distroless_python3_10_linux_arm64_v8",
+    base = "@distroless_python3_10_linux_arm64",
     tars = [
         # Client base packages (tree, ca-certificates, /osmo dir)
         "@debian_packages_arm64//tree/arm64:data",

--- a/ui/BUILD
+++ b/ui/BUILD
@@ -194,7 +194,7 @@ oci_push(
 
 oci_image(
     name = "web_ui_image_arm64",
-    base = "@node_22_distroless_linux_arm64_v8",
+    base = "@node_22_distroless_linux_arm64",
     tars = [
         ":standalone_layers",
         ":react_overlay_tar",


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
The new distroless versions dropped the `/v8` from the architecture specifiers.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
