### PR TITLE
Fix osmo_barrier.py bug with num_nodes=1

### DIFF
--- a/cookbook/dnn_training/torchrun_multinode/osmo_barrier.py
+++ b/cookbook/dnn_training/torchrun_multinode/osmo_barrier.py
@@ -47,6 +47,10 @@ class SyncServer:
             server_task = loop.create_task(self._server.serve_forever())
             loop.create_task(self.status_print())
 
+            # If there are no other nodes to wait for, we're already done
+            if self._num_nodes == 1:
+                self._ready_to_send.set()
+
             # Wait for all connections, or for something to go wrong
             await self._ready_to_send.wait()
             for connection in self._connections:


### PR DESCRIPTION
## Description
Fix bug where osmo_barrier.py hangs when num_nodes=1

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
