### PR TITLE
Backwards compatibility for clean up jobs

### DIFF
--- a/src/utils/job/backend_job_defs.py
+++ b/src/utils/job/backend_job_defs.py
@@ -102,12 +102,14 @@ class BackendSynchronizeQueuesMixin(pydantic.BaseModel):
     - Objects in both cleanup_specs and k8s_resources will be updated (or recreated if immutable)
     - Objects in k8s_resources not matching cleanup_specs will be created
 
-    NOTE: cleanup_specs Union type can be removed after the next release. This is for
-    backwards compatibility with existing BackendSynchronizeQueuesMixin jobs that might
-    be enqueued when OSMO is redeployed with a new version.
+    NOTE: cleanup_specs Union type and empty-list default can be removed after the next
+    release. They exist for backwards compatibility with existing BackendSynchronizeQueuesMixin
+    jobs that might be enqueued when OSMO is redeployed with a new version (the Union handles
+    older jobs with a single spec instead of a list, and the default handles older jobs that
+    predate this field entirely — those jobs will deserialize as a no-op).
     """
     # Search for objects using these specs (one per object type)
-    cleanup_specs: Union[List[BackendCleanupSpec], BackendCleanupSpec]
+    cleanup_specs: Union[List[BackendCleanupSpec], BackendCleanupSpec] = []
     # The k8s specs for all objects to create/update in the backend
     # Can contain mixed types (Queues, Topologies, etc.)
     k8s_resources: List[Dict]


### PR DESCRIPTION
## Description
- Events in queue from a prior deployment will fail during a new deployment under the stricter Pydantic v2 world

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues with legacy job configurations that omit or provide single cleanup specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->