### PR TITLE
fix(ui-datasets): align manifest sort comparator with binary search

### DIFF
--- a/src/ui/src/lib/api/adapter/datasets.test.ts
+++ b/src/ui/src/lib/api/adapter/datasets.test.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { buildDirectoryListing, processManifestItems, type RawFileItem } from "@/lib/api/adapter/datasets";
+
+function createRawItem(relativePath: string): RawFileItem {
+  return {
+    relative_path: relativePath,
+    size: 1,
+    etag: `etag-${relativePath}`,
+    storage_path: `s3://bucket/${relativePath}`,
+    url: `https://example.com/${relativePath}`,
+  };
+}
+
+/**
+ * Drives the full manifest pipeline (sort → binary-search → directory listing)
+ * the same way production does, so sort-vs-search comparator inconsistencies
+ * surface here. The fake manifest is passed raw; processManifestItems sorts it.
+ */
+function listAtPath(paths: string[], path: string) {
+  const manifest = processManifestItems(paths.map(createRawItem));
+  return buildDirectoryListing(manifest.byPath, path);
+}
+
+describe("dataset manifest browsing", () => {
+  it("lists children of a directory whose sibling shares its name as a prefix", () => {
+    // Hive-style partitioned layout: two sibling directories where one directory's
+    // name is a prefix of the other ("processed" vs "processed_invalid"). Under
+    // Unicode collation (localeCompare), "_" and "/" are treated as equivalent
+    // punctuation, which sorts "processed_invalid/..." BEFORE "processed/..." —
+    // the opposite of `<` ordering. binarySearchByPath uses `<`, so if the
+    // manifest sort disagrees the search starts at the wrong index and the
+    // listing comes back empty.
+    const result = listAtPath(
+      [
+        "processed/sequence_id=s01/robot_name=sharpa_wave/a.parquet",
+        "processed/sequence_id=s02/robot_name=sharpa_wave/b.parquet",
+        "processed_invalid/sequence_id=s01/robot_name=sharpa_wave/c.parquet",
+        "processed_invalid/sequence_id=s02/robot_name=sharpa_wave/d.parquet",
+      ],
+      "processed",
+    );
+
+    expect(result).toEqual([
+      { name: "sequence_id=s01", type: "folder" },
+      { name: "sequence_id=s02", type: "folder" },
+    ]);
+  });
+
+  it("lists children of the sibling directory too", () => {
+    const result = listAtPath(
+      [
+        "processed/sequence_id=s01/robot_name=sharpa_wave/a.parquet",
+        "processed_invalid/sequence_id=s01/robot_name=sharpa_wave/c.parquet",
+        "processed_invalid/sequence_id=s02/robot_name=sharpa_wave/d.parquet",
+      ],
+      "processed_invalid",
+    );
+
+    expect(result).toEqual([
+      { name: "sequence_id=s01", type: "folder" },
+      { name: "sequence_id=s02", type: "folder" },
+    ]);
+  });
+
+  it("lists root-level siblings including the prefix-sharing directory", () => {
+    const result = listAtPath(
+      [
+        "processed/sequence_id=s01/robot_name=sharpa_wave/a.parquet",
+        "processed_invalid/sequence_id=s01/robot_name=sharpa_wave/c.parquet",
+        "quality.csv",
+      ],
+      "",
+    );
+
+    expect(result).toEqual([
+      { name: "processed", type: "folder" },
+      { name: "processed_invalid", type: "folder" },
+      expect.objectContaining({ name: "quality.csv", type: "file" }),
+    ]);
+  });
+});

--- a/src/ui/src/lib/api/adapter/datasets.ts
+++ b/src/ui/src/lib/api/adapter/datasets.ts
@@ -464,23 +464,21 @@ export async function fetchDatasetDetailLatest(bucket: string, name: string): Pr
 }
 
 /**
- * Fetch all files for a dataset version from the version's location URL.
+ * Process raw manifest items into sorted/indexed structures for O(log n) lookups.
  *
- * Fetches the raw flat manifest, then builds a ProcessedManifest with three
- * sorted/indexed structures for O(log n) directory listing and file search.
- * The result is cached by React Query — the O(n log n) sort happens once.
- *
- * Returns an empty ProcessedManifest if no location URL is provided.
- *
- * @param location - The version's location URL (DatasetVersion.location)
+ * Exported so tests can exercise the full sort + binary-search + listing pipeline
+ * without stubbing the server action — see datasets.test.ts.
  */
-export async function fetchDatasetFiles(location: string | null): Promise<ProcessedManifest> {
-  if (!location) return { byPath: [], byFilename: [], fileTypes: [] };
-  const { fetchManifest } = await import("@/lib/api/server/dataset-actions");
-  const items = (await fetchManifest(location)) as RawFileItem[];
-
-  // Sort by full relative_path — enables binary-search directory listing
-  const byPath = [...items].sort((a, b) => a.relative_path.localeCompare(b.relative_path));
+export function processManifestItems(items: RawFileItem[]): ProcessedManifest {
+  // Sort by full relative_path — enables binary-search directory listing.
+  // Use codepoint comparison (matches `<` in binarySearchByPath), NOT localeCompare:
+  // Unicode collation treats "/" and "_" as equivalent punctuation, which places
+  // "foo_bar/..." before "foo/..." — the opposite of `<` order. If the sort here
+  // disagreed with the binary-search comparator, buildDirectoryListing would
+  // start at the wrong index and emit an empty listing for "foo".
+  const byPath = [...items].sort((a, b) =>
+    a.relative_path < b.relative_path ? -1 : a.relative_path > b.relative_path ? 1 : 0,
+  );
 
   // Build filename index sorted by lowercase last-segment name — enables binary-search filename filter
   const byFilename = byPath
@@ -496,6 +494,24 @@ export async function fetchDatasetFiles(location: string | null): Promise<Proces
   const fileTypes = [...extSet].sort();
 
   return { byPath, byFilename, fileTypes };
+}
+
+/**
+ * Fetch all files for a dataset version from the version's location URL.
+ *
+ * Fetches the raw flat manifest, then builds a ProcessedManifest with three
+ * sorted/indexed structures for O(log n) directory listing and file search.
+ * The result is cached by React Query — the O(n log n) sort happens once.
+ *
+ * Returns an empty ProcessedManifest if no location URL is provided.
+ *
+ * @param location - The version's location URL (DatasetVersion.location)
+ */
+export async function fetchDatasetFiles(location: string | null): Promise<ProcessedManifest> {
+  if (!location) return { byPath: [], byFilename: [], fileTypes: [] };
+  const { fetchManifest } = await import("@/lib/api/server/dataset-actions");
+  const items = (await fetchManifest(location)) as RawFileItem[];
+  return processManifestItems(items);
 }
 
 /**

--- a/src/ui/src/mocks/generators/dataset-generator.ts
+++ b/src/ui/src/mocks/generators/dataset-generator.ts
@@ -274,6 +274,22 @@ export class DatasetGenerator {
       }
     }
 
+    // Hive-style partitioned directories with a prefix-sharing sibling pair.
+    // Exercises the dataset browser on real-world Parquet layouts and guards
+    // against sort-vs-binary-search regressions where `arctic_processed/` and
+    // `arctic_processed_invalid/` are siblings under the same root.
+    for (const base of ["processed", "processed_invalid"]) {
+      for (const sequence of ["s01", "s02"]) {
+        const filePath = `${base}/sequence_id=${sequence}/robot_name=sharpa_wave/data.parquet`;
+        items.push({
+          relative_path: filePath,
+          size: faker.number.int({ min: 1024, max: 32768 }),
+          url: buildUrl(filePath),
+          storage_path: buildStoragePath(filePath),
+        });
+      }
+    }
+
     return items;
   }
 


### PR DESCRIPTION
## Description

The dataset browser renders an empty directory at paths like `arctic_processed/` whenever a sibling shares the same name prefix (`arctic_processed_invalid/`).

`fetchDatasetFiles` sorted the manifest with `localeCompare`, which treats `/` and `_` as equivalent punctuation; that puts `arctic_processed_invalid/...` before `arctic_processed/...`. `binarySearchByPath` searches the same array with `<`, which orders them the other way. So searching for prefix `arctic_processed/` lands on the first `arctic_processed_invalid/` entry, and the `startsWith` check fails on the first iteration.

Fix: sort with `<` so the two comparators agree. New unit test covers the prefix-sharing case through the full sort + search + listing pipeline.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for dataset manifest browsing with multiple scenarios including nested directories and prefix-shared folder names.
  * Enhanced mock dataset generation with expanded partition-style folder hierarchies.

* **Refactor**
  * Optimized internal dataset manifest processing to improve sorting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->