### PR TITLE
fix: use correct JobResult field names for credential error handling

### DIFF
--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -380,8 +380,8 @@ class UploadWorkflowFiles(WorkflowJob):
 
         if workflow_config.workflow_log.credential is None:
             return JobResult(
-                success=False,
-                error='Workflow log credential is not set',
+                status=JobStatus.FAILED_NO_RETRY,
+                message='Workflow log credential is not set',
             )
 
         storage_client = storage.Client.create(
@@ -1388,8 +1388,8 @@ class CleanupWorkflow(WorkflowJob):
         workflow_config = context.postgres.get_workflow_configs()
         if workflow_config.workflow_log.credential is None:
             return JobResult(
-                success=False,
-                error='Workflow log credential is not set',
+                status=JobStatus.FAILED_NO_RETRY,
+                message='Workflow log credential is not set',
             )
         storage_client = storage.Client.create(
             data_credential=workflow_config.workflow_log.credential,
@@ -1728,8 +1728,8 @@ class UploadApp(FrontendJob):
 
         if workflow_config.workflow_app.credential is None:
             return JobResult(
-                success=False,
-                error='Workflow app credential is not set',
+                status=JobStatus.FAILED_NO_RETRY,
+                message='Workflow app credential is not set',
             )
 
         storage_client = storage.Client.create(
@@ -1789,8 +1789,8 @@ class DeleteApp(FrontendJob):
 
         if workflow_config.workflow_app.credential is None:
             return JobResult(
-                success=False,
-                error='Workflow app credential is not set',
+                status=JobStatus.FAILED_NO_RETRY,
+                message='Workflow app credential is not set',
             )
 
         storage_client = storage.Client.create(


### PR DESCRIPTION
## Summary

Fixes incorrect `JobResult` constructor parameters in four credential-check locations. The code used `success=False` and `error='...'` but `JobResult` only has `status` and `message` fields. Pydantic silently ignores the unknown fields, causing credential failures to return `SUCCESS` instead of `FAILED_NO_RETRY`.

**Affected jobs:**
- `UploadWorkflowFiles.execute()` (L382-386)
- `CleanupWorkflow.execute()` (L1389-1393)
- `UploadApp.execute()` (L1730-1733)
- `DeleteApp.execute()` (L1790-1793)

**Impact:** When `workflow_log.credential` or `workflow_app.credential` is `None`, the worker logs "completed with status SUCCESS" while no files are uploaded to S3. This makes credential misconfiguration completely invisible.

**Fix:** Replace `success=False, error='...'` with `status=JobStatus.FAILED_NO_RETRY, message='...'` — matching the pattern used elsewhere (e.g., `worker.py`, `backend_jobs.py`).

Fixes #748

## Test plan
- [ ] Deploy with `workflow_log.credential` unset
- [ ] Submit a workflow and verify worker logs show `FAILED_NO_RETRY: Workflow log credential is not set`
- [ ] Verify existing workflows with valid credentials still upload logs successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated job execution error handling to use improved failure status reporting when credentials are missing, enhancing consistency in how job failures are communicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->