### PR TITLE
feat(configmap-loader): fail fast at startup + K8s Events on hot-reload failures

### DIFF
--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -158,6 +158,14 @@ spec:
         env:
         - name: OSMO_DISABLE_TASK_METRICS
           value: {{ .Values.services.service.disableTaskMetrics | quote }}
+        {{- if .Values.services.configs.enabled }}
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OSMO_CONFIGMAP_NAME
+          value: {{ .Values.services.service.serviceName }}-configs
+        {{- end }}
         {{- if .Values.services.migration.enabled }}
         - name: OSMO_SCHEMA_VERSION
           value: {{ .Values.services.migration.targetSchema }}

--- a/deployments/charts/service/templates/rbac-configs.yaml
+++ b/deployments/charts/service/templates/rbac-configs.yaml
@@ -25,9 +25,18 @@ metadata:
   labels:
     app: {{ .Values.services.service.serviceName }}
 rules:
+# Emit Events on reload failures/recoveries.
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create", "patch"]
+  verbs: ["create", "get", "patch"]
+# Read the osmo-configs ConfigMap to fetch its UID. `kubectl describe
+# configmap` filters associated events by involvedObject.uid, so without
+# this the events wouldn't appear in that view (though they'd still be
+# visible in `kubectl get events --field-selector` and the ArgoCD UI).
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["{{ .Values.services.service.serviceName }}-configs"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deployments/charts/service/templates/rbac-configs.yaml
+++ b/deployments/charts/service/templates/rbac-configs.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Grants the osmo service the minimum RBAC needed to emit K8s Events
+# on the osmo-configs ConfigMap. Operators see these in the ArgoCD UI,
+# `kubectl describe configmap`, and `kubectl get events`.
+{{- if .Values.services.configs.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.services.service.serviceName }}-configmap-events
+  labels:
+    app: {{ .Values.services.service.serviceName }}
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.services.service.serviceName }}-configmap-events
+  labels:
+    app: {{ .Values.services.service.serviceName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.services.service.serviceName }}-configmap-events
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.serviceAccount.name | default .Values.global.serviceAccountName }}
+{{- end }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -238,6 +238,8 @@ services:
     ## Enable ConfigMap-based configuration.
     ## When true: all configs served from in-memory (parsed from ConfigMap),
     ## CLI/API writes return 409, authz_sidecar reads roles from file.
+    ## A malformed ConfigMap at startup causes the pod to crash-loop so
+    ## the rolling update stalls at the bad revision; old pods keep serving.
     ## When false: configs in database, CLI/API works normally.
     ##
     enabled: false

--- a/src/service/core/config/BUILD
+++ b/src/service/core/config/BUILD
@@ -25,6 +25,7 @@ osmo_py_library(
     srcs = [
         "config_history_helpers.py",
         "config_service.py",
+        "configmap_events.py",
         "configmap_guard.py",
         "configmap_loader.py",
         "helpers.py",
@@ -32,6 +33,7 @@ osmo_py_library(
     ],
     deps = [
         requirement("fastapi"),
+        requirement("kubernetes"),
         requirement("pydantic"),
         requirement("pyyaml"),
         requirement("watchdog"),

--- a/src/service/core/config/configmap_events.py
+++ b/src/service/core/config/configmap_events.py
@@ -27,6 +27,7 @@ import logging
 from typing import Protocol
 
 from kubernetes import client, config as kube_config  # type: ignore
+from kubernetes.client.exceptions import ApiException  # type: ignore
 
 
 # Reasons are user-facing in `kubectl get events`. Keep them stable and
@@ -78,7 +79,17 @@ class ConfigMapEventRecorder:
         self._emit('Normal', REASON_RELOAD_SUCCEEDED, message)
 
     def _emit(self, event_type: str, reason: str, message: str) -> None:
-        if self._core_v1 is None:
+        """Emit or update the deduplicated Event for (configmap, reason).
+
+        A deterministic name (`<configmap>.<reason-lowercase>`) means every
+        emit for the same reason targets one Event object. GET it first:
+        if it exists, PATCH to update the message and bump the count; if
+        not (404), CREATE a fresh one. This matches the kubelet pattern
+        for repeated failures like ImagePullBackOff and prevents event
+        spam during crash-loops.
+        """
+        core_v1 = self._core_v1
+        if core_v1 is None:
             return
 
         # K8s Event messages are capped at ~1KB; truncate with an
@@ -90,9 +101,34 @@ class ConfigMapEventRecorder:
             else f'{message[:max_message_length - 3]}...')
 
         now = datetime.datetime.now(datetime.timezone.utc)
+        event_name = f'{self._configmap_name}.{reason.lower()}'
+
+        try:
+            existing = core_v1.read_namespaced_event(
+                event_name, self._namespace)
+        except ApiException as error:
+            if error.status == 404:
+                self._create_event(
+                    core_v1, event_name, event_type, reason,
+                    truncated_message, now)
+            else:
+                logging.warning(
+                    'Failed to read K8s Event %s: %s', event_name, error)
+            return
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logging.warning(
+                'Failed to read K8s Event %s: %s', event_name, error)
+            return
+
+        self._patch_event(
+            core_v1, event_name, existing, truncated_message, now)
+
+    def _create_event(self, core_v1: client.CoreV1Api, event_name: str,
+                      event_type: str, reason: str, message: str,
+                      now: datetime.datetime) -> None:
         event = client.CoreV1Event(
             metadata=client.V1ObjectMeta(
-                generate_name=f'osmo-configs-{reason.lower()}-',
+                name=event_name,
                 namespace=self._namespace,
             ),
             involved_object=client.V1ObjectReference(
@@ -102,7 +138,7 @@ class ConfigMapEventRecorder:
                 namespace=self._namespace,
             ),
             reason=reason,
-            message=truncated_message,
+            message=message,
             type=event_type,
             source=client.V1EventSource(component=self._component),
             first_timestamp=now,
@@ -113,9 +149,23 @@ class ConfigMapEventRecorder:
             action='Reload',
             count=1,
         )
-
         try:
-            self._core_v1.create_namespaced_event(self._namespace, event)
+            core_v1.create_namespaced_event(self._namespace, event)
         except Exception as error:  # pylint: disable=broad-exception-caught
             logging.warning(
-                'Failed to emit K8s Event (%s): %s', reason, error)
+                'Failed to create K8s Event %s: %s', event_name, error)
+
+    def _patch_event(self, core_v1: client.CoreV1Api, event_name: str,
+                     existing: client.CoreV1Event, message: str,
+                     now: datetime.datetime) -> None:
+        patch = {
+            'count': (existing.count or 1) + 1,
+            'lastTimestamp': now.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'message': message,
+        }
+        try:
+            core_v1.patch_namespaced_event(
+                event_name, self._namespace, patch)
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logging.warning(
+                'Failed to patch K8s Event %s: %s', event_name, error)

--- a/src/service/core/config/configmap_events.py
+++ b/src/service/core/config/configmap_events.py
@@ -1,0 +1,121 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+
+Emits Kubernetes Events attached to the osmo-configs ConfigMap so that
+operators see reload failures in the tools they already use — ArgoCD UI,
+`kubectl describe configmap`, `kubectl get events`. No Prometheus setup
+required. Event exporters (e.g. kubernetes-event-exporter) can route to
+Slack/email/PagerDuty without any OSMO-specific integration.
+"""
+
+import datetime
+import logging
+from typing import Protocol
+
+from kubernetes import client, config as kube_config  # type: ignore
+
+
+# Reasons are user-facing in `kubectl get events`. Keep them stable and
+# CamelCase per K8s convention.
+REASON_RELOAD_FAILED = 'ConfigMapReloadFailed'
+REASON_RELOAD_SUCCEEDED = 'ConfigMapReloaded'
+
+
+class EventRecorder(Protocol):
+    """Structural interface so tests can substitute a fake recorder."""
+
+    def emit_reload_failed(self, message: str) -> None: ...
+    def emit_reload_succeeded(self, message: str) -> None: ...
+
+
+class ConfigMapEventRecorder:
+    """Writes Events to the K8s API, attached to the osmo-configs ConfigMap.
+
+    Failures creating events are logged but never raised — observability
+    must not break the service's reload path.
+    """
+
+    def __init__(self, namespace: str, configmap_name: str,
+                 component: str = 'osmo-service-configmap-loader'):
+        self._namespace = namespace
+        self._configmap_name = configmap_name
+        self._component = component
+
+        try:
+            kube_config.load_incluster_config()
+        except kube_config.ConfigException:
+            # Fall back to kubeconfig for local development. Fail silently
+            # if neither works — the recorder becomes a no-op, which is
+            # preferable to crashing the service.
+            try:
+                kube_config.load_kube_config()
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.warning(
+                    'ConfigMapEventRecorder: no kubeconfig available; '
+                    'events will not be emitted')
+                self._core_v1 = None
+                return
+        self._core_v1 = client.CoreV1Api()
+
+    def emit_reload_failed(self, message: str) -> None:
+        self._emit('Warning', REASON_RELOAD_FAILED, message)
+
+    def emit_reload_succeeded(self, message: str) -> None:
+        self._emit('Normal', REASON_RELOAD_SUCCEEDED, message)
+
+    def _emit(self, event_type: str, reason: str, message: str) -> None:
+        if self._core_v1 is None:
+            return
+
+        # K8s Event messages are capped at ~1KB; truncate with an
+        # ellipsis so we don't get rejected by the apiserver.
+        max_message_length = 1000
+        truncated_message = (
+            message
+            if len(message) <= max_message_length
+            else f'{message[:max_message_length - 3]}...')
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+        event = client.CoreV1Event(
+            metadata=client.V1ObjectMeta(
+                generate_name=f'osmo-configs-{reason.lower()}-',
+                namespace=self._namespace,
+            ),
+            involved_object=client.V1ObjectReference(
+                api_version='v1',
+                kind='ConfigMap',
+                name=self._configmap_name,
+                namespace=self._namespace,
+            ),
+            reason=reason,
+            message=truncated_message,
+            type=event_type,
+            source=client.V1EventSource(component=self._component),
+            first_timestamp=now,
+            last_timestamp=now,
+            event_time=now,
+            reporting_component=self._component,
+            reporting_instance=self._component,
+            action='Reload',
+            count=1,
+        )
+
+        try:
+            self._core_v1.create_namespaced_event(self._namespace, event)
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logging.warning(
+                'Failed to emit K8s Event (%s): %s', reason, error)

--- a/src/service/core/config/configmap_events.py
+++ b/src/service/core/config/configmap_events.py
@@ -35,6 +35,10 @@ from kubernetes.client.exceptions import ApiException  # type: ignore
 REASON_RELOAD_FAILED = 'ConfigMapReloadFailed'
 REASON_RELOAD_SUCCEEDED = 'ConfigMapReloaded'
 
+# K8s Event messages are capped at ~1KB; truncate with an ellipsis so we
+# don't get rejected by the apiserver.
+_MAX_MESSAGE_LENGTH = 1000
+
 
 class EventRecorder(Protocol):
     """Structural interface so tests can substitute a fake recorder."""
@@ -48,6 +52,10 @@ class ConfigMapEventRecorder:
 
     Failures creating events are logged but never raised — observability
     must not break the service's reload path.
+
+    Uses a deterministic event name per (configmap, reason) so that repeated
+    failures dedupe into a single Event with a climbing `count`, matching
+    the kubelet pattern for repeated failures like ImagePullBackOff.
     """
 
     def __init__(self, namespace: str, configmap_name: str,
@@ -55,6 +63,7 @@ class ConfigMapEventRecorder:
         self._namespace = namespace
         self._configmap_name = configmap_name
         self._component = component
+        self._configmap_uid: str | None = None
 
         try:
             kube_config.load_incluster_config()
@@ -81,91 +90,96 @@ class ConfigMapEventRecorder:
     def _emit(self, event_type: str, reason: str, message: str) -> None:
         """Emit or update the deduplicated Event for (configmap, reason).
 
-        A deterministic name (`<configmap>.<reason-lowercase>`) means every
-        emit for the same reason targets one Event object. GET it first:
-        if it exists, PATCH to update the message and bump the count; if
-        not (404), CREATE a fresh one. This matches the kubelet pattern
-        for repeated failures like ImagePullBackOff and prevents event
-        spam during crash-loops.
+        GET the event first: on 404, CREATE; otherwise PATCH with an
+        incremented count and refreshed message/timestamp. This matches
+        the kubelet pattern and prevents event spam during crash-loops.
         """
-        core_v1 = self._core_v1
-        if core_v1 is None:
+        if self._core_v1 is None:
             return
 
-        # K8s Event messages are capped at ~1KB; truncate with an
-        # ellipsis so we don't get rejected by the apiserver.
-        max_message_length = 1000
-        truncated_message = (
-            message
-            if len(message) <= max_message_length
-            else f'{message[:max_message_length - 3]}...')
+        if len(message) > _MAX_MESSAGE_LENGTH:
+            message = f'{message[:_MAX_MESSAGE_LENGTH - 3]}...'
 
         now = datetime.datetime.now(datetime.timezone.utc)
         event_name = f'{self._configmap_name}.{reason.lower()}'
 
         try:
-            existing = core_v1.read_namespaced_event(
+            existing = self._core_v1.read_namespaced_event(
                 event_name, self._namespace)
         except ApiException as error:
-            if error.status == 404:
-                self._create_event(
-                    core_v1, event_name, event_type, reason,
-                    truncated_message, now)
-            else:
+            if error.status != 404:
                 logging.warning(
                     'Failed to read K8s Event %s: %s', event_name, error)
+                return
+            # 404 → create a new event
+            event = client.CoreV1Event(
+                metadata=client.V1ObjectMeta(
+                    name=event_name, namespace=self._namespace),
+                involved_object=self._involved_object(),
+                reason=reason,
+                message=message,
+                type=event_type,
+                source=client.V1EventSource(component=self._component),
+                first_timestamp=now,
+                last_timestamp=now,
+                event_time=now,
+                reporting_component=self._component,
+                reporting_instance=self._component,
+                action='Reload',
+                count=1,
+            )
+            try:
+                self._core_v1.create_namespaced_event(self._namespace, event)
+            except Exception as create_error:  # pylint: disable=broad-exception-caught
+                logging.warning(
+                    'Failed to create K8s Event %s: %s',
+                    event_name, create_error)
             return
-        except Exception as error:  # pylint: disable=broad-exception-caught
-            logging.warning(
-                'Failed to read K8s Event %s: %s', event_name, error)
-            return
 
-        self._patch_event(
-            core_v1, event_name, existing, truncated_message, now)
-
-    def _create_event(self, core_v1: client.CoreV1Api, event_name: str,
-                      event_type: str, reason: str, message: str,
-                      now: datetime.datetime) -> None:
-        event = client.CoreV1Event(
-            metadata=client.V1ObjectMeta(
-                name=event_name,
-                namespace=self._namespace,
-            ),
-            involved_object=client.V1ObjectReference(
-                api_version='v1',
-                kind='ConfigMap',
-                name=self._configmap_name,
-                namespace=self._namespace,
-            ),
-            reason=reason,
-            message=message,
-            type=event_type,
-            source=client.V1EventSource(component=self._component),
-            first_timestamp=now,
-            last_timestamp=now,
-            event_time=now,
-            reporting_component=self._component,
-            reporting_instance=self._component,
-            action='Reload',
-            count=1,
-        )
-        try:
-            core_v1.create_namespaced_event(self._namespace, event)
-        except Exception as error:  # pylint: disable=broad-exception-caught
-            logging.warning(
-                'Failed to create K8s Event %s: %s', event_name, error)
-
-    def _patch_event(self, core_v1: client.CoreV1Api, event_name: str,
-                     existing: client.CoreV1Event, message: str,
-                     now: datetime.datetime) -> None:
+        # Existing event → patch with incremented count
         patch = {
             'count': (existing.count or 1) + 1,
             'lastTimestamp': now.strftime('%Y-%m-%dT%H:%M:%SZ'),
             'message': message,
         }
         try:
-            core_v1.patch_namespaced_event(
+            self._core_v1.patch_namespaced_event(
                 event_name, self._namespace, patch)
-        except Exception as error:  # pylint: disable=broad-exception-caught
+        except Exception as patch_error:  # pylint: disable=broad-exception-caught
             logging.warning(
-                'Failed to patch K8s Event %s: %s', event_name, error)
+                'Failed to patch K8s Event %s: %s', event_name, patch_error)
+
+    def _involved_object(self) -> client.V1ObjectReference:
+        """Build the ObjectReference pointing at the ConfigMap.
+
+        Includes the ConfigMap's UID so events match kubectl's field
+        selector and appear in `kubectl describe configmap` output.
+        Lazily fetches the UID on first use and caches it — a single
+        extra API call over the lifetime of the recorder.
+        """
+        return client.V1ObjectReference(
+            api_version='v1',
+            kind='ConfigMap',
+            name=self._configmap_name,
+            namespace=self._namespace,
+            uid=self._get_configmap_uid(),
+        )
+
+    def _get_configmap_uid(self) -> str | None:
+        if self._configmap_uid is not None:
+            return self._configmap_uid
+        if self._core_v1 is None:
+            return None
+        try:
+            configmap = self._core_v1.read_namespaced_config_map(
+                self._configmap_name, self._namespace)
+            self._configmap_uid = configmap.metadata.uid
+            return self._configmap_uid
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            # Missing UID means events still exist but won't appear in
+            # `kubectl describe configmap` output. They're still visible
+            # via `kubectl get events --field-selector` and ArgoCD UI.
+            logging.warning(
+                'Failed to fetch ConfigMap UID for event involvedObject: %s',
+                error)
+            return None

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -27,7 +27,7 @@ import yaml
 from watchdog import events, observers
 
 from src.lib.utils.common import merge_lists_on_name, recursive_dict_update
-from src.service.core.config import configmap_guard
+from src.service.core.config import configmap_events, configmap_guard
 from src.utils import connectors
 
 
@@ -78,13 +78,21 @@ class ConfigMapWatcher:
     backend runtime data (agent writes heartbeats to backends table).
     """
 
-    def __init__(self, config_file_path: str,
-                 postgres: connectors.PostgresConnector | None = None):
+    def __init__(
+        self,
+        config_file_path: str,
+        postgres: connectors.PostgresConnector | None = None,
+        event_recorder: configmap_events.EventRecorder | None = None,
+    ):
         self._config_file_path = config_file_path
         self._postgres = postgres
+        self._event_recorder = event_recorder
         self._watch_directory = os.path.dirname(config_file_path)
         self._config_filename = os.path.basename(config_file_path)
         self._observer: Any = None
+        # Only emit "reload succeeded" events when recovering from a
+        # previous failure — successful reloads on their own are noise.
+        self._last_reload_failed = False
 
     def start(self) -> None:
         """Load configs, activate ConfigMap mode, start file watcher.
@@ -118,6 +126,20 @@ class ConfigMapWatcher:
             self._observer.stop()
             self._observer.join(timeout=5)
 
+    def _record_failure(self, message: str) -> None:
+        """Log + emit a K8s Warning event for a reload failure."""
+        logging.error(message)
+        if self._event_recorder is not None:
+            self._event_recorder.emit_reload_failed(message)
+        self._last_reload_failed = True
+
+    def _record_success(self) -> None:
+        """Emit a Normal event only if we just recovered from a failure."""
+        if self._last_reload_failed and self._event_recorder is not None:
+            self._event_recorder.emit_reload_succeeded(
+                'ConfigMap reload succeeded after previous failure')
+        self._last_reload_failed = False
+
     def _load_and_apply(self) -> bool:
         """Parse, resolve secrets, validate, and swap the in-memory config dict.
 
@@ -127,15 +149,14 @@ class ConfigMapWatcher:
             with open(self._config_file_path, encoding='utf-8') as f:
                 raw_config = yaml.safe_load(f)
         except (OSError, yaml.YAMLError) as error:
-            logging.error(
-                'Failed to read/parse config file %s: %s',
-                self._config_file_path, error)
+            self._record_failure(
+                f'Failed to read/parse config file '
+                f'{self._config_file_path}: {error}')
             return False
 
         if not raw_config or not isinstance(raw_config, dict):
-            logging.warning(
-                'Config file %s is empty or invalid',
-                self._config_file_path)
+            self._record_failure(
+                f'Config file {self._config_file_path} is empty or invalid')
             return False
 
         managed_configs = raw_config
@@ -155,9 +176,9 @@ class ConfigMapWatcher:
         # by configure_app().
         validation_errors = _validate_configs(managed_configs)
         if validation_errors:
-            logging.error(
-                'ConfigMap validation failed, keeping previous config: %s',
-                validation_errors)
+            self._record_failure(
+                f'ConfigMap validation failed, keeping previous config: '
+                f'{"; ".join(validation_errors)}')
             return False
 
         # Resolve pool computed fields (parsed_pod_template, etc.) from
@@ -179,6 +200,7 @@ class ConfigMapWatcher:
                 'all config writes via CLI/API are blocked')
         logging.info(
             'ConfigMap configs loaded from %s', self._config_file_path)
+        self._record_success()
 
         return True
 

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -176,9 +176,10 @@ class ConfigMapWatcher:
         # by configure_app().
         validation_errors = _validate_configs(managed_configs)
         if validation_errors:
+            joined_errors = '; '.join(validation_errors)
             self._record_failure(
                 f'ConfigMap validation failed, keeping previous config: '
-                f'{"; ".join(validation_errors)}')
+                f'{joined_errors}')
             return False
 
         # Resolve pool computed fields (parsed_pod_template, etc.) from

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -87,11 +87,22 @@ class ConfigMapWatcher:
         self._observer: Any = None
 
     def start(self) -> None:
-        """Load configs, activate ConfigMap mode, start file watcher."""
-        success = self._load_and_apply()
-        if success:
-            configmap_guard.set_configmap_mode(True)
-            logging.info('ConfigMap mode activated — all config writes via CLI/API are blocked')
+        """Load configs, activate ConfigMap mode, start file watcher.
+
+        A startup load failure raises RuntimeError so the pod crashes
+        and K8s stalls the rolling update at the bad revision; old
+        pods keep serving. Same behavior as CoreDNS / NGINX Ingress
+        with a bad config file at startup.
+        """
+        if not self._load_and_apply():
+            raise RuntimeError(
+                f'ConfigMap load failed at startup '
+                f'({self._config_file_path}). Refusing to serve.')
+
+        configmap_guard.set_configmap_mode(True)
+        logging.info(
+            'ConfigMap mode activated — '
+            'all config writes via CLI/API are blocked')
 
         self._observer = observers.Observer()
         self._observer.schedule(

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -28,7 +28,9 @@ from unittest import mock
 import yaml
 
 from src.lib.utils import osmo_errors
-from src.service.core.config import configmap_guard, configmap_loader
+from src.service.core.config import (
+    configmap_events, configmap_guard, configmap_loader,
+)
 from src.utils import configmap_state
 
 
@@ -382,6 +384,186 @@ class TestConfigMapWatcherStart(unittest.TestCase):
             watcher.stop()
         finally:
             os.unlink(path)
+
+
+class _FakeEventRecorder:
+    """Captures emit calls for assertions; conforms to EventRecorder protocol."""
+
+    def __init__(self):
+        self.failures: list[str] = []
+        self.successes: list[str] = []
+
+    def emit_reload_failed(self, message: str) -> None:
+        self.failures.append(message)
+
+    def emit_reload_succeeded(self, message: str) -> None:
+        self.successes.append(message)
+
+
+class TestConfigMapWatcherEvents(unittest.TestCase):
+    """Reload failures/recoveries emit K8s Events for operator visibility."""
+
+    def setUp(self):
+        self.mock_postgres = mock.MagicMock()
+        mock_service_config = mock.MagicMock()
+        mock_service_config.plaintext_dict.return_value = {}
+        self.mock_postgres.get_service_configs.return_value = (
+            mock_service_config)
+        configmap_state.set_configmap_mode(False)
+        configmap_state.set_parsed_configs(None)
+
+    def tearDown(self):
+        configmap_state.set_configmap_mode(False)
+        configmap_state.set_parsed_configs(None)
+
+    def _write(self, config: Dict[str, Any]) -> str:
+        with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.yaml', delete=False) as temp:
+            yaml.dump(config, temp)
+            return temp.name
+
+    def test_emits_warning_on_missing_file(self):
+        recorder = _FakeEventRecorder()
+        watcher = configmap_loader.ConfigMapWatcher(
+            '/nonexistent/path.yaml', self.mock_postgres,
+            event_recorder=recorder)
+        watcher._load_and_apply()
+        self.assertEqual(len(recorder.failures), 1)
+        self.assertIn('/nonexistent/path.yaml', recorder.failures[0])
+        self.assertEqual(recorder.successes, [])
+
+    def test_emits_warning_on_validation_failure(self):
+        bad_path = self._write({'pod_templates': 'not-a-dict'})
+        try:
+            recorder = _FakeEventRecorder()
+            watcher = configmap_loader.ConfigMapWatcher(
+                bad_path, self.mock_postgres, event_recorder=recorder)
+            watcher._load_and_apply()
+            self.assertEqual(len(recorder.failures), 1)
+            self.assertIn('pod_templates', recorder.failures[0])
+        finally:
+            os.unlink(bad_path)
+
+    def test_no_success_event_on_first_time_success(self):
+        """Successful reloads with no prior failure must not emit — noise."""
+        good_path = self._write(
+            {'pod_templates': {'ctrl': {'spec': {'containers': []}}}})
+        try:
+            recorder = _FakeEventRecorder()
+            watcher = configmap_loader.ConfigMapWatcher(
+                good_path, self.mock_postgres, event_recorder=recorder)
+            result = watcher._load_and_apply()
+            self.assertTrue(result)
+            self.assertEqual(recorder.failures, [])
+            self.assertEqual(recorder.successes, [])
+        finally:
+            os.unlink(good_path)
+
+    def test_success_event_emitted_on_recovery(self):
+        """After a failed reload, the next successful one emits Normal."""
+        bad_path = self._write({'pod_templates': 'not-a-dict'})
+        good_path = self._write(
+            {'pod_templates': {'ctrl': {'spec': {'containers': []}}}})
+        try:
+            recorder = _FakeEventRecorder()
+            watcher = configmap_loader.ConfigMapWatcher(
+                bad_path, self.mock_postgres, event_recorder=recorder)
+            watcher._load_and_apply()  # fails
+            watcher._config_file_path = good_path
+            watcher._load_and_apply()  # recovers
+            self.assertEqual(len(recorder.failures), 1)
+            self.assertEqual(len(recorder.successes), 1)
+            self.assertIn('after previous failure', recorder.successes[0])
+        finally:
+            os.unlink(bad_path)
+            os.unlink(good_path)
+
+    def test_no_recorder_does_not_break_reload(self):
+        """Recorder is optional — service must work without one."""
+        bad_path = self._write({'pod_templates': 'not-a-dict'})
+        try:
+            watcher = configmap_loader.ConfigMapWatcher(
+                bad_path, self.mock_postgres, event_recorder=None)
+            # Must not raise despite the failure
+            self.assertFalse(watcher._load_and_apply())
+        finally:
+            os.unlink(bad_path)
+
+
+class TestConfigMapEventRecorder(unittest.TestCase):
+    """Unit tests for the K8s Event emission helper."""
+
+    def test_falls_back_silently_when_no_kubeconfig(self):
+        """Local dev / test environments won't have incluster or kubeconfig.
+        The recorder must degrade to a no-op instead of crashing."""
+        with mock.patch(
+                'src.service.core.config.configmap_events.'
+                'kube_config.load_incluster_config',
+                side_effect=configmap_events.kube_config.ConfigException()), \
+            mock.patch(
+                'src.service.core.config.configmap_events.'
+                'kube_config.load_kube_config',
+                side_effect=Exception('no config')):
+            recorder = configmap_events.ConfigMapEventRecorder(
+                namespace='ns', configmap_name='osmo-configs')
+            # No raise — both emits are no-ops
+            recorder.emit_reload_failed('any error')
+            recorder.emit_reload_succeeded('any success')
+
+    def test_emit_creates_namespaced_event_with_expected_fields(self):
+        with mock.patch(
+                'src.service.core.config.configmap_events.'
+                'kube_config.load_incluster_config'), \
+            mock.patch(
+                'src.service.core.config.configmap_events.client.CoreV1Api'
+                ) as mock_api_class:
+            mock_api = mock_api_class.return_value
+            recorder = configmap_events.ConfigMapEventRecorder(
+                namespace='osmo', configmap_name='osmo-configs')
+            recorder.emit_reload_failed('pod_templates: must be a dict')
+
+            mock_api.create_namespaced_event.assert_called_once()
+            call_args = mock_api.create_namespaced_event.call_args
+            namespace_arg = call_args.args[0]
+            event = call_args.args[1]
+            self.assertEqual(namespace_arg, 'osmo')
+            self.assertEqual(event.type, 'Warning')
+            self.assertEqual(event.reason, 'ConfigMapReloadFailed')
+            self.assertIn('pod_templates', event.message)
+            self.assertEqual(event.involved_object.kind, 'ConfigMap')
+            self.assertEqual(event.involved_object.name, 'osmo-configs')
+
+    def test_emit_truncates_long_messages(self):
+        with mock.patch(
+                'src.service.core.config.configmap_events.'
+                'kube_config.load_incluster_config'), \
+            mock.patch(
+                'src.service.core.config.configmap_events.client.CoreV1Api'
+                ) as mock_api_class:
+            mock_api = mock_api_class.return_value
+            recorder = configmap_events.ConfigMapEventRecorder(
+                namespace='osmo', configmap_name='osmo-configs')
+            long_message = 'x' * 5000
+            recorder.emit_reload_failed(long_message)
+
+            event = mock_api.create_namespaced_event.call_args.args[1]
+            self.assertLessEqual(len(event.message), 1000)
+            self.assertTrue(event.message.endswith('...'))
+
+    def test_api_exception_is_swallowed(self):
+        """Observability must never take down the service."""
+        with mock.patch(
+                'src.service.core.config.configmap_events.'
+                'kube_config.load_incluster_config'), \
+            mock.patch(
+                'src.service.core.config.configmap_events.client.CoreV1Api'
+                ) as mock_api_class:
+            mock_api_class.return_value.create_namespaced_event.side_effect = \
+                RuntimeError('apiserver down')
+            recorder = configmap_events.ConfigMapEventRecorder(
+                namespace='osmo', configmap_name='osmo-configs')
+            # Must not raise
+            recorder.emit_reload_failed('any error')
 
 
 class TestConfigMapWatcherLoadAndApply(unittest.TestCase):

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -515,7 +515,15 @@ class TestConfigMapEventRecorder(unittest.TestCase):
         return configmap_events.ApiException(status=404, reason='Not Found')
 
     @staticmethod
-    def _build_recorder(mock_api):
+    def _stub_configmap_read(mock_api, uid='cm-uid-12345'):
+        """Default mock: ConfigMap fetch returns a UID."""
+        fake_configmap = mock.MagicMock()
+        fake_configmap.metadata.uid = uid
+        mock_api.read_namespaced_config_map.return_value = fake_configmap
+
+    @classmethod
+    def _build_recorder(cls, mock_api):
+        cls._stub_configmap_read(mock_api)
         with mock.patch(
                 'src.service.core.config.configmap_events.'
                 'kube_config.load_incluster_config'), \
@@ -544,7 +552,43 @@ class TestConfigMapEventRecorder(unittest.TestCase):
         self.assertIn('pod_templates', event.message)
         self.assertEqual(event.involved_object.kind, 'ConfigMap')
         self.assertEqual(event.involved_object.name, 'osmo-service-configs')
+        # UID must be populated so events appear in `kubectl describe configmap`
+        self.assertEqual(event.involved_object.uid, 'cm-uid-12345')
         self.assertEqual(event.count, 1)
+
+    def test_configmap_uid_is_cached_across_emits(self):
+        """UID is fetched once on first emit, reused thereafter."""
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.side_effect = (
+            self._not_found_api_exception())
+        recorder = self._build_recorder(mock_api)
+        recorder.emit_reload_failed('first')
+        recorder.emit_reload_failed('second')
+        recorder.emit_reload_failed('third')
+        self.assertEqual(mock_api.read_namespaced_config_map.call_count, 1)
+
+    def test_event_emitted_even_if_configmap_uid_fetch_fails(self):
+        """If fetching the ConfigMap UID fails, still emit the event (with
+        no UID). Operators still see it via `kubectl get events
+        --field-selector`."""
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.side_effect = (
+            self._not_found_api_exception())
+        mock_api.read_namespaced_config_map.side_effect = (
+            RuntimeError('cannot read configmap'))
+        with mock.patch(
+                'src.service.core.config.configmap_events.'
+                'kube_config.load_incluster_config'), \
+            mock.patch(
+                'src.service.core.config.configmap_events.client.CoreV1Api',
+                return_value=mock_api):
+            recorder = configmap_events.ConfigMapEventRecorder(
+                namespace='osmo', configmap_name='osmo-service-configs')
+            recorder.emit_reload_failed('any error')
+
+        mock_api.create_namespaced_event.assert_called_once()
+        event = mock_api.create_namespaced_event.call_args.args[1]
+        self.assertIsNone(event.involved_object.uid)
 
     def test_emit_patches_existing_event_on_repeat(self):
         """Second emit for same reason finds the existing event and PATCHes

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -341,6 +341,49 @@ class TestValidateConfigs(unittest.TestCase):
         self.assertEqual(errors, [])
 
 
+class TestConfigMapWatcherStart(unittest.TestCase):
+    """Tests for ConfigMapWatcher.start() startup behavior."""
+
+    def setUp(self):
+        configmap_state.set_configmap_mode(False)
+        configmap_state.set_parsed_configs(None)
+
+    def tearDown(self):
+        configmap_state.set_configmap_mode(False)
+        configmap_state.set_parsed_configs(None)
+
+    def test_start_raises_on_invalid_configmap(self):
+        """Bad ConfigMap at startup raises RuntimeError — pod crashes,
+        rolling update stalls, old pods keep serving."""
+        watcher = configmap_loader.ConfigMapWatcher(
+            '/nonexistent/path.yaml', postgres=None)
+        with self.assertRaises(RuntimeError) as context:
+            watcher.start()
+        self.assertIn('ConfigMap load failed', str(context.exception))
+        # Watcher must not have been started before the raise
+        self.assertIsNone(watcher._observer)
+        # ConfigMap mode must not be left half-activated
+        self.assertFalse(configmap_guard.is_configmap_mode())
+
+    def test_start_succeeds_on_valid_configmap(self):
+        """Valid ConfigMap at startup: activates mode, starts watcher."""
+        config: Dict[str, Any] = {
+            'pod_templates': {'default_ctrl': {'spec': {'containers': []}}},
+        }
+        with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.yaml', delete=False) as temp:
+            yaml.dump(config, temp)
+            path = temp.name
+        try:
+            watcher = configmap_loader.ConfigMapWatcher(path, postgres=None)
+            watcher.start()
+            self.assertTrue(configmap_guard.is_configmap_mode())
+            self.assertIsNotNone(watcher._observer)
+            watcher.stop()
+        finally:
+            os.unlink(path)
+
+
 class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
     """Tests for ConfigMapWatcher._load_and_apply."""
 

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -510,60 +510,117 @@ class TestConfigMapEventRecorder(unittest.TestCase):
             recorder.emit_reload_failed('any error')
             recorder.emit_reload_succeeded('any success')
 
-    def test_emit_creates_namespaced_event_with_expected_fields(self):
+    @staticmethod
+    def _not_found_api_exception():
+        return configmap_events.ApiException(status=404, reason='Not Found')
+
+    @staticmethod
+    def _build_recorder(mock_api):
         with mock.patch(
                 'src.service.core.config.configmap_events.'
                 'kube_config.load_incluster_config'), \
             mock.patch(
-                'src.service.core.config.configmap_events.client.CoreV1Api'
-                ) as mock_api_class:
-            mock_api = mock_api_class.return_value
-            recorder = configmap_events.ConfigMapEventRecorder(
-                namespace='osmo', configmap_name='osmo-configs')
-            recorder.emit_reload_failed('pod_templates: must be a dict')
+                'src.service.core.config.configmap_events.client.CoreV1Api',
+                return_value=mock_api):
+            return configmap_events.ConfigMapEventRecorder(
+                namespace='osmo', configmap_name='osmo-service-configs')
 
-            mock_api.create_namespaced_event.assert_called_once()
-            call_args = mock_api.create_namespaced_event.call_args
-            namespace_arg = call_args.args[0]
-            event = call_args.args[1]
-            self.assertEqual(namespace_arg, 'osmo')
-            self.assertEqual(event.type, 'Warning')
-            self.assertEqual(event.reason, 'ConfigMapReloadFailed')
-            self.assertIn('pod_templates', event.message)
-            self.assertEqual(event.involved_object.kind, 'ConfigMap')
-            self.assertEqual(event.involved_object.name, 'osmo-configs')
+    def test_emit_creates_event_with_deterministic_name_on_first_call(self):
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.side_effect = (
+            self._not_found_api_exception())
+        recorder = self._build_recorder(mock_api)
+        recorder.emit_reload_failed('pod_templates: must be a dict')
 
-    def test_emit_truncates_long_messages(self):
-        with mock.patch(
-                'src.service.core.config.configmap_events.'
-                'kube_config.load_incluster_config'), \
-            mock.patch(
-                'src.service.core.config.configmap_events.client.CoreV1Api'
-                ) as mock_api_class:
-            mock_api = mock_api_class.return_value
-            recorder = configmap_events.ConfigMapEventRecorder(
-                namespace='osmo', configmap_name='osmo-configs')
-            long_message = 'x' * 5000
-            recorder.emit_reload_failed(long_message)
+        mock_api.create_namespaced_event.assert_called_once()
+        namespace_arg, event = mock_api.create_namespaced_event.call_args.args
+        self.assertEqual(namespace_arg, 'osmo')
+        # Deterministic name enables dedup via GET→PATCH on subsequent emits
+        self.assertEqual(
+            event.metadata.name,
+            'osmo-service-configs.configmapreloadfailed')
+        self.assertEqual(event.type, 'Warning')
+        self.assertEqual(event.reason, 'ConfigMapReloadFailed')
+        self.assertIn('pod_templates', event.message)
+        self.assertEqual(event.involved_object.kind, 'ConfigMap')
+        self.assertEqual(event.involved_object.name, 'osmo-service-configs')
+        self.assertEqual(event.count, 1)
 
-            event = mock_api.create_namespaced_event.call_args.args[1]
-            self.assertLessEqual(len(event.message), 1000)
-            self.assertTrue(event.message.endswith('...'))
+    def test_emit_patches_existing_event_on_repeat(self):
+        """Second emit for same reason finds the existing event and PATCHes
+        it — no duplicate create. Count is incremented, message refreshed."""
+        existing = mock.MagicMock()
+        existing.count = 3
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.return_value = existing
+        recorder = self._build_recorder(mock_api)
+        recorder.emit_reload_failed('pod_templates: must be a dict')
 
-    def test_api_exception_is_swallowed(self):
+        mock_api.create_namespaced_event.assert_not_called()
+        mock_api.patch_namespaced_event.assert_called_once()
+        name, namespace, patch = (
+            mock_api.patch_namespaced_event.call_args.args)
+        self.assertEqual(
+            name, 'osmo-service-configs.configmapreloadfailed')
+        self.assertEqual(namespace, 'osmo')
+        self.assertEqual(patch['count'], 4)
+        self.assertIn('pod_templates', patch['message'])
+        self.assertIn('lastTimestamp', patch)
+
+    def test_emit_truncates_long_messages_on_create(self):
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.side_effect = (
+            self._not_found_api_exception())
+        recorder = self._build_recorder(mock_api)
+        recorder.emit_reload_failed('x' * 5000)
+
+        event = mock_api.create_namespaced_event.call_args.args[1]
+        self.assertLessEqual(len(event.message), 1000)
+        self.assertTrue(event.message.endswith('...'))
+
+    def test_emit_truncates_long_messages_on_patch(self):
+        existing = mock.MagicMock()
+        existing.count = 1
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.return_value = existing
+        recorder = self._build_recorder(mock_api)
+        recorder.emit_reload_failed('y' * 5000)
+
+        patch = mock_api.patch_namespaced_event.call_args.args[2]
+        self.assertLessEqual(len(patch['message']), 1000)
+        self.assertTrue(patch['message'].endswith('...'))
+
+    def test_read_non_404_error_is_swallowed(self):
         """Observability must never take down the service."""
-        with mock.patch(
-                'src.service.core.config.configmap_events.'
-                'kube_config.load_incluster_config'), \
-            mock.patch(
-                'src.service.core.config.configmap_events.client.CoreV1Api'
-                ) as mock_api_class:
-            mock_api_class.return_value.create_namespaced_event.side_effect = \
-                RuntimeError('apiserver down')
-            recorder = configmap_events.ConfigMapEventRecorder(
-                namespace='osmo', configmap_name='osmo-configs')
-            # Must not raise
-            recorder.emit_reload_failed('any error')
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.side_effect = (
+            configmap_events.ApiException(status=500, reason='Internal'))
+        recorder = self._build_recorder(mock_api)
+        # Must not raise; create/patch not attempted when read fails
+        recorder.emit_reload_failed('any error')
+        mock_api.create_namespaced_event.assert_not_called()
+        mock_api.patch_namespaced_event.assert_not_called()
+
+    def test_create_exception_is_swallowed(self):
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.side_effect = (
+            self._not_found_api_exception())
+        mock_api.create_namespaced_event.side_effect = (
+            RuntimeError('apiserver down'))
+        recorder = self._build_recorder(mock_api)
+        # Must not raise
+        recorder.emit_reload_failed('any error')
+
+    def test_patch_exception_is_swallowed(self):
+        existing = mock.MagicMock()
+        existing.count = 1
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.return_value = existing
+        mock_api.patch_namespaced_event.side_effect = (
+            RuntimeError('apiserver down'))
+        recorder = self._build_recorder(mock_api)
+        # Must not raise
+        recorder.emit_reload_failed('any error')
 
 
 class TestConfigMapWatcherLoadAndApply(unittest.TestCase):

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -475,16 +475,11 @@ def configure_app(target_app: fastapi.FastAPI, config: objects.WorkflowServiceCo
     setup_default_admin(postgres, config)
 
     if config.config_file:
-        try:
-            watcher = configmap_loader.ConfigMapWatcher(
-                config.config_file, postgres)
-            watcher.start()
-            # Store on app state to prevent GC from killing the watcher
-            target_app.state.config_watcher = watcher
-        except Exception:  # pylint: disable=broad-exception-caught
-            logging.exception(
-                'Failed to start config watcher — '
-                'service will continue without ConfigMap management')
+        watcher = configmap_loader.ConfigMapWatcher(
+            config.config_file, postgres)
+        watcher.start()
+        # Store on app state to prevent GC from killing the watcher
+        target_app.state.config_watcher = watcher
 
     # Instantiate QueryParser
     query.QueryParser()

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import base64
 import datetime
 import logging
+import os
 from pathlib import Path
 import sys
 from typing import Dict, List
@@ -37,7 +38,8 @@ from src.service.agent import helpers as backend_helpers
 from src.service.core.app import app_service
 from src.service.core.auth import auth_service, objects as auth_objects
 from src.service.core.config import (
-    config_service, configmap_loader, helpers as config_helpers, objects as config_objects
+    config_service, configmap_events, configmap_loader,
+    helpers as config_helpers, objects as config_objects,
 )
 from src.service.core.data import data_service, query
 from src.service.core.profile import profile_service
@@ -475,8 +477,19 @@ def configure_app(target_app: fastapi.FastAPI, config: objects.WorkflowServiceCo
     setup_default_admin(postgres, config)
 
     if config.config_file:
+        event_recorder: configmap_events.EventRecorder | None = None
+        pod_namespace = os.environ.get('POD_NAMESPACE')
+        configmap_name = os.environ.get('OSMO_CONFIGMAP_NAME')
+        if pod_namespace and configmap_name:
+            event_recorder = configmap_events.ConfigMapEventRecorder(
+                namespace=pod_namespace, configmap_name=configmap_name)
+        else:
+            logging.warning(
+                'POD_NAMESPACE or OSMO_CONFIGMAP_NAME unset; '
+                'ConfigMap reload events will not be emitted')
+
         watcher = configmap_loader.ConfigMapWatcher(
-            config.config_file, postgres)
+            config.config_file, postgres, event_recorder=event_recorder)
         watcher.start()
         # Store on app state to prevent GC from killing the watcher
         target_app.state.config_watcher = watcher


### PR DESCRIPTION
## Summary

Closes two silent-failure gaps in ConfigMap mode:

1. **Startup with bad ConfigMap** previously fell back to DB mode silently — the operator might never notice they were serving from a stale DB instead of the ConfigMap they pushed. Now `ConfigMapWatcher.start()` raises `RuntimeError` on load failure: the pod crash-loops, K8s stalls the rolling update at the bad revision, old healthy pods keep serving. Same pattern as CoreDNS / NGINX Ingress / Prometheus.

2. **Hot-reload with bad ConfigMap** previously kept the previous in-memory snapshot (correct — preserves availability) but left only an ERROR log line that's easy to miss. Now the loader emits K8s Events attached to the `osmo-configs` ConfigMap:
   ```
   Type:    Warning
   Reason:  ConfigMapReloadFailed
   Message: "pod_templates: must be a dict, got str"
   ```
`kubectl describe configmap osmo-configs` and `kubectl get events`
A `Normal` event is emitted once on recovery (success after prior failure) so operators can close out the incident. Successful reloads on their own stay silent to avoid noise.

No new chart toggle — fail-fast-at-startup is unconditional. `services.configs.enabled: true` alone gates event emission (via RBAC + env var injection).

## Changes

### Fail-fast at startup
- `ConfigMapWatcher.start()`: raises `RuntimeError` on load failure instead of proceeding silently
- `service.py`: dropped the broad `try/except` that swallowed watcher startup failures
- `values.yaml`: comment documenting the crash-loop behavior

### K8s Events on hot-reload
- New `configmap_events.ConfigMapEventRecorder` — emits Events attached to the `osmo-configs` ConfigMap, auto-truncates long messages, degrades to no-op without a kubeconfig (local dev/tests), swallows apiserver errors so observability never breaks the serving path
- `ConfigMapWatcher` takes an optional `event_recorder`; all failure paths route through a `_record_failure` helper; `_record_success` only emits on recovery from a prior failure
- `service.py` constructs the recorder from `POD_NAMESPACE` (downward API) + `OSMO_CONFIGMAP_NAME` env vars
- Chart: new `rbac-configs.yaml` template granting `events.create/patch` to the service account; `POD_NAMESPACE` + `OSMO_CONFIGMAP_NAME` env vars injected into the api-service Deployment when `services.configs.enabled: true`

## Test plan

New unit test coverage:
- Startup raises on missing/invalid ConfigMap; does not leave mode half-activated
- Startup succeeds normally with valid ConfigMap
- Warning event emitted on file-missing / validation failure
- Normal event emitted only on recovery (success after prior failure)
- No event noise on first-time success
- Loader works with `event_recorder=None` (backward-safe)
- Recorder: falls back to no-op when no kubeconfig available
- Recorder: sets expected Event fields (type, reason, message, involvedObject)
- Recorder: truncates >1KB messages with ellipsis
- Recorder: swallows apiserver exceptions

## Full story after this PR

| Scenario | Behavior |
|----------|----------|
| Startup with bad ConfigMap | Pod crash-loops. Rolling update stalls. Old pods keep serving. |
| Hot-reload with bad ConfigMap | Previous snapshot kept. `Warning` Event fires on the ConfigMap. ArgoCD UI shows it immediately. |
| Recovery after bad reload | One `Normal` Event closes the incident. |
| Successful reloads | Silent (no event noise). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emits ConfigMap reload events to Kubernetes for improved observability; RBAC and env injection added to support this.

* **Bug Fixes**
  * Service now validates ConfigMap at startup and fails fast on invalid/malformed configs to avoid silent misconfiguration.

* **Documentation**
  * Clarified that malformed ConfigMaps at pod startup will cause crashes and can stall rolling updates.

* **Tests**
  * Added unit tests covering startup behavior and event emission/recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->