### PR TITLE
docs: fix azure blob storage creds instructions

### DIFF
--- a/docs/user_guide/getting_started/credentials.rst
+++ b/docs/user_guide/getting_started/credentials.rst
@@ -211,13 +211,14 @@ To access your data storage within workflows, you'll need to set the appropriate
             $ osmo credential set my-azure-cred \
                 --type DATA \
                 --payload \
-                endpoint=azure://<storage-account>/<container> \
+                endpoint=azure://<storage-account> \
                 region=<region> \
                 access_key_id=<access_key_id> \
                 access_key=<access_key>
 
         **Field Mappings:**
 
+            - ``endpoint`` → should **ONLY** include the storage account name
             - ``access_key`` → **Connection String** in Azure
             - ``access_key_id`` → can be **ANY** string value (e.g. ``<storage-account>`` or ``<username>``)
             - ``region`` → **OPTIONAL** (defaults to ``eastus``)


### PR DESCRIPTION
## Description
Fix Azure Blob Storage credentials instructions. Previously suggested you include the blob storage container name in the `endpoint` URI, but you can only pass in the storage account the credentials are scoped to.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
