### PR TITLE
fix migration hook lifecycle

### DIFF
--- a/deployments/charts/service/templates/migration-job.yaml
+++ b/deployments/charts/service/templates/migration-job.yaml
@@ -27,7 +27,8 @@ metadata:
   name: pgroll-migration-files
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
     {{- with .Values.services.migration.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -43,7 +44,7 @@ metadata:
   name: pgroll-migrate-{{ .Release.Revision }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
     {{- with .Values.services.migration.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -201,11 +201,11 @@ services:
     ## PostgreSQL password secret configuration
     ## Name of the Kubernetes secret containing the PostgreSQL password
     ##
-    passwordSecretName: postgres-secret
+    passwordSecretName: db-secret
 
     ## Key name in the secret that contains the PostgreSQL password
     ##
-    passwordSecretKey: password
+    passwordSecretKey: db-password
 
   ## Default admin user configuration
   ## When configured, the service will create an admin user on startup with the osmo-admin role


### PR DESCRIPTION
Title: Fix migration hook lifecycle and align postgres secret defaults

Summary

- Fix ConfigMap not found during migration: Changed hook-delete-policy from hook-succeeded to before-hook-creation on both the ConfigMap and Job. With hook-succeeded, the ConfigMap was deleted immediately after the Job completed, causing mount failures on subsequent upgrades when the new Job pod scheduled before the new ConfigMap was available.
- Keep Job logs accessible: Changing the Job's delete policy to before-hook-creation means completed Jobs remain available for log inspection until the next upgrade, working together with the existing ttlSecondsAfterFinished: 300 for Kubernetes-side cleanup.
- Align postgres secret defaults with rest of chart: The migration Job used configurable secret name/key defaulting to postgres-secret/password, while every other template hardcodes db-secret/db-password. Updated the defaults to match.


Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
