### PR TITLE
No npm packages < 7 days

### DIFF
--- a/src/ui/.npmrc
+++ b/src/ui/.npmrc
@@ -1,3 +1,21 @@
 fetch-retries=5
 legacy-peer-deps=true
 prefer-dedupe=true
+
+# Supply chain security: reject packages published less than 7 days ago.
+# This gives security scanners time to flag malicious versions before CI pulls them.
+# Value is in minutes (7 days = 10,080 minutes).
+minimum-release-age=10080
+
+# To exempt a package (e.g., internal packages or critical security patches):
+#   minimum-release-age-exclude=@my-scope/my-package,another-package
+#
+# Wildcards are supported:
+#   minimum-release-age-exclude=@my-scope/*
+#
+# When to exempt:
+#   - Internal/private packages you publish and trust
+#   - Critical security patches that can't wait 7 days
+#   - Packages with verified provenance (npm attestations)
+#
+# Keep exemptions minimal — each one is a gap in the quarantine window.

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -2,7 +2,7 @@
   "name": "ui-next",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.26.1",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "clean": "rm -rf .next .turbo",
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Description
- Extra guardrails in light of new axios supply chain attack

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package installation age requirement ensuring packages published at least 7 days ago are eligible for installation.
  * Updated package manager version from 10.26.1 to 10.33.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->