### PR TITLE
Add LFS hook cleanup for self-hosted runners

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -107,6 +107,9 @@ jobs:
           echo "Docker version: $(docker --version)"
           echo "Git LFS version: $(git-lfs --version)"
 
+      - name: Clean up stale LFS hooks
+        run: rm -f .git/hooks/pre-push .git/hooks/post-checkout .git/hooks/post-commit .git/hooks/post-merge || true
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -188,6 +188,9 @@ jobs:
           echo "Docker version: $(docker --version)"
           echo "Git LFS version: $(git-lfs --version)"
 
+      - name: Clean up stale LFS hooks
+        run: rm -f .git/hooks/pre-push .git/hooks/post-checkout .git/hooks/post-commit .git/hooks/post-merge || true
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
## Description

Fixes Git LFS `Hook already exists` failures on self-hosted runners.

**Root cause:** Self-hosted runners share workspace between jobs. When `ci-internal` and `coverage` both run on the same runner with `lfs: true`, the first job installs LFS hooks (pre-push, post-checkout, etc.) that persist in the workspace. The second job's `git lfs install --local` (run by `actions/checkout`) refuses to overwrite the existing hooks and fails with exit code 2.

**Fix:** Remove stale LFS hooks before checkout in both self-hosted runner jobs (`ci-internal` and `coverage`). This cleans up any stale hooks from previous runs so `actions/checkout` with `lfs: true` can install them cleanly.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.