### PR TITLE
chore: bump default osmoImageTag to 6.2 across all charts

### DIFF
--- a/deployments/charts/backend-operator/README.md
+++ b/deployments/charts/backend-operator/README.md
@@ -29,7 +29,7 @@ This Helm chart deploys the OSMO Backend-Operator for managing compute backend r
 |-----------|-------------|---------|
 | `global.name` | Name override for deployment (optional) | `null` |
 | `global.osmoImageLocation` | Location of OSMO images | `nvcr.io/nvidia/osmo` |
-| `global.osmoImageTag` | Tag of the OSMO images | `latest` |
+| `global.osmoImageTag` | Tag of the OSMO images | `6.2` |
 | `global.imagePullSecret` | Name of the image pull secret | `null` |
 | `global.nodeSelector` | Global node selector | `{}` |
 | `global.agentNamespace` | Namespace for agent deployment | `osmo` |

--- a/deployments/charts/backend-operator/values.yaml
+++ b/deployments/charts/backend-operator/values.yaml
@@ -27,7 +27,7 @@ global:
 
   ## Docker image tag for Osmo backend operators
   ##
-  osmoImageTag: latest
+  osmoImageTag: 6.2
 
   ## Name of the Kubernetes secret containing Docker registry credentials
   ##

--- a/deployments/charts/quick-start/README.md
+++ b/deployments/charts/quick-start/README.md
@@ -60,7 +60,7 @@ This chart installs and configures:
 | Parameter                               | Description                                                             | Default                            |
 | --------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------- |
 | `global.osmoImageLocation`              | Base location for OSMO Docker images in the registry                    | `nvcr.io/nvidia/osmo`              |
-| `global.osmoImageTag`                   | Docker image tag for OSMO services                                      | `latest`                           |
+| `global.osmoImageTag`                   | Docker image tag for OSMO services                                      | `6.2`                              |
 | `global.nodeSelector.node_group`        | Node group for service pods                                             | `service`                          |
 | `global.imagePullSecret`                | Name of the Kubernetes secret containing Docker registry credentials    | `null`                             |
 | `global.containerRegistry.registry`     | Container registry URL                                                  | `nvcr.io`                          |

--- a/deployments/charts/quick-start/values.yaml
+++ b/deployments/charts/quick-start/values.yaml
@@ -23,7 +23,7 @@ global:
 
   ## Docker image tag for OSMO services
   ##
-  osmoImageTag: latest
+  osmoImageTag: 6.2
 
   ## Node selector constraints for pod scheduling
   ##

--- a/deployments/charts/router/README.md
+++ b/deployments/charts/router/README.md
@@ -46,7 +46,7 @@ helm upgrade my-router ./router -f my-values.yaml
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `global.osmoImageLocation` | Base location for OSMO Docker images | `nvcr.io/nvidia/osmo` |
-| `global.osmoImageTag` | Docker image tag for OSMO router service | `latest` |
+| `global.osmoImageTag` | Docker image tag for OSMO router service | `6.2` |
 | `global.imagePullSecret` | Name of the Kubernetes secret for Docker registry credentials | `null` |
 | `global.nodeSelector` | Global node selector constraints | `{}` |
 | `global.logs.enabled` | Enable centralized logging collection | `true` |

--- a/deployments/charts/router/values.yaml
+++ b/deployments/charts/router/values.yaml
@@ -22,7 +22,7 @@ global:
 
   ## Docker image tag for Osmo router service
   ##
-  osmoImageTag: latest
+  osmoImageTag: 6.2
 
   ## Name of the Kubernetes secret containing Docker registry credentials
   ##

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -27,7 +27,7 @@ This Helm chart deploys the OSMO platform with its core services and required si
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `global.osmoImageLocation` | Location of OSMO images | `nvcr.io/nvidia/osmo` |
-| `global.osmoImageTag` | Tag of the OSMO images | `latest` |
+| `global.osmoImageTag` | Tag of the OSMO images | `6.2` |
 | `global.imagePullSecret` | Name of the Kubernetes secret containing Docker registry credentials | `null` |
 | `global.nodeSelector` | Global node selector | `{}` |
 

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -22,7 +22,7 @@ global:
 
   ## Docker image tag for Osmo services
   ##
-  osmoImageTag: latest
+  osmoImageTag: 6.2
 
   ## Name of the Kubernetes secret containing Docker registry credentials
   ##

--- a/deployments/charts/web-ui/README.md
+++ b/deployments/charts/web-ui/README.md
@@ -27,7 +27,7 @@ This Helm chart deploys the OSMO UI service along with its required sidecars and
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `global.osmoImageLocation` | Location of OSMO images | `nvcr.io/nvidia/osmo` |
-| `global.osmoImageTag` | Tag of the OSMO images | `latest` |
+| `global.osmoImageTag` | Tag of the OSMO images | `6.2` |
 | `global.imagePullSecret` | Name of the Kubernetes secret containing Docker registry credentials | `null` |
 | `global.nodeSelector` | Global node selector | `{}` |
 

--- a/deployments/charts/web-ui/values.yaml
+++ b/deployments/charts/web-ui/values.yaml
@@ -25,7 +25,7 @@ global:
 
   ## Docker image tag for Osmo server components
   ##
-  osmoImageTag: latest
+  osmoImageTag: 6.2
 
   ## Name of the Kubernetes secret containing Docker registry credentials
   ##


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
The default image tag in charts should be consistent between the supported chart and image version.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
