### PR TITLE
Disable experimental Claude Code betas on NVIDIA gateway

### DIFF
--- a/.github/workflows/testbot-respond.yaml
+++ b/.github/workflows/testbot-respond.yaml
@@ -94,4 +94,5 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
           DISABLE_PROMPT_CACHING: "1"  # NVIDIA gateway rejects cache_control.ephemeral.scope
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"  # NVIDIA gateway rejects context_management
           GH_TOKEN: ${{ secrets.SVC_OSMO_CI_TOKEN }}

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -132,6 +132,7 @@ jobs:
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
           ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/claude-opus-4-5' }}
           DISABLE_PROMPT_CACHING: "1"  # NVIDIA gateway rejects cache_control.ephemeral.scope
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"  # NVIDIA gateway rejects context_management
 
       - name: Create PR
         if: inputs.dry_run != true


### PR DESCRIPTION
## Summary

Fix testbot failures with `context_management: Extra inputs are not permitted`.

Claude Code 2.1.91 sends a `context_management` field in API requests as part
of an experimental beta feature. The NVIDIA gateway's pydantic schema rejects
unknown fields, so requests fail with:

```
API Error: 400 {"error":{"message":"{\"message\":\"context_management: Extra inputs are not permitted\"}..."}}
```

Set `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` in both generate and respond
workflows to skip this field. Same pattern as the existing `DISABLE_PROMPT_CACHING`
workaround for `cache_control.ephemeral.scope`.

Issue #760

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes

## Test plan
- [ ] Live test: post `/testbot` on an `ai-generated` PR and verify the respond
      workflow completes without a 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to disable experimental features in automated testing and response generation processes for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->