### PR TITLE
Update the roles field for token set to extend and be nargs

### DIFF
--- a/src/cli/access_token.py
+++ b/src/cli/access_token.py
@@ -60,7 +60,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                             help='Create token for a specific user (admin only). '
                                  'By default, creates token for the current user.')
     set_parser.add_argument('--roles', '-r',
-                            action='append',
+                            action='extend',
+                            nargs='+',
                             help='Role to assign to the token. Can be specified multiple times. '
                                  'If not specified, inherits all of the user\'s current roles.')
     set_parser.add_argument('--format-type', '-t',


### PR DESCRIPTION
Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `--roles/-r` argument handling in the `token set` subcommand to support more flexible input of multiple role values. Users can now provide multiple roles in a single flag invocation or use multiple flag occurrences with improved accumulation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->