### PR TITLE
Don't use regex for localpath detection in workflow submission

### DIFF
--- a/src/ui/src/components/submit-workflow/detect-localpath.test.ts
+++ b/src/ui/src/components/submit-workflow/detect-localpath.test.ts
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { detectLocalpathUsage } from "@/components/submit-workflow/detect-localpath";
+
+describe("detectLocalpathUsage", () => {
+  // ── Early exit ───────────────────────────────────────────────────────────
+
+  describe("early exit", () => {
+    it("returns both false for empty string", () => {
+      expect(detectLocalpathUsage("")).toEqual({
+        hasFileLocalpath: false,
+        hasDatasetLocalpath: false,
+      });
+    });
+
+    it("returns both false when localpath: is absent", () => {
+      const spec = [
+        "workflow:",
+        "  name: test",
+        "  tasks:",
+        "  - name: task1",
+        "    files:",
+        "    - path: /tmp/a.sh",
+        "      contents: hello",
+      ].join("\n");
+      expect(detectLocalpathUsage(spec)).toEqual({
+        hasFileLocalpath: false,
+        hasDatasetLocalpath: false,
+      });
+    });
+
+    it("returns both false when localpath appears without colon", () => {
+      const spec = ["  files:", "  - path: /tmp/localpath_example"].join("\n");
+      expect(detectLocalpathUsage(spec)).toEqual({
+        hasFileLocalpath: false,
+        hasDatasetLocalpath: false,
+      });
+    });
+  });
+
+  // ── hasFileLocalpath ─────────────────────────────────────────────────────
+
+  describe("hasFileLocalpath", () => {
+    describe("detects localpath: inside files block", () => {
+      it("first key in list item", () => {
+        const spec = ["  files:", "  - localpath: /home/user/data"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+      });
+
+      it("subsequent key after path: in same list item", () => {
+        const spec = ["  files:", "  - path: /tmp/a.sh", "    localpath: /home/user/a.sh"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+      });
+
+      it("multiple intermediate lines between files: and localpath:", () => {
+        const spec = [
+          "    files:",
+          "    - path: /tmp/a.sh",
+          "      contents: |",
+          "        #!/bin/bash",
+          "        echo hello",
+          "    - localpath: /home/user/b.sh",
+        ].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+      });
+
+      it("blank lines between files: and localpath:", () => {
+        const spec = ["  files:", "", "  - localpath: /path"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+      });
+
+      it("whitespace-only blank lines between files: and localpath:", () => {
+        const spec = ["  files:", "        ", "  - localpath: /path"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+      });
+
+      it("deeply indented files block (6+ spaces)", () => {
+        const spec = ["      files:", "      - localpath: /path"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+      });
+
+      it("tab indentation", () => {
+        const spec = ["\tfiles:", "\t- localpath: /path"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+      });
+
+      it("mixed tab and space indentation", () => {
+        const spec = ["\t files:", "\t - localpath: /path"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+      });
+    });
+
+    describe("ignores localpath: outside files block", () => {
+      it("files: at column 0 (not indented)", () => {
+        const spec = ["files:", "  - localpath: /path"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(false);
+      });
+
+      it("localpath: in a value string", () => {
+        const spec = ["  files:", "  - path: /tmp/localpath:test"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(false);
+      });
+
+      it("localpath: after a non-list key exits the files block", () => {
+        const spec = [
+          "    files:",
+          "    - path: /tmp/a.sh",
+          "    command: [bash]",
+          "    localpath: /should/not/match",
+        ].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(false);
+      });
+
+      it("files: with inline value", () => {
+        const spec = ["  files: []", "  localpath: /path"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(false);
+      });
+
+      it("localpath: before files: in spec", () => {
+        const spec = ["  localpath: /path", "  files:", "  - path: /tmp/a.sh"].join("\n");
+        expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(false);
+      });
+    });
+  });
+
+  // ── hasDatasetLocalpath ──────────────────────────────────────────────────
+
+  describe("hasDatasetLocalpath", () => {
+    describe("detects localpath: inside dataset block", () => {
+      it("directly under dataset:", () => {
+        const spec = ["  - dataset:", "      localpath: /data"].join("\n");
+        expect(detectLocalpathUsage(spec).hasDatasetLocalpath).toBe(true);
+      });
+
+      it("after sibling key name: under dataset:", () => {
+        const spec = ["  - dataset:", "      name: my-ds", "      localpath: /data"].join("\n");
+        expect(detectLocalpathUsage(spec).hasDatasetLocalpath).toBe(true);
+      });
+
+      it("dataset: without list dash", () => {
+        const spec = ["  dataset:", "    localpath: /data"].join("\n");
+        expect(detectLocalpathUsage(spec).hasDatasetLocalpath).toBe(true);
+      });
+
+      it("dataset: at column 0", () => {
+        const spec = ["dataset:", "  localpath: /data"].join("\n");
+        expect(detectLocalpathUsage(spec).hasDatasetLocalpath).toBe(true);
+      });
+    });
+
+    describe("ignores localpath: outside dataset block", () => {
+      it("dataset: with no localpath: child", () => {
+        const spec = ["  - dataset:", "      name: my-ds"].join("\n");
+        expect(detectLocalpathUsage(spec)).toEqual({
+          hasFileLocalpath: false,
+          hasDatasetLocalpath: false,
+        });
+      });
+
+      it("localpath: in unrelated block", () => {
+        const spec = ["  - dataset:", "      name: my-ds", "  other:", "    localpath: /should/not/match"].join("\n");
+        expect(detectLocalpathUsage(spec).hasDatasetLocalpath).toBe(false);
+      });
+    });
+  });
+
+  // ── Context tracking ─────────────────────────────────────────────────────
+
+  describe("context tracking", () => {
+    it("non-list key at same indent as files: exits context", () => {
+      const spec = [
+        "    files:",
+        "    - path: /tmp/a.sh",
+        "    command: [bash]",
+        "    localpath: /should/not/match",
+      ].join("\n");
+      expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(false);
+    });
+
+    it("line at lesser indent exits context", () => {
+      const spec = ["    files:", "    - path: /tmp/a.sh", "  image: ubuntu", "    localpath: /should/not/match"].join(
+        "\n",
+      );
+      expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(false);
+    });
+
+    it("list item at same indent stays in context", () => {
+      const spec = ["    files:", "    - path: /tmp/a.sh", "    - localpath: /should/match"].join("\n");
+      expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+    });
+
+    it("new files: block replaces previous context", () => {
+      const spec = [
+        "    files:",
+        "    - path: /tmp/a.sh",
+        "    command: [bash]",
+        "    files:",
+        "    - localpath: /path",
+      ].join("\n");
+      expect(detectLocalpathUsage(spec).hasFileLocalpath).toBe(true);
+    });
+
+    it("detects both warnings in same spec", () => {
+      const spec = ["  files:", "  - localpath: /file", "  inputs:", "  - dataset:", "      localpath: /data"].join(
+        "\n",
+      );
+      expect(detectLocalpathUsage(spec)).toEqual({
+        hasFileLocalpath: true,
+        hasDatasetLocalpath: true,
+      });
+    });
+
+    it("dataset context replaces files context", () => {
+      const spec = ["  files:", "  - path: /tmp/a.sh", "  - dataset:", "      localpath: /data"].join("\n");
+      const result = detectLocalpathUsage(spec);
+      expect(result.hasFileLocalpath).toBe(false);
+      expect(result.hasDatasetLocalpath).toBe(true);
+    });
+  });
+
+  // ── Performance ──────────────────────────────────────────────────────────
+
+  describe("performance", () => {
+    it("10,000-line spec without localpath: completes in under 50ms", () => {
+      const lines = ["workflow:", "  name: test", "  tasks:"];
+      for (let i = 0; i < 10_000; i++) {
+        lines.push(`  - name: task-${i}`);
+        lines.push("    image: ubuntu");
+        lines.push("    files:");
+        lines.push("    - path: /tmp/test.sh");
+        lines.push("      contents: |");
+        lines.push("        #!/bin/bash");
+        lines.push("        echo hello");
+        lines.push("        ");
+      }
+      const spec = lines.join("\n");
+
+      const start = performance.now();
+      const result = detectLocalpathUsage(spec);
+      const elapsed = performance.now() - start;
+
+      expect(result).toEqual({ hasFileLocalpath: false, hasDatasetLocalpath: false });
+      expect(elapsed).toBeLessThan(50);
+    });
+  });
+});

--- a/src/ui/src/components/submit-workflow/detect-localpath.ts
+++ b/src/ui/src/components/submit-workflow/detect-localpath.ts
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export interface LocalpathWarnings {
+  hasFileLocalpath: boolean;
+  hasDatasetLocalpath: boolean;
+}
+
+interface ParsedKey {
+  name: string;
+  isBlock: boolean;
+}
+
+/** Count leading whitespace characters (spaces and tabs). Returns `line.length` for blank lines. */
+function leadingWhitespace(line: string): number {
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] !== " " && line[i] !== "\t") return i;
+  }
+  return line.length;
+}
+
+function isOnlyWhitespaceAfter(line: string, from: number): boolean {
+  for (let i = from; i < line.length; i++) {
+    if (line[i] !== " " && line[i] !== "\t") return false;
+  }
+  return true;
+}
+
+/**
+ * Lines deeper than the block are inside. Lines at the same level are inside
+ * only if they are list continuations (start with "-").
+ */
+function isInsideBlock(lineIndent: number, blockIndent: number, line: string): boolean {
+  if (lineIndent > blockIndent) return true;
+  return lineIndent === blockIndent && line[lineIndent] === "-";
+}
+
+/** Strips an optional leading list marker ("- ") before extracting the key. */
+function parseYamlKey(line: string, indent: number): ParsedKey | null {
+  let keyStart = indent;
+
+  if (line[keyStart] === "-" && keyStart + 1 < line.length && line[keyStart + 1] === " ") {
+    for (keyStart += 2; keyStart < line.length && line[keyStart] === " "; keyStart++) {}
+  }
+
+  const colonPos = line.indexOf(":", keyStart);
+  if (colonPos === -1) return null;
+
+  return {
+    name: line.substring(keyStart, colonPos),
+    isBlock: isOnlyWhitespaceAfter(line, colonPos + 1),
+  };
+}
+
+/**
+ * Detect `localpath:` usage in a YAML workflow spec.
+ *
+ * - `hasFileLocalpath`: `localpath:` inside a `files:` block (browser cannot read local files).
+ * - `hasDatasetLocalpath`: `localpath:` inside a `dataset:` block (browser cannot rsync).
+ */
+export function detectLocalpathUsage(spec: string): LocalpathWarnings {
+  if (!spec.includes("localpath:")) {
+    return { hasFileLocalpath: false, hasDatasetLocalpath: false };
+  }
+
+  let hasFileLocalpath = false;
+  let hasDatasetLocalpath = false;
+  let context: "files" | "dataset" | null = null;
+  let contextIndent = 0;
+
+  for (const line of spec.split("\n")) {
+    const indent = leadingWhitespace(line);
+    if (indent === line.length) continue;
+
+    if (context !== null && !isInsideBlock(indent, contextIndent, line)) {
+      context = null;
+    }
+
+    if (line.indexOf(":", indent) === -1) continue; // fast path: no key on this line
+    const parsed = parseYamlKey(line, indent);
+    if (parsed === null) continue;
+
+    // files: must be nested (indent > 0) to exclude top-level `files:` keys that are
+    // not task file lists. dataset: is valid at any indent level, including root.
+    if (parsed.name === "files" && indent > 0 && parsed.isBlock) {
+      context = "files";
+      contextIndent = indent;
+    } else if (parsed.name === "dataset" && parsed.isBlock) {
+      context = "dataset";
+      contextIndent = indent;
+    } else if (parsed.name === "localpath" && context !== null) {
+      if (context === "files") hasFileLocalpath = true;
+      else hasDatasetLocalpath = true;
+      if (hasFileLocalpath && hasDatasetLocalpath) break;
+    }
+  }
+
+  return { hasFileLocalpath, hasDatasetLocalpath };
+}

--- a/src/ui/src/components/submit-workflow/submit-workflow-config-panel.tsx
+++ b/src/ui/src/components/submit-workflow/submit-workflow-config-panel.tsx
@@ -31,7 +31,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/too
 import { CollapsibleSection } from "@/components/workflow/collapsible-section";
 import { PoolPicker } from "@/components/workflow/pool-picker";
 import { PriorityPicker, PRIORITY_LABELS } from "@/components/workflow/priority-picker";
-import type { LocalpathWarnings } from "@/components/submit-workflow/use-submit-workflow-form";
+import type { LocalpathWarnings } from "@/components/submit-workflow/detect-localpath";
 
 /** Inline code token styled to stand out against the red error banner background. */
 function Token({ children }: { children: ReactNode }) {

--- a/src/ui/src/components/submit-workflow/use-submit-workflow-form.ts
+++ b/src/ui/src/components/submit-workflow/use-submit-workflow-form.ts
@@ -31,29 +31,7 @@ import { WorkflowPriority, useSubmitWorkflowApiPoolPoolNameWorkflowPost } from "
 import { useSubmitWorkflowStore } from "@/stores/submit-workflow-store";
 import { useProfile } from "@/lib/api/adapter/hooks";
 import { usePoolSelection } from "@/components/workflow/use-pool-selection";
-
-/**
- * Detect `localpath:` usage in the YAML spec.
- *
- * - hasFileLocalpath: `files[].localpath` — browser cannot read local files.
- * - hasDatasetLocalpath: `dataset.localpath` — browser cannot rsync.
- */
-function detectLocalpathUsage(spec: string): {
-  hasFileLocalpath: boolean;
-  hasDatasetLocalpath: boolean;
-} {
-  // files[].localpath — per docs, localpath: appears as a key inside a files: list item.
-  // Handles both the first-key form (  - localpath:) and subsequent-key form (    localpath:).
-  // The (?:[ \t]+[^\n]*\n)*? intermediary only matches indented lines, so it cannot
-  // skip past a new top-level key and produce a false positive.
-  const hasFileLocalpath = /^\s+files:\s*\n(?:[ \t]+[^\n]*\n)*?[ \t]+(?:-[ \t]+)?localpath:/m.test(spec);
-
-  // inputs[].dataset.localpath — per docs, localpath: appears as a child key of dataset:,
-  // optionally preceded by sibling keys such as name:.
-  const hasDatasetLocalpath = /(?:^|[ \t])-?[ \t]*dataset:\s*\n(?:[ \t]+[^\n]+\n)*?[ \t]+localpath:/m.test(spec);
-
-  return { hasFileLocalpath, hasDatasetLocalpath };
-}
+import { detectLocalpathUsage, type LocalpathWarnings } from "@/components/submit-workflow/detect-localpath";
 
 /** Extract a human-readable error message from various error shapes. */
 function extractErrorMessage(err: unknown): string {
@@ -75,11 +53,6 @@ function extractErrorMessage(err: unknown): string {
     }
   }
   return String(err);
-}
-
-export interface LocalpathWarnings {
-  hasFileLocalpath: boolean;
-  hasDatasetLocalpath: boolean;
 }
 
 /** Validation result tied to the spec that was validated for freshness detection. */


### PR DESCRIPTION
## Description
- Regex during workflow submission to validate against `localpath:` were causing catastrophic backtracking
- Even with fixes to the regex, it remains inefficient (multiple passes) and unmaintainable
- Use a procedural approach to detect `localpath:` for single-pass with no backtracking

<img width="1154" height="228" alt="Screenshot 2026-03-04 at 6 50 49 AM" src="https://github.com/user-attachments/assets/8791254e-7d9a-4b91-9af5-da23239d2513" />

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
