### PR TITLE
Add a way to move back and forth workflow versions

### DIFF
--- a/src/ui/src/features/log-viewer/workflow-selector.tsx
+++ b/src/ui/src/features/log-viewer/workflow-selector.tsx
@@ -214,7 +214,7 @@ export function WorkflowSelector({ error, initialWorkflowId = "" }: WorkflowSele
                 <ul className="mt-1.5 space-y-1 text-sm text-zinc-700 dark:text-zinc-300">
                   <li>
                     <code className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-xs dark:bg-zinc-800 dark:text-zinc-200">
-                      mock-typical-completed
+                      mock-typical-completed-1
                     </code>
                     <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">
                       Standard 3-stage training (2k lines)
@@ -222,7 +222,7 @@ export function WorkflowSelector({ error, initialWorkflowId = "" }: WorkflowSele
                   </li>
                   <li>
                     <code className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-xs dark:bg-zinc-800 dark:text-zinc-200">
-                      mock-empty-completed
+                      mock-empty-completed-1
                     </code>
                     <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">Instant completion (no logs)</span>
                   </li>
@@ -234,7 +234,7 @@ export function WorkflowSelector({ error, initialWorkflowId = "" }: WorkflowSele
                 <ul className="mt-1.5 space-y-1 text-sm text-zinc-700 dark:text-zinc-300">
                   <li>
                     <code className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-xs dark:bg-zinc-800 dark:text-zinc-200">
-                      mock-typical-running
+                      mock-typical-running-1
                     </code>
                     <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">
                       Standard 2-stage job (2k lines)
@@ -242,19 +242,19 @@ export function WorkflowSelector({ error, initialWorkflowId = "" }: WorkflowSele
                   </li>
                   <li>
                     <code className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-xs dark:bg-zinc-800 dark:text-zinc-200">
-                      mock-streaming-running
+                      mock-streaming-running-1
                     </code>
                     <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">Live tailing (infinite)</span>
                   </li>
                   <li>
                     <code className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-xs dark:bg-zinc-800 dark:text-zinc-200">
-                      mock-large-running
+                      mock-large-running-1
                     </code>
                     <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">Performance test (50k lines)</span>
                   </li>
                   <li>
                     <code className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-xs dark:bg-zinc-800 dark:text-zinc-200">
-                      mock-multi-task
+                      mock-multi-task-1
                     </code>
                     <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">Complex DAG (8 groups)</span>
                   </li>
@@ -266,13 +266,13 @@ export function WorkflowSelector({ error, initialWorkflowId = "" }: WorkflowSele
                 <ul className="mt-1.5 space-y-1 text-sm text-zinc-700 dark:text-zinc-300">
                   <li>
                     <code className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-xs dark:bg-zinc-800 dark:text-zinc-200">
-                      mock-typical-failed
+                      mock-typical-failed-1
                     </code>
                     <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">CUDA OOM with retries</span>
                   </li>
                   <li>
                     <code className="rounded bg-zinc-200 px-1.5 py-0.5 font-mono text-xs dark:bg-zinc-800 dark:text-zinc-200">
-                      mock-high-error-failed
+                      mock-high-error-failed-1
                     </code>
                     <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-400">Extreme error spam (30%)</span>
                   </li>

--- a/src/ui/src/features/workflows/detail/components/panel/core/lib/panel-types.ts
+++ b/src/ui/src/features/workflows/detail/components/panel/core/lib/panel-types.ts
@@ -91,6 +91,12 @@ export interface BreadcrumbSegment {
   onClick: () => void;
 }
 
+export interface SequenceNavProps {
+  onPrevious: () => void;
+  onNext: () => void;
+  hasPrevious: boolean;
+}
+
 export interface DetailsPanelHeaderProps {
   title: string;
   subtitle?: string;
@@ -106,4 +112,6 @@ export interface DetailsPanelHeaderProps {
   expandableContent?: React.ReactNode;
   isExpanded?: boolean;
   onToggleExpand?: () => void;
+  /** Prev/next arrows flanking the title for sequential workflows */
+  sequenceNav?: SequenceNavProps;
 }

--- a/src/ui/src/features/workflows/detail/components/panel/ui/details-panel-header.tsx
+++ b/src/ui/src/features/workflows/detail/components/panel/ui/details-panel-header.tsx
@@ -33,7 +33,7 @@
 "use client";
 
 import { memo, useState, useMemo, useCallback, useRef } from "react";
-import { ChevronDown, ChevronRight, MoreVertical, Columns, Search, Check } from "lucide-react";
+import { ChevronDown, ChevronLeft, ChevronRight, MoreVertical, Columns, Search, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
@@ -47,6 +47,7 @@ import {
 } from "@/components/shadcn/dropdown-menu";
 import { PanelHeader, PanelBadge, PanelTitle, PanelSubtitle } from "@/components/panel/panel-header";
 import { getStatusIcon } from "@/features/workflows/detail/lib/status";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/tooltip";
 import type {
   DetailsPanelHeaderProps,
   SiblingTask,
@@ -236,6 +237,7 @@ export const DetailsPanelHeader = memo(function DetailsPanelHeader({
   expandableContent,
   isExpanded: controlledExpanded,
   onToggleExpand,
+  sequenceNav,
 }: ExtendedHeaderProps) {
   // Use controlled state if provided, otherwise fall back to local state
   const [localExpanded, setLocalExpanded] = useState(false);
@@ -270,6 +272,24 @@ export const DetailsPanelHeader = memo(function DetailsPanelHeader({
           </span>
         ))}
 
+      {/* Sequence nav: previous arrow before title */}
+      {sequenceNav && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={sequenceNav.onPrevious}
+              disabled={!sequenceNav.hasPrevious}
+              className="shrink-0 rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 disabled:pointer-events-none disabled:opacity-30 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+              aria-label="Previous workflow"
+            >
+              <ChevronLeft className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{sequenceNav.hasPrevious ? "Previous workflow" : "No previous workflow"}</TooltipContent>
+        </Tooltip>
+      )}
+
       {/* Title - with optional task switcher */}
       {hasSiblings ? (
         <TaskSwitcher
@@ -279,6 +299,23 @@ export const DetailsPanelHeader = memo(function DetailsPanelHeader({
         />
       ) : (
         <PanelTitle>{title}</PanelTitle>
+      )}
+
+      {/* Sequence nav: next arrow after title */}
+      {sequenceNav && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={sequenceNav.onNext}
+              className="shrink-0 rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+              aria-label="Next workflow"
+            >
+              <ChevronRight className="size-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Next workflow</TooltipContent>
+        </Tooltip>
       )}
 
       {/* Subtitle */}

--- a/src/ui/src/features/workflows/detail/components/panel/ui/workflow/workflow-details.tsx
+++ b/src/ui/src/features/workflows/detail/components/panel/ui/workflow/workflow-details.tsx
@@ -58,6 +58,7 @@ import { WorkflowTimeline } from "@/features/workflows/detail/components/panel/u
 import { parseTime } from "@/features/workflows/detail/components/panel/core/lib/timeline-utils";
 import { useTick } from "@/hooks/use-tick";
 import type { WorkflowTab } from "@/features/workflows/detail/hooks/use-navigation-state";
+import { useWorkflowSequenceNav } from "@/features/workflows/detail/hooks/use-workflow-sequence-nav";
 import { WorkflowTasksTab } from "@/features/workflows/detail/components/panel/ui/workflow/workflow-tasks-tab";
 import { LogViewerContainer } from "@/components/log-viewer/components/log-viewer-container";
 
@@ -344,6 +345,8 @@ export const WorkflowDetails = memo(function WorkflowDetails({
   onSelectGroup,
   onSelectTask,
 }: WorkflowDetailsProps) {
+  const sequenceNav = useWorkflowSequenceNav(workflow.name);
+
   // Tab configuration
   const tabs = useMemo<PanelTab[]>(
     () => [
@@ -408,6 +411,7 @@ export const WorkflowDetails = memo(function WorkflowDetails({
         statusContent={statusContent}
         isExpanded={isDetailsExpanded}
         onToggleExpand={onToggleDetailsExpanded}
+        sequenceNav={sequenceNav ?? undefined}
       />
 
       {/* Tab Navigation - Chrome-style tabs with curved connectors */}

--- a/src/ui/src/features/workflows/detail/hooks/use-workflow-sequence-nav.ts
+++ b/src/ui/src/features/workflows/detail/hooks/use-workflow-sequence-nav.ts
@@ -56,11 +56,8 @@ export function useWorkflowSequenceNav(workflowName: string): SequenceNav | null
     router.push(`/workflows/${encodeURIComponent(parsed.prefix + (parsed.number + 1))}`);
   }, [parsed, router]);
 
-  if (!parsed) return null;
-
-  return {
-    onPrevious,
-    onNext,
-    hasPrevious: parsed.number > 1,
-  };
+  return useMemo(() => {
+    if (!parsed) return null;
+    return { onPrevious, onNext, hasPrevious: parsed.number > 1 };
+  }, [parsed, onPrevious, onNext]);
 }

--- a/src/ui/src/features/workflows/detail/hooks/use-workflow-sequence-nav.ts
+++ b/src/ui/src/features/workflows/detail/hooks/use-workflow-sequence-nav.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useMemo, useCallback } from "react";
+import { useNavigationRouter } from "@/hooks/use-navigation-router";
+
+/** Matches workflow names ending with a dash and a number, e.g. "my-workflow-5" */
+const SEQUENCE_PATTERN = /^(.+-)(\d+)$/;
+
+export interface SequenceNav {
+  /** Navigate to the previous workflow in the sequence */
+  onPrevious: () => void;
+  /** Navigate to the next workflow in the sequence */
+  onNext: () => void;
+  /** Whether the previous button should be disabled (at #1) */
+  hasPrevious: boolean;
+}
+
+/**
+ * Parses a sequential workflow name (e.g. "my-workflow-5") and provides
+ * navigation to the previous/next workflow in the sequence.
+ *
+ * Returns null if the workflow name doesn't match the pattern.
+ */
+export function useWorkflowSequenceNav(workflowName: string): SequenceNav | null {
+  const router = useNavigationRouter();
+
+  const parsed = useMemo(() => {
+    const match = SEQUENCE_PATTERN.exec(workflowName);
+    if (!match) return null;
+    return { prefix: match[1], number: parseInt(match[2], 10) };
+  }, [workflowName]);
+
+  const onPrevious = useCallback(() => {
+    if (!parsed || parsed.number <= 1) return;
+    router.push(`/workflows/${encodeURIComponent(parsed.prefix + (parsed.number - 1))}`);
+  }, [parsed, router]);
+
+  const onNext = useCallback(() => {
+    if (!parsed) return;
+    router.push(`/workflows/${encodeURIComponent(parsed.prefix + (parsed.number + 1))}`);
+  }, [parsed, router]);
+
+  if (!parsed) return null;
+
+  return {
+    onPrevious,
+    onNext,
+    hasPrevious: parsed.number > 1,
+  };
+}

--- a/src/ui/src/mocks/generators/workflow-generator.ts
+++ b/src/ui/src/mocks/generators/workflow-generator.ts
@@ -166,8 +166,10 @@ export class WorkflowGenerator {
   private config: GeneratorConfig;
   private nameToIndexCache: Map<string, number> = new Map();
   private cachedUpToIndex: number = -1;
-  /** Pre-computed sequenced names (e.g. "train-llama-1", "train-llama-2") */
-  private sequenceNameCache: Map<number, string> | null = null;
+  /** Incrementally-built sequenced names (e.g. "train-llama-1", "train-llama-2") */
+  private sequenceNameCache: Map<number, string> = new Map();
+  private sequenceBuiltUpTo: number = -1;
+  private baseNameCounter: Map<string, number> = new Map();
 
   constructor(config: Partial<GeneratorConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config };
@@ -176,7 +178,9 @@ export class WorkflowGenerator {
   clearCache(): void {
     this.nameToIndexCache.clear();
     this.cachedUpToIndex = -1;
-    this.sequenceNameCache = null;
+    this.sequenceNameCache.clear();
+    this.sequenceBuiltUpTo = -1;
+    this.baseNameCounter.clear();
   }
 
   get total(): number {
@@ -450,45 +454,36 @@ export class WorkflowGenerator {
   }
 
   /**
-   * Pre-compute sequenced workflow names for all indices.
+   * Incrementally build sequenced names up to the requested index.
    * Each base name (prefix-suffix) gets a sequence number starting at 1,
    * e.g. "train-llama-1", "train-llama-2", "eval-bert-1".
    */
-  private ensureSequenceNames(): Map<number, string> {
-    if (this.sequenceNameCache) return this.sequenceNameCache;
-
-    const indexToBaseName = new Map<number, string>();
-    for (let i = 0; i < this.total; i++) {
+  private ensureSequenceBuiltUpTo(index: number): void {
+    for (let i = this.sequenceBuiltUpTo + 1; i <= index; i++) {
       faker.seed(this.config.baseSeed + i);
       const prefix = faker.helpers.arrayElement(this.config.patterns.namePatterns.prefixes);
       const suffix = faker.helpers.arrayElement(this.config.patterns.namePatterns.suffixes);
-      indexToBaseName.set(i, `${prefix}-${suffix}`);
-    }
-
-    const baseNameCounter = new Map<string, number>();
-    this.sequenceNameCache = new Map();
-    for (let i = 0; i < this.total; i++) {
-      const baseName = indexToBaseName.get(i)!;
-      const seq = (baseNameCounter.get(baseName) ?? 0) + 1;
-      baseNameCounter.set(baseName, seq);
+      const baseName = `${prefix}-${suffix}`;
+      const seq = (this.baseNameCounter.get(baseName) ?? 0) + 1;
+      this.baseNameCounter.set(baseName, seq);
       this.sequenceNameCache.set(i, `${baseName}-${seq}`);
     }
-
-    return this.sequenceNameCache;
+    if (index > this.sequenceBuiltUpTo) {
+      this.sequenceBuiltUpTo = index;
+    }
   }
 
-  private generateName(_index: number): string {
-    const cache = this.ensureSequenceNames();
+  private generateName(index: number): string {
+    this.ensureSequenceBuiltUpTo(index);
 
-    // Re-seed after ensureSequenceNames (which may have changed faker state
-    // during pre-computation), then consume the same faker calls as the
-    // original implementation to keep downstream generation deterministic.
-    faker.seed(this.config.baseSeed + _index);
+    // Re-seed and consume the same faker calls as the original implementation
+    // to keep downstream generation (buildWorkflowBody) deterministic.
+    faker.seed(this.config.baseSeed + index);
     faker.helpers.arrayElement(this.config.patterns.namePatterns.prefixes);
     faker.helpers.arrayElement(this.config.patterns.namePatterns.suffixes);
     faker.string.alphanumeric(8);
 
-    return cache.get(_index) ?? `workflow-${_index + 1}`;
+    return this.sequenceNameCache.get(index) ?? `workflow-${index + 1}`;
   }
 
   private generateSubmitTime(index: number): string {

--- a/src/ui/src/mocks/generators/workflow-generator.ts
+++ b/src/ui/src/mocks/generators/workflow-generator.ts
@@ -166,6 +166,8 @@ export class WorkflowGenerator {
   private config: GeneratorConfig;
   private nameToIndexCache: Map<string, number> = new Map();
   private cachedUpToIndex: number = -1;
+  /** Pre-computed sequenced names (e.g. "train-llama-1", "train-llama-2") */
+  private sequenceNameCache: Map<number, string> | null = null;
 
   constructor(config: Partial<GeneratorConfig> = {}) {
     this.config = { ...DEFAULT_CONFIG, ...config };
@@ -174,6 +176,7 @@ export class WorkflowGenerator {
   clearCache(): void {
     this.nameToIndexCache.clear();
     this.cachedUpToIndex = -1;
+    this.sequenceNameCache = null;
   }
 
   get total(): number {
@@ -446,11 +449,46 @@ export class WorkflowGenerator {
     return Object.keys(distribution)[0];
   }
 
+  /**
+   * Pre-compute sequenced workflow names for all indices.
+   * Each base name (prefix-suffix) gets a sequence number starting at 1,
+   * e.g. "train-llama-1", "train-llama-2", "eval-bert-1".
+   */
+  private ensureSequenceNames(): Map<number, string> {
+    if (this.sequenceNameCache) return this.sequenceNameCache;
+
+    const indexToBaseName = new Map<number, string>();
+    for (let i = 0; i < this.total; i++) {
+      faker.seed(this.config.baseSeed + i);
+      const prefix = faker.helpers.arrayElement(this.config.patterns.namePatterns.prefixes);
+      const suffix = faker.helpers.arrayElement(this.config.patterns.namePatterns.suffixes);
+      indexToBaseName.set(i, `${prefix}-${suffix}`);
+    }
+
+    const baseNameCounter = new Map<string, number>();
+    this.sequenceNameCache = new Map();
+    for (let i = 0; i < this.total; i++) {
+      const baseName = indexToBaseName.get(i)!;
+      const seq = (baseNameCounter.get(baseName) ?? 0) + 1;
+      baseNameCounter.set(baseName, seq);
+      this.sequenceNameCache.set(i, `${baseName}-${seq}`);
+    }
+
+    return this.sequenceNameCache;
+  }
+
   private generateName(_index: number): string {
-    const prefix = faker.helpers.arrayElement(this.config.patterns.namePatterns.prefixes);
-    const suffix = faker.helpers.arrayElement(this.config.patterns.namePatterns.suffixes);
-    const id = faker.string.alphanumeric(8).toLowerCase();
-    return `${prefix}-${suffix}-${id}`;
+    const cache = this.ensureSequenceNames();
+
+    // Re-seed after ensureSequenceNames (which may have changed faker state
+    // during pre-computation), then consume the same faker calls as the
+    // original implementation to keep downstream generation deterministic.
+    faker.seed(this.config.baseSeed + _index);
+    faker.helpers.arrayElement(this.config.patterns.namePatterns.prefixes);
+    faker.helpers.arrayElement(this.config.patterns.namePatterns.suffixes);
+    faker.string.alphanumeric(8);
+
+    return cache.get(_index) ?? `workflow-${_index + 1}`;
   }
 
   private generateSubmitTime(index: number): string {

--- a/src/ui/src/mocks/mock-workflows.ts
+++ b/src/ui/src/mocks/mock-workflows.ts
@@ -27,15 +27,15 @@ import type { LogLevel, LogIOType } from "@/lib/api/log-adapter/types";
  * WORKFLOW NAMING CONVENTION: mock-{scenario}-{status}
  *
  * Available Mock Workflows:
- * - mock-typical-completed: Standard 3-stage training (500-2000 lines)
- * - mock-typical-running: Standard 2-stage job in progress
- * - mock-typical-failed: CUDA OOM with 3 retries
- * - mock-streaming-running: Infinite log stream (100ms delay)
- * - mock-high-error-failed: 30% error rate for error handling testing
- * - mock-large-running: 50k-75k lines for performance testing
- * - mock-empty-completed: No logs (edge case testing)
- * - mock-multi-task: Complex 8-task DAG
- * - mock-canceled-idle: Canceled due to idle shutdown, null exit codes with failure messages
+ * - mock-typical-completed-1: Standard 3-stage training (500-2000 lines)
+ * - mock-typical-running-1: Standard 2-stage job in progress
+ * - mock-typical-failed-1: CUDA OOM with 3 retries
+ * - mock-streaming-running-1: Infinite log stream (100ms delay)
+ * - mock-high-error-failed-1: 30% error rate for error handling testing
+ * - mock-large-running-1: 50k-75k lines for performance testing
+ * - mock-empty-completed-1: No logs (edge case testing)
+ * - mock-multi-task-1: Complex 8-task DAG
+ * - mock-canceled-idle-1: Canceled due to idle shutdown, null exit codes with failure messages
  *
  * HOW TO ADD A NEW SCENARIO:
  * 1. Add entry to MOCK_WORKFLOWS with descriptive ID
@@ -46,10 +46,10 @@ import type { LogLevel, LogIOType } from "@/lib/api/log-adapter/types";
  * EXAMPLE USAGE:
  * ```typescript
  * // In test or dev:
- * <LogViewerContainer workflowId="mock-high-error-failed" />
+ * <LogViewerContainer workflowId="mock-high-error-failed-1" />
  *
  * // URL:
- * /log-viewer?workflow=mock-high-error-failed
+ * /log-viewer?workflow=mock-high-error-failed-1
  *
  * // MSW automatically generates 28% error logs!
  * ```
@@ -128,9 +128,9 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * Standard completed workflow - typical 3-stage training job.
    * Default scenario for testing completed workflows.
    */
-  "mock-typical-completed": {
+  "mock-typical-completed-1": {
     ...MOCK_WORKFLOW_BASE,
-    name: "mock-typical-completed",
+    name: "mock-typical-completed-1",
     uuid: "550e8400-e29b-41d4-a716-446655440001",
     status: WorkflowStatus.COMPLETED,
     priority: WorkflowPriority.NORMAL,
@@ -157,8 +157,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-1",
             start_time: new Date(BASE_SUBMIT_TIME.getTime() + 60_000).toISOString(),
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 360_000).toISOString(),
-            logs: "/api/workflow/mock-typical-completed/logs?task_id=preprocess&retry_id=0",
-            events: "/api/workflow/mock-typical-completed/events?task_id=preprocess&retry_id=0",
+            logs: "/api/workflow/mock-typical-completed-1/logs?task_id=preprocess&retry_id=0",
+            events: "/api/workflow/mock-typical-completed-1/events?task_id=preprocess&retry_id=0",
           },
         ],
       },
@@ -178,8 +178,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-2",
             start_time: new Date(BASE_SUBMIT_TIME.getTime() + 420_000).toISOString(),
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 2_400_000).toISOString(),
-            logs: "/api/workflow/mock-typical-completed/logs?task_id=train&retry_id=0",
-            events: "/api/workflow/mock-typical-completed/events?task_id=train&retry_id=0",
+            logs: "/api/workflow/mock-typical-completed-1/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-typical-completed-1/events?task_id=train&retry_id=0",
           },
         ],
       },
@@ -199,17 +199,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-3",
             start_time: new Date(BASE_SUBMIT_TIME.getTime() + 2_460_000).toISOString(),
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 2_700_000).toISOString(),
-            logs: "/api/workflow/mock-typical-completed/logs?task_id=evaluate&retry_id=0",
-            events: "/api/workflow/mock-typical-completed/events?task_id=evaluate&retry_id=0",
+            logs: "/api/workflow/mock-typical-completed-1/logs?task_id=evaluate&retry_id=0",
+            events: "/api/workflow/mock-typical-completed-1/events?task_id=evaluate&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-typical-completed/spec",
-    template_spec: "/api/workflow/mock-typical-completed/template-spec",
-    logs: "/api/workflow/mock-typical-completed/logs",
-    events: "/api/workflow/mock-typical-completed/events",
-    overview: "/api/workflow/mock-typical-completed/overview",
+    spec: "/api/workflow/mock-typical-completed-1/spec",
+    template_spec: "/api/workflow/mock-typical-completed-1/template-spec",
+    logs: "/api/workflow/mock-typical-completed-1/logs",
+    events: "/api/workflow/mock-typical-completed-1/events",
+    overview: "/api/workflow/mock-typical-completed-1/overview",
     _logConfig: {
       volume: { min: 500, max: 2000 },
       levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
@@ -229,9 +229,9 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * Standard running workflow - typical 2-stage job in progress.
    * Default scenario for testing running workflows.
    */
-  "mock-typical-running": {
+  "mock-typical-running-1": {
     ...MOCK_WORKFLOW_BASE,
-    name: "mock-typical-running",
+    name: "mock-typical-running-1",
     uuid: "550e8400-e29b-41d4-a716-446655440002",
     status: WorkflowStatus.RUNNING,
     priority: WorkflowPriority.HIGH,
@@ -256,8 +256,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-1",
             start_time: new Date(Date.now() - 540_000).toISOString(),
             end_time: new Date(Date.now() - 480_000).toISOString(),
-            logs: "/api/workflow/mock-typical-running/logs?task_id=setup&retry_id=0",
-            events: "/api/workflow/mock-typical-running/events?task_id=setup&retry_id=0",
+            logs: "/api/workflow/mock-typical-running-1/logs?task_id=setup&retry_id=0",
+            events: "/api/workflow/mock-typical-running-1/events?task_id=setup&retry_id=0",
           },
         ],
       },
@@ -276,17 +276,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             pod_name: "train-0-abc789",
             node_name: "node-2",
             start_time: new Date(Date.now() - 450_000).toISOString(),
-            logs: "/api/workflow/mock-typical-running/logs?task_id=train&retry_id=0",
-            events: "/api/workflow/mock-typical-running/events?task_id=train&retry_id=0",
+            logs: "/api/workflow/mock-typical-running-1/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-typical-running-1/events?task_id=train&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-typical-running/spec",
-    template_spec: "/api/workflow/mock-typical-running/template-spec",
-    logs: "/api/workflow/mock-typical-running/logs",
-    events: "/api/workflow/mock-typical-running/events",
-    overview: "/api/workflow/mock-typical-running/overview",
+    spec: "/api/workflow/mock-typical-running-1/spec",
+    template_spec: "/api/workflow/mock-typical-running-1/template-spec",
+    logs: "/api/workflow/mock-typical-running-1/logs",
+    events: "/api/workflow/mock-typical-running-1/events",
+    overview: "/api/workflow/mock-typical-running-1/overview",
     _logConfig: {
       volume: { min: 500, max: 2000 },
       levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
@@ -306,9 +306,9 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * Failed workflow with retries - CUDA OOM after 3 attempts.
    * Good for testing retry UI and failure messages.
    */
-  "mock-typical-failed": {
+  "mock-typical-failed-1": {
     ...MOCK_WORKFLOW_BASE,
-    name: "mock-typical-failed",
+    name: "mock-typical-failed-1",
     uuid: "550e8400-e29b-41d4-a716-446655440003",
     status: WorkflowStatus.FAILED,
     priority: WorkflowPriority.NORMAL,
@@ -335,8 +335,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-1",
             start_time: new Date(BASE_SUBMIT_TIME.getTime() + 30_000).toISOString(),
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 180_000).toISOString(),
-            logs: "/api/workflow/mock-typical-failed/logs?task_id=data_load&retry_id=0",
-            events: "/api/workflow/mock-typical-failed/events?task_id=data_load&retry_id=0",
+            logs: "/api/workflow/mock-typical-failed-1/logs?task_id=data_load&retry_id=0",
+            events: "/api/workflow/mock-typical-failed-1/events?task_id=data_load&retry_id=0",
           },
         ],
       },
@@ -359,8 +359,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 320_000).toISOString(),
             failure_message: "CUDA out of memory",
             exit_code: 1,
-            logs: "/api/workflow/mock-typical-failed/logs?task_id=train&retry_id=0",
-            events: "/api/workflow/mock-typical-failed/events?task_id=train&retry_id=0",
+            logs: "/api/workflow/mock-typical-failed-1/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-typical-failed-1/events?task_id=train&retry_id=0",
           },
           {
             name: "train",
@@ -373,8 +373,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 520_000).toISOString(),
             failure_message: "CUDA out of memory",
             exit_code: 1,
-            logs: "/api/workflow/mock-typical-failed/logs?task_id=train&retry_id=1",
-            events: "/api/workflow/mock-typical-failed/events?task_id=train&retry_id=1",
+            logs: "/api/workflow/mock-typical-failed-1/logs?task_id=train&retry_id=1",
+            events: "/api/workflow/mock-typical-failed-1/events?task_id=train&retry_id=1",
           },
           {
             name: "train",
@@ -387,17 +387,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 900_000).toISOString(),
             failure_message: "CUDA out of memory",
             exit_code: 1,
-            logs: "/api/workflow/mock-typical-failed/logs?task_id=train&retry_id=2",
-            events: "/api/workflow/mock-typical-failed/events?task_id=train&retry_id=2",
+            logs: "/api/workflow/mock-typical-failed-1/logs?task_id=train&retry_id=2",
+            events: "/api/workflow/mock-typical-failed-1/events?task_id=train&retry_id=2",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-typical-failed/spec",
-    template_spec: "/api/workflow/mock-typical-failed/template-spec",
-    logs: "/api/workflow/mock-typical-failed/logs",
-    events: "/api/workflow/mock-typical-failed/events",
-    overview: "/api/workflow/mock-typical-failed/overview",
+    spec: "/api/workflow/mock-typical-failed-1/spec",
+    template_spec: "/api/workflow/mock-typical-failed-1/template-spec",
+    logs: "/api/workflow/mock-typical-failed-1/logs",
+    events: "/api/workflow/mock-typical-failed-1/events",
+    overview: "/api/workflow/mock-typical-failed-1/overview",
     _logConfig: {
       volume: { min: 500, max: 2000 },
       levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
@@ -417,9 +417,9 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * Streaming running workflow - live tailing simulation.
    * Infinite log stream for testing real-time updates and auto-scroll.
    */
-  "mock-streaming-running": {
+  "mock-streaming-running-1": {
     ...MOCK_WORKFLOW_BASE,
-    name: "mock-streaming-running",
+    name: "mock-streaming-running-1",
     uuid: "550e8400-e29b-41d4-a716-446655440004",
     status: WorkflowStatus.RUNNING,
     priority: WorkflowPriority.NORMAL,
@@ -443,17 +443,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             pod_name: "train-streaming-abc",
             node_name: "node-1",
             start_time: new Date(Date.now() - 240_000).toISOString(),
-            logs: "/api/workflow/mock-streaming-running/logs?task_id=train&retry_id=0",
-            events: "/api/workflow/mock-streaming-running/events?task_id=train&retry_id=0",
+            logs: "/api/workflow/mock-streaming-running-1/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-streaming-running-1/events?task_id=train&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-streaming-running/spec",
-    template_spec: "/api/workflow/mock-streaming-running/template-spec",
-    logs: "/api/workflow/mock-streaming-running/logs",
-    events: "/api/workflow/mock-streaming-running/events",
-    overview: "/api/workflow/mock-streaming-running/overview",
+    spec: "/api/workflow/mock-streaming-running-1/spec",
+    template_spec: "/api/workflow/mock-streaming-running-1/template-spec",
+    logs: "/api/workflow/mock-streaming-running-1/logs",
+    events: "/api/workflow/mock-streaming-running-1/events",
+    overview: "/api/workflow/mock-streaming-running-1/overview",
     _logConfig: {
       volume: { min: 500, max: 1000 },
       levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
@@ -473,9 +473,9 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * High-error failed workflow - extreme error rate for UI stress testing.
    * 30% errors, 20% warnings - tests error highlighting and filtering.
    */
-  "mock-high-error-failed": {
+  "mock-high-error-failed-1": {
     ...MOCK_WORKFLOW_BASE,
-    name: "mock-high-error-failed",
+    name: "mock-high-error-failed-1",
     uuid: "550e8400-e29b-41d4-a716-446655440005",
     status: WorkflowStatus.FAILED,
     priority: WorkflowPriority.HIGH,
@@ -505,17 +505,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 600_000).toISOString(),
             failure_message: "Excessive errors during training",
             exit_code: 1,
-            logs: "/api/workflow/mock-high-error-failed/logs?task_id=train&retry_id=0",
-            events: "/api/workflow/mock-high-error-failed/events?task_id=train&retry_id=0",
+            logs: "/api/workflow/mock-high-error-failed-1/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-high-error-failed-1/events?task_id=train&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-high-error-failed/spec",
-    template_spec: "/api/workflow/mock-high-error-failed/template-spec",
-    logs: "/api/workflow/mock-high-error-failed/logs",
-    events: "/api/workflow/mock-high-error-failed/events",
-    overview: "/api/workflow/mock-high-error-failed/overview",
+    spec: "/api/workflow/mock-high-error-failed-1/spec",
+    template_spec: "/api/workflow/mock-high-error-failed-1/template-spec",
+    logs: "/api/workflow/mock-high-error-failed-1/logs",
+    events: "/api/workflow/mock-high-error-failed-1/events",
+    overview: "/api/workflow/mock-high-error-failed-1/overview",
     _logConfig: {
       volume: { min: 500, max: 1000 },
       levelDistribution: {
@@ -548,9 +548,9 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * Large running workflow - performance testing with 50k+ lines.
    * Tests virtualization, memory usage, and scroll performance.
    */
-  "mock-large-running": {
+  "mock-large-running-1": {
     ...MOCK_WORKFLOW_BASE,
-    name: "mock-large-running",
+    name: "mock-large-running-1",
     uuid: "550e8400-e29b-41d4-a716-446655440006",
     status: WorkflowStatus.RUNNING,
     priority: WorkflowPriority.NORMAL,
@@ -574,17 +574,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             pod_name: "train-large-abc",
             node_name: "node-1",
             start_time: new Date(Date.now() - 3_540_000).toISOString(),
-            logs: "/api/workflow/mock-large-running/logs?task_id=train&retry_id=0",
-            events: "/api/workflow/mock-large-running/events?task_id=train&retry_id=0",
+            logs: "/api/workflow/mock-large-running-1/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-large-running-1/events?task_id=train&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-large-running/spec",
-    template_spec: "/api/workflow/mock-large-running/template-spec",
-    logs: "/api/workflow/mock-large-running/logs",
-    events: "/api/workflow/mock-large-running/events",
-    overview: "/api/workflow/mock-large-running/overview",
+    spec: "/api/workflow/mock-large-running-1/spec",
+    template_spec: "/api/workflow/mock-large-running-1/template-spec",
+    logs: "/api/workflow/mock-large-running-1/logs",
+    events: "/api/workflow/mock-large-running-1/events",
+    overview: "/api/workflow/mock-large-running-1/overview",
     _logConfig: {
       volume: { min: 50000, max: 75000 },
       levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
@@ -604,9 +604,9 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * Empty completed workflow - instant completion with no logs.
    * Tests empty state UI and edge cases.
    */
-  "mock-empty-completed": {
+  "mock-empty-completed-1": {
     ...MOCK_WORKFLOW_BASE,
-    name: "mock-empty-completed",
+    name: "mock-empty-completed-1",
     uuid: "550e8400-e29b-41d4-a716-446655440007",
     status: WorkflowStatus.COMPLETED,
     priority: WorkflowPriority.LOW,
@@ -633,17 +633,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-1",
             start_time: new Date(BASE_SUBMIT_TIME.getTime() + 6_000).toISOString(),
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 10_000).toISOString(),
-            logs: "/api/workflow/mock-empty-completed/logs?task_id=noop&retry_id=0",
-            events: "/api/workflow/mock-empty-completed/events?task_id=noop&retry_id=0",
+            logs: "/api/workflow/mock-empty-completed-1/logs?task_id=noop&retry_id=0",
+            events: "/api/workflow/mock-empty-completed-1/events?task_id=noop&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-empty-completed/spec",
-    template_spec: "/api/workflow/mock-empty-completed/template-spec",
-    logs: "/api/workflow/mock-empty-completed/logs",
-    events: "/api/workflow/mock-empty-completed/events",
-    overview: "/api/workflow/mock-empty-completed/overview",
+    spec: "/api/workflow/mock-empty-completed-1/spec",
+    template_spec: "/api/workflow/mock-empty-completed-1/template-spec",
+    logs: "/api/workflow/mock-empty-completed-1/logs",
+    events: "/api/workflow/mock-empty-completed-1/events",
+    overview: "/api/workflow/mock-empty-completed-1/overview",
     _logConfig: {
       volume: { min: 0, max: 0 },
       levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
@@ -661,8 +661,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * Workflow with logs available but task still scheduling (no start_time).
    * Tests that logs/events are fetched even before the task starts running.
    */
-  "mock-has-logs-not-started": {
-    name: "mock-has-logs-not-started",
+  "mock-has-logs-not-started-1": {
+    name: "mock-has-logs-not-started-1",
     uuid: "550e8400-e29b-41d4-a716-446655440009",
     submitted_by: "user@example.com",
     status: WorkflowStatus.PENDING,
@@ -688,17 +688,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             pod_name: "",
             // No start_time — task hasn't started yet
             // But logs and events URLs are present
-            logs: "/api/workflow/mock-has-logs-not-started/logs?task_id=train&retry_id=0",
-            events: "/api/workflow/mock-has-logs-not-started/events?task_id=train&retry_id=0",
+            logs: "/api/workflow/mock-has-logs-not-started-1/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-has-logs-not-started-1/events?task_id=train&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-has-logs-not-started/spec",
-    template_spec: "/api/workflow/mock-has-logs-not-started/template-spec",
-    logs: "/api/workflow/mock-has-logs-not-started/logs",
-    events: "/api/workflow/mock-has-logs-not-started/events",
-    overview: "/api/workflow/mock-has-logs-not-started/overview",
+    spec: "/api/workflow/mock-has-logs-not-started-1/spec",
+    template_spec: "/api/workflow/mock-has-logs-not-started-1/template-spec",
+    logs: "/api/workflow/mock-has-logs-not-started-1/logs",
+    events: "/api/workflow/mock-has-logs-not-started-1/events",
+    overview: "/api/workflow/mock-has-logs-not-started-1/overview",
     outputs: undefined,
     plugins: {},
     _logConfig: {
@@ -721,8 +721,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * task2 retry_id=0 failed with RESCHEDULED, then retry_id=1 succeeded.
    * Based on real restart-1067 workflow from staging.
    */
-  "mock-restart-completed": {
-    name: "mock-restart-completed",
+  "mock-restart-completed-1": {
+    name: "mock-restart-completed-1",
     uuid: "550e8400-e29b-41d4-a716-44665544000a",
     submitted_by: "user@example.com",
     status: WorkflowStatus.COMPLETED,
@@ -763,8 +763,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             output_upload_start_time: new Date(BASE_SUBMIT_TIME.getTime() + 430_000).toISOString(),
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 437_000).toISOString(),
             exit_code: 0,
-            logs: "/api/workflow/mock-restart-completed/logs?task_id=task1&retry_id=0",
-            events: "/api/workflow/mock-restart-completed/events?task_id=task1&retry_id=0",
+            logs: "/api/workflow/mock-restart-completed-1/logs?task_id=task1&retry_id=0",
+            events: "/api/workflow/mock-restart-completed-1/events?task_id=task1&retry_id=0",
           },
           // task2 retry 1: rescheduled attempt that succeeded
           {
@@ -784,8 +784,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             output_upload_start_time: new Date(BASE_SUBMIT_TIME.getTime() + 432_000).toISOString(),
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 437_000).toISOString(),
             exit_code: 0,
-            logs: "/api/workflow/mock-restart-completed/logs?task_id=task2&retry_id=1",
-            events: "/api/workflow/mock-restart-completed/events?task_id=task2&retry_id=1",
+            logs: "/api/workflow/mock-restart-completed-1/logs?task_id=task2&retry_id=1",
+            events: "/api/workflow/mock-restart-completed-1/events?task_id=task2&retry_id=1",
           },
           // task2 retry 0: original attempt that was rescheduled
           {
@@ -807,18 +807,18 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             failure_message:
               "Failure reason:\n- Exit code 1 due to Task task2 failure. Exit Action: RESCHEDULE the task for exit code 1.",
             exit_code: 1,
-            logs: "/api/workflow/mock-restart-completed/logs?task_id=task2&retry_id=0",
-            error_logs: "/api/workflow/mock-restart-completed/error_logs?task_name=task2&retry_id=0",
-            events: "/api/workflow/mock-restart-completed/events?task_id=task2&retry_id=0",
+            logs: "/api/workflow/mock-restart-completed-1/logs?task_id=task2&retry_id=0",
+            error_logs: "/api/workflow/mock-restart-completed-1/error_logs?task_name=task2&retry_id=0",
+            events: "/api/workflow/mock-restart-completed-1/events?task_id=task2&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-restart-completed/spec",
-    template_spec: "/api/workflow/mock-restart-completed/template-spec",
-    logs: "/api/workflow/mock-restart-completed/logs",
-    events: "/api/workflow/mock-restart-completed/events",
-    overview: "/api/workflow/mock-restart-completed/overview",
+    spec: "/api/workflow/mock-restart-completed-1/spec",
+    template_spec: "/api/workflow/mock-restart-completed-1/template-spec",
+    logs: "/api/workflow/mock-restart-completed-1/logs",
+    events: "/api/workflow/mock-restart-completed-1/events",
+    overview: "/api/workflow/mock-restart-completed-1/overview",
     outputs: undefined,
     plugins: { rsync: true },
     _logConfig: {
@@ -840,9 +840,9 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * Multi-task workflow - complex DAG with many groups and tasks.
    * Tests UI with large task counts and complex dependencies.
    */
-  "mock-multi-task": {
+  "mock-multi-task-1": {
     ...MOCK_WORKFLOW_BASE,
-    name: "mock-multi-task",
+    name: "mock-multi-task-1",
     uuid: "550e8400-e29b-41d4-a716-446655440008",
     status: WorkflowStatus.RUNNING,
     priority: WorkflowPriority.NORMAL,
@@ -868,8 +868,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-1",
             start_time: new Date(Date.now() - 1_740_000).toISOString(),
             end_time: new Date(Date.now() - 1_620_000).toISOString(),
-            logs: "/api/workflow/mock-multi-task/logs?task_id=download&retry_id=0",
-            events: "/api/workflow/mock-multi-task/events?task_id=download&retry_id=0",
+            logs: "/api/workflow/mock-multi-task-1/logs?task_id=download&retry_id=0",
+            events: "/api/workflow/mock-multi-task-1/events?task_id=download&retry_id=0",
           },
           {
             name: "validate",
@@ -880,8 +880,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-2",
             start_time: new Date(Date.now() - 1_740_000).toISOString(),
             end_time: new Date(Date.now() - 1_620_000).toISOString(),
-            logs: "/api/workflow/mock-multi-task/logs?task_id=validate&retry_id=0",
-            events: "/api/workflow/mock-multi-task/events?task_id=validate&retry_id=0",
+            logs: "/api/workflow/mock-multi-task-1/logs?task_id=validate&retry_id=0",
+            events: "/api/workflow/mock-multi-task-1/events?task_id=validate&retry_id=0",
           },
           {
             name: "clean",
@@ -892,8 +892,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-3",
             start_time: new Date(Date.now() - 1_740_000).toISOString(),
             end_time: new Date(Date.now() - 1_620_000).toISOString(),
-            logs: "/api/workflow/mock-multi-task/logs?task_id=clean&retry_id=0",
-            events: "/api/workflow/mock-multi-task/events?task_id=clean&retry_id=0",
+            logs: "/api/workflow/mock-multi-task-1/logs?task_id=clean&retry_id=0",
+            events: "/api/workflow/mock-multi-task-1/events?task_id=clean&retry_id=0",
           },
         ],
       },
@@ -914,8 +914,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-1",
             start_time: new Date(Date.now() - 1_560_000).toISOString(),
             end_time: new Date(Date.now() - 1_320_000).toISOString(),
-            logs: "/api/workflow/mock-multi-task/logs?task_id=extract&retry_id=0",
-            events: "/api/workflow/mock-multi-task/events?task_id=extract&retry_id=0",
+            logs: "/api/workflow/mock-multi-task-1/logs?task_id=extract&retry_id=0",
+            events: "/api/workflow/mock-multi-task-1/events?task_id=extract&retry_id=0",
           },
           {
             name: "transform",
@@ -926,8 +926,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             node_name: "node-2",
             start_time: new Date(Date.now() - 1_560_000).toISOString(),
             end_time: new Date(Date.now() - 1_320_000).toISOString(),
-            logs: "/api/workflow/mock-multi-task/logs?task_id=transform&retry_id=0",
-            events: "/api/workflow/mock-multi-task/events?task_id=transform&retry_id=0",
+            logs: "/api/workflow/mock-multi-task-1/logs?task_id=transform&retry_id=0",
+            events: "/api/workflow/mock-multi-task-1/events?task_id=transform&retry_id=0",
           },
         ],
       },
@@ -947,8 +947,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             pod_name: "train-pqr",
             node_name: "node-3",
             start_time: new Date(Date.now() - 1_200_000).toISOString(),
-            logs: "/api/workflow/mock-multi-task/logs?task_id=train&retry_id=0",
-            events: "/api/workflow/mock-multi-task/events?task_id=train&retry_id=0",
+            logs: "/api/workflow/mock-multi-task-1/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-multi-task-1/events?task_id=train&retry_id=0",
           },
         ],
       },
@@ -966,8 +966,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             lead: true,
             task_uuid: "task-multi-007",
             pod_name: "",
-            logs: "/api/workflow/mock-multi-task/logs?task_id=metrics&retry_id=0",
-            events: "/api/workflow/mock-multi-task/events?task_id=metrics&retry_id=0",
+            logs: "/api/workflow/mock-multi-task-1/logs?task_id=metrics&retry_id=0",
+            events: "/api/workflow/mock-multi-task-1/events?task_id=metrics&retry_id=0",
           },
           {
             name: "report",
@@ -975,17 +975,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             status: TaskGroupStatus.WAITING,
             task_uuid: "task-multi-008",
             pod_name: "",
-            logs: "/api/workflow/mock-multi-task/logs?task_id=report&retry_id=0",
-            events: "/api/workflow/mock-multi-task/events?task_id=report&retry_id=0",
+            logs: "/api/workflow/mock-multi-task-1/logs?task_id=report&retry_id=0",
+            events: "/api/workflow/mock-multi-task-1/events?task_id=report&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-multi-task/spec",
-    template_spec: "/api/workflow/mock-multi-task/template-spec",
-    logs: "/api/workflow/mock-multi-task/logs",
-    events: "/api/workflow/mock-multi-task/events",
-    overview: "/api/workflow/mock-multi-task/overview",
+    spec: "/api/workflow/mock-multi-task-1/spec",
+    template_spec: "/api/workflow/mock-multi-task-1/template-spec",
+    logs: "/api/workflow/mock-multi-task-1/logs",
+    events: "/api/workflow/mock-multi-task-1/events",
+    overview: "/api/workflow/mock-multi-task-1/overview",
     _logConfig: {
       volume: { min: 2000, max: 5000 },
       levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
@@ -1004,9 +1004,9 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
    * Canceled workflow - idle job shutdown with multiple workers.
    * Tests failure_message display when exit_code is null (canceled, not crashed).
    */
-  "mock-canceled-idle": {
+  "mock-canceled-idle-1": {
     ...MOCK_WORKFLOW_BASE,
-    name: "mock-canceled-idle",
+    name: "mock-canceled-idle-1",
     uuid: "550e8400-e29b-41d4-a716-44665544000b",
     submitted_by: "jsmith@example.com",
     cancelled_by: "idle-job-shutdown",
@@ -1049,8 +1049,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 11_460_000).toISOString(),
             input_download_start_time: new Date(BASE_SUBMIT_TIME.getTime() + 12_000).toISOString(),
             input_download_end_time: new Date(BASE_SUBMIT_TIME.getTime() + 12_000).toISOString(),
-            logs: "/api/workflow/mock-canceled-idle/logs?task_id=master&retry_id=0",
-            events: "/api/workflow/mock-canceled-idle/events?task_id=master&retry_id=0",
+            logs: "/api/workflow/mock-canceled-idle-1/logs?task_id=master&retry_id=0",
+            events: "/api/workflow/mock-canceled-idle-1/events?task_id=master&retry_id=0",
           },
           {
             name: "worker_1",
@@ -1070,8 +1070,8 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 11_460_000).toISOString(),
             input_download_start_time: new Date(BASE_SUBMIT_TIME.getTime() + 12_000).toISOString(),
             input_download_end_time: new Date(BASE_SUBMIT_TIME.getTime() + 12_000).toISOString(),
-            logs: "/api/workflow/mock-canceled-idle/logs?task_id=worker_1&retry_id=0",
-            events: "/api/workflow/mock-canceled-idle/events?task_id=worker_1&retry_id=0",
+            logs: "/api/workflow/mock-canceled-idle-1/logs?task_id=worker_1&retry_id=0",
+            events: "/api/workflow/mock-canceled-idle-1/events?task_id=worker_1&retry_id=0",
           },
           {
             name: "worker_2",
@@ -1091,17 +1091,17 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
             end_time: new Date(BASE_SUBMIT_TIME.getTime() + 11_460_000).toISOString(),
             input_download_start_time: new Date(BASE_SUBMIT_TIME.getTime() + 12_500).toISOString(),
             input_download_end_time: new Date(BASE_SUBMIT_TIME.getTime() + 12_500).toISOString(),
-            logs: "/api/workflow/mock-canceled-idle/logs?task_id=worker_2&retry_id=0",
-            events: "/api/workflow/mock-canceled-idle/events?task_id=worker_2&retry_id=0",
+            logs: "/api/workflow/mock-canceled-idle-1/logs?task_id=worker_2&retry_id=0",
+            events: "/api/workflow/mock-canceled-idle-1/events?task_id=worker_2&retry_id=0",
           },
         ],
       },
     ],
-    spec: "/api/workflow/mock-canceled-idle/spec",
-    template_spec: "/api/workflow/mock-canceled-idle/template-spec",
-    logs: "/api/workflow/mock-canceled-idle/logs",
-    events: "/api/workflow/mock-canceled-idle/events",
-    overview: "/api/workflow/mock-canceled-idle/overview",
+    spec: "/api/workflow/mock-canceled-idle-1/spec",
+    template_spec: "/api/workflow/mock-canceled-idle-1/template-spec",
+    logs: "/api/workflow/mock-canceled-idle-1/logs",
+    events: "/api/workflow/mock-canceled-idle-1/events",
+    overview: "/api/workflow/mock-canceled-idle-1/overview",
     _logConfig: {
       volume: { min: 200, max: 500 },
       levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
@@ -1114,6 +1114,159 @@ export const MOCK_WORKFLOWS: Record<string, MockWorkflowResponse> = {
         streamDelayMs: 200,
         taskCount: 3,
       },
+    },
+  },
+
+  /**
+   * Sequential workflow series (1 of 3) - for testing sequence navigation buttons.
+   */
+  "mock-sequence-1": {
+    ...MOCK_WORKFLOW_BASE,
+    name: "mock-sequence-1",
+    uuid: "550e8400-e29b-41d4-a716-446655440101",
+    status: WorkflowStatus.COMPLETED,
+    priority: WorkflowPriority.NORMAL,
+    tags: ["sequence-test"],
+    submit_time: BASE_SUBMIT_TIME.toISOString(),
+    start_time: new Date(BASE_SUBMIT_TIME.getTime() + 30_000).toISOString(),
+    end_time: new Date(BASE_SUBMIT_TIME.getTime() + 600_000).toISOString(),
+    queued_time: 30,
+    duration: 570,
+    groups: [
+      {
+        name: "train",
+        status: TaskGroupStatus.COMPLETED,
+        remaining_upstream_groups: [],
+        downstream_groups: [],
+        tasks: [
+          {
+            name: "train",
+            retry_id: 0,
+            status: TaskGroupStatus.COMPLETED,
+            lead: true,
+            task_uuid: "task-seq-1-001",
+            pod_name: "train-0-seq1",
+            node_name: "node-1",
+            start_time: new Date(BASE_SUBMIT_TIME.getTime() + 60_000).toISOString(),
+            end_time: new Date(BASE_SUBMIT_TIME.getTime() + 600_000).toISOString(),
+            logs: "/api/workflow/mock-sequence-1/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-sequence-1/events?task_id=train&retry_id=0",
+          },
+        ],
+      },
+    ],
+    spec: "/api/workflow/mock-sequence-1/spec",
+    template_spec: "/api/workflow/mock-sequence-1/template-spec",
+    logs: "/api/workflow/mock-sequence-1/logs",
+    events: "/api/workflow/mock-sequence-1/events",
+    overview: "/api/workflow/mock-sequence-1/overview",
+    _logConfig: {
+      volume: { min: 50, max: 100 },
+      levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
+      ioTypeDistribution: DEFAULT_IO_DISTRIBUTION,
+      features: { retries: false, multiLine: false, ansiCodes: false },
+    },
+  },
+
+  /**
+   * Sequential workflow series (2 of 3) - for testing sequence navigation buttons.
+   */
+  "mock-sequence-2": {
+    ...MOCK_WORKFLOW_BASE,
+    name: "mock-sequence-2",
+    uuid: "550e8400-e29b-41d4-a716-446655440102",
+    status: WorkflowStatus.COMPLETED,
+    priority: WorkflowPriority.NORMAL,
+    tags: ["sequence-test"],
+    submit_time: new Date(BASE_SUBMIT_TIME.getTime() + 700_000).toISOString(),
+    start_time: new Date(BASE_SUBMIT_TIME.getTime() + 730_000).toISOString(),
+    end_time: new Date(BASE_SUBMIT_TIME.getTime() + 1_300_000).toISOString(),
+    queued_time: 30,
+    duration: 570,
+    groups: [
+      {
+        name: "train",
+        status: TaskGroupStatus.COMPLETED,
+        remaining_upstream_groups: [],
+        downstream_groups: [],
+        tasks: [
+          {
+            name: "train",
+            retry_id: 0,
+            status: TaskGroupStatus.COMPLETED,
+            lead: true,
+            task_uuid: "task-seq-2-001",
+            pod_name: "train-0-seq2",
+            node_name: "node-1",
+            start_time: new Date(BASE_SUBMIT_TIME.getTime() + 760_000).toISOString(),
+            end_time: new Date(BASE_SUBMIT_TIME.getTime() + 1_300_000).toISOString(),
+            logs: "/api/workflow/mock-sequence-2/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-sequence-2/events?task_id=train&retry_id=0",
+          },
+        ],
+      },
+    ],
+    spec: "/api/workflow/mock-sequence-2/spec",
+    template_spec: "/api/workflow/mock-sequence-2/template-spec",
+    logs: "/api/workflow/mock-sequence-2/logs",
+    events: "/api/workflow/mock-sequence-2/events",
+    overview: "/api/workflow/mock-sequence-2/overview",
+    _logConfig: {
+      volume: { min: 50, max: 100 },
+      levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
+      ioTypeDistribution: DEFAULT_IO_DISTRIBUTION,
+      features: { retries: false, multiLine: false, ansiCodes: false },
+    },
+  },
+
+  /**
+   * Sequential workflow series (3 of 3) - for testing sequence navigation buttons.
+   */
+  "mock-sequence-3": {
+    ...MOCK_WORKFLOW_BASE,
+    name: "mock-sequence-3",
+    uuid: "550e8400-e29b-41d4-a716-446655440103",
+    status: WorkflowStatus.COMPLETED,
+    priority: WorkflowPriority.NORMAL,
+    tags: ["sequence-test"],
+    submit_time: new Date(BASE_SUBMIT_TIME.getTime() + 1_400_000).toISOString(),
+    start_time: new Date(BASE_SUBMIT_TIME.getTime() + 1_430_000).toISOString(),
+    end_time: new Date(BASE_SUBMIT_TIME.getTime() + 2_000_000).toISOString(),
+    queued_time: 30,
+    duration: 570,
+    groups: [
+      {
+        name: "train",
+        status: TaskGroupStatus.COMPLETED,
+        remaining_upstream_groups: [],
+        downstream_groups: [],
+        tasks: [
+          {
+            name: "train",
+            retry_id: 0,
+            status: TaskGroupStatus.COMPLETED,
+            lead: true,
+            task_uuid: "task-seq-3-001",
+            pod_name: "train-0-seq3",
+            node_name: "node-1",
+            start_time: new Date(BASE_SUBMIT_TIME.getTime() + 1_460_000).toISOString(),
+            end_time: new Date(BASE_SUBMIT_TIME.getTime() + 2_000_000).toISOString(),
+            logs: "/api/workflow/mock-sequence-3/logs?task_id=train&retry_id=0",
+            events: "/api/workflow/mock-sequence-3/events?task_id=train&retry_id=0",
+          },
+        ],
+      },
+    ],
+    spec: "/api/workflow/mock-sequence-3/spec",
+    template_spec: "/api/workflow/mock-sequence-3/template-spec",
+    logs: "/api/workflow/mock-sequence-3/logs",
+    events: "/api/workflow/mock-sequence-3/events",
+    overview: "/api/workflow/mock-sequence-3/overview",
+    _logConfig: {
+      volume: { min: 50, max: 100 },
+      levelDistribution: DEFAULT_LEVEL_DISTRIBUTION,
+      ioTypeDistribution: DEFAULT_IO_DISTRIBUTION,
+      features: { retries: false, multiLine: false, ansiCodes: false },
     },
   },
 };


### PR DESCRIPTION
Adds some buttons to move forward and back versions + make our mock data follow workflow id naming conventions

<img width="2040" height="560" alt="image" src="https://github.com/user-attachments/assets/a2e221fe-0131-49ad-8338-8bcb3dcfbfbb" />


Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added previous/next workflow navigation controls to the workflow details header with tooltips and proper disabled state.

* **New Features**
  * Added client-side sequence navigation support so the header can drive prev/next workflow transitions for sequenced names.

* **Tests**
  * Updated mock workflow data to use numbered variants and added three sequenced mock workflows to support navigation testing.

* **Chores**
  * Updated displayed test workflow IDs in the development test list to include a “-1” suffix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->