### PR TITLE
feat(skills): add osmo-deploy skill for deployment guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ docs/**/domain_config.js
 .ruff_cache
 
 .lycheecache
+
+# Git worktrees
+.worktrees/

--- a/skills/osmo-deploy/SKILL.md
+++ b/skills/osmo-deploy/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: osmo-deploy
+description: >
+  Deployment, installation, and administration of the OSMO platform on Kubernetes.
+  Use this skill whenever the user asks about deploying OSMO, setting up the OSMO
+  service or backend operator, preparing Helm values files, creating Kubernetes
+  secrets (database, Redis, MEK, OAuth2 proxy), configuring authentication with or
+  without an identity provider, setting up resource pools, pod templates, or resource
+  validation rules, understanding OSMO's control plane / compute plane architecture,
+  troubleshooting a failed deployment, rotating backend operator tokens, or doing a
+  local (KIND) or minimal single-cluster deployment. Also use for questions about
+  OSMO requirements, cloud infrastructure setup, storage bucket configuration, or
+  KAI scheduler setup. Do NOT use for users who already have OSMO deployed and want
+  to submit workflows, monitor runs, or use the osmo CLI for day-to-day operations —
+  use the osmo-agent skill for those.
+---
+
+# OSMO Deployment Guide
+
+## Architecture Overview
+
+OSMO separates compute from orchestration across two planes:
+
+**Control plane** (runs in a single service cluster):
+- **API Service** — workflow operations and API endpoints
+- **Router** — routes HTTP/WebSocket to backend clusters
+- **Web UI** — browser interface
+- **Worker** — background job processing (Kombu/Redis queue)
+- **Logger** — log collection and streaming
+- **Agent** — receives node/pod/event streams from backends
+- **Delayed Job Monitor** — promotes scheduled jobs to main queue
+
+**Compute plane** (one per backend cluster, any number of backends):
+- **Backend Operator** — registers the cluster with OSMO, runs workflows as K8s pods
+- **KAI Scheduler** — co-scheduling, priority, preemption for GPU workloads
+
+One control plane can serve many backend clusters simultaneously.
+
+---
+
+## Requirements
+
+| Component | Minimum Version | Notes |
+|-----------|----------------|-------|
+| Kubernetes | 1.27+ | EKS, AKS, GKE, or on-prem |
+| PostgreSQL | 15+ | External managed DB recommended |
+| Redis | 7.0+ | External managed cache recommended |
+| Helm | 3.x | |
+| kubectl | 1.32+ | |
+| OSMO CLI | latest | `curl -fsSL https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/install.sh \| bash` |
+
+**Instance sizing (control plane cluster):**
+
+| Service | CPU | RAM | Storage |
+|---------|-----|-----|---------|
+| OSMO services | 8 cores | 32 GB | 100 GB |
+| PostgreSQL | 2 cores | 4 GB | 32 GB |
+| Redis | 1 core | 4 GB | — |
+
+**Networking:** FQDN + SSL/TLS certificate + DNS CNAME pointing to the `osmo-gateway` LoadBalancer. VPC required for cloud deployments.
+
+---
+
+## Deployment Path Selection
+
+Match the user's context to the right path. No keyword matching needed — read the signals:
+
+| Signals | Path |
+|---------|------|
+| Experimenting, "try it out", "quick start", no cloud infra, mentions Docker/KIND | **Local** |
+| Simple setup, no IdP/SSO, single cluster, small team, mentions port-forwarding | **Minimal** |
+| Mentions EKS/AKS/GKE, IdP/SSO, multi-user org, external PostgreSQL/Redis, separate backend cluster | **Production** |
+
+When no signals are present, default to **Production** (the primary audience for this skill).
+
+---
+
+## Intent Routing
+
+Before answering a specific question, check here first:
+
+| Question topic | Action |
+|----------------|--------|
+| Helm values configuration | Read `references/helm-values-templates.md` |
+| Authentication / IdP setup | Read `references/auth-guide.md`; for provider-specific steps, also fetch IdP URL from `references/url-index.md` |
+| Pools, pod templates, resource validation, group templates, KAI scheduler | Read `references/advanced-config.md` |
+| Minimal single-cluster deployment | Read `references/deploy-minimal.md` |
+| Storage setup (S3, Azure Blob, GCP, TOS) | Fetch URL from `references/url-index.md` |
+| Keycloak setup | Fetch URL from `references/url-index.md` |
+| Full config schema (pool, workflow, backend, etc.) | Fetch URL from `references/url-index.md` |
+| Local KIND deployment details beyond what's below | Fetch `appendix/deploy_local.md` URL from `references/url-index.md` |
+
+---
+
+## Local Deployment (KIND)
+
+For evaluation and development. No cloud account required. Takes ~10 minutes.
+
+**Prerequisites:** Docker ≥28.3.2, KIND ≥0.29.0 or nvkind (GPU), kubectl ≥1.32.2, helm ≥3.16.2
+
+**Step 1: Create KIND cluster**
+
+CPU workstation:
+```bash
+kind create cluster --config kind-osmo-cluster-config.yaml
+```
+
+GPU workstation (install [nvkind](https://github.com/NVIDIA/nvkind) first):
+```bash
+nvkind cluster create --config-template=kind-osmo-cluster-config.yaml
+```
+
+Fetch `appendix/deploy_local.md` from `references/url-index.md` for the full `kind-osmo-cluster-config.yaml` content — the cluster needs specific node labels (`node_group=service`, `kai-scheduler`, `data`, `compute`).
+
+**Step 2: Install KAI Scheduler**
+```bash
+helm upgrade --install kai-scheduler \
+  oci://ghcr.io/nvidia/kai-scheduler/kai-scheduler \
+  --version v0.12.10 \
+  --create-namespace -n kai-scheduler \
+  --set global.nodeSelector.node_group=kai-scheduler \
+  --set "scheduler.additionalArgs[0]=--default-staleness-grace-period=-1s" \
+  --set "scheduler.additionalArgs[1]=--update-pod-eviction-condition=true" \
+  --wait
+```
+
+**Step 3: Install OSMO (quick-start)**
+```bash
+helm repo add osmo https://helm.ngc.nvidia.com/nvidia/osmo
+helm repo update
+helm upgrade --install osmo osmo/quick-start \
+  --namespace osmo --create-namespace --wait
+```
+
+Monitor: `kubectl get pods --namespace osmo`
+
+**Step 4: Configure access**
+```bash
+echo "127.0.0.1 quick-start.osmo" | sudo tee -a /etc/hosts
+```
+
+**Step 5: Install OSMO CLI**
+```bash
+curl -fsSL https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/install.sh | bash
+```
+
+**Step 6: Log in**
+```bash
+osmo login http://quick-start.osmo --method=dev --username=testuser
+```
+
+OSMO is now available at `http://quick-start.osmo`. To clean up: `kind delete cluster --name osmo`
+
+---
+
+## Production Deployment
+
+### Deploy Service (Control Plane)
+
+**Step 1: Create PostgreSQL database**
+```bash
+export OSMO_DB_HOST=<your-db-host>
+export OSMO_PGPASSWORD=<your-postgres-password>
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: osmo-db-ops
+spec:
+  containers:
+    - name: osmo-db-ops
+      image: alpine/psql:17.5
+      command: ["/bin/sh", "-c"]
+      args:
+        - "PGPASSWORD=$OSMO_PGPASSWORD psql -U postgres -h $OSMO_DB_HOST -p 5432 -d postgres -c 'CREATE DATABASE osmo;'"
+  restartPolicy: Never
+EOF
+kubectl get pod osmo-db-ops   # wait for Completed
+kubectl delete pod osmo-db-ops
+```
+
+**Step 2: Create namespace and secrets**
+```bash
+kubectl create namespace osmo
+
+# Database and Redis credentials
+kubectl create secret generic db-secret \
+  --from-literal=db-password=<your-db-password> --namespace osmo
+kubectl create secret generic redis-secret \
+  --from-literal=redis-password=<your-redis-password> --namespace osmo
+
+# OAuth2 Proxy secret (requires IdP client secret — see references/auth-guide.md)
+kubectl create secret generic oauth2-proxy-secrets \
+  --from-literal=client_secret=<your-idp-client-secret> \
+  --from-literal=cookie_secret=$(openssl rand -base64 32) \
+  --namespace osmo
+```
+
+For **no-IdP (defaultAdmin)** setup instead: read `references/auth-guide.md` — skip the oauth2-proxy secret and enable `services.defaultAdmin` in Helm values.
+
+For **IdP registration** (getting client ID, secret, endpoints): read `references/auth-guide.md`, then fetch the provider-specific URL from `references/url-index.md`.
+
+**Generate and create MEK (Master Encryption Key):**
+```bash
+# Generate 256-bit random key
+export RANDOM_KEY=$(openssl rand -base64 32 | tr -d '\n')
+
+# Format as JWK
+export JWK_JSON="{\"k\":\"$RANDOM_KEY\",\"kid\":\"key1\",\"kty\":\"oct\"}"
+
+# Base64-encode the JWK
+export ENCODED_JWK=$(echo -n "$JWK_JSON" | base64 | tr -d '\n')
+
+# Create ConfigMap
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mek-config
+  namespace: osmo
+data:
+  mek.yaml: |
+    currentMek: key1
+    meks:
+      key1: $ENCODED_JWK
+EOF
+```
+
+> Store the original JWK securely. Never commit it to version control.
+
+**Step 3: Prepare Helm values**
+
+Read `references/helm-values-templates.md` for minimal annotated skeletons of all three values files (`osmo_values.yaml`, `router_values.yaml`, `ui_values.yaml`). For full options, fetch `getting_started/deploy_service.md` from `references/url-index.md`.
+
+**Step 4: Deploy components**
+```bash
+helm repo add osmo https://helm.ngc.nvidia.com/nvidia/osmo
+helm repo update
+
+helm upgrade --install service osmo/service -f ./osmo_values.yaml -n osmo
+helm upgrade --install router osmo/router -f ./router_values.yaml -n osmo
+helm upgrade --install ui osmo/web-ui -f ./ui_values.yaml -n osmo
+```
+
+**Step 5: Verify**
+```bash
+kubectl get pods -n osmo
+# Expected: osmo-agent, osmo-delayed-job-monitor, osmo-logger,
+#           osmo-router, osmo-service, osmo-ui, osmo-worker all Running
+
+kubectl get svc -n osmo | grep gateway
+# osmo-gateway should show an EXTERNAL-IP
+```
+
+**Step 6: Post-deployment**
+1. Create DNS CNAME record: `<your-domain>` → `osmo-gateway` external IP/hostname (`kubectl get svc osmo-gateway -n osmo`)
+2. Test auth flow and IdP role mapping — see `references/auth-guide.md`
+3. Configure storage: `osmo config update WORKFLOW --file /tmp/workflow_log_config.json` (fetch `getting_started/configure_data.md` for the config JSON)
+
+---
+
+### Deploy Backend (Compute Plane)
+
+Run Steps 1–2 against the **control plane** (OSMO CLI pointed at your domain). Run Steps 2–4 against the **backend cluster** (kubectl context pointed at the compute cluster). For minimal deployments, both are the same cluster.
+
+**Step 1: Create service account and token**
+```bash
+osmo login https://osmo.example.com   # replace with your domain
+
+osmo user create backend-operator --roles osmo-backend
+
+export OSMO_SERVICE_TOKEN=$(osmo token set backend-token \
+  --user backend-operator \
+  --expires-at <YYYY-MM-DD> \
+  --description "Backend Operator Token" \
+  --roles osmo-backend \
+  -t json | jq -r '.token')
+```
+
+Save the token securely — it will not be shown again.
+
+**Step 2: Create namespaces and secret**
+```bash
+kubectl create namespace osmo-operator
+kubectl create namespace osmo-workflows
+
+kubectl create secret generic osmo-operator-token -n osmo-operator \
+  --from-literal=token=$OSMO_SERVICE_TOKEN
+```
+
+**Step 3: Install backend dependencies**
+
+Install KAI Scheduler and GPU Operator on the backend cluster. Fetch `install_backend/dependencies/dependencies.md` from `references/url-index.md` for exact commands and chart versions.
+
+**Step 4: Deploy backend operator**
+
+Read `references/helm-values-templates.md` for the `backend_operator_values.yaml` skeleton, then:
+```bash
+helm repo add osmo https://helm.ngc.nvidia.com/nvidia/osmo
+helm repo update
+
+helm upgrade --install osmo-operator osmo/backend-operator \
+  -f ./backend_operator_values.yaml \
+  --version <chart-version> \
+  --namespace osmo-operator
+```
+
+**Step 5: Validate**
+```bash
+export BACKEND_NAME=default  # or your backend name
+osmo config show BACKEND $BACKEND_NAME
+# Check "online": true in the output
+```
+
+**Troubleshoot — token expired:**
+```bash
+osmo token list --user backend-operator   # check expiry
+
+# Rotate token: generate new one (Step 1), then update the secret:
+kubectl delete secret osmo-operator-token -n osmo-operator
+kubectl create secret generic osmo-operator-token -n osmo-operator \
+  --from-literal=token=$OSMO_SERVICE_TOKEN
+```
+
+---
+
+### Configure Pool
+
+After the backend is online, link it to the default pool:
+```bash
+cat << EOF > /tmp/pool_config.json
+{
+  "pools": {
+    "default": {
+      "backend": "<your-backend-name>",
+      "description": "Default pool"
+    }
+  }
+}
+EOF
+
+osmo config update POOL --file /tmp/pool_config.json
+osmo pool list   # verify: default pool shows ONLINE
+```
+
+For multi-pool setups, hardware differentiation, or topology-aware scheduling: read `references/advanced-config.md`.
+
+---
+
+## Troubleshooting
+
+| Symptom | Action |
+|---------|--------|
+| DB connection failure | Verify `db-secret` values; check `kubectl logs -f <osmo-service-pod> -n osmo` |
+| `osmo-gateway` has no EXTERNAL-IP | Check cloud LoadBalancer provisioner; verify cloud LB quota |
+| Auth failures / 401 errors | Verify IdP client ID, client secret, and issuer URL in `osmo_values.yaml`; check `oauth2-proxy-secrets` |
+| Backend `"online": false` | Run `kubectl logs -f <osmo-operator-pod> -n osmo-operator`; check token expiry |
+| Pods in CrashLoopBackOff | Run `kubectl logs -f <pod-name> -n osmo`; check for missing secrets or misconfigured values |
+| "Too many open files" (local) | Raise inotify limits: `echo fs.inotify.max_user_watches=1048576 \| sudo tee -a /etc/sysctl.conf && sudo sysctl -p` |
+
+---
+
+## Reference Files
+
+Read these when the user's question goes beyond the inline steps above:
+
+| File | When to read |
+|------|-------------|
+| `references/helm-values-templates.md` | Configuring any Helm values file |
+| `references/auth-guide.md` | Auth setup (with/without IdP), roles, service accounts, token rotation |
+| `references/advanced-config.md` | Pools, pod templates, resource validation, group templates, KAI scheduler, dataset buckets |
+| `references/deploy-minimal.md` | Minimal single-cluster deployment (no IdP, port-forward access) |
+| `references/url-index.md` | Finding the fetch URL for any section of the deployment guide |
+
+---
+
+## Fetching Online Docs
+
+Base URL: `https://nvidia.github.io/OSMO/main/deployment_guide/`
+
+Rule: any `.html` URL → replace with `.md` to get fetchable Markdown.
+
+Always fetch (don't guess) for: Keycloak setup, per-cloud storage bucket setup, IdP provider-specific registration, full config schema definitions, observability/Grafana setup, on-prem cluster creation.
+
+Use `references/url-index.md` to find the exact path for any section before fetching.

--- a/skills/osmo-deploy/references/advanced-config.md
+++ b/skills/osmo-deploy/references/advanced-config.md
@@ -1,0 +1,276 @@
+# Advanced Configuration
+
+Post-deployment configuration for pools, pod templates, resource validation, and more.
+All configs are applied with `osmo config update <TYPE> --file <file.json>`.
+
+---
+
+## Resource Pools
+
+Pools organize compute resources into logical groups. Users submit workflows to a pool,
+which routes them to the right hardware on the right backend.
+
+**Pool architecture:**
+```
+Backend (K8s cluster)
+├── Pool: training-pool
+│   ├── Platform: a100
+│   └── Platform: h100
+└── Pool: simulation-pool
+    └── Platform: l40s
+```
+
+**Basic pool config:**
+```json
+{
+  "pools": {
+    "<pool-name>": {
+      "backend": "<backend-name>",
+      "description": "<description>"
+    }
+  }
+}
+```
+
+**Pool with platforms (hardware differentiation):**
+```json
+{
+  "pools": {
+    "gpu-pool": {
+      "backend": "default",
+      "description": "GPU training pool",
+      "platforms": {
+        "a100": {
+          "pod_template": "a100-template",
+          "resource_validation": "gpu-validation"
+        },
+        "h100": {
+          "pod_template": "h100-template",
+          "resource_validation": "gpu-validation"
+        }
+      }
+    }
+  }
+}
+```
+
+```bash
+osmo config update POOL --file /tmp/pool_config.json
+osmo pool list
+```
+
+For topology-aware scheduling, role-based pool access, and full pool reference:
+fetch `advanced_config/pool.md` from `references/url-index.md`.
+
+---
+
+## Pod Templates
+
+Pod templates define Kubernetes scheduling constraints applied to workflow task pods.
+
+**Minimal template structure:**
+```json
+{
+  "<template-name>": {
+    "spec": {
+      "nodeSelector": {
+        "<node-label-key>": "<value>"
+      },
+      "tolerations": [
+        {
+          "key": "<taint-key>",
+          "effect": "NoSchedule"
+        }
+      ],
+      "containers": [
+        {
+          "name": "user-container",
+          "resources": {
+            "requests": {
+              "cpu": "{{USER_CPU}}",
+              "memory": "{{USER_MEMORY}}",
+              "nvidia.com/gpu": "{{USER_GPU}}"
+            },
+            "limits": {
+              "memory": "{{USER_MEMORY}}",
+              "nvidia.com/gpu": "{{USER_GPU}}"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+**Available template variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `{{USER_CPU}}` | CPU requested by user's workflow task |
+| `{{USER_MEMORY}}` | Memory requested |
+| `{{USER_GPU}}` | GPU count requested |
+| `{{USER_STORAGE}}` | Storage requested |
+| `{{WF_ID}}` | Workflow ID |
+| `{{TASK_ID}}` | Task ID |
+
+```bash
+osmo config update POD_TEMPLATE --file /tmp/pod_template.json
+```
+
+For Jinja2 conditionals, template merging, security contexts, and `/dev/shm` shared memory:
+fetch `advanced_config/pod_template.md` from `references/url-index.md`.
+
+---
+
+## Resource Validation
+
+Pre-flight rules that reject workflows requesting invalid resources before they reach the scheduler.
+
+**Rule structure:**
+```json
+{
+  "rules": [
+    {
+      "operator": "LE",
+      "left_operand": "{{USER_GPU}}",
+      "right_operand": "8",
+      "assert_message": "Cannot request more than 8 GPUs per task"
+    }
+  ]
+}
+```
+
+**Operators:** `LE` (≤), `LT` (<), `GE` (≥), `GT` (>), `EQ` (=), `NE` (≠)
+
+**Available variables:** `{{USER_CPU}}`, `{{USER_GPU}}`, `{{USER_MEMORY}}`, `{{USER_STORAGE}}`
+(also `{{K8_CPU}}`, `{{K8_GPU}}`, `{{K8_MEMORY}}` for K8s-format values)
+
+**Example — GPU and memory guardrails:**
+```json
+{
+  "rules": [
+    {
+      "operator": "LE",
+      "left_operand": "{{USER_GPU}}",
+      "right_operand": "8",
+      "assert_message": "Max 8 GPUs per task on this pool"
+    },
+    {
+      "operator": "GE",
+      "left_operand": "{{USER_GPU}}",
+      "right_operand": "1",
+      "assert_message": "GPU pool requires at least 1 GPU"
+    },
+    {
+      "operator": "LE",
+      "left_operand": "{{USER_MEMORY}}",
+      "right_operand": "400",
+      "assert_message": "Memory limit is 400 GB per task"
+    }
+  ]
+}
+```
+
+```bash
+osmo config update RESOURCE_VALIDATION --file /tmp/resource_validation.json
+```
+
+Reference a validation config in a pool's platform:
+```json
+"platforms": { "a100": { "resource_validation": "<validation-config-name>" } }
+```
+
+For full validation reference and troubleshooting: fetch `advanced_config/resource_validation.md`.
+
+---
+
+## Group Templates
+
+Group templates create Kubernetes resources (ConfigMaps, CRDs) alongside workflow task groups —
+useful for NVLink ComputeDomain, custom schedulers, or shared cluster state.
+
+The backend operator needs RBAC permissions for any resource kinds used in group templates.
+Add to `backend_operator_values.yaml`:
+```yaml
+services:
+  backendWorker:
+    extraRBACRules:
+      - apiGroups: ["<api-group>"]
+        resources: ["<resource-kind>"]
+        verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+```
+
+For full group template structure and the NVLink ComputeDomain example:
+fetch `advanced_config/group_template.md` from `references/url-index.md`.
+
+---
+
+## KAI Scheduler
+
+KAI provides co-scheduling, preemption, and fair GPU sharing. Installed on the backend cluster.
+
+**Install:**
+```bash
+helm upgrade --install kai-scheduler \
+  oci://ghcr.io/nvidia/kai-scheduler/kai-scheduler \
+  --version <version> \
+  --create-namespace -n kai-scheduler \
+  --set global.nodeSelector.node_group=kai-scheduler \
+  --set "scheduler.additionalArgs[0]=--default-staleness-grace-period=-1s" \
+  --set "scheduler.additionalArgs[1]=--update-pod-eviction-condition=true" \
+  --wait
+```
+
+For GPU allocation model (Guarantee/Weight/Maximum), preemption policies, and fair sharing:
+fetch `advanced_config/scheduler.md` from `references/url-index.md`.
+
+---
+
+## Dataset Buckets
+
+Register external cloud storage buckets so OSMO can reference datasets by name.
+
+```bash
+cat << EOF > /tmp/dataset_config.json
+{
+  "buckets": {
+    "<bucket-alias>": {
+      "uri": "s3://<bucket-name>",
+      "credentials": "<credential-name>"
+    }
+  }
+}
+EOF
+osmo config update DATASET --file /tmp/dataset_config.json
+osmo bucket list   # verify registration
+```
+
+For multi-cloud buckets, team-based organization, and naming conventions:
+fetch `advanced_config/dataset_buckets.md` from `references/url-index.md`.
+
+---
+
+## Common `osmo config` Commands
+
+```bash
+# Show current config for a type
+osmo config show POOL
+osmo config show BACKEND <name>
+osmo config show POD_TEMPLATE <name>
+
+# List all configs of a type
+osmo config list POOL
+
+# Update from file
+osmo config update <TYPE> --file <file.json>
+
+# Diff current vs. previous version
+osmo config diff <TYPE> <name>
+
+# View config history
+osmo config history <TYPE> <name>
+
+# Roll back to a previous version
+osmo config rollback <TYPE> <name> --version <N>
+```

--- a/skills/osmo-deploy/references/auth-guide.md
+++ b/skills/osmo-deploy/references/auth-guide.md
@@ -1,0 +1,163 @@
+# Authentication Guide
+
+OSMO authentication operates in two modes. Choose based on your environment.
+
+---
+
+## Which path are you on?
+
+**No IdP (defaultAdmin)**
+Best for: development, testing, environments without a corporate SSO system.
+- A single admin user is created at startup with a configured password
+- That password is the access token — use it with `osmo login` or `Authorization: Bearer <password>`
+- Users and roles are managed entirely through OSMO's API/CLI
+
+**With IdP (OAuth2/OIDC)**
+Best for: production with Microsoft Entra ID, Google Workspace, Okta, AWS IAM Identity Center, etc.
+- Users log in via browser SSO or CLI device flow; your IdP issues JWTs
+- Envoy validates JWTs and forwards identity to OSMO
+- Roles can come from OSMO's database, your IdP groups (via role mapping), or both
+
+---
+
+## No-IdP Setup (defaultAdmin)
+
+**1. Create the password secret** (must be exactly 43 characters):
+```bash
+kubectl create secret generic default-admin-secret \
+  --namespace osmo \
+  --from-literal=password='<your-43-char-password>'
+```
+
+**2. Enable in `osmo_values.yaml`:**
+```yaml
+services:
+  defaultAdmin:
+    enabled: true
+    username: "admin"
+    passwordSecretName: default-admin-secret
+    passwordSecretKey: password
+  service:
+    auth:
+      enabled: false   # disable IdP auth
+
+gateway:
+  oauth2Proxy:
+    enabled: false     # disable OAuth2 Proxy
+```
+
+**3. Log in:**
+```bash
+osmo login https://osmo.example.com
+# When prompted for token, enter the 43-char password
+```
+
+After login, create additional users, assign roles, and create access tokens via CLI or UI.
+
+---
+
+## With-IdP Setup
+
+**What you need from your IdP:**
+
+| Value | Used in |
+|-------|---------|
+| Client ID | `services.service.auth.device_client_id`, `browser_client_id`; `gateway.oauth2Proxy.clientId`; `gateway.envoy.jwt.providers[].audience` |
+| Client secret | `oauth2-proxy-secrets` K8s secret (`client_secret` key) |
+| Issuer URL | `gateway.envoy.jwt.providers[].issuer`; `gateway.oauth2Proxy.oidcIssuerUrl` |
+| JWKS URI | `gateway.envoy.jwt.providers[].jwks_uri` |
+| Token endpoint | `services.service.auth.token_endpoint` |
+| Authorize URL | `services.service.auth.browser_endpoint` |
+| Device auth URL | `services.service.auth.device_endpoint` |
+| Logout URL | `services.service.auth.logout_endpoint` |
+
+Register OSMO as an OAuth2/OIDC application in your IdP and use the redirect URI:
+`https://<your-domain>/oauth2/callback`
+
+For provider-specific registration steps, fetch the URL from `references/url-index.md`:
+- Microsoft Entra ID, Google, AWS IAM: `appendix/authentication/identity_provider_setup.md`
+- Keycloak (self-hosted broker): `appendix/keycloak_setup.md`
+
+---
+
+## Built-in Roles
+
+| Role | Description |
+|------|-------------|
+| `osmo-admin` | Full platform management (users, roles, pools, backends, configs) |
+| `osmo-user` | Submit workflows, manage own datasets and access tokens |
+| `osmo-backend` | Backend operator authentication (used by the backend operator service account) |
+| `osmo-ctrl` | Internal use by osmo-ctrl container (do not assign to human users) |
+| `osmo-default` | Read-only access; assigned to users who log in before being granted a role |
+
+For the full role/policy reference, fetch `appendix/authentication/roles_policies.md`.
+
+---
+
+## Service Account Pattern (Backend Operator)
+
+The backend operator authenticates as an OSMO user with the `osmo-backend` role:
+
+```bash
+# 1. Create user
+osmo user create backend-operator --roles osmo-backend
+
+# 2. Create access token
+export OSMO_SERVICE_TOKEN=$(osmo token set backend-token \
+  --user backend-operator \
+  --expires-at <YYYY-MM-DD> \
+  --roles osmo-backend \
+  -t json | jq -r '.token')
+
+# 3. Store in K8s secret on the backend cluster
+kubectl create secret generic osmo-operator-token -n osmo-operator \
+  --from-literal=token=$OSMO_SERVICE_TOKEN
+```
+
+For other service accounts (CI/CD, automation): same pattern, different user/role.
+Full details: fetch `appendix/authentication/service_accounts.md`.
+
+---
+
+## Token Rotation
+
+```bash
+# Check current token expiry
+osmo token list --user backend-operator
+
+# Create a new token (same as Step 2 above)
+export OSMO_SERVICE_TOKEN=$(osmo token set backend-token \
+  --user backend-operator \
+  --expires-at <YYYY-MM-DD> \
+  --roles osmo-backend \
+  -t json | jq -r '.token')
+
+# Update the K8s secret
+kubectl delete secret osmo-operator-token -n osmo-operator
+kubectl create secret generic osmo-operator-token -n osmo-operator \
+  --from-literal=token=$OSMO_SERVICE_TOKEN
+
+# Restart the backend operator to pick up the new secret
+kubectl rollout restart deployment -n osmo-operator
+```
+
+---
+
+## Managing Users and Roles (no-IdP or supplemental)
+
+```bash
+# Create user with role
+osmo user create <username> --roles osmo-user
+
+# List users
+osmo user list
+
+# Create access token for a user
+osmo token set <token-name> --user <username> --expires-at <YYYY-MM-DD> --roles osmo-user
+
+# List tokens for a user
+osmo token list --user <username>
+```
+
+For IdP group → OSMO role mapping: fetch `appendix/authentication/idp_role_mapping.md`.
+For managing users via API/UI: fetch `appendix/authentication/managing_users.md`.

--- a/skills/osmo-deploy/references/deploy-minimal.md
+++ b/skills/osmo-deploy/references/deploy-minimal.md
@@ -1,0 +1,231 @@
+# Minimal Deployment
+
+Single-cluster deployment: service and backend operator in the same Kubernetes cluster.
+No identity provider — uses defaultAdmin for authentication. Suitable for testing, evaluation,
+and small teams. Not recommended for production (no SSO, limited auth).
+
+For full production deployment (separate clusters, IdP): see the inline production steps in `SKILL.md`.
+For requirements (K8s, PostgreSQL, Redis): fetch `requirements/prereqs.md` from `references/url-index.md`.
+
+---
+
+## Step 1: Create Namespace and Add Helm Repo
+
+```bash
+kubectl create namespace osmo-minimal
+
+helm repo add osmo https://helm.ngc.nvidia.com/nvidia/osmo
+helm repo update
+```
+
+## Step 2: Create Secrets
+
+```bash
+# Database and Redis passwords
+kubectl create secret generic db-secret \
+  --from-literal=db-password=<your-db-password> --namespace osmo-minimal
+kubectl create secret generic redis-secret \
+  --from-literal=redis-password=<your-redis-password> --namespace osmo-minimal
+
+# Default admin password (must be exactly 43 characters)
+kubectl create secret generic default-admin-secret \
+  --namespace osmo-minimal \
+  --from-literal=password='<your-43-char-password>'
+```
+
+**Generate MEK (Master Encryption Key):**
+```bash
+export RANDOM_KEY=$(openssl rand -base64 32 | tr -d '\n')
+export JWK_JSON="{\"k\":\"$RANDOM_KEY\",\"kid\":\"key1\",\"kty\":\"oct\"}"
+export ENCODED_JWK=$(echo -n "$JWK_JSON" | base64 | tr -d '\n')
+
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mek-config
+  namespace: osmo-minimal
+data:
+  mek.yaml: |
+    currentMek: key1
+    meks:
+      key1: $ENCODED_JWK
+EOF
+```
+
+## Step 3: Create PostgreSQL Database
+
+```bash
+export OSMO_DB_HOST=<your-db-host>
+export OSMO_PGPASSWORD=<your-postgres-password>
+
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: osmo-db-ops
+spec:
+  containers:
+    - name: osmo-db-ops
+      image: alpine/psql:17.5
+      command: ["/bin/sh", "-c"]
+      args:
+        - "PGPASSWORD=$OSMO_PGPASSWORD psql -U postgres -h $OSMO_DB_HOST -p 5432 -d postgres -c 'CREATE DATABASE osmo_db;'"
+  restartPolicy: Never
+EOF
+
+kubectl get pod osmo-db-ops   # wait for Completed
+kubectl delete pod osmo-db-ops
+```
+
+## Step 4: Prepare Helm Values
+
+**`osmo_values.yaml`:**
+```yaml
+global:
+  osmoImageLocation: <osmo-image-registry>   # REQUIRED
+  osmoImageTag: <version>                     # REQUIRED
+
+services:
+  configFile:
+    enabled: true
+  postgres:
+    enabled: false
+    serviceName: <your-postgres-host>
+    db: osmo_db
+  redis:
+    enabled: false
+    serviceName: <your-redis-host>
+    port: 6379
+    tlsEnabled: true   # set false if Redis has no TLS
+  defaultAdmin:
+    enabled: true
+    username: "admin"
+    passwordSecretName: default-admin-secret
+    passwordSecretKey: password
+
+gateway:
+  oauth2Proxy:
+    enabled: false
+  authz:
+    enabled: false
+```
+
+**`ui_values.yaml`:**
+```yaml
+global:
+  osmoImageLocation: <osmo-image-registry>
+  osmoImageTag: <version>
+
+services:
+  ui:
+    apiHostname: osmo-gateway.osmo-minimal.svc.cluster.local:80
+```
+
+**`router_values.yaml`:**
+```yaml
+global:
+  osmoImageLocation: <osmo-image-registry>
+  osmoImageTag: <version>
+
+services:
+  configFile:
+    enabled: true
+  postgres:
+    serviceName: <your-postgres-host>
+    db: osmo_db
+```
+
+## Step 5: Deploy
+
+```bash
+helm upgrade --install osmo-minimal osmo/service \
+  -f ./osmo_values.yaml --namespace osmo-minimal
+
+helm upgrade --install ui-minimal osmo/web-ui \
+  -f ./ui_values.yaml --namespace osmo-minimal
+
+helm upgrade --install router-minimal osmo/router \
+  -f ./router_values.yaml --namespace osmo-minimal
+```
+
+## Step 6: Verify and Access
+
+```bash
+kubectl get pods -n osmo-minimal
+# Expected: osmo-agent, osmo-delayed-job-monitor, osmo-logger,
+#           osmo-router, osmo-service, osmo-ui, osmo-worker all Running
+
+# Access OSMO via port-forward
+kubectl port-forward service/osmo-gateway 9000:80 -n osmo-minimal
+```
+
+OSMO UI: http://localhost:9000
+OSMO API: http://localhost:9000/api
+
+## Step 7: Deploy Backend Operator (same cluster)
+
+```bash
+# Port-forward first, then log in
+kubectl port-forward service/osmo-gateway 9000:80 -n osmo-minimal &
+osmo login http://localhost:9000 --method=dev --username=testuser
+
+# Create service account and token
+osmo user create backend-operator --roles osmo-backend
+export BACKEND_TOKEN=$(osmo token set backend-token \
+  --user backend-operator \
+  --expires-at <YYYY-MM-DD> \
+  --roles osmo-backend \
+  -t json | jq -r '.token')
+
+# Create namespaces and secret in same cluster
+kubectl create namespace osmo-operator
+kubectl create namespace osmo-workflows
+kubectl create secret generic osmo-operator-token -n osmo-operator \
+  --from-literal=token=$BACKEND_TOKEN
+```
+
+**`backend_operator_values.yaml`:**
+```yaml
+global:
+  osmoImageLocation: <osmo-image-registry>
+  osmoImageTag: <version>
+  serviceUrl: http://osmo-gateway.osmo-minimal.svc.cluster.local
+  agentNamespace: osmo-operator
+  backendNamespace: osmo-workflows
+  backendName: default
+  accountTokenSecret: osmo-operator-token
+  loginMethod: token
+```
+
+```bash
+helm upgrade --install osmo-operator osmo/backend-operator \
+  -f ./backend_operator_values.yaml \
+  --namespace osmo-operator
+
+# Validate
+osmo config show BACKEND default   # check "online": true
+```
+
+## Step 8: Basic Configuration
+
+```bash
+# Configure default pool
+cat << EOF > /tmp/pool_config.json
+{"pools": {"default": {"backend": "default", "description": "Default pool"}}}
+EOF
+osmo config update POOL --file /tmp/pool_config.json
+
+# Set service base URL (for CLI access outside port-forward)
+cat << EOF > /tmp/service_config.json
+{"service": {"service_base_url": "http://localhost:9000"}}
+EOF
+osmo config update SERVICE --file /tmp/service_config.json
+```
+
+## Upgrading to Production
+
+When ready to move to production (separate clusters, IdP, cloud LB):
+- See the production deploy steps in `SKILL.md`
+- For IdP setup: read `references/auth-guide.md`
+- For cloud infrastructure: fetch from `references/url-index.md`

--- a/skills/osmo-deploy/references/helm-values-templates.md
+++ b/skills/osmo-deploy/references/helm-values-templates.md
@@ -1,0 +1,189 @@
+# Helm Values Templates
+
+Minimal annotated skeletons for all OSMO Helm charts. These cover required fields only.
+For optional fields (custom resource limits, advanced gateway config, additional replicas),
+fetch `getting_started/deploy_service.md` or `install_backend/deploy_backend.md` from the URL index.
+
+> **Version staleness:** If a field doesn't exist in your chart version, fetch the full values from
+> the deploy guide for the current schema.
+
+---
+
+## `osmo_values.yaml` — API Service + Gateway
+
+```yaml
+# Global config shared by all OSMO services
+global:
+  osmoImageLocation: nvcr.io/nvidia/osmo   # REQUIRED
+  osmoImageTag: <version>                   # REQUIRED — e.g. "6.0.0"
+  serviceAccountName: osmo
+
+services:
+  configFile:
+    enabled: true
+
+  # External PostgreSQL (set enabled: false to use external DB)
+  postgres:
+    enabled: false
+    serviceName: <your-postgres-host>   # REQUIRED
+    port: 5432
+    db: osmo                            # REQUIRED — database name created in deploy step 1
+    user: postgres
+
+  # External Redis (set enabled: false to use external cache)
+  redis:
+    enabled: false
+    serviceName: <your-redis-host>      # REQUIRED
+    port: 6379
+    tlsEnabled: true                    # set false if Redis has no TLS
+
+  service:
+    hostname: <your-domain>             # REQUIRED — e.g. "osmo.example.com"
+    # IdP endpoints — required when using an identity provider
+    # Skip this block and enable defaultAdmin below if not using an IdP
+    auth:
+      enabled: true
+      device_endpoint: <idp-device-auth-url>    # for CLI device flow login
+      device_client_id: <client-id>
+      browser_endpoint: <idp-authorize-url>     # for browser SSO login
+      browser_client_id: <client-id>
+      token_endpoint: <idp-token-url>
+      logout_endpoint: <idp-logout-url>
+
+  # Default admin — enable this INSTEAD of auth above when not using an IdP
+  # Password must be exactly 43 characters. Acts as the bootstrap access token.
+  defaultAdmin:
+    enabled: false                           # set true for no-IdP deployments
+    username: "admin"
+    passwordSecretName: default-admin-secret # kubectl create secret with 43-char password
+    passwordSecretKey: password
+
+gateway:
+  envoy:
+    hostname: <your-domain>                  # REQUIRED — same as services.service.hostname
+
+    # Hostname of your IdP for JWT JWKS fetching (extracted from jwks_uri below)
+    idp:
+      host: <idp-hostname>                   # e.g. "login.microsoftonline.com"
+
+    # Internal OSMO JWT cluster (for access-token-based auth)
+    internalJwks:
+      enabled: true
+      cluster: osmo-service-jwks
+      host: osmo-service
+      port: 80
+
+    # JWT providers — add one entry per token source
+    jwt:
+      user_header: x-osmo-user
+      providers:
+        # Your IdP (example: Microsoft Entra ID — adjust issuer/audience/jwks_uri for your provider)
+        - issuer: <idp-issuer-url>           # REQUIRED — e.g. "https://login.microsoftonline.com/<tenant-id>/v2.0"
+          audience: <client-id>             # REQUIRED
+          jwks_uri: <idp-jwks-uri>          # REQUIRED — e.g. "https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys"
+          user_claim: preferred_username
+          cluster: idp
+        # OSMO-issued JWTs (keep this entry for access-token support)
+        - issuer: osmo
+          audience: osmo
+          jwks_uri: http://osmo-service/api/auth/keys
+          user_claim: unique_name
+          cluster: osmo-service-jwks
+
+  # OAuth2 Proxy — handles browser SSO flow; skip when using defaultAdmin
+  oauth2Proxy:
+    enabled: true                            # set false for defaultAdmin deployments
+    provider: oidc
+    oidcIssuerUrl: <idp-issuer-url>          # REQUIRED — same as jwt.providers[0].issuer
+    clientId: <client-id>                    # REQUIRED
+    cookieDomain: .<your-domain>             # REQUIRED — note leading dot
+    scope: "openid email profile"
+    useKubernetesSecrets: true
+    secretName: oauth2-proxy-secrets         # created in deploy step 2
+    clientSecretKey: client_secret
+    cookieSecretKey: cookie_secret
+```
+
+---
+
+## `router_values.yaml` — Router Service
+
+```yaml
+global:
+  osmoImageLocation: nvcr.io/nvidia/osmo   # REQUIRED
+  osmoImageTag: <version>                   # REQUIRED — match service chart version
+
+services:
+  configFile:
+    enabled: true
+
+  service:
+    hostname: <your-domain>                  # REQUIRED — same as in osmo_values.yaml
+    serviceAccountName: router
+
+  postgres:
+    serviceName: <your-postgres-host>        # REQUIRED
+    port: 5432
+    db: osmo                                 # REQUIRED — same database
+    user: postgres
+```
+
+---
+
+## `ui_values.yaml` — Web UI
+
+```yaml
+global:
+  osmoImageLocation: nvcr.io/nvidia/osmo   # REQUIRED
+  osmoImageTag: <version>                   # REQUIRED
+
+services:
+  ui:
+    hostname: <your-domain>                  # REQUIRED
+    apiHostname: osmo-gateway:80             # internal gateway address — keep as-is
+```
+
+---
+
+## `backend_operator_values.yaml` — Backend Operator
+
+```yaml
+global:
+  osmoImageTag: <version>                    # REQUIRED — match service chart version
+  serviceUrl: https://<your-domain>          # REQUIRED — OSMO control plane URL
+  agentNamespace: osmo-operator             # namespace created in deploy step 2
+  backendNamespace: osmo-workflows          # namespace created in deploy step 2
+  backendName: <your-backend-name>          # REQUIRED — e.g. "default" or "gpu-cluster-1"
+  accountTokenSecret: osmo-operator-token   # secret created in deploy step 2
+  loginMethod: token
+
+  services:
+    backendListener:
+      resources:
+        requests:
+          cpu: "1"
+          memory: "1Gi"
+        limits:
+          memory: "1Gi"
+    backendWorker:
+      resources:
+        requests:
+          cpu: "1"
+          memory: "1Gi"
+        limits:
+          memory: "1Gi"
+      # Uncomment and extend if using group templates that create CRDs or ConfigMaps:
+      # extraRBACRules:
+      #   - apiGroups: [""]
+      #     resources: ["configmaps"]
+      #     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+```
+
+---
+
+## Notes
+
+- All `<your-...>` placeholders must be replaced with real values before deploying
+- The `osmoImageTag` must be consistent across all charts deployed in the same release
+- For `defaultAdmin` deployments: set `gateway.oauth2Proxy.enabled: false` and `services.service.auth.enabled: false`, and add a `default-admin-secret` K8s secret with a 43-character password
+- For IdP provider-specific values (Entra ID, Google, AWS): read `references/auth-guide.md` then fetch `appendix/authentication/identity_provider_setup.md`

--- a/skills/osmo-deploy/references/url-index.md
+++ b/skills/osmo-deploy/references/url-index.md
@@ -1,0 +1,121 @@
+# OSMO Deployment Guide — URL Index
+
+**Base URL:** `https://nvidia.github.io/OSMO/main/deployment_guide/`
+
+**URL rule:** any `.html` page URL → replace with `.md` to get fetchable Markdown.
+
+**Usage:** Read this file to find the exact fetch URL before calling WebFetch on any deployment guide page. Append the path below to the base URL.
+
+---
+
+## Introduction
+
+| Topic | Path |
+|-------|------|
+| Guide overview | `index.md` |
+| Architecture (control/compute planes, component roles) | `introduction/architecture.md` |
+
+## Requirements
+
+| Topic | Path |
+|-------|------|
+| Cloud prerequisites (K8s, PostgreSQL, Redis, VPC) | `requirements/prereqs.md` |
+| Required tools (Helm, kubectl, psql, OSMO CLI) | `requirements/tools.md` |
+| Networking (FQDN, SSL/TLS, DNS, load balancer) | `requirements/networking.md` |
+| Instance sizing (CPU, RAM, storage) | `requirements/system_reqs.md` |
+
+## Getting Started
+
+| Topic | Path |
+|-------|------|
+| Infrastructure setup (Terraform / manual cloud setup) | `getting_started/infrastructure_setup.md` |
+| Deploy service — full guide with complete Helm values | `getting_started/deploy_service.md` |
+| Configure data storage (workflow logs, datasets) | `getting_started/configure_data.md` |
+| Storage: AWS S3 | `getting_started/create_storage/s3/index.md` |
+| Storage: Azure Blob | `getting_started/create_storage/azure/index.md` |
+| Storage: GCP Cloud Storage | `getting_started/create_storage/gcp/index.md` |
+| Storage: TOS (Torch Object Storage) | `getting_started/create_storage/tos/index.md` |
+
+## Install Backend
+
+| Topic | Path |
+|-------|------|
+| Backend overview (cloud vs. on-prem) | `install_backend/create_backend/index.md` |
+| Cloud cluster setup (EKS, AKS, GKE) | `install_backend/create_backend/cloud_setup.md` |
+| On-prem cluster setup (kubeadm) | `install_backend/create_backend/onprem_setup.md` |
+| Dependencies (KAI scheduler, GPU Operator) | `install_backend/dependencies/dependencies.md` |
+| Deploy backend operator | `install_backend/deploy_backend.md` |
+| Configure resource pool | `install_backend/configure_pool.md` |
+| Validate (run sample workflows) | `install_backend/validate_osmo.md` |
+| Observability (Grafana dashboards, alerts) | `install_backend/observability.md` |
+
+## Advanced Configuration
+
+| Topic | Path |
+|-------|------|
+| Resource pools (multi-pool, platforms, topology) | `advanced_config/pool.md` |
+| Pod templates | `advanced_config/pod_template.md` |
+| Group templates (CRDs alongside pods) | `advanced_config/group_template.md` |
+| Resource validation rules | `advanced_config/resource_validation.md` |
+| KAI scheduler (preemption, fair sharing, GPU allocation) | `advanced_config/scheduler.md` |
+| Rsync (live file sync during workflows) | `advanced_config/rsync.md` |
+| Dataset buckets (external cloud storage registration) | `advanced_config/dataset_buckets.md` |
+
+## Appendix
+
+| Topic | Path |
+|-------|------|
+| Local deployment (KIND / nvkind) | `appendix/deploy_local.md` |
+| Minimal deployment (single cluster) | `appendix/deploy_minimal.md` |
+| Workflow execution (3-container pod architecture) | `appendix/workflow_execution.md` |
+| Authentication overview | `appendix/authentication/index.md` |
+| Authentication flow (with / without IdP) | `appendix/authentication/authentication_flow.md` |
+| Roles and policies (full reference) | `appendix/authentication/roles_policies.md` |
+| Managing users | `appendix/authentication/managing_users.md` |
+| IdP setup (Microsoft Entra ID, Google, AWS) | `appendix/authentication/identity_provider_setup.md` |
+| IdP role mapping | `appendix/authentication/idp_role_mapping.md` |
+| Service accounts (access tokens, backend operators) | `appendix/authentication/service_accounts.md` |
+| Keycloak setup (self-hosted IdP broker) | `appendix/keycloak_setup.md` |
+
+## Config Schema Reference
+
+| Topic | Path |
+|-------|------|
+| Backend config schema | `references/configs_definitions/backend.md` |
+| Pool config schema | `references/configs_definitions/pool.md` |
+| Pod template schema | `references/configs_definitions/pod_template.md` |
+| Group template schema | `references/configs_definitions/group_template.md` |
+| Resource validation schema | `references/configs_definitions/resource_validation.md` |
+| Workflow config schema | `references/configs_definitions/workflow.md` |
+| Dataset config schema | `references/configs_definitions/dataset.md` |
+| Roles config schema | `references/configs_definitions/roles.md` |
+| Service config schema | `references/configs_definitions/service.md` |
+
+## Config CLI Reference
+
+| Command | Path |
+|---------|------|
+| `osmo config show` | `references/config_cli/config_show.md` |
+| `osmo config list` | `references/config_cli/config_list.md` |
+| `osmo config update` | `references/config_cli/config_update.md` |
+| `osmo config get` | `references/config_cli/config_get.md` |
+| `osmo config set` | `references/config_cli/config_set.md` |
+| `osmo config delete` | `references/config_cli/config_delete.md` |
+| `osmo config diff` | `references/config_cli/config_diff.md` |
+| `osmo config history` | `references/config_cli/config_history.md` |
+| `osmo config tag` | `references/config_cli/config_tag.md` |
+| `osmo config rollback` | `references/config_cli/config_rollback.md` |
+
+## User CLI Reference
+
+| Command | Path |
+|---------|------|
+| `osmo user create` | `references/user_cli/user_create.md` |
+| `osmo user list` | `references/user_cli/user_list.md` |
+| `osmo user get` | `references/user_cli/user_get.md` |
+| `osmo user update` | `references/user_cli/user_update.md` |
+| `osmo user delete` | `references/user_cli/user_delete.md` |
+| `osmo token set` | `references/user_cli/token_set.md` |
+| `osmo token list` | `references/user_cli/token_list.md` |
+| `osmo token delete` | `references/user_cli/token_delete.md` |
+| `osmo token roles` | `references/user_cli/token_roles.md` |


### PR DESCRIPTION
Condenses the OSMO deployment guide into a Claude skill that covers all three deployment paths (local KIND, minimal single-cluster, production), with exact commands inlined for the critical flows and fetchable online docs for the long-tail reference content.

<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->

Issue #<issue number | "None">

## Checklist
- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive OSMO deployment guide covering local KIND setup, production deployment, and backend cluster provisioning.
  * Added authentication guide documenting defaultAdmin and OAuth2/OIDC modes.
  * Added minimal deployment guide for single-cluster deployments without IdP.
  * Added advanced configuration reference for resource pools, scheduling, and external datasets.
  * Added Helm values template reference for deployment configuration.
  * Added URL index for documentation navigation.

* **Chores**
  * Updated `.gitignore` to exclude Git worktree files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->