### PR TITLE
Refactor and fix data-table variable height rows

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -65,7 +65,7 @@
     "@replit/codemirror-indentation-markers": "^6.5.3",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-table": "^8.21.3",
-    "@tanstack/react-virtual": "3.13.12",
+    "@tanstack/react-virtual": "^3.13.21",
     "@uiw/react-codemirror": "^4.25.4",
     "@use-gesture/react": "^10.3.1",
     "@xterm/addon-fit": "^0.11.0",

--- a/src/ui/pnpm-lock.yaml
+++ b/src/ui/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-virtual':
-        specifier: 3.13.12
-        version: 3.13.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^3.13.21
+        version: 3.13.21(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@uiw/react-codemirror':
         specifier: ^4.25.4
         version: 4.25.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/state@6.5.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.39.15)(codemirror@6.0.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2052,8 +2052,8 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
-  '@tanstack/react-virtual@3.13.12':
-    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+  '@tanstack/react-virtual@3.13.21':
+    resolution: {integrity: sha512-SYXFrmrbPgXBvf+HsOsKhFgqSe4M6B29VHOsX9Jih9TlNkNkDWx0hWMiMLUghMEzyUz772ndzdEeCEBx+3GIZw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2062,8 +2062,8 @@ packages:
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
 
-  '@tanstack/virtual-core@3.13.12':
-    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
+  '@tanstack/virtual-core@3.13.21':
+    resolution: {integrity: sha512-ww+fmLHyCbPSf7JNbWZP3g7wl6SdNo3ah5Aiw+0e9FDErkVHLKprYUrwTm7dF646FtEkN/KkAKPYezxpmvOjxw==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -6972,15 +6972,15 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@tanstack/react-virtual@3.13.12(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+  '@tanstack/react-virtual@3.13.21(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@tanstack/virtual-core': 3.13.12
+      '@tanstack/virtual-core': 3.13.21
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
   '@tanstack/table-core@8.21.3': {}
 
-  '@tanstack/virtual-core@3.13.12': {}
+  '@tanstack/virtual-core@3.13.21': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/src/ui/src/components/data-table/data-table.tsx
+++ b/src/ui/src/components/data-table/data-table.tsx
@@ -85,8 +85,10 @@ export interface DataTableProps<TData, TSectionMeta = unknown> {
   headerClassName?: string;
   /** Extra classes applied to the <thead> element (e.g. "file-browser-thead" for a shadow-based bottom divider) */
   theadClassName?: string;
-  rowClassName?: string | ((item: TData) => string);
+  rowClassName?: string | ((item: TData, index: number) => string);
   sectionClassName?: string | ((section: Section<TData, TSectionMeta>) => string);
+  /** Whether a given row should show hover/pointer styles. Defaults to !!onRowClick for all rows. */
+  isRowInteractive?: (row: TData) => boolean;
   columnSizeConfigs?: readonly ColumnSizeConfig[];
   columnSizingPreferences?: ColumnSizingPreferences;
   onColumnSizingPreferenceChange?: (columnId: string, preference: ColumnSizingPreference) => void;
@@ -128,7 +130,6 @@ function DataTableInner<TData, TSectionMeta = unknown>({
   onLoadMore,
   isFetchingNextPage,
   totalCount,
-  // Row heights use canonical constants from @/lib/config
   rowHeight = TABLE_ROW_HEIGHTS.NORMAL,
   sectionHeight = TABLE_ROW_HEIGHTS.SECTION,
   className,
@@ -151,6 +152,7 @@ function DataTableInner<TData, TSectionMeta = unknown>({
   suspendResize,
   resizeCompleteEvent,
   registerLayoutStableCallback,
+  isRowInteractive,
 }: DataTableProps<TData, TSectionMeta>) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const tableElementRef = useRef<HTMLTableElement>(null);
@@ -178,7 +180,6 @@ function DataTableInner<TData, TSectionMeta = unknown>({
     return columns
       .map((c) => {
         if (typeof c.id === "string") return c.id;
-        // AccessorKeyColumnDef has accessorKey property
         if ("accessorKey" in c && c.accessorKey) return String(c.accessorKey);
         return "";
       })
@@ -199,38 +200,20 @@ function DataTableInner<TData, TSectionMeta = unknown>({
 
   const visibleColumnCount = visibleColumnIds.length;
 
-  const columnMinSizes = useMemo(() => {
-    const sizes: Record<string, number> = {};
-    for (const col of columns) {
-      const colId = col.id ?? ("accessorKey" in col && col.accessorKey ? String(col.accessorKey) : "");
-      if (colId && col.minSize != null) {
-        sizes[colId] = col.minSize;
-      }
-    }
-    return sizes;
-  }, [columns]);
-
-  const columnInitialSizes = useMemo(() => {
-    const sizes: Record<string, number> = {};
-    for (const col of columns) {
-      const colId = col.id ?? ("accessorKey" in col && col.accessorKey ? String(col.accessorKey) : "");
-      if (colId && col.size != null) {
-        sizes[colId] = col.size;
-      }
-    }
-    return sizes;
-  }, [columns]);
-
-  const columnResizability = useMemo(() => {
+  const { columnMinSizes, columnInitialSizes, columnResizability } = useMemo(() => {
+    const mins: Record<string, number> = {};
+    const initials: Record<string, number> = {};
     const resizability: Record<string, boolean> = {};
+
     for (const col of columns) {
       const colId = col.id ?? ("accessorKey" in col && col.accessorKey ? String(col.accessorKey) : "");
-      if (colId) {
-        // enableResizing defaults to true if not specified
-        resizability[colId] = col.enableResizing !== false;
-      }
+      if (!colId) continue;
+      if (col.minSize != null) mins[colId] = col.minSize;
+      if (col.size != null) initials[colId] = col.size;
+      resizability[colId] = col.enableResizing !== false;
     }
-    return resizability;
+
+    return { columnMinSizes: mins, columnInitialSizes: initials, columnResizability: resizability };
   }, [columns]);
 
   const showSkeleton = isLoading && allItems.length === 0;
@@ -252,19 +235,34 @@ function DataTableInner<TData, TSectionMeta = unknown>({
     registerLayoutStableCallback,
   });
 
-  // Track previous data length to detect empty → populated transitions
-  const prevDataLength = usePrevious(allItems.length);
+  // Toggle `is-scrolling` class to suppress row-position transitions during scroll.
+  // Removed 150ms after the last scroll event so expand/collapse animations work.
+  useEffect(() => {
+    const scrollEl = scrollRef.current;
+    if (!scrollEl) return;
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const onScroll = () => {
+      scrollEl.classList.add("is-scrolling");
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => scrollEl.classList.remove("is-scrolling"), 150);
+    };
+    scrollEl.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      scrollEl.removeEventListener("scroll", onScroll);
+      clearTimeout(timeoutId);
+    };
+  }, []);
 
-  // When transitioning from empty (0 items) to populated (>0 items),
-  // trigger column recalculation to ensure columns fill available space
+  // Recalculate column widths when data first arrives (empty -> populated)
+  const prevDataLength = usePrevious(allItems.length);
+  const { recalculate } = columnSizingHook;
   useEffect(() => {
     if (prevDataLength === 0 && allItems.length > 0) {
-      // Use RAF to ensure DOM has updated before recalculating
       requestAnimationFrame(() => {
-        columnSizingHook.recalculate();
+        recalculate();
       });
     }
-  }, [prevDataLength, allItems.length, columnSizingHook]);
+  }, [prevDataLength, allItems.length, recalculate]);
 
   // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table returns unstable functions by design
   const table = useReactTable({
@@ -316,7 +314,6 @@ function DataTableInner<TData, TSectionMeta = unknown>({
     useVirtualizedTable<TData, TSectionMeta>({
       items: sections ? undefined : data,
       sections,
-      getRowId,
       scrollRef,
       rowHeight,
       sectionHeight,
@@ -369,7 +366,9 @@ function DataTableInner<TData, TSectionMeta = unknown>({
 
   const rowNavigation = useRowNavigation({
     rowCount: virtualItemCount,
-    visibleRowCount: Math.floor(600 / rowHeight),
+    visibleRowCount: scrollRef.current
+      ? Math.max(1, Math.floor(scrollRef.current.clientHeight / rowHeight))
+      : Math.floor(600 / rowHeight),
     onRowActivate: useCallback(
       (virtualIndex: number) => {
         const item = getItem(virtualIndex);
@@ -511,7 +510,6 @@ function DataTableInner<TData, TSectionMeta = unknown>({
 
                         const colIndex = headerIndex + 1;
 
-                        // Get custom header className from column meta (dependency injection)
                         const headerClassName = header.column.columnDef.meta?.headerClassName;
 
                         if (isFixed) {
@@ -577,6 +575,7 @@ function DataTableInner<TData, TSectionMeta = unknown>({
                 onRowKeyDown={rowNavigation.handleRowKeyDown}
                 measureElement={measureElement}
                 compact={compact}
+                isRowInteractive={isRowInteractive}
               />
             </table>
 
@@ -635,5 +634,4 @@ function DataTableInner<TData, TSectionMeta = unknown>({
   );
 }
 
-// Memoize with generic type preservation
 export const DataTable = memo(DataTableInner) as typeof DataTableInner;

--- a/src/ui/src/components/data-table/hooks/use-column-sizing.ts
+++ b/src/ui/src/components/data-table/hooks/use-column-sizing.ts
@@ -269,6 +269,8 @@ export function useColumnSizing({
 
   // Track pending idle callback for cleanup
   const pendingIdleCallbackRef = useRef<number | ReturnType<typeof setTimeout> | null>(null);
+  // Track which scheduler was used so cleanup uses the correct cancel API
+  const useRicRef = useRef(typeof requestIdleCallback !== "undefined");
 
   // Remeasure when a column becomes NO_TRUNCATE
   useEffect(() => {
@@ -305,7 +307,11 @@ export function useColumnSizing({
       }
     };
 
-    if (typeof requestIdleCallback !== "undefined") {
+    // Capture the scheduler flag at effect setup time so the cleanup function
+    // can use the same value (lint: ref values may change by cleanup time).
+    const useRic = useRicRef.current;
+
+    if (useRic) {
       pendingIdleCallbackRef.current = requestIdleCallback(measureNewColumns, { timeout: 500 });
     } else {
       // Safari fallback: Use RAF to ensure DOM measurement happens at optimal time
@@ -317,13 +323,11 @@ export function useColumnSizing({
 
     return () => {
       if (pendingIdleCallbackRef.current !== null) {
-        if (typeof cancelIdleCallback !== "undefined" && typeof pendingIdleCallbackRef.current === "number") {
-          cancelIdleCallback(pendingIdleCallbackRef.current);
-        } else if (typeof cancelAnimationFrame !== "undefined") {
+        if (useRic) {
+          cancelIdleCallback(pendingIdleCallbackRef.current as number);
+        } else {
           // Safari fallback uses RAF, so cancel with cancelAnimationFrame
           cancelAnimationFrame(pendingIdleCallbackRef.current as number);
-        } else {
-          clearTimeout(pendingIdleCallbackRef.current as ReturnType<typeof setTimeout>);
         }
         pendingIdleCallbackRef.current = null;
       }

--- a/src/ui/src/components/data-table/hooks/use-virtualized-table.ts
+++ b/src/ui/src/components/data-table/hooks/use-virtualized-table.ts
@@ -14,27 +14,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Hook for virtualized table rendering.
- *
- * Wraps TanStack Virtual to work with native <table> elements.
- * Provides row indices, positions, and infinite scroll detection.
- *
- * Note: Requires @tanstack/react-virtual 3.13.12 (not 3.13.13+) to avoid
- * flushSync warnings during render. See https://github.com/TanStack/virtual/issues/1094
- */
-
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { useVirtualizer, type Virtualizer } from "@tanstack/react-virtual";
 import { useSyncedRef, usePrevious } from "@react-hookz/web";
 import type { Section } from "@/components/data-table/types";
 import { VirtualItemTypes } from "@/components/data-table/constants";
-
-// =============================================================================
-// Types
-// =============================================================================
 
 export interface VirtualizedRow {
   index: number;
@@ -48,10 +34,8 @@ export interface UseVirtualizedTableOptions<T, TSectionMeta = unknown> {
   items?: T[];
   /** Sectioned data (mutually exclusive with items) */
   sections?: Section<T, TSectionMeta>[];
-  getRowId: (item: T) => string;
   scrollRef: React.RefObject<HTMLElement | null>;
   rowHeight: number;
-  /** Section header height (required if using sections) */
   sectionHeight?: number;
   overscan?: number;
   hasNextPage?: boolean;
@@ -62,9 +46,7 @@ export interface UseVirtualizedTableOptions<T, TSectionMeta = unknown> {
 export interface UseVirtualizedTableResult<T, TSectionMeta = unknown> {
   virtualRows: VirtualizedRow[];
   totalHeight: number;
-  /** Total data row count (excluding section headers, for aria-rowcount) */
   totalRowCount: number;
-  /** Total virtual item count (sections + data rows, for navigation) */
   virtualItemCount: number;
   getItem: (
     index: number,
@@ -74,18 +56,12 @@ export interface UseVirtualizedTableResult<T, TSectionMeta = unknown> {
     | null;
   measure: () => void;
   scrollToIndex: (index: number, options?: { align?: "start" | "center" | "end" | "auto" }) => void;
-  /** Ref callback for dynamic row measurement - attach to row elements */
   measureElement: (node: Element | null) => void;
 }
-
-// =============================================================================
-// Hook
-// =============================================================================
 
 export function useVirtualizedTable<T, TSectionMeta = unknown>({
   items,
   sections,
-  getRowId,
   scrollRef,
   rowHeight,
   sectionHeight = 36,
@@ -94,7 +70,6 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
   onLoadMore,
   isFetchingNextPage = false,
 }: UseVirtualizedTableOptions<T, TSectionMeta>): UseVirtualizedTableResult<T, TSectionMeta> {
-  // Build flat list of virtual items (sections + rows or just rows)
   const virtualItems = useMemo(() => {
     if (sections && sections.length > 0) {
       const result: Array<
@@ -103,8 +78,7 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
       > = [];
 
       for (const section of sections) {
-        // Use height 0 for sections with skipGroupRow (e.g., single-task groups)
-        // so they don't allocate vertical space in the virtual list
+        // Height 0 for skipped headers so they don't allocate vertical space
         const metadata = section.metadata as { skipGroupRow?: boolean } | undefined;
         const shouldSkipHeader = metadata?.skipGroupRow === true;
         const headerHeight = shouldSkipHeader ? 0 : sectionHeight;
@@ -129,31 +103,30 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
     return [];
   }, [items, sections, rowHeight, sectionHeight]);
 
-  // Stable refs for accessing changing data in stable callbacks
-  // Note: Use useSyncedRef (not useEventCallback) for getRowId because it's called
-  // during render by getItemKey. useEventCallback throws when called during render.
   const virtualItemsRef = useSyncedRef(virtualItems);
-  const getRowIdRef = useSyncedRef(getRowId);
+  const virtualizerRef = useRef<Virtualizer<HTMLElement, Element> | null>(null);
 
-  // Estimate size function - stable callback using ref
+  // Dispatched from TV's onChange(sync=false); captured by flushSync in makeRowRef
+  // to commit row positions synchronously before paint.
+  const [, forceSyncTick] = useReducer((x: number) => x + 1, 0);
+
   const estimateSize = useCallback(
     (index: number) => virtualItemsRef.current[index]?.height ?? rowHeight,
     [virtualItemsRef, rowHeight],
   );
 
-  // Get item key - stable callback using refs
-  // Called during render by virtualizer, so must use refs (not useEventCallback)
+  // Uses virtual index (not item ID) so duplicate items (e.g. a resource in
+  // multiple pools) get independent entries in TV's itemSizeCache.
   const getItemKey = useCallback(
     (index: number) => {
       const item = virtualItemsRef.current[index];
       if (!item) return index;
       if (item.type === VirtualItemTypes.SECTION) return `section-${item.section.id}`;
-      return getRowIdRef.current(item.item);
+      return index;
     },
-    [virtualItemsRef, getRowIdRef],
+    [virtualItemsRef],
   );
 
-  // Create virtualizer with stable callbacks
   // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Virtual returns unstable functions by design. React Compiler skips optimization. See: https://github.com/facebook/react/issues/33057
   const virtualizer = useVirtualizer({
     count: virtualItems.length,
@@ -161,30 +134,36 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
     estimateSize,
     overscan,
     getItemKey,
+    onChange: (_instance, sync) => {
+      // Only for resize events (sync=false), not scroll updates
+      if (!sync) {
+        forceSyncTick();
+      }
+    },
   });
 
-  // Re-measure when heights change
+  virtualizerRef.current = virtualizer;
+
+  const measure = useCallback(() => {
+    virtualizerRef.current?.measure();
+  }, []);
+
   useEffect(() => {
     virtualizer.measure();
   }, [rowHeight, sectionHeight, virtualizer]);
 
-  // Get virtual items - TanStack Virtual handles reactivity internally
-  const virtualRows: VirtualizedRow[] = virtualizer.getVirtualItems().map((row) => ({
+  const rawVirtualItems = virtualizer.getVirtualItems();
+  const virtualRows: VirtualizedRow[] = rawVirtualItems.map((row) => ({
     index: row.index,
     start: row.start,
     size: row.size,
     key: String(row.key),
   }));
 
-  // Stable ref for optional load more callback
   const onLoadMoreRef = useSyncedRef(onLoadMore);
-
-  // Track if we've already triggered load more to prevent duplicate calls
   const loadMoreTriggeredRef = useRef(false);
 
-  // Reset the trigger flag when new data arrives (item count changes).
-  // This single mechanism works for both slow network responses and instant
-  // cached responses, making the logic agnostic of data source timing.
+  // Reset when new data arrives so another page can be requested
   const currentItemCount = items?.length ?? 0;
   const prevItemCount = usePrevious(currentItemCount);
   useEffect(() => {
@@ -199,20 +178,16 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
     const scrollElement = scrollRef.current;
     if (!scrollElement) return;
 
-    // Track if effect is still active to prevent stale callback execution
     let isActive = true;
 
     const checkLoadMore = () => {
-      // Guard against stale execution after unmount
       if (!isActive) return;
-
       if (loadMoreTriggeredRef.current) return;
 
       const rows = virtualizer.getVirtualItems();
       const lastRow = rows.at(-1);
       if (!lastRow) return;
 
-      // Trigger load when within threshold items of end (balances UX with network efficiency)
       const LOAD_MORE_THRESHOLD = 10;
       if (lastRow.index >= virtualItems.length - LOAD_MORE_THRESHOLD) {
         loadMoreTriggeredRef.current = true;
@@ -222,7 +197,6 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
 
     scrollElement.addEventListener("scroll", checkLoadMore, { passive: true });
 
-    // Initial check after layout settles (100ms is typical for initial render)
     const INITIAL_CHECK_DELAY_MS = 100;
     const timeoutId = setTimeout(checkLoadMore, INITIAL_CHECK_DELAY_MS);
 
@@ -233,7 +207,6 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
     };
   }, [scrollRef, virtualItems.length, hasNextPage, isFetchingNextPage, virtualizer, onLoadMoreRef]);
 
-  // Get item for a virtual row index
   const getItem = useCallback(
     (index: number) => {
       const item = virtualItems[index];
@@ -246,7 +219,6 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
     [virtualItems],
   );
 
-  // Count total data rows (excluding section headers)
   const totalRowCount = useMemo(() => {
     if (sections) {
       return sections.reduce((sum, s) => sum + s.items.length, 0);
@@ -254,12 +226,11 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
     return items?.length ?? 0;
   }, [items, sections]);
 
-  // Scroll to a specific index
   const scrollToIndex = useCallback(
     (index: number, options?: { align?: "start" | "center" | "end" | "auto" }) => {
       virtualizer.scrollToIndex(index, {
         align: options?.align ?? "auto",
-        behavior: "auto", // instant for keyboard nav
+        behavior: "auto",
       });
     },
     [virtualizer],
@@ -271,7 +242,7 @@ export function useVirtualizedTable<T, TSectionMeta = unknown>({
     totalRowCount,
     virtualItemCount: virtualItems.length,
     getItem,
-    measure: () => virtualizer.measure(),
+    measure,
     scrollToIndex,
     measureElement: virtualizer.measureElement,
   };

--- a/src/ui/src/components/data-table/styles.css
+++ b/src/ui/src/components/data-table/styles.css
@@ -57,6 +57,10 @@
   align-items: stretch;
   will-change: transform;
   backface-visibility: hidden;
+  /* Smooth repositioning when a preceding row changes height (e.g. ExpandableChips expand).
+     Disabled during active scroll (.is-scrolling) to prevent virtualized rows from animating
+     as they enter the viewport — only expand/collapse-driven position changes are animated. */
+  transition: transform var(--duration-normal) var(--ease-out);
   /* Subtle fade-in prevents jarring "pop" when rows appear during fast scroll */
   animation: row-fade-in var(--duration-quick) var(--ease-out);
 
@@ -99,6 +103,21 @@
   align-items: center;
   flex: 1;
   padding: 0;
+}
+
+/* Suppress position transition during active scroll — virtualized rows must snap to position
+   when entering/leaving the viewport. The .is-scrolling class is toggled by DataTable. */
+.is-scrolling .data-table-row {
+  transition: none;
+}
+
+/* Interactive rows: pointer cursor + hover highlight */
+.data-table-row[data-interactive] {
+  cursor: pointer;
+}
+
+.data-table-row[data-interactive]:hover {
+  @apply bg-zinc-50 dark:bg-zinc-900;
 }
 
 /* Focus state for group rows */

--- a/src/ui/src/components/data-table/virtual-table-body.tsx
+++ b/src/ui/src/components/data-table/virtual-table-body.tsx
@@ -14,16 +14,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * VirtualTableBody
- *
- * Virtualized <tbody> using native table elements.
- * Renders only visible rows with absolute positioning for performance.
- */
-
 "use client";
 
 import { memo, useCallback, useRef } from "react";
+import { flushSync } from "react-dom";
+import { useSyncedRef } from "@react-hookz/web";
 import { flexRender, type Row } from "@tanstack/react-table";
 import { cn } from "@/lib/utils";
 import type { VirtualizedRow } from "@/components/data-table/hooks/use-virtualized-table";
@@ -31,59 +26,31 @@ import type { Section } from "@/components/data-table/types";
 import { getColumnCSSValue } from "@/components/data-table/utils/column-sizing";
 import { VirtualItemTypes } from "@/components/data-table/constants";
 
-// =============================================================================
-// Types
-// =============================================================================
-
 export interface VirtualTableBodyProps<TData, TSectionMeta = unknown> {
-  /** Virtual rows to render */
   virtualRows: VirtualizedRow[];
-  /** Total height of all rows */
   totalHeight: number;
-  /** Get table row by virtual index */
   getTableRow: (index: number) => Row<TData> | undefined;
-  /** Get item info by virtual index (for sections) */
   getItem: (
     index: number,
   ) => { type: "section"; section: Section<TData, TSectionMeta> } | { type: "row"; item: TData } | null;
-  /** Number of columns (for section header colSpan) */
   columnCount: number;
-  /** Row click handler */
   onRowClick?: (item: TData, index: number) => void;
-  /** Row double-click handler */
   onRowDoubleClick?: (item: TData, index: number) => void;
-  /**
-   * Get the href for a row (if clicking navigates to a page).
-   * Used for middle-click behavior:
-   * - If getRowHref returns a URL → middle-click opens in new tab
-   * - If getRowHref returns undefined or is not provided → middle-click calls onRowClick (shows overlay)
-   */
+  /** Returns URL for middle-click "open in new tab", or undefined to fall back to onRowClick */
   getRowHref?: (item: TData) => string | undefined;
-  /** Selected row ID */
   selectedRowId?: string;
-  /** Get row ID for comparison */
   getRowId?: (item: TData) => string;
-  /** Custom row class name */
-  rowClassName?: string | ((item: TData) => string);
-  /** Custom section row class name (for zebra striping, borders, etc.) */
+  rowClassName?: string | ((item: TData, index: number) => string);
   sectionClassName?: string | ((section: Section<TData, TSectionMeta>) => string);
-  /** Render custom section header */
   renderSectionHeader?: (section: Section<TData, TSectionMeta>) => React.ReactNode;
-  /** Get tabIndex for a row (roving tabindex pattern) */
   getRowTabIndex?: (index: number) => 0 | -1;
-  /** Row focus handler */
   onRowFocus?: (index: number) => void;
-  /** Row keydown handler */
   onRowKeyDown?: (e: React.KeyboardEvent, index: number) => void;
-  /** Ref callback for dynamic row measurement */
   measureElement?: (node: Element | null) => void;
-  /** Compact mode - reduces cell padding */
   compact?: boolean;
+  /** Whether a given row should show hover/pointer styles. Defaults to !!onRowClick for all rows. */
+  isRowInteractive?: (row: TData) => boolean;
 }
-
-// =============================================================================
-// Component
-// =============================================================================
 
 function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
   virtualRows,
@@ -104,20 +71,32 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
   onRowKeyDown,
   measureElement,
   compact = false,
+  isRowInteractive,
 }: VirtualTableBodyProps<TData, TSectionMeta>) {
-  /**
-   * Stores the row item resolved at mousedown time (first click of a potential
-   * double-click). Used as a fallback in handleTbodyDoubleClick when the
-   * virtualizer has remounted rows between the first click and the dblclick
-   * event (e.g. because opening a slideout panel narrowed the table).
-   */
+  // Fallback for dblclick when virtualizer remounts rows between clicks
   const lastMouseDownItemRef = useRef<{ item: TData; index: number } | null>(null);
 
-  /**
-   * Resolve row data from a delegated event target.
-   * Walks up the DOM to find the row element, parses its index,
-   * and returns the row item if it's a data row (not a section header).
-   */
+  // Stable ref: TV recreates measureElement every render by design
+  const measureElementRef = useSyncedRef(measureElement);
+
+  // Registers row with TV and attaches a supplemental ResizeObserver that
+  // wraps measureElement in flushSync. This captures TV's onChange(sync=false)
+  // dispatch synchronously, so row positions are correct before paint.
+  const makeRowRef = useCallback(
+    (node: HTMLTableRowElement | null): void | (() => void) => {
+      if (!node) return;
+      measureElementRef.current?.(node);
+      const observer = new ResizeObserver(() => {
+        flushSync(() => {
+          measureElementRef.current?.(node);
+        });
+      });
+      observer.observe(node, { box: "border-box" });
+      return () => observer.disconnect();
+    },
+    [measureElementRef],
+  );
+
   const resolveRowItem = useCallback(
     (target: HTMLElement): { item: TData; index: number } | null => {
       const row = target.closest<HTMLTableRowElement>('[role="row"][data-index]');
@@ -134,13 +113,9 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
     (e: React.MouseEvent<HTMLTableSectionElement>) => {
       if (!onRowClick && !getRowHref) return;
 
-      // When a double-click handler is registered, skip the second click
-      // (detail >= 2) of a multi-click sequence. Without this guard the second
-      // click fires onRowClick → startViewTransition a second time, and the
-      // resulting document.startViewTransition competes with the one triggered
-      // by the immediately-following dblclick event. The browser cannot
-      // reliably run two overlapping view-transition update callbacks, so the
-      // dblclick's router.push never executes.
+      // Skip the second click of a multi-click sequence when dblclick is handled,
+      // otherwise two competing startViewTransition calls cause the dblclick's
+      // router.push to never execute.
       if (onRowDoubleClick && e.detail >= 2) return;
 
       const resolved = resolveRowItem(e.target as HTMLElement);
@@ -203,9 +178,6 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
   const handleTbodyMouseDown = useCallback(
     (e: React.MouseEvent<HTMLTableSectionElement>) => {
       if (!onRowDoubleClick) return;
-      // Only capture on the first press of a potential double-click (detail=1).
-      // This is used as a fallback in handleTbodyDoubleClick in case the
-      // virtualizer remounts rows between the first click and the dblclick event.
       if (e.detail !== 1) return;
       lastMouseDownItemRef.current = resolveRowItem(e.target as HTMLElement);
     },
@@ -215,8 +187,7 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
   const handleTbodyDoubleClick = useCallback(
     (e: React.MouseEvent<HTMLTableSectionElement>) => {
       if (!onRowDoubleClick) return;
-      // Fall back to the item captured at mousedown if the target element is no
-      // longer in the DOM (e.g. virtualizer remounted rows while panel opened).
+      // Fall back to mousedown capture if virtualizer remounted rows between clicks
       const resolved = resolveRowItem(e.target as HTMLElement) ?? lastMouseDownItemRef.current;
       if (!resolved) return;
       onRowDoubleClick(resolved.item, resolved.index);
@@ -242,7 +213,6 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
         if (!item) return null;
 
         if (item.type === VirtualItemTypes.SECTION) {
-          // Render section header content
           const sectionContent = renderSectionHeader ? (
             renderSectionHeader(item.section)
           ) : (
@@ -258,17 +228,14 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
             </td>
           );
 
-          // Skip rendering entire row if renderSectionHeader returns null
-          // (e.g., for single-task groups that don't need a section header)
+          // renderSectionHeader can return null to skip headers (e.g. single-item groups)
           if (sectionContent === null) {
             return null;
           }
 
-          // Calculate custom class name for section row (zebra striping, borders)
           const customSectionClassName =
             typeof sectionClassName === "function" ? sectionClassName(item.section) : sectionClassName;
 
-          // Use index in key to guarantee uniqueness in virtualized list
           return (
             <tr
               key={`section-${virtualRow.index}`}
@@ -278,7 +245,6 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
               className={cn("data-table-section-row sticky", customSectionClassName)}
               style={{
                 height: virtualRow.size,
-                // translate3d triggers GPU compositor layer for smoother animation
                 transform: `translate3d(0, ${virtualRow.start}px, 0)`,
               }}
             >
@@ -294,25 +260,25 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
         const rowId = getRowId?.(rowData);
         const isSelected = selectedRowId && rowId === selectedRowId;
 
-        const customClassName = typeof rowClassName === "function" ? rowClassName(rowData) : rowClassName;
+        const customClassName =
+          typeof rowClassName === "function" ? rowClassName(rowData, virtualRow.index) : rowClassName;
 
-        // Keyboard navigation support
         const tabIndex = getRowTabIndex?.(virtualRow.index) ?? (onRowClick ? 0 : undefined);
+        const isInteractive = isRowInteractive ? isRowInteractive(rowData) : !!onRowClick;
 
-        // Use virtual index in key to guarantee uniqueness even with duplicate data
         return (
           <tr
             key={`row-${virtualRow.index}`}
-            ref={measureElement}
+            ref={makeRowRef}
             data-index={virtualRow.index}
             role="row"
             data-row-id={rowId}
+            data-interactive={isInteractive || undefined}
             aria-rowindex={virtualRow.index + 2}
             aria-selected={isSelected ? true : undefined}
             tabIndex={tabIndex}
             className={cn(
               "data-table-row border-b border-zinc-200 dark:border-zinc-800",
-              onRowClick && "cursor-pointer hover:bg-zinc-50 dark:hover:bg-zinc-900",
               isSelected && "bg-zinc-100 dark:bg-zinc-800",
               customClassName,
             )}
@@ -322,12 +288,7 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
             }}
           >
             {row.getVisibleCells().map((cell, cellIndex) => {
-              // Cache CSS variable string to avoid duplicate function calls
               const cssWidth = getColumnCSSValue(cell.column.id);
-
-              // Get cell className from column meta (if provided).
-              // This allows columns to inject their styling requirements
-              // without VirtualTableBody needing specific knowledge of column types.
               const cellClassName = cell.column.columnDef.meta?.cellClassName;
 
               return (
@@ -339,13 +300,9 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
                   style={{
                     width: cssWidth,
                     minWidth: cssWidth,
-                    flexShrink: 0, // Prevent shrinking below specified width
+                    flexShrink: 0,
                   }}
-                  className={cn(
-                    "flex items-center",
-                    // Use custom className if provided, otherwise apply default padding
-                    cellClassName ?? (compact ? "px-4 py-1.5" : "px-4 py-3"),
-                  )}
+                  className={cn("flex items-center", cellClassName ?? (compact ? "px-4 py-1.5" : "px-4 py-3"))}
                 >
                   {flexRender(cell.column.columnDef.cell, cell.getContext())}
                 </td>
@@ -358,5 +315,4 @@ function VirtualTableBodyInner<TData, TSectionMeta = unknown>({
   );
 }
 
-// Memo with generic support
 export const VirtualTableBody = memo(VirtualTableBodyInner) as typeof VirtualTableBodyInner;

--- a/src/ui/src/features/datasets/detail/components/file-browser-table.tsx
+++ b/src/ui/src/features/datasets/detail/components/file-browser-table.tsx
@@ -24,6 +24,7 @@
 "use client";
 
 import { useMemo, useCallback, memo, useRef, useEffect, useState } from "react";
+import { useSyncedRef } from "@react-hookz/web";
 import type { ColumnDef } from "@tanstack/react-table";
 import { Folder, File, FileText, FileImage, FileVideo, Copy, Database } from "lucide-react";
 import { DataTable } from "@/components/data-table/data-table";
@@ -351,10 +352,16 @@ export const FileBrowserTable = memo(function FileBrowserTable({
 
   const tableAreaRef = useRef<HTMLDivElement>(null);
 
-  // Auto-focus first row when data first loads or when the directory changes,
-  // but only if nothing else on the page currently has focus.
+  // Stable ref to sortedFiles — updated automatically by useSyncedRef without
+  // triggering re-renders. Lets the focus effect read the current length without
+  // including sortedFiles in the dependency array.
+  const sortedFilesRef = useSyncedRef(sortedFiles);
+
+  // Auto-focus first row when the user navigates to a new directory.
+  // Dep is `path` (not `sortedFiles`) so the effect only fires on directory change,
+  // not on every sort/filter update (which creates a new array reference each render).
   useEffect(() => {
-    if (sortedFiles.length === 0) return;
+    if (sortedFilesRef.current.length === 0) return;
 
     const activeEl = document.activeElement;
     const isBodyFocused = !activeEl || activeEl === document.body;
@@ -366,7 +373,7 @@ export const FileBrowserTable = memo(function FileBrowserTable({
       firstRow?.focus({ preventScroll: true });
     });
     return () => cancelAnimationFrame(raf);
-  }, [sortedFiles]);
+  }, [path, sortedFilesRef]);
 
   // Handle directory navigation and selection shortcuts
   const handleKeyDown = useCallback(

--- a/src/ui/src/features/datasets/list/components/table/datasets-data-table.tsx
+++ b/src/ui/src/features/datasets/list/components/table/datasets-data-table.tsx
@@ -36,7 +36,7 @@ import { DataTable } from "@/components/data-table/data-table";
 import { TableEmptyState } from "@/components/data-table/table-empty-state";
 import { TableLoadingSkeleton, TableErrorState } from "@/components/data-table/table-states";
 import { useColumnVisibility } from "@/components/data-table/hooks/use-column-visibility";
-import type { ColumnSizingPreference, SortState } from "@/components/data-table/types";
+import type { SortState } from "@/components/data-table/types";
 import { useCompactMode } from "@/hooks/shared-preferences-hooks";
 import { TABLE_ROW_HEIGHTS } from "@/lib/config";
 import type { Dataset } from "@/lib/api/adapter/datasets";
@@ -88,6 +88,9 @@ export interface DatasetsDataTableProps {
 /** Stable row ID extractor */
 const getRowId = (dataset: Dataset) => `${dataset.bucket}-${dataset.name}`;
 
+// Module-level constant — stable reference, no useMemo needed
+const FIXED_COLUMNS = Array.from(MANDATORY_COLUMN_IDS);
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -126,28 +129,11 @@ export const DatasetsDataTable = memo(function DatasetsDataTable({
 
   const columns = useMemo(() => createDatasetColumns(openPanel), [openPanel]);
 
-  const fixedColumns = useMemo(() => Array.from(MANDATORY_COLUMN_IDS), []);
-
-  const handleColumnOrderChange = useCallback(
-    (newOrder: string[]) => {
-      setColumnOrder(newOrder);
-    },
-    [setColumnOrder],
-  );
-
-  // Handle column sizing preference change
-  const handleColumnSizingPreferenceChange = useCallback(
-    (columnId: string, preference: ColumnSizingPreference) => {
-      setColumnSizingPreference(columnId, preference);
-    },
-    [setColumnSizingPreference],
-  );
-
   // Row click navigates to dataset detail page
   const handleRowClick = useCallback(
     (dataset: Dataset) => {
       const detailPath = `/datasets/${encodeURIComponent(dataset.bucket)}/${encodeURIComponent(dataset.name)}`;
-      const currentUrl = pathname + window.location.search;
+      const currentUrl = pathname + (typeof window !== "undefined" ? window.location.search : "");
       setOrigin(detailPath, currentUrl);
       startTransition(() => {
         router.push(detailPath);
@@ -161,16 +147,9 @@ export const DatasetsDataTable = memo(function DatasetsDataTable({
     return `/datasets/${encodeURIComponent(dataset.bucket)}/${encodeURIComponent(dataset.name)}`;
   }, []);
 
-  // Augment datasets with visual row index for zebra striping
-  const datasetsWithIndex = useMemo(
-    () => datasets.map((dataset, index) => ({ ...dataset, _visualRowIndex: index })),
-    [datasets],
-  );
-
   // Row class for zebra striping
-  const rowClassName = useCallback((dataset: Dataset & { _visualRowIndex?: number }) => {
-    const visualIndex = dataset._visualRowIndex ?? 0;
-    return visualIndex % 2 === 0 ? "bg-white dark:bg-zinc-950" : "bg-gray-100/60 dark:bg-zinc-900/50";
+  const rowClassName = useCallback((_dataset: Dataset, index: number) => {
+    return index % 2 === 0 ? "bg-white dark:bg-zinc-950" : "bg-gray-100/60 dark:bg-zinc-900/50";
   }, []);
 
   const emptyContent = useMemo(() => <TableEmptyState message="No datasets found" />, []);
@@ -193,22 +172,22 @@ export const DatasetsDataTable = memo(function DatasetsDataTable({
 
   return (
     <div className="table-container relative flex h-full flex-col">
-      <DataTable<Dataset & { _visualRowIndex?: number }>
-        data={datasetsWithIndex}
+      <DataTable<Dataset>
+        data={datasets}
         columns={columns}
         getRowId={getRowId}
         // Column management
         columnOrder={columnOrder}
-        onColumnOrderChange={handleColumnOrderChange}
+        onColumnOrderChange={setColumnOrder}
         columnVisibility={columnVisibility}
-        fixedColumns={fixedColumns}
+        fixedColumns={FIXED_COLUMNS}
         // Sorting
         sorting={sorting}
         onSortingChange={onSortingChange}
         // Column sizing
         columnSizeConfigs={DATASET_COLUMN_SIZE_CONFIG}
         columnSizingPreferences={columnSizingPreferences}
-        onColumnSizingPreferenceChange={handleColumnSizingPreferenceChange}
+        onColumnSizingPreferenceChange={setColumnSizingPreference}
         // Pagination
         hasNextPage={hasNextPage}
         onLoadMore={onLoadMore}

--- a/src/ui/src/features/occupancy/components/occupancy-data-table.tsx
+++ b/src/ui/src/features/occupancy/components/occupancy-data-table.tsx
@@ -1,18 +1,18 @@
-//SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
-
-//Licensed under the Apache License, Version 2.0 (the "License");
-//you may not use this file except in compliance with the License.
-//You may obtain a copy of the License at
-
-//http://www.apache.org/licenses/LICENSE-2.0
-
-//Unless required by applicable law or agreed to in writing, software
-//distributed under the License is distributed on an "AS IS" BASIS,
-//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//See the License for the specific language governing permissions and
-//limitations under the License.
-
-//SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
 
 "use client";
 
@@ -36,6 +36,9 @@ import "@/features/occupancy/styles/occupancy.css";
 
 // Module-level constant — stable reference, no useMemo needed
 const FIXED_COLUMNS = Array.from(MANDATORY_COLUMN_IDS);
+
+// Parent rows are interactive (toggle expand); child rows are not
+const isOccupancyRowInteractive = (row: OccupancyFlatRow) => row._type === "parent";
 
 // =============================================================================
 // Helpers
@@ -125,10 +128,9 @@ export const OccupancyDataTable = memo(function OccupancyDataTable({
     [setSort],
   );
 
-  // Row click toggles expand on parent rows; no-op on children
   const handleRowClick = useCallback(
     (row: OccupancyFlatRow) => {
-      if (row._type === "parent") onToggleExpand(row.key);
+      if (isOccupancyRowInteractive(row)) onToggleExpand(row.key);
     },
     [onToggleExpand],
   );
@@ -192,6 +194,7 @@ export const OccupancyDataTable = memo(function OccupancyDataTable({
         // Interaction
         onRowClick={handleRowClick}
         rowClassName={rowClassName}
+        isRowInteractive={isOccupancyRowInteractive}
       />
     </div>
   );

--- a/src/ui/src/features/occupancy/styles/occupancy.css
+++ b/src/ui/src/features/occupancy/styles/occupancy.css
@@ -30,7 +30,7 @@
    Row Styles
    ============================================================================= */
 
-.occupancy-row {
+.occupancy-row:not(.occupancy-row--child) {
   @apply cursor-pointer transition-colors duration-75 ease-out;
 }
 
@@ -51,7 +51,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .occupancy-row {
+  .occupancy-row:not(.occupancy-row--child) {
     @apply transition-none;
   }
 }

--- a/src/ui/src/features/pools/components/table/pools-data-table.tsx
+++ b/src/ui/src/features/pools/components/table/pools-data-table.tsx
@@ -32,7 +32,7 @@ import { DataTable } from "@/components/data-table/data-table";
 import { TableEmptyState } from "@/components/data-table/table-empty-state";
 import { TableLoadingSkeleton, TableErrorState } from "@/components/data-table/table-states";
 import { useColumnVisibility } from "@/components/data-table/hooks/use-column-visibility";
-import type { SortState, ColumnSizingPreference } from "@/components/data-table/types";
+import type { SortState } from "@/components/data-table/types";
 import { useCompactMode } from "@/hooks/shared-preferences-hooks";
 import type { Pool } from "@/lib/api/adapter/types";
 import type { SearchChip } from "@/stores/types";
@@ -73,6 +73,9 @@ export interface PoolsDataTableProps {
 
 /** Stable row ID extractor */
 const getRowId = (pool: Pool) => pool.name;
+
+// Module-level constant — stable reference, no useMemo needed
+const FIXED_COLUMNS = Array.from(MANDATORY_COLUMN_IDS);
 
 // =============================================================================
 // Component
@@ -153,9 +156,6 @@ export const PoolsDataTable = memo(function PoolsDataTable({
     [compactMode, sharingMap, filterBySharedPoolsMap],
   );
 
-  // Fixed columns (not draggable)
-  const fixedColumns = useMemo(() => Array.from(MANDATORY_COLUMN_IDS), []);
-
   // Handle sort change
   const handleSortChange = useCallback(
     (newSort: SortState<string>) => {
@@ -166,22 +166,6 @@ export const PoolsDataTable = memo(function PoolsDataTable({
     [setSort],
   );
 
-  // Handle column order change
-  const handleColumnOrderChange = useCallback(
-    (newOrder: string[]) => {
-      setColumnOrder(newOrder);
-    },
-    [setColumnOrder],
-  );
-
-  // Handle column sizing preference change
-  const handleColumnSizingPreferenceChange = useCallback(
-    (columnId: string, preference: ColumnSizingPreference) => {
-      setColumnSizingPreference(columnId, preference);
-    },
-    [setColumnSizingPreference],
-  );
-
   // Handle row click - call onPoolSelect with pool name
   const handleRowClick = useCallback(
     (pool: Pool) => {
@@ -190,19 +174,12 @@ export const PoolsDataTable = memo(function PoolsDataTable({
     [onPoolSelect],
   );
 
-  // Augment pools with visual row index for zebra striping
-  const poolsWithIndex = useMemo(
-    () => sortedPools.map((pool, index) => ({ ...pool, _visualRowIndex: index })),
-    [sortedPools],
-  );
-
   // Row class for status styling + zebra striping
   const rowClassName = useCallback(
-    (pool: Pool & { _visualRowIndex?: number }) => {
+    (pool: Pool, index: number) => {
       const { category } = getStatusDisplay(pool.status);
       const isSelected = selectedPoolName === pool.name;
-      const visualIndex = pool._visualRowIndex ?? 0;
-      const zebraClass = visualIndex % 2 === 0 ? "bg-white dark:bg-zinc-950" : "bg-gray-100/60 dark:bg-zinc-900/50";
+      const zebraClass = index % 2 === 0 ? "bg-white dark:bg-zinc-950" : "bg-gray-100/60 dark:bg-zinc-900/50";
       return ["pools-row", `pools-row--${category}`, isSelected && "pools-row--selected", zebraClass]
         .filter(Boolean)
         .join(" ");
@@ -236,19 +213,19 @@ export const PoolsDataTable = memo(function PoolsDataTable({
 
   return (
     <div className="pools-table-container table-container relative h-full">
-      <DataTable<Pool & { _visualRowIndex?: number }>
-        data={poolsWithIndex}
+      <DataTable<Pool>
+        data={sortedPools}
         columns={columns}
         getRowId={getRowId}
         // Column management
         columnOrder={columnOrder}
-        onColumnOrderChange={handleColumnOrderChange}
+        onColumnOrderChange={setColumnOrder}
         columnVisibility={columnVisibility}
-        fixedColumns={fixedColumns}
+        fixedColumns={FIXED_COLUMNS}
         // Column sizing
         columnSizeConfigs={POOL_COLUMN_SIZE_CONFIG}
         columnSizingPreferences={columnSizingPreferences}
-        onColumnSizingPreferenceChange={handleColumnSizingPreferenceChange}
+        onColumnSizingPreferenceChange={setColumnSizingPreference}
         // Sorting
         sorting={sortState ?? undefined}
         onSortingChange={handleSortChange}

--- a/src/ui/src/features/resources/components/table/resources-data-table.tsx
+++ b/src/ui/src/features/resources/components/table/resources-data-table.tsx
@@ -28,7 +28,7 @@ import { DataTable } from "@/components/data-table/data-table";
 import { TableEmptyState } from "@/components/data-table/table-empty-state";
 import { TableLoadingSkeleton, TableErrorState } from "@/components/data-table/table-states";
 import { useColumnVisibility } from "@/components/data-table/hooks/use-column-visibility";
-import type { SortState, ColumnSizingPreference } from "@/components/data-table/types";
+import type { SortState } from "@/components/data-table/types";
 import type { DisplayMode } from "@/stores/shared-preferences-store";
 import { useDisplayMode, useCompactMode } from "@/hooks/shared-preferences-hooks";
 import type { Resource } from "@/lib/api/adapter/types";
@@ -48,6 +48,9 @@ import { naturalCompare } from "@/lib/utils";
 
 /** Stable row ID extractor - defined outside component to avoid recreating */
 const getRowId = (resource: Resource) => resource.name;
+
+// Module-level constant — stable reference, no useMemo needed
+const FIXED_COLUMNS = Array.from(MANDATORY_COLUMN_IDS);
 
 /**
  * Sort resources by column and direction.
@@ -184,18 +187,7 @@ export const ResourcesDataTable = memo(function ResourcesDataTable({
     [displayMode],
   );
 
-  // Fixed columns (not draggable)
-  const fixedColumns = useMemo(() => Array.from(MANDATORY_COLUMN_IDS), []);
-
-  // Handle column sizing preference change
-  const handleColumnSizingPreferenceChange = useCallback(
-    (columnId: string, preference: ColumnSizingPreference) => {
-      setColumnSizingPreference(columnId, preference);
-    },
-    [setColumnSizingPreference],
-  );
-
-  // Handle sort change - simply pass the column to the store
+  // Handle sort change
   const handleSortChange = useCallback(
     (newSort: SortState<string>) => {
       if (newSort.column) {
@@ -205,24 +197,9 @@ export const ResourcesDataTable = memo(function ResourcesDataTable({
     [setSort],
   );
 
-  // Handle column order change
-  const handleColumnOrderChange = useCallback(
-    (newOrder: string[]) => {
-      setColumnOrder(newOrder);
-    },
-    [setColumnOrder],
-  );
-
-  // Augment resources with visual row index for zebra striping
-  const resourcesWithIndex = useMemo(
-    () => sortedResources.map((resource, index) => ({ ...resource, _visualRowIndex: index })),
-    [sortedResources],
-  );
-
   // Row class for zebra striping
-  const rowClassName = useCallback((resource: Resource & { _visualRowIndex?: number }) => {
-    const visualIndex = resource._visualRowIndex ?? 0;
-    return visualIndex % 2 === 0 ? "bg-white dark:bg-zinc-950" : "bg-gray-100/60 dark:bg-zinc-900/50";
+  const rowClassName = useCallback((_resource: Resource, index: number) => {
+    return index % 2 === 0 ? "bg-white dark:bg-zinc-950" : "bg-gray-100/60 dark:bg-zinc-900/50";
   }, []);
 
   const emptyContent = useMemo(() => <TableEmptyState message="No resources found" />, []);
@@ -245,19 +222,19 @@ export const ResourcesDataTable = memo(function ResourcesDataTable({
 
   return (
     <div className="table-container relative flex h-full flex-col">
-      <DataTable<Resource & { _visualRowIndex?: number }>
-        data={resourcesWithIndex}
+      <DataTable<Resource>
+        data={sortedResources}
         columns={columns}
         getRowId={getRowId}
         // Column management
         columnOrder={columnOrder}
-        onColumnOrderChange={handleColumnOrderChange}
+        onColumnOrderChange={setColumnOrder}
         columnVisibility={columnVisibility}
-        fixedColumns={fixedColumns}
+        fixedColumns={FIXED_COLUMNS}
         // Column sizing
         columnSizeConfigs={RESOURCE_COLUMN_SIZE_CONFIG}
         columnSizingPreferences={columnSizingPreferences}
-        onColumnSizingPreferenceChange={handleColumnSizingPreferenceChange}
+        onColumnSizingPreferenceChange={setColumnSizingPreference}
         // Sorting
         sorting={sortState ?? undefined}
         onSortingChange={handleSortChange}

--- a/src/ui/src/features/workflows/detail/components/panel/ui/group/group-tasks-tab.tsx
+++ b/src/ui/src/features/workflows/detail/components/panel/ui/group/group-tasks-tab.tsx
@@ -24,12 +24,12 @@
 "use client";
 
 import { useState, useMemo, useCallback, memo } from "react";
-import { naturalCompare } from "@/lib/utils";
 import { DataTable } from "@/components/data-table/data-table";
 import { TableToolbar } from "@/components/data-table/table-toolbar";
+import { useColumnVisibility } from "@/components/data-table/hooks/use-column-visibility";
 import type { SortState } from "@/components/data-table/types";
 import { useCompactMode } from "@/hooks/shared-preferences-hooks";
-import { STATUS_SORT_ORDER } from "@/features/workflows/detail/lib/status";
+import { createTaskSortComparator } from "@/features/workflows/detail/lib/status";
 import type { TaskWithDuration, GroupWithLayout } from "@/features/workflows/detail/lib/workflow-types";
 import type { TaskQueryResponse } from "@/features/workflows/detail/lib/workflow-types";
 import {
@@ -118,68 +118,25 @@ export const GroupTasksTab = memo(function GroupTasksTab({
     const cols = createTaskColumns({
       renderTaskNameCell: (props) => <TaskNameCell {...props} />,
     });
-    // Find name column and remove custom headerClassName
-    const nameColumn = cols.find((col) => col.id === "name");
-    if (nameColumn?.meta) {
-      delete nameColumn.meta.headerClassName;
-    }
-    return cols;
+    // Return immutable-mapped columns, removing headerClassName from name column
+    return cols.map((col) =>
+      col.id === "name" && col.meta?.headerClassName !== undefined
+        ? { ...col, meta: { ...col.meta, headerClassName: undefined } }
+        : col,
+    );
   }, []);
 
   // Fixed columns (not draggable)
   const fixedColumns = useMemo(() => Array.from(MANDATORY_COLUMN_IDS), []);
 
   // Column visibility map for TanStack
-  const columnVisibility = useMemo(() => {
-    const visibility: Record<string, boolean> = {};
-    columnOrder.forEach((id) => {
-      visibility[id] = false;
-    });
-    visibleColumnIds.forEach((id) => {
-      visibility[id] = true;
-    });
-    return visibility;
-  }, [columnOrder, visibleColumnIds]);
+  const columnVisibility = useColumnVisibility(columnOrder, visibleColumnIds);
 
-  // Sort comparator for client-side sorting
-  const sortComparator = useMemo(() => {
-    const column = sort?.column;
-    const direction = sort?.direction;
-    if (!column) return null;
-    const dir = direction === "asc" ? 1 : -1;
-
-    switch (column) {
-      case "status":
-        return (a: TaskWithDuration, b: TaskWithDuration) =>
-          ((STATUS_SORT_ORDER[a.status] ?? 99) - (STATUS_SORT_ORDER[b.status] ?? 99)) * dir;
-      case "name":
-        return (a: TaskWithDuration, b: TaskWithDuration) => naturalCompare(a.name, b.name) * dir;
-      case "duration":
-        return (a: TaskWithDuration, b: TaskWithDuration) => ((a.duration ?? 0) - (b.duration ?? 0)) * dir;
-      case "node":
-        return (a: TaskWithDuration, b: TaskWithDuration) => naturalCompare(a.node_name ?? "", b.node_name ?? "") * dir;
-      case "podIp":
-        return (a: TaskWithDuration, b: TaskWithDuration) => naturalCompare(a.pod_ip ?? "", b.pod_ip ?? "") * dir;
-      case "exitCode":
-        return (a: TaskWithDuration, b: TaskWithDuration) => ((a.exit_code ?? -1) - (b.exit_code ?? -1)) * dir;
-      case "startTime":
-        return (a: TaskWithDuration, b: TaskWithDuration) => {
-          const aTime = a.start_time ? new Date(a.start_time).getTime() : 0;
-          const bTime = b.start_time ? new Date(b.start_time).getTime() : 0;
-          return (aTime - bTime) * dir;
-        };
-      case "endTime":
-        return (a: TaskWithDuration, b: TaskWithDuration) => {
-          const aTime = a.end_time ? new Date(a.end_time).getTime() : 0;
-          const bTime = b.end_time ? new Date(b.end_time).getTime() : 0;
-          return (aTime - bTime) * dir;
-        };
-      case "retry":
-        return (a: TaskWithDuration, b: TaskWithDuration) => (a.retry_id - b.retry_id) * dir;
-      default:
-        return null;
-    }
-  }, [sort]);
+  // Sort comparator (shared with WorkflowTasksTable via createTaskSortComparator)
+  const sortComparator = useMemo(
+    () => createTaskSortComparator<TaskWithDuration>(sort?.column, sort?.direction),
+    [sort],
+  );
 
   // Filter and sort tasks
   const filteredTasks = useMemo(() => {
@@ -190,23 +147,12 @@ export const GroupTasksTab = memo(function GroupTasksTab({
     return result;
   }, [tasksWithDuration, searchChips, sortComparator]);
 
-  // Static presets for state filtering
-  const taskPresets = TASK_PRESETS;
-
   // Results count for FilterBar display
   const resultsCount = useResultsCount({
     total: totalTasks,
     filteredTotal: filteredTasks.length,
     hasActiveFilters: searchChips.length > 0,
   });
-
-  // Callbacks
-  const handleColumnOrderChange = useCallback(
-    (newOrder: string[]) => {
-      setColumnOrder(newOrder);
-    },
-    [setColumnOrder],
-  );
 
   const handleSortChange = useCallback(
     (newSort: SortState<string>) => {
@@ -235,12 +181,6 @@ export const GroupTasksTab = memo(function GroupTasksTab({
     [],
   );
 
-  // Convert store sort to DataTable format
-  const tableSorting = useMemo<SortState<string> | undefined>(() => {
-    if (!sort) return undefined;
-    return { column: sort.column, direction: sort.direction };
-  }, [sort]);
-
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Toolbar: Search + Controls */}
@@ -255,7 +195,7 @@ export const GroupTasksTab = memo(function GroupTasksTab({
           onSearchChipsChange={setSearchChips}
           defaultField="name"
           placeholder="Filter by name, status:, ip:, duration:..."
-          searchPresets={taskPresets}
+          searchPresets={TASK_PRESETS}
           resultsCount={resultsCount}
         />
       </div>
@@ -267,7 +207,7 @@ export const GroupTasksTab = memo(function GroupTasksTab({
         getRowId={getRowId}
         // Column management
         columnOrder={columnOrder}
-        onColumnOrderChange={handleColumnOrderChange}
+        onColumnOrderChange={setColumnOrder}
         columnVisibility={columnVisibility}
         fixedColumns={fixedColumns}
         // Column sizing
@@ -275,7 +215,7 @@ export const GroupTasksTab = memo(function GroupTasksTab({
         suspendResize={isSuspended}
         registerLayoutStableCallback={registerLayoutStableCallback}
         // Sorting
-        sorting={tableSorting}
+        sorting={sort ?? undefined}
         onSortingChange={handleSortChange}
         // Layout
         rowHeight={rowHeight}

--- a/src/ui/src/features/workflows/detail/components/panel/ui/table/workflow-tasks-table.tsx
+++ b/src/ui/src/features/workflows/detail/components/panel/ui/table/workflow-tasks-table.tsx
@@ -29,9 +29,11 @@
 "use client";
 
 import { useMemo, useCallback, useState, memo, useRef } from "react";
+import { useSyncedRef } from "@react-hookz/web";
 import { naturalCompare } from "@/lib/utils";
 import { DataTable } from "@/components/data-table/data-table";
 import { TableToolbar } from "@/components/data-table/table-toolbar";
+import { useColumnVisibility } from "@/components/data-table/hooks/use-column-visibility";
 import type { Section, SortState } from "@/components/data-table/types";
 import { useCompactMode } from "@/hooks/shared-preferences-hooks";
 import { TABLE_ROW_HEIGHTS } from "@/lib/config";
@@ -45,7 +47,7 @@ import {
 
 import { calculateTaskDuration } from "@/features/workflows/detail/lib/workflow-types";
 import { TaskGroupStatus } from "@/lib/api/generated";
-import { computeTaskStats, STATUS_SORT_ORDER } from "@/features/workflows/detail/lib/status";
+import { computeTaskStats, createTaskSortComparator } from "@/features/workflows/detail/lib/status";
 import { createTaskColumns } from "@/features/workflows/detail/components/panel/core/lib/task-column-defs";
 import {
   TASK_WITH_TREE_COLUMN_SIZE_CONFIG,
@@ -69,6 +71,13 @@ import type {
   TaskQueryResponse,
   TaskWithDuration,
 } from "@/features/workflows/detail/lib/workflow-types";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Fixed columns (not draggable) — tree column must be first */
+const FIXED_COLUMNS = ["_tree", ...Array.from(MANDATORY_COLUMN_IDS)];
 
 // =============================================================================
 // Types
@@ -164,52 +173,34 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
     return map;
   }, [groups]);
 
-  // Sort comparator (same as GroupDetails)
-  const sortComparator = useMemo(() => {
-    const column = sort?.column;
-    const direction = sort?.direction;
-    if (!column) return null;
-    const dir = direction === "asc" ? 1 : -1;
-
-    switch (column) {
-      case "status":
-        return (a: TaskWithDuration, b: TaskWithDuration) =>
-          ((STATUS_SORT_ORDER[a.status] ?? 99) - (STATUS_SORT_ORDER[b.status] ?? 99)) * dir;
-      case "name":
-        return (a: TaskWithDuration, b: TaskWithDuration) => naturalCompare(a.name, b.name) * dir;
-      case "duration":
-        return (a: TaskWithDuration, b: TaskWithDuration) => ((a.duration ?? 0) - (b.duration ?? 0)) * dir;
-      case "node":
-        return (a: TaskWithDuration, b: TaskWithDuration) => naturalCompare(a.node_name ?? "", b.node_name ?? "") * dir;
-      case "podIp":
-        return (a: TaskWithDuration, b: TaskWithDuration) => naturalCompare(a.pod_ip ?? "", b.pod_ip ?? "") * dir;
-      case "exitCode":
-        return (a: TaskWithDuration, b: TaskWithDuration) => ((a.exit_code ?? -1) - (b.exit_code ?? -1)) * dir;
-      case "startTime":
-        return (a: TaskWithDuration, b: TaskWithDuration) => {
-          const aTime = a.start_time ? new Date(a.start_time).getTime() : 0;
-          const bTime = b.start_time ? new Date(b.start_time).getTime() : 0;
-          return (aTime - bTime) * dir;
-        };
-      case "endTime":
-        return (a: TaskWithDuration, b: TaskWithDuration) => {
-          const aTime = a.end_time ? new Date(a.end_time).getTime() : 0;
-          const bTime = b.end_time ? new Date(b.end_time).getTime() : 0;
-          return (aTime - bTime) * dir;
-        };
-      case "retry":
-        return (a: TaskWithDuration, b: TaskWithDuration) => (a.retry_id - b.retry_id) * dir;
-      default:
-        return null;
-    }
-  }, [sort]);
+  // Sort comparator (shared with GroupTasksTab via createTaskSortComparator)
+  const sortComparator = useMemo(
+    () => createTaskSortComparator<TaskWithDuration>(sort?.column, sort?.direction),
+    [sort],
+  );
 
   // Calculate total task count
   const totalTasks = useMemo(() => {
     return groups.reduce((sum, group) => sum + (group.tasks?.length ?? 0), 0);
   }, [groups]);
 
-  // Flatten all tasks for TableToolbar (needed for data prop)
+  // Flatten all tasks for TableToolbar search index — no `now` dep so the index
+  // only rebuilds when the task *list* changes, not every tick.
+  const allTasksForToolbar = useMemo(() => {
+    const tasks: TaskWithDuration[] = [];
+    for (const group of groups) {
+      for (const task of group.tasks || []) {
+        tasks.push({
+          ...task,
+          duration: calculateTaskDuration(task.start_time, task.end_time, task.status as TaskGroupStatus, 0),
+          _groupName: group.name,
+        });
+      }
+    }
+    return tasks;
+  }, [groups]);
+
+  // Flatten all tasks with live durations (for sections computation and live display)
   const allTasksWithDuration = useMemo(() => {
     const tasks: TaskWithDuration[] = [];
     for (const group of groups) {
@@ -217,14 +208,27 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
         tasks.push({
           ...task,
           duration: calculateTaskDuration(task.start_time, task.end_time, task.status as TaskGroupStatus, now),
+          _groupName: group.name,
         });
       }
     }
     return tasks;
   }, [groups, now]);
 
+  // Build a lookup map from allTasksWithDuration for use in sections (avoids re-computing durations)
+  const taskDurationMap = useMemo(() => {
+    const map = new Map<string, TaskWithDuration>();
+    for (const task of allTasksWithDuration) {
+      const key = `${task._groupName ?? ""}:${task.name}:${task.retry_id}`;
+      map.set(key, task);
+    }
+    return map;
+  }, [allTasksWithDuration]);
+
   // Transform groups into sections with computed metadata
   // Critical flow: Raw tasks → Filter → Sort → Calculate position (_isLastTask) → Render
+  // Reuses allTasksWithDuration (memoized with [groups, now]) via taskDurationMap to avoid
+  // recomputing durations inside this useMemo.
   const { sections, filteredTaskCount } = useMemo((): {
     sections: Section<TaskWithDuration, GroupSectionMeta>[];
     filteredTaskCount: number;
@@ -235,17 +239,16 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
       const totalTaskCount = taskArray.length;
       const isSingleTaskOriginal = totalTaskCount === 1;
 
-      // Build tasks with duration (status-aware calculation)
-      const buildTaskWithDuration = (task: (typeof taskArray)[0]): TaskWithDuration => ({
-        ...task,
-        duration: calculateTaskDuration(task.start_time, task.end_time, task.status as TaskGroupStatus, now),
-        _groupName: group.name,
-      });
+      // Look up task with live duration from the pre-computed map
+      const getTaskWithDuration = (task: (typeof taskArray)[0]): TaskWithDuration => {
+        const key = `${group.name}:${task.name}:${task.retry_id}`;
+        return taskDurationMap.get(key) ?? { ...task, duration: 0, _groupName: group.name };
+      };
 
       // ==== SINGLE-TASK GROUP ====
       if (isSingleTaskOriginal) {
         const singleTask = taskArray[0];
-        const taskWithDuration = buildTaskWithDuration(singleTask);
+        const taskWithDuration = getTaskWithDuration(singleTask);
 
         // Apply search filter
         const filteredArray = filterByChips([taskWithDuration], searchChips, TASK_SEARCH_FIELDS);
@@ -286,8 +289,8 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
 
       if (!isExpanded) {
         // Collapsed: check if ANY task matches the filter
-        const allTasksWithDuration = taskArray.map(buildTaskWithDuration);
-        const matchingTasks = filterByChips(allTasksWithDuration, searchChips, TASK_SEARCH_FIELDS);
+        const groupTasksWithDuration = taskArray.map(getTaskWithDuration);
+        const matchingTasks = filterByChips(groupTasksWithDuration, searchChips, TASK_SEARCH_FIELDS);
 
         if (matchingTasks.length === 0) {
           // No matching tasks: skip entire group (don't show group header)
@@ -301,7 +304,7 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
           items: [],
           metadata: {
             group,
-            stats: computeTaskStats(allTasksWithDuration),
+            stats: computeTaskStats(groupTasksWithDuration),
             taskCount: totalTaskCount,
             isSingleTask: false,
             skipGroupRow: false,
@@ -310,8 +313,8 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
         };
       }
 
-      // Expanded: build all tasks with duration
-      const tasksWithDuration = taskArray.map(buildTaskWithDuration);
+      // Expanded: get all tasks with live durations from the pre-computed map
+      const tasksWithDuration = taskArray.map(getTaskWithDuration);
 
       // Step 1: Apply search filtering
       const filteredTasks = filterByChips(tasksWithDuration, searchChips, TASK_SEARCH_FIELDS);
@@ -392,7 +395,7 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
     });
 
     return { sections: finalSections, filteredTaskCount: totalFiltered };
-  }, [groups, collapsedGroups, sortComparator, searchChips, now]);
+  }, [groups, taskDurationMap, collapsedGroups, sortComparator, searchChips]);
 
   // Results count for FilterBar display
   const resultsCount = useResultsCount({
@@ -435,25 +438,11 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
     return [treeColumn, ...baseColumns];
   }, []);
 
-  // Fixed columns (not draggable) - tree column must be first
-  const fixedColumns = useMemo(() => ["_tree", ...Array.from(MANDATORY_COLUMN_IDS)], []);
-
   // Ensure tree column is always first in the order
   const tableColumnOrder = useMemo(() => ["_tree", ...columnOrder], [columnOrder]);
 
-  // Column visibility map for TanStack
-  const columnVisibility = useMemo(() => {
-    const visibility: Record<string, boolean> = {
-      _tree: true, // Tree column is always visible
-    };
-    columnOrder.forEach((id) => {
-      visibility[id] = false;
-    });
-    visibleColumnIds.forEach((id) => {
-      visibility[id] = true;
-    });
-    return visibility;
-  }, [columnOrder, visibleColumnIds]);
+  // Column visibility map for TanStack — _tree is always visible, included in visibleIds
+  const columnVisibility = useColumnVisibility(tableColumnOrder, ["_tree", ...visibleColumnIds]);
 
   // Get row ID - includes group name for uniqueness
   const getRowId = useCallback((task: TaskWithDuration) => {
@@ -494,16 +483,22 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
     [handleToggleGroup],
   );
 
+  // Stable ref to always access the current groupMap in cached callbacks
+  const groupMapRef = useSyncedRef(groupMap);
+
   // Get or create stable details callback for a group
   const getDetailsCallback = useCallback(
     (group: GroupWithLayout) => {
       const groupId = group.name;
       if (!detailsCallbacksRef.current.has(groupId)) {
-        detailsCallbacksRef.current.set(groupId, () => onSelectGroup(group));
+        detailsCallbacksRef.current.set(groupId, () => {
+          const currentGroup = groupMapRef.current.get(groupId);
+          if (currentGroup) onSelectGroup(currentGroup);
+        });
       }
       return detailsCallbacksRef.current.get(groupId)!;
     },
-    [onSelectGroup],
+    [onSelectGroup, groupMapRef],
   );
 
   // Render section header (as a single td spanning all columns)
@@ -623,7 +618,7 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
       {/* Toolbar: Search + Controls */}
       <div className="border-b border-gray-200 px-4 py-3 dark:border-zinc-800">
         <TableToolbar
-          data={allTasksWithDuration}
+          data={allTasksForToolbar}
           searchFields={TASK_SEARCH_FIELDS}
           columns={OPTIONAL_COLUMNS_ALPHABETICAL}
           visibleColumnIds={visibleColumnIds}
@@ -648,7 +643,7 @@ export const WorkflowTasksTable = memo(function WorkflowTasksTable({
         columnOrder={tableColumnOrder}
         onColumnOrderChange={handleColumnOrderChange}
         columnVisibility={columnVisibility}
-        fixedColumns={fixedColumns}
+        fixedColumns={FIXED_COLUMNS}
         // Column sizing (includes tree column + task columns)
         columnSizeConfigs={TASK_WITH_TREE_COLUMN_SIZE_CONFIG}
         suspendResize={isSuspended}

--- a/src/ui/src/features/workflows/detail/lib/status-utils.ts
+++ b/src/ui/src/features/workflows/detail/lib/status-utils.ts
@@ -16,6 +16,7 @@
 
 // Pure status functions. Metadata generated from backend via `pnpm generate-api`.
 
+import { naturalCompare } from "@/lib/utils";
 import { TaskGroupStatus, WorkflowStatus } from "@/lib/api/generated";
 import {
   TASK_STATUS_METADATA,
@@ -346,4 +347,59 @@ export function computeGroupDuration(stats: TaskStats, now?: number): number | n
   const endTime = stats.hasRunning ? (now ?? Date.now()) : stats.latestEnd;
   if (endTime === null) return null;
   return Math.max(0, Math.floor((endTime - stats.earliestStart) / 1000));
+}
+
+// =============================================================================
+// Task Sort Comparator
+// =============================================================================
+
+/** Minimal shape required by the sort comparator (satisfied by TaskWithDuration) */
+interface SortableTask {
+  status: string;
+  name: string;
+  duration?: number | null;
+  node_name?: string | null;
+  pod_ip?: string | null;
+  exit_code?: number | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  retry_id: number;
+}
+
+/**
+ * Create a comparator for sorting tasks by the given column and direction.
+ * Returns null if the column is unknown or not provided.
+ *
+ * Shared by WorkflowTasksTable (tree view) and GroupTasksTab (flat view).
+ */
+export function createTaskSortComparator<T extends SortableTask>(
+  column: string | undefined,
+  direction: "asc" | "desc" | undefined,
+): ((a: T, b: T) => number) | null {
+  if (!column) return null;
+  const dir = direction === "asc" ? 1 : -1;
+
+  switch (column) {
+    case "status":
+      return (a, b) => ((STATUS_SORT_ORDER[a.status] ?? 99) - (STATUS_SORT_ORDER[b.status] ?? 99)) * dir;
+    case "name":
+      return (a, b) => naturalCompare(a.name, b.name) * dir;
+    case "duration":
+      return (a, b) => ((a.duration ?? 0) - (b.duration ?? 0)) * dir;
+    case "node":
+      return (a, b) => naturalCompare(a.node_name ?? "", b.node_name ?? "") * dir;
+    case "podIp":
+      return (a, b) => naturalCompare(a.pod_ip ?? "", b.pod_ip ?? "") * dir;
+    case "exitCode":
+      return (a, b) => ((a.exit_code ?? -1) - (b.exit_code ?? -1)) * dir;
+    case "startTime":
+      return (a, b) =>
+        ((a.start_time ? Date.parse(a.start_time) : 0) - (b.start_time ? Date.parse(b.start_time) : 0)) * dir;
+    case "endTime":
+      return (a, b) => ((a.end_time ? Date.parse(a.end_time) : 0) - (b.end_time ? Date.parse(b.end_time) : 0)) * dir;
+    case "retry":
+      return (a, b) => (a.retry_id - b.retry_id) * dir;
+    default:
+      return null;
+  }
 }

--- a/src/ui/src/features/workflows/detail/lib/status.tsx
+++ b/src/ui/src/features/workflows/detail/lib/status.tsx
@@ -47,6 +47,8 @@ export {
   computeTaskStats,
   computeGroupStatus,
   computeGroupDuration,
+  // Sort
+  createTaskSortComparator,
   // Constants
   STATUS_CATEGORY_MAP,
   STATUS_SORT_ORDER,

--- a/src/ui/src/features/workflows/list/components/table/workflows-data-table.tsx
+++ b/src/ui/src/features/workflows/list/components/table/workflows-data-table.tsx
@@ -36,7 +36,7 @@ import { DataTable } from "@/components/data-table/data-table";
 import { TableEmptyState } from "@/components/data-table/table-empty-state";
 import { TableLoadingSkeleton, TableErrorState } from "@/components/data-table/table-states";
 import { useColumnVisibility } from "@/components/data-table/hooks/use-column-visibility";
-import type { SortState, ColumnSizingPreference } from "@/components/data-table/types";
+import type { SortState } from "@/components/data-table/types";
 import { useCompactMode } from "@/hooks/shared-preferences-hooks";
 import { cn } from "@/lib/utils";
 import { TABLE_ROW_HEIGHTS } from "@/lib/config";
@@ -83,6 +83,9 @@ export interface WorkflowsDataTableProps {
 /** Stable row ID extractor */
 const getRowId = (workflow: WorkflowListEntry) => workflow.name;
 
+// Module-level constant — stable reference, no useMemo needed
+const FIXED_COLUMNS = Array.from(MANDATORY_COLUMN_IDS);
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -124,9 +127,6 @@ export const WorkflowsDataTable = memo(function WorkflowsDataTable({
   // Create TanStack columns
   const columns = useMemo(() => createWorkflowColumns(), []);
 
-  // Fixed columns (not draggable)
-  const fixedColumns = useMemo(() => Array.from(MANDATORY_COLUMN_IDS), []);
-
   // Handle sort change
   const handleSortChange = useCallback(
     (newSort: SortState<string>) => {
@@ -137,26 +137,10 @@ export const WorkflowsDataTable = memo(function WorkflowsDataTable({
     [setSort],
   );
 
-  // Handle column order change
-  const handleColumnOrderChange = useCallback(
-    (newOrder: string[]) => {
-      setColumnOrder(newOrder);
-    },
-    [setColumnOrder],
-  );
-
-  // Handle column sizing preference change
-  const handleColumnSizingPreferenceChange = useCallback(
-    (columnId: string, preference: ColumnSizingPreference) => {
-      setColumnSizingPreference(columnId, preference);
-    },
-    [setColumnSizingPreference],
-  );
-
   const handleRowClick = useCallback(
     (workflow: WorkflowListEntry) => {
       const detailPath = `/workflows/${encodeURIComponent(workflow.name)}`;
-      const currentUrl = pathname + window.location.search;
+      const currentUrl = pathname + (typeof window !== "undefined" ? window.location.search : "");
       setOrigin(detailPath, currentUrl);
       startTransition(() => {
         router.push(detailPath);
@@ -171,17 +155,10 @@ export const WorkflowsDataTable = memo(function WorkflowsDataTable({
     [],
   );
 
-  // Augment workflows with visual row index for zebra striping
-  const workflowsWithIndex = useMemo(
-    () => workflows.map((workflow, index) => ({ ...workflow, _visualRowIndex: index })),
-    [workflows],
-  );
-
   // Row class for status styling + zebra striping
-  const rowClassName = useCallback((workflow: WorkflowListEntry & { _visualRowIndex?: number }) => {
+  const rowClassName = useCallback((workflow: WorkflowListEntry, index: number) => {
     const { category } = getStatusDisplay(workflow.status);
-    const visualIndex = workflow._visualRowIndex ?? 0;
-    const zebraClass = visualIndex % 2 === 0 ? "bg-white dark:bg-zinc-950" : "bg-gray-100/60 dark:bg-zinc-900/50";
+    const zebraClass = index % 2 === 0 ? "bg-white dark:bg-zinc-950" : "bg-gray-100/60 dark:bg-zinc-900/50";
     return cn("workflows-row", `workflows-row--${category}`, zebraClass);
   }, []);
 
@@ -205,19 +182,19 @@ export const WorkflowsDataTable = memo(function WorkflowsDataTable({
 
   return (
     <div className="table-container relative flex h-full flex-col">
-      <DataTable<WorkflowListEntry & { _visualRowIndex?: number }>
-        data={workflowsWithIndex}
+      <DataTable<WorkflowListEntry>
+        data={workflows}
         columns={columns}
         getRowId={getRowId}
         // Column management
         columnOrder={columnOrder}
-        onColumnOrderChange={handleColumnOrderChange}
+        onColumnOrderChange={setColumnOrder}
         columnVisibility={columnVisibility}
-        fixedColumns={fixedColumns}
+        fixedColumns={FIXED_COLUMNS}
         // Column sizing
         columnSizeConfigs={WORKFLOW_COLUMN_SIZE_CONFIG}
         columnSizingPreferences={columnSizingPreferences}
-        onColumnSizingPreferenceChange={handleColumnSizingPreferenceChange}
+        onColumnSizingPreferenceChange={setColumnSizingPreference}
         // Sorting
         sorting={sortState ?? undefined}
         onSortingChange={handleSortChange}


### PR DESCRIPTION
## Description
- Fixes variable row height visual bug in data-tables. Prevents one row from clipping into another row.
- Run Claude `/simplify` and `code-simplifier` against data-table components
- Run `/react-doctor` against data-table components
- Upgrade to latest `tanstack/react-virtual`

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable row interactivity to control per-row hover and click behaviors.
  * Enhanced row measurement with ResizeObserver for improved virtualization.

* **Improvements**
  * Optimized column sizing state management and calculations.
  * Refined row positioning during scrolling for smoother interactions.
  * Improved section header rendering robustness.

* **Style**
  * Added hover effects for interactive rows.
  * Updated cursor styling to indicate interactive rows.

* **Dependencies**
  * Updated @tanstack/react-virtual from 3.13.12 to 3.13.21.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->