### PR TITLE
Unify flag for enabling OTEL in Listener

### DIFF
--- a/deployments/charts/backend-operator/README.md
+++ b/deployments/charts/backend-operator/README.md
@@ -115,7 +115,6 @@ This Helm chart deploys the OSMO Backend-Operator for managing compute backend r
 | `services.backendListener.eventCacheTTLMin` | Event deduplication cache TTL in minutes | `15` |
 | `services.backendListener.enableNodeLabelUpdate` | Enable updating node verified label based on availability | `false` |
 | `services.backendListener.labelUpdateChanSize` | Buffer size for label update channel | `200` |
-| `services.backendListener.metrics.enabled` | Enable OpenTelemetry metrics collection | `true` |
 | `services.backendListener.metrics.component` | Service component name for metrics | `osmo-backend-listener` |
 | `services.backendListener.metrics.version` | Service version for metrics (defaults to image tag if empty) | `""` |
 | `services.backendListener.extraArgs` | Additional command line arguments | `[]` |

--- a/deployments/charts/backend-operator/templates/backend-listener.yaml
+++ b/deployments/charts/backend-operator/templates/backend-listener.yaml
@@ -114,7 +114,7 @@ spec:
         - --labelUpdateChanSize
         - '{{ .Values.services.backendListener.labelUpdateChanSize }}'
         - --metricsOtelEnable
-        - '{{ .Values.services.backendListener.metrics.enabled }}'
+        - '{{ .Values.sidecars.OTEL.enabled }}'
         - --serviceVersion
         - '{{ .Values.services.backendListener.metrics.version | default .Values.global.osmoImageTag }}'
         - --metricsOtelCollectorHost

--- a/deployments/charts/backend-operator/values.yaml
+++ b/deployments/charts/backend-operator/values.yaml
@@ -291,10 +291,6 @@ services:
     ## OpenTelemetry metrics configuration
     ##
     metrics:
-      ## Enable OpenTelemetry metrics collection
-      ##
-      enabled: true
-
       ## Service component name for metrics
       ##
       component: "osmo-backend-listener"


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
Previously there were two flags for enabling OTEL, one to turn it on in listener, and another to add the sidecar. There should be a unifying flag.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
