### PR TITLE
charts: Fix XHR calls so they return 401 if not auth

### DIFF
--- a/deployments/charts/router/templates/_sidecar-helpers.tpl
+++ b/deployments/charts/router/templates/_sidecar-helpers.tpl
@@ -112,6 +112,7 @@ OAuth2 Proxy sidecar container
     - --redirect-url=https://{{ .Values.sidecars.envoy.service.hostname }}/oauth2/callback
     - --silence-ping-logging=true
     - --skip-provider-button=true
+    - --api-route=/api/.+
     {{- range .Values.sidecars.oauth2Proxy.extraArgs }}
     - {{ . }}
     {{- end }}

--- a/deployments/charts/service/templates/_sidecar-helpers.tpl
+++ b/deployments/charts/service/templates/_sidecar-helpers.tpl
@@ -238,6 +238,7 @@ OAuth2 Proxy sidecar container
     - --redirect-url=https://{{ .Values.sidecars.envoy.service.hostname }}/oauth2/callback
     - --silence-ping-logging=true
     - --skip-provider-button=true
+    - --api-route=/api/.+
     {{- range .Values.sidecars.oauth2Proxy.extraArgs }}
     - {{ . }}
     {{- end }}

--- a/deployments/charts/web-ui/templates/_sidecar-helpers.tpl
+++ b/deployments/charts/web-ui/templates/_sidecar-helpers.tpl
@@ -162,6 +162,7 @@ OAuth2 Proxy sidecar container
     - --redirect-url=https://{{ .Values.sidecars.envoy.service.hostname }}/oauth2/callback
     - --silence-ping-logging=true
     - --skip-provider-button=true
+    - --api-route=/api/.+
     {{- range .Values.sidecars.oauth2Proxy.extraArgs }}
     - {{ . }}
     {{- end }}


### PR DESCRIPTION
## Description
Previously it would do a redirect to the OIDC provider, which the UI did not present in a way that made sense for the user.

With this fix it becomes

<img width="1520" height="376" alt="Screenshot 2026-03-09 at 3 10 50 PM" src="https://github.com/user-attachments/assets/f0c01475-e3b0-4d44-956a-045b390d8e82" />

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
