### PR TITLE
Make Redis Oauth2 Session Store Enabled by Default and Update READMEs

### DIFF
--- a/deployments/charts/router/README.md
+++ b/deployments/charts/router/README.md
@@ -133,10 +133,10 @@ helm upgrade my-router ./router -f my-values.yaml
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `services.redis.serviceName` | Kubernetes service name for Redis (leave empty to use in-memory session store for Oauth2-Proxy) | `""` |
+| `services.redis.serviceName` | Kubernetes service name for Redis (used for OAuth2-Proxy session store) | `redis` |
 | `services.redis.port` | Redis service port | `6379` |
 | `services.redis.dbNumber` | Redis database number to use (0–15) | `0` |
-| `services.redis.tlsEnabled` | Enable TLS encryption for Redis connections | `false` |
+| `services.redis.tlsEnabled` | Enable TLS encryption for Redis connections | `true` |
 
 ## Sidecar Configuration
 
@@ -205,7 +205,7 @@ helm upgrade my-router ./router -f my-values.yaml
 | `sidecars.oauth2Proxy.cookieRefresh` | Cookie refresh interval | `1h` |
 | `sidecars.oauth2Proxy.scope` | OAuth2 scopes to request | `openid email profile` |
 | `sidecars.oauth2Proxy.passAccessToken` | Pass the access token to upstream | `false` |
-| `sidecars.oauth2Proxy.redisSessionStore` | Use Redis (`services.redis`) as the session store instead of in-memory | `false` |
+| `sidecars.oauth2Proxy.redisSessionStore` | Use Redis (`services.redis`) as the session store instead of in-memory | `true` |
 | `sidecars.oauth2Proxy.useKubernetesSecrets` | Use Kubernetes secrets for credentials | `false` |
 | `sidecars.oauth2Proxy.secretName` | Kubernetes secret name (when `useKubernetesSecrets` is true) | `oauth2-proxy-secrets` |
 | `sidecars.oauth2Proxy.secretPaths.clientSecret` | File path for client secret | `/etc/oauth2-proxy/client-secret` |

--- a/deployments/charts/router/values.yaml
+++ b/deployments/charts/router/values.yaml
@@ -282,9 +282,9 @@ services:
   ## Redis cache service configuration
   ##
   redis:
-    ## Kubernetes service name for Redis (leave empty to use in-memory session store)
+    ## Kubernetes service name for Redis (used for OAuth2-Proxy session store)
     ##
-    serviceName: ""
+    serviceName: redis
 
     ## Redis service port
     ##
@@ -296,7 +296,7 @@ services:
 
     ## Enable TLS encryption for Redis connections
     ##
-    tlsEnabled: false
+    tlsEnabled: true
 
 ## Configuration for sidecar containers
 ##
@@ -517,7 +517,7 @@ sidecars:
 
     ## Use Redis (services.redis) as the session store instead of in-memory
     ##
-    redisSessionStore: false
+    redisSessionStore: true
 
     ## Use Kubernetes secrets for credentials
     ##
@@ -695,4 +695,3 @@ extraConfigMaps: []
 #   data:
 #     config.yaml: |
 #       key: value
-

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -281,7 +281,7 @@ Any field from `sidecars.envoy` can be overridden at the service level. Fields n
 | `sidecars.oauth2Proxy.cookieRefresh` | Cookie refresh interval | `1h` |
 | `sidecars.oauth2Proxy.scope` | OAuth2 scopes to request | `openid email profile` |
 | `sidecars.oauth2Proxy.passAccessToken` | Pass the access token to upstream | `false` |
-| `sidecars.oauth2Proxy.redisSessionStore` | Use Redis (`services.redis`) as the session store instead of in-memory | `false` |
+| `sidecars.oauth2Proxy.redisSessionStore` | Use Redis (`services.redis`) as the session store instead of in-memory | `true` |
 | `sidecars.oauth2Proxy.useKubernetesSecrets` | Use Kubernetes secrets for credentials | `false` |
 | `sidecars.oauth2Proxy.secretName` | Kubernetes secret name (when `useKubernetesSecrets` is true) | `oauth2-proxy-secrets` |
 | `sidecars.oauth2Proxy.secretPaths.clientSecret` | File path for client secret | `/etc/oauth2-proxy/client-secret` |

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1521,7 +1521,7 @@ sidecars:
 
     ## Use Redis (services.redis) as the session store instead of in-memory
     ##
-    redisSessionStore: false
+    redisSessionStore: true
 
     ## Use Kubernetes secrets for credentials
     ##

--- a/deployments/charts/web-ui/README.md
+++ b/deployments/charts/web-ui/README.md
@@ -115,10 +115,10 @@ This Helm chart deploys the OSMO UI service along with its required sidecars and
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `services.redis.serviceName` | Kubernetes service name for Redis (leave empty to use in-memory session store) | `""` |
+| `services.redis.serviceName` | Kubernetes service name for Redis (used for OAuth2-Proxy session store) | `redis` |
 | `services.redis.port` | Redis service port | `6379` |
 | `services.redis.dbNumber` | Redis database number to use (0–15) | `0` |
-| `services.redis.tlsEnabled` | Enable TLS encryption for Redis connections | `false` |
+| `services.redis.tlsEnabled` | Enable TLS encryption for Redis connections | `true` |
 
 #### OAuth2 Proxy Sidecar
 
@@ -137,7 +137,7 @@ This Helm chart deploys the OSMO UI service along with its required sidecars and
 | `sidecars.oauth2Proxy.cookieRefresh` | Cookie refresh interval | `1h` |
 | `sidecars.oauth2Proxy.scope` | OAuth2 scopes to request | `openid email profile` |
 | `sidecars.oauth2Proxy.oidcEndSessionUrl` | IdP end-session endpoint for federated logout. When set, Envoy exposes `/signout` which redirects to `/oauth2/sign_out?rd=<url>`, clearing both the local session cookie and the IdP's SSO session. Requires `--whitelist-domain=<idp-domain>` in `extraArgs`. | `""` (disabled) |
-| `sidecars.oauth2Proxy.redisSessionStore` | Use Redis (`services.redis`) as the session store instead of in-memory | `false` |
+| `sidecars.oauth2Proxy.redisSessionStore` | Use Redis (`services.redis`) as the session store instead of in-memory | `true` |
 | `sidecars.oauth2Proxy.extraArgs` | Additional arguments passed to oauth2-proxy | `[]` |
 | `sidecars.oauth2Proxy.useKubernetesSecrets` | Use Kubernetes secrets for credentials | `false` |
 | `sidecars.oauth2Proxy.secretName` | Kubernetes secret name (when `useKubernetesSecrets` is true) | `oauth2-proxy-secrets` |

--- a/deployments/charts/web-ui/values.yaml
+++ b/deployments/charts/web-ui/values.yaml
@@ -370,7 +370,7 @@ services:
   redis:
     ## Kubernetes service name for Redis (leave empty to use in-memory session store)
     ##
-    serviceName: ""
+    serviceName: redis
 
     ## Redis service port
     ##
@@ -382,7 +382,7 @@ services:
 
     ## Enable TLS encryption for Redis connections
     ##
-    tlsEnabled: false
+    tlsEnabled: true
 
 ## Configuration for sidecar containers
 ##
@@ -619,7 +619,7 @@ sidecars:
 
     ## Use Redis (services.redis) as the session store instead of in-memory
     ##
-    redisSessionStore: false
+    redisSessionStore: true
 
     ## Use Kubernetes secrets for credentials
     ##


### PR DESCRIPTION
## Description
Update Readme after latest Oauth2-Proxy additions

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
