### PR TITLE
Add ability to submit to default pool with osmo-user

### DIFF
--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -4516,6 +4516,12 @@ DEFAULT_ROLES: Dict[str, Role] = {
                     'resources:Read',
                 ],
                 resources=['*']
+            ),
+            role.RolePolicy(
+                actions=[
+                    'workflow:Create',
+                ],
+                resources=['pool/default']
             )
         ]
     ),


### PR DESCRIPTION
Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The default user role now has permission to create workflows in the default pool, expanding workflow management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->