### PR TITLE
#893 - Fix deploy-k8s.sh to match project conventions

### DIFF
--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -413,6 +413,8 @@ sidecars:
     enabled: false
   oauth2Proxy:
     enabled: false
+podMonitor:
+  enabled: false
 EOF
 
     # UI values
@@ -509,6 +511,8 @@ services:
 sidecars:
   otel:
     enabled: false
+podMonitor:
+  enabled: false
 EOF
 
     log_success "Helm values files created"
@@ -577,13 +581,16 @@ setup_backend_operator() {
 
         if command -v osmo &> /dev/null; then
             log_info "Logging into OSMO..."
-            osmo login http://localhost:9000 --method=dev --username=testuser || true
+            osmo login http://localhost:9000 --method=dev --username=admin || true
+
+            log_info "Creating backend-operator user..."
+            osmo user create backend-operator --roles osmo-backend 2>/dev/null || true
 
             log_info "Generating backend operator token..."
             local backend_token=$(osmo token set backend-token \
                 --expires-at "$BACKEND_TOKEN_EXPIRY" \
                 --description "Backend Operator Token" \
-                --service \
+                --user backend-operator \
                 --roles osmo-backend \
                 -t json 2>/dev/null | jq -r '.token' || echo "")
 


### PR DESCRIPTION
## Description

`deployments/scripts/deploy-k8s.sh` does not produce a working cluster from a clean state. Two independent failures surface before any workload runs:

1. **PodMonitor enabled by default** — `services.api.podMonitor` defaults to `true` in the sub-charts, so `helm install` fails with `no matches for kind "PodMonitor"` on any cluster without the Prometheus Operator. The umbrella quick-start chart and `docs/deployment_guide/appendix/deploy_minimal.rst` both disable this; the script does not.
2. **Backend-operator token uses removed `--service` flag and skips user creation** — The CLI removed `--service` in favor of `--user`, and tokens require a pre-existing user. The minimal deploy docs create a `backend-operator` user first and use `--user backend-operator`; the script still passes `--service` and silently produces an empty token, leaving all backend pods in CrashLoopBackOff.

This patch aligns `deploy-k8s.sh` with the minimal-deploy documentation:

- Append `podMonitor.enabled: false` to the generated `values-*.yaml` for both renders.
- Create the `backend-operator` user before token creation, and replace `--service` with `--user backend-operator`.

Verified end-to-end on a fresh EKS 1.30 cluster (sa-east-1): all core pods reach `1/1 Running`, backend-operator token is generated and consumed cleanly, no CrashLoopBackOff.

Issue #893

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes deployment configuration to adjust pod monitoring settings for service sidecars and refined backend service authentication setup during environment initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->