### PR TITLE
Migrate NodeListener from bidi streaming to unary RPC

### DIFF
--- a/src/operator/event_listener.go
+++ b/src/operator/event_listener.go
@@ -33,7 +33,7 @@ import (
 	pb "go.corp.nvidia.com/osmo/proto/operator"
 )
 
-// EventListener manages the bidirectional gRPC stream connection for Kubernetes events
+// EventListener manages unary RPC calls for Kubernetes events
 type EventListener struct {
 	*utils.BaseListener
 	args utils.ListenerArgs
@@ -51,12 +51,12 @@ func NewEventListener(args utils.ListenerArgs, inst *utils.Instruments) *EventLi
 	return el
 }
 
-// Run manages the bidirectional streaming lifecycle
+// Run manages the unary RPC lifecycle
 func (el *EventListener) Run(ctx context.Context) error {
 	ch := make(chan *pb.ListenerMessage, el.args.EventChanSize)
 	return el.BaseListener.Run(
 		ctx,
-		"Connected to the service, event listener stream established",
+		"Connected to operator service, unary event listener established",
 		ch,
 		el.watchEvents,
 		el.sendMessages,
@@ -70,6 +70,15 @@ func (el *EventListener) sendMessages(
 ) error {
 	el.Logf("Starting message sender for event channel")
 	defer el.Logf("Stopping event message sender")
+	defer el.DrainMessageChannel(ch)
+
+	// Resend any unacked messages from a previous connection before processing new ones
+	err := el.GetUnackedMessages().ResendAll(
+		ctx, el.SendMessage)
+	if err != nil {
+		el.Logf("Failed to resend unacked messages: %v", err)
+		return fmt.Errorf("failed to resend unacked messages: %w", err)
+	}
 
 	progressTicker := time.NewTicker(time.Duration(el.args.ProgressFrequencySec) * time.Second)
 	defer progressTicker.Stop()
@@ -90,7 +99,8 @@ func (el *EventListener) sendMessages(
 				el.inst.MessageChannelClosedUnexpectedly.Add(ctx, 1, el.MetricAttrs)
 				return fmt.Errorf("event watcher stopped")
 			}
-			if err := el.BaseListener.SendMessage(ctx, msg); err != nil {
+			if err := el.SendMessage(ctx, msg); err != nil {
+				el.GetUnackedMessages().AddMessageDropOldest(msg)
 				return fmt.Errorf("failed to send message: %w", err)
 			}
 		}

--- a/src/operator/event_listener_test.go
+++ b/src/operator/event_listener_test.go
@@ -17,12 +17,15 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"go.corp.nvidia.com/osmo/operator/utils"
 	pb "go.corp.nvidia.com/osmo/proto/operator"
 )
 
@@ -224,6 +227,115 @@ func TestEventKeyComposite(t *testing.T) {
 	// Different event type should create different key
 	if key1 == key3 {
 		t.Error("Different event types should create different keys")
+	}
+}
+
+// TestEventListenerDrainPopulatesUnackedQueue verifies that drainMessageChannel
+// moves pending channel messages into the unacked queue using drop-oldest semantics.
+func TestEventListenerDrainPopulatesUnackedQueue(t *testing.T) {
+	args := utils.ListenerArgs{
+		EventChanSize:        10,
+		ProgressFrequencySec: 60,
+	}
+	inst := utils.NewNoopInstruments()
+	el := NewEventListener(args, inst)
+
+	ch := make(chan *pb.ListenerMessage, 5)
+	// Pre-fill channel with messages
+	for i := 0; i < 3; i++ {
+		ch <- &pb.ListenerMessage{Uuid: fmt.Sprintf("drain-%d", i)}
+	}
+
+	el.DrainMessageChannel(ch)
+
+	unacked := el.GetUnackedMessages()
+	if unacked.Qsize() != 3 {
+		t.Errorf("Qsize() = %d, expected 3 after drain", unacked.Qsize())
+	}
+
+	var sent []string
+	unacked.ResendAll(context.Background(), func(_ context.Context, msg *pb.ListenerMessage) error {
+		sent = append(sent, msg.Uuid)
+		return nil
+	})
+	for i, uuid := range sent {
+		expected := fmt.Sprintf("drain-%d", i)
+		if uuid != expected {
+			t.Errorf("sent[%d] = %s, expected %s", i, uuid, expected)
+		}
+	}
+}
+
+// TestEventListenerDrainRespectsCapacity verifies that drainMessageChannel
+// uses drop-oldest semantics when the queue is at capacity.
+func TestEventListenerDrainRespectsCapacity(t *testing.T) {
+	args := utils.ListenerArgs{
+		EventChanSize:        10,
+		MaxUnackedMessages:   3,
+		ProgressFrequencySec: 60,
+	}
+	inst := utils.NewNoopInstruments()
+	el := NewEventListener(args, inst)
+
+	ch := make(chan *pb.ListenerMessage, 10)
+	// Pre-fill channel with 5 messages (exceeds capacity of 3)
+	for i := 0; i < 5; i++ {
+		ch <- &pb.ListenerMessage{Uuid: fmt.Sprintf("drain-%d", i)}
+	}
+
+	el.DrainMessageChannel(ch)
+
+	unacked := el.GetUnackedMessages()
+	if unacked.Qsize() != 3 {
+		t.Errorf("Qsize() = %d, expected 3 (capped at capacity)", unacked.Qsize())
+	}
+
+	// Oldest messages should have been evicted, newest 3 remain
+	var sent []string
+	unacked.ResendAll(context.Background(), func(_ context.Context, msg *pb.ListenerMessage) error {
+		sent = append(sent, msg.Uuid)
+		return nil
+	})
+	for i, uuid := range sent {
+		expected := fmt.Sprintf("drain-%d", i+2)
+		if uuid != expected {
+			t.Errorf("sent[%d] = %s, expected %s", i, uuid, expected)
+		}
+	}
+}
+
+// TestEventListenerResendBeforeNewMessages verifies that ResendAll is invoked
+// on the unacked queue at the start of sendMessages, before reading from the channel.
+func TestEventListenerResendBeforeNewMessages(t *testing.T) {
+	// This test verifies the ResendAll integration at the UnackMessages level,
+	// since sendMessages requires a live gRPC connection for SendMessage.
+	unacked := utils.NewUnackMessages(10)
+	unacked.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "old-1"})
+	unacked.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "old-2"})
+
+	var sentOrder []string
+	sendFunc := func(_ context.Context, msg *pb.ListenerMessage) error {
+		sentOrder = append(sentOrder, msg.Uuid)
+		return nil
+	}
+
+	ctx := context.Background()
+	err := unacked.ResendAll(ctx, sendFunc)
+	if err != nil {
+		t.Fatalf("ResendAll failed: %v", err)
+	}
+
+	// Verify old messages were sent in order
+	if len(sentOrder) != 2 {
+		t.Fatalf("Expected 2 messages sent, got %d", len(sentOrder))
+	}
+	if sentOrder[0] != "old-1" || sentOrder[1] != "old-2" {
+		t.Errorf("Expected send order [old-1, old-2], got %v", sentOrder)
+	}
+
+	// Queue should be empty after successful resend
+	if unacked.Qsize() != 0 {
+		t.Errorf("Qsize() = %d, expected 0 after successful resend", unacked.Qsize())
 	}
 }
 

--- a/src/operator/node_listener.go
+++ b/src/operator/node_listener.go
@@ -59,12 +59,12 @@ func NewNodeListener(
 	return nl
 }
 
-// Run manages the bidirectional streaming lifecycle
+// Run manages the unary RPC lifecycle for node events
 func (nl *NodeListener) Run(ctx context.Context) error {
 	ch := make(chan *pb.ListenerMessage, nl.args.NodeUpdateChanSize)
 	return nl.BaseListener.Run(
 		ctx,
-		"Connected to operator service, node stream established",
+		"Connected to operator service, unary node listener established",
 		ch,
 		nl.watchNodes,
 		nl.sendMessages,
@@ -96,7 +96,7 @@ func (nl *NodeListener) sendMessages(
 				nl.inst.MessageChannelClosedUnexpectedly.Add(ctx, 1, nl.MetricAttrs)
 				return fmt.Errorf("node watcher stopped")
 			}
-			if err := nl.BaseListener.SendMessage(ctx, msg); err != nil {
+			if err := nl.SendMessage(ctx, msg); err != nil {
 				return fmt.Errorf("failed to send node message: %w", err)
 			}
 		}

--- a/src/operator/node_listener_test.go
+++ b/src/operator/node_listener_test.go
@@ -17,10 +17,12 @@
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"go.corp.nvidia.com/osmo/operator/utils"
+	pb "go.corp.nvidia.com/osmo/proto/operator"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -93,3 +95,154 @@ func TestNewNodeListener(t *testing.T) {
 		t.Error("Expected unackedMessages to be initialized")
 	}
 }
+
+func TestNodeListener_SendMessages_ChannelClosed(t *testing.T) {
+	args := utils.ListenerArgs{
+		ServiceURL:           "http://localhost:8000",
+		Backend:              "test-backend",
+		Namespace:            "osmo",
+		NodeUpdateChanSize:   100,
+		MaxUnackedMessages:   100,
+		NodeConditionPrefix:  "osmo.nvidia.com/",
+		ProgressDir:          "/tmp/osmo/operator/",
+		ProgressFrequencySec: 15,
+	}
+
+	nodeConditionRules := utils.NewNodeConditionRules()
+	listener := NewNodeListener(args, nodeConditionRules, utils.NewNoopInstruments())
+
+	ch := make(chan *pb.ListenerMessage, 10)
+	close(ch)
+
+	ctx := context.Background()
+	err := listener.sendMessages(ctx, ch)
+	if err == nil {
+		t.Fatal("expected error when channel is closed, got nil")
+	}
+	expectedMsg := "node watcher stopped"
+	if err.Error() != expectedMsg {
+		t.Errorf("expected error %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestNodeListener_SendMessages_ContextCancelled(t *testing.T) {
+	args := utils.ListenerArgs{
+		ServiceURL:           "http://localhost:8000",
+		Backend:              "test-backend",
+		Namespace:            "osmo",
+		NodeUpdateChanSize:   100,
+		MaxUnackedMessages:   100,
+		NodeConditionPrefix:  "osmo.nvidia.com/",
+		ProgressDir:          "/tmp/osmo/operator/",
+		ProgressFrequencySec: 15,
+	}
+
+	nodeConditionRules := utils.NewNodeConditionRules()
+	listener := NewNodeListener(args, nodeConditionRules, utils.NewNoopInstruments())
+
+	ch := make(chan *pb.ListenerMessage, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := listener.sendMessages(ctx, ch)
+	if err != nil {
+		t.Fatalf("expected nil error on context cancellation, got: %v", err)
+	}
+}
+
+func TestNodeListener_SendMessages_ProgressReport(t *testing.T) {
+	args := utils.ListenerArgs{
+		ServiceURL:           "http://localhost:8000",
+		Backend:              "test-backend",
+		Namespace:            "osmo",
+		NodeUpdateChanSize:   100,
+		MaxUnackedMessages:   100,
+		NodeConditionPrefix:  "osmo.nvidia.com/",
+		ProgressDir:          "/tmp/osmo/operator/",
+		ProgressFrequencySec: 1,
+	}
+
+	nodeConditionRules := utils.NewNodeConditionRules()
+	listener := NewNodeListener(args, nodeConditionRules, utils.NewNoopInstruments())
+
+	ch := make(chan *pb.ListenerMessage, 10)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- listener.sendMessages(ctx, ch)
+	}()
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Fatalf("expected nil error, got: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("test timed out")
+	}
+}
+
+func TestNodeListener_BuildResourceMessage(t *testing.T) {
+	args := utils.ListenerArgs{
+		ServiceURL:           "http://localhost:8000",
+		Backend:              "test-backend",
+		Namespace:            "osmo",
+		NodeUpdateChanSize:   100,
+		MaxUnackedMessages:   100,
+		NodeConditionPrefix:  "osmo.nvidia.com/",
+		ProgressDir:          "/tmp/osmo/operator/",
+		ProgressFrequencySec: 15,
+	}
+
+	nodeConditionRules := utils.NewNodeConditionRules()
+	listener := NewNodeListener(args, nodeConditionRules, utils.NewNoopInstruments())
+
+	tracker := utils.NewNodeStateTracker(1 * time.Minute)
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"kubernetes.io/hostname": "test-node",
+			},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	msg := listener.buildResourceMessage(node, tracker, false, nil)
+	if msg == nil {
+		t.Fatal("expected non-nil message for new node")
+	}
+
+	updateNode := msg.GetUpdateNode()
+	if updateNode == nil {
+		t.Fatal("expected UpdateNode body")
+	}
+	if updateNode.Hostname != "test-node" {
+		t.Errorf("expected hostname test-node, got %s", updateNode.Hostname)
+	}
+
+	// Second call should return nil (no change)
+	msg2 := listener.buildResourceMessage(node, tracker, false, nil)
+	if msg2 != nil {
+		t.Error("expected nil message for unchanged node")
+	}
+
+	// Delete should always return a message
+	msg3 := listener.buildResourceMessage(node, tracker, true, nil)
+	if msg3 == nil {
+		t.Fatal("expected non-nil message for delete event")
+	}
+	if !msg3.GetUpdateNode().Delete {
+		t.Error("expected Delete to be true")
+	}
+}
+

--- a/src/operator/node_usage_listener.go
+++ b/src/operator/node_usage_listener.go
@@ -32,7 +32,7 @@ import (
 	pb "go.corp.nvidia.com/osmo/proto/operator"
 )
 
-// NodeUsageListener manages the bidirectional gRPC stream for pod resource usage
+// NodeUsageListener manages unary RPC calls for pod resource usage
 type NodeUsageListener struct {
 	*utils.BaseListener
 	args       utils.ListenerArgs
@@ -52,12 +52,12 @@ func NewNodeUsageListener(args utils.ListenerArgs, inst *utils.Instruments) *Nod
 	return nul
 }
 
-// Run manages the bidirectional streaming lifecycle
+// Run manages the unary RPC lifecycle
 func (nul *NodeUsageListener) Run(ctx context.Context) error {
 	ch := make(chan *pb.ListenerMessage, nul.args.UsageChanSize)
 	return nul.BaseListener.Run(
 		ctx,
-		"Connected to the service, node usage listener stream established",
+		"Connected to operator service, unary node usage listener established",
 		ch,
 		nul.watchPods,
 		nul.sendMessages,
@@ -88,7 +88,7 @@ func (nul *NodeUsageListener) sendMessages(
 				nul.inst.MessageChannelClosedUnexpectedly.Add(ctx, 1, nul.MetricAttrs)
 				return fmt.Errorf("usage watcher stopped")
 			}
-			if err := nul.BaseListener.SendMessage(ctx, msg); err != nil {
+			if err := nul.SendMessage(ctx, msg); err != nil {
 				return fmt.Errorf("failed to send UpdateNodeUsageBody message: %w", err)
 			}
 		}

--- a/src/operator/utils/BUILD
+++ b/src/operator/utils/BUILD
@@ -123,3 +123,12 @@ go_test(
     embed = [":utils"],
     deps = [],
 )
+
+go_test(
+    name = "base_listener_test",
+    srcs = ["base_listener_test.go"],
+    embed = [":utils"],
+    deps = [
+        "//src/proto/operator:operator_go_proto",
+    ],
+)

--- a/src/operator/utils/base_listener.go
+++ b/src/operator/utils/base_listener.go
@@ -33,6 +33,19 @@ import (
 	"go.corp.nvidia.com/osmo/utils/progress_check"
 )
 
+const RETRY_SERVICE_CONFIG = `{
+	"methodConfig": [{
+		"name": [{"service": "operator.ListenerService", "method": "SendListenerMessage"}],
+		"retryPolicy": {
+			"maxAttempts": 5,
+			"initialBackoff": "1s",
+			"maxBackoff": "20s",
+			"backoffMultiplier": 2,
+			"retryableStatusCodes": ["UNAVAILABLE", "DEADLINE_EXCEEDED"]
+		}
+	}]
+}`
+
 // WatchFunc writes listener messages to a channel.
 type WatchFunc func(
 	ctx context.Context,
@@ -65,12 +78,8 @@ type BaseListener struct {
 	// Connection state
 	conn   *grpc.ClientConn
 	client pb.ListenerServiceClient
-	stream pb.ListenerService_ListenerStreamClient
 
 	// Stream coordination
-	mu            sync.RWMutex // Protects stream field access
-	wg            sync.WaitGroup
-	closeOnce     sync.Once // Ensures stream is closed only once
 	connCloseOnce sync.Once // Ensures connection is closed only once
 
 	// Configuration
@@ -126,6 +135,8 @@ func (bl *BaseListener) initConnection() error {
 		return fmt.Errorf("failed to get dial options: %w", err)
 	}
 
+	dialOpts = append(dialOpts, grpc.WithDefaultServiceConfig(RETRY_SERVICE_CONFIG))
+
 	bl.conn, err = grpc.NewClient(serviceAddr, dialOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to connect to service: %w", err)
@@ -135,85 +146,10 @@ func (bl *BaseListener) initConnection() error {
 	return nil
 }
 
-// receiveAcks handles receiving ACK messages from the server
-func (bl *BaseListener) receiveAcks(ctx context.Context) error {
-	// Rate limit progress reporting
-	lastProgressReport := time.Now()
-	progressInterval := time.Duration(bl.args.ProgressFrequencySec) * time.Second
-
-	for {
-		msg, err := bl.stream.Recv()
-		if err != nil {
-			bl.inst.GRPCDisconnectCount.Add(ctx, 1)
-			return fmt.Errorf("failed to receive ACKs: %w", err)
-		}
-
-		// Handle ACK messages by removing from unacked queue
-		bl.unackedMessages.RemoveMessage(msg.AckUuid)
-
-		bl.inst.MessageAckReceivedTotal.Add(ctx, 1, bl.MetricAttrs)
-		bl.inst.UnackedMessageQueueDepth.Record(ctx, float64(bl.unackedMessages.Qsize()), bl.MetricAttrs)
-
-		// Report progress after receiving ACK (rate-limited)
-		now := time.Now()
-		if bl.progressWriter != nil && now.Sub(lastProgressReport) >= progressInterval {
-			if err := bl.progressWriter.ReportProgress(); err != nil {
-				bl.Logf("Warning: failed to report progress: %v", err)
-			}
-			lastProgressReport = now
-		}
-	}
-}
-
-// waitForCompletion waits for goroutines to finish
-func (bl *BaseListener) waitForCompletion(ctx context.Context, streamCtx context.Context) error {
-	// Wait for context cancellation (from parent or goroutines)
-	<-streamCtx.Done()
-
-	// Check if error came from a goroutine or parent context
-	var finalErr error
-	if cause := context.Cause(streamCtx); cause != nil && cause != context.Canceled && cause != io.EOF {
-		bl.Logf("Error from goroutine: %v", cause)
-		finalErr = fmt.Errorf("stream error: %w", cause)
-	} else if ctx.Err() != nil {
-		bl.Logf("Context cancelled, initiating graceful shutdown...")
-		finalErr = ctx.Err()
-	}
-
-	// Wait for goroutines with timeout
-	shutdownComplete := make(chan struct{})
-	go func() {
-		bl.wg.Wait()
-		close(shutdownComplete)
-	}()
-
-	select {
-	case <-shutdownComplete:
-		bl.Logf("All listener goroutines stopped gracefully")
-	case <-time.After(5 * time.Second):
-		bl.Logf("Warning: listener goroutines did not stop within timeout")
-	}
-
-	return finalErr
-}
-
-// close cleans up all resources including stream and connection.
+// close cleans up the connection.
 // It is safe to call multiple times due to sync.Once protection.
 func (bl *BaseListener) close() error {
-	var streamErr, connErr error
-
-	// Close stream (idempotent via sync.Once)
-	bl.closeOnce.Do(func() {
-		bl.mu.RLock()
-		stream := bl.stream
-		bl.mu.RUnlock()
-		if stream != nil {
-			streamErr = stream.CloseSend()
-			if streamErr != nil {
-				bl.Logf("Error closing stream: %v", streamErr)
-			}
-		}
-	})
+	var connErr error
 
 	// Close connection (idempotent via sync.Once)
 	bl.connCloseOnce.Do(func() {
@@ -225,16 +161,35 @@ func (bl *BaseListener) close() error {
 		}
 	})
 
-	// Return combined errors if any occurred
-	if streamErr != nil || connErr != nil {
-		return fmt.Errorf("close errors: stream=%v, conn=%v", streamErr, connErr)
-	}
-	return nil
+	return connErr
 }
 
 // GetUnackedMessages returns the unacked messages queue
 func (bl *BaseListener) GetUnackedMessages() *UnackMessages {
 	return bl.unackedMessages
+}
+
+// DrainMessageChannel reads remaining messages from ch and adds them to the unacked
+// queue using drop-oldest eviction. This prevents message loss during connection breaks
+// while respecting the queue capacity bound.
+func (bl *BaseListener) DrainMessageChannel(ch <-chan *pb.ListenerMessage) {
+	drained := 0
+	unackedMessages := bl.GetUnackedMessages()
+	for {
+		select {
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			unackedMessages.AddMessageDropOldest(msg)
+			drained++
+		default:
+			if drained > 0 {
+				bl.Logf("Drained %d messages from channel to unacked queue", drained)
+			}
+			return
+		}
+	}
 }
 
 // GetProgressWriter returns the progress writer
@@ -247,8 +202,7 @@ func (bl *BaseListener) GetStreamName() StreamName {
 	return bl.streamName
 }
 
-// Run manages the bidirectional streaming lifecycle with three goroutines:
-// receiveAcks, watch, and sendMessages.
+// Run manages the unary RPC lifecycle with two goroutines: watch and sendMessages.
 func (bl *BaseListener) Run(
 	ctx context.Context,
 	logMessage string,
@@ -256,95 +210,72 @@ func (bl *BaseListener) Run(
 	watch WatchFunc,
 	sendMessages SendMessagesFunc,
 ) error {
-	// Ensure cleanup on exit
+	// Reset cleanup guard so close() works on retry (sync.Once is single-fire)
+	bl.connCloseOnce = sync.Once{}
 	defer bl.close()
-	// Initialize the base connection
+
 	if err := bl.initConnection(); err != nil {
 		return err
 	}
 
-	// Create stream context FIRST (before stream creation)
-	streamCtx, streamCancel := context.WithCancelCause(ctx)
-	defer streamCancel(nil) // Ensure cleanup
-
-	// Establish the bidirectional stream using the derived context
-	var err error
-	stream, err := bl.client.ListenerStream(streamCtx)
-	if err != nil {
-		return fmt.Errorf("failed to create stream: %w", err)
-	}
-
-	// Set stream with mutex protection
-	bl.mu.Lock()
-	bl.stream = stream
-	bl.mu.Unlock()
+	runCtx, runCancel := context.WithCancelCause(ctx)
+	defer runCancel(nil)
 
 	bl.Logf("%s", logMessage)
 
-	// Resend all unacked messages from previous connection (if any)
-	if err := bl.unackedMessages.ResendAll(bl.stream); err != nil {
-		return err
-	}
-
-	// Launch three goroutines: receiveAcks, watch, sendMessages
-	bl.wg.Add(3)
+	// Use local WaitGroup to avoid cross-run interference on retry
+	var wg sync.WaitGroup
+	wg.Add(2)
 	go func() {
-		defer bl.wg.Done()
-		err = bl.receiveAcks(streamCtx)
-		if err != nil {
-			bl.Logf("Error in receiveAcks goroutine: %v", err)
-			streamCancel(err)
-		}
-	}()
-
-	go func() {
-		defer bl.wg.Done()
+		defer wg.Done()
 		defer close(msgChan)
-		err = watch(streamCtx, msgChan)
-		if err != nil {
+		if err := watch(runCtx, msgChan); err != nil {
 			bl.Logf("Error in watch goroutine: %v", err)
-			streamCancel(err)
+			runCancel(err)
 		}
 	}()
-
 	go func() {
-		defer bl.wg.Done()
-		err = sendMessages(streamCtx, msgChan)
-		if err != nil {
+		defer wg.Done()
+		if err := sendMessages(runCtx, msgChan); err != nil {
 			bl.Logf("Error in sendMessages goroutine: %v", err)
-			streamCancel(err)
+			runCancel(err)
 		}
 	}()
 
-	// Wait for completion
-	return bl.waitForCompletion(ctx, streamCtx)
-}
+	// Wait for context cancellation then drain goroutines
+	<-runCtx.Done()
 
-// GetStream returns the gRPC stream
-func (bl *BaseListener) GetStream() pb.ListenerService_ListenerStreamClient {
-	bl.mu.RLock()
-	defer bl.mu.RUnlock()
-	return bl.stream
-}
-
-// SendMessage sends a single listener message
-func (bl *BaseListener) SendMessage(ctx context.Context, msg *pb.ListenerMessage) error {
-	if err := bl.GetUnackedMessages().AddMessage(ctx, msg); err != nil {
-		bl.Logf("Failed to add message to unacked queue: %v", err)
-		return nil
+	var finalErr error
+	if cause := context.Cause(runCtx); cause != nil && cause != context.Canceled && cause != io.EOF {
+		bl.Logf("Error from goroutine: %v", cause)
+		finalErr = fmt.Errorf("listener error: %w", cause)
+	} else if ctx.Err() != nil {
+		bl.Logf("Context cancelled, initiating graceful shutdown...")
+		finalErr = ctx.Err()
 	}
 
-	bl.inst.UnackedMessageQueueDepth.Record(ctx, float64(bl.unackedMessages.Qsize()), bl.MetricAttrs)
+	shutdownComplete := make(chan struct{})
+	go func() { wg.Wait(); close(shutdownComplete) }()
+	select {
+	case <-shutdownComplete:
+		bl.Logf("All listener goroutines stopped gracefully")
+	case <-time.After(5 * time.Second):
+		bl.Logf("Warning: listener goroutines did not stop within timeout")
+	}
 
-	// Record gRPC send duration
+	return finalErr
+}
+
+// SendMessage sends a single listener message via the unary RPC.
+// gRPC built-in retry handles transient failures transparently.
+func (bl *BaseListener) SendMessage(ctx context.Context, msg *pb.ListenerMessage) error {
 	start := time.Now()
-	if err := bl.GetStream().Send(msg); err != nil {
+	_, err := bl.client.SendListenerMessage(ctx, msg)
+	if err != nil {
 		bl.inst.GRPCStreamSendErrorTotal.Add(ctx, 1, bl.MetricAttrs)
 		return err
 	}
-
 	bl.inst.GRPCMessageSendDuration.Record(ctx, time.Since(start).Seconds(), bl.MetricAttrs)
 	bl.inst.MessageSentTotal.Add(ctx, 1, bl.MetricAttrs)
-
 	return nil
 }

--- a/src/operator/utils/base_listener_test.go
+++ b/src/operator/utils/base_listener_test.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	pb "go.corp.nvidia.com/osmo/proto/operator"
+)
+
+func TestRun_WatchError(t *testing.T) {
+	bl := NewBaseListener(
+		ListenerArgs{
+			ServiceURL:         "http://localhost:19999",
+			Backend:            "test-backend",
+			MaxUnackedMessages: 100,
+			ProgressDir:        "/tmp/osmo/test/",
+		},
+		"test_progress",
+		StreamNameNode,
+		NewNoopInstruments(),
+	)
+
+	watchErr := fmt.Errorf("watch failed")
+	watch := func(ctx context.Context, ch chan<- *pb.ListenerMessage) error {
+		return watchErr
+	}
+	sendMessages := func(ctx context.Context, ch <-chan *pb.ListenerMessage) error {
+		for range ch {
+			// drain
+		}
+		return nil
+	}
+
+	ch := make(chan *pb.ListenerMessage, 10)
+	err := bl.Run(context.Background(), "test", ch, watch, sendMessages)
+	if err == nil {
+		t.Fatal("expected error from Run, got nil")
+	}
+	if err.Error() != "listener error: watch failed" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_ContextCancellation(t *testing.T) {
+	bl := NewBaseListener(
+		ListenerArgs{
+			ServiceURL:         "http://localhost:19999",
+			Backend:            "test-backend",
+			MaxUnackedMessages: 100,
+			ProgressDir:        "/tmp/osmo/test/",
+		},
+		"test_progress",
+		StreamNameNode,
+		NewNoopInstruments(),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	watch := func(ctx context.Context, ch chan<- *pb.ListenerMessage) error {
+		<-ctx.Done()
+		return nil
+	}
+	sendMessages := func(ctx context.Context, ch <-chan *pb.ListenerMessage) error {
+		<-ctx.Done()
+		return nil
+	}
+
+	errChan := make(chan error, 1)
+	go func() {
+		ch := make(chan *pb.ListenerMessage, 10)
+		errChan <- bl.Run(ctx, "test", ch, watch, sendMessages)
+	}()
+
+	// Cancel after a short delay
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errChan:
+		if err != context.Canceled {
+			t.Errorf("expected context.Canceled, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("test timed out")
+	}
+}
+
+func TestRun_SendMessagesError(t *testing.T) {
+	bl := NewBaseListener(
+		ListenerArgs{
+			ServiceURL:         "http://localhost:19999",
+			Backend:            "test-backend",
+			MaxUnackedMessages: 100,
+			ProgressDir:        "/tmp/osmo/test/",
+		},
+		"test_progress",
+		StreamNameNode,
+		NewNoopInstruments(),
+	)
+
+	sendErr := fmt.Errorf("send failed")
+	watch := func(ctx context.Context, ch chan<- *pb.ListenerMessage) error {
+		<-ctx.Done()
+		return nil
+	}
+	sendMessages := func(ctx context.Context, ch <-chan *pb.ListenerMessage) error {
+		return sendErr
+	}
+
+	ch := make(chan *pb.ListenerMessage, 10)
+	err := bl.Run(context.Background(), "test", ch, watch, sendMessages)
+	if err == nil {
+		t.Fatal("expected error from Run, got nil")
+	}
+	if err.Error() != "listener error: send failed" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestBaseListener_Logf(t *testing.T) {
+	bl := NewBaseListener(
+		ListenerArgs{
+			ServiceURL:         "http://localhost:19999",
+			Backend:            "test-backend",
+			MaxUnackedMessages: 100,
+			ProgressDir:        "/tmp/osmo/test/",
+		},
+		"test_progress",
+		StreamNameNode,
+		NewNoopInstruments(),
+	)
+
+	// Should not panic
+	bl.Logf("test message %s", "hello")
+}
+
+func TestBaseListener_GetStreamName(t *testing.T) {
+	bl := NewBaseListener(
+		ListenerArgs{
+			ServiceURL:         "http://localhost:19999",
+			Backend:            "test-backend",
+			MaxUnackedMessages: 100,
+			ProgressDir:        "/tmp/osmo/test/",
+		},
+		"test_progress",
+		StreamNameNode,
+		NewNoopInstruments(),
+	)
+
+	if bl.GetStreamName() != StreamNameNode {
+		t.Errorf("expected %s, got %s", StreamNameNode, bl.GetStreamName())
+	}
+}

--- a/src/operator/utils/unack_messages.go
+++ b/src/operator/utils/unack_messages.go
@@ -27,25 +27,13 @@ import (
 	pb "go.corp.nvidia.com/osmo/proto/operator"
 )
 
-// MessageSender defines the interface for sending messages
-type MessageSender interface {
-	Send(*pb.ListenerMessage) error
-}
-
-// UnackMessages provides flow control and reliability by tracking messages that have been sent
-// but not yet acknowledged by the server. When the max limit is reached, sending is
-// paused until ACKs are received, preventing unbounded memory growth.
-//
-// Key features:
-// - Thread-safe message tracking using mutex
-// - Flow control via readyToSend channel
-// - Automatic backpressure when max unacked messages limit is reached
-// - Message persistence for potential reconnection scenarios
+// UnackMessages tracks messages that have been sent but not yet delivered
+// to the server. It provides a bounded buffer with oldest-eviction policy,
+// and bulk resend for reconnection scenarios.
 type UnackMessages struct {
-	mu                 sync.RWMutex
-	messages           map[string]*pb.ListenerMessage // key: message UUID
-	readyToSend        chan struct{}                  // buffered channel for flow control
-	maxUnackedMessages int                            // 0 means unlimited
+	mu                 sync.Mutex
+	messages           []*pb.ListenerMessage
+	maxUnackedMessages int // 0 means unlimited
 }
 
 // NewUnackMessages creates a new unack messages tracker
@@ -54,103 +42,59 @@ func NewUnackMessages(maxUnackedMessages int) *UnackMessages {
 		maxUnackedMessages = 0
 	}
 
-	readyChan := make(chan struct{}, 1)
-	readyChan <- struct{}{} // Start in ready state
-
 	return &UnackMessages{
-		messages:           make(map[string]*pb.ListenerMessage),
-		readyToSend:        readyChan,
 		maxUnackedMessages: maxUnackedMessages,
 	}
 }
 
-// AddMessage adds a message to the unacked queue
-func (um *UnackMessages) AddMessage(ctx context.Context, msg *pb.ListenerMessage) error {
-	// Wait for flow control signal (non-blocking if not at capacity)
-	select {
-	case <-um.readyToSend:
-		// Got the ready signal, proceed
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-
+// AddMessageDropOldest adds a message to the unacked queue, evicting the oldest
+// message if at capacity. This is non-blocking and used for fire-and-forget
+// listeners (e.g., events) where backpressure would cause memory leaks.
+func (um *UnackMessages) AddMessageDropOldest(msg *pb.ListenerMessage) {
 	um.mu.Lock()
 	defer um.mu.Unlock()
 
-	um.messages[msg.Uuid] = msg
-	queueSize := len(um.messages)
-
-	// Check if we've reached the limit after adding
-	if um.maxUnackedMessages > 0 && queueSize >= um.maxUnackedMessages {
-		log.Printf("Warning: Reached max unacked message count of %d", um.maxUnackedMessages)
-		// Don't put back the ready signal - we're at capacity
-	} else {
-		// Put the ready signal back
-		select {
-		case um.readyToSend <- struct{}{}:
-		default:
-			// Channel already has a signal
-		}
+	if um.maxUnackedMessages > 0 && len(um.messages) >= um.maxUnackedMessages {
+		um.messages = um.messages[1:]
 	}
-
-	return nil
-}
-
-// AddMessageForced adds a message bypassing flow control limits
-// Used during channel draining to preserve all pending messages
-func (um *UnackMessages) AddMessageForced(msg *pb.ListenerMessage) {
-	um.mu.Lock()
-	defer um.mu.Unlock()
-	um.messages[msg.Uuid] = msg
-}
-
-// RemoveMessage removes a message from the unacked queue
-func (um *UnackMessages) RemoveMessage(uuid string) {
-	um.mu.Lock()
-	defer um.mu.Unlock()
-
-	if _, exists := um.messages[uuid]; exists {
-		delete(um.messages, uuid)
-		select {
-		case um.readyToSend <- struct{}{}:
-		default:
-			// Channel already has a signal
-		}
-	}
-}
-
-// ListMessages returns a slice of all unacked messages in order
-func (um *UnackMessages) ListMessages() []*pb.ListenerMessage {
-	um.mu.RLock()
-	defer um.mu.RUnlock()
-
-	messages := make([]*pb.ListenerMessage, 0, len(um.messages))
-	for _, msg := range um.messages {
-		messages = append(messages, msg)
-	}
-	return messages
+	um.messages = append(um.messages, msg)
 }
 
 // Qsize returns the number of unacked messages
 func (um *UnackMessages) Qsize() int {
-	um.mu.RLock()
-	defer um.mu.RUnlock()
+	um.mu.Lock()
+	defer um.mu.Unlock()
 	return len(um.messages)
 }
 
-// ResendAll resends all unacked messages using the provided sender
-// This is typically used after reconnection to ensure no messages are lost
-func (um *UnackMessages) ResendAll(sender MessageSender) error {
-	messages := um.ListMessages()
+// ResendAll resends all unacked messages using a unary RPC callback.
+// Successfully sent messages are removed from the queue. On failure, iteration
+// stops immediately and remaining messages stay in the queue for the next attempt.
+func (um *UnackMessages) ResendAll(
+	ctx context.Context,
+	send func(context.Context, *pb.ListenerMessage) error,
+) error {
+	um.mu.Lock()
+	messages := make([]*pb.ListenerMessage, len(um.messages))
+	copy(messages, um.messages)
+	um.mu.Unlock()
+
 	if len(messages) == 0 {
 		return nil
 	}
 
-	log.Printf("Resending %d unacked messages from previous connection", len(messages))
-	for _, msg := range messages {
-		if err := sender.Send(msg); err != nil {
+	log.Printf("Resending %d unacked messages via unary RPC", len(messages))
+	for i, msg := range messages {
+		if err := send(ctx, msg); err != nil {
+			um.mu.Lock()
+			um.messages = um.messages[i:]
+			um.mu.Unlock()
 			return fmt.Errorf("failed to resend unacked message %s: %w", msg.Uuid, err)
 		}
 	}
+
+	um.mu.Lock()
+	um.messages = um.messages[:0]
+	um.mu.Unlock()
 	return nil
 }

--- a/src/operator/utils/unack_messages_test.go
+++ b/src/operator/utils/unack_messages_test.go
@@ -21,45 +21,10 @@ package utils
 import (
 	"context"
 	"fmt"
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	pb "go.corp.nvidia.com/osmo/proto/operator"
 )
-
-// Mock MessageSender for testing
-type mockMessageSender struct {
-	messages []*pb.ListenerMessage
-	mu       sync.Mutex
-	failNext bool
-}
-
-func (m *mockMessageSender) Send(msg *pb.ListenerMessage) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if m.failNext {
-		m.failNext = false
-		return fmt.Errorf("mock send error")
-	}
-
-	m.messages = append(m.messages, msg)
-	return nil
-}
-
-func (m *mockMessageSender) GetMessages() []*pb.ListenerMessage {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return append([]*pb.ListenerMessage{}, m.messages...)
-}
-
-func (m *mockMessageSender) SetFailNext(fail bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.failNext = fail
-}
 
 func TestNewUnackMessages(t *testing.T) {
 	tests := []struct {
@@ -85,348 +50,160 @@ func TestNewUnackMessages(t *testing.T) {
 	}
 }
 
-func TestUnackMessages_AddAndRemove(t *testing.T) {
-	um := NewUnackMessages(10)
-	ctx := context.Background()
+func TestAddMessageDropOldest_Basic(t *testing.T) {
+	um := NewUnackMessages(3)
 
-	msg1 := &pb.ListenerMessage{Uuid: "msg-1"}
-	msg2 := &pb.ListenerMessage{Uuid: "msg-2"}
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-1"})
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-2"})
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-3"})
 
-	// Add messages
-	err := um.AddMessage(ctx, msg1)
-	if err != nil {
-		t.Fatalf("AddMessage failed: %v", err)
-	}
-
-	err = um.AddMessage(ctx, msg2)
-	if err != nil {
-		t.Fatalf("AddMessage failed: %v", err)
-	}
-
-	if um.Qsize() != 2 {
-		t.Errorf("Qsize() = %d, expected 2", um.Qsize())
-	}
-
-	// Remove message
-	um.RemoveMessage("msg-1")
-	if um.Qsize() != 1 {
-		t.Errorf("Qsize() after remove = %d, expected 1", um.Qsize())
-	}
-
-	// Remove non-existent message (should not error)
-	um.RemoveMessage("non-existent")
-	if um.Qsize() != 1 {
-		t.Errorf("Qsize() after removing non-existent = %d, expected 1", um.Qsize())
-	}
-
-	// Remove remaining message
-	um.RemoveMessage("msg-2")
-	if um.Qsize() != 0 {
-		t.Errorf("Qsize() after removing all = %d, expected 0", um.Qsize())
-	}
-}
-
-func TestUnackMessages_AddMessageForced(t *testing.T) {
-	um := NewUnackMessages(2)
-	ctx := context.Background()
-
-	// Fill to capacity
-	um.AddMessage(ctx, &pb.ListenerMessage{Uuid: "msg-1"})
-	um.AddMessage(ctx, &pb.ListenerMessage{Uuid: "msg-2"})
-
-	// Try to add normally (should block if we didn't use forced)
-	// Instead use forced to bypass limit
-	um.AddMessageForced(&pb.ListenerMessage{Uuid: "msg-3"})
+	// Add one more — should evict msg-1
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-4"})
 
 	if um.Qsize() != 3 {
 		t.Errorf("Qsize() = %d, expected 3", um.Qsize())
 	}
+
+	// Verify contents via ResendAll
+	var sent []string
+	um.ResendAll(context.Background(), func(_ context.Context, msg *pb.ListenerMessage) error {
+		sent = append(sent, msg.Uuid)
+		return nil
+	})
+
+	if len(sent) != 3 {
+		t.Fatalf("len(sent) = %d, expected 3", len(sent))
+	}
+	if sent[0] != "msg-2" {
+		t.Errorf("Expected oldest to be msg-2 after eviction, got %s", sent[0])
+	}
+	if sent[2] != "msg-4" {
+		t.Errorf("Expected newest to be msg-4, got %s", sent[2])
+	}
 }
 
-func TestUnackMessages_ListMessages(t *testing.T) {
+func TestAddMessageDropOldest_OrderPreserved(t *testing.T) {
+	um := NewUnackMessages(10)
+
+	for i := 0; i < 5; i++ {
+		um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: fmt.Sprintf("msg-%d", i)})
+	}
+
+	// Verify order via ResendAll
+	var sent []string
+	um.ResendAll(context.Background(), func(_ context.Context, msg *pb.ListenerMessage) error {
+		sent = append(sent, msg.Uuid)
+		return nil
+	})
+
+	if len(sent) != 5 {
+		t.Fatalf("len(sent) = %d, expected 5", len(sent))
+	}
+
+	for i, uuid := range sent {
+		expected := fmt.Sprintf("msg-%d", i)
+		if uuid != expected {
+			t.Errorf("sent[%d] = %s, expected %s", i, uuid, expected)
+		}
+	}
+}
+
+func TestResendAll_Success(t *testing.T) {
 	um := NewUnackMessages(10)
 	ctx := context.Background()
 
-	msg1 := &pb.ListenerMessage{Uuid: "msg-1"}
-	msg2 := &pb.ListenerMessage{Uuid: "msg-2"}
-	msg3 := &pb.ListenerMessage{Uuid: "msg-3"}
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-1"})
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-2"})
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-3"})
 
-	um.AddMessage(ctx, msg1)
-	um.AddMessage(ctx, msg2)
-	um.AddMessage(ctx, msg3)
-
-	messages := um.ListMessages()
-	if len(messages) != 3 {
-		t.Errorf("len(ListMessages()) = %d, expected 3", len(messages))
+	var sent []*pb.ListenerMessage
+	sendFunc := func(_ context.Context, msg *pb.ListenerMessage) error {
+		sent = append(sent, msg)
+		return nil
 	}
 
-	// Check that all UUIDs are present
-	uuids := make(map[string]bool)
-	for _, msg := range messages {
-		uuids[msg.Uuid] = true
-	}
-
-	if !uuids["msg-1"] || !uuids["msg-2"] || !uuids["msg-3"] {
-		t.Error("Not all messages found in ListMessages()")
-	}
-}
-
-func TestUnackMessages_FlowControl(t *testing.T) {
-	um := NewUnackMessages(2)
-	ctx := context.Background()
-
-	// Add up to limit
-	err := um.AddMessage(ctx, &pb.ListenerMessage{Uuid: "msg-1"})
-	if err != nil {
-		t.Fatalf("First AddMessage failed: %v", err)
-	}
-
-	err = um.AddMessage(ctx, &pb.ListenerMessage{Uuid: "msg-2"})
-	if err != nil {
-		t.Fatalf("Second AddMessage failed: %v", err)
-	}
-
-	// Try to add one more - should block
-	ctx2, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-	defer cancel()
-
-	err = um.AddMessage(ctx2, &pb.ListenerMessage{Uuid: "msg-3"})
-	if err == nil {
-		t.Error("Expected context timeout error when exceeding limit")
-	}
-
-	// Remove one message to unblock
-	um.RemoveMessage("msg-1")
-
-	// Now we should be able to add
-	err = um.AddMessage(context.Background(), &pb.ListenerMessage{Uuid: "msg-3"})
-	if err != nil {
-		t.Errorf("AddMessage after remove failed: %v", err)
-	}
-}
-
-func TestUnackMessages_ResendAll(t *testing.T) {
-	um := NewUnackMessages(10)
-	ctx := context.Background()
-
-	msg1 := &pb.ListenerMessage{Uuid: "msg-1"}
-	msg2 := &pb.ListenerMessage{Uuid: "msg-2"}
-	msg3 := &pb.ListenerMessage{Uuid: "msg-3"}
-
-	um.AddMessage(ctx, msg1)
-	um.AddMessage(ctx, msg2)
-	um.AddMessage(ctx, msg3)
-
-	// Create mock sender
-	sender := &mockMessageSender{}
-
-	// Resend all
-	err := um.ResendAll(sender)
+	err := um.ResendAll(ctx, sendFunc)
 	if err != nil {
 		t.Fatalf("ResendAll failed: %v", err)
 	}
 
-	// Check that all messages were sent
-	sentMessages := sender.GetMessages()
-	if len(sentMessages) != 3 {
-		t.Errorf("len(sentMessages) = %d, expected 3", len(sentMessages))
+	if len(sent) != 3 {
+		t.Errorf("len(sent) = %d, expected 3", len(sent))
+	}
+	if um.Qsize() != 0 {
+		t.Errorf("Qsize() = %d, expected 0 after successful resend", um.Qsize())
 	}
 }
 
-func TestUnackMessages_ResendAll_Error(t *testing.T) {
+func TestResendAll_PartialFailure(t *testing.T) {
 	um := NewUnackMessages(10)
 	ctx := context.Background()
 
-	msg1 := &pb.ListenerMessage{Uuid: "msg-1"}
-	um.AddMessage(ctx, msg1)
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-1"})
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-2"})
+	um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: "msg-3"})
 
-	// Create mock sender that fails
-	sender := &mockMessageSender{}
-	sender.SetFailNext(true)
+	callCount := 0
+	sendFunc := func(_ context.Context, msg *pb.ListenerMessage) error {
+		callCount++
+		if callCount == 2 {
+			return fmt.Errorf("send error on second message")
+		}
+		return nil
+	}
 
-	// Resend should fail
-	err := um.ResendAll(sender)
+	err := um.ResendAll(ctx, sendFunc)
 	if err == nil {
-		t.Error("Expected error from ResendAll when sender fails")
+		t.Fatal("Expected error from ResendAll on partial failure")
+	}
+
+	// msg-1 was sent successfully, msg-2 failed — msg-2 and msg-3 should remain
+	if um.Qsize() != 2 {
+		t.Errorf("Qsize() = %d, expected 2 after partial failure", um.Qsize())
+	}
+
+	// Verify remaining messages via a second ResendAll
+	var remaining []string
+	um.ResendAll(ctx, func(_ context.Context, msg *pb.ListenerMessage) error {
+		remaining = append(remaining, msg.Uuid)
+		return nil
+	})
+
+	if len(remaining) != 2 {
+		t.Fatalf("len(remaining) = %d, expected 2", len(remaining))
+	}
+	if remaining[0] != "msg-2" {
+		t.Errorf("Expected first remaining message to be msg-2, got %s", remaining[0])
+	}
+	if remaining[1] != "msg-3" {
+		t.Errorf("Expected second remaining message to be msg-3, got %s", remaining[1])
 	}
 }
 
-func TestUnackMessages_ResendAll_Empty(t *testing.T) {
+func TestResendAll_Empty(t *testing.T) {
 	um := NewUnackMessages(10)
+	ctx := context.Background()
 
-	// Create mock sender
-	sender := &mockMessageSender{}
+	callCount := 0
+	sendFunc := func(_ context.Context, msg *pb.ListenerMessage) error {
+		callCount++
+		return nil
+	}
 
-	// Resend with no messages
-	err := um.ResendAll(sender)
+	err := um.ResendAll(ctx, sendFunc)
 	if err != nil {
 		t.Errorf("ResendAll on empty queue failed: %v", err)
 	}
-
-	// No messages should be sent
-	sentMessages := sender.GetMessages()
-	if len(sentMessages) != 0 {
-		t.Errorf("len(sentMessages) = %d, expected 0", len(sentMessages))
-	}
-}
-
-func TestUnackMessages_Concurrent(t *testing.T) {
-	um := NewUnackMessages(100)
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	numGoroutines := 20 // Reduced to avoid overwhelming the system
-	messagesPerRoutine := 10
-
-	var wg sync.WaitGroup
-	var addedCount, removedCount int64
-
-	// Add messages concurrently
-	wg.Add(numGoroutines)
-	for i := 0; i < numGoroutines; i++ {
-		go func(id int) {
-			defer wg.Done()
-			for j := 0; j < messagesPerRoutine; j++ {
-				msg := &pb.ListenerMessage{
-					Uuid: fmt.Sprintf("msg-%d-%d", id, j),
-				}
-				if err := um.AddMessage(ctx, msg); err == nil {
-					atomic.AddInt64(&addedCount, 1)
-				}
-			}
-		}(i)
-	}
-
-	// Remove messages concurrently - remove whatever actually exists
-	wg.Add(numGoroutines)
-	for i := 0; i < numGoroutines; i++ {
-		go func(id int) {
-			defer wg.Done()
-			for j := 0; j < messagesPerRoutine; j++ {
-				// Keep trying until we successfully remove or context times out
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					default:
-					}
-
-					messages := um.ListMessages()
-					if len(messages) > 0 {
-						um.RemoveMessage(messages[0].Uuid)
-						atomic.AddInt64(&removedCount, 1)
-						break
-					}
-					// No messages available, wait a bit
-					time.Sleep(time.Millisecond)
-				}
-			}
-		}(i)
-	}
-
-	wg.Wait()
-
-	// Check that we added and removed messages successfully
-	t.Logf("Added: %d, Removed: %d, Final queue size: %d", addedCount, removedCount, um.Qsize())
-
-	// Final queue size should be small (most removes should have succeeded)
-	finalSize := um.Qsize()
-	if finalSize > messagesPerRoutine*numGoroutines/2 {
-		t.Errorf("Unexpected queue size after concurrent ops: %d (added: %d, removed: %d)", finalSize, addedCount, removedCount)
-	}
-}
-
-func TestUnackMessages_UnlimitedCapacity(t *testing.T) {
-	um := NewUnackMessages(0) // 0 means unlimited
-	ctx := context.Background()
-
-	// Add many messages
-	for i := 0; i < 1000; i++ {
-		msg := &pb.ListenerMessage{Uuid: fmt.Sprintf("msg-%d", i)}
-		err := um.AddMessage(ctx, msg)
-		if err != nil {
-			t.Fatalf("AddMessage failed at %d: %v", i, err)
-		}
-	}
-
-	if um.Qsize() != 1000 {
-		t.Errorf("Qsize() = %d, expected 1000", um.Qsize())
-	}
-}
-
-func TestUnackMessages_ContextCancellation(t *testing.T) {
-	um := NewUnackMessages(1)
-	ctx := context.Background()
-
-	// Fill to capacity
-	um.AddMessage(ctx, &pb.ListenerMessage{Uuid: "msg-1"})
-
-	// Create cancelled context
-	ctx2, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	// Try to add with cancelled context
-	err := um.AddMessage(ctx2, &pb.ListenerMessage{Uuid: "msg-2"})
-	if err == nil {
-		t.Error("Expected error when adding with cancelled context")
-	}
-	if err != context.Canceled {
-		t.Errorf("Expected context.Canceled error, got %v", err)
-	}
-}
-
-// Benchmark tests
-func BenchmarkUnackMessages_AddMessage(b *testing.B) {
-	um := NewUnackMessages(0) // Unlimited
-	ctx := context.Background()
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		msg := &pb.ListenerMessage{Uuid: fmt.Sprintf("msg-%d", i)}
-		um.AddMessage(ctx, msg)
-	}
-}
-
-func BenchmarkUnackMessages_RemoveMessage(b *testing.B) {
-	um := NewUnackMessages(0)
-	ctx := context.Background()
-
-	// Pre-populate
-	for i := 0; i < b.N; i++ {
-		msg := &pb.ListenerMessage{Uuid: fmt.Sprintf("msg-%d", i)}
-		um.AddMessage(ctx, msg)
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		um.RemoveMessage(fmt.Sprintf("msg-%d", i))
-	}
-}
-
-func BenchmarkUnackMessages_ListMessages(b *testing.B) {
-	um := NewUnackMessages(0)
-	ctx := context.Background()
-
-	// Add 100 messages
-	for i := 0; i < 100; i++ {
-		msg := &pb.ListenerMessage{Uuid: fmt.Sprintf("msg-%d", i)}
-		um.AddMessage(ctx, msg)
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		um.ListMessages()
+	if callCount != 0 {
+		t.Errorf("callCount = %d, expected 0 (callback should not be called)", callCount)
 	}
 }
 
 func BenchmarkUnackMessages_Qsize(b *testing.B) {
 	um := NewUnackMessages(0)
-	ctx := context.Background()
 
-	// Add some messages
 	for i := 0; i < 50; i++ {
-		msg := &pb.ListenerMessage{Uuid: fmt.Sprintf("msg-%d", i)}
-		um.AddMessage(ctx, msg)
+		um.AddMessageDropOldest(&pb.ListenerMessage{Uuid: fmt.Sprintf("msg-%d", i)})
 	}
 
 	b.ResetTimer()

--- a/src/operator/workflow_listener.go
+++ b/src/operator/workflow_listener.go
@@ -34,7 +34,7 @@ import (
 	pb "go.corp.nvidia.com/osmo/proto/operator"
 )
 
-// WorkflowListener manages the bidirectional gRPC stream connection to the operator service
+// WorkflowListener manages unary RPC calls to the operator service
 type WorkflowListener struct {
 	*utils.BaseListener
 	args utils.ListenerArgs
@@ -68,12 +68,12 @@ func NewWorkflowListener(args utils.ListenerArgs, inst *utils.Instruments) *Work
 	return wl
 }
 
-// Run manages the bidirectional streaming lifecycle
+// Run manages the unary RPC lifecycle
 func (wl *WorkflowListener) Run(ctx context.Context) error {
 	ch := make(chan *pb.ListenerMessage, wl.args.PodUpdateChanSize)
 	return wl.BaseListener.Run(
 		ctx,
-		"Connected to the service, workflow listener stream established",
+		"Connected to operator service, unary workflow listener established",
 		ch,
 		wl.watchPods,
 		wl.sendMessages,
@@ -87,6 +87,15 @@ func (wl *WorkflowListener) sendMessages(
 ) error {
 	wl.Logf("Starting message sender for workflow channel")
 	defer wl.Logf("Stopping workflow message sender")
+	defer wl.DrainMessageChannel(ch)
+
+	// Resend any unacked messages from a previous connection before processing new ones
+	err := wl.GetUnackedMessages().ResendAll(
+		ctx, wl.SendMessage)
+	if err != nil {
+		wl.Logf("Failed to resend unacked messages: %v", err)
+		return fmt.Errorf("failed to resend unacked messages: %w", err)
+	}
 
 	progressTicker := time.NewTicker(time.Duration(wl.args.ProgressFrequencySec) * time.Second)
 	defer progressTicker.Stop()
@@ -94,8 +103,6 @@ func (wl *WorkflowListener) sendMessages(
 	for {
 		select {
 		case <-ctx.Done():
-			wl.Logf("Stopping message sender, draining channel...")
-			wl.drainMessageChannel(ch)
 			return nil
 		case <-progressTicker.C:
 			progressWriter := wl.GetProgressWriter()
@@ -106,40 +113,18 @@ func (wl *WorkflowListener) sendMessages(
 			}
 		case msg, ok := <-ch:
 			if !ok {
-				wl.Logf("Pod watcher stopped, draining channel...")
 				wl.inst.MessageChannelClosedUnexpectedly.Add(ctx, 1, wl.MetricAttrs)
-				wl.drainMessageChannel(ch)
 				return fmt.Errorf("pod watcher stopped")
 			}
-			if err := wl.BaseListener.SendMessage(ctx, msg); err != nil {
+			if err := wl.SendMessage(ctx, msg); err != nil {
+				wl.GetUnackedMessages().AddMessageDropOldest(msg)
 				return fmt.Errorf("failed to send message: %w", err)
 			}
 		}
 	}
 }
 
-// drainMessageChannel reads remaining messages from ch and adds them to unacked queue.
-// This prevents message loss during connection breaks
-// TODO watch should call drainMessageChannel before returning
-func (wl *WorkflowListener) drainMessageChannel(ch <-chan *pb.ListenerMessage) {
-	drained := 0
-	unackedMessages := wl.GetUnackedMessages()
-	for {
-		select {
-		case msg, ok := <-ch:
-			if !ok {
-				return
-			}
-			unackedMessages.AddMessageForced(msg)
-			drained++
-		default:
-			if drained > 0 {
-				wl.Logf("Drained %d messages from channel to unacked queue", drained)
-			}
-			return
-		}
-	}
-}
+
 
 // watchPods watches for pod changes and writes ListenerMessages to ch.
 func (wl *WorkflowListener) watchPods(

--- a/src/proto/operator/services.proto
+++ b/src/proto/operator/services.proto
@@ -46,10 +46,10 @@ message NodeConditionStreamResponse {
   }
 }
 
-// ListenerService handles bidirectional streaming connections from workflow backends
+// ListenerService handles connections from workflow backends
 service ListenerService {
-  // Bidirectional stream for backend communication (workflow updates, resource events, etc.)
-  rpc ListenerStream(stream ListenerMessage) returns (stream AckMessage);
+  // Unary RPC for sending a single listener message and receiving an ACK.
+  rpc SendListenerMessage(ListenerMessage) returns (AckMessage);
 
   // Bidirectional stream: client sends heartbeats to keep stream alive; server sends node
   // condition rule updates (initial rules from DB, then pushed on Redis queue updates).

--- a/src/service/operator/BUILD
+++ b/src/service/operator/BUILD
@@ -81,7 +81,9 @@ go_test(
     deps = [
         "//src/proto/operator:operator_go_proto",
         "@com_github_redis_go_redis_v9//:go-redis",
+        "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
     ],
 )
 

--- a/src/service/operator/listener_service/listener_service.go
+++ b/src/service/operator/listener_service/listener_service.go
@@ -47,10 +47,10 @@ const (
 // ListenerService handles workflow listener gRPC streaming operations
 type ListenerService struct {
 	pb.UnimplementedListenerServiceServer
-	logger           *slog.Logger
-	redisClient      *redis.Client
-	pgPool           *pgxpool.Pool
-	serviceHostname  string
+	logger            *slog.Logger
+	redisClient       *redis.Client
+	pgPool            *pgxpool.Pool
+	serviceHostname   string
 	progressWriter    *progress_check.ProgressWriter
 	progressInterval  time.Duration
 	heartbeatInterval time.Duration
@@ -84,10 +84,10 @@ func NewListenerService(
 	}
 
 	return &ListenerService{
-		logger:           logger,
-		redisClient:      redisClient,
-		pgPool:           pgPool,
-		serviceHostname:  args.ServiceHostname,
+		logger:            logger,
+		redisClient:       redisClient,
+		pgPool:            pgPool,
+		serviceHostname:   args.ServiceHostname,
 		progressWriter:    progressWriter,
 		progressInterval:  time.Duration(args.OperatorProgressFrequencySec) * time.Second,
 		heartbeatInterval: time.Duration(args.HeartbeatIntervalSec) * time.Second,
@@ -130,79 +130,27 @@ func (ls *ListenerService) pushMessageToRedis(
 	return nil
 }
 
-// handleListenerStream processes messages from a bidirectional gRPC stream.
-// It handles receiving messages, pushing to Redis, sending ACK responses, and reporting progress.
-func (ls *ListenerService) handleListenerStream(
-	stream pb.ListenerService_ListenerStreamServer,
-) error {
-	ctx := stream.Context()
-
-	// Extract backend name from gRPC metadata (required)
+// SendListenerMessage handles a single unary listener message and returns an ACK.
+func (ls *ListenerService) SendListenerMessage(
+	ctx context.Context,
+	msg *pb.ListenerMessage,
+) (*pb.AckMessage, error) {
 	backendName, err := utils.ExtractBackendName(ctx)
 	if err != nil {
-		ls.logger.ErrorContext(
-			ctx,
-			"failed to extract backend name",
+		ls.logger.ErrorContext(ctx, "failed to extract backend name",
+			slog.String("error", err.Error()))
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if err := ls.pushMessageToRedis(ctx, msg, backendName); err != nil {
+		ls.logger.ErrorContext(ctx, "failed to push message to Redis stream",
 			slog.String("error", err.Error()),
-		)
-		return status.Error(codes.InvalidArgument, err.Error())
+			slog.String("uuid", msg.Uuid),
+			slog.String("backend_name", backendName))
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	ls.logger.InfoContext(ctx, "listener stream opened",
-		slog.String("backend_name", backendName))
-	defer ls.logger.InfoContext(ctx, "listener stream closed",
-		slog.String("backend_name", backendName))
-
-	lastProgressReport := time.Now()
-
-	// Handle bidirectional streaming
-	for {
-		// Receive message from backend
-		msg, err := stream.Recv()
-		if err != nil {
-			if utils.IsExpectedClose(err) {
-				return nil
-			}
-			ls.logger.ErrorContext(
-				ctx, "failed to receive message", slog.String("error", err.Error()))
-			return err
-		}
-
-		// Push message to Redis Stream before sending ACK
-		if err := ls.pushMessageToRedis(ctx, msg, backendName); err != nil {
-			ls.logger.ErrorContext(ctx, "failed to push message to Redis stream",
-				slog.String("error", err.Error()),
-				slog.String("uuid", msg.Uuid))
-			return err
-		}
-
-		// Send ACK response
-		ack := &pb.AckMessage{
-			AckUuid: msg.Uuid, // Acknowledge the received message UUID
-		}
-
-		if err := stream.Send(ack); err != nil {
-			ls.logger.ErrorContext(ctx, "failed to send ACK", slog.String("error", err.Error()))
-			return err
-		}
-
-		// Report progress after successfully processing message
-		now := time.Now()
-		if ls.progressWriter != nil && now.Sub(lastProgressReport) >= ls.progressInterval {
-			if err := ls.progressWriter.ReportProgress(); err != nil {
-				ls.logger.WarnContext(ctx, "failed to report progress",
-					slog.String("error", err.Error()))
-			}
-			lastProgressReport = now
-		}
-	}
-}
-
-// ListenerStream handles bidirectional streaming for backend communication.
-// It receives all types of messages (update_pod, logging, resource, resource_usage) and sends ACK responses.
-func (ls *ListenerService) ListenerStream(
-	stream pb.ListenerService_ListenerStreamServer) error {
-	return ls.handleListenerStream(stream)
+	return &pb.AckMessage{AckUuid: msg.Uuid}, nil
 }
 
 // NodeConditionStream sends initial node conditions from the DB, then streams updates.

--- a/src/service/operator/listener_service/listener_service_test.go
+++ b/src/service/operator/listener_service/listener_service_test.go
@@ -20,7 +20,6 @@ package listener_service
 
 import (
 	"context"
-	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -36,64 +35,6 @@ import (
 	pb "go.corp.nvidia.com/osmo/proto/operator"
 	"go.corp.nvidia.com/osmo/service/operator/utils"
 )
-
-// mockStream implements pb.ListenerService_ListenerStreamServer for testing
-type mockStream struct {
-	grpc.ServerStream
-	recvMessages []*pb.ListenerMessage
-	sentMessages []*pb.AckMessage
-	recvIndex    int
-	recvError    error
-	sendError    error
-	ctx          context.Context
-}
-
-func newMockStream() *mockStream {
-	return newMockStreamWithBackend("test-backend")
-}
-
-func newMockStreamWithBackend(backendName string) *mockStream {
-	ctx := context.Background()
-	// Add backend-name metadata to context
-	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("backend-name", backendName))
-	return &mockStream{
-		recvMessages: []*pb.ListenerMessage{},
-		sentMessages: []*pb.AckMessage{},
-		recvIndex:    0,
-		ctx:          ctx,
-	}
-}
-
-func (m *mockStream) Context() context.Context {
-	if m.ctx == nil {
-		return context.Background()
-	}
-	return m.ctx
-}
-
-func (m *mockStream) Send(msg *pb.AckMessage) error {
-	if m.sendError != nil {
-		return m.sendError
-	}
-	m.sentMessages = append(m.sentMessages, msg)
-	return nil
-}
-
-func (m *mockStream) Recv() (*pb.ListenerMessage, error) {
-	if m.recvError != nil {
-		return nil, m.recvError
-	}
-	if m.recvIndex >= len(m.recvMessages) {
-		return nil, io.EOF
-	}
-	msg := m.recvMessages[m.recvIndex]
-	m.recvIndex++
-	return msg, nil
-}
-
-func (m *mockStream) addRecvMessage(msg *pb.ListenerMessage) {
-	m.recvMessages = append(m.recvMessages, msg)
-}
 
 // mockNodeConditionStream implements pb.ListenerService_NodeConditionStreamServer for testing.
 type mockNodeConditionStream struct {
@@ -191,283 +132,6 @@ func TestNewListenerService(t *testing.T) {
 	})
 }
 
-func TestListenerStream_HappyPath(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-
-	// Add test messages
-	msg1 := &pb.ListenerMessage{
-		Uuid:      "test-uuid-1",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdatePod{
-			UpdatePod: &pb.UpdatePodBody{
-				WorkflowUuid: "test-workflow",
-				TaskUuid:     "test-task",
-				RetryId:      0,
-				Container:    "test-container",
-				Status:       "running",
-				Backend:      "test-backend",
-			},
-		},
-	}
-	msg2 := &pb.ListenerMessage{
-		Uuid:      "test-uuid-2",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdatePod{
-			UpdatePod: &pb.UpdatePodBody{
-				WorkflowUuid: "test-workflow",
-				TaskUuid:     "test-task-2",
-				RetryId:      0,
-				Container:    "test-container",
-				Status:       "completed",
-				Backend:      "test-backend",
-			},
-		},
-	}
-
-	stream.addRecvMessage(msg1)
-	stream.addRecvMessage(msg2)
-
-	// Start a goroutine to handle the stream
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- service.ListenerStream(stream)
-	}()
-
-	// Wait for completion or timeout
-	select {
-	case err := <-errChan:
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("test timed out")
-	}
-
-	// Verify ACKs were sent
-	if len(stream.sentMessages) != 2 {
-		t.Fatalf("expected 2 ACK messages, got %d", len(stream.sentMessages))
-	}
-
-	// Verify first ACK
-	ack1 := stream.sentMessages[0]
-	if ack1.AckUuid != msg1.Uuid {
-		t.Errorf("expected AckUuid %s, got %s", msg1.Uuid, ack1.AckUuid)
-	}
-
-	// Verify second ACK
-	ack2 := stream.sentMessages[1]
-	if ack2.AckUuid != msg2.Uuid {
-		t.Errorf("expected AckUuid %s, got %s", msg2.Uuid, ack2.AckUuid)
-	}
-}
-
-func TestListenerStream_EOFClose(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-	stream.recvError = io.EOF
-
-	err := service.ListenerStream(stream)
-	if err != nil {
-		t.Fatalf("expected nil error for EOF, got: %v", err)
-	}
-}
-
-func TestListenerStream_ContextCanceled(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-	stream.recvError = context.Canceled
-
-	err := service.ListenerStream(stream)
-	if err != nil {
-		t.Fatalf("expected nil error for context.Canceled, got: %v", err)
-	}
-}
-
-func TestListenerStream_CanceledStatusCode(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-	stream.recvError = status.Error(codes.Canceled, "canceled")
-
-	err := service.ListenerStream(stream)
-	if err != nil {
-		t.Fatalf("expected nil error for status.Canceled, got: %v", err)
-	}
-}
-
-func TestListenerStream_RecvError(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-	expectedErr := errors.New("recv error")
-	stream.recvError = expectedErr
-
-	err := service.ListenerStream(stream)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if err != expectedErr {
-		t.Fatalf("expected error %v, got %v", expectedErr, err)
-	}
-}
-
-func TestListenerStream_SendError(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-
-	// Add a message to receive
-	msg := &pb.ListenerMessage{
-		Uuid:      "test-uuid",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdatePod{
-			UpdatePod: &pb.UpdatePodBody{
-				WorkflowUuid: "test-workflow",
-				TaskUuid:     "test-task",
-				RetryId:      0,
-				Container:    "test-container",
-				Status:       "running",
-				Backend:      "test-backend",
-			},
-		},
-	}
-	stream.addRecvMessage(msg)
-
-	// Set send error
-	expectedErr := errors.New("send error")
-	stream.sendError = expectedErr
-
-	err := service.ListenerStream(stream)
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if err != expectedErr {
-		t.Fatalf("expected error %v, got %v", expectedErr, err)
-	}
-}
-
-func TestListenerStream_LatencyCalculation(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-
-	// Create a message with a timestamp in the past
-	pastTime := time.Now().Add(-100 * time.Millisecond)
-	msg := &pb.ListenerMessage{
-		Uuid:      "test-uuid",
-		Timestamp: pastTime.Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdatePod{
-			UpdatePod: &pb.UpdatePodBody{
-				WorkflowUuid: "test-workflow",
-				TaskUuid:     "test-task",
-				RetryId:      0,
-				Container:    "test-container",
-				Status:       "running",
-				Backend:      "test-backend",
-			},
-		},
-	}
-	stream.addRecvMessage(msg)
-
-	// Start stream handling in goroutine
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- service.ListenerStream(stream)
-	}()
-
-	// Wait for completion
-	select {
-	case err := <-errChan:
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("test timed out")
-	}
-
-	// Verify ACK was sent
-	if len(stream.sentMessages) != 1 {
-		t.Fatalf("expected 1 ACK message, got %d", len(stream.sentMessages))
-	}
-
-	ack := stream.sentMessages[0]
-	if ack.AckUuid != msg.Uuid {
-		t.Errorf("expected AckUuid %s, got %s", msg.Uuid, ack.AckUuid)
-	}
-}
-
-func TestListenerStream_MultipleMessages(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-
-	// Add multiple messages
-	numMessages := 10
-	for i := 0; i < numMessages; i++ {
-		msg := &pb.ListenerMessage{
-			Uuid:      "test-uuid-" + string(rune(i)),
-			Timestamp: time.Now().Format(time.RFC3339Nano),
-			Body: &pb.ListenerMessage_UpdatePod{
-				UpdatePod: &pb.UpdatePodBody{
-					WorkflowUuid: "test-workflow",
-					TaskUuid:     "test-task",
-					RetryId:      int32(i),
-					Container:    "test-container",
-					Status:       "running",
-					Backend:      "test-backend",
-				},
-			},
-		}
-		stream.addRecvMessage(msg)
-	}
-
-	// Start stream handling in goroutine
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- service.ListenerStream(stream)
-	}()
-
-	// Wait for completion
-	select {
-	case err := <-errChan:
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("test timed out")
-	}
-
-	// Verify all ACKs were sent
-	if len(stream.sentMessages) != numMessages {
-		t.Fatalf("expected %d ACK messages, got %d", numMessages, len(stream.sentMessages))
-	}
-
-	// Verify all ACKs have been sent
-	if len(stream.sentMessages) != numMessages {
-		t.Errorf("expected %d ACKs, got %d", numMessages, len(stream.sentMessages))
-	}
-}
-
 func TestRegisterServices(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	redisClient := setupTestRedis(t)
@@ -483,464 +147,22 @@ func TestRegisterServices(t *testing.T) {
 	// No assertions needed - if we reach here without panicking, the test passes
 }
 
-func TestIsExpectedClose(t *testing.T) {
-	tests := []struct {
-		name     string
-		err      error
-		expected bool
-	}{
-		{
-			name:     "nil error",
-			err:      nil,
-			expected: false,
-		},
-		{
-			name:     "io.EOF",
-			err:      io.EOF,
-			expected: true,
-		},
-		{
-			name:     "context.Canceled",
-			err:      context.Canceled,
-			expected: true,
-		},
-		{
-			name:     "status codes.Canceled",
-			err:      status.Error(codes.Canceled, "canceled"),
-			expected: true,
-		},
-		{
-			name:     "other error",
-			err:      errors.New("some error"),
-			expected: false,
-		},
-		{
-			name:     "status codes.Internal",
-			err:      status.Error(codes.Internal, "internal error"),
-			expected: false,
-		},
-		{
-			name:     "status codes.Unknown",
-			err:      status.Error(codes.Unknown, "unknown error"),
-			expected: false,
-		},
-	}
-
-	// Test that ListenerStream properly handles expected close errors
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-			redisClient := setupTestRedis(t)
-			service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-			stream := newMockStream()
-			stream.recvError = tt.err
-
-			err := service.ListenerStream(stream)
-
-			if tt.expected {
-				// Expected close errors should return nil
-				if err != nil {
-					t.Errorf("expected nil error for expected close, got: %v", err)
-				}
-			} else {
-				if tt.err != nil {
-					// Non-expected errors should be returned
-					if err == nil {
-						t.Error("expected error to be returned, got nil")
-					}
-				}
-			}
-		})
-	}
-}
-
-func TestListenerStream_WithCanceledContext(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	// Add backend-name metadata to context before canceling
-	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("backend-name", "test-backend"))
-	stream := &mockStream{
-		recvMessages: []*pb.ListenerMessage{},
-		sentMessages: []*pb.AckMessage{},
-		recvIndex:    0,
-		ctx:          ctx,
-	}
-
-	// Add a message
-	msg := &pb.ListenerMessage{
-		Uuid:      "test-uuid",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdatePod{
-			UpdatePod: &pb.UpdatePodBody{
-				WorkflowUuid: "test-workflow",
-				TaskUuid:     "test-task",
-				RetryId:      0,
-				Container:    "test-container",
-				Status:       "running",
-				Backend:      "test-backend",
-			},
-		},
-	}
-	stream.addRecvMessage(msg)
-
-	// Cancel the context before processing
-	cancel()
-	stream.recvError = context.Canceled
-
-	err := service.ListenerStream(stream)
-	if err != nil {
-		t.Fatalf("expected nil error for canceled context, got: %v", err)
-	}
-}
-
-func TestListenerStream_EmptyData(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-
-	// Add message with empty data
-	msg := &pb.ListenerMessage{
-		Uuid:      "test-uuid",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdatePod{
-			UpdatePod: &pb.UpdatePodBody{
-				WorkflowUuid: "",
-				TaskUuid:     "",
-				RetryId:      0,
-				Container:    "",
-				Status:       "",
-				Backend:      "",
-			},
-		},
-	}
-	stream.addRecvMessage(msg)
-
-	// Start stream handling in goroutine
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- service.ListenerStream(stream)
-	}()
-
-	// Wait for completion
-	select {
-	case err := <-errChan:
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("test timed out")
-	}
-
-	// Verify ACK was still sent
-	if len(stream.sentMessages) != 1 {
-		t.Fatalf("expected 1 ACK message, got %d", len(stream.sentMessages))
-	}
-
-	ack := stream.sentMessages[0]
-	if ack.AckUuid != msg.Uuid {
-		t.Errorf("expected AckUuid %s, got %s", msg.Uuid, ack.AckUuid)
-	}
-}
-
-func TestListenerStream_WithBackendNameMetadata(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	// Create stream with specific backend name
-	stream := newMockStreamWithBackend("production-backend")
-
-	// Add a message
-	msg := &pb.ListenerMessage{
-		Uuid:      "test-uuid",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdatePod{
-			UpdatePod: &pb.UpdatePodBody{
-				WorkflowUuid: "test-workflow",
-				TaskUuid:     "test-task",
-				RetryId:      0,
-				Container:    "test-container",
-				Status:       "running",
-				Backend:      "test-backend",
-			},
-		},
-	}
-	stream.addRecvMessage(msg)
-
-	// Don't set recvError - let it naturally EOF after processing the message
-
-	// Start stream handling in goroutine
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- service.ListenerStream(stream)
-	}()
-
-	// Wait for completion
-	select {
-	case err := <-errChan:
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("test timed out")
-	}
-
-	// Verify ACK was sent
-	if len(stream.sentMessages) != 1 {
-		t.Fatalf("expected 1 ACK message, got %d", len(stream.sentMessages))
-	}
-}
-
-func TestListenerStream_WithoutBackendNameMetadata(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	// Create stream without metadata (should be rejected)
-	stream := &mockStream{
-		recvMessages: []*pb.ListenerMessage{},
-		sentMessages: []*pb.AckMessage{},
-		recvIndex:    0,
-		ctx:          context.Background(), // No metadata
-	}
-
-	// Try to establish stream - should fail immediately
-	err := service.ListenerStream(stream)
-	if err == nil {
-		t.Fatal("expected error for missing backend-name metadata, got nil")
-	}
-
-	// Verify no messages were processed
-	if len(stream.sentMessages) != 0 {
-		t.Fatalf("expected 0 messages sent when connection is rejected, got %d", len(stream.sentMessages))
-	}
-}
-
-func TestListenerStream_WithEmptyBackendName(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	// Create stream with empty backend name (should be rejected)
-	ctx := context.Background()
-	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("backend-name", ""))
-	stream := &mockStream{
-		recvMessages: []*pb.ListenerMessage{},
-		sentMessages: []*pb.AckMessage{},
-		recvIndex:    0,
-		ctx:          ctx,
-	}
-
-	// Try to establish stream - should fail immediately
-	err := service.ListenerStream(stream)
-	if err == nil {
-		t.Fatal("expected error for empty backend-name metadata, got nil")
-	}
-
-	// Verify no messages were processed
-	if len(stream.sentMessages) != 0 {
-		t.Fatalf("expected 0 messages sent when connection is rejected, got %d", len(stream.sentMessages))
-	}
-}
-
 // ============================================================================
-// ListenerStream Tests
+// SendListenerMessage Tests
 // ============================================================================
 
-func TestListenerStream_HappyPath_UpdateNodeBody(t *testing.T) {
+func TestSendListenerMessage_HappyPath(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	redisClient := setupTestRedis(t)
 	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
 
-	stream := newMockStream()
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("backend-name", "test-backend"),
+	)
 
-	// Add test messages with UpdateNodeBody
-	msg1 := &pb.ListenerMessage{
-		Uuid:      "resource-uuid-1",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdateNode{
-			UpdateNode: &pb.UpdateNodeBody{
-				Hostname:   "node-1",
-				Available:  true,
-				Conditions: []string{"Ready"},
-				AllocatableFields: map[string]string{
-					"cpu":    "4000m",
-					"memory": "16Gi",
-				},
-				LabelFields: map[string]string{
-					"kubernetes.io/hostname": "node-1",
-				},
-			},
-		},
-	}
-	msg2 := &pb.ListenerMessage{
-		Uuid:      "resource-uuid-2",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdateNode{
-			UpdateNode: &pb.UpdateNodeBody{
-				Hostname:   "node-2",
-				Available:  false,
-				Conditions: []string{"Ready", "DiskPressure"},
-			},
-		},
-	}
-
-	stream.addRecvMessage(msg1)
-	stream.addRecvMessage(msg2)
-
-	// Start a goroutine to handle the stream
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- service.ListenerStream(stream)
-	}()
-
-	// Wait for completion or timeout
-	select {
-	case err := <-errChan:
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("test timed out")
-	}
-
-	// Verify ACKs were sent
-	if len(stream.sentMessages) != 2 {
-		t.Fatalf("expected 2 ACK messages, got %d", len(stream.sentMessages))
-	}
-
-	// Verify first ACK
-	ack1 := stream.sentMessages[0]
-	if ack1.AckUuid != msg1.Uuid {
-		t.Errorf("expected AckUuid %s, got %s", msg1.Uuid, ack1.AckUuid)
-	}
-
-	// Verify second ACK
-	ack2 := stream.sentMessages[1]
-	if ack2.AckUuid != msg2.Uuid {
-		t.Errorf("expected AckUuid %s, got %s", msg2.Uuid, ack2.AckUuid)
-	}
-}
-
-func TestListenerStream_HappyPath_UpdateNodeUsageBody(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-
-	// Add test message with UpdateNodeUsageBody
 	msg := &pb.ListenerMessage{
-		Uuid:      "usage-uuid-1",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdateNodeUsage{
-			UpdateNodeUsage: &pb.UpdateNodeUsageBody{
-				Hostname: "node-1",
-				UsageFields: map[string]string{
-					"cpu":    "2000m",
-					"memory": "8Gi",
-				},
-				NonWorkflowUsageFields: map[string]string{
-					"cpu":    "500m",
-					"memory": "2Gi",
-				},
-			},
-		},
-	}
-
-	stream.addRecvMessage(msg)
-
-	// Start a goroutine to handle the stream
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- service.ListenerStream(stream)
-	}()
-
-	// Wait for completion or timeout
-	select {
-	case err := <-errChan:
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("test timed out")
-	}
-
-	// Verify ACK was sent
-	if len(stream.sentMessages) != 1 {
-		t.Fatalf("expected 1 ACK message, got %d", len(stream.sentMessages))
-	}
-
-	ack := stream.sentMessages[0]
-	if ack.AckUuid != msg.Uuid {
-		t.Errorf("expected AckUuid %s, got %s", msg.Uuid, ack.AckUuid)
-	}
-}
-
-func TestListenerStream_HappyPath_DeleteResource(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-
-	// Add test message with UpdateNodeBody and delete=true
-	msg := &pb.ListenerMessage{
-		Uuid:      "delete-uuid-1",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdateNode{
-			UpdateNode: &pb.UpdateNodeBody{
-				Hostname: "node-to-delete",
-				Delete:   true,
-			},
-		},
-	}
-
-	stream.addRecvMessage(msg)
-
-	// Start a goroutine to handle the stream
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- service.ListenerStream(stream)
-	}()
-
-	// Wait for completion or timeout
-	select {
-	case err := <-errChan:
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("test timed out")
-	}
-
-	// Verify ACK was sent
-	if len(stream.sentMessages) != 1 {
-		t.Fatalf("expected 1 ACK message, got %d", len(stream.sentMessages))
-	}
-
-	ack := stream.sentMessages[0]
-	if ack.AckUuid != msg.Uuid {
-		t.Errorf("expected AckUuid %s, got %s", msg.Uuid, ack.AckUuid)
-	}
-}
-
-func TestListenerStream_MixedMessageTypes(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	redisClient := setupTestRedis(t)
-	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
-
-	stream := newMockStream()
-
-	// Add mixed message types
-	msg1 := &pb.ListenerMessage{
-		Uuid:      "resource-uuid-1",
+		Uuid:      "unary-uuid-1",
 		Timestamp: time.Now().Format(time.RFC3339Nano),
 		Body: &pb.ListenerMessage_UpdateNode{
 			UpdateNode: &pb.UpdateNodeBody{
@@ -949,60 +171,68 @@ func TestListenerStream_MixedMessageTypes(t *testing.T) {
 			},
 		},
 	}
-	msg2 := &pb.ListenerMessage{
-		Uuid:      "usage-uuid-1",
-		Timestamp: time.Now().Format(time.RFC3339Nano),
-		Body: &pb.ListenerMessage_UpdateNodeUsage{
-			UpdateNodeUsage: &pb.UpdateNodeUsageBody{
-				Hostname: "node-1",
-				UsageFields: map[string]string{
-					"cpu": "2000m",
-				},
-			},
-		},
+
+	ack, err := service.SendListenerMessage(ctx, msg)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	msg3 := &pb.ListenerMessage{
-		Uuid:      "delete-uuid-1",
+	if ack.AckUuid != msg.Uuid {
+		t.Errorf("expected AckUuid %s, got %s", msg.Uuid, ack.AckUuid)
+	}
+}
+
+func TestSendListenerMessage_MissingBackendName(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	redisClient := setupTestRedis(t)
+	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
+
+	ctx := context.Background() // No metadata
+
+	msg := &pb.ListenerMessage{
+		Uuid:      "unary-uuid-2",
 		Timestamp: time.Now().Format(time.RFC3339Nano),
 		Body: &pb.ListenerMessage_UpdateNode{
 			UpdateNode: &pb.UpdateNodeBody{
-				Hostname: "node-2",
-				Delete:   true,
+				Hostname: "node-1",
 			},
 		},
 	}
 
-	stream.addRecvMessage(msg1)
-	stream.addRecvMessage(msg2)
-	stream.addRecvMessage(msg3)
+	_, err := service.SendListenerMessage(ctx, msg)
+	if err == nil {
+		t.Fatal("expected error for missing backend-name metadata, got nil")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", status.Code(err))
+	}
+}
 
-	// Start a goroutine to handle the stream
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- service.ListenerStream(stream)
-	}()
+func TestSendListenerMessage_EmptyBackendName(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	redisClient := setupTestRedis(t)
+	service := NewListenerService(logger, redisClient, nil, setupTestOperatorArgs())
 
-	// Wait for completion or timeout
-	select {
-	case err := <-errChan:
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("test timed out")
+	ctx := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs("backend-name", ""),
+	)
+
+	msg := &pb.ListenerMessage{
+		Uuid:      "unary-uuid-3",
+		Timestamp: time.Now().Format(time.RFC3339Nano),
+		Body: &pb.ListenerMessage_UpdateNode{
+			UpdateNode: &pb.UpdateNodeBody{
+				Hostname: "node-1",
+			},
+		},
 	}
 
-	// Verify all ACKs were sent
-	if len(stream.sentMessages) != 3 {
-		t.Fatalf("expected 3 ACK messages, got %d", len(stream.sentMessages))
+	_, err := service.SendListenerMessage(ctx, msg)
+	if err == nil {
+		t.Fatal("expected error for empty backend-name metadata, got nil")
 	}
-
-	// Verify ACKs match messages
-	expectedUuids := []string{msg1.Uuid, msg2.Uuid, msg3.Uuid}
-	for i, ack := range stream.sentMessages {
-		if ack.AckUuid != expectedUuids[i] {
-			t.Errorf("ACK %d: expected AckUuid %s, got %s", i, expectedUuids[i], ack.AckUuid)
-		}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", status.Code(err))
 	}
 }
 

--- a/src/utils/roles/action_registry_test.go
+++ b/src/utils/roles/action_registry_test.go
@@ -304,8 +304,8 @@ func TestGRPCPathsResolveToActionInternalOperator(t *testing.T) {
 		wantAction string
 	}{
 		{
-			name:       "ListenerStream resolves to ActionInternalOperator",
-			path:       "/operator.ListenerService/ListenerStream",
+			name:       "SendListenerMessage resolves to ActionInternalOperator",
+			path:       "/operator.ListenerService/SendListenerMessage",
 			method:     "POST",
 			wantAction: ActionInternalOperator,
 		},
@@ -342,8 +342,8 @@ func TestExtractResourceFromPathGRPC(t *testing.T) {
 		wantResource string
 	}{
 		{
-			name:         "gRPC path returns backend wildcard (no agent segment)",
-			path:         "/operator.ListenerService/ListenerStream",
+			name:         "gRPC SendListenerMessage returns backend wildcard",
+			path:         "/operator.ListenerService/SendListenerMessage",
 			action:       ActionInternalOperator,
 			wantResource: "backend/*",
 		},


### PR DESCRIPTION
Add SendListenerMessage unary RPC to ListenerService, enabling NodeListener to use simple request-reply instead of bidirectional streaming. This improves AWS ALB compatibility (no HTTP/2 PING needed), simplifies the code (2 goroutines instead of 3, no unacked message queue), and enables better load balancing.

Changes:
- Proto: add SendListenerMessage RPC to ListenerService
- Server: add SendListenerMessage handler with Redis push and ACK
- BaseListener: add RunUnary (2-goroutine lifecycle), SendUnaryMessage, and gRPC built-in retry config for transient failures
- NodeListener: switch from Run/SendMessage to RunUnary/SendUnaryMessage
- Tests: add coverage for unary handler, base listener RunUnary, and node listener sendMessages paths

<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->

Issue #147 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
