### PR TITLE
Extend testbot respond to general dev PRs

### DIFF
--- a/.github/workflows/testbot-respond.yaml
+++ b/.github/workflows/testbot-respond.yaml
@@ -39,7 +39,7 @@ jobs:
     if: >-
       contains(github.event.pull_request.labels.*.name, 'ai-generated') &&
       github.event.pull_request.head.repo.full_name == github.repository
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
@@ -87,8 +87,8 @@ jobs:
             --pr-number ${{ github.event.pull_request.number }} \
             --trigger-phrase /testbot \
             --max-responses 10 \
-            --max-turns 50 \
-            --timeout 720 \
+            --max-turns 75 \
+            --timeout 900 \
             --model aws/anthropic/claude-opus-4-5
         env:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -35,7 +35,7 @@ Claude Code is sandboxed: it can only read files, edit test files, and run test 
 
 | Feature | Description |
 |---------|-------------|
-| **Trigger** | Comment starting with `/testbot` on inline review threads of `ai-generated` PRs |
+| **Trigger** | Comment starting with `/testbot` on any PR with the `ai-generated` label |
 | **Thread context** | Full conversation history (all nested comments) passed to Claude |
 | **Structured output** | `--json-schema` returns per-thread replies and commit message |
 | **Safety** | Repo-member-only access, crash recovery, push retry |
@@ -72,15 +72,26 @@ Runs automatically on weekdays at 6 AM UTC.
 
 ### Review response
 
-Start an inline review comment with `/testbot <instruction>` on any `ai-generated` PR. The command must be the first text in the comment. Examples:
+Add the `ai-generated` label to your PR, then start an inline review comment with `/testbot <instruction>`. The command must be the first text in the comment. Examples:
 
 ```text
+/testbot add unit tests for this file
+/testbot fix this based on the CodeRabbit suggestion above
 /testbot rename test methods to follow test_<behavior>_<condition> convention
-/testbot add edge case tests for empty input
-/testbot remove the redundant tests for preset labels
+/testbot refactor this function to reduce duplication
 ```
 
 The bot responds only to repo members (OWNER, MEMBER, COLLABORATOR). It will not respond to its own replies or comments from bots.
+
+### Reverting a testbot commit
+
+If the bot's commit isn't what you wanted, revert it and retry:
+
+```bash
+git pull && git revert HEAD --no-edit && git push
+```
+
+Then post a new `/testbot` comment with clearer instructions.
 
 ## Configuration
 

--- a/src/scripts/testbot/TESTBOT_RESPOND_PROMPT.md
+++ b/src/scripts/testbot/TESTBOT_RESPOND_PROMPT.md
@@ -1,24 +1,25 @@
 # Testbot Respond Instructions
 
-You are **testbot**, an AI assistant that addresses inline review feedback on
-AI-generated test PRs. A human reviewer left `/testbot` comments asking you to
-fix, improve, or remove tests. Your job is to apply the requested changes, verify
-them, and produce a structured JSON reply for every thread.
+You are **testbot**, an AI assistant that applies changes requested via
+`/testbot` comments on pull requests. Requests may include adding unit tests,
+applying code fixes, addressing reviewer or CodeRabbit feedback, or refactoring.
 
 Read `AGENTS.md` at the repo root for project coding standards.
-Read `src/scripts/testbot/TESTBOT_RULES.md` for test quality rules, language
-conventions, and verification steps.
+When writing or modifying tests, also read `src/scripts/testbot/TESTBOT_RULES.md`
+for test quality rules, language conventions, and verification steps.
 
 ## Process
 
-For each review thread below:
+For each review comment below:
 
-1. **Read** the referenced source and test files.
+1. **Understand the context.** Read the referenced file and the full thread
+   history. Use `gh pr diff` or `gh pr view` if you need to understand what
+   the PR changed and why.
 2. **Apply** the change requested in the latest `/testbot` comment.
-   Pay attention to the FULL thread history — earlier comments provide context,
-   but the latest `/testbot` comment is the instruction to follow.
-3. **Run the test** and verify code style per TESTBOT_RULES.md.
-   If the test fails, follow the bug detection steps in TESTBOT_RULES.md.
+3. **Verify.** Run relevant tests and linting:
+   - Python: `bazel test <target>` and `bazel test <target>-pylint`
+   - Go: `bazel test <target>`
+   - TypeScript: `pnpm --dir src/ui test -- --run <file>` and `pnpm --dir src/ui validate`
 4. Do NOT create git commits or branches.
 
 ## Output Format
@@ -48,4 +49,4 @@ yourself based on what was accomplished.
 
 **Fields:**
 - `commit_message`: A concise summary prefixed with `testbot: ` (subject under 72 chars).
-- `replies`: One entry per comment. `comment_id` is the ID from the `### Comment` header below. `reply` explains what you did. Include any SUSPECTED BUG markers found.
+- `replies`: One entry per comment. `comment_id` is the ID from the `### Comment` header below. `reply` explains what you did.

--- a/src/scripts/testbot/respond.py
+++ b/src/scripts/testbot/respond.py
@@ -31,10 +31,10 @@ SELF_AUTHORS = frozenset({"github-actions[bot]", "svc-osmo-ci"})
 ALLOWED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 # Shared with testbot.yaml — update both when changing the tool allowlist.
 ALLOWED_TOOLS = (
-    "Read,Edit,Write,"
+    "Read,Edit,Write,Glob,Grep,"
     "Bash(bazel test *),Bash(pnpm --dir src/ui test *),"
     "Bash(pnpm --dir src/ui validate),Bash(pnpm --dir src/ui format),"
-    "Glob,Grep"
+    "Bash(gh pr view *),Bash(gh pr diff *),Bash(gh pr checks *)"
 )
 
 THREADS_QUERY = """
@@ -271,7 +271,7 @@ def filter_actionable(
     return actionable
 
 
-def build_prompt(threads: list[dict]) -> str:
+def build_prompt(threads: list[dict], pr_number: int) -> str:
     """Build a single prompt with all actionable threads for Claude Code.
 
     Each thread includes the full conversation history so Claude
@@ -281,7 +281,7 @@ def build_prompt(threads: list[dict]) -> str:
         "Read and follow src/scripts/testbot/TESTBOT_RESPOND_PROMPT.md for your role,",
         "process, and output format.",
         "",
-        "Address these review threads on an AI-generated test PR.",
+        f"Address these review comments on PR #{pr_number}.",
         "Each thread includes the full conversation history — pay attention to",
         "the LATEST request (the one containing /testbot), not just the first comment.",
         "",
@@ -502,7 +502,7 @@ def main() -> None:
         capture_output=True, text=True, check=True,
     ).stdout.strip()
 
-    prompt = build_prompt(actionable)
+    prompt = build_prompt(actionable, args.pr_number)
     logger.info("Running Claude Code for %d comment(s)...", len(actionable))
     claude_output = run_claude(
         prompt, model=args.model, max_turns=args.max_turns, timeout=args.timeout,

--- a/src/scripts/testbot/tests/test_respond.py
+++ b/src/scripts/testbot/tests/test_respond.py
@@ -297,7 +297,7 @@ class TestBuildPrompt(unittest.TestCase):
             "line": 42,
             "thread_history": "  [reviewer]: /testbot add edge cases",
         }]
-        prompt = build_prompt(threads)
+        prompt = build_prompt(threads, pr_number=99)
         self.assertIn("`src/ui/src/lib/foo.test.ts` line 42", prompt)
         self.assertIn("### Comment 123", prompt)
         self.assertIn("[reviewer]: /testbot add edge cases", prompt)
@@ -309,18 +309,18 @@ class TestBuildPrompt(unittest.TestCase):
             "line": 1,
             "thread_history": "  [user]: /testbot fix",
         }]
-        prompt = build_prompt(threads)
+        prompt = build_prompt(threads, pr_number=99)
         self.assertIn("TESTBOT_RESPOND_PROMPT.md", prompt)
 
-    def test_includes_latest_comment_guidance(self):
+    def test_includes_pr_number(self):
         threads = [{
             "reply_comment_id": 1,
             "path": "foo.py",
             "line": 1,
             "thread_history": "  [user]: /testbot fix",
         }]
-        prompt = build_prompt(threads)
-        self.assertIn("LATEST request", prompt)
+        prompt = build_prompt(threads, pr_number=857)
+        self.assertIn("PR #857", prompt)
 
 
 class TestRunClaude(unittest.TestCase):


### PR DESCRIPTION
## Summary

Extend the testbot respond workflow so any developer can use `/testbot` on their
PR — not just testbot-generated test PRs. Devs add the `ai-generated` label and
post inline comments to request test generation, CodeRabbit fix triage, source
code fixes, or refactors.

- Generalize prompt: remove "AI-generated test PR" framing, support any
  `/testbot` request (tests, code fixes, CodeRabbit triage, refactors)
- Add read-only `gh` CLI access (`gh pr view/diff/checks`) so Claude can
  understand PR context on the fly
- Pass PR number to prompt so Claude knows which PR to query
- Increase max-turns to 75, timeout to 900s, workflow timeout to 20 min
- Add revert instructions to README

Issue #760

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes

## Test plan
- [x] 142 unit tests pass
- [x] Live test: on a dev PR, add `ai-generated` label, post `/testbot add unit tests for this file`
- [x] Live test: reply `/testbot` to a CodeRabbit suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)