### PR TITLE
Minor fix for backend resource enum type

### DIFF
--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -2459,7 +2459,7 @@ class BackendResource(pydantic.BaseModel):
                     updated_workflow_allocatable_fields=updated_workflow_allocatable_fields,
                     available_fields=available_fields,
                     backend=resource['backend'],
-                    resource_type=resource['resource_type']))
+                    resource_type=BackendResourceType(resource['resource_type'])))
 
         return all_resources
 


### PR DESCRIPTION
## Description
Fix service warnings due to Pydantic v2 migration
```
pydantic/type_adapter.py:605: UserWarning: Pydantic serializer warnings:                                                                                                                                                                                                                                                
    PydanticSerializationUnexpectedValue(Expected `enum` - serialized value may not be as expected [field_name='resource_type', input_value='RESERVED', input_type=str])                                                                                                                                                  
    PydanticSerializationUnexpectedValue(Expected `PoolResourcesResponse` - serialized value may not be as expected [input_value=ResourcesResponse(resourc...ource_type='RESERVED')]), input_type=ResourcesResponse])                                                                                                     
    return self.serializer.to_python( 
```

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced consistency in resource type data handling through standardized internal representations for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->