### PR TITLE
chore: remove _v8 from architecture specifiers for node distroless version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -298,7 +298,7 @@ oci.pull(
     image = BASE_DISTROLESS_IMAGE_URL + "node:22-v4.0.2",
     platforms = [
         "linux/amd64",
-        "linux/arm64/v8",
+        "linux/arm64",
     ],
 )
 use_repo(
@@ -311,7 +311,7 @@ use_repo(
     # "distroless_python3_10_dev_linux_arm64_v8",
     "node_22_distroless",
     "node_22_distroless_linux_amd64",
-    "node_22_distroless_linux_arm64_v8",
+    "node_22_distroless_linux_arm64",
     "ubuntu_22_04",
     "ubuntu_22_04_linux_amd64",
     "ubuntu_22_04_linux_arm64",

--- a/ui/BUILD
+++ b/ui/BUILD
@@ -194,7 +194,7 @@ oci_push(
 
 oci_image(
     name = "web_ui_image_arm64",
-    base = "@node_22_distroless_linux_arm64_v8",
+    base = "@node_22_distroless_linux_arm64",
     tars = [
         ":standalone_layers",
         ":react_overlay_tar",


### PR DESCRIPTION
…rsion

<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
Cherry pick #497 - node distroless image only

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
