### PR TITLE
fix: wait for Envoy proxy listeners before declaring SSL proxy ready

### DIFF
--- a/src/tests/common/envoy/ssl_proxy.py
+++ b/src/tests/common/envoy/ssl_proxy.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import itertools
 import logging
 import os
+import socket
 import tempfile
 from typing import Dict, List
 
@@ -217,6 +218,18 @@ exec envoy -c /etc/envoy/envoy.yaml
                 f'Unexpected status code: {response.status_code}')
         if response.text.strip() != ENVOY_LIVE_STATUS:
             raise ConnectionError(f'Envoy is not ready yet: {response.text}')
+
+        # Verify each proxy listener is accepting TCP connections. Envoy may report LIVE
+        # on the admin port before all forwarding listeners have finished binding.
+        for assigned_ports in self.backend_alias_to_assigned_ports.values():
+            for assigned_port in assigned_ports.values():
+                proxy_port = self.get_exposed_port(assigned_port)
+                try:
+                    with socket.create_connection((host, proxy_port), timeout=1):
+                        pass
+                except (socket.error, OSError) as e:
+                    raise requests.ConnectionError(
+                        f'Proxy listener not ready at {host}:{proxy_port}') from e
 
     def start(self):
         super().start()


### PR DESCRIPTION
## Description
The _wait_until_ready check only polled the Envoy admin port (/ready), which can report LIVE before all forwarding listeners have finished binding. Add a TCP socket probe for each proxy port so the readiness check retries until the ports the tests actually use are accepting connections.

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced proxy readiness verification to ensure listeners are fully operational before tests proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->