### PR TITLE
Fix oauth2-proxy TOML parse error when using Kubernetes secrets

### DIFF
--- a/deployments/charts/router/templates/_sidecar-helpers.tpl
+++ b/deployments/charts/router/templates/_sidecar-helpers.tpl
@@ -188,7 +188,12 @@ OAuth2 Proxy sidecar container
   securityContext:
     {{- toYaml .Values.sidecars.oauth2Proxy.securityContext | nindent 4 }}
   args:
+    {{- if .Values.sidecars.oauth2Proxy.useKubernetesSecrets }}
+    - --client-secret-file=/etc/oauth2-proxy/client-secret
+    - --cookie-secret-file=/etc/oauth2-proxy/cookie-secret
+    {{- else }}
     - --config={{ .Values.sidecars.oauth2Proxy.secretPaths.cookieSecret }}
+    {{- end }}
     - --http-address=0.0.0.0:{{ .Values.sidecars.oauth2Proxy.httpPort }}
     - --metrics-address=0.0.0.0:{{ .Values.sidecars.oauth2Proxy.metricsPort }}
     - --reverse-proxy=true

--- a/deployments/charts/router/values.yaml
+++ b/deployments/charts/router/values.yaml
@@ -293,10 +293,6 @@ sidecars:
     ##
     enabled: true
 
-    ## Use Kubernetes secrets to store credentials
-    ##
-    useKubernetesSecrets: false
-
     ## Paths that should skip authentication
     ##
     skipAuthPaths:

--- a/deployments/charts/service/templates/_sidecar-helpers.tpl
+++ b/deployments/charts/service/templates/_sidecar-helpers.tpl
@@ -375,7 +375,12 @@ OAuth2 Proxy sidecar container
   securityContext:
     {{- toYaml .Values.sidecars.oauth2Proxy.securityContext | nindent 4 }}
   args:
+    {{- if .Values.sidecars.oauth2Proxy.useKubernetesSecrets }}
+    - --client-secret-file=/etc/oauth2-proxy/client-secret
+    - --cookie-secret-file=/etc/oauth2-proxy/cookie-secret
+    {{- else }}
     - --config={{ .Values.sidecars.oauth2Proxy.secretPaths.cookieSecret }}
+    {{- end }}
     - --http-address=0.0.0.0:{{ .Values.sidecars.oauth2Proxy.httpPort }}
     - --metrics-address=0.0.0.0:{{ .Values.sidecars.oauth2Proxy.metricsPort }}
     - --reverse-proxy=true

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1050,10 +1050,6 @@ sidecars:
     ##
     enabled: true
 
-    ## Use Kubernetes secret for credentials
-    ##
-    useKubernetesSecrets: false
-
     livenessProbe:
       httpGet:
         path: /ready

--- a/deployments/charts/web-ui/templates/_sidecar-helpers.tpl
+++ b/deployments/charts/web-ui/templates/_sidecar-helpers.tpl
@@ -242,7 +242,12 @@ OAuth2 Proxy sidecar container
   securityContext:
     {{- toYaml .Values.sidecars.oauth2Proxy.securityContext | nindent 4 }}
   args:
+    {{- if .Values.sidecars.oauth2Proxy.useKubernetesSecrets }}
+    - --client-secret-file=/etc/oauth2-proxy/client-secret
+    - --cookie-secret-file=/etc/oauth2-proxy/cookie-secret
+    {{- else }}
     - --config={{ .Values.sidecars.oauth2Proxy.secretPaths.cookieSecret }}
+    {{- end }}
     - --http-address=0.0.0.0:{{ .Values.sidecars.oauth2Proxy.httpPort }}
     - --metrics-address=0.0.0.0:{{ .Values.sidecars.oauth2Proxy.metricsPort }}
     - --reverse-proxy=true

--- a/deployments/charts/web-ui/values.yaml
+++ b/deployments/charts/web-ui/values.yaml
@@ -378,11 +378,6 @@ sidecars:
   ## Envoy proxy sidecar configuration
   ##
   envoy:
-    ## Use Kubernetes secrets for Envoy credentials
-    ## Set to false when managing secrets with custom secrets management solution
-    ##
-    useKubernetesSecrets: false
-
     ## Secret file paths (legacy, kept for backward compatibility)
     ##
     secretPaths:


### PR DESCRIPTION
Title: Fix oauth2-proxy secret handling for Kubernetes secrets mode

## Description 

- Fix TOML parse error in oauth2-proxy across all 3 charts (service, router, web-ui): When useKubernetesSecrets: true, the --config flag was pointing at a raw secret file, causing failed to load config. Now conditionally uses `--client-secret-file` and `--cookie-secret-file` flags.
- Remove dead envoy.useKubernetesSecrets config from all 3 chart values.yaml. This value was defined to pass in secrets in earlier version of the charts but no longer referenced in any template — only the oauth2Proxy.useKubernetesSecrets is actually used.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
