### PR TITLE
Fix release-notes prompt overflow: stream stdin and pull diffs on demand

### DIFF
--- a/.github/workflows/draft-release-notes.yaml
+++ b/.github/workflows/draft-release-notes.yaml
@@ -126,6 +126,10 @@ jobs:
         run: |
           set -euo pipefail
           bundle="$RUNNER_TEMP/release-notes-input.md"
+          # Bundle is intentionally lean: commit log + diff stat only. Full
+          # per-file diffs are dropped because a feature-heavy release blows
+          # past the model context window. The model is instructed below to
+          # pull diffs on-demand for commits it judges important.
           {
             echo "## Range"
             echo
@@ -143,29 +147,6 @@ jobs:
             echo '```'
             git diff --stat "$PREV_TAG..$CURRENT_REF"
             echo '```'
-            echo
-            echo "## Per-file diffs (user-facing surfaces)"
-            for path in \
-              src/cli \
-              src/service/core/auth \
-              src/service/core/workflow \
-              src/service/core/data \
-              src/service/core/app \
-              src/service/core/config \
-              src/service/core/profile \
-              src/utils/roles \
-              src/lib/data \
-              src/ui ; do
-              if git diff --quiet "$PREV_TAG..$CURRENT_REF" -- "$path" 2>/dev/null; then
-                continue
-              fi
-              echo
-              echo "### $path"
-              echo
-              echo '```diff'
-              git diff "$PREV_TAG..$CURRENT_REF" -- "$path" || true
-              echo '```'
-            done
           } > "$bundle"
           echo "bundle_path=$bundle" >> "$GITHUB_OUTPUT"
           echo "::group::Input bundle (first 200 lines)"
@@ -182,6 +163,8 @@ jobs:
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
           VERSION: ${{ inputs.version }}
           BUNDLE: ${{ steps.bundle.outputs.bundle_path }}
+          PREV_TAG: ${{ steps.tags.outputs.prev_tag }}
+          CURRENT_REF: ${{ steps.tags.outputs.current_ref }}
         run: |
           set -euo pipefail
           template=".github/release-notes-template.md"
@@ -190,29 +173,41 @@ jobs:
             exit 1
           fi
           out="$RUNNER_TEMP/release-notes.md"
+          prompt_file="$RUNNER_TEMP/release-notes-prompt.md"
 
-          prompt=$(cat <<EOF
-          $(cat "$template")
-
-          ----
-
-          Generate release notes for OSMO $VERSION following the template above.
-          Output ONLY the markdown body of the release notes file — no
-          surrounding commentary, no code fences. Start with the RC notice
-          block (this is a pre-release variant) and end with the Getting OSMO
-          section verbatim from the template.
-
-          Inputs from git history follow:
-
-          $(cat "$BUNDLE")
-          EOF
-          )
+          # Build the prompt as a file rather than an argv string — for large
+          # releases the bundle can still approach the OS argv limit even
+          # after dropping full diffs.
+          {
+            cat "$template"
+            printf '\n\n----\n\n'
+            printf 'Generate release notes for OSMO %s following the template above.\n' "$VERSION"
+            printf 'Output ONLY the markdown body of the release notes file — no\n'
+            printf 'surrounding commentary, no code fences. Start with the RC notice\n'
+            printf 'block (this is a pre-release variant) and end with the Getting OSMO\n'
+            printf 'section verbatim from the template.\n\n'
+            printf 'Per-file diffs are not pre-loaded. The repo is checked out at\n'
+            printf '%s and the previous release tag is %s. For any commit whose\n' "$CURRENT_REF" "$PREV_TAG"
+            printf 'message is vague, ambiguous, or describes a user-visible change\n'
+            printf 'whose details matter for the release notes, investigate using:\n'
+            printf '\n'
+            printf '  git show <hash>                        # full diff for one commit\n'
+            printf '  git diff %s..%s -- <path>              # full diff for a path\n' "$PREV_TAG" "$CURRENT_REF"
+            printf '  git log %s..%s -- <path>               # commits touching a path\n' "$PREV_TAG" "$CURRENT_REF"
+            printf '\n'
+            printf 'Use these tools deliberately — pull diffs only for commits where\n'
+            printf 'the log message alone is insufficient. Do not pull diffs for\n'
+            printf 'every commit; trust the message when it is clear.\n\n'
+            printf 'Inputs from git history follow:\n\n'
+            cat "$BUNDLE"
+          } > "$prompt_file"
+          echo "prompt size: $(wc -c < "$prompt_file") bytes"
 
           npx @anthropic-ai/claude-code@2.1.91 --print \
             --model "$ANTHROPIC_MODEL" \
-            --allowedTools "Read,Glob,Grep" \
-            --max-turns 20 \
-            "$prompt" > "$out"
+            --allowedTools "Read,Glob,Grep,Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git tag:*),Bash(git rev-parse:*)" \
+            --max-turns 40 \
+            < "$prompt_file" > "$out"
 
           if [[ ! -s "$out" ]]; then
             echo "::error::Claude returned empty output"


### PR DESCRIPTION
## Description

The first `draft-release-notes` run against `version=6.3.0` failed at the `Generate release notes` step with `npx: Argument list too long`, then would have failed at the model layer too — the assembled prompt was 2.82 MB (~700K tokens) against Claude's 200K-token window.

Two fixes:

- Build the prompt as a file and pipe to `claude-code` via stdin instead of passing as an argv string. Avoids `execve` argv overflow regardless of size.
- Drop the 10-path full-diff dump from the bundle. Now bundle = `git log --no-merges` + `git diff --stat`. Measured for `6.2.10..6.3.0`: 2.81 MB → 122 KB (~22x). Prompt the model to investigate diffs on-demand for commits whose log message alone is insufficient, and add `Bash(git log|diff|show|tag|rev-parse:*)` to the allowed tools so it can.

`--max-turns` bumped from 20 to 40 to leave room for the investigative tool calls plus the final write.

Issue #None

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the automated release-notes workflow to produce clearer, less noisy summaries by omitting full per-file diffs and fetching file-level changes on demand. It now feeds more context about comparison points and has greater capacity to retrieve repository history, yielding more accurate and comprehensive release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->