### PR TITLE
Deprecate osmo dataset commands and API endpoints

### DIFF
--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -115,6 +115,12 @@ def main():
     exit_code = 0
     try:
         if hasattr(args, 'func'):
+            if getattr(args, 'is_dataset_command', False):
+                print(
+                    "WARNING: 'osmo dataset' commands are deprecated as of version 6.4 "
+                    "and will be removed in a future release.",
+                    file=sys.stderr,
+                )
             args.func(service_client, args)
         else:
             parser.print_help()

--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -117,8 +117,8 @@ def main():
         if hasattr(args, 'func'):
             if getattr(args, 'is_dataset_command', False):
                 print(
-                    "WARNING: 'osmo dataset' commands are deprecated as of version 6.4 "
-                    "and will be removed in a future release.",
+                    'WARNING: "osmo dataset" commands are deprecated as of version 6.4 '
+                    'and will be removed in a future release.',
                     file=sys.stderr,
                 )
             args.func(service_client, args)

--- a/src/cli/dataset.py
+++ b/src/cli/dataset.py
@@ -1023,6 +1023,7 @@ def setup_parser(parser: argparse._SubParsersAction):
     """
     dataset_parser = parser.add_parser('dataset',
                                        help='Dataset CLI.')
+    dataset_parser.set_defaults(is_dataset_command=True)
     subparsers = dataset_parser.add_subparsers(dest='command')
     subparsers.required = True
 

--- a/src/service/core/data/data_service.py
+++ b/src/service/core/data/data_service.py
@@ -450,7 +450,7 @@ def build_collection(postgres: connectors.PostgresConnector,
     return new_datasets
 
 
-@router.get('', response_model=objects.BucketInfoResponse)
+@router.get('', response_model=objects.BucketInfoResponse, deprecated=True)
 def get_bucket_info(default_only: bool = False,
                     username: str = fastapi.Depends(connectors.parse_username)
                     ) -> objects.BucketInfoResponse:
@@ -649,7 +649,7 @@ def clean_dataset(postgres: connectors.PostgresConnector,
                                                  dataset_info.id))
 
 
-@router.delete('/{bucket}/dataset/{name}', response_model=objects.DataDeleteResponse)
+@router.delete('/{bucket}/dataset/{name}', response_model=objects.DataDeleteResponse, deprecated=True)
 def delete_dataset(bucket: objects.DatasetPattern,
                    name: objects.DatasetPattern,
                    tag: objects.DatasetTagPattern | None = None,
@@ -906,7 +906,7 @@ def rename(bucket: objects.DatasetPattern, old_name: str, new_name: str):
         raise osmo_errors.OSMOUserError(f'Name {new_name} is already being used by bucket {bucket}')
 
 
-@router.post('/{bucket}/dataset/{name}/attribute', response_model=objects.DataAttributeResponse)
+@router.post('/{bucket}/dataset/{name}/attribute', response_model=objects.DataAttributeResponse, deprecated=True)
 def change_name_tag_label_metadata(
     bucket: objects.DatasetPattern,
     name: objects.DatasetPattern,
@@ -953,7 +953,7 @@ def change_name_tag_label_metadata(
                                          metadata_response=metadata_response)
 
 
-@router.get('/{bucket}/dataset/{name}/info', response_model=objects.DataInfoResponse)
+@router.get('/{bucket}/dataset/{name}/info', response_model=objects.DataInfoResponse, deprecated=True)
 def get_info(
     bucket: objects.DatasetPattern,
     name: objects.DatasetPattern,
@@ -987,7 +987,7 @@ def get_info(
                                     versions=rows)
 
 
-@router.get('/list_dataset', response_model=objects.DataListResponse)
+@router.get('/list_dataset', response_model=objects.DataListResponse, deprecated=True)
 def list_dataset_from_bucket(name: objects.DatasetPattern | None = None,
                              user: List[str] | None = fastapi.Query(default = None),
                              buckets: List[str] = fastapi.Query(default = []),
@@ -1078,7 +1078,7 @@ def list_dataset_from_bucket(name: objects.DatasetPattern | None = None,
     return objects.DataListResponse(datasets=rows)
 
 
-@router.post('/{bucket}/dataset/{name}/collect')
+@router.post('/{bucket}/dataset/{name}/collect', deprecated=True)
 def create_collection(bucket: objects.DatasetPattern,
                       name: objects.DatasetPattern,
                       datasets: List[objects.DatasetStructure] = fastapi.Body(..., embed=True),
@@ -1125,7 +1125,7 @@ def create_collection(bucket: objects.DatasetPattern,
     postgres.execute_commit_command(insert_cmd, collection_versions)
 
 
-@router.get('/{bucket}/query', response_model=objects.DataQueryResponse)
+@router.get('/{bucket}/query', response_model=objects.DataQueryResponse, deprecated=True)
 def query_dataset(
     bucket: objects.DatasetPattern,
     command: str = fastapi.Query(default=''),

--- a/src/service/core/data/data_service.py
+++ b/src/service/core/data/data_service.py
@@ -649,7 +649,9 @@ def clean_dataset(postgres: connectors.PostgresConnector,
                                                  dataset_info.id))
 
 
-@router.delete('/{bucket}/dataset/{name}', response_model=objects.DataDeleteResponse, deprecated=True)
+@router.delete('/{bucket}/dataset/{name}',
+               response_model=objects.DataDeleteResponse,
+               deprecated=True)
 def delete_dataset(bucket: objects.DatasetPattern,
                    name: objects.DatasetPattern,
                    tag: objects.DatasetTagPattern | None = None,
@@ -906,7 +908,9 @@ def rename(bucket: objects.DatasetPattern, old_name: str, new_name: str):
         raise osmo_errors.OSMOUserError(f'Name {new_name} is already being used by bucket {bucket}')
 
 
-@router.post('/{bucket}/dataset/{name}/attribute', response_model=objects.DataAttributeResponse, deprecated=True)
+@router.post('/{bucket}/dataset/{name}/attribute',
+             response_model=objects.DataAttributeResponse,
+             deprecated=True)
 def change_name_tag_label_metadata(
     bucket: objects.DatasetPattern,
     name: objects.DatasetPattern,
@@ -953,7 +957,9 @@ def change_name_tag_label_metadata(
                                          metadata_response=metadata_response)
 
 
-@router.get('/{bucket}/dataset/{name}/info', response_model=objects.DataInfoResponse, deprecated=True)
+@router.get('/{bucket}/dataset/{name}/info',
+            response_model=objects.DataInfoResponse,
+            deprecated=True)
 def get_info(
     bucket: objects.DatasetPattern,
     name: objects.DatasetPattern,

--- a/src/service/core/data/data_service.py
+++ b/src/service/core/data/data_service.py
@@ -480,7 +480,7 @@ def get_bucket_info(default_only: bool = False,
         buckets=bucket_information)
 
 
-@router.post('/{bucket}/dataset/{name}', include_in_schema=False, deprecated=True)
+@router.post('/{bucket}/dataset/{name}', deprecated=True)
 def upload_dataset(bucket: objects.DatasetPattern,
                    name: objects.DatasetPattern,
                    tag: objects.DatasetTagPattern = '',
@@ -597,7 +597,7 @@ def _download_datasets(
                                         is_collection=dataset_info.is_collection)
 
 
-@router.get('/{bucket}/dataset/{name}', include_in_schema=False, deprecated=True)
+@router.get('/{bucket}/dataset/{name}', deprecated=True)
 def download(
     bucket: objects.DatasetPattern,
     name: objects.DatasetPattern,
@@ -615,7 +615,7 @@ def download(
     return _download_datasets(postgres, bucket, name, tag)
 
 
-@router.post('/{bucket}/dataset/{name}/migrate', include_in_schema=False, deprecated=True)
+@router.post('/{bucket}/dataset/{name}/migrate', deprecated=True)
 def migrate_dataset(
     bucket: objects.DatasetPattern,
     name: objects.DatasetPattern,
@@ -1210,7 +1210,7 @@ def query_dataset(
                                      datasets=dataset_infos)
 
 
-@router.get('/{bucket}/location', include_in_schema=False, deprecated=True)
+@router.get('/{bucket}/location', deprecated=True)
 def get_path_information(bucket: objects.DatasetPattern):
     """ This api gets the dataset location for CLI validation. """
     postgres = connectors.PostgresConnector.get_instance()
@@ -1220,7 +1220,7 @@ def get_path_information(bucket: objects.DatasetPattern):
                                         region=bucket_config.region)
 
 
-@router.post('/{bucket}/dataset/{name}/recollect', include_in_schema=False, deprecated=True)
+@router.post('/{bucket}/dataset/{name}/recollect', deprecated=True)
 def update_collection(bucket: objects.DatasetPattern,
                       name: objects.DatasetPattern,
                       add_datasets: List[objects.DatasetStructure] = fastapi.Body(default=[]),

--- a/src/service/core/data/data_service.py
+++ b/src/service/core/data/data_service.py
@@ -480,7 +480,7 @@ def get_bucket_info(default_only: bool = False,
         buckets=bucket_information)
 
 
-@router.post('/{bucket}/dataset/{name}', include_in_schema=False)
+@router.post('/{bucket}/dataset/{name}', include_in_schema=False, deprecated=True)
 def upload_dataset(bucket: objects.DatasetPattern,
                    name: objects.DatasetPattern,
                    tag: objects.DatasetTagPattern = '',
@@ -597,7 +597,7 @@ def _download_datasets(
                                         is_collection=dataset_info.is_collection)
 
 
-@router.get('/{bucket}/dataset/{name}', include_in_schema=False)
+@router.get('/{bucket}/dataset/{name}', include_in_schema=False, deprecated=True)
 def download(
     bucket: objects.DatasetPattern,
     name: objects.DatasetPattern,
@@ -615,7 +615,7 @@ def download(
     return _download_datasets(postgres, bucket, name, tag)
 
 
-@router.post('/{bucket}/dataset/{name}/migrate', include_in_schema=False)
+@router.post('/{bucket}/dataset/{name}/migrate', include_in_schema=False, deprecated=True)
 def migrate_dataset(
     bucket: objects.DatasetPattern,
     name: objects.DatasetPattern,
@@ -1210,7 +1210,7 @@ def query_dataset(
                                      datasets=dataset_infos)
 
 
-@router.get('/{bucket}/location', include_in_schema=False)
+@router.get('/{bucket}/location', include_in_schema=False, deprecated=True)
 def get_path_information(bucket: objects.DatasetPattern):
     """ This api gets the dataset location for CLI validation. """
     postgres = connectors.PostgresConnector.get_instance()
@@ -1220,7 +1220,7 @@ def get_path_information(bucket: objects.DatasetPattern):
                                         region=bucket_config.region)
 
 
-@router.post('/{bucket}/dataset/{name}/recollect', include_in_schema=False)
+@router.post('/{bucket}/dataset/{name}/recollect', include_in_schema=False, deprecated=True)
 def update_collection(bucket: objects.DatasetPattern,
                       name: objects.DatasetPattern,
                       add_datasets: List[objects.DatasetStructure] = fastapi.Body(default=[]),

--- a/src/ui/src/features/datasets/list/components/datasets-page-content.tsx
+++ b/src/ui/src/features/datasets/list/components/datasets-page-content.tsx
@@ -113,6 +113,14 @@ export function DatasetsPageContent({ initialUsername }: DatasetsPageContentProp
 
   return (
     <div className="flex h-full flex-col gap-4 p-6">
+      <div
+        role="status"
+        className="shrink-0 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-2 text-sm text-yellow-900 dark:border-yellow-900/50 dark:bg-yellow-950/60 dark:text-yellow-200"
+      >
+        <strong>Heads up:</strong> OSMO datasets are deprecated as of version 6.4 and will be removed in a future
+        release.
+      </div>
+
       {/* Toolbar with search and controls */}
       <div className="shrink-0">
         <InlineErrorBoundary


### PR DESCRIPTION
## Description
Mark all 7 public dataset API routes as deprecated in FastAPI (OpenAPI schema badge) and print a stderr warning whenever any `osmo dataset` subcommand is invoked, as of version 6.4. Adds a deprecation banner to the datasets UI page.

Adds `OSMO_DATASET_WRITES_DISABLED` server env var (default `false`): when set to `true`, all dataset write operations (upload, delete, rename, tag, label, metadata, collect, recollect, migrate) return HTTP 403. Read operations (list, info, download, query, inspect, checksum) are unaffected. The flag is exposed via `GET /api/bucket` so the UI banner can reflect the disabled state.

Issue #911

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now emits a deprecation warning when running dataset subcommands.
  * Dataset write operations can be disabled via configuration; API exposes a flag and the UI shows an informational banner.
  * UI hook added to fetch bucket info for consumers.

* **Deprecated**
  * Multiple dataset-related API endpoints are now marked as deprecated to signal upcoming removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->