### PR TITLE
Update KAI to v0.12 in scripts and docs

### DIFF
--- a/docs/deployment_guide/advanced_config/pool.rst
+++ b/docs/deployment_guide/advanced_config/pool.rst
@@ -435,7 +435,7 @@ Enabling Topology-Aware Scheduling
 
 Topology-aware scheduling ensures that tasks requiring high-bandwidth or low-latency
 communication are placed on physically co-located nodes—such as the same NVLink rack, spine
-switch, or availability zone. This requires KAI Scheduler v0.10 or later and nodes with the
+switch, or availability zone. This requires KAI Scheduler v0.12 or later and nodes with the
 appropriate Kubernetes labels applied.
 
 .. note::

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -274,7 +274,7 @@ KAI scheduler provides co-scheduling, priority, and preemption for workflows:
 
    $ helm upgrade --install kai-scheduler \
      oci://ghcr.io/nvidia/kai-scheduler/kai-scheduler \
-     --version v0.8.1 \
+     --version v0.12.10 \
      --create-namespace -n kai-scheduler \
      --set global.nodeSelector.node_group=kai-scheduler \
      --set "scheduler.additionalArgs[0]=--default-staleness-grace-period=-1s" \

--- a/docs/deployment_guide/references/configs_definitions/pool.rst
+++ b/docs/deployment_guide/references/configs_definitions/pool.rst
@@ -121,7 +121,7 @@ Pool
      - Array[`TopologyKey`_]
      - Ordered list of topology levels available in this pool, from coarsest to finest
        granularity. Enables topology-aware scheduling when non-empty. Only supported on pools
-       backed by KAI Scheduler v0.10 or later. See :ref:`concepts_topology` for details.
+       backed by KAI Scheduler v0.12 or later. See :ref:`concepts_topology` for details.
      - ``[]``
 
 .. _pool_config-resource-constraint:


### PR DESCRIPTION
## Description
Update KAI scheduler to v0.12 in scripts and docs to support topology aware scheduling
Topology aware scheduling was introduced in v0.10, but v0.12 has the topology CRD and other updates

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
