### PR TITLE
Improve testbot respond: prompt design, harness resilience, observability

### DIFF
--- a/.github/workflows/testbot-respond.yaml
+++ b/.github/workflows/testbot-respond.yaml
@@ -14,9 +14,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Responds to /testbot commands in review comments and PR comments on
-# AI-generated PRs. Delegates fixes to Claude Code CLI, posts inline
-# replies, and resolves addressed threads.
+# Responds to /testbot commands in review comments on AI-generated PRs.
+# Delegates fixes to Claude Code CLI and posts inline replies.
 name: Testbot - Respond to Reviews
 
 on:
@@ -89,6 +88,7 @@ jobs:
             --trigger-phrase /testbot \
             --max-responses 10 \
             --max-turns 50 \
+            --timeout 720 \
             --model aws/anthropic/claude-opus-4-5
         env:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -28,20 +28,17 @@ Claude Code is sandboxed: it can only read files, edit test files, and run test 
   ├─ fetch all thread comments (GraphQL)
   ├─ filter: trigger phrase, author, dedup
   ├─ Claude Code CLI: read files, apply fix, run tests
-  ├─ guardrails: filter non-test changes
   ├─ respond.py: git commit + push
   ├─ structured reply via --json-schema
-  ├─ post inline reply to each thread
-  └─ resolve addressed threads (GraphQL)
+  └─ post inline reply to each thread
 ```
 
 | Feature | Description |
 |---------|-------------|
 | **Trigger** | Comment starting with `/testbot` on inline review threads of `ai-generated` PRs |
 | **Thread context** | Full conversation history (all nested comments) passed to Claude |
-| **Structured output** | `--json-schema` returns per-comment replies with resolve verdict and commit message |
-| **Thread resolution** | Resolved via GraphQL mutation after fix is applied |
-| **Safety** | Repo-member-only access, test-file-only guardrail, crash recovery, push retry |
+| **Structured output** | `--json-schema` returns per-thread replies and commit message |
+| **Safety** | Repo-member-only access, crash recovery, push retry |
 | **Dedup** | Skips threads where the bot already replied and is awaiting human follow-up |
 
 ### Security Boundary
@@ -98,13 +95,14 @@ The bot responds only to repo members (OWNER, MEMBER, COLLABORATOR). It will not
 | `model` | `aws/anthropic/claude-opus-4-5` | LLM model on API gateway |
 | `dry_run` | `false` | Generate without creating PR |
 
-### Review response (env vars)
+### Review response (CLI args in `testbot-respond.yaml`)
 
-| Env Var | Default | Description |
-|---------|---------|-------------|
-| `TESTBOT_MAX_TURNS` | `50` | Claude Code agent turns |
-| `TESTBOT_MAX_RESPONSES` | `10` | Max threads to address per trigger |
-| `ANTHROPIC_MODEL` | `aws/anthropic/claude-opus-4-5` | LLM model |
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `--max-turns` | `50` | Claude Code agent turns |
+| `--max-responses` | `10` | Max threads to address per trigger |
+| `--timeout` | `720` | Claude Code CLI timeout in seconds |
+| `--model` | `aws/anthropic/claude-opus-4-5` | LLM model |
 
 ### Coverage target selection (constants in `coverage_targets.py`)
 
@@ -117,12 +115,14 @@ The bot responds only to repo members (OWNER, MEMBER, COLLABORATOR). It will not
 
 ```text
 src/scripts/testbot/
-├── coverage_targets.py    # Codecov API → select low-coverage targets
-├── create_pr.py           # Branch, commit, push, open PR
-├── guardrails.py          # Test-file-only filter, shared by all scripts
-├── respond.py             # Review response: Claude Code CLI + GraphQL
-├── TESTBOT_PROMPT.md      # Quality rules and conventions for Claude Code
-├── README.md              # This file
+├── coverage_targets.py         # Codecov API → select low-coverage targets
+├── create_pr.py                # Branch, commit, push, open PR
+├── guardrails.py               # Test-file-only filter, shared by all scripts
+├── respond.py                  # Review response: Claude Code CLI + GitHub API
+├── TESTBOT_RULES.md            # Shared test quality rules and conventions
+├── TESTBOT_PROMPT.md           # Prompt for generate workflow (coverage targets)
+├── TESTBOT_RESPOND_PROMPT.md   # Prompt for respond workflow (review feedback)
+├── README.md                   # This file
 └── tests/
     ├── test_coverage_targets.py
     ├── test_create_pr.py
@@ -130,6 +130,7 @@ src/scripts/testbot/
     └── test_respond.py
 
 .github/workflows/
-├── testbot.yaml           # Scheduled test generation
-└── testbot-respond.yaml   # /testbot review response
+├── testbot.yaml                    # Scheduled test generation
+├── testbot-respond.yaml            # /testbot review response
+└── testbot-respond-approve.yaml    # Auto-approve for org members
 ```

--- a/src/scripts/testbot/TESTBOT_PROMPT.md
+++ b/src/scripts/testbot/TESTBOT_PROMPT.md
@@ -1,8 +1,10 @@
-# Testbot Instructions
+# Testbot Generate Instructions
 
 You are generating tests for the OSMO codebase to improve code coverage.
 Read `AGENTS.md` at the repo root for project coding standards (import rules,
 naming conventions, type annotations, assertion style).
+Read `src/scripts/testbot/TESTBOT_RULES.md` for test quality rules, language
+conventions, and verification steps.
 
 ## Coverage Targets
 
@@ -31,83 +33,15 @@ The targets are appended below this prompt. For each target you receive:
    - Check the `BUILD` file in the test directory for an existing `py_test()` entry.
    - If missing, add a `py_test()` rule. Infer `deps` from other `py_test` entries
      in the same BUILD file. Do NOT guess target names.
-7. Run the test:
-   - Python/Go: `bazel test <target>` (derive the target from the BUILD file)
-   - TypeScript: `pnpm --dir src/ui test -- --run <test_file_path>`
-8. If the test fails, read the error output and fix. Retry up to 3 times.
-   - **Setup errors** (import, mock, syntax): fix the test.
-   - **Assertion failures**: re-read the source to understand WHY the actual
-     output differs. If your expectation was wrong, update the assertion.
-     If the output contradicts the function's docstring/name/comments,
-     do NOT change the assertion to match — this is likely a source bug.
-     Skip the test with a reason (`@unittest.skip`, `t.Skip`, `it.skip`)
-     and add a comment above the skipped test using the language's comment
-     syntax: `# SUSPECTED BUG: <file>:<function> — <description>` (Python)
-     or `// SUSPECTED BUG: <file>:<function> — <description>` (Go/TypeScript).
-     Never blindly match assertions to actual output.
-9. Verify code style (same checks as PR CI). Fix and re-verify until clean:
-   - Python: `bazel test <target>-pylint` (append `-pylint` to the test target
-     name). If pylint reports errors, fix the test code and re-run.
-   - TypeScript: `pnpm --dir src/ui validate` (runs type-check, lint,
-     format:check, tests, and build). If formatting fails, run
-     `pnpm --dir src/ui format` to auto-fix. If lint or type-check
-     fails, fix the code manually. Re-run validate until it passes.
-   - Go: no additional checks beyond step 7.
-10. Move to the next target.
+7. Run the test and verify code style per TESTBOT_RULES.md.
+   If the test fails, follow the bug detection steps in TESTBOT_RULES.md.
+8. Move to the next target.
 
 ## Guardrails
 
-- **Test files only (generate workflow)**: When generating tests from coverage
-  targets, you may ONLY create or modify test files (`test_*.py`, `*_test.go`,
-  `*.test.ts`, `*.test.tsx`) and `BUILD` files (for `py_test` entries).
-  Do NOT modify source code, configuration, or other non-test files.
-  (The respond workflow may override this when explicitly asked to fix source bugs.)
+- **Test files only**: You may ONLY create or modify test files (`test_*.py`,
+  `*_test.go`, `*.test.ts`, `*.test.tsx`) and `BUILD` files (for `py_test`
+  entries). Do NOT modify source code, configuration, or other non-test files.
 - **No git or gh commands**: Do NOT run `git`, `gh`, or any commands that
   modify version control state. The harness script handles branch creation,
   committing, pushing, and PR creation.
-
-## Test Quality Rules
-
-Follow these rules strictly (from Google SWE Book Ch.12):
-
-- Test PUBLIC behavior only. Never call underscore-prefixed methods.
-- One behavior per test method. Name: `test_<behavior>_<condition>_<expected>`.
-- Given-When-Then structure: setup, single action, assertions.
-- **NO `for`/`while` loops or `if`/`elif` in test methods.**
-  Write separate test methods for each input case instead.
-- Deterministic: no `random`, no `sleep`, no `datetime.now()`.
-  Use fixed dates or mock `datetime` when the source uses it.
-- Every test method MUST have at least one assertion
-  (`self.assertEqual`, `t.Errorf`, `expect(...)`).
-- DAMP over DRY: each test readable in isolation, important values visible.
-- Prefer state verification over interaction verification.
-- Include both happy-path AND error/edge cases.
-
-### CLI output testing (Python)
-
-When testing functions that print formatted output:
-- Mock `builtins.print`, join all positional args into one string:
-  `output = " ".join(str(arg) for call in mock_print.call_args_list for arg in call.args)`
-- Assert with `self.assertIn("expected", output)`.
-
-## Language Conventions
-
-### Python
-- `unittest.TestCase` (not pytest)
-- SPDX copyright header on line 1
-- All imports at top of file (no inline imports)
-- `self.assertEqual`, `self.assertIn`, `self.assertRaises` (not bare `assert`)
-- Descriptive variable names (no abbreviations)
-
-### Go
-- Standard `testing` package
-- Table-driven tests with `[]struct` and `t.Run()`
-- Names: `Test<Behavior>_<Condition>`
-- Same package as source (white-box OK)
-- SPDX header
-
-### TypeScript (Vitest)
-- Import `describe`, `it`, `expect`, `vi` from `vitest`
-- Absolute imports: `@/lib/...`
-- `vi.fn().mockResolvedValue()` for async mocking
-- SPDX header

--- a/src/scripts/testbot/TESTBOT_RESPOND_PROMPT.md
+++ b/src/scripts/testbot/TESTBOT_RESPOND_PROMPT.md
@@ -1,0 +1,51 @@
+# Testbot Respond Instructions
+
+You are **testbot**, an AI assistant that addresses inline review feedback on
+AI-generated test PRs. A human reviewer left `/testbot` comments asking you to
+fix, improve, or remove tests. Your job is to apply the requested changes, verify
+them, and produce a structured JSON reply for every thread.
+
+Read `AGENTS.md` at the repo root for project coding standards.
+Read `src/scripts/testbot/TESTBOT_RULES.md` for test quality rules, language
+conventions, and verification steps.
+
+## Process
+
+For each review thread below:
+
+1. **Read** the referenced source and test files.
+2. **Apply** the change requested in the latest `/testbot` comment.
+   Pay attention to the FULL thread history — earlier comments provide context,
+   but the latest `/testbot` comment is the instruction to follow.
+3. **Run the test** and verify code style per TESTBOT_RULES.md.
+   If the test fails, follow the bug detection steps in TESTBOT_RULES.md.
+4. Do NOT create git commits or branches.
+
+## Output Format
+
+After completing all work, your final response MUST be structured JSON matching
+the provided schema. You MUST include a reply for EVERY comment listed below.
+
+If you delegated work to sub-agents, review their results and write the replies
+yourself based on what was accomplished.
+
+**Example output:**
+```json
+{
+  "commit_message": "testbot: rename describe block, add edge case for empty input",
+  "replies": [
+    {
+      "comment_id": "3066587176",
+      "reply": "Renamed the describe block to match the function name. Also added an edge case test for empty input."
+    },
+    {
+      "comment_id": "3066590421",
+      "reply": "Removed the redundant assertion. The behavior is already covered by test_parse_basic."
+    }
+  ]
+}
+```
+
+**Fields:**
+- `commit_message`: A concise summary prefixed with `testbot: ` (subject under 72 chars).
+- `replies`: One entry per comment. `comment_id` is the ID from the `### Comment` header below. `reply` explains what you did. Include any SUSPECTED BUG markers found.

--- a/src/scripts/testbot/TESTBOT_RULES.md
+++ b/src/scripts/testbot/TESTBOT_RULES.md
@@ -1,0 +1,77 @@
+# Testbot Shared Rules
+
+Shared test quality rules, language conventions, and verification steps
+used by both the generate and respond workflows.
+
+## Test Quality Rules
+
+Follow these rules strictly (from Google SWE Book Ch.12):
+
+- Test PUBLIC behavior only. Never call underscore-prefixed methods.
+- One behavior per test method. Name: `test_<behavior>_<condition>_<expected>`.
+- Given-When-Then structure: setup, single action, assertions.
+- **NO `for`/`while` loops or `if`/`elif` in test methods.**
+  Write separate test methods for each input case instead.
+- Deterministic: no `random`, no `sleep`, no `datetime.now()`.
+  Use fixed dates or mock `datetime` when the source uses it.
+- Every test method MUST have at least one assertion
+  (`self.assertEqual`, `t.Errorf`, `expect(...)`).
+- DAMP over DRY: each test readable in isolation, important values visible.
+- Prefer state verification over interaction verification.
+- Include both happy-path AND error/edge cases.
+
+### CLI output testing (Python)
+
+When testing functions that print formatted output:
+- Mock `builtins.print`, join all positional args into one string:
+  `output = " ".join(str(arg) for call in mock_print.call_args_list for arg in call.args)`
+- Assert with `self.assertIn("expected", output)`.
+
+## Bug Detection
+
+When a test fails:
+- **Setup errors** (import, mock, syntax): fix the test.
+- **Assertion failures**: re-read the source to understand WHY the actual
+  output differs. If your expectation was wrong, update the assertion.
+  If the output contradicts the function's docstring/name/comments,
+  do NOT change the assertion to match — this is likely a source bug.
+  Skip the test with a reason (`@unittest.skip`, `t.Skip`, `it.skip`)
+  and add a comment above the skipped test using the language's comment
+  syntax: `# SUSPECTED BUG: <file>:<function> — <description>` (Python)
+  or `// SUSPECTED BUG: <file>:<function> — <description>` (Go/TypeScript).
+  Never blindly match assertions to actual output.
+
+## Verification
+
+1. **Run the test**:
+   - Python/Go: `bazel test <target>` (derive the Bazel target from the BUILD file)
+   - TypeScript: `pnpm --dir src/ui test -- --run <test_file_path>`
+2. If the test fails, read the error and fix. Retry up to 3 times.
+3. **Verify code style** (same checks as PR CI). Fix and re-verify until clean:
+   - Python: `bazel test <target>-pylint` (append `-pylint` to the test target name)
+   - TypeScript: `pnpm --dir src/ui validate` (runs type-check, lint,
+     format:check, tests, and build). If formatting fails, run
+     `pnpm --dir src/ui format` to auto-fix.
+   - Go: no additional checks beyond step 1.
+
+## Language Conventions
+
+### Python
+- `unittest.TestCase` (not pytest)
+- SPDX copyright header on line 1
+- All imports at top of file (no inline imports)
+- `self.assertEqual`, `self.assertIn`, `self.assertRaises` (not bare `assert`)
+- Descriptive variable names (no abbreviations)
+
+### Go
+- Standard `testing` package
+- Table-driven tests with `[]struct` and `t.Run()`
+- Names: `Test<Behavior>_<Condition>`
+- Same package as source (white-box OK)
+- SPDX header
+
+### TypeScript (Vitest)
+- Import `describe`, `it`, `expect`, `vi` from `vitest`
+- Absolute imports: `@/lib/...`
+- `vi.fn().mockResolvedValue()` for async mocking
+- SPDX header

--- a/src/scripts/testbot/create_pr.py
+++ b/src/scripts/testbot/create_pr.py
@@ -107,7 +107,13 @@ def main() -> None:
     logger.info("Changed test files: %s", changed_files)
 
     basenames = sorted({f.rsplit("/", maxsplit=1)[-1] for f in changed_files})
-    files_summary = ", ".join(basenames)
+    # Strip test prefixes/suffixes to show source file names in the PR title.
+    # test_foo.py → foo.py, foo_test.go → foo.go, foo.test.ts → foo.ts
+    source_names = sorted({
+        re.sub(r"^test_", "", re.sub(r"[._]test(\.\w+)$", r"\1", name))
+        for name in basenames
+    })
+    files_summary = ", ".join(source_names)
     files_list = "\n".join(f"- `{f}`" for f in changed_files)
 
     branch = f"testbot/{datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y%m%d-%H%M')}"

--- a/src/scripts/testbot/respond.py
+++ b/src/scripts/testbot/respond.py
@@ -4,7 +4,7 @@
 
 Fetches unresolved review threads containing a trigger phrase, runs a
 single Claude Code CLI session to apply all fixes, then posts per-comment
-inline replies and resolves addressed threads.
+inline replies.
 
 Usage:
     python respond.py --pr-number 789 --trigger-phrase /testbot
@@ -29,6 +29,13 @@ logger = logging.getLogger(__name__)
 MAX_PUSH_RETRIES = 3
 SELF_AUTHORS = frozenset({"github-actions[bot]", "svc-osmo-ci"})
 ALLOWED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+# Shared with testbot.yaml — update both when changing the tool allowlist.
+ALLOWED_TOOLS = (
+    "Read,Edit,Write,"
+    "Bash(bazel test *),Bash(pnpm --dir src/ui test *),"
+    "Bash(pnpm --dir src/ui validate),Bash(pnpm --dir src/ui format),"
+    "Glob,Grep"
+)
 
 THREADS_QUERY = """
 query($owner: String!, $repo: String!, $pr: Int!) {
@@ -55,13 +62,6 @@ query($owner: String!, $repo: String!, $pr: Int!) {
 }
 """
 
-RESOLVE_MUTATION = """
-mutation($threadId: ID!) {
-  resolveReviewThread(input: {threadId: $threadId}) {
-    thread { isResolved }
-  }
-}
-"""
 
 REPLY_SCHEMA = json.dumps({
     "type": "object",
@@ -77,23 +77,23 @@ REPLY_SCHEMA = json.dumps({
         },
         "replies": {
             "type": "array",
+            "description": (
+                "One reply per review comment. Each entry maps a comment ID "
+                "from the prompt to a short explanation of what was done."
+            ),
             "items": {
                 "type": "object",
                 "properties": {
                     "comment_id": {
-                        "type": "integer",
-                        "description": "The comment ID being replied to",
+                        "type": "string",
+                        "description": "The comment ID from the prompt header (e.g. '3066587176')",
                     },
                     "reply": {
                         "type": "string",
-                        "description": "Explanation of what was done and why",
-                    },
-                    "resolve": {
-                        "type": "boolean",
-                        "description": "True if the issue is fully addressed",
+                        "description": "What was done for this thread",
                     },
                 },
-                "required": ["comment_id", "reply", "resolve"],
+                "required": ["comment_id", "reply"],
             },
         },
     },
@@ -219,42 +219,25 @@ def filter_actionable(
             logger.info("  SKIP (testbot source) path=%s", path)
             continue
 
-        # Skip if the bot already replied (last comment is from us — awaiting human)
-        last_author = comments[-1]["author"]
-        if last_author in SELF_AUTHORS:
-            logger.info(
-                "  SKIP (bot already replied, awaiting human) path=%s last_author=%s",
-                path, last_author,
-            )
-            continue
-
-        # Only trigger if the LAST non-bot comment contains the trigger phrase.
-        # This prevents an old /testbot from re-firing when a human follows up
-        # with a non-trigger comment like "still failing".
-        last_human_comment = None
-        for comment in reversed(comments):
-            if comment["author"] not in SELF_AUTHORS:
-                last_human_comment = comment
-                break
-
+        # Find the latest authorized /testbot comment that hasn't been
+        # replied to by the bot. Walk backwards: stop at bot replies (prior
+        # triggers already handled), skip unauthorized triggers so an earlier
+        # authorized one can still be found.
         trigger_comment = None
-        if last_human_comment and _has_trigger(last_human_comment["body"], trigger_phrase):
-            trigger_comment = last_human_comment
+        for comment in reversed(comments):
+            if comment["author"] in SELF_AUTHORS:
+                break  # Bot already replied — all prior triggers handled
+            if not _has_trigger(comment["body"], trigger_phrase):
+                continue
+            if comment.get("association", "NONE") not in ALLOWED_ASSOCIATIONS:
+                continue  # Unauthorized trigger — keep searching earlier comments
+            trigger_comment = comment
+            break
 
         if not trigger_comment:
             logger.info(
-                "  SKIP (no trigger in %d comments) path=%s body=%s",
+                "  SKIP (no unprocessed trigger in %d comments) path=%s body=%s",
                 len(comments), path, first_body,
-            )
-            continue
-
-        # Only allow repo members to trigger the bot
-        association = trigger_comment.get("association", "NONE")
-        if association not in ALLOWED_ASSOCIATIONS:
-            logger.info(
-                "  SKIP (author %s has association %s, need %s) path=%s",
-                trigger_comment["author"], association,
-                ALLOWED_ASSOCIATIONS, path,
             )
             continue
 
@@ -295,7 +278,8 @@ def build_prompt(threads: list[dict]) -> str:
     understands the context (original comment + follow-up replies).
     """
     lines = [
-        "Read and follow the test quality rules in src/scripts/testbot/TESTBOT_PROMPT.md.",
+        "Read and follow src/scripts/testbot/TESTBOT_RESPOND_PROMPT.md for your role,",
+        "process, and output format.",
         "",
         "Address these review threads on an AI-generated test PR.",
         "Each thread includes the full conversation history — pay attention to",
@@ -304,25 +288,10 @@ def build_prompt(threads: list[dict]) -> str:
     ]
     for thread in threads:
         location = f"`{thread['path']}` line {thread['line']}"
-        lines.append(f"### Thread {thread['reply_comment_id']} ({location})")
+        lines.append(f"### Comment {thread['reply_comment_id']} ({location})")
         lines.append(thread["thread_history"])
         lines.append("")
 
-    lines.extend([
-        "Steps:",
-        "1. Read the relevant source and test files.",
-        "2. Apply the requested changes from the LATEST /testbot comment in each thread.",
-        "3. Follow the test run, bug detection, and verification steps in TESTBOT_PROMPT.md.",
-        "   Pay special attention to assertion failures: if the output looks like a source",
-        "   bug (contradicts the function's docstring/name/comments), skip the test with",
-        "   a SUSPECTED BUG marker — do NOT change the assertion to match buggy output.",
-        "4. Do NOT create git commits or branches.",
-        "",
-        "After completing all work, produce a structured JSON reply for each thread.",
-        "Each reply should explain what you did and whether the issue is resolved.",
-        "If you flagged any SUSPECTED BUG markers, mention them in the reply.",
-        "Use the reply_comment_id as comment_id so replies are posted to the right thread.",
-    ])
     return "\n".join(lines)
 
 
@@ -330,78 +299,95 @@ def run_claude(
     prompt: str,
     model: str = "aws/anthropic/claude-opus-4-5",
     max_turns: int = 50,
+    timeout: int = 720,
 ) -> dict:
     """Run Claude Code CLI and return parsed JSON output.
 
     Returns a dict with 'structured_output' and/or 'result' fields.
     Returns empty dict on failure.
     """
+    claude_bin = os.environ.get("CLAUDE_CODE_BIN", "npx @anthropic-ai/claude-code@2.1.91")
     cmd = [
-        "npx", "@anthropic-ai/claude-code@2.1.91", "--print",
+        *shlex.split(claude_bin), "--print",
         "--model", model,
         "--output-format", "json",
         "--json-schema", REPLY_SCHEMA,
-        "--allowedTools",
-        "Read,Edit,Write,Bash(bazel test *),Bash(pnpm --dir src/ui test *),Bash(pnpm --dir src/ui validate),Bash(pnpm --dir src/ui format),Glob,Grep",
+        "--allowedTools", ALLOWED_TOOLS,
         "--max-turns", str(max_turns),
         prompt,
     ]
     logger.info("Claude Code command: %s", " ".join(shlex.quote(c) for c in cmd))
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600, check=False)
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False,
+        )
     except subprocess.TimeoutExpired:
-        logger.error("Claude Code CLI timed out after 600s")
-        return {}
+        logger.error("Claude Code CLI timed out after %ds", timeout)
+        return {"is_error": True, "subtype": "timeout"}
 
     if result.returncode != 0:
-        logger.error(
-            "Claude Code CLI exited %d: stdout=%s stderr=%s",
-            result.returncode, result.stdout[:500], result.stderr[:500],
+        logger.warning(
+            "Claude Code CLI exited %d: stderr=%s",
+            result.returncode, result.stderr[:500],
         )
-        return {}
 
+    # Claude Code returns valid JSON even on non-zero exit (max turns, auth errors).
     try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError:
-        logger.error("Failed to parse Claude Code JSON output: %s", result.stdout[:500])
+        parsed = json.loads(result.stdout)
+        if result.returncode != 0 and parsed.get("is_error"):
+            logger.warning(
+                "Claude Code reported error: subtype=%s result=%s",
+                parsed.get("subtype", ""), str(parsed.get("result", ""))[:300],
+            )
+        return parsed
+    except (json.JSONDecodeError, ValueError):
+        if result.returncode == 0:
+            logger.error("Failed to parse Claude Code JSON output: %s", result.stdout[:500])
         return {}
 
 
-def parse_replies(claude_output: dict, comments: list[dict]) -> list[dict]:
-    """Extract replies from Claude Code output with three-tier fallback."""
-    # Tier 1: structured_output
+def _extract_replies(claude_output: dict) -> dict[str, str]:
+    """Extract per-comment replies from Claude output with tiered fallback.
+
+    Returns a dict mapping comment_id (str) to reply text.
+    """
+    def _parse_replies_list(replies: list) -> dict[str, str]:
+        result: dict[str, str] = {}
+        for entry in replies:
+            if not isinstance(entry, dict):
+                continue
+            comment_id = str(entry.get("comment_id", ""))
+            reply = entry.get("reply", "")
+            if comment_id and reply:
+                result[comment_id] = reply
+        return result
+
+    # Tier 1: structured_output.replies
     structured = claude_output.get("structured_output")
-    if isinstance(structured, dict) and "replies" in structured:
-        replies = structured["replies"]
-        if isinstance(replies, list) and replies:
+    if isinstance(structured, dict) and isinstance(structured.get("replies"), list):
+        replies = _parse_replies_list(structured["replies"])
+        if replies:
             logger.info("Parsed %d replies from structured_output (tier 1)", len(replies))
             return replies
 
     # Tier 2: extract JSON from result text
     result_text = claude_output.get("result", "")
-    if result_text:
+    if isinstance(result_text, str) and result_text:
         try:
             start = result_text.index("{")
             end = result_text.rindex("}") + 1
             data = json.loads(result_text[start:end])
-            replies = data.get("replies") if isinstance(data, dict) else None
-            if isinstance(replies, list) and replies and isinstance(replies[0], dict):
-                logger.info("Parsed replies from result text (tier 2)")
-                return replies
+            if isinstance(data, dict) and isinstance(data.get("replies"), list):
+                replies = _parse_replies_list(data["replies"])
+                if replies:
+                    logger.info("Parsed %d replies from result text (tier 2)", len(replies))
+                    return replies
         except (ValueError, json.JSONDecodeError):
             pass
 
-    # Tier 3: fallback — single reply with raw text on the first comment
-    if result_text and comments:
-        logger.warning("Using raw text fallback (tier 3)")
-        return [{
-            "comment_id": comments[0]["reply_comment_id"],
-            "reply": result_text[:2000],
-            "resolve": False,
-        }]
-
-    return []
+    logger.warning("No per-thread replies found in Claude output")
+    return {}
 
 
 def discard_changes() -> None:
@@ -429,10 +415,18 @@ def commit_and_push(files: list[str], message: str) -> bool:
         )
         if result.returncode == 0:
             return True
+        stderr = result.stderr.strip()
         logger.warning(
             "git push failed (attempt %d/%d): %s",
-            attempt, MAX_PUSH_RETRIES, result.stderr[:200],
+            attempt, MAX_PUSH_RETRIES, stderr[:500],
         )
+        # Repository rule violations (GH013) won't resolve with retries.
+        if "GH013" in stderr:
+            logger.error(
+                "Push blocked by repository ruleset. "
+                "The service account may need bypass permissions."
+            )
+            return False
         if attempt < MAX_PUSH_RETRIES:
             subprocess.run(["git", "pull", "--rebase"], check=False)
 
@@ -467,17 +461,6 @@ def reply_to_comment(
     return True
 
 
-def resolve_thread(thread_id: str) -> None:
-    """Mark a review thread as resolved via GraphQL."""
-    logger.info("Resolving thread %s", thread_id)
-    result = run_gh(
-        f"api graphql -f query={shlex.quote(RESOLVE_MUTATION)} "
-        f"-F threadId={shlex.quote(thread_id)}"
-    )
-    if result.returncode != 0:
-        logger.warning("Failed to resolve thread %s: %s", thread_id, result.stderr[:300])
-
-
 def main() -> None:
     """Fetch actionable review threads, delegate to Claude Code, post replies."""
     parser = argparse.ArgumentParser(
@@ -489,6 +472,8 @@ def main() -> None:
                         help="Max threads to address per trigger (default: 10)")
     parser.add_argument("--max-turns", type=int, default=50,
                         help="Max Claude Code agent turns (default: 50)")
+    parser.add_argument("--timeout", type=int, default=720,
+                        help="Claude Code CLI timeout in seconds (default: 720)")
     parser.add_argument("--model", default="aws/anthropic/claude-opus-4-5",
                         help="LLM model name (default: aws/anthropic/claude-opus-4-5)")
     args = parser.parse_args()
@@ -512,7 +497,6 @@ def main() -> None:
             thread["trigger_body"][:120].replace("\n", " "),
         )
 
-    comment_lookup = {t["reply_comment_id"]: t for t in actionable}
     head_sha = subprocess.run(
         ["git", "rev-parse", "HEAD"],
         capture_output=True, text=True, check=True,
@@ -520,24 +504,50 @@ def main() -> None:
 
     prompt = build_prompt(actionable)
     logger.info("Running Claude Code for %d comment(s)...", len(actionable))
-    claude_output = run_claude(prompt, model=args.model, max_turns=args.max_turns)
+    claude_output = run_claude(
+        prompt, model=args.model, max_turns=args.max_turns, timeout=args.timeout,
+    )
 
     if not claude_output:
         logger.error("Claude Code failed — discarding any partial changes")
         discard_changes()
-        reply_to_comment(
-            owner, repo, args.pr_number, actionable[0],
-            "I encountered an error processing this request. Needs human review.",
+        for comment in actionable:
+            reply_to_comment(
+                owner, repo, args.pr_number, comment,
+                "I encountered an error processing this request. Please retry or handle manually.",
+            )
+        return
+
+    # On timeout or max-turns, discard partial file changes (may be incomplete)
+    # and post an informative reply.
+    subtype = claude_output.get("subtype")
+    if subtype in ("timeout", "error_max_turns"):
+        reason = "timed out" if subtype == "timeout" else "hit the max-turns limit"
+        turns_used = claude_output.get("num_turns", "?")
+        logger.warning("Claude %s after %s turns — discarding partial changes", reason, turns_used)
+        discard_changes()
+        status_msg = (
+            f"I {reason} after {turns_used} turns. "
+            f"Try breaking this into smaller requests, or handle manually."
         )
+        for comment in actionable:
+            reply_to_comment(owner, repo, args.pr_number, comment, status_msg)
         return
 
     logger.info("Claude output keys: %s", list(claude_output.keys()))
+    logger.info(
+        "Claude diagnostics: num_turns=%s stop_reason=%s terminal_reason=%s cost=$%s",
+        claude_output.get("num_turns"),
+        claude_output.get("stop_reason"),
+        claude_output.get("terminal_reason"),
+        claude_output.get("total_cost_usd"),
+    )
     if "structured_output" in claude_output:
         logger.info("structured_output: %s", json.dumps(claude_output["structured_output"]))
     if "result" in claude_output:
         logger.info("result text: %s", claude_output["result"])
 
-    replies = parse_replies(claude_output, actionable)
+    per_thread_replies = _extract_replies(claude_output)
     structured = claude_output.get("structured_output", {})
     raw_commit_message = (
         structured.get("commit_message", "testbot: address review feedback")
@@ -557,44 +567,32 @@ def main() -> None:
     else:
         logger.info("No file modifications detected")
 
-    logger.info(
-        "Processing %d replies (comment_lookup IDs: %s)",
-        len(replies), list(comment_lookup.keys()),
-    )
-    replied = 0
-    for reply_data in replies:
-        comment_id = reply_data.get("comment_id")
-        if isinstance(comment_id, str) and comment_id.isdigit():
-            comment_id = int(comment_id)
-        logger.info(
-            "Reply entry: comment_id=%s (type=%s) resolve=%s reply=%s",
-            comment_id, type(comment_id).__name__,
-            reply_data.get("resolve"), reply_data.get("reply", ""),
+    # When push fails, Claude's per-thread replies describe work that wasn't
+    # applied — discard them so we don't mislead the reviewer.
+    if modified_files and not push_succeeded:
+        per_thread_replies = {}
+        fallback_message = (
+            "I prepared a fix but could not push it. "
+            "Please retry or push manually."
         )
-        comment = comment_lookup.get(comment_id)
-        if not comment:
-            logger.warning(
-                "Reply for unknown comment_id %s, skipping. Known IDs: %s",
-                comment_id, list(comment_lookup.keys()),
-            )
-            continue
+    elif not modified_files:
+        fallback_message = (
+            "I reviewed this but didn't find changes to make. "
+            "Please retry or review manually."
+        )
+    else:
+        fallback_message = "Fix applied — see the latest commit for details."
 
-        message = reply_data.get("reply", "Acknowledged.")
-        should_resolve = reply_data.get("resolve", False)
-
-        if modified_files and not push_succeeded:
-            message = (
-                f"I applied a fix locally but could not push. "
-                f"Needs human review.\n\n**Intended fix:** {message}"
-            )
-            should_resolve = False
-
-        reply_posted = reply_to_comment(owner, repo, args.pr_number, comment, message)
+    # Post reply to each actionable thread
+    replied = 0
+    for comment in actionable:
+        comment_id = str(comment["reply_comment_id"])
+        message = per_thread_replies.get(comment_id, fallback_message)
+        reply_posted = reply_to_comment(
+            owner, repo, args.pr_number, comment, message,
+        )
         if reply_posted:
             replied += 1
-
-        if reply_posted and should_resolve and comment.get("thread_id"):
-            resolve_thread(comment["thread_id"])
 
     logger.info(
         "Done: responded to %d comment(s) on PR #%d", replied, args.pr_number,

--- a/src/scripts/testbot/tests/test_respond.py
+++ b/src/scripts/testbot/tests/test_respond.py
@@ -9,10 +9,10 @@ from typing import Any
 from unittest.mock import patch
 
 from src.scripts.testbot.respond import (
+    _extract_replies,
     _has_trigger,
     build_prompt,
     filter_actionable,
-    parse_replies,
     run_claude,
     sanitize_commit_message,
 )
@@ -187,85 +187,104 @@ class TestFilterActionable(unittest.TestCase):
         result = filter_actionable(threads, "/testbot", max_responses=2)
         self.assertEqual(len(result), 2)
 
+    def test_trigger_with_coderabbit_followup(self):
+        """CodeRabbit posting after /testbot should not cause skip."""
+        comments = [
+            {"id": 100, "body": "/testbot fix this", "author": "jiaenren", "association": "MEMBER"},
+            {"id": 200, "body": "I suggest refactoring...", "author": "coderabbitai[bot]", "association": "NONE"},
+        ]
+        threads = [self._make_thread(comments=comments)]
+        result = filter_actionable(threads, "/testbot")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["reply_comment_id"], 100)
 
-class TestParseReplies(unittest.TestCase):
-    """Tests for parse_replies 3-tier fallback."""
+    def test_trigger_handled_then_coderabbit_followup(self):
+        """After bot replied, CodeRabbit followup should not re-trigger."""
+        comments = [
+            {"id": 100, "body": "/testbot fix this", "author": "jiaenren", "association": "MEMBER"},
+            {"id": 200, "body": "Fix applied.", "author": "svc-osmo-ci", "association": "NONE"},
+            {"id": 300, "body": "I suggest refactoring...", "author": "coderabbitai[bot]", "association": "NONE"},
+        ]
+        threads = [self._make_thread(comments=comments)]
+        result = filter_actionable(threads, "/testbot")
+        self.assertEqual(result, [])
 
-    def _make_comments(self):
-        return [{"reply_comment_id": 123, "path": "foo.py", "line": 10}]
+    def test_new_trigger_after_bot_reply(self):
+        """New /testbot after bot reply should be actionable."""
+        comments = [
+            {"id": 100, "body": "/testbot fix this", "author": "jiaenren", "association": "MEMBER"},
+            {"id": 200, "body": "Fix applied.", "author": "svc-osmo-ci", "association": "NONE"},
+            {"id": 300, "body": "/testbot try again", "author": "jiaenren", "association": "MEMBER"},
+        ]
+        threads = [self._make_thread(comments=comments)]
+        result = filter_actionable(threads, "/testbot")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["reply_comment_id"], 300)
+
+
+class TestExtractReplies(unittest.TestCase):
+    """Tests for _extract_replies tiered fallback."""
 
     def test_tier1_structured_output(self):
         claude_output = {
             "structured_output": {
                 "replies": [
-                    {"comment_id": 123, "reply": "Fixed.", "resolve": True},
+                    {"comment_id": "123", "reply": "Added edge case tests."},
+                    {"comment_id": "456", "reply": "Fixed the assertion."},
                 ],
             },
         }
-        result = parse_replies(claude_output, self._make_comments())
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["comment_id"], 123)
-        self.assertEqual(result[0]["reply"], "Fixed.")
-        self.assertTrue(result[0]["resolve"])
+        result = _extract_replies(claude_output)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result["123"], "Added edge case tests.")
+        self.assertEqual(result["456"], "Fixed the assertion.")
 
     def test_tier1_empty_replies_falls_through(self):
         claude_output: dict[str, Any] = {"structured_output": {"replies": []}}
-        result = parse_replies(claude_output, self._make_comments())
-        self.assertEqual(result, [])
+        self.assertEqual(_extract_replies(claude_output), {})
 
-    def test_tier1_structured_output_not_dict_falls_through(self):
+    def test_tier1_not_dict_falls_through(self):
         claude_output = {"structured_output": "not a dict", "result": ""}
-        result = parse_replies(claude_output, self._make_comments())
-        self.assertEqual(result, [])
+        self.assertEqual(_extract_replies(claude_output), {})
 
     def test_tier2_json_in_result_text(self):
-        replies_json = json.dumps({
-            "replies": [{"comment_id": 456, "reply": "Done.", "resolve": True}],
+        data = json.dumps({
+            "replies": [{"comment_id": "789", "reply": "Done."}],
         })
-        claude_output = {"result": f"Here is the output: {replies_json}"}
-        result = parse_replies(claude_output, self._make_comments())
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["comment_id"], 456)
+        claude_output = {"result": f"Here is the output: {data}"}
+        result = _extract_replies(claude_output)
+        self.assertEqual(result["789"], "Done.")
 
-    def test_tier2_no_replies_key_falls_through(self):
+    def test_tier2_no_replies_key(self):
         claude_output = {"result": '{"other_key": "value"}'}
-        comments = self._make_comments()
-        result = parse_replies(claude_output, comments)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["comment_id"], 123)
-        self.assertFalse(result[0]["resolve"])
+        self.assertEqual(_extract_replies(claude_output), {})
 
-    def test_tier2_malformed_json_falls_through(self):
+    def test_tier2_malformed_json(self):
         claude_output = {"result": "this is {not valid json"}
-        comments = self._make_comments()
-        result = parse_replies(claude_output, comments)
-        self.assertEqual(len(result), 1)
-        self.assertFalse(result[0]["resolve"])
+        self.assertEqual(_extract_replies(claude_output), {})
 
-    def test_tier3_raw_text_fallback(self):
-        claude_output = {"result": "I made some changes to the test file."}
-        comments = self._make_comments()
-        result = parse_replies(claude_output, comments)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]["comment_id"], 123)
-        self.assertIn("I made some changes", result[0]["reply"])
-        self.assertFalse(result[0]["resolve"])
+    def test_skips_entries_without_comment_id(self):
+        claude_output = {
+            "structured_output": {
+                "replies": [{"reply": "no comment id"}],
+            },
+        }
+        self.assertEqual(_extract_replies(claude_output), {})
 
-    def test_tier3_truncates_long_text(self):
-        claude_output = {"result": "x" * 3000}
-        comments = self._make_comments()
-        result = parse_replies(claude_output, comments)
-        self.assertEqual(len(result[0]["reply"]), 2000)
+    def test_skips_entries_without_reply(self):
+        claude_output = {
+            "structured_output": {
+                "replies": [{"comment_id": "123", "reply": ""}],
+            },
+        }
+        self.assertEqual(_extract_replies(claude_output), {})
 
-    def test_all_tiers_fail_returns_empty(self):
+    def test_empty_output(self):
+        self.assertEqual(_extract_replies({}), {})
+
+    def test_no_result_no_structured(self):
         claude_output = {"result": ""}
-        result = parse_replies(claude_output, self._make_comments())
-        self.assertEqual(result, [])
-
-    def test_no_result_no_structured_returns_empty(self):
-        claude_output: dict[str, Any] = {}
-        result = parse_replies(claude_output, self._make_comments())
-        self.assertEqual(result, [])
+        self.assertEqual(_extract_replies(claude_output), {})
 
 
 class TestBuildPrompt(unittest.TestCase):
@@ -280,10 +299,10 @@ class TestBuildPrompt(unittest.TestCase):
         }]
         prompt = build_prompt(threads)
         self.assertIn("`src/ui/src/lib/foo.test.ts` line 42", prompt)
-        self.assertIn("### Thread 123", prompt)
+        self.assertIn("### Comment 123", prompt)
         self.assertIn("[reviewer]: /testbot add edge cases", prompt)
 
-    def test_includes_test_run_instructions(self):
+    def test_references_respond_prompt(self):
         threads = [{
             "reply_comment_id": 1,
             "path": "foo.test.ts",
@@ -291,10 +310,9 @@ class TestBuildPrompt(unittest.TestCase):
             "thread_history": "  [user]: /testbot fix",
         }]
         prompt = build_prompt(threads)
-        self.assertIn("TESTBOT_PROMPT.md", prompt)
-        self.assertIn("SUSPECTED BUG", prompt)
+        self.assertIn("TESTBOT_RESPOND_PROMPT.md", prompt)
 
-    def test_includes_no_git_instruction(self):
+    def test_includes_latest_comment_guidance(self):
         threads = [{
             "reply_comment_id": 1,
             "path": "foo.py",
@@ -302,7 +320,7 @@ class TestBuildPrompt(unittest.TestCase):
             "thread_history": "  [user]: /testbot fix",
         }]
         prompt = build_prompt(threads)
-        self.assertIn("Do NOT create git commits", prompt)
+        self.assertIn("LATEST request", prompt)
 
 
 class TestRunClaude(unittest.TestCase):
@@ -326,10 +344,11 @@ class TestRunClaude(unittest.TestCase):
         self.assertEqual(result, {})
 
     @patch("src.scripts.testbot.respond.subprocess.run")
-    def test_timeout_returns_empty(self, mock_run):
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=600)
+    def test_timeout_returns_timeout_marker(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=720)
         result = run_claude("test prompt")
-        self.assertEqual(result, {})
+        self.assertTrue(result.get("is_error"))
+        self.assertEqual(result.get("subtype"), "timeout")
 
     @patch("src.scripts.testbot.respond.subprocess.run")
     def test_invalid_json_returns_empty(self, mock_run):
@@ -338,6 +357,15 @@ class TestRunClaude(unittest.TestCase):
         )
         result = run_claude("test prompt")
         self.assertEqual(result, {})
+
+    @patch("src.scripts.testbot.respond.subprocess.run")
+    def test_nonzero_exit_with_valid_json_returns_parsed(self, mock_run):
+        expected = {"is_error": True, "subtype": "error_max_turns", "result": "partial"}
+        mock_run.return_value = subprocess.CompletedProcess(
+            [], 1, stdout=json.dumps(expected), stderr="",
+        )
+        result = run_claude("test prompt")
+        self.assertEqual(result, expected)
 
     @patch("src.scripts.testbot.respond.subprocess.run")
     def test_uses_model_and_turns_args(self, mock_run):


### PR DESCRIPTION
## Summary

Improve the testbot respond workflow:

- Extract shared test quality rules, bug detection, verification steps, and
  language conventions into `TESTBOT_RULES.md` — single source of truth for
  both generate and respond prompts (previously duplicated and had drifted)
- Create dedicated `TESTBOT_RESPOND_PROMPT.md` with role framing and JSON
  output example — replaces fragmented instructions split across inline prompt,
  `--append-system-prompt`, and generate-workflow prompt file
- Restructure `build_prompt()` with explicit `Thread ID:` headers matching
  the `thread_id` schema field name
- Restructure `_extract_replies()` with tiered fallback (`dict[str, str]`)
- Rewrite thread filter to walk backwards with bot-reply boundary, fixing
  CodeRabbit interleaving causing thread skips
- Parse Claude output on non-zero exit for graceful degradation (max-turns
  and timeout no longer discard structured output)
- Add configurable `--timeout` CLI arg (720s default, up from hardcoded 600s)
- Discard partial file changes on timeout/max-turns and post informative reply
- Detect GH013 rule violations and skip futile push retries
- Fix `create_pr.py` PR title to show source file names instead of test names
- Extract `ALLOWED_TOOLS` constant; add `CLAUDE_CODE_BIN` env var
- Remove thread resolution logic, dead code, stale references

Issue #760

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes

## Test plan
- [x] 142 unit tests pass (54 for respond, 88 for other testbot modules)
- [x] Local e2e A/B: new prompt passes all quality gates; old prompt fails
  (hit max turns, no structured output, 0 thread IDs found)
- [x] Complex scenario (Go unit test generation for 388-line gRPC server)
  completes within timeout across haiku, sonnet, and opus models
- [x] Live test: verify `/testbot` comment on an ai-generated PR: https://github.com/NVIDIA/OSMO/pull/857


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable AI runner timeout (default 720s), tool allowlist, and runtime binary override; structured timeout/error metadata and non-fatal handling of runner exits; reply extraction now returns per-comment mapping keyed by string IDs.

* **Bug Fixes**
  * Improved trigger selection to avoid duplicate processing; uniform status posting when failures/timeouts occur; clearer fallback behavior on push failures and faster fail-on-specific push errors.

* **Documentation**
  * Split/reorganized prompts and rules into generate/respond prompts and a shared rules document; updated README and workflow guidance.

* **Tests**
  * Updated tests to match new reply format, validation, and control-flow behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->