### PR TITLE
Fix template in backend test runner (#648)

### DIFF
--- a/deployments/charts/backend-operator/templates/backend-test-runner-config.yaml
+++ b/deployments/charts/backend-operator/templates/backend-test-runner-config.yaml
@@ -245,7 +245,7 @@ data:
                 - name: {{ .Values.backendTestRunner.volumes.testConfigName }}
                   configMap:
                     {{- $configMapName := .Values.backendTestRunner.configMap.nameTemplate }}
-                    name: {{ $configMapName | replace "{{.BackendName}}" "{{backend_name}}" | replace "{{.TestName}}" "{{test_name}}" | quote }}
+                    name: {{ $configMapName | replace "{{.TestName}}" "{{test_name}}" | quote }}
                     defaultMode: {{ .Values.backendTestRunner.configMap.defaultMode }}
                     optional: {{ .Values.backendTestRunner.configMap.optional }}
 

--- a/deployments/charts/backend-operator/values.yaml
+++ b/deployments/charts/backend-operator/values.yaml
@@ -592,7 +592,8 @@ backendTestRunner:
   configMap:
     ## ConfigMap name template
     ##
-    nameTemplate: "{{.BackendName}}-{{.TestName}}-config"
+    nameTemplate: "{{.TestName}}-config"
+
     ## Default mode for ConfigMap files
     ##
     defaultMode: 0644


### PR DESCRIPTION
## Description
Cherry-pick of #648 from main into release/6.x
Fixes configmap name mismatch in backend test runner template — `nameTemplate` used `{{.BackendName}}-{{.TestName}}-config` but Python code creates `{test_name}-config`. Also removes unused `{{.BackendName}}` replace in the Helm template.

Issue - None

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
