### PR TITLE
Consolidate PR coverage into ci-internal to reduce bazel cache memory usage

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -14,9 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Runs coverage and uploads to Codecov.
-# - On push to main: provides base reports so Codecov can compute diffs on PRs.
-# - On pull_request: provides head reports for the PR branch.
+# Coverage base reports.
+#
+# PR head coverage is produced by pr-checks.yaml (ci-internal for backend,
+# ui-build for UI) so we don't double-run tests on the self-hosted runner.
+# This workflow runs only on push to main (and workflow_dispatch) to refresh
+# the Codecov base report that PRs are diffed against.
 name: Coverage
 
 on:
@@ -24,9 +27,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main, 'feature/**', 'release/**']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -207,15 +207,25 @@ jobs:
           bazelisk-cache: true
           bazelisk-version: 1.27.0
 
-      - name: Run Tests
+      - name: Run Tests with Coverage
         run: |
-          bazel test --config=ci \
+          bazel coverage --config=ci \
             --remote_cache=${{ secrets.BAZEL_REMOTE_CACHE_URL }} \
             --test_env=DOCKER_HOST=tcp://docker:2375 \
             --test_env=TESTCONTAINERS_HOST_OVERRIDE=docker \
             --test_output=errors \
             -- \
             //...
+
+      - name: Upload coverage to Codecov
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: bazel-out/_coverage/_coverage_report.dat
+          flags: backend
+          fail_ci_if_error: false
 
       - name: Docker cleanup
         if: always()
@@ -470,6 +480,16 @@ jobs:
         working-directory: src/ui
         run: pnpm exec playwright install chromium
 
-      - name: Validate UI
+      - name: Validate UI with Coverage
         working-directory: src/ui
-        run: pnpm validate
+        run: pnpm validate:coverage
+
+      - name: Upload UI coverage to Codecov
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: src/ui/coverage/lcov.info
+          flags: ui
+          fail_ci_if_error: false

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -100,14 +100,21 @@ bazel_dep(name = "rules_shell", version = "0.7.1")
 bazel_dep(name = "aspect_rules_py", version = "1.11.2")
 bazel_dep(name = "rules_python", version = "1.9.0")
 
-# Patch: single_version_platform_override.coverage_tool is attr.label() but
-# python_repository.coverage_tool is attr.string(), causing a type mismatch.
-# This one-line patch converts the Label to string before it flows through.
-# TODO: Remove once rules_python fixes this upstream.
+# Patches:
+#   - coverage_tool_label: single_version_platform_override.coverage_tool is
+#     attr.label() but python_repository.coverage_tool is attr.string(). Patch
+#     converts the Label to string before it flows through.
+#   - coverage_empty_data: wrap lcov_report() in try/except so tests whose
+#     imports resolve outside the tracked source tree (e.g. wheel-only tests)
+#     emit an empty lcov instead of raising NoDataError and failing.
+# TODO: Remove both once rules_python fixes these upstream.
 single_version_override(
     module_name = "rules_python",
     patch_strip = 1,
-    patches = ["//bzl/patches:rules_python_coverage_tool_label.patch"],
+    patches = [
+        "//bzl/patches:rules_python_coverage_tool_label.patch",
+        "//bzl/patches:rules_python_coverage_empty_data.patch",
+    ],
 )
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/bzl/patches/BUILD
+++ b/bzl/patches/BUILD
@@ -16,5 +16,6 @@
 
 exports_files([
     "coverage_syspath.patch",
+    "rules_python_coverage_empty_data.patch",
     "rules_python_coverage_tool_label.patch",
 ])

--- a/bzl/patches/rules_python_coverage_empty_data.patch
+++ b/bzl/patches/rules_python_coverage_empty_data.patch
@@ -1,0 +1,41 @@
+Tolerate empty coverage data in py_test coverage collection.
+
+Tests whose imports resolve outside the tracked source tree (e.g. imports from a
+built wheel via osmo_py_wheel_unpacked) collect no data. coverage.py then
+raises NoDataError from lcov_report(), which rules_python's stage 2 bootstrap
+surfaces as a test failure even though the test itself passed.
+
+Wrap lcov_report() in a try/except so that tests with no collectable coverage
+emit an empty lcov file instead of failing the run.
+
+diff --git a/python/private/stage2_bootstrap_template.py b/python/private/stage2_bootstrap_template.py
+--- a/python/private/stage2_bootstrap_template.py
++++ b/python/private/stage2_bootstrap_template.py
+@@ -357,13 +357,20 @@ def _maybe_collect_coverage(enable):
+             cov.stop()
+             lcov_path = os.path.join(coverage_dir, "pylcov.dat")
+             print_verbose_coverage("generating lcov from:", lcov_path)
+-            cov.lcov_report(
+-                outfile=lcov_path,
+-                # Ignore errors because sometimes instrumented files aren't
+-                # readable afterwards. e.g. if they come from /dev/fd or if
+-                # they were transient code-under-test in /tmp
+-                ignore_errors=True,
+-            )
++            try:
++                cov.lcov_report(
++                    outfile=lcov_path,
++                    # Ignore errors because sometimes instrumented files aren't
++                    # readable afterwards. e.g. if they come from /dev/fd or if
++                    # they were transient code-under-test in /tmp
++                    ignore_errors=True,
++                )
++            except coverage.CoverageException as err:
++                # Tests whose imports resolve outside the tracked source tree
++                # (e.g. from a built wheel) collect no data; coverage.py raises
++                # NoDataError. Emit an empty lcov so the test still passes.
++                print_verbose_coverage("lcov report failed, writing empty file:", err)
++                open(lcov_path, "w").close()
+             if os.path.isfile(lcov_path):
+                 unresolve_symlinks(lcov_path)
+     finally:

--- a/src/lib/tests/BUILD
+++ b/src/lib/tests/BUILD
@@ -20,8 +20,6 @@ load("@osmo_python_deps//:requirements.bzl", "requirement")
 osmo_py_test(
     name = "test_import",
     srcs = ["test_import.py"],
-    # nocoverage: imports from the wheel, not source files — coverage.py crashes with NoDataError.
-    tags = ["nocoverage"],
     deps = [
         "//src/lib/distribution:osmo_py_wheel_unpacked",
     ],

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -29,7 +29,8 @@
     "licenses:check": "node scripts/check-licenses.mjs",
     "licenses:generate": "node scripts/generate-licenses.mjs",
     "licenses": "node scripts/check-licenses.mjs && node scripts/generate-licenses.mjs",
-    "validate": "pnpm licenses:check && pnpm type-check && pnpm lint && pnpm format:check && pnpm test:all && pnpm build"
+    "validate": "pnpm licenses:check && pnpm type-check && pnpm lint && pnpm format:check && pnpm test:all && pnpm build",
+    "validate:coverage": "pnpm licenses:check && pnpm type-check && pnpm lint && pnpm format:check && pnpm test:coverage && pnpm test:e2e && pnpm build"
   },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.2",


### PR DESCRIPTION
## Description

On PRs, `ci-internal` (`bazel test`) from `pr-checks.yaml` and the `coverage` job (`bazel coverage`) from `coverage.yaml` both ran on the same self-hosted runner with 8g container + 4g DinD envelopes each, and they had separate concurrency groups so GitHub Actions didn't serialize them. Running all tests twice (`test` and `coverage` use different Bazel action cache keys, so there's no reuse between them) in parallel was OOM'ing the bazel cache.

This PR folds PR coverage into the existing PR-check jobs so tests run once:

- `ci-internal` now runs `bazel coverage --config=ci` and uploads backend lcov to Codecov. Replaces the previous `bazel test`. Codecov upload is `continue-on-error` so it doesn't block merge if the upload flakes.
- `ui-build` runs a new `pnpm validate:coverage` script (vitest `--coverage` instead of `vitest run`) and uploads UI lcov. UI runs on ubuntu-latest, so it wasn't part of the OOM, but consolidating keeps the pattern consistent.
- `coverage.yaml` is reduced to `push: main` + `workflow_dispatch` only, so it no longer competes for the self-hosted runner on PRs. It still refreshes Codecov base reports on merge to main, reusing the remote cache entries uploaded by `ci-internal` during the PR.

### rules_python coverage patch

Switching `ci-internal` from `bazel test` to `bazel coverage` also re-included `//src/lib/tests:test_import`, previously excluded via `tags = ["nocoverage"]`. The test imports only from a built wheel (outside the tracked source tree), so coverage.py collects no data and raises `NoDataError` from `lcov_report()`, failing the test even though it passes.

`bzl/patches/rules_python_coverage_empty_data.patch` wraps `lcov_report()` in a `try/except coverage.CoverageException` so tests with no collected data emit an empty lcov file instead of failing. Verified load-bearing in #874 (this PR minus the patch — `ci-internal` fails with `NoDataError` as expected).

Issue #720

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to refresh the base coverage report on main (push) and manual runs; PR coverage remains produced by PR checks. Validation now includes a coverage-aware UI validation flow and coverage uploads for backend and UI during CI.
* **Bug Fixes**
  * Coverage generation now tolerates missing/no-data results by producing an empty coverage artifact to avoid spurious failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->