### PR TITLE
fix vim rendering issue by dynamic terminal size

### DIFF
--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -51,6 +51,7 @@ from src.lib.utils import (client, common, osmo_errors, paths, port_forward, pri
 
 
 INTERACTIVE_COMMANDS = ['bash', 'sh', 'zsh', 'fish', 'tcsh', 'csh', 'ksh']
+RESIZE_PREFIX = b'\x00RESIZE:'
 
 
 class TemplateData(pydantic.BaseModel, extra=pydantic.Extra.forbid):
@@ -1275,11 +1276,33 @@ async def _connect_stdin_stdout() -> Tuple[asyncio.StreamReader, asyncio.StreamW
     return reader, writer
 
 
-async def send_terminal_size(ws: websockets.WebSocketClientProtocol):  # type: ignore
+def _get_terminal_size() -> bytes:
     s = struct.pack('HHHH', 0, 0, 0, 0)
     rows, cols = struct.unpack('HHHH', fcntl.ioctl(sys.stdin, termios.TIOCGWINSZ, s))[:2]
-    size_message = json.dumps({'Rows': rows, 'Cols': cols}).encode('utf-8')
-    await ws.send(size_message)
+    return json.dumps({'Rows': rows, 'Cols': cols}).encode('utf-8')
+
+
+async def send_terminal_size(ws: websockets.WebSocketClientProtocol):  # type: ignore
+    await ws.send(_get_terminal_size())
+
+
+async def _send_terminal_resize(ws: websockets.WebSocketClientProtocol):  # type: ignore
+    await ws.send(RESIZE_PREFIX + _get_terminal_size())
+
+
+async def _watch_terminal_resize(ws: websockets.WebSocketClientProtocol):  # type: ignore
+    loop = asyncio.get_event_loop()
+    resize_event = asyncio.Event()
+    loop.add_signal_handler(signal.SIGWINCH, resize_event.set)
+    try:
+        while True:
+            await resize_event.wait()
+            resize_event.clear()
+            await _send_terminal_resize(ws)
+    except (websockets.exceptions.ConnectionClosed, asyncio.CancelledError):
+        pass
+    finally:
+        loop.remove_signal_handler(signal.SIGWINCH)
 
 
 async def _run_exec_interactive(service_client: client.ServiceClient, args: argparse.Namespace,
@@ -1313,7 +1336,8 @@ async def _run_exec_interactive(service_client: client.ServiceClient, args: argp
         loop = asyncio.get_event_loop()
         coroutines = [
             loop.create_task(port_forward.write_data(writer, ws)),
-            loop.create_task(port_forward.read_data(reader, ws))
+            loop.create_task(port_forward.read_data(reader, ws)),
+            loop.create_task(_watch_terminal_resize(ws)),
         ]
         done, pending = await asyncio.wait(coroutines, return_when=asyncio.FIRST_COMPLETED)
         for i in pending:

--- a/src/runtime/cmd/user/user.go
+++ b/src/runtime/cmd/user/user.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -101,7 +102,8 @@ func userExec(entryCommand string, socketPath string, historyFilePath string) {
 	defer conn.Close()
 
 	// Read the first message from conn to get initial window size
-	dec := json.NewDecoder(conn)
+	connReader := bufio.NewReader(conn)
+	dec := json.NewDecoder(connReader)
 	var initSize struct {
 		Rows uint16 `json:"rows"`
 		Cols uint16 `json:"cols"`
@@ -153,9 +155,60 @@ func userExec(entryCommand string, socketPath string, historyFilePath string) {
 	waitGroup.Add(1)
 
 	go func() {
-		_, err = io.Copy(terminal, conn)
-		if err != nil {
-			log.Println("User Exec: Error writing to exec instance", err)
+		resizePrefix := []byte("\x00RESIZE:")
+		buf := make([]byte, 32*1024)
+		var carry []byte
+		for {
+			n, readErr := connReader.Read(buf)
+			if readErr != nil {
+				if readErr != io.EOF {
+					log.Println("User Exec: Error reading from connection", readErr)
+				}
+				return
+			}
+			var data []byte
+			if len(carry) > 0 {
+				data = append(carry, buf[:n]...)
+				carry = nil
+			} else {
+				data = buf[:n]
+			}
+
+			for len(data) > 0 {
+				idx := bytes.IndexByte(data, 0x00)
+				if idx == -1 {
+					terminal.Write(data)
+					break
+				}
+				if idx > 0 {
+					terminal.Write(data[:idx])
+					data = data[idx:]
+				}
+				if len(data) < len(resizePrefix) {
+					carry = append(carry, data...)
+					break
+				}
+				if !bytes.HasPrefix(data, resizePrefix) {
+					terminal.Write(data[:1])
+					data = data[1:]
+					continue
+				}
+				end := bytes.IndexByte(data[len(resizePrefix):], '}')
+				if end == -1 {
+					carry = append(carry, data...)
+					break
+				}
+				jsonEnd := len(resizePrefix) + end + 1
+				var size struct {
+					Rows uint16 `json:"Rows"`
+					Cols uint16 `json:"Cols"`
+				}
+				if jsonErr := json.Unmarshal(data[len(resizePrefix):jsonEnd], &size); jsonErr == nil {
+					pty.Setsize(terminal, &pty.Winsize{Rows: size.Rows, Cols: size.Cols})
+					execCmd.Process.Signal(syscall.SIGWINCH)
+				}
+				data = data[jsonEnd:]
+			}
 		}
 	}()
 


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->
Solve vim rendering issue using osmo workflow exec

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic terminal resize handling for interactive sessions: window size is now synchronized in real-time over connections, improving display formatting.
  * Interactive sessions now watch for terminal resize events and transmit size updates continuously while connected.

* **Bug Fixes**
  * Improved robustness of interactive input/output forwarding to prevent truncation or missed resize updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->