### PR TITLE
Fix privilege escalation: empty resources policy grants scoped access

### DIFF
--- a/src/utils/roles/action_registry.go
+++ b/src/utils/roles/action_registry.go
@@ -1148,6 +1148,9 @@ func CheckSemanticAction(
 
 // checkResolvedAction checks if a policy action string matches a pre-resolved
 // action and resource pair. Returns (true, result) on match, (false, _) otherwise.
+//
+// A policy with empty resources does not match non-empty resource targets
+// (unscoped policies don't grant scoped resource access).
 func checkResolvedAction(
 	policyActionStr string,
 	policyResources []string,
@@ -1156,9 +1159,9 @@ func checkResolvedAction(
 	// Universal wildcard — admin roles that should have access to all endpoints,
 	// even ones not registered in the action registry.
 	if policyActionStr == "*:*" || policyActionStr == "*" {
-		resourceAllowed := len(policyResources) == 0
+		resourceAllowed := len(policyResources) == 0 && resolvedResource == ""
 		for _, pr := range policyResources {
-			if pr == "*" {
+			if matchResource(pr, resolvedResource) {
 				resourceAllowed = true
 				break
 			}
@@ -1186,8 +1189,15 @@ func checkResolvedAction(
 		return false, AccessResult{}
 	}
 
-	// Check if the resource matches (if resources are specified)
-	if len(policyResources) > 0 {
+	// Check if the resource matches. An empty resources list only matches
+	// when the resolved resource is also empty (unscoped). This prevents
+	// policies like {"actions": ["auth:Token"], "resources": []} from
+	// granting access to resource-scoped paths (e.g., other users' tokens).
+	if len(policyResources) == 0 {
+		if resolvedResource != "" {
+			return false, AccessResult{}
+		}
+	} else {
 		resourceMatched := false
 		for _, policyResource := range policyResources {
 			if matchResource(policyResource, resolvedResource) {

--- a/src/utils/roles/action_registry_test.go
+++ b/src/utils/roles/action_registry_test.go
@@ -1364,8 +1364,8 @@ func TestEmptyResourcesAcrossActionTypes(t *testing.T) {
 			wantAllowed: false,
 		},
 		{
-			name:        "bucket:* on specific bucket (scoped) denied",
-			action:      "bucket:*",
+			name:        "dataset:* on specific bucket (scoped) denied",
+			action:      "dataset:*",
 			path:        "/api/bucket/my-bucket",
 			method:      "GET",
 			wantAllowed: false,

--- a/src/utils/roles/action_registry_test.go
+++ b/src/utils/roles/action_registry_test.go
@@ -1219,3 +1219,203 @@ func TestCheckPolicyAccessTrailingWildcardConfig(t *testing.T) {
 		t.Errorf("want denied for config/global-settings, got allowed")
 	}
 }
+
+// TestEmptyResourcesDeniesResourceScopedAccess verifies that a policy with
+// an empty resources list cannot access resource-scoped endpoints. This
+// prevents privilege escalation where e.g. auth:Token with no resources
+// could manage other users' tokens.
+func TestEmptyResourcesDeniesResourceScopedAccess(t *testing.T) {
+	ctx := context.Background()
+
+	// A policy with auth:Token and no resources should only allow
+	// the user's own token endpoints, not admin endpoints for other users.
+	tokenRole := &Role{
+		Name: "token-user",
+		Policies: []RolePolicy{
+			{
+				Effect:    EffectAllow,
+				Actions:   RoleActions{{Action: ActionAuthToken}},
+				Resources: []string{},
+			},
+		},
+	}
+
+	// Own tokens (unscoped) — should be allowed
+	result := CheckPolicyAccess(ctx, tokenRole, "/api/auth/access_token", "GET", nil)
+	if !result.Allowed {
+		t.Error("empty resources should allow unscoped /api/auth/access_token")
+	}
+
+	result = CheckPolicyAccess(ctx, tokenRole, "/api/auth/access_token/my-token", "DELETE", nil)
+	if !result.Allowed {
+		t.Error("empty resources should allow unscoped /api/auth/access_token/my-token")
+	}
+
+	// Other user's tokens (resource-scoped) — must be denied
+	result = CheckPolicyAccess(ctx, tokenRole, "/api/auth/user/alice/access_token", "GET", nil)
+	if result.Allowed {
+		t.Error("empty resources must deny resource-scoped /api/auth/user/alice/access_token")
+	}
+
+	result = CheckPolicyAccess(ctx, tokenRole, "/api/auth/user/alice/access_token/tok1", "DELETE", nil)
+	if result.Allowed {
+		t.Error("empty resources must deny resource-scoped /api/auth/user/alice/access_token/tok1")
+	}
+}
+
+// TestExplicitResourceAllowsResourceScopedAccess verifies that a policy with
+// an explicit resource grant can access resource-scoped endpoints.
+func TestExplicitResourceAllowsResourceScopedAccess(t *testing.T) {
+	ctx := context.Background()
+
+	// Admin token policy with explicit user/* resource
+	adminTokenRole := &Role{
+		Name: "token-admin",
+		Policies: []RolePolicy{
+			{
+				Effect:    EffectAllow,
+				Actions:   RoleActions{{Action: ActionAuthToken}},
+				Resources: []string{"user/*"},
+			},
+		},
+	}
+
+	// Other user's tokens — should be allowed with explicit resource grant
+	result := CheckPolicyAccess(ctx, adminTokenRole, "/api/auth/user/alice/access_token", "GET", nil)
+	if !result.Allowed {
+		t.Error("explicit user/* resource should allow /api/auth/user/alice/access_token")
+	}
+
+	result = CheckPolicyAccess(ctx, adminTokenRole, "/api/auth/user/bob/access_token/tok1", "DELETE", nil)
+	if !result.Allowed {
+		t.Error("explicit user/* resource should allow /api/auth/user/bob/access_token/tok1")
+	}
+}
+
+// TestWildcardEmptyResourcesDeniesResourceScoped verifies that even a *:*
+// policy with empty resources cannot access resource-scoped endpoints.
+func TestWildcardEmptyResourcesDeniesResourceScoped(t *testing.T) {
+	ctx := context.Background()
+
+	role := &Role{
+		Name: "wildcard-no-resources",
+		Policies: []RolePolicy{
+			{
+				Effect:  EffectAllow,
+				Actions: RoleActions{{Action: "*:*"}},
+			},
+		},
+	}
+
+	// Unscoped path — should be allowed
+	result := CheckPolicyAccess(ctx, role, "/api/profile/settings", "GET", nil)
+	if !result.Allowed {
+		t.Error("*:* with empty resources should allow unscoped paths")
+	}
+
+	// Resource-scoped path — must be denied
+	result = CheckPolicyAccess(ctx, role, "/api/auth/user/alice/access_token", "GET", nil)
+	if result.Allowed {
+		t.Error("*:* with empty resources must deny resource-scoped paths")
+	}
+}
+
+// TestEmptyResourcesAcrossActionTypes verifies the empty-resources-denies-scoped
+// behavior applies consistently across different action types, including partial
+// wildcards like config:* and the universal wildcard *:*.
+func TestEmptyResourcesAcrossActionTypes(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		action      string
+		path        string
+		method      string
+		wantAllowed bool
+	}{
+		// Unscoped paths — should be allowed with empty resources
+		{
+			name:        "workflow:List unscoped allowed",
+			action:      "workflow:List",
+			path:        "/api/workflow",
+			method:      "GET",
+			wantAllowed: true,
+		},
+		{
+			name:        "auth:Token own tokens (unscoped) allowed",
+			action:      ActionAuthToken,
+			path:        "/api/auth/access_token",
+			method:      "GET",
+			wantAllowed: true,
+		},
+		{
+			name:        "*:* on unscoped path allowed",
+			action:      "*:*",
+			path:        "/api/profile/settings",
+			method:      "GET",
+			wantAllowed: true,
+		},
+		// Resource-scoped paths — must be denied with empty resources
+		{
+			name:        "auth:Token other user's tokens (scoped) denied",
+			action:      ActionAuthToken,
+			path:        "/api/auth/user/alice/access_token",
+			method:      "GET",
+			wantAllowed: false,
+		},
+		{
+			name:        "bucket:* on specific bucket (scoped) denied",
+			action:      "bucket:*",
+			path:        "/api/bucket/my-bucket",
+			method:      "GET",
+			wantAllowed: false,
+		},
+		{
+			name:        "config:* on specific config (scoped) denied",
+			action:      "config:*",
+			path:        "/api/configs/my-config",
+			method:      "GET",
+			wantAllowed: false,
+		},
+		{
+			name:        "*:* on other user's tokens (scoped) denied",
+			action:      "*:*",
+			path:        "/api/auth/user/alice/access_token",
+			method:      "GET",
+			wantAllowed: false,
+		},
+		{
+			name:        "*:* on specific config (scoped) denied",
+			action:      "*:*",
+			path:        "/api/configs/my-config",
+			method:      "GET",
+			wantAllowed: false,
+		},
+		{
+			name:        "*:* on specific bucket (scoped) denied",
+			action:      "*:*",
+			path:        "/api/bucket/my-bucket",
+			method:      "GET",
+			wantAllowed: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role := &Role{
+				Name: "empty-resources",
+				Policies: []RolePolicy{
+					{
+						Effect:    EffectAllow,
+						Actions:   RoleActions{{Action: tt.action}},
+						Resources: []string{},
+					},
+				},
+			}
+			result := CheckPolicyAccess(ctx, role, tt.path, tt.method, nil)
+			if result.Allowed != tt.wantAllowed {
+				t.Errorf("Allowed = %v, want %v", result.Allowed, tt.wantAllowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Policies with an empty resources list (e.g. {"actions": ["auth:Token"], "resources": []}) were incorrectly allowed to access resource-scoped endpoints. For example, a user with auth:Token and no resources could manage other users' tokens via /api/auth/user/{id}/access_token.

The bug was in checkResolvedAction() which skipped the resource check entirely when policyResources was empty, treating it as "no restriction". The correct semantics is: empty resources only matches when the resolved resource is also empty (unscoped paths).

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authorization so policies with no resources only match unscoped endpoints; they no longer grant access to resource-scoped endpoints. Wildcard actions respect this restriction while resource-specific policies continue to work as intended.

* **Tests**
  * Added unit tests covering empty-resource policy behavior across multiple actions and endpoint patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->