### PR TITLE
Backend Messages Queue Metric from Message Worker

### DIFF
--- a/src/service/agent/message_worker.py
+++ b/src/service/agent/message_worker.py
@@ -90,13 +90,14 @@ class MessageWorker:
         # Progress writer for liveness/readiness probes
         self._progress_writer = progress.ProgressWriter(config.progress_file)
 
-        # Register observable gauge for stream queue length
-        self.metric_creator.send_observable_gauge(
-            'osmo_backend_messages_queue_length',
-            callbacks=self.get_operator_stream_length,
-            description='Messages queue length for backend listener messages queue',
-            unit='count'
-        )
+        if config.method != 'dev':
+            # Register observable gauge for stream queue length
+            self.metric_creator.send_observable_gauge(
+                'osmo_backend_messages_queue_length',
+                callbacks=self.get_operator_stream_length,
+                description='Messages queue length for backend listener messages queue',
+                unit='count'
+            )
 
         # Create consumer group if it doesn't exist
         self._ensure_consumer_group()


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
Allow message worker to track the backend messages queue length periodically.

Issue #377 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
