### PR TITLE
build: add backports-tarfile dependency for CLI builder

### DIFF
--- a/src/cli/BUILD
+++ b/src/cli/BUILD
@@ -93,6 +93,7 @@ osmo_py_binary(
     srcs = ["cli_builder.py"],
     deps = [
         ":cli_lib",
+        requirement("backports-tarfile"),
         requirement("pyinstaller"),
         requirement("shtab"),
     ],

--- a/src/locked_requirements.txt
+++ b/src/locked_requirements.txt
@@ -48,6 +48,10 @@ azure-storage-blob==12.26.0 \
     --hash=sha256:5dd7d7824224f7de00bfeb032753601c982655173061e242f13be6e26d78d71f \
     --hash=sha256:8c5631b8b22b4f53ec5fff2f3bededf34cfef111e2af613ad42c9e6de00a77fe
     # via -r requirements.txt
+backports-tarfile==1.2.0 \
+    --hash=sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34 \
+    --hash=sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991
+    # via -r requirements.txt
 boto3==1.38.0 \
     --hash=sha256:8b6544eca17e31d1bfd538e5d152b96a68d6c92950352a0cd9679f89d217d53a \
     --hash=sha256:96898facb164b47859d40a4271007824a0a791c3811a7079ce52459d753d4474
@@ -594,7 +598,9 @@ lark==1.1.5 \
 macholib==1.16.3 \
     --hash=sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30 \
     --hash=sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   pyinstaller
 markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -59,6 +59,7 @@ jwcrypto==1.5.6
 
 # Pyinstaller
 pyinstaller==6.12.0
+backports-tarfile==1.2.0  # Required by jaraco.context (vendored in setuptools 82+) on Python < 3.12
 
 # Yaml
 pyyaml==6.0.3


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
The `setuptools` upgrade to 82.0.0 (introduced in #485) brought in a newer vendored version of `jaraco.context` that conditionally imports `backports.tarfile` on Python < 3.12. Since the CLI is built with Python 3.10, this import always executes, but `backports-tarfile` was not in the project's dependencies — causing every PyInstaller-built CLI binary to crash immediately on startup with `ModuleNotFoundError: No module named 'backports'`, regardless of platform.

Verification: built `//src/cli/packaging/macos:macos_client_unsigned_pkg_arm64`, install it, and confirm `osmo login <url>` no longer crashes with `ModuleNotFoundError`

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
