### PR TITLE
feat(configmap-loader): support per-field Secret mounts

### DIFF
--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -430,6 +430,11 @@ def _resolve_platform_fields(
 # Secret resolution
 # ---------------------------------------------------------------------------
 
+# Root directory where K8s Secrets are mounted by the chart. Overridable
+# for unit tests that don't run against a real pod.
+SECRETS_ROOT = '/etc/osmo/secrets'
+
+
 def _resolve_secret_file_references(config_data: Dict[str, Any],
                                      parent_key: str = '') -> None:
     """Recursively resolve secret_file / secretName references in a config dict.
@@ -438,6 +443,12 @@ def _resolve_secret_file_references(config_data: Dict[str, Any],
     - Reads the YAML file from the mounted K8s Secret path
     - If the file contains a dict: merges the file contents into the parent dict
     - If the file contains a 'value' key: replaces the entire dict with that value
+
+    For secretName references without an explicit secretKey, supports two
+    K8s Secret creation styles:
+    - Single-file (`--from-file=cred.yaml=...`): reads `cred.yaml` from the mount
+    - Per-field (`--from-literal=access_key_id=... --from-literal=access_key=...`):
+      reads each file in the mount directory as a key-value pair
     """
     if not isinstance(config_data, dict):
         return
@@ -448,18 +459,34 @@ def _resolve_secret_file_references(config_data: Dict[str, Any],
         if not isinstance(value, dict):
             continue
 
-        secret_file_path = value.get('secret_file')
-        if not secret_file_path:
-            secret_name = value.get('secretName')
-            if secret_name:
-                secret_key = value.get('secretKey', 'cred.yaml')
-                secret_file_path = f'/etc/osmo/secrets/{secret_name}/{secret_key}'
+        label = f'{parent_key}.{key}' if parent_key else key
 
+        secret_file_path = value.get('secret_file')
         if secret_file_path:
-            _resolve_single_secret(config_data, key, value, secret_file_path,
-                                   f'{parent_key}.{key}' if parent_key else key)
-        else:
-            _resolve_secret_file_references(value, f'{parent_key}.{key}' if parent_key else key)
+            _resolve_single_secret(
+                config_data, key, value, secret_file_path, label)
+            continue
+
+        secret_name = value.get('secretName')
+        if secret_name:
+            secret_dir = os.path.join(SECRETS_ROOT, secret_name)
+            explicit_key = value.get('secretKey')
+            if explicit_key:
+                _resolve_single_secret(
+                    config_data, key, value,
+                    os.path.join(secret_dir, explicit_key), label)
+            else:
+                # Backward compatible: prefer cred.yaml if present,
+                # otherwise treat the mount as --from-literal fields.
+                default_path = os.path.join(secret_dir, 'cred.yaml')
+                if os.path.isfile(default_path):
+                    _resolve_single_secret(
+                        config_data, key, value, default_path, label)
+                else:
+                    _resolve_secret_directory(value, secret_dir, label)
+            continue
+
+        _resolve_secret_file_references(value, label)
 
 
 def _resolve_single_secret(parent_dict: Dict[str, Any], key: str,
@@ -523,6 +550,43 @@ def _resolve_single_secret(parent_dict: Dict[str, Any], key: str,
     current_value.pop('secretKey', None)
     current_value.update(secret_data)
     logging.info('Loaded credentials for %s from secret file', path_label)
+
+
+def _resolve_secret_directory(current_value: Dict[str, Any],
+                              dir_path: str, path_label: str) -> None:
+    """Load each file in a Secret mount directory as a credential field.
+
+    Used when a K8s Secret was created with `--from-literal` (one file per
+    field) rather than `--from-file=cred.yaml=...` (a single YAML file).
+    Skips kubelet internals (`..data` symlink and the timestamped directory
+    it points to) and strips trailing newlines from each value.
+    """
+    fields: Dict[str, str] = {}
+    try:
+        for entry in os.listdir(dir_path):
+            if entry.startswith('..'):
+                continue
+            file_path = os.path.join(dir_path, entry)
+            if not os.path.isfile(file_path):
+                continue
+            with open(file_path, encoding='utf-8') as field_file:
+                fields[entry] = field_file.read().rstrip('\n')
+    except OSError as error:
+        logging.error('Failed to read secret directory %s for %s: %s',
+                      dir_path, path_label, error)
+        return
+
+    if not fields:
+        logging.error('No secret fields found in %s for %s',
+                      dir_path, path_label)
+        return
+
+    current_value.pop('secret_file', None)
+    current_value.pop('secretName', None)
+    current_value.pop('secretKey', None)
+    current_value.update(fields)
+    logging.info('Loaded %d secret fields for %s from %s',
+                 len(fields), path_label, dir_path)
 
 
 def _default_dataset_credential_endpoints(config_data: Dict[str, Any]) -> None:

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -170,6 +170,145 @@ class TestResolveSecretFileReferences(unittest.TestCase):
             configmap_loader._resolve_secret_file_references(config_data)
 
 
+class TestResolveSecretDirectory(unittest.TestCase):
+    """Tests for per-field Secret mount support (--from-literal)."""
+
+    def _write_field(self, directory: str, name: str, value: str) -> None:
+        with open(os.path.join(directory, name), 'w', encoding='utf-8') as fh:
+            fh.write(value)
+
+    def test_per_field_mount_loads_all_fields(self):
+        """Secret created with --from-literal loads each file as a field."""
+        with tempfile.TemporaryDirectory() as secret_dir:
+            self._write_field(secret_dir, 'access_key_id', 'AKIAEXAMPLE')
+            self._write_field(
+                secret_dir, 'access_key', 'wJalrXUtnFEMI/EXAMPLE')
+            self._write_field(secret_dir, 'region', 'us-west-2')
+
+            config_data: Dict[str, Any] = {'credential': {}}
+            configmap_loader._resolve_secret_directory(
+                config_data['credential'], secret_dir, 'credential')
+
+            credential = config_data['credential']
+            self.assertEqual(credential['access_key_id'], 'AKIAEXAMPLE')
+            self.assertEqual(credential['access_key'], 'wJalrXUtnFEMI/EXAMPLE')
+            self.assertEqual(credential['region'], 'us-west-2')
+
+    def test_per_field_mount_strips_trailing_newlines(self):
+        with tempfile.TemporaryDirectory() as secret_dir:
+            self._write_field(secret_dir, 'token', 'abc123\n')
+
+            config_data: Dict[str, Any] = {'credential': {}}
+            configmap_loader._resolve_secret_directory(
+                config_data['credential'], secret_dir, 'credential')
+
+            self.assertEqual(config_data['credential']['token'], 'abc123')
+
+    def test_per_field_mount_skips_kubelet_internals(self):
+        """..data and timestamped ..YYYY_MM_DD... entries must be ignored."""
+        with tempfile.TemporaryDirectory() as secret_dir:
+            # Real kubelet mount: actual file + a ..data symlink to a
+            # timestamped hidden dir. We only care that `..`-prefixed
+            # entries are skipped, regardless of type.
+            self._write_field(secret_dir, 'access_key', 'real-value')
+            self._write_field(secret_dir, '..data', 'should-be-ignored')
+            os.makedirs(os.path.join(secret_dir, '..2024_01_01_00_00_00'))
+
+            config_data: Dict[str, Any] = {'credential': {}}
+            configmap_loader._resolve_secret_directory(
+                config_data['credential'], secret_dir, 'credential')
+
+            credential = config_data['credential']
+            self.assertEqual(credential, {'access_key': 'real-value'})
+
+    def test_per_field_mount_removes_reference_fields(self):
+        """secretName/secretKey keys are stripped after resolution."""
+        with tempfile.TemporaryDirectory() as secret_dir:
+            self._write_field(secret_dir, 'access_key', 'value')
+
+            current = {'secretName': 'my-cred'}
+            configmap_loader._resolve_secret_directory(
+                current, secret_dir, 'credential')
+
+            self.assertNotIn('secretName', current)
+            self.assertNotIn('secretKey', current)
+            self.assertEqual(current['access_key'], 'value')
+
+    def test_per_field_mount_empty_directory_logs_error(self):
+        with tempfile.TemporaryDirectory() as secret_dir:
+            current: Dict[str, Any] = {}
+            with self.assertLogs(level=logging.ERROR):
+                configmap_loader._resolve_secret_directory(
+                    current, secret_dir, 'credential')
+
+    def test_secret_name_falls_back_to_per_field(self):
+        """secretName with no cred.yaml loads per-field files from the mount."""
+        with tempfile.TemporaryDirectory() as tmp_root:
+            secret_dir = os.path.join(tmp_root, 'my-cred')
+            os.makedirs(secret_dir)
+            self._write_field(secret_dir, 'access_key_id', 'AKIA')
+            self._write_field(secret_dir, 'access_key', 'SECRET')
+
+            config_data: Dict[str, Any] = {
+                'credential': {'secretName': 'my-cred'},
+            }
+            with mock.patch.object(
+                    configmap_loader, 'SECRETS_ROOT', tmp_root):
+                configmap_loader._resolve_secret_file_references(config_data)
+
+            credential = config_data['credential']
+            self.assertEqual(credential['access_key_id'], 'AKIA')
+            self.assertEqual(credential['access_key'], 'SECRET')
+            self.assertNotIn('secretName', credential)
+
+    def test_secret_name_prefers_cred_yaml_when_present(self):
+        """With both cred.yaml and per-field files, cred.yaml wins."""
+        with tempfile.TemporaryDirectory() as tmp_root:
+            secret_dir = os.path.join(tmp_root, 'my-cred')
+            os.makedirs(secret_dir)
+            self._write_field(secret_dir, 'access_key_id', 'stale-value')
+            with open(os.path.join(secret_dir, 'cred.yaml'),
+                      'w', encoding='utf-8') as fh:
+                yaml.dump({'access_key_id': 'fresh-value'}, fh)
+
+            config_data: Dict[str, Any] = {
+                'credential': {'secretName': 'my-cred'},
+            }
+            with mock.patch.object(
+                    configmap_loader, 'SECRETS_ROOT', tmp_root):
+                configmap_loader._resolve_secret_file_references(config_data)
+
+            self.assertEqual(
+                config_data['credential']['access_key_id'], 'fresh-value')
+
+    def test_secretkey_explicit_does_not_fall_back(self):
+        """Explicit secretKey uses the single-file path (no directory scan)."""
+        with tempfile.TemporaryDirectory() as tmp_root:
+            secret_dir = os.path.join(tmp_root, 'my-cred')
+            os.makedirs(secret_dir)
+            # Per-field files exist but should be ignored because
+            # secretKey is explicit and points to a (missing) single file.
+            self._write_field(secret_dir, 'access_key_id', 'value')
+
+            config_data: Dict[str, Any] = {
+                'credential': {
+                    'secretName': 'my-cred',
+                    'secretKey': 'typo.yaml',
+                },
+            }
+            with mock.patch.object(
+                    configmap_loader, 'SECRETS_ROOT', tmp_root):
+                with self.assertLogs(level=logging.ERROR):
+                    configmap_loader._resolve_secret_file_references(
+                        config_data)
+
+            # Per-field fallback did NOT happen — config still has the
+            # reference keys, not loaded field values.
+            credential = config_data['credential']
+            self.assertNotIn('access_key_id', credential)
+            self.assertIn('secretName', credential)
+
+
 class TestValidateConfigs(unittest.TestCase):
     """Tests for _validate_configs."""
 


### PR DESCRIPTION
## Summary

The ConfigMap loader previously required credentials to be packed into a single `cred.yaml` file in the mounted Secret directory. This PR adds a feature so users can also create Secrets with `kubectl create secret generic ... --from-literal=...`, which mounts each field as its own file.

Resolution logic when a config has `secretName: <name>`:
- If `secretKey` is explicitly set → read that specific file (unchanged; protects against typos)
- Otherwise → try `cred.yaml` first (backward compatible), fall back to scanning the mount directory and loading each non-`..` file as a credential field

Both styles work now:
\`\`\`bash
### Single file (existing)
kubectl create secret generic my-cred --from-file=cred.yaml=my-cred.yaml

### Per-field (new)
kubectl create secret generic my-cred \\
    --from-literal=access_key_id=AKIA... \\
    --from-literal=access_key=...
\`\`\`

Addresses review feedback from PR #883.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved secret resolution logic with enhanced fallback mechanisms for per-field secret mounts
  * Streamlined secret loading to prevent redundant file system traversal

* **Tests**
  * Added comprehensive test coverage for directory-based secret resolution
  * Added integration tests validating secret loading precedence and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->