### PR TITLE
#686 - Add verbose option for config show POOL

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -20,7 +20,6 @@ import argparse
 import enum
 import json
 import subprocess
-import sys
 from typing import Any, Dict, Literal, Set, TypedDict
 
 from src.cli import editor
@@ -357,6 +356,10 @@ def _run_show_command(service_client: client.ServiceClient, args: argparse.Names
     # Parse the config identifier
     if ':' in args.config:
         # Format is <CONFIG_TYPE>:<revision>
+        if args.verbose:
+            raise osmo_errors.OSMOUserError(
+                '--verbose is not supported for historical revisions'
+            )
         revision = config_history.ConfigHistoryRevision(args.config)
         params: Dict[str, Any] = {
             'config_types': [revision.config_type.value],
@@ -375,12 +378,11 @@ def _run_show_command(service_client: client.ServiceClient, args: argparse.Names
         data = result['configs'][0]['data']
     else:
         # Format is <CONFIG_TYPE>
-        verbose = args.verbose
-        if verbose and args.config != config_history.ConfigHistoryType.POOL.value:
-            print(f'Warning: --verbose is only supported for POOL configs, ignoring for {args.config}',
-                  file=sys.stderr)
-            verbose = False
-        request_params: Dict[str, Any] | None = {'verbose': True} if verbose else None
+        if args.verbose and args.config != config_history.ConfigHistoryType.POOL.value:
+            raise osmo_errors.OSMOUserError(
+                f'--verbose is only supported for POOL configs, not {args.config}'
+            )
+        request_params: Dict[str, Any] | None = {'verbose': True} if args.verbose else None
         data = _get_current_config(service_client, args.config, params=request_params)
 
     # Handle multiple name arguments for indexing


### PR DESCRIPTION
## Description
Add an option to show POOL config --verbose

Issue #686 

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--verbose` / `-v` option to the show command to produce enhanced output for POOL configurations.

* **Bug Fixes**
  * Prevented `--verbose` from being used with historical revisions and non-POOL types; now returns a clear error when invalid.
  * Verbose requests are correctly transmitted to the service to produce detailed POOL output.

* **Documentation**
  * Updated help and examples to clarify POOL-only verbose usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->