### PR TITLE
Apply fixes to osmo-skill for delegating workflow orchestration to sub-agent

### DIFF
--- a/.claude/skills/osmo-skill/SKILL.md
+++ b/.claude/skills/osmo-skill/SKILL.md
@@ -14,7 +14,22 @@ description: >
 # OSMO CLI Use Cases
 
 OSMO is a cloud platform for robotics compute and data storage. This skill covers
-common OSMO CLI workflows.
+common OSMO CLI use cases.
+
+## Reference Files
+
+The `agents/` directory contains instructions for specialized subagents. Read them when you need to spawn the relevant subagent.
+
+- `agents/workflow-expert.md` — expert for workflow generation, resource check, submission, failure diagnosis
+- `agents/logs-reader.md` - expert for fetching and reading logs, extracting important information for monitoring and failure diagnosis.
+
+The `references/` directory has additional documentation:
+
+- `references/cookbook.md` — Real-world workflow examples to use as starting points
+- `references/workflow-patterns.md` — Multi-task, parallel execution, data dependencies, Jinja templating
+- `references/advanced-patterns.md` — Checkpointing, retry/exit behavior, node exclusion
+
+---
 
 ## Use Case: Check Available Resources
 
@@ -99,6 +114,8 @@ Derive GPU type from pool names when possible:
 
 **When to use:** The user wants to submit a job to run on OSMO (e.g. "submit a workflow
 to run SDG", "run RL training for me", "submit this yaml to OSMO").
+
+Evaluate the complexity of the user's request: if user also wants monitoring, debugging workflows, reporting results, or the workflow complexity is too high, refer to `Orchestrate a Workflow End-to-End` use case to delegate this to a sub-agent instead.
 
 ### Steps
 
@@ -227,14 +244,21 @@ Also used as the polling step when monitoring a workflow during end-to-end orche
    osmo workflow query <workflow name> --format-type json
    ```
 
-2. **Report to the user:**
+2. **Get recent logs** — Choose the log-fetching method based on task count
+   (this rule applies everywhere logs are needed — monitoring, failure diagnosis, etc.):
+   - **1 task:** fetch logs inline with `osmo workflow logs <workflow_id> -n 10000`.
+   - **2+ tasks:** you MUST delegate to `/agents/logs-reader.md` subagents — do NOT
+     fetch logs inline yourself. Spawn one logs-reader subagent per 5 tasks
+     (e.g. 3 tasks → 1 subagent, 7 tasks → 2 subagents).
+
+3. **Report to the user:**
    - State the current status clearly (e.g. RUNNING, COMPLETED, FAILED, PENDING)
    - Concisely summarize what the logs show — what stage the job is at, any errors,
      or what it completed successfully
    - If the workflow failed, highlight the error and suggest next steps if possible
    - **If the workflow is COMPLETED and has output datasets, you MUST ask this
-     explicit question before ending your response:**  
-     `Would you like me to download the output dataset now?`  
+     explicit question before ending your response:**
+     `Would you like me to download the output dataset now?`
      Also ask whether they want a specific output folder (default to `~/` if not).
      Then run the download yourself:
      ```
@@ -264,37 +288,27 @@ Also used as the polling step when monitoring a workflow during end-to-end orche
    ```
    osmo resource list -p <pool>
    ```
-
-3. **Get recent logs** — Refer to the logs-reader subagent. Based on the number of tasks
-   that are present in the response JSON from workflow query, *spawn* a log-reader agent
-   for every 5 tasks that are present. Use the Task tool to spawn the `logs-reader` agent.
-
 ---
 
 ## Use Case: Orchestrate a Workflow End-to-End
 
-**When to use:** The user wants to create, submit AND monitor a workflow to completion,
+**When to use:** The user wants to create workflow, submit and monitor it to completion,
 or requests an autonomous workflow cycle (e.g. "train GR00T on my data", "create a SDG workflow and run it",
 "submit and monitor my workflow", "run end-to-end training", "submit this and
 tell me when it's done").
 
 ### Phase-Split Pattern
 
-The lifecycle is split between the **workflow-expert agent** (resource
-check, YAML generation, submission, failure diagnosis) and **you** (live
-monitoring so the user sees real-time updates). Follow these steps exactly:
+The lifecycle is split between the `/agents/workflow-expert.md` subagent (workflow generation creation, resource check, submission, failure diagnosis) and **you** (live monitoring so the user sees real-time updates). Follow these steps exactly:
 
-#### Step 1: Spawn the workflow-expert for setup and submission
+#### Step 1: Spawn a `/agents/workflow-expert.md` subagent for setup and submission
 
-Use the Task tool to spawn the `workflow-expert` agent. Ask it to
-**check resources and submit the workflow only**. Do NOT ask it to monitor,
-poll status, or report results — that is your job.
+Spawn the `/agents/workflow-expert.md` subagent. Ask it to **write workflow YAML if needed, check resources and submit the workflow only**. Do NOT ask it to monitor, poll status, or report results — that is your job.
 
 Example prompt:
-> Submit the workflow at workflow.yaml to an available GPU pool. Check
-> resources first, then submit. Return the workflow ID when done.
+> Create a workflow based on user's request, if any. Check resources first, then submit the workflow to an available resource pool. Return the workflow ID when done.
 
-The agent returns: workflow ID, pool name, and OSMO Web link.
+The subagent returns: workflow ID, pool name, and OSMO Web link.
 
 #### Step 2: Monitor the workflow inline (you do this — user sees live updates)
 
@@ -312,10 +326,12 @@ Report each state transition to the user:
 In the same completion message, ask: `Would you like me to download the output dataset now?`
 Then follow the COMPLETED handling in "Check Workflow Status".
 
-**If FAILED:** Resume the workflow expert (use the `resume` parameter with the
-agent ID from Step 1) and tell it: "Workflow <id> FAILED. Diagnose and fix."
-It returns a new workflow ID. Resume monitoring from Step 2. Max 3 retries
-before asking the user for guidance.
+**If FAILED:** First, fetch logs using the log-fetching rule from "Check Workflow Status"
+Step 2 (1 task = inline, 2+ tasks = delegate to logs-reader subagents). Then resume the
+`workflow-expert` subagent (use the `resume` parameter with the agent ID from Step 1)
+and pass the logs summary: "Workflow <id> FAILED. Here is the logs summary: <summary>.
+Diagnose and fix." It returns a new workflow ID. Resume monitoring from Step 2. Max 3
+retries before asking the user for guidance.
 
 ---
 

--- a/.claude/skills/osmo-skill/agents/workflow-expert.md
+++ b/.claude/skills/osmo-skill/agents/workflow-expert.md
@@ -1,9 +1,9 @@
 ---
 name: workflow-expert
 description: >
-  OSMO workflow specialist for resource checking, YAML generation,
-  submission, and failure diagnosis. Checks resources, generates or
-  validates YAML, submits — then RETURNS the workflow ID. It does NOT
+  OSMO workflow specialist for workflow creation, resource checking,
+  submission, and failure diagnosis. Generates or validates YAML,
+  checks resources, submits — then RETURNS the workflow ID. It does NOT
   monitor workflows. The calling agent handles monitoring inline (see
   the osmo skill's "Orchestrate a Workflow End-to-End" use case). On
   failure, resume this agent for diagnosis.
@@ -14,11 +14,11 @@ memory: user
 ---
 
 You are a workflow specialist for the OSMO platform. You handle the heavy
-lifting — resource selection, YAML generation, submission, and failure
+lifting — workflow generation, resource selection, submission, and failure
 diagnosis — then return control so the calling agent can monitor inline
 with live status updates visible to the user.
 
-The osmo skill is preloaded in your context with all CLI procedures and
+Load the [osmo skill](/osmo-skill/SKILL.md) in your context with all CLI procedures and
 reference files. Use its procedures directly — do not reinvent them.
 
 Your agent memory persists across sessions. Consult it before starting
@@ -33,8 +33,11 @@ Execute these steps using your preloaded osmo skill:
    Pick the pool with the best GPU match for the user's needs.
 
 2. **Workflow Generation** — If `workflow.yaml` already exists and the user
-   referenced it, use it as-is. Otherwise, follow the "Generate and Submit
-   a Workflow" use case to create one.
+   referenced it, submit it as-is. Do NOT modify the YAML — no adding/removing
+   tasks, renaming tasks, changing resource values, or altering the script
+   contents. If you spot an obvious issue (e.g. wrong template variable),
+   flag it in your return message but still submit the original unchanged.
+   Otherwise, follow the "Generate and Submit a Workflow" use case to create one.
 
 3. **Submit** — Follow the submission steps from the skill. Skip user
    confirmation if pre-authorized. On validation errors, auto-adjust
@@ -51,12 +54,16 @@ Execute these steps using your preloaded osmo skill:
 
 When resumed with a failure context (workflow ID + status):
 
-1. **Fetch logs**: `osmo workflow logs <workflow_id> -n 10000`
+1. **Analyze logs**: Analyze the logs summary that is provided to you frist. If the summary is not informational enough for root-casue analysis, fetch more detailed logs with `osmo workflow logs <workflow_id> -n 10000`.
 2. **Root-cause analysis**: Identify the failure (OOM/exit 137, script error,
    image pull failure, NCCL timeout, template variable errors, etc.)
 3. **Proactive review**: When fixing a script error, review the ENTIRE script
-   for other potential issues — not just the line that failed. Fix all issues
-   found in a single pass to minimize retry cycles.
+   for other potential issues that would cause a runtime failure — not just the
+   line that failed. Fix all such issues in a single pass to minimize retry
+   cycles. Limit fixes to things that would break execution (missing commands,
+   wrong template variables, syntax errors, bad paths). Do NOT change resource
+   values (CPU, GPU, memory), task structure, or make optimizations the user
+   did not ask for.
 4. **Explain the fix**: State what failed, what you changed, and any other
    issues you caught proactively. Use plain language.
 5. **Resubmit** to the same pool.


### PR DESCRIPTION
Apply fixes to osmo-skill for workflow orchestration and add reference file index to allow for correct sub-agent delegation.

Moving sub-agent definition from .claude/agents/ to .claude/skills/osmo-skill/agents caused Claude Code not be able to auto-discover the sub-agent. This broke the end-to-end workflow orchestration use cases since the workflow-expert sub-agent never gets spawned.

<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->

Issue #532 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
