### PR TITLE
fix: allow oauth2 proxy to redirect browser to a logout endpoint

### DIFF
--- a/deployments/charts/web-ui/README.md
+++ b/deployments/charts/web-ui/README.md
@@ -127,7 +127,7 @@ This Helm chart deploys the OSMO UI service along with its required sidecars and
 | `sidecars.oauth2Proxy.cookieExpire` | Cookie expiration duration | `168h` |
 | `sidecars.oauth2Proxy.cookieRefresh` | Cookie refresh interval | `1h` |
 | `sidecars.oauth2Proxy.scope` | OAuth2 scopes to request | `openid email profile` |
-| `sidecars.oauth2Proxy.oidcEndSessionUrl` | IdP end-session endpoint for federated logout. When set, Envoy exposes `/oauth2/idp_sign_out` which redirects to `/oauth2/sign_out?rd=<url>`, clearing both the local session cookie and the IdP's SSO session. Requires `--whitelist-domain=<idp-domain>` in `extraArgs`. | `""` (disabled) |
+| `sidecars.oauth2Proxy.oidcEndSessionUrl` | IdP end-session endpoint for federated logout. When set, Envoy exposes `/signout` which redirects to `/oauth2/sign_out?rd=<url>`, clearing both the local session cookie and the IdP's SSO session. Requires `--whitelist-domain=<idp-domain>` in `extraArgs`. | `""` (disabled) |
 | `sidecars.oauth2Proxy.extraArgs` | Additional arguments passed to oauth2-proxy | `[]` |
 | `sidecars.oauth2Proxy.useKubernetesSecrets` | Use Kubernetes secrets for credentials | `false` |
 | `sidecars.oauth2Proxy.secretName` | Kubernetes secret name (when `useKubernetesSecrets` is true) | `oauth2-proxy-secrets` |

--- a/deployments/charts/web-ui/templates/_envoy-config-helpers.tpl
+++ b/deployments/charts/web-ui/templates/_envoy-config-helpers.tpl
@@ -155,7 +155,7 @@ virtual_hosts:
   routes:
   {{- if $.Values.sidecars.oauth2Proxy.enabled }}
   - match:
-      path: /oauth2/idp_sign_out
+      path: /signout
     redirect:
       {{- if $.Values.sidecars.oauth2Proxy.oidcEndSessionUrl }}
       path_redirect: "/oauth2/sign_out?rd={{ $.Values.sidecars.oauth2Proxy.oidcEndSessionUrl | urlquery }}"

--- a/deployments/charts/web-ui/values.yaml
+++ b/deployments/charts/web-ui/values.yaml
@@ -615,7 +615,7 @@ sidecars:
       cookieSecret: /etc/oauth2-proxy/cookie-secret
 
     ## OIDC end session endpoint URL for federated logout.
-    ## When set, Envoy exposes /oauth2/idp_sign_out which redirects the browser to
+    ## When set, Envoy exposes /signout which redirects the browser to
     ## /oauth2/sign_out?rd=<oidcEndSessionUrl>, clearing both the local session cookie
     ## and the IdP's SSO session. Requires --whitelist-domain=<idp-domain> in extraArgs.
     ## Example (Azure AD): https://login.microsoftonline.com/<tenant>/oauth2/v2.0/logout

--- a/src/ui/src/lib/auth/user-context.tsx
+++ b/src/ui/src/lib/auth/user-context.tsx
@@ -50,7 +50,7 @@ interface UserProviderProps {
  */
 export function UserProvider({ children, initialUser }: UserProviderProps) {
   const logout = () => {
-    window.location.href = getBasePathUrl("/oauth2/idp_sign_out");
+    window.location.href = getBasePathUrl("/signout");
   };
 
   return (


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
In the UI, signing out did not fully log users out — after clicking "Sign out," users were immediately redirected back to the app with an active session because OAuth2 Proxy cleared its own cookie but the identity provider's browser-side SSO session remained alive, triggering silent re-authentication. The fix adds a configurable `oidcEndSessionUrl` value and an Envoy Lua filter that injects a `rd=<oidcEndSessionUrl>` redirect parameter on `/oauth2/sign_out` requests, causing the browser to visit the IdP's end-session endpoint after the local session is cleared. A companion `--whitelist-domain` entry in `extraArgs` is required to allow OAuth2 Proxy to honor the external redirect target.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
