### PR TITLE
Fix runtime controller to only add Bearer prefix for Authorization header

### DIFF
--- a/src/runtime/cmd/ctrl/ctrl.go
+++ b/src/runtime/cmd/ctrl/ctrl.go
@@ -226,7 +226,11 @@ func dialWebsocket(url string, conn **websocket.Conn, cmdArgs args.CtrlArgs, ret
 	headerKey := cmdArgs.TokenHeader
 	headers := make(http.Header)
 	jwtTokenMux.RLock()
-	headers.Add(headerKey, "Bearer "+jwtToken)
+	if strings.EqualFold(headerKey, "authorization") {
+		headers.Add(headerKey, "Bearer "+jwtToken)
+	} else {
+		headers.Add(headerKey, jwtToken)
+	}
 	jwtTokenMux.RUnlock()
 
 	newConn, resp, err = dialer.Dial(url, headers)
@@ -359,7 +363,11 @@ func createWebsocketConnection(
 	headerKey := cmdArgs.TokenHeader
 	headers := make(http.Header)
 	jwtTokenMux.RLock()
-	headers.Add(headerKey, "Bearer "+jwtToken)
+	if strings.EqualFold(headerKey, "authorization") {
+		headers.Add(headerKey, "Bearer "+jwtToken)
+	} else {
+		headers.Add(headerKey, jwtToken)
+	}
 	jwtTokenMux.RUnlock()
 	headers.Add("Cookie", cookie)
 


### PR DESCRIPTION
follow up to https://github.com/NVIDIA/OSMO/pull/593

## Description
- Makes the `Bearer ` prefix conditional on the header being `Authorization` (case-insensitive)
- Fixes backward compat bug from #593 where `-tokenHeader=x-osmo-auth` would send `Bearer <token>` in the `x-osmo-auth` header, which Envoy rejects (expects raw JWT, no prefix)
- Default behavior unchanged: new pods still send `Authorization: Bearer <jwt>`

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
