### PR TITLE
fix: persist client_id in TokenLoginStorage to fix token refresh after device code login

### DIFF
--- a/src/cli/login.py
+++ b/src/cli/login.py
@@ -100,11 +100,11 @@ def _login(service_client: client.ServiceClient, args: argparse.Namespace):
 
     # Construct device endpoint
     device_endpoint = args.device_endpoint
-    client_id: str | None = None
+    client_id: str = service_client.login_manager.login_config.client_id
     if not device_endpoint:
         login_info = login.fetch_login_info(url)
         device_endpoint = login_info['device_endpoint']
-        client_id = login_info['device_client_id']
+        client_id = login_info['device_client_id'] or client_id
 
     # Login through device code flow
     if args.method == 'code':

--- a/src/lib/utils/client.py
+++ b/src/lib/utils/client.py
@@ -155,11 +155,11 @@ class LoginManager():
     def login_config(self) -> login.LoginConfig:
         return self._login_config
 
-    def device_code_login(self, url: str, device_endpoint: str, client_id: str | None):
+    def device_code_login(self, url: str, device_endpoint: str, client_id: str):
         """ Log in using OAUTH2 device flow """
         # Generate a user code
         response = requests.post(device_endpoint, data={
-            'client_id': client_id or self._login_config.client_id,
+            'client_id': client_id,
             'scope': 'openid offline_access profile'
         }, timeout=login.TIMEOUT, headers={'User-Agent': self.user_agent})
 
@@ -191,7 +191,7 @@ class LoginManager():
             result = requests.post(token_endpoint, data={
                 'grant_type': 'urn:ietf:params:oauth:grant-type:device_code',
                 'device_code': device_code,
-                'client_id': client_id or self._login_config.client_id
+                'client_id': client_id
             }, timeout=login.TIMEOUT, headers={'User-Agent': self.user_agent})
             result = result.json()
             error = result.get('error')
@@ -210,7 +210,8 @@ class LoginManager():
             token_login=login.TokenLoginStorage(
                 id_token=result['id_token'],
                 refresh_token=result['refresh_token'],
-                refresh_url=token_endpoint
+                refresh_url=token_endpoint,
+                client_id=client_id
             )
         )
         self._save_login_info(self._login_storage, welcome=True)

--- a/src/lib/utils/login.py
+++ b/src/lib/utils/login.py
@@ -118,6 +118,7 @@ class TokenLoginStorage(pydantic.BaseModel):
     id_token: str
     refresh_url: str | None = None
     username: str | None = None
+    client_id: str | None = None
     _id_token_jwt: Jwt | None = pydantic.PrivateAttr(None)
 
     @property
@@ -263,7 +264,7 @@ def refresh_id_token(config: LoginConfig, user_agent: str | None,
         result = requests.post(token_endpoint, data={
             'grant_type': 'refresh_token',
             'refresh_token': token_login_storage.refresh_token,
-            'client_id': config.client_id,
+            'client_id': token_login_storage.client_id or config.client_id,
         }, timeout=TIMEOUT, headers=headers)
 
     if result.status_code >= 300:


### PR DESCRIPTION
## Description
The client_id used during device code login was fetched from the server (device_client_id) but not saved. On token refresh, the default client_id was used instead, causing Azure AD to reject the request with AADSTS70000 invalid_grant since the client_id must match the one used to issue the token.

Issue #None

## Testing Plan

1. Backup an old (id) token from `~/.config/osmo/login.yaml`
2. Perform a new `bazel run //src/cli:cli login` to obtain a valid refresh token and also update the client_id
3. Splice in the old id token into the new `~/.config/osmo/login.yaml`
4. `bazel run //src/cli:cli version` or another call will perform a refresh and error out if it didn't work.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
