### PR TITLE
Automate release notes drafting and GitHub release body sync

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -1,0 +1,213 @@
+<!--
+Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+NVIDIA CORPORATION and its licensors retain all intellectual property
+and proprietary rights in and to this software, related documentation
+and any modifications thereto. Any use, reproduction, disclosure or
+distribution of this software and related documentation without an express
+license agreement from NVIDIA CORPORATION is strictly prohibited.
+-->
+
+# Release Notes Template
+
+This file documents the format for release notes in `releases/X.Y.Z.md`. Two
+variants of the actual template follow: the pre-release variant (committed via
+the `draft-release-notes` workflow when generating notes for an upcoming RC)
+and the stable variant (the form left when the release ships and the RC notice
+block is removed).
+
+---
+
+## Pre-release variant
+
+Use this when creating `X.Y.Z.md` for a new pre-release. Paste below the
+horizontal rule into the release file, then fill in the content.
+
+---
+
+```markdown
+> **This is a pre-release** (`X.Y.Z-prerelease-rcN`). It has been validated in
+> staging and is undergoing SQA testing. Production deployments should await
+> the stable release.
+
+## Highlights
+
+- **Feature name** — One-sentence summary of the change and why it matters.
+- **Feature name** — One-sentence summary of the change and why it matters.
+
+## Breaking Changes
+
+- **Change name**: What breaks, and what operators or users need to do.
+
+## Authentication and Authorization
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Workflow Engine
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Data and Storage
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Scheduling and Compute
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Web UI
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## CLI
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Bug Fixes
+
+- **Fix name**: Description of the fix. (#NNN)
+
+## Getting OSMO
+
+### Helm Charts and Containers
+
+Helm charts and container images are available on
+[NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/containers/osmo).
+
+### CLI Client
+
+Installers for the CLI client for macOS (Apple Silicon), x86-64 Linux, and
+ARM64 Linux are attached as assets to this release.
+```
+
+---
+
+## Stable variant
+
+When the release ships, remove the RC notice block at the top of the file. All
+other sections remain identical. The resulting file looks like this:
+
+---
+
+```markdown
+## Highlights
+
+- **Feature name** — One-sentence summary of the change and why it matters.
+- **Feature name** — One-sentence summary of the change and why it matters.
+
+## Breaking Changes
+
+- **Change name**: What breaks, and what operators or users need to do.
+
+## Authentication and Authorization
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Workflow Engine
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Data and Storage
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Scheduling and Compute
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Web UI
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## CLI
+
+- **Feature or fix name**: Description of the change. (#NNN)
+
+## Bug Fixes
+
+- **Fix name**: Description of the fix. (#NNN)
+
+## Getting OSMO
+
+### Helm Charts and Containers
+
+Helm charts and container images are available on
+[NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/containers/osmo).
+
+### CLI Client
+
+Installers for the CLI client for macOS (Apple Silicon), x86-64 Linux, and
+ARM64 Linux are attached as assets to this release.
+```
+
+---
+
+## Section reference
+
+| Section | When to include | Content |
+|---|---|---|
+| RC notice block | Pre-release only | Removed at stable promotion |
+| Highlights | Always | 3-6 bullets; one per major change across all sections |
+| Breaking Changes | Only if applicable | API removals, config format changes, behavior requiring action |
+| Authentication and Authorization | If changes exist | RBAC, OAuth2/OIDC, JWT, authz sidecar, access tokens, credentials |
+| Workflow Engine | If changes exist | Submission, execution, scheduling, task lifecycle, backend integration, quotas, pools, priority |
+| Data and Storage | If changes exist | Datasets, collections, versioning, multi-backend storage, upload/download |
+| Scheduling and Compute | If changes exist | KAI Scheduler, NVLink/topology placement, GPU resources, node pools |
+| Web UI | If changes exist | User-visible UI changes, accessibility, new views, log viewer |
+| CLI | If changes exist | CLI commands, output formatting, tab completion, packaging |
+| Bug Fixes | If changes exist | Cross-cutting fixes not belonging to a functional section above |
+| Getting OSMO | Always | Standard boilerplate; do not modify |
+
+Empty sections must be removed. Do not leave sections with no bullets or a
+"(none)" placeholder.
+
+## Bullet format
+
+Each bullet follows this pattern:
+
+```
+- **Short noun phrase**: One-sentence description of the user-visible change. (#NNN)
+```
+
+Multiple PRs for one change: `(#NNN, #NNN)`. No PR available: omit the reference
+entirely. Do not fabricate PR numbers.
+
+Highlights bullets use an em-dash instead of a colon:
+
+```
+- **Short noun phrase** — One-sentence summary of why it matters.
+```
+
+## AI generation guidance
+
+When generating content for a release file from `git log`:
+
+1. Run: `git log --oneline <prior-stable-tag>..<nominated-sha> -- .`
+   (from the repo root). Exclude merge commits (`--no-merges`).
+
+2. Exclude from release notes:
+   - CI, test infrastructure, and build system changes
+   - Dependency version bumps with no user-visible effect
+   - Internal refactors with no behavioral change
+   - Documentation-only commits
+   - Formatting or linting fixes
+
+3. Map each remaining commit to a section using the commit message prefix or
+   the changed file paths as a signal. Commits touching `src/ui/` map to
+   Web UI. Commits touching `src/cli/` map to CLI. Commits touching
+   `src/service/core/auth/` or `src/utils/roles/` map to Authentication and
+   Authorization. And so on.
+
+4. Write in user-facing language. "Users can now submit to a default pool
+   without specifying one." Not "Refactored pool resolution to fall back to
+   default."
+
+5. Write the Highlights section last, pulling the 3-6 most significant items
+   from the body sections you have already written.
+
+6. Target length: 300-600 words for a patch release (primarily bug fixes),
+   600-1000 words for a feature-heavy minor release.
+
+7. For pre-releases: fill in the RC number (`rcN`) in the notice block using
+   the RC number from the nomination (the count of existing
+   `X.Y.*-prerelease-rc*` tags + 1).

--- a/.github/workflows/draft-release-notes.yaml
+++ b/.github/workflows/draft-release-notes.yaml
@@ -1,0 +1,256 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Generates release notes for an OSMO version using Claude Code, then opens
+# (or updates) a PR adding releases/X.Y.Z.md on main.
+#
+# Inputs come from git history between the previous release tag and the
+# current X.Y.Z tag (or main HEAD if the tag does not yet exist). The system
+# prompt is .github/release-notes-template.md.
+
+name: Draft release notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 6.3.0)'
+        required: true
+      model:
+        description: 'LLM model name on NVIDIA gateway'
+        default: 'aws/anthropic/claude-opus-4-7'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  # Serialize per-version so re-running for the same version replaces the
+  # in-flight PR rather than racing.
+  group: draft-release-notes-${{ inputs.version }}
+  cancel-in-progress: true
+
+jobs:
+  draft:
+    environment: testbot-generate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SVC_OSMO_CI_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "svc-osmo-ci"
+          git config user.email "svc-osmo-ci@users.noreply.github.com"
+
+      - name: Resolve tag range
+        id: tags
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must be MAJOR.MINOR.PATCH (got: $VERSION)"
+            exit 1
+          fi
+
+          # Largest semver tag strictly less than VERSION wins. sort -V handles
+          # the ordering; awk filters out the requested version and any non-
+          # semver tags.
+          prev_tag=$(git tag --list '[0-9]*.[0-9]*.[0-9]*' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | awk -v v="$VERSION" '$0 != v' \
+            | sort -V \
+            | awk -v v="$VERSION" '
+                {
+                  split($0, a, ".");
+                  split(v, b, ".");
+                  if (a[1] < b[1] ||
+                      (a[1] == b[1] && a[2] < b[2]) ||
+                      (a[1] == b[1] && a[2] == b[2] && a[3] < b[3])) {
+                    print $0;
+                  }
+                }
+              ' \
+            | tail -n1)
+          if [[ -z "$prev_tag" ]]; then
+            echo "::error::no previous semver tag less than $VERSION"
+            exit 1
+          fi
+          echo "prev_tag=$prev_tag"
+
+          # Upper bound: prefer the X.Y.Z tag if it exists (set by the GitLab
+          # nominate pipeline). Otherwise use main HEAD, but only if main's
+          # version.yaml matches the requested version.
+          if git rev-parse --verify --quiet "refs/tags/$VERSION" >/dev/null; then
+            current_ref="refs/tags/$VERSION"
+            echo "Using tag $VERSION as upper bound"
+          else
+            file_version=$(yq -r '"\(.major).\(.minor).\(.revision)"' \
+              src/lib/utils/version.yaml 2>/dev/null || echo "")
+            if [[ "$file_version" != "$VERSION" ]]; then
+              echo "::error::tag $VERSION does not exist and version.yaml on main is '$file_version' (need '$VERSION'). Bump version on main first or wait for nominate."
+              exit 1
+            fi
+            current_ref="HEAD"
+            echo "Tag $VERSION not found; using main HEAD (version.yaml matches)"
+          fi
+
+          {
+            echo "prev_tag=$prev_tag"
+            echo "current_ref=$current_ref"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build input bundle
+        id: bundle
+        env:
+          PREV_TAG: ${{ steps.tags.outputs.prev_tag }}
+          CURRENT_REF: ${{ steps.tags.outputs.current_ref }}
+        run: |
+          set -euo pipefail
+          bundle="$RUNNER_TEMP/release-notes-input.md"
+          {
+            echo "## Range"
+            echo
+            echo "From: \`$PREV_TAG\`  →  To: \`$CURRENT_REF\`"
+            echo
+            echo "## git log --no-merges (with bodies)"
+            echo
+            echo '```'
+            git log --no-merges --pretty=format:'%h %s%n%b' "$PREV_TAG..$CURRENT_REF"
+            echo
+            echo '```'
+            echo
+            echo "## git diff --stat"
+            echo
+            echo '```'
+            git diff --stat "$PREV_TAG..$CURRENT_REF"
+            echo '```'
+            echo
+            echo "## Per-file diffs (user-facing surfaces)"
+            for path in \
+              src/cli \
+              src/service/core/auth \
+              src/service/core/workflow \
+              src/service/core/data \
+              src/service/core/app \
+              src/service/core/config \
+              src/service/core/profile \
+              src/utils/roles \
+              src/lib/data \
+              src/ui ; do
+              if git diff --quiet "$PREV_TAG..$CURRENT_REF" -- "$path" 2>/dev/null; then
+                continue
+              fi
+              echo
+              echo "### $path"
+              echo
+              echo '```diff'
+              git diff "$PREV_TAG..$CURRENT_REF" -- "$path" || true
+              echo '```'
+            done
+          } > "$bundle"
+          echo "bundle_path=$bundle" >> "$GITHUB_OUTPUT"
+          echo "::group::Input bundle (first 200 lines)"
+          head -200 "$bundle"
+          echo "::endgroup::"
+
+      - name: Generate release notes
+        id: generate
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
+          ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
+          ANTHROPIC_MODEL: ${{ inputs.model }}
+          DISABLE_PROMPT_CACHING: "1"
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          VERSION: ${{ inputs.version }}
+          BUNDLE: ${{ steps.bundle.outputs.bundle_path }}
+        run: |
+          set -euo pipefail
+          template=".github/release-notes-template.md"
+          if [[ ! -f "$template" ]]; then
+            echo "::error::missing $template"
+            exit 1
+          fi
+          out="$RUNNER_TEMP/release-notes.md"
+
+          prompt=$(cat <<EOF
+          $(cat "$template")
+
+          ----
+
+          Generate release notes for OSMO $VERSION following the template above.
+          Output ONLY the markdown body of the release notes file — no
+          surrounding commentary, no code fences. Start with the RC notice
+          block (this is a pre-release variant) and end with the Getting OSMO
+          section verbatim from the template.
+
+          Inputs from git history follow:
+
+          $(cat "$BUNDLE")
+          EOF
+          )
+
+          npx @anthropic-ai/claude-code@2.1.91 --print \
+            --model "$ANTHROPIC_MODEL" \
+            --allowedTools "Read,Glob,Grep" \
+            --max-turns 20 \
+            "$prompt" > "$out"
+
+          if [[ ! -s "$out" ]]; then
+            echo "::error::Claude returned empty output"
+            exit 1
+          fi
+
+          mkdir -p releases
+          cp "$out" "releases/${VERSION}.md"
+          echo "wrote releases/${VERSION}.md ($(wc -c < "releases/${VERSION}.md") bytes)"
+          echo "::group::Generated release notes"
+          cat "releases/${VERSION}.md"
+          echo "::endgroup::"
+
+      - name: Open or update PR
+        env:
+          GH_TOKEN: ${{ secrets.SVC_OSMO_CI_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          branch="release-notes/${VERSION}"
+          title="release notes: ${VERSION}"
+
+          git checkout -B "$branch"
+          git add "releases/${VERSION}.md"
+          if git diff --cached --quiet; then
+            echo "no changes to commit; release notes already up to date"
+            exit 0
+          fi
+          git commit -m "$title"
+          git push --force-with-lease origin "$branch"
+
+          if existing=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null) && [[ -n "$existing" ]]; then
+            echo "Updated existing PR #$existing on branch $branch"
+            gh pr comment "$existing" --body "Refreshed by workflow run ${{ github.run_id }}."
+          else
+            gh pr create \
+              --title "$title" \
+              --body "Release notes for OSMO ${VERSION}, generated by the draft-release-notes workflow. Review the content for accuracy before merging." \
+              --base main \
+              --head "$branch"
+          fi

--- a/.github/workflows/sync-release-body.yaml
+++ b/.github/workflows/sync-release-body.yaml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Sync release body
+
+# Whenever release notes change on main, push the new content to the
+# matching GitHub release body. Skips silently if the release does not
+# yet exist (the GitLab nominate pipeline creates the draft).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'releases/*.md'
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 2
+
+      - name: Sync changed release notes to GitHub releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" -- 'releases/*.md' || true)
+          if [ -z "$changed" ]; then
+            echo "No release notes files changed."
+            exit 0
+          fi
+          echo "Changed release notes files:"
+          echo "$changed"
+          while IFS= read -r path; do
+            [ -z "$path" ] && continue
+            version="$(basename "$path" .md)"
+            echo "--- $version ---"
+            if ! gh release view "$version" >/dev/null 2>&1; then
+              echo "release $version does not exist yet; skipping"
+              continue
+            fi
+            gh release edit "$version" --notes-file "$path"
+            echo "updated body of release $version"
+          done <<< "$changed"


### PR DESCRIPTION
## Description

Adds two GitHub Actions and a release notes template that together automate maintaining `releases/X.Y.Z.md` and the GitHub release body.

- `.github/release-notes-template.md` — release notes section format used as the system prompt for the drafting workflow
- `.github/workflows/draft-release-notes.yaml` — manually triggered (`workflow_dispatch` with `version` input) workflow that uses Claude via the NVIDIA inference gateway to generate release notes from `git log` + `git diff` between the previous release tag and the current version, then opens (or updates) a PR adding `releases/<version>.md`.
- `.github/workflows/sync-release-body.yaml` — fires on push to `main` affecting `releases/*.md` and updates the corresponding GitHub release body via `gh release edit --notes-file`. Skips silently if the release does not yet exist.

Issue #None

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a standardized release notes template with pre-release and stable variants, required/optional sections, and guidance for writing user-facing entries.
  * Added a manual "draft release notes" workflow that builds a changelog bundle, generates a draft release markdown, and opens/updates a PR.
  * Added a sync workflow that updates published release notes when corresponding release markdown files change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->