### PR TITLE
Support for Azure workload identity in AKS and Arc clusters (#141)

### DIFF
--- a/deployments/charts/router/templates/service-account.yaml
+++ b/deployments/charts/router/templates/service-account.yaml
@@ -13,7 +13,13 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: router
+  name: {{ .Values.serviceAccount.name | default "router" }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deployments/charts/router/values.yaml
+++ b/deployments/charts/router/values.yaml
@@ -51,6 +51,23 @@ global:
     ##
     k8sLogLevel: WARNING
 
+## Service account configuration for router service
+##
+serviceAccount:
+  ## Create the chart-managed ServiceAccount. Set to false to re-use
+  ## an existing ServiceAccount that already has workload identity bindings.
+  ##
+  create: true
+
+  ## ServiceAccount name override. When empty, uses 'router'.
+  ##
+  name: ""
+
+  ## Extra ServiceAccount annotations such as
+  ## `azure.workload.identity/client-id` for AKS workload identity.
+  ##
+  annotations: {}
+
 ## Configuration for individual Osmo services
 ##
 services:

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -31,6 +31,9 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.agent.serviceName }}
+        {{- with .Values.services.agent.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- include "osmo.extra-annotations" .Values.services.agent | nindent 8 }}
         {{- if .Values.sidecars.otel.enabled }}

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -30,6 +30,9 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.service.serviceName }}
+        {{- with .Values.services.service.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- include "osmo.extra-annotations" .Values.services.service | nindent 8 }}
         {{- if .Values.sidecars.otel.enabled }}

--- a/deployments/charts/service/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/service/templates/delayed-job-monitor.yaml
@@ -28,6 +28,9 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.delayedJobMonitor.serviceName }}
+        {{- with .Values.services.delayedJobMonitor.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
       {{- include "osmo.extra-annotations" .Values.services.delayedJobMonitor | nindent 8 }}
       {{- if .Values.sidecars.otel.enabled }}

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -31,6 +31,9 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.logger.serviceName }}
+        {{- with .Values.services.logger.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- include "osmo.extra-annotations" .Values.services.logger | nindent 8 }}
         {{- if .Values.sidecars.otel.enabled }}

--- a/deployments/charts/service/templates/service-account.yaml
+++ b/deployments/charts/service/templates/service-account.yaml
@@ -13,11 +13,18 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.global.serviceAccountName }}
-  {{- if and .Values.sidecars.logAgent.cloudwatch .Values.sidecars.logAgent.cloudwatch.enabled }}
+  name: {{ .Values.serviceAccount.name | default .Values.global.serviceAccountName }}
+  {{- if or (and .Values.sidecars.logAgent.cloudwatch .Values.sidecars.logAgent.cloudwatch.enabled) .Values.serviceAccount.annotations }}
   annotations:
+    {{- if and .Values.sidecars.logAgent.cloudwatch .Values.sidecars.logAgent.cloudwatch.enabled }}
     eks.amazonaws.com/role-arn: {{ .Values.sidecars.logAgent.cloudwatch.role }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
+{{- end }}

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -27,6 +27,9 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.worker.serviceName }}
+        {{- with .Values.services.worker.extraPodLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- include "osmo.extra-annotations" .Values.services.worker | nindent 8 }}
         {{- if .Values.sidecars.otel.enabled }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -55,6 +55,23 @@ global:
     ##
     k8sLogLevel: WARNING
 
+## Service account configuration for core Osmo services
+##
+serviceAccount:
+  ## Create the chart-managed ServiceAccount. Set to false to re-use
+  ## an existing ServiceAccount that already has workload identity bindings.
+  ##
+  create: true
+
+  ## ServiceAccount name override. When empty, uses global.serviceAccountName.
+  ##
+  name: ""
+
+  ## Extra ServiceAccount annotations such as
+  ## `azure.workload.identity/client-id` for AKS workload identity.
+  ##
+  annotations: {}
+
 ## Configuration for individual Osmo services
 ##
 services:
@@ -335,6 +352,11 @@ services:
     ##
     extraPodAnnotations: {}
 
+    ## Extra pod labels for the delayed job monitor service pods.
+    ## Use for workload identity labels like `azure.workload.identity/use`.
+    ##
+    extraPodLabels: {}
+
     ## Extra environment variables for the delayed job monitor service container
     ##
     extraEnv: []
@@ -438,6 +460,11 @@ services:
     ## Extra pod annotations for the worker service
     ##
     extraPodAnnotations: {}
+
+    ## Extra pod labels for the worker service pods.
+    ## Use for workload identity labels like `azure.workload.identity/use`.
+    ##
+    extraPodLabels: {}
 
     ## Extra environment variables for the worker service container
     ##
@@ -663,6 +690,11 @@ services:
     ##
     extraPodAnnotations: {}
 
+    ## Extra pod labels for the API service pods.
+    ## Use for workload identity labels like `azure.workload.identity/use`.
+    ##
+    extraPodLabels: {}
+
     ## Extra environment variables for the API service container
     ##
     extraEnv: []
@@ -775,6 +807,11 @@ services:
     ##
     extraPodAnnotations: {}
 
+    ## Extra pod labels for the logger service pods.
+    ## Use for workload identity labels like `azure.workload.identity/use`.
+    ##
+    extraPodLabels: {}
+
     ## Extra environment variables for the logger service container
     ##
     extraEnv: []
@@ -883,6 +920,11 @@ services:
     ## Extra pod annotations for the agent service
     ##
     extraPodAnnotations: {}
+
+    ## Extra pod labels for the agent service pods.
+    ## Use for workload identity labels like `azure.workload.identity/use`.
+    ##
+    extraPodLabels: {}
 
     ## Extra environment variables for the agent service container
     ##

--- a/src/lib/data/storage/backends/backends.py
+++ b/src/lib/data/storage/backends/backends.py
@@ -908,7 +908,10 @@ class AzureBlobStorageBackend(common.StorageBackend):
             data_cred = self.resolved_data_credential
 
         def _validate_auth():
-            with azure.create_client(data_cred) as service_client:
+            with azure.create_client(
+                data_cred,
+                account_url=self.auth_endpoint,
+            ) as service_client:
                 if self.container:
                     with service_client.get_container_client(self.container) as container_client:
                         container_client.get_container_properties()
@@ -954,7 +957,10 @@ class AzureBlobStorageBackend(common.StorageBackend):
         if data_cred is None:
             data_cred = self.resolved_data_credential
 
-        return azure.AzureBlobStorageClientFactory(data_cred=data_cred)
+        return azure.AzureBlobStorageClientFactory(
+            data_cred=data_cred,
+            account_url=self.auth_endpoint,
+        )
 
 
 def construct_storage_backend(

--- a/src/lib/data/storage/backends/tests/BUILD
+++ b/src/lib/data/storage/backends/tests/BUILD
@@ -25,5 +25,6 @@ osmo_py_test(
         "//src/lib/data/storage/backends",
         "//src/lib/data/storage/core",
         "//src/lib/data/storage/credentials",
+        "//src/utils/connectors",
     ],
 )

--- a/src/lib/data/storage/credentials/credentials.py
+++ b/src/lib/data/storage/credentials/credentials.py
@@ -88,12 +88,27 @@ class DefaultDataCredential(DataCredentialBase, extra=pydantic.Extra.forbid):
     Data credential that delegates resolution to the underlying SDK.
 
     Uses the SDK's default credential chain (e.g., Azure's DefaultAzureCredential,
-    boto3's credential resolution) which may include environment variables, 
+    boto3's credential resolution) which may include environment variables,
     workload identity, instance metadata, and other provider-specific methods.
 
     Intentionally left empty as all credential resolution is handled by the SDK.
     """
-    pass
+
+    def to_decrypted_dict(self) -> dict[str, str]:
+        """Return credential dict for SDK-based authentication.
+
+        For DefaultDataCredential, only endpoint and region are provided.
+        The actual credential resolution occurs at runtime via the SDK's
+        default credential chain (workload identity, managed identity, etc.).
+        """
+        output = {
+            'endpoint': self.endpoint,
+        }
+
+        if self.region:
+            output['region'] = self.region
+
+        return output
 
 
 DataCredential = Union[

--- a/src/lib/utils/credentials.py
+++ b/src/lib/utils/credentials.py
@@ -20,6 +20,8 @@ import pydantic
 
 from ..data.storage import credentials
 
+DataCredential = credentials.DataCredential
+DefaultDataCredential = credentials.DefaultDataCredential
 StaticDataCredential = credentials.StaticDataCredential
 get_static_data_credential_from_config = credentials.get_static_data_credential_from_config
 


### PR DESCRIPTION
Cherry-pick #141 

* feat(src): add Azure service account and extra pod labels configuration

- implement service account creation with customizable name and annotations
- enhance service templates to support extra pod labels for various services
- update Azure backend to utilize DefaultAzureCredential for authentication
- add tests for Azure credential extraction and client creation

* feat(src): extract account key from connection string for Azure Blob Storage

- add function to extract AccountKey from connection string
- update AzureBlobStorageClient to handle different credential types

* feat(test): add tests for account key extraction from Azure connection strings

* chore: clean up linting issues for tests

* refactor(src): update data credential types in PostgresConnector and TaskGroup

- change StaticDataCredential to DataCredential in get_all_data_creds method
- update fetch_creds function signature to use DataCredential

* feat(src): update Azure client creation to include storage account and account URL

- remove deprecated storage account extraction function
- modify create_client to accept storage_account and account_url parameters
- update AzureBlobStorageClientFactory to use new parameters
- adjust tests to reflect changes in client creation

🔒 - Generated by Copilot

* refactor(src): mark storage_account parameter as unused in create_client function

🔧 - Generated by Copilot

* refactor(src): remove unused storage_account parameter from client creation

🔧 - Generated by Copilot

<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
