### PR TITLE
Ensure /usr/local/bin exists before running postinstall

### DIFF
--- a/src/cli/packaging/macos/postinstall
+++ b/src/cli/packaging/macos/postinstall
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,9 @@ set -e
 OSMO_CLI_INSTALL_PATH="/usr/local/osmo"
 OSMO_CLI_SYMLINK_PATH="/usr/local/bin"
 OSMO_CLI_AUTOCOMPLETE_DIR="/usr/local/share/zsh/site-functions"
+
+# Ensure symlink directory exists (may not exist on fresh macOS installs)
+mkdir -p "$OSMO_CLI_SYMLINK_PATH"
 
 # Create symlink
 ln -s -f "$OSMO_CLI_INSTALL_PATH/osmo" "$OSMO_CLI_SYMLINK_PATH/osmo"


### PR DESCRIPTION
## Description
- `/usr/local/bin` on MacOS may not exist (especially with a fresh macbook)
- Ensure this exists during `postinstall` hook

Issue #713

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS installation reliability by ensuring required system directories are properly initialized during fresh installations, preventing potential setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->