### PR TITLE
feat(charts): expose extraEnv on oauth2-proxy container

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -290,6 +290,7 @@ Envoy uses filesystem-based dynamic configuration (LDS/CDS). When the ConfigMap 
 | `gateway.oauth2Proxy.clientId` | OAuth2 client ID | `""` |
 | `gateway.oauth2Proxy.cookieName` | Session cookie name | `_osmo_session` |
 | `gateway.oauth2Proxy.redisSessionStore` | Use Redis for session store | `true` |
+| `gateway.oauth2Proxy.extraEnv` | Extra environment variables for the oauth2-proxy container (e.g. `OAUTH2_PROXY_REDIS_PASSWORD` from a Secret ref when Redis requires AUTH) | `[]` |
 
 #### Gateway Authz
 

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -317,6 +317,10 @@ spec:
           {{- range $gw.oauth2Proxy.extraArgs }}
           - {{ . }}
           {{- end }}
+        {{- with (include "osmo.extra-env" $gw.oauth2Proxy) }}
+        env:
+          {{- . | nindent 10 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: {{ $gw.oauth2Proxy.httpPort }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1539,6 +1539,10 @@ gateway:
       clientSecret: /etc/oauth2-proxy/client-secret
       cookieSecret: /etc/oauth2-proxy/cookie-secret
     extraArgs: []
+    ## Extra environment variables for the oauth2-proxy container. Useful for
+    ## passing credentials from Secrets — e.g. Redis password via
+    ## OAUTH2_PROXY_REDIS_PASSWORD when redisSessionStore is enabled.
+    extraEnv: []
     redis:
       serviceName: ""
       port: 6379


### PR DESCRIPTION
## Summary

Adds an `extraEnv` values field on `gateway.oauth2Proxy` so users can inject environment variables — most importantly `OAUTH2_PROXY_REDIS_PASSWORD` — from Kubernetes Secret refs.

## Why

Before this change, if you enable Redis session storage (`gateway.oauth2Proxy.redisSessionStore: true`) against a Redis that requires authentication (e.g. Azure Cache for Redis, any password-protected Redis), there's no way to supply the password:
- The chart's `--redis-connection-url` template doesn't embed credentials.
- `oauth2-proxy` v7.14.2 has no `--redis-password-file` flag.
- Putting `--redis-password=<plaintext>` in `extraArgs` leaks the password into the rendered pod spec.

Hit this on sandbox-azure when enabling the new gateway — oauth2-proxy crashed on startup with `unable to set a redis initialization key: NOAUTH Authentication required`.

## What

Follows the same `osmo.extra-env` helper pattern already used by the `authz` container and by the per-service deployments (worker, logger, api, agent, delayed-job-monitor). Default `extraEnv: []`, so no behavior change for existing deployments.

Example values:
```yaml
gateway:
  oauth2Proxy:
    redisSessionStore: true
    redis:
      serviceName: my-redis.example.com
      port: 10000
      tlsEnabled: true
      dbNumber: 0
    extraEnv:
      - name: OAUTH2_PROXY_REDIS_PASSWORD
        valueFrom:
          secretKeyRef:
            name: redis-secret
            key: redis-password
```

## Test plan

- [x] `helm template` renders the new `env:` block only when `extraEnv` is non-empty
- [x] `helm upgrade` on sandbox-azure: oauth2-proxy pod transitions Running, accepts traffic, session cookies persist across replicas (verified via external `/api/version` and login flow)
- [x] `helm template` with default values (`extraEnv: []`) produces identical output to before this change (reviewer spot-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing configurable environment variables into the OAuth2 Proxy container.

* **Documentation**
  * Updated chart documentation to include the new configuration option for extra environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->