### PR TITLE
fix: set min redis version as 7 for azure terraform

### DIFF
--- a/deployments/terraform/azure/example/example.tf
+++ b/deployments/terraform/azure/example/example.tf
@@ -312,6 +312,7 @@ resource "azurerm_redis_cache" "main" {
   family              = var.redis_family
   sku_name            = var.redis_sku_name
   minimum_tls_version = "1.2"
+  redis_version       = var.redis_version
 
   redis_configuration {
     maxmemory_policy = "volatile-lru"

--- a/deployments/terraform/azure/example/variables.tf
+++ b/deployments/terraform/azure/example/variables.tf
@@ -233,6 +233,17 @@ variable "redis_capacity" {
   default     = 1
 }
 
+variable "redis_version" {
+  description = "Redis version (must be 7 or higher)"
+  type        = string
+  default     = "7"
+
+  validation {
+    condition     = tonumber(var.redis_version) >= 7
+    error_message = "Redis version must be 7 or higher."
+  }
+}
+
 # Log Analytics Variables
 variable "log_analytics_sku" {
   description = "The SKU of the Log Analytics Workspace"


### PR DESCRIPTION
## Description
set minimum redis version as 7 for azure terraform

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
