### PR TITLE
Pool Quota: Address Case when Pools have No Nodes

### DIFF
--- a/src/service/core/workflow/tests/test_calculate_pool_quotas.py
+++ b/src/service/core/workflow/tests/test_calculate_pool_quotas.py
@@ -454,6 +454,31 @@ class TestCalculatePoolQuotas(unittest.TestCase):
         self.assertEqual(usage.total_free, '0')
         self.assertEqual(usage.quota_limit, '0')
 
+    def test_multiple_pools_with_no_resources_same_backend(self):
+        """Multiple pools on the same backend with no nodes should each appear
+        as their own entry in the response, not silently overwrite each other."""
+        pool_configs = {
+            'pool-a': make_pool_config('pool-a', 'k8s-1'),
+            'pool-b': make_pool_config('pool-b', 'k8s-1'),
+            'pool-c': make_pool_config('pool-c', 'k8s-1'),
+        }
+
+        response = calculate_pool_quotas(pool_configs, [], [])
+
+        # All three pools should be present in the response
+        pool_names = {
+            pool.name
+            for node_set in response.node_sets
+            for pool in node_set.pools
+        }
+        self.assertEqual(pool_names, {'pool-a', 'pool-b', 'pool-c'})
+
+        for pool_name in ('pool-a', 'pool-b', 'pool-c'):
+            usage = get_pool_usage(response, pool_name)
+            self.assertEqual(usage.total_capacity, '0')
+            self.assertEqual(usage.total_free, '0')
+            self.assertEqual(usage.quota_limit, '0')
+
     def test_no_tasks(self):
         """No running tasks should show zero usage."""
         pool_configs = {'pool-a': make_pool_config('pool-a', 'k8s-1')}

--- a/src/service/core/workflow/workflow_service.py
+++ b/src/service/core/workflow/workflow_service.py
@@ -253,7 +253,11 @@ def calculate_pool_quotas(
         merged_nodes: frozenset[str] = frozenset().union(
             *(node_sets[pool].nodes for pool in component_pools)
         )
-        pools_by_nodeset[NodeSet(start_nodeset.backend, merged_nodes)] = component_pools
+        nodeset_key = NodeSet(start_nodeset.backend, merged_nodes)
+        if nodeset_key in pools_by_nodeset:
+            pools_by_nodeset[nodeset_key].extend(component_pools)
+        else:
+            pools_by_nodeset[nodeset_key] = component_pools
 
     gpu_usage_by_nodeset = {
         nodeset: sum((node_gpu_usage.get(node, NodeGpuUsage()) for node in nodeset.nodes),


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
This addresses the issue where pools with no nodes are not present in the response from `/api/pool_quota`.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quota calculation logic to properly handle and accumulate multiple resource pools assigned to the same backend, preventing previous pool data from being overwritten.

* **Tests**
  * Added comprehensive test coverage for scenarios with multiple pools on identical backends, ensuring each pool is independently represented in quota responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->