### PR TITLE
fix: add missing schema version in service authz sidecar

### DIFF
--- a/deployments/charts/service/templates/_sidecar-helpers.tpl
+++ b/deployments/charts/service/templates/_sidecar-helpers.tpl
@@ -484,6 +484,10 @@ Authorization sidecar container
     - "--log-name=authz_sidecar"
     {{- end }}
   env:
+    {{- if .Values.services.migration.enabled }}
+    - name: OSMO_SCHEMA_VERSION
+      value: {{ .Values.services.migration.targetSchema }}
+    {{- end }}
     {{- include "osmo.extra-env" .Values.sidecars.authz | nindent 4 }}
     {{- if .Values.services.postgres.password }}
     - name: OSMO_POSTGRES_PASSWORD


### PR DESCRIPTION
## Description
add missing schema version in service authz sidecar charts

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
