### PR TITLE
Fix Internal CI

### DIFF
--- a/src/tests/common/storage/s3.py
+++ b/src/tests/common/storage/s3.py
@@ -28,7 +28,9 @@ from src.tests.common.core import network, utils
 
 logger = logging.getLogger(__name__)
 
-S3_IMAGE = f'{utils.DOCKER_HUB_REGISTRY}/localstack/localstack:s3-latest'
+# TODO: Switch the localstack image
+#   https://blog.localstack.cloud/localstack-for-aws-release-2026-03-0/
+S3_IMAGE = f'{utils.DOCKER_HUB_REGISTRY}/localstack/localstack:s3-community-archive'
 S3_NAME = f's3-{labels.SESSION_ID}'
 S3_PORT = 4566
 S3_REGION = 'us-east-1'


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
The localstack image has been removed; https://blog.localstack.cloud/localstack-for-aws-release-2026-03-0/

```
podman run --rm -ti --entrypoint sh localstack/localstack:s3-latest -c "cat error.sh"
#!/bin/sh
cat << EOF
ERROR
============================================================================
  The LocalStack Docker image you started (localstack/localstack:s3-latest)
  is no longer available.
  This image was discontinued with the release of v2026.03 on
  23rd March 2026. Please switch to localstack/localstack-pro.

  See: https://blog.localstack.cloud/localstack-for-aws-release-2026-03-0/
============================================================================
EOF
exit
```

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated S3 testcontainer Docker image reference to the community archive version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->