### PR TITLE
Fix OTel collector memory pressure after SDK upgrade

### DIFF
--- a/deployments/charts/service/templates/otel-config.yaml
+++ b/deployments/charts/service/templates/otel-config.yaml
@@ -37,7 +37,7 @@ data:
     processors:
       memory_limiter:
         check_interval: 5s
-        limit_mib: 30
+        limit_mib: 128
       batch:
         send_batch_size: 100
 

--- a/src/utils/metrics/metrics.py
+++ b/src/utils/metrics/metrics.py
@@ -32,7 +32,7 @@ import pydantic
 from src.lib.utils import osmo_errors, version
 
 
-DEFAULT_INTERVAL_IN_MILLISECONDS = 6000
+DEFAULT_INTERVAL_IN_MILLISECONDS = 15000
 
 class InstrumentType(enum.Enum):
     """Describes the execution status of a job"""


### PR DESCRIPTION
# Description
Increase collector memory_limiter from 30 MiB to 128 MiB and reduce metric export frequency from 6s to 15s to prevent data drops under high-cardinality metric load.


Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
