### PR TITLE
Use NVIDIA_ORG_MEMBER_READ_TOKEN for testbot auto-approver

### DIFF
--- a/.github/workflows/testbot-respond-approve.yaml
+++ b/.github/workflows/testbot-respond-approve.yaml
@@ -19,9 +19,7 @@
 # Runs from main via workflow_run, so PR authors cannot tamper
 # with this logic.
 #
-# SVC_OSMO_CI_TOKEN requires:
-#   - read:org (to check NVIDIA/osmo-dev team membership)
-#   - repo (to approve environment deployments)
+# NVIDIA_ORG_MEMBER_READ_TOKEN requires read:org + repo scopes.
 # The token owner (svc-osmo-ci) must be listed as a required
 # reviewer on the 'testbot-respond' environment.
 name: Testbot - Auto-approve Respond
@@ -41,7 +39,7 @@ jobs:
       - name: Check membership and approve
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ secrets.SVC_OSMO_CI_TOKEN }}
+          github-token: ${{ secrets.NVIDIA_ORG_MEMBER_READ_TOKEN }}
           script: |
             const run = context.payload.workflow_run;
             const actor = run.triggering_actor.login;


### PR DESCRIPTION
## Description

`SVC_OSMO_CI_TOKEN` lacks `read:org` scope needed for the team membership check in the auto-approver. `NVIDIA_ORG_MEMBER_READ_TOKEN` has both `read:org` and `repo`, and is owned by the same `svc-osmo-ci` account.

Verified both tokens' scopes via test workflow in #843.

Issue #760

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow authentication configuration.

---

*Note: This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->