### PR TITLE
Increase agent memory after 3.14 migration

### DIFF
--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1135,7 +1135,7 @@ services:
       ## Resource limits (maximum allocation)
       ##
       limits:
-        memory: "500Mi"
+        memory: "1Gi"
 
     ## Tolerations for agent service pod scheduling on tainted nodes
     ##


### PR DESCRIPTION
## Description
- Python 3.14 upgrade
- Redis 7.4 upgrade
- Both of the above pushed agent service memory over the edge of 500Mi
- Doubling the Agent service default memory to 1Gi

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased agent container memory resource allocation limit to 1GB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->