### PR TITLE
Assign unique Prometheus metrics ports per service in bazel mode

### DIFF
--- a/run/start_backend_bazel.py
+++ b/run/start_backend_bazel.py
@@ -123,6 +123,7 @@ def _start_backend_operator(service_type: Literal['listener', 'worker'], emoji: 
 
     host_ip = get_host_ip()
 
+    metrics_port = '9467' if service_type == 'listener' else '9468'
     cmd = [
         'bazel', 'run', f'@osmo_workspace//src/operator:{service_name}',
         '--',
@@ -131,7 +132,8 @@ def _start_backend_operator(service_type: Literal['listener', 'worker'], emoji: 
         '--backend', 'default',
         '--namespace', 'default',
         '--username', 'testuser',
-        '--progress_folder_path', '/tmp/osmo/operator'
+        '--progress_folder_path', '/tmp/osmo/operator',
+        '--metrics_prometheus_port', metrics_port
     ]
 
     process = run_command_with_logging(

--- a/run/start_service_bazel.py
+++ b/run/start_service_bazel.py
@@ -315,7 +315,8 @@ def _start_service_worker():
         'bazel', 'run', '@osmo_workspace//src/service/worker:worker_binary',
         '--',
         '--method=dev',
-        '--progress_file', '/tmp/osmo/service/last_progress_worker'
+        '--progress_file', '/tmp/osmo/service/last_progress_worker',
+        '--metrics_prometheus_port', '9465'
     ]
 
     process = run_command_with_logging(
@@ -387,7 +388,8 @@ def _start_delayed_job_monitor():
         '@osmo_workspace//src/service/delayed_job_monitor:delayed_job_monitor_binary',
         '--',
         '--method=dev',
-        '--progress_file', '/tmp/osmo/service/last_progress_delayed_job_monitor'
+        '--progress_file', '/tmp/osmo/service/last_progress_delayed_job_monitor',
+        '--metrics_prometheus_port', '9466'
     ]
 
     process = run_command_with_logging(

--- a/src/utils/metrics/metrics.py
+++ b/src/utils/metrics/metrics.py
@@ -119,6 +119,8 @@ class MetricCreator:
 
     def start_server(self):
         """Start the Prometheus scrape endpoint, listening on all interfaces."""
+        if not self._config.metrics_otel_enable:
+            return None
         prometheus_client.start_http_server(
             self._config.metrics_prometheus_port, addr='0.0.0.0')
 


### PR DESCRIPTION
## Description
Prevents port conflicts when running all services locally via bazel. Core: 9464, worker: 9465, delayed_job_monitor: 9466, backend_listener: 9467, backend_worker: 9468.

Issue #633

Tested with `bazel run @osmo_workspace//run:start_service -- --mode bazel`

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
