### PR TITLE
Testbot: fix bazelisk, add observability, broaden allowlist - 80% cost cut

### DIFF
--- a/.github/workflows/testbot-respond.yaml
+++ b/.github/workflows/testbot-respond.yaml
@@ -72,10 +72,16 @@ jobs:
       # bazelisk binary, but as of 2026-04-27 that endpoint returns an empty
       # array for bazelbuild/bazelisk while /releases/tags/v<X> still works.
       # Install bazelisk directly from the asset URL to bypass the broken path.
+      # Bazelisk doesn't publish official checksums for v1.27.0 (issue #306),
+      # so we pin the SHA256 we observed and verify before sudo-installing.
       - name: Install Bazelisk
+        env:
+          BAZELISK_VERSION: v1.27.0
+          BAZELISK_SHA256: e1508323f347ad1465a887bc5d2bfb91cffc232d11e8e997b623227c6b32fb76
         run: |
           curl -fsSL -o "$RUNNER_TEMP/bazelisk" \
-            https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-amd64
+            "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64"
+          echo "${BAZELISK_SHA256}  $RUNNER_TEMP/bazelisk" | sha256sum -c -
           sudo install -m 0755 "$RUNNER_TEMP/bazelisk" /usr/local/bin/bazelisk
           sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
 

--- a/.github/workflows/testbot-respond.yaml
+++ b/.github/workflows/testbot-respond.yaml
@@ -74,9 +74,9 @@ jobs:
       # Install bazelisk directly from the asset URL to bypass the broken path.
       - name: Install Bazelisk
         run: |
-          curl -fsSL -o /usr/local/bin/bazelisk \
+          curl -fsSL -o "$RUNNER_TEMP/bazelisk" \
             https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-amd64
-          sudo chmod +x /usr/local/bin/bazelisk
+          sudo install -m 0755 "$RUNNER_TEMP/bazelisk" /usr/local/bin/bazelisk
           sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
 
       - name: Setup Bazel

--- a/.github/workflows/testbot-respond.yaml
+++ b/.github/workflows/testbot-respond.yaml
@@ -68,11 +68,21 @@ jobs:
         working-directory: src/ui
         run: pnpm install --frozen-lockfile
 
+      # bazel-contrib/setup-bazel uses GitHub's listReleases API to find the
+      # bazelisk binary, but as of 2026-04-27 that endpoint returns an empty
+      # array for bazelbuild/bazelisk while /releases/tags/v<X> still works.
+      # Install bazelisk directly from the asset URL to bypass the broken path.
+      - name: Install Bazelisk
+        run: |
+          curl -fsSL -o /usr/local/bin/bazelisk \
+            https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-amd64
+          sudo chmod +x /usr/local/bin/bazelisk
+          sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
+
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8
         with:
           bazelisk-cache: true
-          bazelisk-version: 1.27.0
           disk-cache: ${{ github.workflow }}
           repository-cache: true
 
@@ -87,7 +97,7 @@ jobs:
             --pr-number ${{ github.event.pull_request.number }} \
             --trigger-phrase /testbot \
             --max-responses 10 \
-            --max-turns 75 \
+            --max-turns 200 \
             --timeout 900 \
             --model aws/anthropic/claude-opus-4-5
         env:

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -31,7 +31,7 @@ on:
         default: '300'
       max_turns:
         description: 'Max Claude Code agent turns'
-        default: '50'
+        default: '200'
       timeout_minutes:
         description: 'Workflow timeout in minutes'
         default: '30'
@@ -83,11 +83,21 @@ jobs:
         working-directory: src/ui
         run: pnpm install --frozen-lockfile
 
+      # bazel-contrib/setup-bazel uses GitHub's listReleases API to find the
+      # bazelisk binary, but as of 2026-04-27 that endpoint returns an empty
+      # array for bazelbuild/bazelisk while /releases/tags/v<X> still works.
+      # Install bazelisk directly from the asset URL to bypass the broken path.
+      - name: Install Bazelisk
+        run: |
+          curl -fsSL -o /usr/local/bin/bazelisk \
+            https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-amd64
+          sudo chmod +x /usr/local/bin/bazelisk
+          sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
+
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8
         with:
           bazelisk-cache: true
-          bazelisk-version: 1.27.0
           disk-cache: ${{ github.workflow }}
           repository-cache: true
           external-cache: |
@@ -119,14 +129,56 @@ jobs:
       - name: Generate tests
         run: |
           TARGETS=$(cat "$RUNNER_TEMP/targets.txt")
-          npx @anthropic-ai/claude-code@2.1.91 --print \
-            --model "$ANTHROPIC_MODEL" \
-            --allowedTools "Read,Edit,Write,Bash(bazel test *),Bash(pnpm --dir src/ui test *),Bash(pnpm --dir src/ui validate),Bash(pnpm --dir src/ui format),Glob,Grep" \
-            --max-turns ${{ inputs.max_turns || '50' }} \
-            "$(cat src/scripts/testbot/TESTBOT_PROMPT.md)
+          PROMPT="$(cat src/scripts/testbot/TESTBOT_PROMPT.md)
 
           Coverage targets:
           $TARGETS"
+          STREAM_LOG="$RUNNER_TEMP/claude-stream.jsonl"
+
+          # Stream every turn and tool use to the action log (matches the
+          # diagnostics surfaced by the respond workflow). The final result
+          # message is parsed below for a summary. We disable -e so the
+          # diagnostics block runs even when Claude exits non-zero.
+          set +e
+          npx @anthropic-ai/claude-code@2.1.91 --print \
+            --model "$ANTHROPIC_MODEL" \
+            --output-format stream-json --verbose \
+            --allowedTools "Read,Edit,Write,Bash(bazel test *),Bash(pnpm --dir src/ui test *),Bash(pnpm --dir src/ui validate),Bash(pnpm --dir src/ui format),Glob,Grep" \
+            --max-turns ${{ inputs.max_turns || '200' }} \
+            "$PROMPT" | tee "$STREAM_LOG"
+          status=$?
+
+          echo "::group::Claude Code diagnostics"
+          python3 - "$STREAM_LOG" "$status" <<'PY'
+          import json, sys
+          path, status = sys.argv[1], sys.argv[2]
+          final = None
+          with open(path) as f:
+              for line in f:
+                  line = line.strip()
+                  if not line:
+                      continue
+                  try:
+                      msg = json.loads(line)
+                  except json.JSONDecodeError:
+                      continue
+                  if msg.get("type") == "result":
+                      final = msg
+          print(f"exit_status: {status}")
+          if final is None:
+              print("no final result message captured")
+              sys.exit(0)
+          for key in ("subtype", "is_error", "num_turns", "duration_ms",
+                      "duration_api_ms", "total_cost_usd"):
+              if key in final:
+                  print(f"{key}: {final[key]}")
+          result = final.get("result")
+          if isinstance(result, str) and result:
+              print("result:")
+              print(result[:2000])
+          PY
+          echo "::endgroup::"
+          exit $status
         env:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -143,7 +143,7 @@ jobs:
           npx @anthropic-ai/claude-code@2.1.91 --print \
             --model "$ANTHROPIC_MODEL" \
             --output-format stream-json --verbose \
-            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(bazel test *),Bash(bazel build *),Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *)" \
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cd *),Bash(bazel test *),Bash(bazel build *),Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *)" \
             --max-turns ${{ inputs.max_turns || '200' }} \
             "$PROMPT" | tee "$STREAM_LOG"
           status=$?

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -143,7 +143,7 @@ jobs:
           npx @anthropic-ai/claude-code@2.1.91 --print \
             --model "$ANTHROPIC_MODEL" \
             --output-format stream-json --verbose \
-            --allowedTools "Read,Edit,Write,Bash(bazel test *),Bash(pnpm --dir src/ui test *),Bash(pnpm --dir src/ui validate),Bash(pnpm --dir src/ui format),Glob,Grep" \
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(bazel test *),Bash(bazel build *),Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *)" \
             --max-turns ${{ inputs.max_turns || '200' }} \
             "$PROMPT" | tee "$STREAM_LOG"
           status=$?

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -89,9 +89,9 @@ jobs:
       # Install bazelisk directly from the asset URL to bypass the broken path.
       - name: Install Bazelisk
         run: |
-          curl -fsSL -o /usr/local/bin/bazelisk \
+          curl -fsSL -o "$RUNNER_TEMP/bazelisk" \
             https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-amd64
-          sudo chmod +x /usr/local/bin/bazelisk
+          sudo install -m 0755 "$RUNNER_TEMP/bazelisk" /usr/local/bin/bazelisk
           sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
 
       - name: Setup Bazel

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -166,9 +166,12 @@ jobs:
           python3 - "$STREAM_LOG" "$status" <<'PY'
           import json, sys
           path, status = sys.argv[1], sys.argv[2]
+          # Result message is the final stream-json event; iterate in reverse
+          # and stop at the first match instead of parsing every assistant
+          # turn and tool-use line.
           final = None
           with open(path) as f:
-              for line in f:
+              for line in reversed(f.readlines()):
                   line = line.strip()
                   if not line:
                       continue
@@ -178,6 +181,7 @@ jobs:
                       continue
                   if msg.get("type") == "result":
                       final = msg
+                      break
           print(f"exit_status: {status}")
           if final is None:
               print("no final result message captured")
@@ -198,8 +202,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
           ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/claude-opus-4-5' }}
-          # Inputs go via env (literal string) instead of being interpolated
-          # into the run script, then validated below before use.
           MAX_TURNS: ${{ inputs.max_turns || '200' }}
           DISABLE_PROMPT_CACHING: "1"  # NVIDIA gateway rejects cache_control.ephemeral.scope
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"  # NVIDIA gateway rejects context_management

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -87,10 +87,16 @@ jobs:
       # bazelisk binary, but as of 2026-04-27 that endpoint returns an empty
       # array for bazelbuild/bazelisk while /releases/tags/v<X> still works.
       # Install bazelisk directly from the asset URL to bypass the broken path.
+      # Bazelisk doesn't publish official checksums for v1.27.0 (issue #306),
+      # so we pin the SHA256 we observed and verify before sudo-installing.
       - name: Install Bazelisk
+        env:
+          BAZELISK_VERSION: v1.27.0
+          BAZELISK_SHA256: e1508323f347ad1465a887bc5d2bfb91cffc232d11e8e997b623227c6b32fb76
         run: |
           curl -fsSL -o "$RUNNER_TEMP/bazelisk" \
-            https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/bazelisk-linux-amd64
+            "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64"
+          echo "${BAZELISK_SHA256}  $RUNNER_TEMP/bazelisk" | sha256sum -c -
           sudo install -m 0755 "$RUNNER_TEMP/bazelisk" /usr/local/bin/bazelisk
           sudo ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
 

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -31,7 +31,7 @@ on:
         default: '300'
       max_turns:
         description: 'Max Claude Code agent turns'
-        default: '200'
+        default: '100'
       timeout_minutes:
         description: 'Workflow timeout in minutes'
         default: '30'
@@ -158,7 +158,7 @@ jobs:
           npx @anthropic-ai/claude-code@2.1.91 --print \
             --model "$ANTHROPIC_MODEL" \
             --output-format stream-json --verbose \
-            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cd *),Bash(bazel test *),Bash(bazel build *),Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *)" \
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cd *),Bash(mv *),Bash(bazel test *),Bash(bazel build *),Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *)" \
             --max-turns "$MAX_TURNS" \
             "$PROMPT" | tee "$STREAM_LOG"
           # PIPESTATUS[0] is the npx exit code; $? would be tee's, masking

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -128,6 +128,14 @@ jobs:
 
       - name: Generate tests
         run: |
+          # Validate workflow_dispatch input before splicing it into the
+          # shell command (defense in depth — the input is interpolated
+          # by GitHub Actions, not the shell, so quoting alone isn't enough).
+          if ! [[ "$MAX_TURNS" =~ ^[0-9]+$ ]]; then
+            echo "max_turns must be a non-negative integer, got: $MAX_TURNS" >&2
+            exit 2
+          fi
+
           TARGETS=$(cat "$RUNNER_TEMP/targets.txt")
           PROMPT="$(cat src/scripts/testbot/TESTBOT_PROMPT.md)
 
@@ -144,11 +152,17 @@ jobs:
             --model "$ANTHROPIC_MODEL" \
             --output-format stream-json --verbose \
             --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cd *),Bash(bazel test *),Bash(bazel build *),Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *)" \
-            --max-turns ${{ inputs.max_turns || '200' }} \
+            --max-turns "$MAX_TURNS" \
             "$PROMPT" | tee "$STREAM_LOG"
-          status=$?
+          # PIPESTATUS[0] is the npx exit code; $? would be tee's, masking
+          # Claude failures as success.
+          status=${PIPESTATUS[0]}
 
+          # Wrap untrusted Claude result text in ::stop-commands:: so it can't
+          # inject workflow commands (::warning::, ::add-mask::, etc.).
+          STOP_TOKEN=$(python3 -c 'import secrets; print(secrets.token_hex(16))')
           echo "::group::Claude Code diagnostics"
+          echo "::stop-commands::$STOP_TOKEN"
           python3 - "$STREAM_LOG" "$status" <<'PY'
           import json, sys
           path, status = sys.argv[1], sys.argv[2]
@@ -177,12 +191,16 @@ jobs:
               print("result:")
               print(result[:2000])
           PY
+          echo "::$STOP_TOKEN::"
           echo "::endgroup::"
           exit $status
         env:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
           ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/claude-opus-4-5' }}
+          # Inputs go via env (literal string) instead of being interpolated
+          # into the run script, then validated below before use.
+          MAX_TURNS: ${{ inputs.max_turns || '200' }}
           DISABLE_PROMPT_CACHING: "1"  # NVIDIA gateway rejects cache_control.ephemeral.scope
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"  # NVIDIA gateway rejects context_management
 

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -149,11 +149,12 @@ jobs:
           $TARGETS"
           STREAM_LOG="$RUNNER_TEMP/claude-stream.jsonl"
 
-          # Stream every turn and tool use to the action log (matches the
-          # diagnostics surfaced by the respond workflow). The final result
-          # message is parsed below for a summary. We disable -e so the
-          # diagnostics block runs even when Claude exits non-zero.
+          # Stream every turn and tool use into a foldable group so the
+          # diagnostics summary stays visible by default; the verbose
+          # stream is one click away. We disable -e so the diagnostics
+          # block runs even when Claude exits non-zero.
           set +e
+          echo "::group::Claude Code stream (click to expand turn-by-turn log)"
           npx @anthropic-ai/claude-code@2.1.91 --print \
             --model "$ANTHROPIC_MODEL" \
             --output-format stream-json --verbose \
@@ -163,6 +164,7 @@ jobs:
           # PIPESTATUS[0] is the npx exit code; $? would be tee's, masking
           # Claude failures as success.
           status=${PIPESTATUS[0]}
+          echo "::endgroup::"
 
           # Wrap untrusted Claude result text in ::stop-commands:: so it can't
           # inject workflow commands (::warning::, ::add-mask::, etc.).

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -62,7 +62,7 @@ Claude Code is sandboxed: it can only read files, edit test files, and run test 
 gh workflow run testbot.yaml --ref <branch> \
   -f max_targets=1 \
   -f max_uncovered=300 \
-  -f max_turns=50 \
+  -f max_turns=200 \
   -f model=aws/anthropic/claude-opus-4-5
 ```
 
@@ -101,7 +101,7 @@ Then post a new `/testbot` comment with clearer instructions.
 |-------|---------|-------------|
 | `max_targets` | `1` | Files to target per run |
 | `max_uncovered` | `300` | Uncovered lines cap per target (0 = no cap) |
-| `max_turns` | `50` | Claude Code agent turns |
+| `max_turns` | `200` | Claude Code agent turns |
 | `timeout_minutes` | `30` | Workflow timeout |
 | `model` | `aws/anthropic/claude-opus-4-5` | LLM model on API gateway |
 | `dry_run` | `false` | Generate without creating PR |
@@ -110,7 +110,7 @@ Then post a new `/testbot` comment with clearer instructions.
 
 | Arg | Default | Description |
 |-----|---------|-------------|
-| `--max-turns` | `50` | Claude Code agent turns |
+| `--max-turns` | `200` | Claude Code agent turns |
 | `--max-responses` | `10` | Max threads to address per trigger |
 | `--timeout` | `720` | Claude Code CLI timeout in seconds |
 | `--model` | `aws/anthropic/claude-opus-4-5` | LLM model |

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -62,7 +62,7 @@ Claude Code is sandboxed: it can only read files, edit test files, and run test 
 gh workflow run testbot.yaml --ref <branch> \
   -f max_targets=1 \
   -f max_uncovered=300 \
-  -f max_turns=200 \
+  -f max_turns=100 \
   -f model=aws/anthropic/claude-opus-4-5
 ```
 
@@ -101,7 +101,7 @@ Then post a new `/testbot` comment with clearer instructions.
 |-------|---------|-------------|
 | `max_targets` | `1` | Files to target per run |
 | `max_uncovered` | `300` | Uncovered lines cap per target (0 = no cap) |
-| `max_turns` | `200` | Claude Code agent turns |
+| `max_turns` | `100` | Claude Code agent turns |
 | `timeout_minutes` | `30` | Workflow timeout |
 | `model` | `aws/anthropic/claude-opus-4-5` | LLM model on API gateway |
 | `dry_run` | `false` | Generate without creating PR |

--- a/src/scripts/testbot/TESTBOT_RULES.md
+++ b/src/scripts/testbot/TESTBOT_RULES.md
@@ -43,10 +43,14 @@ When a test fails:
 
 ## Verification
 
-> **Run commands as a single program with arguments — no `cd`, `&&`, `;`, `|`,
-> `||`, or `2>&1`.** The tool sandbox rejects compound commands and redirects.
-> For UI scripts use `pnpm --dir src/ui <script>` with the relative path
-> (`src/ui`), not the absolute runner path.
+> **Allowed shell forms**: a single program with arguments (e.g. `pnpm --dir
+> src/ui test ...`), or `cd <dir> && <single-allowed-cmd>`. **Not allowed**:
+> pipes (`|`), `||`, `;`, output redirects (`>`, `>>`).
+>
+> You don't need `2>&1`, `| head`, or `|| true` — the Bash tool already
+> returns stdout and stderr separately, auto-truncates very long output
+> before handing it to you, and reports the exit code separately so you
+> see both the failure and the output. Just run the command directly.
 
 1. **Run the test**:
    - Python/Go: `bazel test <target>` (derive the Bazel target from the BUILD file)

--- a/src/scripts/testbot/TESTBOT_RULES.md
+++ b/src/scripts/testbot/TESTBOT_RULES.md
@@ -43,6 +43,11 @@ When a test fails:
 
 ## Verification
 
+> **Run commands as a single program with arguments — no `cd`, `&&`, `;`, `|`,
+> `||`, or `2>&1`.** The tool sandbox rejects compound commands and redirects.
+> For UI scripts use `pnpm --dir src/ui <script>` with the relative path
+> (`src/ui`), not the absolute runner path.
+
 1. **Run the test**:
    - Python/Go: `bazel test <target>` (derive the Bazel target from the BUILD file)
    - TypeScript: `pnpm --dir src/ui test -- --run <test_file_path>`

--- a/src/scripts/testbot/respond.py
+++ b/src/scripts/testbot/respond.py
@@ -32,8 +32,9 @@ ALLOWED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 # Shared with testbot.yaml — update both when changing the tool allowlist.
 ALLOWED_TOOLS = (
     "Read,Edit,Write,Glob,Grep,"
-    "Bash(bazel test *),Bash(pnpm --dir src/ui test *),"
-    "Bash(pnpm --dir src/ui validate),Bash(pnpm --dir src/ui format),"
+    "Bash(bazel test *),Bash(bazel build *),"
+    "Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),"
+    "Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *),"
     "Bash(gh pr view *),Bash(gh pr diff *),Bash(gh pr checks *)"
 )
 

--- a/src/scripts/testbot/respond.py
+++ b/src/scripts/testbot/respond.py
@@ -32,7 +32,7 @@ ALLOWED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 # Shared with testbot.yaml — update both when changing the tool allowlist.
 ALLOWED_TOOLS = (
     "Read,Edit,Write,Glob,Grep,"
-    "Bash(bazel test *),Bash(bazel build *),"
+    "Bash(cd *),Bash(bazel test *),Bash(bazel build *),"
     "Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),"
     "Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *),"
     "Bash(gh pr view *),Bash(gh pr diff *),Bash(gh pr checks *)"

--- a/src/scripts/testbot/respond.py
+++ b/src/scripts/testbot/respond.py
@@ -32,7 +32,7 @@ ALLOWED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 # Shared with testbot.yaml — update both when changing the tool allowlist.
 ALLOWED_TOOLS = (
     "Read,Edit,Write,Glob,Grep,"
-    "Bash(cd *),Bash(bazel test *),Bash(bazel build *),"
+    "Bash(cd *),Bash(mv *),Bash(bazel test *),Bash(bazel build *),"
     "Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),"
     "Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *),"
     "Bash(gh pr view *),Bash(gh pr diff *),Bash(gh pr checks *)"


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description

Fixes a hard outage on testbot, brings generate-side observability up to par
with respond, and broadens the tool allowlist for ~80% lower spend.

**1. Bazelisk install workaround.** `setup-bazel@0.15.0` resolves bazelisk
via GitHub's `listReleases` API on `bazelbuild/bazelisk`, which returns `[]`
as of 2026-04-27 (the `tags/v1.27.0` endpoint and asset URLs still work).
Every fresh `ubuntu-latest` run failed with `Unable to find Bazelisk version
1.27.0` (run [25012620541](https://github.com/NVIDIA/OSMO/actions/runs/25012620541)).
Workaround: download from the asset URL into `$RUNNER_TEMP`, verify SHA256
against a pinned hash, `sudo install` to `/usr/local/bin`. setup-bazel still
runs for caching.

**2. Generate-side observability.** Switch to `--output-format stream-json
--verbose` so each turn streams live; wrap in a foldable `::group::` so it
collapses by default. After the run, parse the final `result` event and
print `subtype`/`is_error`/`num_turns`/`duration_ms`/`duration_api_ms`/
`total_cost_usd`/result text in a `Claude Code diagnostics` group. Reverse-
iterate + break for O(1) parsing. `set +e` + `${PIPESTATUS[0]}` so the
diagnostics print on Claude failure and step exit code matches Claude's.

**3. Broaden tool allowlist.** Replace narrow `Bash(pnpm --dir src/ui ...)`
with `Bash(pnpm *)`; add `Bash(bazel build *)`, `Bash(npx vitest *)`,
`Bash(npx tsc *)`, direct `./node_modules/.bin/{vitest,tsc} *`,
`Bash(cd *)`, `Bash(mv *)`. `cd` and `mv` are zero-exec by themselves;
following segments still need their own pattern. Pipes, output redirects,
`rm`, `tee`, `curl`, `git`, `gh write` remain blocked. `mv` was added after
a runaway run (Claude wrote `.test.ts`, needed `.test.tsx`, looped 180
turns trying `mv`/`rm`/`git rm`).

**4. Security hardening (CodeRabbit).** `${PIPESTATUS[0]}` instead of `$?`
so tee doesn't mask Claude failures. `inputs.max_turns` routed through
`env:` (literal) and validated `^[0-9]+$` (defense vs. shell injection from
malicious workflow_dispatch). Untrusted Claude `result` text wrapped in
`::stop-commands::<random-token>::` so it can't inject `::warning::` /
`::add-mask::` etc.

**5. `max_turns` calibrated to 100.** Was 50 (too low), bumped to 200
(turned a runaway into ~$88), now 100 — covers legitimate work (best run
was 21 turns) and caps blast radius. `mv` allowance means filename mistakes
recover in 1 turn instead of 200.

### Verification — A/B on this branch

Both runs: `max_targets=1`, `max_uncovered=300`, dry run, opus-4-5.

| Metric | Before allowlist (run 25026758807) | After (run 25028953472) |
|---|---|---|
| `num_turns` | 57 | 21 |
| `total_cost_usd` | $29.73 | $5.91 |
| `duration_api_ms` | 461s | 119s |
| Permission denials | 67 of 161 (42%) | 0 of 9 (0%) |
| Step wall time | 7m 53s | 6m 39s |

Subsequent run [25069219888](https://github.com/NVIDIA/OSMO/actions/runs/25069219888)
verified SHA256 install + foldable stream group + diagnostics summary
end-to-end and surfaced the `mv` denial loop that drove fix #5.

Issue #760

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
