### PR TITLE
Catch error when logs time out

### DIFF
--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -886,7 +886,8 @@ def _workflow_events(service_client: client.ServiceClient, args: argparse.Namesp
     except requests.exceptions.ChunkedEncodingError as error:
         # Check if this is specifically the timeout case with InvalidChunkLength
         error_str = str(error)
-        if 'InvalidChunkLength' in error_str and "got length b''" in error_str:
+        if ('InvalidChunkLength' in error_str and "got length b''" in error_str) or \
+            ('Response ended prematurely' in error_str):
             print('\nEvent stream has timed out or failed. '
                   'Please run the command again to continue viewing events.')
             return


### PR DESCRIPTION
I tried a bunch of fixes to send like a hidden message or keep alive to ensure the stream worked, but didn't like any of the solutions. I think the correct fix is to reevaluate how we stream the logs to the CLI instead of fix the current implementation. This is just to stop the error and report something to the user for the time being

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in command-line log streaming to better detect and gracefully handle connection timeouts and premature stream endings, reducing unexpected failures.
  * Applied the same robust handling to event streams so event delivery also recovers more gracefully from interrupted or truncated responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->