### PR TITLE
Add ability for users to specify custom HPA metrics

### DIFF
--- a/deployments/charts/router/README.md
+++ b/deployments/charts/router/README.md
@@ -62,6 +62,7 @@ helm install my-router ./router -f my-values.yaml
 | `services.service.scaling.maxReplicas` | Maximum number of replicas | `5` |
 | `services.service.scaling.memoryTarget` | Target memory utilization percentage for HPA | `80` |
 | `services.service.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA | `80` |
+| `services.service.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
 
 #### Ingress Configuration
 

--- a/deployments/charts/router/templates/router-service.yaml
+++ b/deployments/charts/router/templates/router-service.yaml
@@ -286,3 +286,6 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.service.scaling.hpaCpuTarget }}
+  {{- with .Values.services.service.scaling.customMetrics }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/deployments/charts/router/values.yaml
+++ b/deployments/charts/router/values.yaml
@@ -110,6 +110,10 @@ services:
       ##
       hpaCpuTarget: 80
 
+      ## Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs)
+      ##
+      customMetrics: []
+
     ## Docker image name for the router service (without registry or tag)
     ##
     imageName: router

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -127,6 +127,7 @@ To add new migrations for future releases, drop JSON files into the chart's `mig
 | `services.worker.scaling.maxReplicas` | Maximum replicas | `10` |
 | `services.worker.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA scaling | `80` |
 | `services.worker.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA scaling | `80` |
+| `services.worker.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
 | `services.worker.imageName` | Worker image name | `worker` |
 | `services.worker.serviceName` | Service name | `osmo-worker` |
 | `services.worker.initContainers` | Init containers for worker | `[]` |
@@ -144,6 +145,7 @@ To add new migrations for future releases, drop JSON files into the chart's `mig
 | `services.service.scaling.maxReplicas` | Maximum replicas | `9` |
 | `services.service.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA scaling | `80` |
 | `services.service.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA scaling | `80` |
+| `services.service.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
 | `services.service.imageName` | Service image name | `service` |
 | `services.service.serviceName` | Service name | `osmo-service` |
 | `services.service.initContainers` | Init containers for API service | `[]` |
@@ -165,6 +167,7 @@ To add new migrations for future releases, drop JSON files into the chart's `mig
 | `services.logger.scaling.maxReplicas` | Maximum replicas | `9` |
 | `services.logger.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA scaling | `80` |
 | `services.logger.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA scaling | `80` |
+| `services.logger.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
 | `services.logger.imageName` | Logger image name | `logger` |
 | `services.logger.serviceName` | Service name | `osmo-logger` |
 | `services.logger.initContainers` | Init containers for logger service | `[]` |
@@ -181,6 +184,7 @@ To add new migrations for future releases, drop JSON files into the chart's `mig
 | `services.agent.scaling.maxReplicas` | Maximum replicas | `9` |
 | `services.agent.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA scaling | `80` |
 | `services.agent.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA scaling | `80` |
+| `services.agent.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
 | `services.agent.imageName` | Agent image name | `agent` |
 | `services.agent.serviceName` | Service name | `osmo-agent` |
 | `services.agent.initContainers` | Init containers for agent service | `[]` |
@@ -234,6 +238,7 @@ Benefits of the separate gateway model:
 | `gateway.envoy.scaling.maxReplicas` | Maximum number of Envoy replicas | `6` |
 | `gateway.envoy.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA | `80` |
 | `gateway.envoy.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA | `80` |
+| `gateway.envoy.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
 | `gateway.envoy.image` | Envoy image | `envoyproxy/envoy:v1.29.0` |
 | `gateway.envoy.logLevel` | Envoy log level | `info` |
 | `gateway.envoy.listenerPort` | Listener port | `8080` |
@@ -278,6 +283,7 @@ Envoy uses filesystem-based dynamic configuration (LDS/CDS). When the ConfigMap 
 | `gateway.oauth2Proxy.scaling.maxReplicas` | Maximum number of OAuth2 Proxy replicas | `3` |
 | `gateway.oauth2Proxy.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA | `80` |
 | `gateway.oauth2Proxy.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA | `80` |
+| `gateway.oauth2Proxy.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
 | `gateway.oauth2Proxy.image` | OAuth2 Proxy image | `quay.io/oauth2-proxy/oauth2-proxy:v7.14.2` |
 | `gateway.oauth2Proxy.provider` | OIDC provider type | `oidc` |
 | `gateway.oauth2Proxy.oidcIssuerUrl` | OIDC issuer URL | `""` |
@@ -294,6 +300,7 @@ Envoy uses filesystem-based dynamic configuration (LDS/CDS). When the ConfigMap 
 | `gateway.authz.scaling.maxReplicas` | Maximum number of Authz replicas | `3` |
 | `gateway.authz.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA | `80` |
 | `gateway.authz.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA | `80` |
+| `gateway.authz.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
 | `gateway.authz.imageName` | Authz image name | `authz-sidecar` |
 | `gateway.authz.imageTag` | Override image tag (defaults to `global.osmoImageTag`) | `""` |
 | `gateway.authz.grpcPort` | gRPC port | `50052` |

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -266,3 +266,6 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.agent.scaling.hpaCpuTarget }}
+  {{- with .Values.services.agent.scaling.customMetrics }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -295,3 +295,6 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.service.scaling.hpaCpuTarget }}
+  {{- with .Values.services.service.scaling.customMetrics }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -232,6 +232,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $gw.envoy.scaling.hpaMemoryTarget }}
+  {{- with $gw.envoy.scaling.customMetrics }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 
 {{- end }}{{/* end envoy.enabled */}}
 
@@ -402,6 +405,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $gw.oauth2Proxy.scaling.hpaMemoryTarget }}
+  {{- with $gw.oauth2Proxy.scaling.customMetrics }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}
 
 ---
@@ -549,6 +555,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $gw.authz.scaling.hpaMemoryTarget }}
+  {{- with $gw.authz.scaling.customMetrics }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}
 
 ---

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -258,3 +258,6 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.logger.scaling.hpaCpuTarget }}
+  {{- with .Values.services.logger.scaling.customMetrics }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -228,3 +228,6 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.worker.scaling.hpaCpuTarget }}
+  {{- with .Values.services.worker.scaling.customMetrics }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -472,6 +472,10 @@ services:
       ##
       hpaCpuTarget: 80
 
+      ## Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs)
+      ##
+      customMetrics: []
+
     ## Docker image name for the worker service
     ##
     imageName: worker
@@ -582,6 +586,10 @@ services:
       ## Target CPU utilization percentage for HPA scaling
       ##
       hpaCpuTarget: 80
+
+      ## Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs)
+      ##
+      customMetrics: []
 
     ## Docker image name for the API service
     ##
@@ -777,6 +785,10 @@ services:
       ##
       hpaCpuTarget: 80
 
+      ## Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs)
+      ##
+      customMetrics: []
+
     ## Docker image name for the logger service
     ##
     imageName: logger
@@ -890,6 +902,10 @@ services:
       ## Target CPU utilization percentage for HPA scaling
       ##
       hpaCpuTarget: 80
+
+      ## Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs)
+      ##
+      customMetrics: []
 
     ## Docker image name for the agent service
     ##
@@ -1042,6 +1058,10 @@ gateway:
       ## Target memory utilization percentage for HPA scaling
       ##
       hpaMemoryTarget: 80
+
+      ## Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs)
+      ##
+      customMetrics: []
 
     ## Envoy container image
     ##
@@ -1304,6 +1324,10 @@ gateway:
       ##
       hpaMemoryTarget: 80
 
+      ## Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs)
+      ##
+      customMetrics: []
+
     image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"
     imagePullPolicy: IfNotPresent
     httpPort: 4180
@@ -1376,6 +1400,10 @@ gateway:
       ## Target memory utilization percentage for HPA scaling
       ##
       hpaMemoryTarget: 80
+
+      ## Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs)
+      ##
+      customMetrics: []
 
     imageName: "authz-sidecar"
     ## Override the image tag for authz. Defaults to global.osmoImageTag.

--- a/deployments/charts/web-ui/README.md
+++ b/deployments/charts/web-ui/README.md
@@ -60,6 +60,7 @@ This Helm chart deploys the OSMO UI (Next.js web frontend). Authentication and t
 | `services.ui.scaling.minReplicas` | Minimum number of replicas | `1` |
 | `services.ui.scaling.maxReplicas` | Maximum number of replicas | `3` |
 | `services.ui.scaling.hpaTarget` | Target Memory Utilization Percentage | `85` |
+| `services.ui.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
 
 ### Ingress Settings
 

--- a/deployments/charts/web-ui/templates/ui.yaml
+++ b/deployments/charts/web-ui/templates/ui.yaml
@@ -315,4 +315,7 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.ui.scaling.hpaTarget }}
+  {{- with .Values.services.ui.scaling.customMetrics }}
+  {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/deployments/charts/web-ui/values.yaml
+++ b/deployments/charts/web-ui/values.yaml
@@ -151,6 +151,10 @@ services:
       ##
       hpaTarget: 85
 
+      ## Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs)
+      ##
+      customMetrics: []
+
     ## Kubernetes service configuration
     ##
     service:


### PR DESCRIPTION
Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom Horizontal Pod Autoscaler metrics for all services and gateway components; users can supply additional autoscaling/v2 metric specs alongside CPU/memory.

* **Documentation**
  * Chart READMEs and values documentation updated to expose new scaling.customMetrics Helm values (defaults documented as empty lists).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->