### PR TITLE
Bump testbot workflows to Python 3.14.2 + guard test

### DIFF
--- a/.github/workflows/BUILD
+++ b/.github/workflows/BUILD
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+filegroup(
+    name = "workflows",
+    srcs = glob(
+        [
+            "*.yaml",
+            "*.yml",
+        ],
+    ),
+    visibility = ["//src/scripts/testbot/tests:__pkg__"],
+)

--- a/.github/workflows/testbot-respond.yaml
+++ b/.github/workflows/testbot-respond.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.10'
+          python-version: '3.14.2'
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.10'
+          python-version: '3.14.2'
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/BUILD
+++ b/BUILD
@@ -13,3 +13,5 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
+
+exports_files(["MODULE.bazel"])

--- a/src/scripts/testbot/tests/BUILD
+++ b/src/scripts/testbot/tests/BUILD
@@ -26,3 +26,12 @@ osmo_py_test(
     srcs = ["test_create_pr.py"],
     deps = ["//src/scripts/testbot"],
 )
+
+osmo_py_test(
+    name = "test_workflow_python_version",
+    srcs = ["test_workflow_python_version.py"],
+    data = [
+        "//:MODULE.bazel",
+        "//.github/workflows:workflows",
+    ],
+)

--- a/src/scripts/testbot/tests/test_workflow_python_version.py
+++ b/src/scripts/testbot/tests/test_workflow_python_version.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+# SPDX-License-Identifier: Apache-2.0
+"""Guard against GitHub Actions Python pins drifting from MODULE.bazel.
+
+If MODULE.bazel bumps Python but a workflow's actions/setup-python pin is not
+updated with it, scripts using newer syntax (e.g. PEP 701 nested-quote
+f-strings) fail on the workflow runner. This test catches that drift.
+"""
+
+import os
+import re
+import unittest
+from pathlib import Path
+
+# MODULE.bazel example: `python.toolchain(python_version = "3.14.2", ...)`.
+_CANONICAL_PYTHON_RE = re.compile(
+    r'python\.toolchain\([^)]*python_version\s*=\s*"([\d.]+)"',
+    re.DOTALL,
+)
+# Workflow example: `python-version: '3.14.2'`.
+_WORKFLOW_PYTHON_RE = re.compile(r"""python-version:\s*['"]([\d.]+)['"]""")
+
+
+def _repo_root() -> Path:
+    """Return the repo root whether running under Bazel or directly."""
+    test_srcdir = os.environ.get("TEST_SRCDIR")
+    if test_srcdir:
+        # Bazel layout: <TEST_SRCDIR>/_main/... for bzlmod workspaces.
+        return Path(test_srcdir) / "_main"
+    # Direct invocation: walk up to find MODULE.bazel.
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "MODULE.bazel").is_file():
+            return parent
+    raise RuntimeError("Could not locate repo root (no MODULE.bazel found).")
+
+
+class TestWorkflowPythonVersion(unittest.TestCase):
+    """Workflow Python pins must match MODULE.bazel's canonical version."""
+
+    root: Path
+    canonical_version: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.root = _repo_root()
+        module_bazel = (cls.root / "MODULE.bazel").read_text()
+        match = _CANONICAL_PYTHON_RE.search(module_bazel)
+        if match is None:
+            raise AssertionError(
+                "Could not find python.toolchain(python_version=...) in MODULE.bazel"
+            )
+        cls.canonical_version = match.group(1)
+
+    def test_all_workflows_match_canonical_python(self) -> None:
+        workflows_dir = self.root / ".github" / "workflows"
+        workflows = sorted(p for p in workflows_dir.iterdir() if p.suffix in {".yaml", ".yml"})
+        self.assertTrue(workflows, f"No workflows found in {workflows_dir}")
+
+        mismatches: list[tuple[str, str]] = []
+        for workflow in workflows:
+            for match in _WORKFLOW_PYTHON_RE.finditer(workflow.read_text()):
+                pinned = match.group(1)
+                if pinned != self.canonical_version:
+                    mismatches.append((workflow.name, pinned))
+
+        self.assertFalse(
+            mismatches,
+            msg=(
+                f"Workflow Python pins must match MODULE.bazel's "
+                f"{self.canonical_version}. Mismatches (workflow, pinned): {mismatches}"
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

PR #840 migrated the repo from Python 3.10 to 3.14.2 but didn't update two of the testbot workflows that install Python. \`coverage_targets.py:210\` uses PEP 701 nested-quote f-string syntax (Python 3.12+), which fails on the 3.10 runner with:

\`\`\`
SyntaxError: f-string: unmatched '['
\`\`\`

Seen in: https://github.com/NVIDIA/OSMO/actions/runs/24587886786/job/71901963338.

### Fix

Align \`testbot.yaml\` and \`testbot-respond.yaml\` with \`pr-checks.yaml\` and \`docs-deploy.yaml\`, which already run on 3.14.2. \`testbot-respond-approve.yaml\` uses only \`actions/github-script\` (no Python), so it's unchanged.

### Guard

Add \`src/scripts/testbot/tests/test_workflow_python_version.py\`. It parses \`MODULE.bazel\`'s \`python.toolchain(python_version=...)\` and asserts every \`python-version: 'X.Y.Z'\` in \`.github/workflows/*.yaml\` matches. Next time someone bumps Python in MODULE.bazel, this test fails until all workflow pins are updated in the same PR. Verified by temporarily reverting one pin — test reports \`[('testbot.yaml', '3.10')] is not false\`.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test
Verified in https://github.com/NVIDIA/OSMO/pull/877.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded Python runtime to version 3.14.2 in GitHub Actions workflows for continuous integration operations.
  * Enhanced build configuration to improve artifact packaging and dependencies.

* **Tests**
  * Added automated validation to enforce Python version consistency across all workflow configurations and project specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->