### PR TITLE
fix: move backports-tarfile comment to its own line to prevent it from being embedded in wheel metadata

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -59,7 +59,8 @@ jwcrypto==1.5.6
 
 # Pyinstaller
 pyinstaller==6.12.0
-backports-tarfile==1.2.0  # Required by jaraco.context (vendored in setuptools 82+) on Python < 3.12
+# backports-tarfile: required by jaraco.context (vendored in setuptools 82+) on Python < 3.12
+backports-tarfile==1.2.0
 
 # Yaml
 pyyaml==6.0.3


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
The requires.bzl wheel metadata parser includes inline comments verbatim in Requires-Dist, causing twine to reject the nvidia_osmo wheel with InvalidMetadata when uploading to Artifactory. Fixed by moving the backports-tarfile comment
  to its own line so the parser strips it correctly. Verified by building //src/lib/distribution:osmo_py_wheel_stampless and confirming twine check passes before and after the change.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
