### PR TITLE
feat: support DefaultDataCredential for workflow_log and workflow_data

### DIFF
--- a/src/runtime/pkg/data/data.go
+++ b/src/runtime/pkg/data/data.go
@@ -414,8 +414,14 @@ func MountURL(downloadType string, credentialInfo ConfigInfo, urlPath string,
 		osmoChan <- fmt.Sprintf("Missing data credential for %s.", storageBackend.GetProfile())
 		return isEmpty
 	}
-	os.Setenv("AWS_ACCESS_KEY_ID", dataCredential.AccessKeyId)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", dataCredential.AccessKey)
+	// Only set static key env vars when keys are provided.
+	// When using DefaultDataCredential (ambient credentials via Pod Identity,
+	// IRSA, etc.), keys are empty — setting empty env vars would clobber the
+	// SDK's default credential chain.
+	if dataCredential.AccessKeyId != "" {
+		os.Setenv("AWS_ACCESS_KEY_ID", dataCredential.AccessKeyId)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", dataCredential.AccessKey)
+	}
 
 	var commandArgs []string
 

--- a/src/runtime/pkg/data/data.go
+++ b/src/runtime/pkg/data/data.go
@@ -422,6 +422,9 @@ func MountURL(downloadType string, credentialInfo ConfigInfo, urlPath string,
 		os.Setenv("AWS_ACCESS_KEY_ID", dataCredential.AccessKeyId)
 		os.Setenv("AWS_SECRET_ACCESS_KEY", dataCredential.AccessKey)
 	}
+	if dataCredential.Region != "" {
+		os.Setenv("AWS_REGION", dataCredential.Region)
+	}
 
 	var commandArgs []string
 

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1480,7 +1480,7 @@ class PostgresConnector:
 
             return None
 
-    def get_all_data_creds(self, user: str) -> Dict[str, credentials.DataCredential]:
+    def get_all_data_creds(self, user: str) -> Dict[str, credentials.StaticDataCredential]:
         """ Fetch all data credentials for user. """
         select_data_cmd = PostgresSelectCommand(
             table='credential',

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1480,7 +1480,7 @@ class PostgresConnector:
 
             return None
 
-    def get_all_data_creds(self, user: str) -> Dict[str, credentials.StaticDataCredential]:
+    def get_all_data_creds(self, user: str) -> Dict[str, credentials.DataCredential]:
         """ Fetch all data credentials for user. """
         select_data_cmd = PostgresSelectCommand(
             table='credential',
@@ -2557,7 +2557,7 @@ def construct_path(endpoint: str, bucket: str, path: str):
 
 class LogConfig(ExtraArgBaseModel):
     """ Config for storing information about data. """
-    credential: credentials.StaticDataCredential | None = None
+    credential: credentials.DataCredential | None = None
 
 
 class WorkflowInfo(ExtraArgBaseModel):
@@ -2574,7 +2574,7 @@ class WorkflowInfo(ExtraArgBaseModel):
 
 class DataConfig(ExtraArgBaseModel):
     """ Config for storing information about data. """
-    credential: credentials.StaticDataCredential | None = None
+    credential: credentials.DataCredential | None = None
 
     base_url: str = ''
     # Timeout in mins for osmo-ctrl to retry connecting to the OSMO service until exiting the task

--- a/src/utils/job/task.py
+++ b/src/utils/job/task.py
@@ -102,7 +102,7 @@ def create_login_dict(user: str,
 
 
 def create_config_dict(
-    data_info: dict[str, credentials.StaticDataCredential],
+    data_info: dict[str, credentials.DataCredential],
 ) -> dict:
     '''
     Creates the config dict where the input should be a dict containing key values like:
@@ -2339,7 +2339,7 @@ class TaskGroup(pydantic.BaseModel):
         service_config: connectors.ServiceConfig | None = None,
         dataset_config: connectors.DatasetConfig | None = None,
         pool_info: connectors.Pool | None = None,
-        data_endpoints: Dict[str, credentials.StaticDataCredential] | None = None,
+        data_endpoints: Dict[str, credentials.DataCredential] | None = None,
         skip_refresh_token: bool = False,
         auth_token: str | None = None,
     ) -> Tuple[Dict, Dict[str, kb_objects.FileMount], Optional[Tuple[str, str]]]:


### PR DESCRIPTION
## Summary

Widens `LogConfig`, `DataConfig`, and related function signatures from `StaticDataCredential` to `DataCredential` so workflow log/data storage can use ambient credentials (IRSA, Pod Identity, instance metadata) instead of requiring static IAM access keys.

This picks up where #508 (Azure workload identity) left off — the `DataCredential` union, S3 backend, and `storage.Client.create()` already support `DefaultDataCredential`, but the workflow config types were still locked to `StaticDataCredential`.

### Changes

**Python — type annotations only (postgres.py, task.py):**
- `LogConfig.credential`: `StaticDataCredential | None` → `DataCredential | None`
- `DataConfig.credential`: `StaticDataCredential | None` → `DataCredential | None`
- `get_all_data_creds` return type: `Dict[str, StaticDataCredential]` → `Dict[str, DataCredential]`
- `create_config_dict` / `data_endpoints`: widened to `DataCredential`

**Go — sidecar credential guard (data.go):**
- Skip `os.Setenv("AWS_ACCESS_KEY_ID", ...)` when keys are empty, preventing ambient credential clobbering

### No changes needed
- `workflow_service.py` — already delegates to `Client.create()` generically
- `client.py` — already accepts `DataCredential` union
- `s3.py` — already has `DefaultDataCredential` match arm
- `credentials.py` — `DataCredential` union already defined

Fixes Issue #749

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Test plan
- [ ] Configure workflow_log with endpoint + region only (no access keys): `curl -X PATCH /api/configs/workflow -d '{"workflow_log": {"credential": {"endpoint": "s3://bucket", "region": "us-west-2"}}}'`
- [ ] Verify 200 OK (previously 422)
- [ ] Submit workflow, verify logs upload to S3 using ambient credentials
- [ ] Verify existing deployments with static keys still work (backwards compatible)
- [ ] Verify Go sidecar mounts data correctly with both credential types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential handling so empty static values no longer override existing environment or ambient credential resolution.

* **Compatibility**
  * Broadened credential types used in workflow/config handling and task orchestration to accept a wider range of credential formats, improving interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->