### PR TITLE
Fix various API issues after orval migration

### DIFF
--- a/src/scripts/export_openapi.py
+++ b/src/scripts/export_openapi.py
@@ -55,6 +55,17 @@ def main():
     # Generate OpenAPI spec
     openapi_spec = app.openapi()
 
+    # Explicitly set explode=True for all array query parameters.
+    # OpenAPI 3 implies explode=True by default for query params, but orval's
+    # fetch client generator only honors it when explicitly present in the spec.
+    for path_item in openapi_spec.get('paths', {}).values():
+        for operation in path_item.values():
+            if not isinstance(operation, dict):
+                continue
+            for param in operation.get('parameters', []):
+                if param.get('in') == 'query' and param.get('schema', {}).get('type') == 'array':
+                    param.setdefault('explode', True)
+
     # Format JSON
     indent = 2 if args.pretty else None
     json_output = json.dumps(openapi_spec, indent=indent)

--- a/src/ui/e2e/mocks/generated-mocks.ts
+++ b/src/ui/e2e/mocks/generated-mocks.ts
@@ -1709,6 +1709,13 @@ export interface TemplateSpec {
 }
 
 /**
+ * Request body containing a token for JWT generation.
+ */
+export interface TokenRequest {
+  token: string;
+}
+
+/**
  * Request body for updating config tags endpoint.
  */
 export interface UpdateConfigTagsRequest {
@@ -2006,6 +2013,13 @@ second_revision: number;
 
 export type GetNewJwtTokenApiAuthJwtRefreshTokenGetParams = {
 refresh_token: string;
+workflow_id: string;
+group_name: string;
+task_name: string;
+retry_id?: number;
+};
+
+export type PostNewJwtTokenApiAuthJwtRefreshTokenPostParams = {
 workflow_id: string;
 group_name: string;
 task_name: string;
@@ -4897,7 +4911,15 @@ export const getGetConfigsHistoryApiConfigsHistoryGetUrl = (params?: GetConfigsH
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["config_types","tags"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -5171,6 +5193,8 @@ export const getConfigDiffApiConfigsDiffGet = async (params: GetConfigDiffApiCon
 
 /**
  * API to fetch for a new access token using a refresh token.
+
+Deprecated: Use POST /api/auth/jwt/refresh_token instead.
  * @summary Get New Jwt Token
  */
 export type getNewJwtTokenApiAuthJwtRefreshTokenGetResponse200 = {
@@ -5227,7 +5251,68 @@ export const getNewJwtTokenApiAuthJwtRefreshTokenGet = async (params: GetNewJwtT
 
 
 /**
+ * API to fetch for a new access token using a refresh token.
+ * @summary Post New Jwt Token
+ */
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponse200 = {
+  data: unknown
+  status: 200
+}
+
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponse422 = {
+  data: HTTPValidationError
+  status: 422
+}
+
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponseSuccess = (postNewJwtTokenApiAuthJwtRefreshTokenPostResponse200) & {
+  headers: Headers;
+};
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponseError = (postNewJwtTokenApiAuthJwtRefreshTokenPostResponse422) & {
+  headers: Headers;
+};
+
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponse = (postNewJwtTokenApiAuthJwtRefreshTokenPostResponseSuccess | postNewJwtTokenApiAuthJwtRefreshTokenPostResponseError)
+
+export const getPostNewJwtTokenApiAuthJwtRefreshTokenPostUrl = (params: PostNewJwtTokenApiAuthJwtRefreshTokenPostParams,) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString())
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0 ? `/api/auth/jwt/refresh_token?${stringifiedParams}` : `/api/auth/jwt/refresh_token`
+}
+
+export const postNewJwtTokenApiAuthJwtRefreshTokenPost = async (tokenRequest: TokenRequest,
+    params: PostNewJwtTokenApiAuthJwtRefreshTokenPostParams, options?: RequestInit): Promise<postNewJwtTokenApiAuthJwtRefreshTokenPostResponse> => {
+  
+  const res = await fetch(getPostNewJwtTokenApiAuthJwtRefreshTokenPostUrl(params),
+  {      
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      tokenRequest,)
+  }
+)
+
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  
+  const data: postNewJwtTokenApiAuthJwtRefreshTokenPostResponse['data'] = body ? JSON.parse(body) : {}
+  return { data, status: res.status, headers: res.headers } as postNewJwtTokenApiAuthJwtRefreshTokenPostResponse
+}
+  
+
+
+/**
  * API to create a new jwt token from an access token.
+
+Deprecated: Use POST /api/auth/jwt/access_token instead.
  * @summary Get Jwt Token From Access Token
  */
 export type getJwtTokenFromAccessTokenApiAuthJwtAccessTokenGetResponse200 = {
@@ -5284,6 +5369,57 @@ export const getJwtTokenFromAccessTokenApiAuthJwtAccessTokenGet = async (params:
 
 
 /**
+ * API to create a new jwt token from an access token.
+ * @summary Post Jwt Token From Access Token
+ */
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse200 = {
+  data: unknown
+  status: 200
+}
+
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse422 = {
+  data: HTTPValidationError
+  status: 422
+}
+
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponseSuccess = (postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse200) & {
+  headers: Headers;
+};
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponseError = (postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse422) & {
+  headers: Headers;
+};
+
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse = (postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponseSuccess | postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponseError)
+
+export const getPostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostUrl = () => {
+
+
+  
+
+  return `/api/auth/jwt/access_token`
+}
+
+export const postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost = async (tokenRequest: TokenRequest, options?: RequestInit): Promise<postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse> => {
+  
+  const res = await fetch(getPostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostUrl(),
+  {      
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      tokenRequest,)
+  }
+)
+
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+  
+  const data: postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse['data'] = body ? JSON.parse(body) : {}
+  return { data, status: res.status, headers: res.headers } as postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse
+}
+  
+
+
+/**
  * API to create a new access token.
 
 If roles are specified, all specified roles must be assigned to the user.
@@ -5316,7 +5452,15 @@ export const getCreateAccessTokenApiAuthAccessTokenTokenNamePostUrl = (tokenName
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["roles"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -5552,7 +5696,15 @@ export const getAdminCreateAccessTokenApiAuthUserUserIdAccessTokenTokenNamePostU
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["roles"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -5733,7 +5885,15 @@ export const getListUsersApiAuthUserGetUrl = (params?: ListUsersApiAuthUserGetPa
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["roles"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -6247,7 +6407,15 @@ export const getListAppsApiAppGetUrl = (params?: ListAppsApiAppGetParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["users"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -6698,7 +6866,15 @@ export const getListWorkflowApiWorkflowGetUrl = (params?: ListWorkflowApiWorkflo
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["users","statuses","pools","tags","priority"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -6806,7 +6982,15 @@ export const getListTaskApiTaskGetUrl = (params?: ListTaskApiTaskGetParams,) => 
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["statuses","users","pools","nodes","priority"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -7159,7 +7343,15 @@ export const getTagWorkflowApiWorkflowNameTagPostUrl = (name: string,
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["add","remove"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -7341,7 +7533,15 @@ export const getPortForwardTaskApiWorkflowNamePortforwardTaskNamePostUrl = (name
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["task_ports"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -7665,7 +7865,15 @@ export const getGetResourcesApiResourcesGetUrl = (params?: GetResourcesApiResour
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["pools","platforms"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -7776,7 +7984,15 @@ export const getGetPoolsApiPoolGetUrl = (params?: GetPoolsApiPoolGetParams,) => 
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["pools"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -7832,7 +8048,15 @@ export const getGetPoolQuotasApiPoolQuotaGetUrl = (params?: GetPoolQuotasApiPool
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["pools"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -7890,7 +8114,15 @@ export const getSubmitWorkflowApiPoolPoolNameWorkflowPostUrl = (poolName: string
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["env_vars"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -8123,7 +8355,15 @@ export const getChangeNameTagLabelMetadataApiBucketBucketDatasetNameAttributePos
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["set_tag","delete_tag","delete_label","delete_metadata"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -8245,7 +8485,15 @@ export const getListDatasetFromBucketApiBucketListDatasetGetUrl = (params?: List
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["user","buckets"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -9544,8 +9792,28 @@ export const getGetNewJwtTokenApiAuthJwtRefreshTokenGetMockHandler = (overrideRe
   }, options)
 }
 
+export const getPostNewJwtTokenApiAuthJwtRefreshTokenPostMockHandler = (overrideResponse?: unknown | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<unknown> | unknown), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/jwt/refresh_token', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+  
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
 export const getGetJwtTokenFromAccessTokenApiAuthJwtAccessTokenGetMockHandler = (overrideResponse?: unknown | ((info: Parameters<Parameters<typeof http.get>[1]>[0]) => Promise<unknown> | unknown), options?: RequestHandlerOptions) => {
   return http.get('*/api/auth/jwt/access_token', async (info: Parameters<Parameters<typeof http.get>[1]>[0]) => {await delay(0);
+  if (typeof overrideResponse === 'function') {await overrideResponse(info); }
+  
+    return new HttpResponse(null,
+      { status: 200
+      })
+  }, options)
+}
+
+export const getPostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostMockHandler = (overrideResponse?: unknown | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Promise<unknown> | unknown), options?: RequestHandlerOptions) => {
+  return http.post('*/api/auth/jwt/access_token', async (info: Parameters<Parameters<typeof http.post>[1]>[0]) => {await delay(0);
   if (typeof overrideResponse === 'function') {await overrideResponse(info); }
   
     return new HttpResponse(null,
@@ -10328,7 +10596,9 @@ export const getFastAPIMock = () => [
   getUpdateConfigHistoryTagsApiConfigsHistoryConfigTypeRevisionRevisionTagsPostMockHandler(),
   getGetConfigDiffApiConfigsDiffGetMockHandler(),
   getGetNewJwtTokenApiAuthJwtRefreshTokenGetMockHandler(),
+  getPostNewJwtTokenApiAuthJwtRefreshTokenPostMockHandler(),
   getGetJwtTokenFromAccessTokenApiAuthJwtAccessTokenGetMockHandler(),
+  getPostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostMockHandler(),
   getCreateAccessTokenApiAuthAccessTokenTokenNamePostMockHandler(),
   getDeleteAccessTokenApiAuthAccessTokenTokenNameDeleteMockHandler(),
   getListAccessTokenRolesApiAuthAccessTokenTokenNameRolesGetMockHandler(),

--- a/src/ui/openapi.json
+++ b/src/ui/openapi.json
@@ -2595,7 +2595,8 @@
               "description": "Filter by config types"
             },
             "name": "config_types",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "description": "Filter by config name",
@@ -2632,7 +2633,8 @@
               "description": "Filter by tags"
             },
             "name": "tags",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "description": "Filter by creation time before",
@@ -2951,7 +2953,7 @@
           "Auth API"
         ],
         "summary": "Get New Jwt Token",
-        "description": "API to fetch for a new access token using a refresh token.",
+        "description": "API to fetch for a new access token using a refresh token.\n\nDeprecated: Use POST /api/auth/jwt/refresh_token instead.",
         "operationId": "get_new_jwt_token_api_auth_jwt_refresh_token_get",
         "parameters": [
           {
@@ -3021,6 +3023,83 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "Auth API"
+        ],
+        "summary": "Post New Jwt Token",
+        "description": "API to fetch for a new access token using a refresh token.",
+        "operationId": "post_new_jwt_token_api_auth_jwt_refresh_token_post",
+        "parameters": [
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            },
+            "name": "workflow_id",
+            "in": "query"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Group Name"
+            },
+            "name": "group_name",
+            "in": "query"
+          },
+          {
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Task Name"
+            },
+            "name": "task_name",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Retry Id",
+              "default": 0
+            },
+            "name": "retry_id",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/auth/jwt/access_token": {
@@ -3029,7 +3108,7 @@
           "Auth API"
         ],
         "summary": "Get Jwt Token From Access Token",
-        "description": "API to create a new jwt token from an access token.",
+        "description": "API to create a new jwt token from an access token.\n\nDeprecated: Use POST /api/auth/jwt/access_token instead.",
         "operationId": "get_jwt_token_from_access_token_api_auth_jwt_access_token_get",
         "parameters": [
           {
@@ -3042,6 +3121,44 @@
             "in": "query"
           }
         ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Auth API"
+        ],
+        "summary": "Post Jwt Token From Access Token",
+        "description": "API to create a new jwt token from an access token.",
+        "operationId": "post_jwt_token_from_access_token_api_auth_jwt_access_token_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -3111,7 +3228,8 @@
               "title": "Roles"
             },
             "name": "roles",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -3348,7 +3466,8 @@
               "title": "Roles"
             },
             "name": "roles",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -3525,7 +3644,8 @@
               "title": "Roles"
             },
             "name": "roles",
-            "in": "query"
+            "in": "query",
+            "explode": true
           }
         ],
         "responses": {
@@ -3968,7 +4088,8 @@
               "title": "Users"
             },
             "name": "users",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4526,7 +4647,8 @@
               "title": "Users"
             },
             "name": "users",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4546,7 +4668,8 @@
               "type": "array"
             },
             "name": "statuses",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4601,7 +4724,8 @@
               "title": "Pools"
             },
             "name": "pools",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4643,7 +4767,8 @@
               "title": "Tags"
             },
             "name": "tags",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4663,7 +4788,8 @@
               "type": "array"
             },
             "name": "priority",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4777,7 +4903,8 @@
               "type": "array"
             },
             "name": "statuses",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4789,7 +4916,8 @@
               "title": "Users"
             },
             "name": "users",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4811,7 +4939,8 @@
               "title": "Pools"
             },
             "name": "pools",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4833,7 +4962,8 @@
               "title": "Nodes"
             },
             "name": "nodes",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -4917,7 +5047,8 @@
               "type": "array"
             },
             "name": "priority",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -5316,7 +5447,8 @@
               "title": "Add"
             },
             "name": "add",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -5328,7 +5460,8 @@
               "title": "Remove"
             },
             "name": "remove",
-            "in": "query"
+            "in": "query",
+            "explode": true
           }
         ],
         "responses": {
@@ -5516,7 +5649,8 @@
               "title": "Task Ports"
             },
             "name": "task_ports",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -5849,7 +5983,8 @@
               "title": "Pools"
             },
             "name": "pools",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -5861,7 +5996,8 @@
               "title": "Platforms"
             },
             "name": "platforms",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -5989,7 +6125,8 @@
               "title": "Pools"
             },
             "name": "pools",
-            "in": "query"
+            "in": "query",
+            "explode": true
           }
         ],
         "responses": {
@@ -6044,7 +6181,8 @@
               "title": "Pools"
             },
             "name": "pools",
-            "in": "query"
+            "in": "query",
+            "explode": true
           }
         ],
         "responses": {
@@ -6160,7 +6298,8 @@
               "default": []
             },
             "name": "env_vars",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -6472,7 +6611,8 @@
               "default": []
             },
             "name": "set_tag",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -6485,7 +6625,8 @@
               "default": []
             },
             "name": "delete_tag",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -6498,7 +6639,8 @@
               "default": []
             },
             "name": "delete_label",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -6511,7 +6653,8 @@
               "default": []
             },
             "name": "delete_metadata",
-            "in": "query"
+            "in": "query",
+            "explode": true
           }
         ],
         "requestBody": {
@@ -6669,7 +6812,8 @@
               "title": "User"
             },
             "name": "user",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -6682,7 +6826,8 @@
               "default": []
             },
             "name": "buckets",
-            "in": "query"
+            "in": "query",
+            "explode": true
           },
           {
             "required": false,
@@ -11258,6 +11403,20 @@
         ],
         "title": "TokenIdentity",
         "description": "Identity when the request is authenticated with an access token. "
+      },
+      "TokenRequest": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          }
+        },
+        "type": "object",
+        "required": [
+          "token"
+        ],
+        "title": "TokenRequest",
+        "description": "Request body containing a token for JWT generation."
       },
       "Toleration": {
         "properties": {

--- a/src/ui/src/components/submit-workflow/submit-workflow-content.tsx
+++ b/src/ui/src/components/submit-workflow/submit-workflow-content.tsx
@@ -73,133 +73,143 @@ function useColumnResizer(initialPct = 55) {
   return { editorWidthPct, isDragging, splitRef, startDrag };
 }
 
-export const SubmitWorkflowContent = memo(function SubmitWorkflowContent() {
-  const form = useSubmitWorkflowForm();
-  const { editorWidthPct, isDragging, splitRef, startDrag } = useColumnResizer();
-  const isOpen = useSubmitWorkflowStore((s) => s.isOpen);
+function SubmitTopBar({ onClose, disabled = false }: { onClose: () => void; disabled?: boolean }) {
+  return (
+    <div className="flex h-[50px] shrink-0 items-center gap-3.5 border-b border-zinc-200 bg-zinc-50 pr-2 pl-5 dark:border-zinc-700/60 dark:bg-zinc-950">
+      <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Submit Workflow</span>
+      <div className="flex-1" />
+      <button
+        type="button"
+        onClick={onClose}
+        disabled={disabled}
+        aria-label="Close submit workflow"
+        className="flex size-8 items-center justify-center text-zinc-400 transition-colors hover:text-zinc-700 disabled:opacity-50 dark:text-zinc-500 dark:hover:text-zinc-200"
+      >
+        <X
+          className="size-4"
+          aria-hidden="true"
+        />
+      </button>
+    </div>
+  );
+}
 
-  // Show source picker until the user picks a source, then keep it dismissed
-  // for the rest of the session (even if spec is cleared on close). Resets when
-  // the overlay reopens so the next session starts fresh at the source picker.
-  const [showSourcePicker, setShowSourcePicker] = useState(true);
+export const SubmitWorkflowContent = memo(function SubmitWorkflowContent() {
+  const isOpen = useSubmitWorkflowStore((s) => s.isOpen);
+  const close = useSubmitWorkflowStore((s) => s.close);
+
+  // null = source picker phase (no form hooks, no API calls)
+  // string = form phase (form hooks mount, pool validation fires)
+  const [selectedSpec, setSelectedSpec] = useState<string | null>(null);
+
+  // Reset to source picker when overlay reopens
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
   if (prevIsOpen !== isOpen) {
     setPrevIsOpen(isOpen);
-    if (isOpen) setShowSourcePicker(true);
+    if (isOpen) setSelectedSpec(null);
   }
-
-  const handleSourceSelect = useCallback(
-    (spec: string) => {
-      form.setSpec(spec);
-      setShowSourcePicker(false);
-    },
-    [form],
-  );
 
   return (
     <div className="flex h-full flex-col bg-white dark:bg-zinc-900">
-      {/* ── Top bar ─────────────────────────────────────────────── */}
-      <div className="flex h-[50px] shrink-0 items-center gap-3.5 border-b border-zinc-200 bg-zinc-50 pr-2 pl-5 dark:border-zinc-700/60 dark:bg-zinc-950">
-        <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">Submit Workflow</span>
-
-        <div className="flex-1" />
-
-        {/* Close button */}
-        <button
-          type="button"
-          onClick={form.handleClose}
-          disabled={form.isPending}
-          aria-label="Close submit workflow"
-          className="flex size-8 items-center justify-center text-zinc-400 transition-colors hover:text-zinc-700 disabled:opacity-50 dark:text-zinc-500 dark:hover:text-zinc-200"
-        >
-          <X
-            className="size-4"
-            aria-hidden="true"
-          />
-        </button>
-      </div>
-
-      {/* ── Body ────────────────────────────────────────────────── */}
-      {showSourcePicker ? (
-        /* Source picker spans the full width before a spec is chosen */
-        <SourcePicker onSelect={handleSourceSelect} />
+      {selectedSpec !== null ? (
+        <SubmitWorkflowFormView
+          key={selectedSpec}
+          initialSpec={selectedSpec}
+        />
       ) : (
-        /* Split view: editor + resizer + config */
-        <div
-          ref={splitRef}
-          className="flex min-h-0 flex-1"
-        >
-          {/* Left: YAML editor */}
-          <div
-            className="flex flex-col"
-            style={{ flexBasis: `${editorWidthPct}%`, flexShrink: 1, minWidth: EDITOR_MIN_WIDTH_PX }}
-          >
-            <SubmitWorkflowEditorPanel
-              value={form.spec}
-              onChange={form.setSpec}
-              previewSpec={form.dryRunSpec}
-              onClearPreview={form.clearDryRun}
-            />
-          </div>
-
-          {/* Resizer */}
-          <div
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Drag to resize panels"
-            className="group relative z-10 w-4 shrink-0 cursor-col-resize"
-            onMouseDown={startDrag}
-          >
-            {/* Vertical line */}
-            <div
-              className={cn(
-                "absolute inset-y-0 left-0 w-0.5 transition-colors",
-                isDragging
-                  ? "bg-blue-500"
-                  : "bg-zinc-200 group-hover:bg-zinc-300 dark:bg-zinc-700 dark:group-hover:bg-zinc-600",
-              )}
-            />
-            {/* Grip handle */}
-            <div
-              className={cn(
-                "absolute top-1/2 left-px z-10 -translate-x-1/2 -translate-y-1/2",
-                "rounded-sm bg-zinc-100 px-px py-1 shadow-md transition-opacity duration-150",
-                "dark:bg-zinc-800",
-                isDragging ? "opacity-100" : "opacity-0 group-hover:opacity-100",
-              )}
-              aria-hidden="true"
-            >
-              <GripVertical
-                className="size-3 text-zinc-400 dark:text-zinc-500"
-                strokeWidth={1.5}
-              />
-            </div>
-          </div>
-
-          {/* Right: Config panel */}
-          <SubmitWorkflowConfigPanel
-            pool={form.pool}
-            onPoolChange={form.setPool}
-            priority={form.priority}
-            onPriorityChange={form.setPriority}
-            localpathWarnings={form.localpathWarnings}
-            error={form.error}
-            isPending={form.isPending}
-            canSubmit={form.canSubmit}
-            onClose={form.handleClose}
-            onSubmit={form.handleSubmit}
-            isDryRunPending={form.isDryRunPending}
-            dryRunError={form.dryRunError}
-            canDryRun={form.canDryRun}
-            onDryRun={form.handleDryRun}
-            isValidatePending={form.isValidatePending}
-            validationOk={form.validationOk}
-            validationError={form.validationError}
-            canValidate={form.canValidate}
-            onValidate={form.handleValidate}
-          />
-        </div>
+        <>
+          <SubmitTopBar onClose={close} />
+          <SourcePicker onSelect={setSelectedSpec} />
+        </>
       )}
     </div>
+  );
+});
+
+const SubmitWorkflowFormView = memo(function SubmitWorkflowFormView({ initialSpec }: { initialSpec: string }) {
+  const form = useSubmitWorkflowForm(initialSpec);
+  const { editorWidthPct, isDragging, splitRef, startDrag } = useColumnResizer();
+
+  return (
+    <>
+      <SubmitTopBar
+        onClose={form.handleClose}
+        disabled={form.isPending}
+      />
+
+      {/* Split view: editor + resizer + config */}
+      <div
+        ref={splitRef}
+        className="flex min-h-0 flex-1"
+      >
+        {/* Left: YAML editor */}
+        <div
+          className="flex flex-col"
+          style={{ flexBasis: `${editorWidthPct}%`, flexShrink: 1, minWidth: EDITOR_MIN_WIDTH_PX }}
+        >
+          <SubmitWorkflowEditorPanel
+            value={form.spec}
+            onChange={form.setSpec}
+            previewSpec={form.dryRunSpec}
+            onClearPreview={form.clearDryRun}
+          />
+        </div>
+
+        {/* Resizer */}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Drag to resize panels"
+          className="group relative z-10 w-4 shrink-0 cursor-col-resize"
+          onMouseDown={startDrag}
+        >
+          <div
+            className={cn(
+              "absolute inset-y-0 left-0 w-0.5 transition-colors",
+              isDragging
+                ? "bg-blue-500"
+                : "bg-zinc-200 group-hover:bg-zinc-300 dark:bg-zinc-700 dark:group-hover:bg-zinc-600",
+            )}
+          />
+          <div
+            className={cn(
+              "absolute top-1/2 left-px z-10 -translate-x-1/2 -translate-y-1/2",
+              "rounded-sm bg-zinc-100 px-px py-1 shadow-md transition-opacity duration-150",
+              "dark:bg-zinc-800",
+              isDragging ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+            )}
+            aria-hidden="true"
+          >
+            <GripVertical
+              className="size-3 text-zinc-400 dark:text-zinc-500"
+              strokeWidth={1.5}
+            />
+          </div>
+        </div>
+
+        {/* Right: Config panel */}
+        <SubmitWorkflowConfigPanel
+          pool={form.pool}
+          onPoolChange={form.setPool}
+          priority={form.priority}
+          onPriorityChange={form.setPriority}
+          localpathWarnings={form.localpathWarnings}
+          error={form.error}
+          isPending={form.isPending}
+          canSubmit={form.canSubmit}
+          onClose={form.handleClose}
+          onSubmit={form.handleSubmit}
+          isDryRunPending={form.isDryRunPending}
+          dryRunError={form.dryRunError}
+          canDryRun={form.canDryRun}
+          onDryRun={form.handleDryRun}
+          isValidatePending={form.isValidatePending}
+          validationOk={form.validationOk}
+          validationError={form.validationError}
+          canValidate={form.canValidate}
+          onValidate={form.handleValidate}
+        />
+      </div>
+    </>
   );
 });

--- a/src/ui/src/components/submit-workflow/use-submit-workflow-form.ts
+++ b/src/ui/src/components/submit-workflow/use-submit-workflow-form.ts
@@ -92,16 +92,16 @@ export interface UseSubmitWorkflowFormReturn {
   handleClose: () => void;
 }
 
-export function useSubmitWorkflowForm(): UseSubmitWorkflowFormReturn {
+export function useSubmitWorkflowForm(initialSpec = ""): UseSubmitWorkflowFormReturn {
   const router = useNavigationRouter();
   const close = useSubmitWorkflowStore((s) => s.close);
   const { announcer } = useServices();
 
   const { profile } = useProfile();
   const defaultPool = profile?.pool.default ?? "";
-  const { pool, setPool, resetPool } = usePoolSelection(defaultPool);
+  const { pool, setPool } = usePoolSelection(defaultPool);
 
-  const [spec, setSpec] = useState("");
+  const [spec, setSpec] = useState(initialSpec);
   const [priority, setPriority] = useState<WorkflowPriority>(WorkflowPriority.NORMAL);
   const [error, setError] = useState<string | null>(null);
   const [dryRunSpec, setDryRunSpec] = useState<string | null>(null);
@@ -222,16 +222,9 @@ export function useSubmitWorkflowForm(): UseSubmitWorkflowFormReturn {
 
   const handleClose = useCallback(() => {
     if (!isPending) {
-      setSpec("");
-      resetPool();
-      setPriority(WorkflowPriority.NORMAL);
-      setError(null);
-      setDryRunSpec(null);
-      setDryRunError(null);
-      setValidationState(null);
       close();
     }
-  }, [isPending, close, resetPool]);
+  }, [isPending, close]);
 
   return useMemo(
     () => ({

--- a/src/ui/src/lib/api/generated.ts
+++ b/src/ui/src/lib/api/generated.ts
@@ -1716,6 +1716,13 @@ export interface TemplateSpec {
 }
 
 /**
+ * Request body containing a token for JWT generation.
+ */
+export interface TokenRequest {
+  token: string;
+}
+
+/**
  * Request body for updating config tags endpoint.
  */
 export interface UpdateConfigTagsRequest {
@@ -2013,6 +2020,13 @@ second_revision: number;
 
 export type GetNewJwtTokenApiAuthJwtRefreshTokenGetParams = {
 refresh_token: string;
+workflow_id: string;
+group_name: string;
+task_name: string;
+retry_id?: number;
+};
+
+export type PostNewJwtTokenApiAuthJwtRefreshTokenPostParams = {
 workflow_id: string;
 group_name: string;
 task_name: string;
@@ -7563,7 +7577,15 @@ export const getGetConfigsHistoryApiConfigsHistoryGetUrl = (params?: GetConfigsH
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["config_types","tags"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -8095,6 +8117,8 @@ export function useGetConfigDiffApiConfigsDiffGet<TData = Awaited<ReturnType<typ
 
 /**
  * API to fetch for a new access token using a refresh token.
+
+Deprecated: Use POST /api/auth/jwt/refresh_token instead.
  * @summary Get New Jwt Token
  */
 export type getNewJwtTokenApiAuthJwtRefreshTokenGetResponse200 = {
@@ -8220,7 +8244,108 @@ export function useGetNewJwtTokenApiAuthJwtRefreshTokenGet<TData = Awaited<Retur
 
 
 /**
+ * API to fetch for a new access token using a refresh token.
+ * @summary Post New Jwt Token
+ */
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponse200 = {
+  data: unknown
+  status: 200
+}
+
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponse422 = {
+  data: HTTPValidationError
+  status: 422
+}
+
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponseSuccess = (postNewJwtTokenApiAuthJwtRefreshTokenPostResponse200) & {
+  headers: Headers;
+};
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponseError = (postNewJwtTokenApiAuthJwtRefreshTokenPostResponse422) & {
+  headers: Headers;
+};
+
+export type postNewJwtTokenApiAuthJwtRefreshTokenPostResponse = (postNewJwtTokenApiAuthJwtRefreshTokenPostResponseSuccess | postNewJwtTokenApiAuthJwtRefreshTokenPostResponseError)
+
+export const getPostNewJwtTokenApiAuthJwtRefreshTokenPostUrl = (params: PostNewJwtTokenApiAuthJwtRefreshTokenPostParams,) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString())
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0 ? `/api/auth/jwt/refresh_token?${stringifiedParams}` : `/api/auth/jwt/refresh_token`
+}
+
+export const postNewJwtTokenApiAuthJwtRefreshTokenPost = async (tokenRequest: TokenRequest,
+    params: PostNewJwtTokenApiAuthJwtRefreshTokenPostParams, options?: RequestInit): Promise<postNewJwtTokenApiAuthJwtRefreshTokenPostResponse> => {
+  
+  return customFetch<postNewJwtTokenApiAuthJwtRefreshTokenPostResponse>(getPostNewJwtTokenApiAuthJwtRefreshTokenPostUrl(params),
+  {      
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      tokenRequest,)
+  }
+);}
+  
+
+
+
+export const getPostNewJwtTokenApiAuthJwtRefreshTokenPostMutationOptions = <TError = HTTPValidationError,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postNewJwtTokenApiAuthJwtRefreshTokenPost>>, TError,{data: TokenRequest;params: PostNewJwtTokenApiAuthJwtRefreshTokenPostParams}, TContext>, request?: SecondParameter<typeof customFetch>}
+): UseMutationOptions<Awaited<ReturnType<typeof postNewJwtTokenApiAuthJwtRefreshTokenPost>>, TError,{data: TokenRequest;params: PostNewJwtTokenApiAuthJwtRefreshTokenPostParams}, TContext> => {
+
+const mutationKey = ['postNewJwtTokenApiAuthJwtRefreshTokenPost'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postNewJwtTokenApiAuthJwtRefreshTokenPost>>, {data: TokenRequest;params: PostNewJwtTokenApiAuthJwtRefreshTokenPostParams}> = (props) => {
+          const {data,params} = props ?? {};
+
+          return  postNewJwtTokenApiAuthJwtRefreshTokenPost(data,params,requestOptions)
+        }
+
+
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PostNewJwtTokenApiAuthJwtRefreshTokenPostMutationResult = NonNullable<Awaited<ReturnType<typeof postNewJwtTokenApiAuthJwtRefreshTokenPost>>>
+    export type PostNewJwtTokenApiAuthJwtRefreshTokenPostMutationBody = TokenRequest
+    export type PostNewJwtTokenApiAuthJwtRefreshTokenPostMutationError = HTTPValidationError
+
+    /**
+ * @summary Post New Jwt Token
+ */
+export const usePostNewJwtTokenApiAuthJwtRefreshTokenPost = <TError = HTTPValidationError,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postNewJwtTokenApiAuthJwtRefreshTokenPost>>, TError,{data: TokenRequest;params: PostNewJwtTokenApiAuthJwtRefreshTokenPostParams}, TContext>, request?: SecondParameter<typeof customFetch>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof postNewJwtTokenApiAuthJwtRefreshTokenPost>>,
+        TError,
+        {data: TokenRequest;params: PostNewJwtTokenApiAuthJwtRefreshTokenPostParams},
+        TContext
+      > => {
+      return useMutation(getPostNewJwtTokenApiAuthJwtRefreshTokenPostMutationOptions(options), queryClient);
+    }
+    
+/**
  * API to create a new jwt token from an access token.
+
+Deprecated: Use POST /api/auth/jwt/access_token instead.
  * @summary Get Jwt Token From Access Token
  */
 export type getJwtTokenFromAccessTokenApiAuthJwtAccessTokenGetResponse200 = {
@@ -8346,6 +8471,97 @@ export function useGetJwtTokenFromAccessTokenApiAuthJwtAccessTokenGet<TData = Aw
 
 
 /**
+ * API to create a new jwt token from an access token.
+ * @summary Post Jwt Token From Access Token
+ */
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse200 = {
+  data: unknown
+  status: 200
+}
+
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse422 = {
+  data: HTTPValidationError
+  status: 422
+}
+
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponseSuccess = (postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse200) & {
+  headers: Headers;
+};
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponseError = (postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse422) & {
+  headers: Headers;
+};
+
+export type postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse = (postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponseSuccess | postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponseError)
+
+export const getPostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostUrl = () => {
+
+
+  
+
+  return `/api/auth/jwt/access_token`
+}
+
+export const postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost = async (tokenRequest: TokenRequest, options?: RequestInit): Promise<postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse> => {
+  
+  return customFetch<postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostResponse>(getPostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostUrl(),
+  {      
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      tokenRequest,)
+  }
+);}
+  
+
+
+
+export const getPostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostMutationOptions = <TError = HTTPValidationError,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost>>, TError,{data: TokenRequest}, TContext>, request?: SecondParameter<typeof customFetch>}
+): UseMutationOptions<Awaited<ReturnType<typeof postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost>>, TError,{data: TokenRequest}, TContext> => {
+
+const mutationKey = ['postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost>>, {data: TokenRequest}> = (props) => {
+          const {data} = props ?? {};
+
+          return  postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost(data,requestOptions)
+        }
+
+
+
+        
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type PostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostMutationResult = NonNullable<Awaited<ReturnType<typeof postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost>>>
+    export type PostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostMutationBody = TokenRequest
+    export type PostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostMutationError = HTTPValidationError
+
+    /**
+ * @summary Post Jwt Token From Access Token
+ */
+export const usePostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost = <TError = HTTPValidationError,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost>>, TError,{data: TokenRequest}, TContext>, request?: SecondParameter<typeof customFetch>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof postJwtTokenFromAccessTokenApiAuthJwtAccessTokenPost>>,
+        TError,
+        {data: TokenRequest},
+        TContext
+      > => {
+      return useMutation(getPostJwtTokenFromAccessTokenApiAuthJwtAccessTokenPostMutationOptions(options), queryClient);
+    }
+    
+/**
  * API to create a new access token.
 
 If roles are specified, all specified roles must be assigned to the user.
@@ -8378,7 +8594,15 @@ export const getCreateAccessTokenApiAuthAccessTokenTokenNamePostUrl = (tokenName
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["roles"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -8832,7 +9056,15 @@ export const getAdminCreateAccessTokenApiAuthUserUserIdAccessTokenTokenNamePostU
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["roles"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -9162,7 +9394,15 @@ export const getListUsersApiAuthUserGetUrl = (params?: ListUsersApiAuthUserGetPa
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["roles"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -10152,7 +10392,15 @@ export const getListAppsApiAppGetUrl = (params?: ListAppsApiAppGetParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["users"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -11022,7 +11270,15 @@ export const getListWorkflowApiWorkflowGetUrl = (params?: ListWorkflowApiWorkflo
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["users","statuses","pools","tags","priority"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -11274,7 +11530,15 @@ export const getListTaskApiTaskGetUrl = (params?: ListTaskApiTaskGetParams,) => 
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["statuses","users","pools","nodes","priority"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -12071,7 +12335,15 @@ export const getTagWorkflowApiWorkflowNameTagPostUrl = (name: string,
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["add","remove"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -12373,7 +12645,15 @@ export const getPortForwardTaskApiWorkflowNamePortforwardTaskNamePostUrl = (name
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["task_ports"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -12966,7 +13246,15 @@ export const getGetResourcesApiResourcesGetUrl = (params?: GetResourcesApiResour
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["pools","platforms"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -13215,7 +13503,15 @@ export const getGetPoolsApiPoolGetUrl = (params?: GetPoolsApiPoolGetParams,) => 
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["pools"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -13340,7 +13636,15 @@ export const getGetPoolQuotasApiPoolQuotaGetUrl = (params?: GetPoolQuotasApiPool
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["pools"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -13467,7 +13771,15 @@ export const getSubmitWorkflowApiPoolPoolNameWorkflowPostUrl = (poolName: string
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["env_vars"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -13889,7 +14201,15 @@ export const getChangeNameTagLabelMetadataApiBucketBucketDatasetNameAttributePos
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["set_tag","delete_tag","delete_label","delete_metadata"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
@@ -14132,7 +14452,15 @@ export const getListDatasetFromBucketApiBucketListDatasetGetUrl = (params?: List
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
-    
+    const explodeParameters = ["user","buckets"];
+
+    if (Array.isArray(value) && explodeParameters.includes(key)) {
+      value.forEach((v) => {
+        normalizedParams.append(key, v === null ? 'null' : v.toString());
+      });
+      return;
+    }
+      
     if (value !== undefined) {
       normalizedParams.append(key, value === null ? 'null' : value.toString())
     }


### PR DESCRIPTION
## Description
- Make /pool_quota fetch for workflow submission lazy (i.e. don't trigger it on initial page load)
- Annotate openapi.json APIs with `explode` for array query params (e.g. `/workflow?statuses=PENDING&statuses=WAITING` instead of `/workflow?statuses=PENDING,WAITING`)

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
