### PR TITLE
fix(configmap-loader): redact secret values from validation errors

### DIFF
--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -23,6 +23,7 @@ import os
 import threading
 from typing import Any, Callable, Dict, List
 
+import pydantic
 import yaml
 from watchdog import events, observers
 
@@ -242,6 +243,58 @@ _EXPECTED_CONFIG_KEYS = {
 }
 
 
+# Leaf field names whose input_value must be redacted from validation
+# errors. Pydantic's default error formatter echoes input_value into the
+# error message, which flows into logs and K8s Events — dangerous if the
+# input is a resolved secret. This list covers the credential fields
+# OSMO receives via secret resolution. `secretName` / `secretKey` are
+# safe (they're references, not the secret itself) and are deliberately
+# NOT included.
+_SENSITIVE_FIELD_NAMES = frozenset({
+    'access_key',
+    'api_key',
+    'auth',
+    'password',
+    'secret_key',
+    'slack_token',
+    'smtp_password',
+    'value',  # matches {value: ...} single-string secret format
+})
+
+_REDACTED = '<redacted>'
+
+
+def _format_validation_error(error: pydantic.ValidationError) -> str:
+    """Rebuild a Pydantic error message with sensitive input values redacted.
+
+    Pydantic's default `str(error)` includes `input_value=<repr>` for every
+    rejected field. When the rejected field is a credential (e.g.
+    `access_key` rejected because of a discriminator mismatch), the
+    original plaintext ends up in logs and K8s Events. Walk the
+    structured errors list, detect sensitive leaf field names, and
+    replace their input repr with a placeholder.
+    """
+    parts: List[str] = []
+    for err in error.errors():
+        loc_parts = tuple(str(p) for p in err.get('loc', ()))
+        loc = '.'.join(loc_parts) if loc_parts else '<root>'
+        msg = err.get('msg', '')
+        input_value = err.get('input')
+
+        if any(p in _SENSITIVE_FIELD_NAMES for p in loc_parts):
+            input_repr = _REDACTED
+        elif input_value is None:
+            input_repr = None
+        else:
+            input_repr = repr(input_value)
+
+        if input_repr is None:
+            parts.append(f'{loc}: {msg}')
+        else:
+            parts.append(f'{loc}: {msg} (input={input_repr})')
+    return '; '.join(parts)
+
+
 def _validate_configs(managed_configs: Dict[str, Any]) -> List[str]:
     """Validate ConfigMap data by constructing typed Pydantic models.
 
@@ -265,6 +318,9 @@ def _validate_configs(managed_configs: Dict[str, Any]) -> List[str]:
             continue
         try:
             config_class(**section)
+        except pydantic.ValidationError as error:
+            errors.append(
+                f'{config_key}: {_format_validation_error(error)}')
         except Exception as error:  # pylint: disable=broad-exception-caught
             errors.append(f'{config_key}: {error}')
 

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -243,36 +243,74 @@ _EXPECTED_CONFIG_KEYS = {
 }
 
 
-# Leaf field names whose input_value must be redacted from validation
-# errors. Pydantic's default error formatter echoes input_value into the
-# error message, which flows into logs and K8s Events — dangerous if the
-# input is a resolved secret. This list covers the credential fields
-# OSMO receives via secret resolution. `secretName` / `secretKey` are
-# safe (they're references, not the secret itself) and are deliberately
-# NOT included.
-_SENSITIVE_FIELD_NAMES = frozenset({
-    'access_key',
-    'api_key',
-    'auth',
+# Field-name substrings that indicate the value is sensitive. Matching
+# is case-insensitive and substring-based so that variants like
+# `postgres_password`, `redis_password`, `cluster_api_key`,
+# `default_admin_password`, `private_key`, `slack_token`,
+# `smtp_password`, `oidc_secret` all get caught. Explicit safe names
+# (metadata/references that only look sensitive) are listed below and
+# override a substring match.
+_SENSITIVE_NAME_SUBSTRINGS = (
     'password',
-    'secret_key',
-    'slack_token',
-    'smtp_password',
-    'value',  # matches {value: ...} single-string secret format
+    'token',
+    'secret',     # caught by 'secret' but `secretName`/`secretKey` are whitelisted below
+    'access_key', # caught but `access_key_id` is whitelisted below
+    'private_key',
+    'api_key',
+)
+
+# Names that contain a sensitive-looking substring but are metadata
+# (references, IDs, file paths). Treated as NON-sensitive so operators
+# can still see their values in validation errors.
+_NON_SENSITIVE_FIELD_NAMES = frozenset({
+    'access_key_id',   # public half of an S3-style credential pair
+    'secretName',      # K8s Secret name — a reference, not the secret
+    'secretKey',       # key within a K8s Secret mount — a reference
+    'secret_file',     # filesystem path to a secret file
+    'mek_file',        # filesystem path
+    'currentMek',      # key identifier, not the key itself
 })
 
 _REDACTED = '<redacted>'
 
 
+def _is_sensitive_name(name: str) -> bool:
+    """Return True if a field name should trigger value redaction."""
+    if name in _NON_SENSITIVE_FIELD_NAMES:
+        return False
+    lower = name.lower()
+    return any(token in lower for token in _SENSITIVE_NAME_SUBSTRINGS)
+
+
+def _redact_nested(value: Any) -> Any:
+    """Recursively redact sensitive values from a dict/list for display.
+
+    Pydantic validation errors can surface an entire parent dict as the
+    `input` when a union discriminator fails. That dict contains the
+    secret plaintext keyed under e.g. `access_key`. Walk it and replace
+    the values of sensitive keys so the resulting repr is safe to log.
+    """
+    if isinstance(value, dict):
+        return {
+            k: (_REDACTED if _is_sensitive_name(str(k)) else _redact_nested(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_nested(item) for item in value]
+    return value
+
+
 def _format_validation_error(error: pydantic.ValidationError) -> str:
     """Rebuild a Pydantic error message with sensitive input values redacted.
 
-    Pydantic's default `str(error)` includes `input_value=<repr>` for every
-    rejected field. When the rejected field is a credential (e.g.
-    `access_key` rejected because of a discriminator mismatch), the
-    original plaintext ends up in logs and K8s Events. Walk the
-    structured errors list, detect sensitive leaf field names, and
-    replace their input repr with a placeholder.
+    Pydantic's default `str(error)` includes `input_value=<repr>` for
+    every rejected field. When the rejected field is a credential (e.g.
+    `access_key` rejected because of a discriminator mismatch) OR the
+    parent dict containing a credential, the plaintext ends up in logs
+    and K8s Events. This walker:
+
+    - redacts the whole input when any path component is sensitive, OR
+    - walks a dict/list input and redacts sensitive keys within it.
     """
     parts: List[str] = []
     for err in error.errors():
@@ -281,12 +319,16 @@ def _format_validation_error(error: pydantic.ValidationError) -> str:
         msg = err.get('msg', '')
         input_value = err.get('input')
 
-        if any(p in _SENSITIVE_FIELD_NAMES for p in loc_parts):
+        path_is_sensitive = any(_is_sensitive_name(p) for p in loc_parts)
+
+        if input_value is None:
+            input_repr: str | None = None
+        elif path_is_sensitive:
             input_repr = _REDACTED
-        elif input_value is None:
-            input_repr = None
         else:
-            input_repr = repr(input_value)
+            # Walk the input in case it's a parent dict containing a
+            # secret-keyed entry (union-discriminator failure case).
+            input_repr = repr(_redact_nested(input_value))
 
         if input_repr is None:
             parts.append(f'{loc}: {msg}')

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -244,23 +244,9 @@ _EXPECTED_CONFIG_KEYS = {
 
 
 def _format_validation_error(error: pydantic.ValidationError) -> str:
-    """Format a Pydantic ValidationError without echoing input values.
+    """Format a Pydantic error as `<path>: <reason> (input_type=<type>)`.
 
-    Pydantic's default `str(error)` includes `input_value=<repr>` for
-    every rejected field. When the rejected field is a resolved secret
-    (e.g. `access_key` plaintext) or a parent dict containing one, the
-    value ends up in logs and the K8s Event the loader writes.
-
-    Policy: emit `<path>: <reason> (input_type=<type>)`. The operator
-    gets the full field path to locate the offending config, Pydantic's
-    reason, and the Python type of the submitted value (e.g. `str`,
-    `int`, `NoneType`) — enough to diagnose common mistakes like "I
-    put a string where an int was expected" — but never the value
-    itself. The checked-in Helm values / ConfigMap are already the
-    source of truth for what was submitted; no value in the error
-    message is needed for debugging. This mirrors the error style of
-    K8s admission webhooks and eliminates the whole class of "did we
-    remember every sensitive field name?" bugs.
+    Never echoes submitted values — they can be resolved secrets.
     """
     parts: List[str] = []
     for err in error.errors():

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -243,97 +243,35 @@ _EXPECTED_CONFIG_KEYS = {
 }
 
 
-# Field-name substrings that indicate the value is sensitive. Matching
-# is case-insensitive and substring-based so that variants like
-# `postgres_password`, `redis_password`, `cluster_api_key`,
-# `default_admin_password`, `private_key`, `slack_token`,
-# `smtp_password`, `oidc_secret` all get caught. Explicit safe names
-# (metadata/references that only look sensitive) are listed below and
-# override a substring match.
-_SENSITIVE_NAME_SUBSTRINGS = (
-    'password',
-    'token',
-    'secret',     # caught by 'secret' but `secretName`/`secretKey` are whitelisted below
-    'access_key', # caught but `access_key_id` is whitelisted below
-    'private_key',
-    'api_key',
-)
-
-# Names that contain a sensitive-looking substring but are metadata
-# (references, IDs, file paths). Treated as NON-sensitive so operators
-# can still see their values in validation errors.
-_NON_SENSITIVE_FIELD_NAMES = frozenset({
-    'access_key_id',   # public half of an S3-style credential pair
-    'secretName',      # K8s Secret name — a reference, not the secret
-    'secretKey',       # key within a K8s Secret mount — a reference
-    'secret_file',     # filesystem path to a secret file
-    'mek_file',        # filesystem path
-    'currentMek',      # key identifier, not the key itself
-})
-
-_REDACTED = '<redacted>'
-
-
-def _is_sensitive_name(name: str) -> bool:
-    """Return True if a field name should trigger value redaction."""
-    if name in _NON_SENSITIVE_FIELD_NAMES:
-        return False
-    lower = name.lower()
-    return any(token in lower for token in _SENSITIVE_NAME_SUBSTRINGS)
-
-
-def _redact_nested(value: Any) -> Any:
-    """Recursively redact sensitive values from a dict/list for display.
-
-    Pydantic validation errors can surface an entire parent dict as the
-    `input` when a union discriminator fails. That dict contains the
-    secret plaintext keyed under e.g. `access_key`. Walk it and replace
-    the values of sensitive keys so the resulting repr is safe to log.
-    """
-    if isinstance(value, dict):
-        return {
-            k: (_REDACTED if _is_sensitive_name(str(k)) else _redact_nested(v))
-            for k, v in value.items()
-        }
-    if isinstance(value, list):
-        return [_redact_nested(item) for item in value]
-    return value
-
-
 def _format_validation_error(error: pydantic.ValidationError) -> str:
-    """Rebuild a Pydantic error message with sensitive input values redacted.
+    """Format a Pydantic ValidationError without echoing input values.
 
     Pydantic's default `str(error)` includes `input_value=<repr>` for
-    every rejected field. When the rejected field is a credential (e.g.
-    `access_key` rejected because of a discriminator mismatch) OR the
-    parent dict containing a credential, the plaintext ends up in logs
-    and K8s Events. This walker:
+    every rejected field. When the rejected field is a resolved secret
+    (e.g. `access_key` plaintext) or a parent dict containing one, the
+    value ends up in logs and the K8s Event the loader writes.
 
-    - redacts the whole input when any path component is sensitive, OR
-    - walks a dict/list input and redacts sensitive keys within it.
+    Policy: emit `<path>: <reason> (input_type=<type>)`. The operator
+    gets the full field path to locate the offending config, Pydantic's
+    reason, and the Python type of the submitted value (e.g. `str`,
+    `int`, `NoneType`) — enough to diagnose common mistakes like "I
+    put a string where an int was expected" — but never the value
+    itself. The checked-in Helm values / ConfigMap are already the
+    source of truth for what was submitted; no value in the error
+    message is needed for debugging. This mirrors the error style of
+    K8s admission webhooks and eliminates the whole class of "did we
+    remember every sensitive field name?" bugs.
     """
     parts: List[str] = []
     for err in error.errors():
         loc_parts = tuple(str(p) for p in err.get('loc', ()))
         loc = '.'.join(loc_parts) if loc_parts else '<root>'
         msg = err.get('msg', '')
-        input_value = err.get('input')
-
-        path_is_sensitive = any(_is_sensitive_name(p) for p in loc_parts)
-
-        if input_value is None:
-            input_repr: str | None = None
-        elif path_is_sensitive:
-            input_repr = _REDACTED
+        if 'input' in err:
+            input_type = type(err['input']).__name__
+            parts.append(f'{loc}: {msg} (input_type={input_type})')
         else:
-            # Walk the input in case it's a parent dict containing a
-            # secret-keyed entry (union-discriminator failure case).
-            input_repr = repr(_redact_nested(input_value))
-
-        if input_repr is None:
             parts.append(f'{loc}: {msg}')
-        else:
-            parts.append(f'{loc}: {msg} (input={input_repr})')
     return '; '.join(parts)
 
 

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -343,6 +343,90 @@ class TestValidateConfigs(unittest.TestCase):
         self.assertEqual(errors, [])
 
 
+class TestValidationErrorRedaction(unittest.TestCase):
+    """Pydantic validation errors must redact sensitive field values.
+
+    Background: Pydantic's default str(error) includes `input_value=<repr>`
+    for every rejected field. If a credential (e.g. access_key) is
+    rejected by a discriminator mismatch, the plaintext ends up in logs
+    and K8s Events. The loader's error formatter must redact those
+    values while preserving visibility for non-sensitive fields.
+    """
+
+    def _make_error(self, *field_errors) -> configmap_loader.pydantic.ValidationError:
+        """Build a ValidationError by defining a small model + running it."""
+        class FakeModel(configmap_loader.pydantic.BaseModel):
+            model_config = {'extra': 'forbid'}
+            name: str = ''
+
+        # Provide a dict with only "extra" fields so Pydantic rejects each
+        # as extra_forbidden with the input_value echoed in the error.
+        try:
+            FakeModel(**dict(field_errors))
+        except configmap_loader.pydantic.ValidationError as error:
+            return error
+        raise AssertionError('Expected a ValidationError')
+
+    def test_sensitive_field_value_redacted(self):
+        error = self._make_error(
+            ('access_key', 'SECRET_PLAINTEXT_VALUE'))
+        formatted = configmap_loader._format_validation_error(error)
+        self.assertIn('access_key', formatted)
+        self.assertIn('<redacted>', formatted)
+        self.assertNotIn('SECRET_PLAINTEXT_VALUE', formatted)
+
+    def test_nonsensitive_field_value_preserved(self):
+        """Debugging depends on seeing the actual bad value for public fields."""
+        error = self._make_error(
+            ('_comment', 'Create K8s Secret with: ...'))
+        formatted = configmap_loader._format_validation_error(error)
+        self.assertIn('_comment', formatted)
+        self.assertIn('Create K8s Secret', formatted)
+        self.assertNotIn('<redacted>', formatted)
+
+    def test_mixed_sensitive_and_public_fields(self):
+        error = self._make_error(
+            ('_comment', 'docs'),
+            ('access_key', 'SENSITIVE_KEY_123'),
+            ('slack_token', 'xoxb-SENSITIVE'),
+            ('password', 'hunter2'),
+            ('endpoint', 's3://bucket'),
+        )
+        formatted = configmap_loader._format_validation_error(error)
+        # Sensitive values must not leak
+        for secret in ('SENSITIVE_KEY_123', 'xoxb-SENSITIVE', 'hunter2'):
+            self.assertNotIn(secret, formatted)
+        # Public values preserved
+        self.assertIn('docs', formatted)
+        self.assertIn('s3://bucket', formatted)
+
+    def test_full_validation_flow_redacts_access_key(self):
+        """Regression: the staging _comment bug leaked access_key via
+        _validate_configs because of discriminator mismatch. This
+        exercises the real path end-to-end."""
+        configs: Dict[str, Any] = {
+            'workflow': {
+                'workflow_data': {
+                    'credential': {
+                        # Loader-merged secret fields that should never
+                        # appear in the resulting error message.
+                        'access_key': 'LEAKED_IF_BUG_PRESENT',
+                        'access_key_id': 'team-osmo-ops',
+                        'endpoint': 'swift://host/bucket',
+                        'region': 'us-east-1',
+                        # Extra field that triggers Pydantic rejection
+                        '_comment': 'docs',
+                    },
+                },
+            },
+        }
+        errors = configmap_loader._validate_configs(configs)
+        combined = '; '.join(errors)
+        self.assertNotIn('LEAKED_IF_BUG_PRESENT', combined)
+        # Non-sensitive fields can still appear to help operators debug
+        self.assertIn('_comment', combined)
+
+
 class TestConfigMapWatcherStart(unittest.TestCase):
     """Tests for ConfigMapWatcher.start() startup behavior."""
 

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -426,6 +426,59 @@ class TestValidationErrorRedaction(unittest.TestCase):
         # Non-sensitive fields can still appear to help operators debug
         self.assertIn('_comment', combined)
 
+    def test_substring_matches_real_field_names(self):
+        """Field names actually used in OSMO models must all be detected,
+        not just the leafs hardcoded in the original name set."""
+        error = self._make_error(
+            ('postgres_password', 'PG_LEAK_CANARY'),
+            ('redis_password', 'REDIS_LEAK_CANARY'),
+            ('cluster_api_key', 'CLUSTER_LEAK_CANARY'),
+            ('default_admin_password', 'ADMIN_LEAK_CANARY'),
+            ('private_key', 'PRIVATE_KEY_LEAK_CANARY'),
+            ('oidc_secret', 'OIDC_LEAK_CANARY'),
+        )
+        formatted = configmap_loader._format_validation_error(error)
+        for canary in (
+            'PG_LEAK_CANARY', 'REDIS_LEAK_CANARY', 'CLUSTER_LEAK_CANARY',
+            'ADMIN_LEAK_CANARY', 'PRIVATE_KEY_LEAK_CANARY',
+            'OIDC_LEAK_CANARY',
+        ):
+            self.assertNotIn(canary, formatted)
+
+    def test_whitelisted_metadata_fields_not_redacted(self):
+        """Reference/metadata fields contain sensitive-looking substrings
+        but are safe — their values must still be visible."""
+        error = self._make_error(
+            ('access_key_id', 'team-osmo-ops'),
+            ('secretName', 'my-k8s-secret'),
+            ('secretKey', 'cred.yaml'),
+            ('secret_file', '/etc/osmo/secrets/path.yaml'),
+        )
+        formatted = configmap_loader._format_validation_error(error)
+        for public in (
+            'team-osmo-ops', 'my-k8s-secret', 'cred.yaml',
+            '/etc/osmo/secrets/path.yaml',
+        ):
+            self.assertIn(public, formatted)
+
+    def test_redact_nested_walks_deeply(self):
+        """Nested dicts and lists get redacted key-by-key."""
+        value = {
+            'nested': {
+                'api_key': 'DEEP_LEAK_CANARY',
+                'endpoint': 'https://api',
+            },
+            'items': [
+                {'password': 'LIST_LEAK_CANARY', 'name': 'foo'},
+            ],
+        }
+        redacted = configmap_loader._redact_nested(value)
+        rendered = repr(redacted)
+        self.assertNotIn('DEEP_LEAK_CANARY', rendered)
+        self.assertNotIn('LIST_LEAK_CANARY', rendered)
+        self.assertIn('https://api', rendered)
+        self.assertIn('foo', rendered)
+
 
 class TestConfigMapWatcherStart(unittest.TestCase):
     """Tests for ConfigMapWatcher.start() startup behavior."""

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -343,78 +343,83 @@ class TestValidateConfigs(unittest.TestCase):
         self.assertEqual(errors, [])
 
 
-class TestValidationErrorRedaction(unittest.TestCase):
-    """Pydantic validation errors must redact sensitive field values.
+class TestValidationErrorFormatting(unittest.TestCase):
+    """Pydantic validation errors must never echo input values.
 
-    Background: Pydantic's default str(error) includes `input_value=<repr>`
-    for every rejected field. If a credential (e.g. access_key) is
-    rejected by a discriminator mismatch, the plaintext ends up in logs
-    and K8s Events. The loader's error formatter must redact those
-    values while preserving visibility for non-sensitive fields.
+    Policy (see `_format_validation_error` docstring): only the field
+    path and Pydantic's reason are included in the error message. The
+    submitted value is never echoed back — this eliminates the whole
+    class of 'did we remember every sensitive field?' leak bugs.
     """
 
-    def _make_error(self, *field_errors) -> configmap_loader.pydantic.ValidationError:
-        """Build a ValidationError by defining a small model + running it."""
+    def _make_error(
+        self, *field_errors,
+    ) -> configmap_loader.pydantic.ValidationError:
+        """Build a ValidationError by running extra fields through a
+        strict model so each one is rejected with extra_forbidden."""
         class FakeModel(configmap_loader.pydantic.BaseModel):
             model_config = {'extra': 'forbid'}
             name: str = ''
 
-        # Provide a dict with only "extra" fields so Pydantic rejects each
-        # as extra_forbidden with the input_value echoed in the error.
         try:
             FakeModel(**dict(field_errors))
         except configmap_loader.pydantic.ValidationError as error:
             return error
         raise AssertionError('Expected a ValidationError')
 
-    def test_sensitive_field_value_redacted(self):
-        error = self._make_error(
-            ('access_key', 'SECRET_PLAINTEXT_VALUE'))
+    def test_output_contains_field_path_reason_and_input_type(self):
+        """Operators need loc + msg + input_type to diagnose quickly;
+        all three are kept, value is NOT."""
+        error = self._make_error(('extra_field', 'anything'))
         formatted = configmap_loader._format_validation_error(error)
-        self.assertIn('access_key', formatted)
-        self.assertIn('<redacted>', formatted)
-        self.assertNotIn('SECRET_PLAINTEXT_VALUE', formatted)
+        self.assertIn('extra_field', formatted)
+        self.assertIn('Extra inputs are not permitted', formatted)
+        self.assertIn('input_type=str', formatted)
+        self.assertNotIn('anything', formatted)
 
-    def test_nonsensitive_field_value_preserved(self):
-        """Debugging depends on seeing the actual bad value for public fields."""
-        error = self._make_error(
-            ('_comment', 'Create K8s Secret with: ...'))
-        formatted = configmap_loader._format_validation_error(error)
-        self.assertIn('_comment', formatted)
-        self.assertIn('Create K8s Secret', formatted)
-        self.assertNotIn('<redacted>', formatted)
+    def test_input_type_reflects_actual_python_type(self):
+        """A non-string input should be reported with its Python type."""
+        class IntModel(configmap_loader.pydantic.BaseModel):
+            port: int = 80
 
-    def test_mixed_sensitive_and_public_fields(self):
+        try:
+            IntModel(port='not-a-number')
+        except configmap_loader.pydantic.ValidationError as error:
+            formatted = configmap_loader._format_validation_error(error)
+            self.assertIn('port', formatted)
+            self.assertIn('input_type=str', formatted)
+            # The submitted value itself is NEVER echoed
+            self.assertNotIn('not-a-number', formatted)
+
+    def test_output_never_contains_input_value(self):
+        """Submitted values — sensitive or not — must not appear."""
         error = self._make_error(
-            ('_comment', 'docs'),
-            ('access_key', 'SENSITIVE_KEY_123'),
-            ('slack_token', 'xoxb-SENSITIVE'),
-            ('password', 'hunter2'),
-            ('endpoint', 's3://bucket'),
+            ('access_key', 'ACCESS_KEY_CANARY'),
+            ('password', 'PASSWORD_CANARY'),
+            ('private_key', 'PRIVATE_KEY_CANARY'),
+            ('endpoint', 'ENDPOINT_CANARY'),
+            ('_comment', 'COMMENT_CANARY'),
         )
         formatted = configmap_loader._format_validation_error(error)
-        # Sensitive values must not leak
-        for secret in ('SENSITIVE_KEY_123', 'xoxb-SENSITIVE', 'hunter2'):
-            self.assertNotIn(secret, formatted)
-        # Public values preserved
-        self.assertIn('docs', formatted)
-        self.assertIn('s3://bucket', formatted)
+        for canary in (
+            'ACCESS_KEY_CANARY', 'PASSWORD_CANARY',
+            'PRIVATE_KEY_CANARY', 'ENDPOINT_CANARY', 'COMMENT_CANARY',
+        ):
+            self.assertNotIn(canary, formatted)
 
-    def test_full_validation_flow_redacts_access_key(self):
-        """Regression: the staging _comment bug leaked access_key via
-        _validate_configs because of discriminator mismatch. This
-        exercises the real path end-to-end."""
+    def test_real_models_never_leak_any_value(self):
+        """End-to-end: drive _validate_configs with the exact shape
+        that caused the staging leak (nested credential dict with a
+        secret and an extra field that trips Pydantic). No submitted
+        value appears in the output; field path is retained."""
         configs: Dict[str, Any] = {
             'workflow': {
                 'workflow_data': {
                     'credential': {
-                        # Loader-merged secret fields that should never
-                        # appear in the resulting error message.
                         'access_key': 'LEAKED_IF_BUG_PRESENT',
                         'access_key_id': 'team-osmo-ops',
                         'endpoint': 'swift://host/bucket',
                         'region': 'us-east-1',
-                        # Extra field that triggers Pydantic rejection
                         '_comment': 'docs',
                     },
                 },
@@ -422,62 +427,15 @@ class TestValidationErrorRedaction(unittest.TestCase):
         }
         errors = configmap_loader._validate_configs(configs)
         combined = '; '.join(errors)
-        self.assertNotIn('LEAKED_IF_BUG_PRESENT', combined)
-        # Non-sensitive fields can still appear to help operators debug
-        self.assertIn('_comment', combined)
-
-    def test_substring_matches_real_field_names(self):
-        """Field names actually used in OSMO models must all be detected,
-        not just the leafs hardcoded in the original name set."""
-        error = self._make_error(
-            ('postgres_password', 'PG_LEAK_CANARY'),
-            ('redis_password', 'REDIS_LEAK_CANARY'),
-            ('cluster_api_key', 'CLUSTER_LEAK_CANARY'),
-            ('default_admin_password', 'ADMIN_LEAK_CANARY'),
-            ('private_key', 'PRIVATE_KEY_LEAK_CANARY'),
-            ('oidc_secret', 'OIDC_LEAK_CANARY'),
-        )
-        formatted = configmap_loader._format_validation_error(error)
-        for canary in (
-            'PG_LEAK_CANARY', 'REDIS_LEAK_CANARY', 'CLUSTER_LEAK_CANARY',
-            'ADMIN_LEAK_CANARY', 'PRIVATE_KEY_LEAK_CANARY',
-            'OIDC_LEAK_CANARY',
+        # No submitted values leak — sensitive or otherwise.
+        for value in (
+            'LEAKED_IF_BUG_PRESENT', 'team-osmo-ops',
+            'swift://host/bucket', 'us-east-1', 'docs',
         ):
-            self.assertNotIn(canary, formatted)
-
-    def test_whitelisted_metadata_fields_not_redacted(self):
-        """Reference/metadata fields contain sensitive-looking substrings
-        but are safe — their values must still be visible."""
-        error = self._make_error(
-            ('access_key_id', 'team-osmo-ops'),
-            ('secretName', 'my-k8s-secret'),
-            ('secretKey', 'cred.yaml'),
-            ('secret_file', '/etc/osmo/secrets/path.yaml'),
-        )
-        formatted = configmap_loader._format_validation_error(error)
-        for public in (
-            'team-osmo-ops', 'my-k8s-secret', 'cred.yaml',
-            '/etc/osmo/secrets/path.yaml',
-        ):
-            self.assertIn(public, formatted)
-
-    def test_redact_nested_walks_deeply(self):
-        """Nested dicts and lists get redacted key-by-key."""
-        value = {
-            'nested': {
-                'api_key': 'DEEP_LEAK_CANARY',
-                'endpoint': 'https://api',
-            },
-            'items': [
-                {'password': 'LIST_LEAK_CANARY', 'name': 'foo'},
-            ],
-        }
-        redacted = configmap_loader._redact_nested(value)
-        rendered = repr(redacted)
-        self.assertNotIn('DEEP_LEAK_CANARY', rendered)
-        self.assertNotIn('LIST_LEAK_CANARY', rendered)
-        self.assertIn('https://api', rendered)
-        self.assertIn('foo', rendered)
+            self.assertNotIn(value, combined)
+        # The field path is still visible so operators can locate it
+        self.assertIn('workflow_data', combined)
+        self.assertIn('credential', combined)
 
 
 class TestConfigMapWatcherStart(unittest.TestCase):


### PR DESCRIPTION
## Problem

Pydantic's default `ValidationError` echoes `input_value=<repr>` into the error message. When a rejected field holds a resolved secret (e.g. an `access_key` merged from a mounted K8s Secret), the plaintext lands in the loader's ERROR log line and in the K8s Event the loader writes to the ConfigMap. 

## Fix

Never echo submitted values. Output: `<path>: <reason> (input_type=<type>)`.

**Before**:
```
workflow.workflow_data.credential.DefaultDataCredential.access_key:
  Extra inputs are not permitted [input_value='abcdefg...', input_type=str]
```

**After**:
```
workflow.workflow_data.credential.DefaultDataCredential.access_key:
  Extra inputs are not permitted (input_type=str)
```

Earlier revisions tried a curated sensitive-name allowlist — review surfaced that it kept missing real OSMO fields (`postgres_password`, etc.). The final version has zero hardcoding: no allowlist, no introspection, no per-field work when new secret fields are added.

## What operators lose

For type typos like `max_num_tasks: 'not-a-number'`, the echoed `'not-a-number'` is gone. Operator sees the path + `input_type=str` and grep their values file. Checked-in Helm values are the source of truth.

## Test plan

- [x] `bazel test //src/service/core/config/...` — pass (4 new tests)
- [x] pylint + mypy green

Regression test `test_real_models_never_leak_any_value` reproduces the staging scenario and asserts no submitted value appears in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration validation errors now provide enhanced feedback with complete field path information and input data types while preventing sensitive credential data from appearing in error messages.

* **Tests**
  * Comprehensive test coverage added for validation error formatting to verify proper error reporting and credential protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->