### PR TITLE
Speedup UpdateGroup Jobs

### DIFF
--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -24,6 +24,7 @@ import enum
 import json
 import logging
 import math
+import types
 import os
 import re
 import threading
@@ -446,15 +447,12 @@ class PostgresConnector:
                 cur = conn.cursor(
                     cursor_factory=psycopg2.extras.RealDictCursor)
                 cur.execute(command, args)
-                # Create a pydantic instance from dictionary pairs
                 rows = cur.fetchall()
                 if not return_raw:
-                    # Pydantic cannot deep copy memoryview object, so cast it to bytes object
+                    # Cast memoryview objects to bytes and provide attribute access
                     rows = [
-                        pydantic.create_model(
-                            'DynamicModel', **{k: common.handle_memoryview(v) or \
-                                               (Any, common.handle_memoryview(v))
-                                               for k, v in row.items()})()  # type: ignore
+                        types.SimpleNamespace(**{k: common.handle_memoryview(v)
+                                                for k, v in row.items()})
                         for row in rows]
                 cur.close()
                 conn.commit()

--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -855,7 +855,8 @@ class UpdateGroup(WorkflowJob):
 
         workflow_config = context.postgres.get_workflow_configs()
         backend_config_cache = connectors.BackendConfigCache()
-        workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, self.workflow_id)
+        workflow_obj = workflow.Workflow.fetch_from_db(
+            context.postgres, self.workflow_id, fetch_groups=False)
         total_timeout = task_common.calculate_total_timeout(
             workflow_obj.workflow_id,
             workflow_obj.timeout.queue_timeout, workflow_obj.timeout.exec_timeout)


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description

This PR optimizes our `UpdateGroup` job by:
- minimizing the amount of data the worker is fetching when calling `Workflow.fetch_from_db`
- replacing `pydantic.create_model()` with `types.SimpleNamespace`, which is much more lightweight and supports `.attribute` access

Here is the benchmark analysis, running a workflow with 50 tasks:

 | Category | Current Avg | New Avg | Change | Current Median | New Median | Change |
  |---|---|---|---|---|---|---|
  | UpdateGroup (SCHEDULING) | 1.553s | 0.864s | -44.4% | 1.543s | 0.851s | -44.8% |
  | UpdateGroup (INITIALIZING) | 2.222s | 1.556s | -30.0% | 2.191s | 1.563s | -28.7% |
  | UpdateGroup (RUNNING) | 2.223s | 1.705s | -23.3% | 2.210s | 1.670s | -24.4% |
  | UpdateGroup (COMPLETED) | 2.575s | 1.779s | -30.9% | 2.451s | 1.526s | -37.7% |

  Total UpdateGroup time: Current=428.7s vs New=300.1s (**-30.0%**)

Issue #411 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal data handling mechanisms for improved performance and reduced memory overhead.
  * Enhanced workflow data retrieval to streamline background job processing with more efficient resource utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->