### PR TITLE
ci: label fork PRs as external without team lookup

### DIFF
--- a/.github/workflows/label-external.yaml
+++ b/.github/workflows/label-external.yaml
@@ -19,7 +19,7 @@ name: Label external contributors
 on:
   issues:
     types: [opened, reopened]
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
 
 permissions:
@@ -32,6 +32,7 @@ jobs:
     steps:
       - name: Check if author is in osmo-dev
         id: team-check
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662
         with:
           # Use a PAT or org-level token with read:org / members:read
@@ -41,14 +42,12 @@ jobs:
           team: osmo-dev
 
       - name: Label issue or PR as external
-        if: ${{ steps.team-check.outputs.isTeamMember == 'false' }}
+        if: ${{ github.event.pull_request.head.repo.fork || steps.team-check.outputs.isTeamMember == 'false' }}
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const isPR = !!context.payload.pull_request;
             const number = (context.payload.issue || context.payload.pull_request).number;
-
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Description

Secrets aren't passed to workflows triggered by `pull_request` from a fork, so `label-external` failed with `Input required and not supplied: GITHUB_TOKEN` on every external PR. This switches the trigger to `pull_request_target` (so `GITHUB_TOKEN` has write scope) and short-circuits the team-membership check for fork PRs — if it's from a fork, it's external by definition. Non-fork PRs and issues still go through the existing osmo-dev team check.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request workflow automation to improve classification and handling of external contributor submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->