### PR TITLE
Temporary: test token scopes

### DIFF
--- a/.github/workflows/test-token-scopes.yaml
+++ b/.github/workflows/test-token-scopes.yaml
@@ -1,0 +1,89 @@
+# Temporary workflow to test PAT scopes. Delete after testing.
+name: Test Token Scopes
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.github/workflows/test-token-scopes.yaml'
+
+permissions: {}
+
+jobs:
+  test-nvidia-org-token:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test NVIDIA_ORG_MEMBER_READ_TOKEN
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.NVIDIA_ORG_MEMBER_READ_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            core.info('=== NVIDIA_ORG_MEMBER_READ_TOKEN ===');
+
+            core.info('--- read:org (team membership) ---');
+            try {
+              const { data } = await github.rest.teams.getMembershipForUserInOrg({
+                org: 'NVIDIA', team_slug: 'osmo-dev', username: 'jiaenren',
+              });
+              core.info(`PASS: state=${data.state}, role=${data.role}`);
+            } catch (err) {
+              core.error(`FAIL: ${err.status} — ${err.message}`);
+            }
+
+            core.info('--- repo (list workflow runs) ---');
+            try {
+              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner, repo, per_page: 1,
+              });
+              core.info(`PASS: latest run ${data.workflow_runs[0]?.id}`);
+            } catch (err) {
+              core.error(`FAIL: ${err.status} — ${err.message}`);
+            }
+
+            core.info('--- authenticated user ---');
+            try {
+              const { data } = await github.rest.users.getAuthenticated();
+              core.info(`PASS: authenticated as ${data.login}`);
+            } catch (err) {
+              core.error(`FAIL: ${err.status} — ${err.message}`);
+            }
+
+  test-svc-osmo-ci-token:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test SVC_OSMO_CI_TOKEN
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.SVC_OSMO_CI_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            core.info('=== SVC_OSMO_CI_TOKEN ===');
+
+            core.info('--- read:org (team membership) ---');
+            try {
+              const { data } = await github.rest.teams.getMembershipForUserInOrg({
+                org: 'NVIDIA', team_slug: 'osmo-dev', username: 'jiaenren',
+              });
+              core.info(`PASS: state=${data.state}, role=${data.role}`);
+            } catch (err) {
+              core.error(`FAIL: ${err.status} — ${err.message}`);
+            }
+
+            core.info('--- repo (list workflow runs) ---');
+            try {
+              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner, repo, per_page: 1,
+              });
+              core.info(`PASS: latest run ${data.workflow_runs[0]?.id}`);
+            } catch (err) {
+              core.error(`FAIL: ${err.status} — ${err.message}`);
+            }
+
+            core.info('--- authenticated user ---');
+            try {
+              const { data } = await github.rest.users.getAuthenticated();
+              core.info(`PASS: authenticated as ${data.login}`);
+            } catch (err) {
+              core.error(`FAIL: ${err.status} — ${err.message}`);
+            }


### PR DESCRIPTION
Temporary PR to test PAT scopes for the auto-approver workflow.
Tests both `NVIDIA_ORG_MEMBER_READ_TOKEN` and `SVC_OSMO_CI_TOKEN` in parallel.
Delete after testing.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated testing workflow to validate API token permissions in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->