### PR TITLE
Migrate cookbook workflows from dataset: to url:

### DIFF
--- a/cookbook/cosmos/predict/README.md
+++ b/cookbook/cosmos/predict/README.md
@@ -41,7 +41,7 @@ conditions for pulling the model. The terms and conditions submission can be fou
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/cosmos/cosmos_video2world.yaml
-osmo workflow submit cosmos_video2world.yaml
+osmo workflow submit cosmos_video2world.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 The workflow will take this input image below, and create a video from this image.
@@ -51,10 +51,10 @@ The workflow will take this input image below, and create a video from this imag
 
 ## Output
 
-After the workflow completes successfully, you can access the generated video through the `cosmos_video2world` dataset:
+After the workflow completes successfully, you can download the generated video from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-osmo dataset download cosmos_video2world
+osmo data download s3://my-bucket/datasets/cosmos_video2world/<workflow-id>/ ./
 ```
 
 ## More Information

--- a/cookbook/cosmos/predict/cosmos_video2world.yaml
+++ b/cookbook/cosmos/predict/cosmos_video2world.yaml
@@ -45,7 +45,7 @@ workflow:
             mv output/hf_video2world {{output}}/output/
 
       outputs:
-        - url: {{ storage_url }}/cosmos_video2world/{{ workflow_id }}/
+        - url: {{ storage_url }}/cosmos_video2world/{{workflow_id}}/
   resources:
     default:
       cpu: 16

--- a/cookbook/cosmos/predict/cosmos_video2world.yaml
+++ b/cookbook/cosmos/predict/cosmos_video2world.yaml
@@ -45,9 +45,7 @@ workflow:
             mv output/hf_video2world {{output}}/output/
 
       outputs:
-        - dataset:
-            name: cosmos_video2world
-            path: output
+        - url: {{ storage_url }}/cosmos_video2world/{{ workflow_id }}/
   resources:
     default:
       cpu: 16

--- a/cookbook/cosmos/predict/cosmos_video2world.yaml
+++ b/cookbook/cosmos/predict/cosmos_video2world.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit cosmos_video2world.yaml
+# osmo workflow submit cosmos_video2world.yaml --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: cosmos_video2world

--- a/cookbook/cosmos/reason/README.md
+++ b/cookbook/cosmos/reason/README.md
@@ -47,7 +47,7 @@ In order for your workflow to pull the Cosmos model from HuggingFace, you will *
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/cosmos/reason/cosmos_reason.yaml
-osmo workflow submit cosmos_reason.yaml
+osmo workflow submit cosmos_reason.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 ## Output
@@ -98,10 +98,10 @@ The workflow will also answer the question asked in the workflow:
 [reason]   </answer>
 ```
 
-After the workflow completes successfully, you can access the generated temporal caption results and extracted frames through the `cosmos-reason-sample` dataset:
+After the workflow completes successfully, you can download the generated temporal caption results and extracted frames from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-$ osmo dataset download cosmos-reason-sample ~/
+osmo data download s3://my-bucket/datasets/cosmos-reason-sample/<workflow-id>/ ~/
 ```
 
 

--- a/cookbook/cosmos/reason/cosmos_reason.yaml
+++ b/cookbook/cosmos/reason/cosmos_reason.yaml
@@ -52,7 +52,7 @@ workflow:
               --timestamp -v -o {{output}}/temporal_caption_text
 
       outputs:
-        - url: {{ storage_url }}/cosmos-reason-sample/{{ workflow_id }}/
+        - url: {{ storage_url }}/cosmos-reason-sample/{{workflow_id}}/
   resources:
     default:
       cpu: 16

--- a/cookbook/cosmos/reason/cosmos_reason.yaml
+++ b/cookbook/cosmos/reason/cosmos_reason.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit cosmos_reason.yaml
+# osmo workflow submit cosmos_reason.yaml --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: cosmos-reason

--- a/cookbook/cosmos/reason/cosmos_reason.yaml
+++ b/cookbook/cosmos/reason/cosmos_reason.yaml
@@ -52,8 +52,7 @@ workflow:
               --timestamp -v -o {{output}}/temporal_caption_text
 
       outputs:
-        - dataset:
-            name: cosmos-reason-sample
+        - url: {{ storage_url }}/cosmos-reason-sample/{{ workflow_id }}/
   resources:
     default:
       cpu: 16

--- a/cookbook/cosmos/transfer/README.md
+++ b/cookbook/cosmos/transfer/README.md
@@ -50,7 +50,7 @@ You must agree to the terms and conditions for the Cosmos model on Hugging Face:
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/cosmos/transfer/cosmos_transfer.yaml
-osmo workflow submit cosmos_transfer.yaml
+osmo workflow submit cosmos_transfer.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 ## What the workflow does
@@ -79,16 +79,16 @@ The workflow uses multiple control modalities with balanced weights:
 
 ## Output
 
-After successful completion, you can access the results through two datasets:
+After successful completion, you can download the results from the URLs the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ### Isaac Sim Synthetic Data
 ```bash
-osmo dataset download isaac-sim-cosmos-warehouse-sample
+osmo data download s3://my-bucket/datasets/isaac-sim-cosmos-warehouse-sample/<workflow-id>/ ./
 ```
 
 ### Cosmos Transfer Augmented Data
 ```bash
-osmo dataset download cosmos-transfer-sample
+osmo data download s3://my-bucket/datasets/cosmos-transfer-sample/<workflow-id>/ ./
 ```
 
 The final output includes:

--- a/cookbook/cosmos/transfer/cosmos_transfer.yaml
+++ b/cookbook/cosmos/transfer/cosmos_transfer.yaml
@@ -53,7 +53,6 @@ workflow:
     resource: cosmos
     inputs:
     - task: isaac-sim-sdg
-    - url: {{ storage_url }}/isaac-sim-cosmos-warehouse-sample/{{workflow_id}}/
     files:
       - path: /tmp/entry.sh
         contents: |
@@ -79,15 +78,15 @@ workflow:
           {
               "name": "cosmos-transfer-sample",
               "prompt": "High-quality warehouse simulation...",
-              "video_path": "{{input:1}}/clip_0000/rgb.mp4",
+              "video_path": "{{input:0}}/clip_0000/rgb.mp4",
               "vis": {"control_weight": 0.25},
               "edge": {"control_weight": 0.25},
               "depth": {
-                  "input_control": "{{input:1}}/clip_0000/depth.mp4",
+                  "input_control": "{{input:0}}/clip_0000/depth.mp4",
                   "control_weight": 0.25
               },
               "seg": {
-                  "input_control": "{{input:1}}/clip_0000/segmentation.mp4",
+                  "input_control": "{{input:0}}/clip_0000/segmentation.mp4",
                   "control_weight": 0.25
               }
           }

--- a/cookbook/cosmos/transfer/cosmos_transfer.yaml
+++ b/cookbook/cosmos/transfer/cosmos_transfer.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit cosmos_transfer.yaml
+# osmo workflow submit cosmos_transfer.yaml --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: isaac-sim-cosmos-transfer

--- a/cookbook/cosmos/transfer/cosmos_transfer.yaml
+++ b/cookbook/cosmos/transfer/cosmos_transfer.yaml
@@ -42,7 +42,7 @@ workflow:
         }
       path: /tmp/config.json
     outputs:
-    - url: {{ storage_url }}/isaac-sim-cosmos-warehouse-sample/{{ workflow_id }}/
+    - url: {{ storage_url }}/isaac-sim-cosmos-warehouse-sample/{{workflow_id}}/
   - name: cosmos-transfer
     image: nvcr.io/nvidia/cosmos/cosmos-predict2-container:1.2
     command: ["bash"]
@@ -53,7 +53,7 @@ workflow:
     resource: cosmos
     inputs:
     - task: isaac-sim-sdg
-    - url: {{ storage_url }}/isaac-sim-cosmos-warehouse-sample/{{ workflow_id }}/
+    - url: {{ storage_url }}/isaac-sim-cosmos-warehouse-sample/{{workflow_id}}/
     files:
       - path: /tmp/entry.sh
         contents: |
@@ -92,7 +92,7 @@ workflow:
               }
           }
     outputs:
-      - url: {{ storage_url }}/cosmos-transfer-sample/{{ workflow_id }}/
+      - url: {{ storage_url }}/cosmos-transfer-sample/{{workflow_id}}/
   resources:
     cosmos:
       cpu: 16

--- a/cookbook/cosmos/transfer/cosmos_transfer.yaml
+++ b/cookbook/cosmos/transfer/cosmos_transfer.yaml
@@ -42,8 +42,7 @@ workflow:
         }
       path: /tmp/config.json
     outputs:
-    - dataset:
-        name: isaac-sim-cosmos-warehouse-sample
+    - url: {{ storage_url }}/isaac-sim-cosmos-warehouse-sample/{{ workflow_id }}/
   - name: cosmos-transfer
     image: nvcr.io/nvidia/cosmos/cosmos-predict2-container:1.2
     command: ["bash"]
@@ -54,8 +53,7 @@ workflow:
     resource: cosmos
     inputs:
     - task: isaac-sim-sdg
-    - dataset:
-        name: isaac-sim-cosmos-warehouse-sample
+    - url: {{ storage_url }}/isaac-sim-cosmos-warehouse-sample/{{ workflow_id }}/
     files:
       - path: /tmp/entry.sh
         contents: |
@@ -81,21 +79,20 @@ workflow:
           {
               "name": "cosmos-transfer-sample",
               "prompt": "High-quality warehouse simulation...",
-              "video_path": "{{input:1}}/isaac-sim-cosmos-warehouse-sample/clip_0000/rgb.mp4",
+              "video_path": "{{input:1}}/clip_0000/rgb.mp4",
               "vis": {"control_weight": 0.25},
               "edge": {"control_weight": 0.25},
               "depth": {
-                  "input_control": "{{input:1}}/isaac-sim-cosmos-warehouse-sample/clip_0000/depth.mp4",
+                  "input_control": "{{input:1}}/clip_0000/depth.mp4",
                   "control_weight": 0.25
               },
               "seg": {
-                  "input_control": "{{input:1}}/isaac-sim-cosmos-warehouse-sample/clip_0000/segmentation.mp4",
+                  "input_control": "{{input:1}}/clip_0000/segmentation.mp4",
                   "control_weight": 0.25
               }
           }
     outputs:
-      - dataset:
-          name: cosmos-transfer-sample
+      - url: {{ storage_url }}/cosmos-transfer-sample/{{ workflow_id }}/
   resources:
     cosmos:
       cpu: 16

--- a/cookbook/dnn_training/deepspeed_multinode/README.md
+++ b/cookbook/dnn_training/deepspeed_multinode/README.md
@@ -48,7 +48,7 @@ The workflow creates `n_nodes` tasks (configurable), each with `n_gpus_per_node`
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/deepspeed_multinode/train.py
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/deepspeed_multinode/train.yaml
-osmo workflow submit train.yaml --set n_nodes=2 n_gpus_per_node=4 n_epochs=10
+osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets n_nodes=2 n_gpus_per_node=4 n_epochs=10
 ```
 
 > **Note:** The DeepSpeed configuration file (`/tmp/ds_config.json`) in the workflow specifies

--- a/cookbook/dnn_training/deepspeed_multinode/train.yaml
+++ b/cookbook/dnn_training/deepspeed_multinode/train.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit train.yaml --set n_nodes=2 n_gpus_per_node=4 n_epochs=10
+# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets n_nodes=2 n_gpus_per_node=4 n_epochs=10
 
 workflow:
   name: deepspeed-sample

--- a/cookbook/dnn_training/deepspeed_multinode/train.yaml
+++ b/cookbook/dnn_training/deepspeed_multinode/train.yaml
@@ -34,9 +34,7 @@ workflow:
     - name: master
       lead: true
       outputs:
-      - dataset:
-          name: {{ dataset }}
-          path: models
+      - url: {{ storage_url }}/{{ dataset }}/{{ workflow_id }}/
     {% else %}
     - name: worker_{{item}}
     {% endif %}
@@ -91,4 +89,4 @@ default-values:
   master_port: 29400
   n_epochs: 10
   batch_size: 32
-  dataset: model-sample
+  dataset: model-sample  # Name of the output dataset under storage_url.

--- a/cookbook/dnn_training/deepspeed_multinode/train.yaml
+++ b/cookbook/dnn_training/deepspeed_multinode/train.yaml
@@ -34,7 +34,7 @@ workflow:
     - name: master
       lead: true
       outputs:
-      - url: {{ storage_url }}/{{ dataset }}/{{ workflow_id }}/
+      - url: {{ storage_url }}/{{ dataset }}/{{workflow_id}}/
     {% else %}
     - name: worker_{{item}}
     {% endif %}

--- a/cookbook/dnn_training/single_node/README.md
+++ b/cookbook/dnn_training/single_node/README.md
@@ -34,7 +34,7 @@ This workflow example contains:
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/single_node/train.yaml
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/single_node/train.py
-osmo workflow submit train.yaml
+osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 ## Open Tensorboard

--- a/cookbook/dnn_training/single_node/train.yaml
+++ b/cookbook/dnn_training/single_node/train.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit train.yaml
+# osmo workflow submit train.yaml --set storage_url=s3://my-bucket
 
 workflow:
   name: train-single-gpu
@@ -39,7 +39,7 @@ workflow:
 
           # Directory of training inputs
           {% if input_dataset %}
-          INPUT_DIR="{{input:0}}/{{input_dataset}}"
+          INPUT_DIR="{{input:0}}"
           {% else %}
           INPUT_DIR="./data"
           {% endif %}
@@ -66,13 +66,10 @@ workflow:
         localpath: train.py
     {% if input_dataset %}
     inputs:
-      - dataset:
-          name: {{ input_dataset }}
+      - url: {{ storage_url }}/{{ input_dataset }}/
     {% endif %}
     outputs:
-      - dataset:
-          name: {{ output_dataset }}
-          path: experiments/models  # The local path of the output dataset
+      - url: {{ storage_url }}/{{ output_dataset }}/{{ workflow_id }}/
     {% if checkpoint_url %}
     checkpoint:
     - path: experiments/checkpoints  # The local path of the checkpoints
@@ -82,6 +79,6 @@ workflow:
     {% endif %}
 
 default-values:
-  input_dataset: ""  # The name of the input dataset
-  output_dataset: my-trained-model  # The name of the output dataset
+  input_dataset: ""  # Optional. Name of the input dataset under storage_url.
+  output_dataset: my-trained-model  # Name of the output dataset under storage_url.
   checkpoint_url: ""  # The remote path in the data store to checkpoint to

--- a/cookbook/dnn_training/single_node/train.yaml
+++ b/cookbook/dnn_training/single_node/train.yaml
@@ -69,7 +69,7 @@ workflow:
       - url: {{ storage_url }}/{{ input_dataset }}/
     {% endif %}
     outputs:
-      - url: {{ storage_url }}/{{ output_dataset }}/{{ workflow_id }}/
+      - url: {{ storage_url }}/{{ output_dataset }}/{{workflow_id}}/
     {% if checkpoint_url %}
     checkpoint:
     - path: experiments/checkpoints  # The local path of the checkpoints

--- a/cookbook/dnn_training/torchrun_elastic/README.md
+++ b/cookbook/dnn_training/torchrun_elastic/README.md
@@ -35,5 +35,5 @@ This workflow example contains:
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_elastic/train.py
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_elastic/train.yaml
-osmo workflow submit train.yaml --set min_nodes=2 max_nodes=4 n_epochs=10
+osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets min_nodes=2 max_nodes=4 n_epochs=10
 ```

--- a/cookbook/dnn_training/torchrun_elastic/train.yaml
+++ b/cookbook/dnn_training/torchrun_elastic/train.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit train.yaml --set min_nodes=2 max_nodes=4 n_epochs=10
+# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets min_nodes=2 max_nodes=4 n_epochs=10
 
 workflow:
   name: elastic-sample

--- a/cookbook/dnn_training/torchrun_elastic/train.yaml
+++ b/cookbook/dnn_training/torchrun_elastic/train.yaml
@@ -34,7 +34,7 @@ workflow:
     - name: master  # Master task for torchrun
       lead: true
       outputs:
-      - url: {{ storage_url }}/{{ dataset }}/{{ workflow_id }}/
+      - url: {{ storage_url }}/{{ dataset }}/{{workflow_id}}/
     {% else %}
     - name: worker_{{item}}  # Worker task that will communicate with the master task
     {% endif %}

--- a/cookbook/dnn_training/torchrun_elastic/train.yaml
+++ b/cookbook/dnn_training/torchrun_elastic/train.yaml
@@ -34,9 +34,7 @@ workflow:
     - name: master  # Master task for torchrun
       lead: true
       outputs:
-      - dataset:
-          name: {{ dataset }}
-          path: models
+      - url: {{ storage_url }}/{{ dataset }}/{{ workflow_id }}/
     {% else %}
     - name: worker_{{item}}  # Worker task that will communicate with the master task
     {% endif %}
@@ -69,4 +67,4 @@ default-values:
   master_port: 29400
   n_epochs: 10
   batch_size: 32
-  dataset: model-sample
+  dataset: model-sample  # Name of the output dataset under storage_url.

--- a/cookbook/dnn_training/torchrun_multinode/README.md
+++ b/cookbook/dnn_training/torchrun_multinode/README.md
@@ -36,5 +36,5 @@ This workflow example contains:
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_multinode/train_template.yaml
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_multinode/train.py
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_multinode/osmo_barrier.py
-osmo workflow submit train_template.yaml
+osmo workflow submit train_template.yaml --set storage_url=s3://my-bucket/datasets
 ```

--- a/cookbook/dnn_training/torchrun_multinode/train.yaml
+++ b/cookbook/dnn_training/torchrun_multinode/train.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit train.yaml
+# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: train-multi-gpu

--- a/cookbook/dnn_training/torchrun_multinode/train.yaml
+++ b/cookbook/dnn_training/torchrun_multinode/train.yaml
@@ -48,7 +48,7 @@ workflow:
       - path: /tmp/train.py
         localpath: train.py
       outputs:
-        - url: {{ storage_url }}/{{ output_dataset }}/{{ workflow_id }}/
+        - url: {{ storage_url }}/{{ output_dataset }}/{{workflow_id}}/
 
     - name: worker  # Worker task that will communicate with the master task
       image: nvcr.io/nvidia/pytorch:24.03-py3

--- a/cookbook/dnn_training/torchrun_multinode/train.yaml
+++ b/cookbook/dnn_training/torchrun_multinode/train.yaml
@@ -48,9 +48,7 @@ workflow:
       - path: /tmp/train.py
         localpath: train.py
       outputs:
-        - dataset:
-            name: {{ output_dataset }}
-            path: models
+        - url: {{ storage_url }}/{{ output_dataset }}/{{ workflow_id }}/
 
     - name: worker  # Worker task that will communicate with the master task
       image: nvcr.io/nvidia/pytorch:24.03-py3
@@ -71,4 +69,4 @@ workflow:
         localpath: train.py
 
 default-values:
-  output_dataset: my-trained-model  # The name of the output dataset
+  output_dataset: my-trained-model  # Name of the output dataset under storage_url.

--- a/cookbook/dnn_training/torchrun_multinode/train_template.yaml
+++ b/cookbook/dnn_training/torchrun_multinode/train_template.yaml
@@ -14,6 +14,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# This workflow has multiple files. Please refer to README for more details.
+# To submit:
+# osmo workflow submit train_template.yaml --set storage_url=s3://my-bucket/datasets
+
 workflow:
   name: train-torchrun
   resources:

--- a/cookbook/dnn_training/torchrun_multinode/train_template.yaml
+++ b/cookbook/dnn_training/torchrun_multinode/train_template.yaml
@@ -30,9 +30,7 @@ workflow:
     - name: master  # Master task for torchrun
       lead: true  # Set to the lead of the group
       outputs:  # Only save the trained model in lead task
-      - dataset:
-          name: {{ output_dataset }}
-          path: models
+      - url: {{ storage_url }}/{{ output_dataset }}/{{ workflow_id }}/
     {% else %}
     - name: worker_{{item}}  # Worker task that will communicate with the master task
     {% endif %}
@@ -65,4 +63,4 @@ default-values:
   master_port: 29400
   n_epochs: 10
   batch_size: 32
-  output_dataset: my-trained-model  # The name of the output dataset
+  output_dataset: my-trained-model  # Name of the output dataset under storage_url.

--- a/cookbook/dnn_training/torchrun_multinode/train_template.yaml
+++ b/cookbook/dnn_training/torchrun_multinode/train_template.yaml
@@ -30,7 +30,7 @@ workflow:
     - name: master  # Master task for torchrun
       lead: true  # Set to the lead of the group
       outputs:  # Only save the trained model in lead task
-      - url: {{ storage_url }}/{{ output_dataset }}/{{ workflow_id }}/
+      - url: {{ storage_url }}/{{ output_dataset }}/{{workflow_id}}/
     {% else %}
     - name: worker_{{item}}  # Worker task that will communicate with the master task
     {% endif %}

--- a/cookbook/groot/groot_finetune/README.md
+++ b/cookbook/groot/groot_finetune/README.md
@@ -25,11 +25,11 @@ This workflow how to perform fine-tuning using [Isaac Groot](https://github.com/
 ## Running the Workflow
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/groot/groot_finetune/groot_finetune.yaml
-osmo workflow submit groot_finetune.yaml
+osmo workflow submit groot_finetune.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
-You can find the generated demonstrations through the `groot-finetune-dataset` dataset after the workflow completes:
+You can download the generated demonstrations from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-osmo dataset download groot-finetune-dataset
+osmo data download s3://my-bucket/datasets/groot-finetune-dataset/<workflow-id>/ ./
 ```

--- a/cookbook/groot/groot_finetune/groot_finetune.yaml
+++ b/cookbook/groot/groot_finetune/groot_finetune.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit groot_finetune.yaml
+# osmo workflow submit groot_finetune.yaml --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: groot-finetune

--- a/cookbook/groot/groot_finetune/groot_finetune.yaml
+++ b/cookbook/groot/groot_finetune/groot_finetune.yaml
@@ -72,6 +72,4 @@ workflow:
 
       path: /tmp/entry.sh
     outputs:
-    - dataset:
-        name: groot-finetune-dataset
-        path: finetuned-model
+    - url: {{ storage_url }}/groot-finetune-dataset/{{ workflow_id }}/

--- a/cookbook/groot/groot_finetune/groot_finetune.yaml
+++ b/cookbook/groot/groot_finetune/groot_finetune.yaml
@@ -72,4 +72,4 @@ workflow:
 
       path: /tmp/entry.sh
     outputs:
-    - url: {{ storage_url }}/groot-finetune-dataset/{{ workflow_id }}/
+    - url: {{ storage_url }}/groot-finetune-dataset/{{workflow_id}}/

--- a/cookbook/groot/groot_mimic/README.md
+++ b/cookbook/groot/groot_mimic/README.md
@@ -29,11 +29,11 @@ The full tutorial from Isaac Lab can be found [here](https://isaac-sim.github.io
 ## Running the Workflow
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/groot/groot_mimic/groot_mimic.yaml
-osmo workflow submit groot_mimic.yaml
+osmo workflow submit groot_mimic.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
-You can find the generated demonstrations and agent checkpoints through the `mimic-dataset` dataset after the workflow completes:
+You can download the generated demonstrations and agent checkpoints from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-osmo dataset download mimic-dataset
+osmo data download s3://my-bucket/datasets/mimic-dataset/<workflow-id>/ ./
 ```

--- a/cookbook/groot/groot_mimic/groot_mimic.yaml
+++ b/cookbook/groot/groot_mimic/groot_mimic.yaml
@@ -62,7 +62,7 @@ workflow:
       image: nvcr.io/nvidia/isaac-lab:2.3.0
       name: mimic
       outputs:
-      - url: {{ storage_url }}/mimic-dataset/{{ workflow_id }}/
+      - url: {{ storage_url }}/mimic-dataset/{{workflow_id}}/
   name: groot-mimic
   resources:
     default:

--- a/cookbook/groot/groot_mimic/groot_mimic.yaml
+++ b/cookbook/groot/groot_mimic/groot_mimic.yaml
@@ -15,10 +15,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit groot_mimic.yaml
+# osmo workflow submit groot_mimic.yaml --set storage_url=s3://my-bucket/datasets
 #
 # To use more demonstrations:
-# osmo workflow submit groot_mimic.yaml --set num_envs=10 num_trials=1000
+# osmo workflow submit groot_mimic.yaml --set storage_url=s3://my-bucket/datasets num_envs=10 num_trials=1000
 
 workflow:
   groups:

--- a/cookbook/groot/groot_mimic/groot_mimic.yaml
+++ b/cookbook/groot/groot_mimic/groot_mimic.yaml
@@ -62,9 +62,7 @@ workflow:
       image: nvcr.io/nvidia/isaac-lab:2.3.0
       name: mimic
       outputs:
-      - dataset:
-          name: mimic-dataset
-          path: output/mimic
+      - url: {{ storage_url }}/mimic-dataset/{{ workflow_id }}/
   name: groot-mimic
   resources:
     default:

--- a/cookbook/integration_and_tools/wandb/README.md
+++ b/cookbook/integration_and_tools/wandb/README.md
@@ -42,7 +42,7 @@ osmo credential set wandb --type GENERIC --payload wandb_api_key=<YOUR_API_KEY>
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/integration_and_tools/wandb/train.yaml
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/integration_and_tools/wandb/train.py
-osmo workflow submit train.yaml
+osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 ## Monitoring Training

--- a/cookbook/integration_and_tools/wandb/train.yaml
+++ b/cookbook/integration_and_tools/wandb/train.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit train.yaml --set n_nodes=<number of nodes> n_gpus_per_node=<number of GPUs per node>
+# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets n_nodes=<number of nodes> n_gpus_per_node=<number of GPUs per node>
 
 workflow:
   name: wandb-sample

--- a/cookbook/integration_and_tools/wandb/train.yaml
+++ b/cookbook/integration_and_tools/wandb/train.yaml
@@ -33,7 +33,7 @@ workflow:
     - name: master  # Master task for torchrun
       lead: true
       outputs:
-      - url: {{ storage_url }}/{{ dataset }}/{{ workflow_id }}/
+      - url: {{ storage_url }}/{{ dataset }}/{{workflow_id}}/
     {% else %}
     - name: worker_{{item}}  # Worker task that will communicate with the master task
     {% endif %}

--- a/cookbook/integration_and_tools/wandb/train.yaml
+++ b/cookbook/integration_and_tools/wandb/train.yaml
@@ -33,9 +33,7 @@ workflow:
     - name: master  # Master task for torchrun
       lead: true
       outputs:
-      - dataset:
-          name: {{ dataset }}
-          path: models
+      - url: {{ storage_url }}/{{ dataset }}/{{ workflow_id }}/
     {% else %}
     - name: worker_{{item}}  # Worker task that will communicate with the master task
     {% endif %}
@@ -72,4 +70,4 @@ default-values:
   master_port: 29400
   n_epochs: 10
   batch_size: 32
-  dataset: model-sample
+  dataset: model-sample  # Name of the output dataset under storage_url.

--- a/cookbook/mobility_gen/README.md
+++ b/cookbook/mobility_gen/README.md
@@ -81,7 +81,7 @@ Once raw trajectories are recorded, use Cosmos Transfer to apply diffusion-based
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/mobility_gen/cosmos_augmentation.yaml
-osmo workflow submit cosmos_augmentation.yaml
+osmo workflow submit cosmos_augmentation.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 **Example Prompt:**

--- a/cookbook/mobility_gen/cosmos_augmentation.yaml
+++ b/cookbook/mobility_gen/cosmos_augmentation.yaml
@@ -2,7 +2,7 @@
 # Generates photorealistic videos from synthetic robot data using Cosmos Transfer
 #
 # To submit:
-#   osmo workflow submit cosmos_transfer_mobility.yaml --pool isaac-hil
+#   osmo workflow submit cosmos_transfer_mobility.yaml --pool isaac-hil --set storage_url=s3://my-bucket/datasets
 #
 # To connect:
 #   osmo workflow exec <workflow-id> -t cosmos_transfer

--- a/cookbook/mobility_gen/cosmos_augmentation.yaml
+++ b/cookbook/mobility_gen/cosmos_augmentation.yaml
@@ -93,8 +93,7 @@ workflow:
               }
           }
     outputs:
-      - dataset:
-          name: cosmos-transfer-augmented-mobility
+      - url: {{ storage_url }}/cosmos-transfer-augmented-mobility/{{ workflow_id }}/
 
 default-values:
   workflow_name: cosmos_transfer_mobility

--- a/cookbook/mobility_gen/cosmos_augmentation.yaml
+++ b/cookbook/mobility_gen/cosmos_augmentation.yaml
@@ -93,7 +93,7 @@ workflow:
               }
           }
     outputs:
-      - url: {{ storage_url }}/cosmos-transfer-augmented-mobility/{{ workflow_id }}/
+      - url: {{ storage_url }}/cosmos-transfer-augmented-mobility/{{workflow_id}}/
 
 default-values:
   workflow_name: cosmos_transfer_mobility

--- a/cookbook/mobility_gen/cosmos_augmentation.yaml
+++ b/cookbook/mobility_gen/cosmos_augmentation.yaml
@@ -76,22 +76,22 @@ workflow:
         echo "  python examples/inference.py -i <spec_file> -o /workspace/output"
         echo ""
     - path: /workspace/params.json
-        contents: |
-          {
-              "name": "cosmos-transfer-mobility",
-              "prompt": "High-quality warehouse simulation...",
-              "video_path": "/workspace/input/clip_0000/rgb.mp4",
-              "vis": {"control_weight": 0.25},
-              "edge": {"control_weight": 0.25},
-              "depth": {
-                  "input_control": "/workspace/input/clip_0000/depth.mp4",
-                  "control_weight": 0.25
-              },
-              "seg": {
-                  "input_control": "/workspace/input/clip_0000/segmentation.mp4",
-                  "control_weight": 0.25
-              }
-          }
+      contents: |
+        {
+            "name": "cosmos-transfer-mobility",
+            "prompt": "High-quality warehouse simulation...",
+            "video_path": "/workspace/input/clip_0000/rgb.mp4",
+            "vis": {"control_weight": 0.25},
+            "edge": {"control_weight": 0.25},
+            "depth": {
+                "input_control": "/workspace/input/clip_0000/depth.mp4",
+                "control_weight": 0.25
+            },
+            "seg": {
+                "input_control": "/workspace/input/clip_0000/segmentation.mp4",
+                "control_weight": 0.25
+            }
+        }
     outputs:
       - url: {{ storage_url }}/cosmos-transfer-augmented-mobility/{{workflow_id}}/
 

--- a/cookbook/nut_pouring/01_mimic_generation.yaml
+++ b/cookbook/nut_pouring/01_mimic_generation.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 1: Generate MimicGen dataset from teleop data
-# Usage: osmo workflow submit 01_mimic_generation.yaml --pool default
+# Usage: osmo workflow submit 01_mimic_generation.yaml --pool default --set storage_url=s3://my-bucket/datasets
 
 version: 2
 workflow:

--- a/cookbook/nut_pouring/01_mimic_generation.yaml
+++ b/cookbook/nut_pouring/01_mimic_generation.yaml
@@ -37,7 +37,7 @@ workflow:
           ls -lah {{input:0}}
           echo ""
           echo "=== HDF5 file ==="
-          ls -lah {{input:0}}/{{input_dataset}}/dataset_annotated_gr1_nut_pouring.hdf5
+          ls -lah {{input:0}}/dataset_annotated_gr1_nut_pouring.hdf5
           echo ""
           echo "=== Copying nutpour_gr1t2_base_env_cfg.py ==="
           cp /tmp/nutpour_gr1t2_base_env_cfg.py /workspace/isaaclab/source/isaaclab_tasks/isaaclab_tasks/manager_based/manipulation/pick_place/
@@ -60,7 +60,7 @@ workflow:
             --task Isaac-NutPour-GR1T2-Pink-IK-Abs-Mimic-v0 \
             --generation_num_trials 1000 \
             --num_envs 5 \
-            --input_file {{input:0}}/input_mimic/dataset_annotated_gr1_nut_pouring.hdf5 \
+            --input_file {{input:0}}/dataset_annotated_gr1_nut_pouring.hdf5 \
             --output_file ./datasets/generated_dataset_gr1_nut_pouring.hdf5
 
           echo ""
@@ -84,9 +84,9 @@ workflow:
         path: /tmp/nutpour_gr1t2_base_env_cfg.py
       image: {{ image_name }}
       inputs:
-      - dataset: {{ input_dataset }}
+      - url: {{ storage_url }}/{{ input_dataset }}/
       outputs:
-      - dataset: {{ output_dataset }}
+      - url: {{ storage_url }}/{{ output_dataset }}/
       lead: true
       name: mimic_task
   name: isaac_mimic_25
@@ -102,5 +102,5 @@ workflow:
 
 default-values:
   image_name: nvcr.io/nvidia/isaac-lab:2.3.0
-  input_dataset: PhysAI-InputMimic
-  output_dataset: PhysAI-MimicGen
+  input_dataset: PhysAI-InputMimic  # Name of the input dataset under storage_url.
+  output_dataset: PhysAI-MimicGen  # Name of the output dataset under storage_url; consumed by stage 02.

--- a/cookbook/nut_pouring/02_hdf5_to_mp4.yaml
+++ b/cookbook/nut_pouring/02_hdf5_to_mp4.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 2: Convert HDF5 camera observations to MP4 videos
-# Usage: osmo workflow submit 02_hdf5_to_mp4.yaml --pool default
+# Usage: osmo workflow submit 02_hdf5_to_mp4.yaml --pool default --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: {{ workflow_name }}

--- a/cookbook/nut_pouring/02_hdf5_to_mp4.yaml
+++ b/cookbook/nut_pouring/02_hdf5_to_mp4.yaml
@@ -41,9 +41,9 @@ workflow:
           HF_TOKEN: token
 
     inputs:
-    - dataset: {{ input_dataset }}
+    - url: {{ storage_url }}/{{ input_dataset }}/
     outputs:
-    - dataset: {{ output_dataset }}
+    - url: {{ storage_url }}/{{ output_dataset }}/
 
     args:
     - /tmp/entry.sh
@@ -131,5 +131,5 @@ default-values:
   storage: 256Gi
   num_gpu: 1
   num_cpu: 16
-  input_dataset: PhysAI-MimicGen
-  output_dataset: PhysAI-MP4Videos
+  input_dataset: PhysAI-MimicGen  # Produced by stage 01.
+  output_dataset: PhysAI-MP4Videos  # Consumed by stage 03.

--- a/cookbook/nut_pouring/03_cosmos_augmentation.yaml
+++ b/cookbook/nut_pouring/03_cosmos_augmentation.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 3: Apply Cosmos Transfer 2.5 for visual augmentation
-# Usage: osmo workflow submit 03_cosmos_augmentation.yaml --pool default
+# Usage: osmo workflow submit 03_cosmos_augmentation.yaml --pool default --set storage_url=s3://my-bucket/datasets
 
 workflow:
   groups:

--- a/cookbook/nut_pouring/03_cosmos_augmentation.yaml
+++ b/cookbook/nut_pouring/03_cosmos_augmentation.yaml
@@ -143,11 +143,11 @@ workflow:
         path: /tmp/entry.sh
       image: nvcr.io/nvidia/cosmos/cosmos-predict2-container:1.2
       inputs:
-      - dataset: {{ input_dataset }}
+      - url: {{ storage_url }}/{{ input_dataset }}/
       lead: true
       name: cosmos_transfer_augmentation
       outputs:
-      - dataset: {{ output_dataset }}
+      - url: {{ storage_url }}/{{ output_dataset }}/
   name: cosmos_transfer_augmentation
   resources:
     default:
@@ -160,5 +160,5 @@ workflow:
     queue_timeout: 1d
 
 default-values:
-  input_dataset: PhysAI-MP4Videos
-  output_dataset: PhysAI-CosmosAugmentedMP4
+  input_dataset: PhysAI-MP4Videos  # Produced by stage 02.
+  output_dataset: PhysAI-CosmosAugmentedMP4  # Consumed by stage 04.

--- a/cookbook/nut_pouring/04_mp4_to_hdf5.yaml
+++ b/cookbook/nut_pouring/04_mp4_to_hdf5.yaml
@@ -41,10 +41,10 @@ workflow:
         HF_TOKEN: token
 
     inputs:
-    - dataset: {{ input_dataset_mimic_gen}}
-    - dataset: {{ input_dataset_cosmos_augmented_mp4}}
+    - url: {{ storage_url }}/{{ input_dataset_mimic_gen }}/
+    - url: {{ storage_url }}/{{ input_dataset_cosmos_augmented_mp4 }}/
     outputs:
-    - dataset: {{ output_dataset }}
+    - url: {{ storage_url }}/{{ output_dataset }}/
 
     args:
     - /tmp/entry.sh
@@ -105,6 +105,6 @@ default-values:
   storage: 256Gi
   num_gpu: 1
   num_cpu: 16
-  input_dataset_mimic_gen: PhysAI-MimicGen
-  input_dataset_cosmos_augmented_mp4: PhysAI-CosmosAugmentedMP4
-  output_dataset: PhysAI-CosmosAugmentedHDF5
+  input_dataset_mimic_gen: PhysAI-MimicGen  # Produced by stage 01.
+  input_dataset_cosmos_augmented_mp4: PhysAI-CosmosAugmentedMP4  # Produced by stage 03.
+  output_dataset: PhysAI-CosmosAugmentedHDF5  # Consumed by stage 05.

--- a/cookbook/nut_pouring/04_mp4_to_hdf5.yaml
+++ b/cookbook/nut_pouring/04_mp4_to_hdf5.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 4: Merge augmented MP4 videos back into HDF5 format
-# Usage: osmo workflow submit 04_mp4_to_hdf5.yaml --pool default
+# Usage: osmo workflow submit 04_mp4_to_hdf5.yaml --pool default --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: {{ workflow_name }}

--- a/cookbook/nut_pouring/05_lerobot_conversion.yaml
+++ b/cookbook/nut_pouring/05_lerobot_conversion.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 5: Convert HDF5 to LeRobot dataset format for GROOT training
-# Usage: osmo workflow submit 05_lerobot_conversion.yaml --pool default
+# Usage: osmo workflow submit 05_lerobot_conversion.yaml --pool default --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: {{workflow_name}}

--- a/cookbook/nut_pouring/05_lerobot_conversion.yaml
+++ b/cookbook/nut_pouring/05_lerobot_conversion.yaml
@@ -38,10 +38,10 @@ workflow:
       OMNI_KIT_ALLOW_ROOT: 1
 
     inputs:
-    - dataset: {{ input_dataset }}
+    - url: {{ storage_url }}/{{ input_dataset }}/
 
     outputs:
-    - dataset: {{ output_dataset }}
+    - url: {{ storage_url }}/{{ output_dataset }}/
 
     command: ["bash"]
     args: ["/tmp/entry.sh"]
@@ -139,5 +139,5 @@ default-values:
   num_cpu: 32
   platform: ovx-a40
   image_name: nvcr.io/nvidia/isaac-lab:2.3.0
-  input_dataset: PhysAI-CosmosAugmentedHDF5
-  output_dataset: PhysAI-LeRobotDataset
+  input_dataset: PhysAI-CosmosAugmentedHDF5  # Produced by stage 04.
+  output_dataset: PhysAI-LeRobotDataset  # Consumed by stage 06.

--- a/cookbook/nut_pouring/06_groot_finetune.yaml
+++ b/cookbook/nut_pouring/06_groot_finetune.yaml
@@ -93,11 +93,11 @@ workflow:
         path: /tmp/entry.sh
       image: pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel
       inputs:
-      - dataset: {{ input_dataset }}
+      - url: {{ storage_url }}/{{ input_dataset }}/
       lead: true
       name: master
       outputs:
-      - dataset: {{ output_dataset }}
+      - url: {{ storage_url }}/{{ output_dataset }}/{{ workflow_id }}/
   name: groot_finetune_nut_pouring
   resources:
     default:
@@ -110,5 +110,5 @@ workflow:
     queue_timeout: 2d
 
 default-values:
-  input_dataset: PhysAI-LeRobotDataset
-  output_dataset: PhysAI-GR00T-Finetuned
+  input_dataset: PhysAI-LeRobotDataset  # Produced by stage 05.
+  output_dataset: PhysAI-GR00T-Finetuned  # Per-run outputs are written to <output_dataset>/<workflow_id>/.

--- a/cookbook/nut_pouring/06_groot_finetune.yaml
+++ b/cookbook/nut_pouring/06_groot_finetune.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 6: Fine-tune GROOT-N1.5 VLA model on prepared dataset
-# Usage: osmo workflow submit 06_groot_finetune.yaml --pool default
+# Usage: osmo workflow submit 06_groot_finetune.yaml --pool default --set storage_url=s3://my-bucket/datasets
 
 workflow:
   groups:

--- a/cookbook/nut_pouring/06_groot_finetune.yaml
+++ b/cookbook/nut_pouring/06_groot_finetune.yaml
@@ -97,7 +97,7 @@ workflow:
       lead: true
       name: master
       outputs:
-      - url: {{ storage_url }}/{{ output_dataset }}/{{ workflow_id }}/
+      - url: {{ storage_url }}/{{ output_dataset }}/{{workflow_id}}/
   name: groot_finetune_nut_pouring
   resources:
     default:

--- a/cookbook/nut_pouring/README.md
+++ b/cookbook/nut_pouring/README.md
@@ -72,37 +72,44 @@ Set your credential for Huggingface in order to access datasets:
 osmo credential set huggingface_token --type GENERIC --payload token=<your-hf-token>
 ```
 
-Set up the first input dataset:
+Pick a base storage URL for the chain (every stage will read from / write to it),
+and upload the seed input HDF5 to `$STORAGE_URL/PhysAI-InputMimic/`:
 
 ```bash
-mkdir -p input_mimic
+export STORAGE_URL=s3://my-bucket/datasets
+
 curl -O https://download.isaacsim.omniverse.nvidia.com/isaaclab/dataset/dataset_annotated_gr1_nut_pouring.hdf5
-osmo dataset upload PhysAI-InputMimic dataset_annotated_gr1_nut_pouring.hdf5
+osmo data upload $STORAGE_URL/PhysAI-InputMimic/ dataset_annotated_gr1_nut_pouring.hdf5
 ```
 
-Execute each step sequentially:
+Execute each step sequentially. All six stages share the same `storage_url` so each
+stage's output URL matches the next stage's input URL — pass the same value via
+`--set storage_url=...` on every submission:
 
 ```bash
 mkdir -p nut_pouring && cd nut_pouring
 curl https://codeload.github.com/NVIDIA/OSMO/tar.gz/main | tar -xz --strip=4 OSMO-main/cookbook/nut_pouring
 
+# Pick a base URL the entire chain will read from and write to.
+export STORAGE_URL=s3://my-bucket/datasets
+
 # Step 1: MimicGen data generation
-osmo workflow submit 01_mimic_generation.yaml
+osmo workflow submit 01_mimic_generation.yaml --set storage_url=$STORAGE_URL
 
 # Step 2: HDF5 to MP4 conversion
-osmo workflow submit 02_hdf5_to_mp4.yaml
+osmo workflow submit 02_hdf5_to_mp4.yaml --set storage_url=$STORAGE_URL
 
 # Step 3: Cosmos Transfer augmentation
-osmo workflow submit 03_cosmos_augmentation.yaml
+osmo workflow submit 03_cosmos_augmentation.yaml --set storage_url=$STORAGE_URL
 
 # Step 4: MP4 to HDF5 conversion
-osmo workflow submit 04_mp4_to_hdf5.yaml
+osmo workflow submit 04_mp4_to_hdf5.yaml --set storage_url=$STORAGE_URL
 
 # Step 5: LeRobot format conversion
-osmo workflow submit 05_lerobot_conversion.yaml
+osmo workflow submit 05_lerobot_conversion.yaml --set storage_url=$STORAGE_URL
 
 # Step 6: GROOT fine-tuning
-osmo workflow submit 06_groot_finetune.yaml
+osmo workflow submit 06_groot_finetune.yaml --set storage_url=$STORAGE_URL
 ```
 
 ## Configuration
@@ -111,6 +118,7 @@ Each workflow uses parameterized default values. Override as needed:
 
 ```bash
 osmo workflow submit 06_groot_finetune.yaml \
+  --set storage_url=$STORAGE_URL \
   --set max_steps=20000 \
   --set batch_size=64
 ```

--- a/cookbook/reinforcement_learning/multi_gpu/README.md
+++ b/cookbook/reinforcement_learning/multi_gpu/README.md
@@ -39,7 +39,7 @@ This workflow example contains:
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
-osmo workflow submit train_policy.yaml
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 ### Customizing GPU Count
@@ -47,5 +47,5 @@ osmo workflow submit train_policy.yaml
 To run with a different number of GPUs, override the default value:
 
 ```bash
-osmo workflow submit train_policy.yaml --set num_gpu=4
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets num_gpu=4
 ```

--- a/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
+++ b/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
@@ -41,8 +41,7 @@ workflow:
 
       path: /tmp/entry.sh
     outputs:
-    - dataset:
-        name: robot-policy-dataset
+    - url: {{ storage_url }}/robot-policy-dataset/{{ workflow_id }}/
   name: train-robot-multi-gpu
   resources:
     default:

--- a/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
+++ b/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
@@ -41,7 +41,7 @@ workflow:
 
       path: /tmp/entry.sh
     outputs:
-    - url: {{ storage_url }}/robot-policy-dataset/{{ workflow_id }}/
+    - url: {{ storage_url }}/robot-policy-dataset/{{workflow_id}}/
   name: train-robot-multi-gpu
   resources:
     default:

--- a/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
+++ b/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit train_policy.yaml
+# osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
 
 workflow:
   tasks:

--- a/cookbook/reinforcement_learning/multi_node/README.md
+++ b/cookbook/reinforcement_learning/multi_node/README.md
@@ -40,7 +40,7 @@ This workflow example contains:
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/reinforcement_learning/multi_node/train_policy.yaml
-osmo workflow submit train_policy.yaml
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 ### Customizing GPU Count
@@ -48,7 +48,7 @@ osmo workflow submit train_policy.yaml
 To run with a different number of GPUs per node, override the default value:
 
 ```bash
-osmo workflow submit train_policy.yaml --set num_gpu=4
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets num_gpu=4
 ```
 
 ## Architecture

--- a/cookbook/reinforcement_learning/multi_node/train_policy.yaml
+++ b/cookbook/reinforcement_learning/multi_node/train_policy.yaml
@@ -44,7 +44,7 @@ workflow:
 
         path: /tmp/entry.sh
       outputs:
-      - url: {{ storage_url }}/robot-policy-dataset/{{ workflow_id }}/
+      - url: {{ storage_url }}/robot-policy-dataset/{{workflow_id}}/
     {% for i in range(1, num_nodes) %}
     - name: worker-{{i}}
       command: ["bash"]

--- a/cookbook/reinforcement_learning/multi_node/train_policy.yaml
+++ b/cookbook/reinforcement_learning/multi_node/train_policy.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit train_policy.yaml
+# osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
 
 workflow:
   groups:

--- a/cookbook/reinforcement_learning/multi_node/train_policy.yaml
+++ b/cookbook/reinforcement_learning/multi_node/train_policy.yaml
@@ -44,8 +44,7 @@ workflow:
 
         path: /tmp/entry.sh
       outputs:
-      - dataset:
-          name: robot-policy-dataset
+      - url: {{ storage_url }}/robot-policy-dataset/{{ workflow_id }}/
     {% for i in range(1, num_nodes) %}
     - name: worker-{{i}}
       command: ["bash"]

--- a/cookbook/reinforcement_learning/single_gpu/README.md
+++ b/cookbook/reinforcement_learning/single_gpu/README.md
@@ -32,7 +32,7 @@ This workflow example contains:
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
-osmo workflow submit train_policy.yaml
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 ## Open Tensorboard

--- a/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
+++ b/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit train_policy.yaml
+# osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
 # To see TensorBoard dashboard:
 # osmo workflow port-forward <workflow ID> train --port 6006
 

--- a/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
+++ b/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
@@ -51,7 +51,7 @@ workflow:
 
       path: /tmp/entry.sh
     outputs:
-    - url: {{ storage_url }}/robot-policy-dataset/{{ workflow_id }}/
+    - url: {{ storage_url }}/robot-policy-dataset/{{workflow_id}}/
   name: train-robot-policy
   resources:
     default:

--- a/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
+++ b/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
@@ -51,8 +51,7 @@ workflow:
 
       path: /tmp/entry.sh
     outputs:
-    - dataset:
-        name: robot-policy-dataset
+    - url: {{ storage_url }}/robot-policy-dataset/{{ workflow_id }}/
   name: train-robot-policy
   resources:
     default:

--- a/cookbook/synthetic_data_generation/gazebo/README.md
+++ b/cookbook/synthetic_data_generation/gazebo/README.md
@@ -32,15 +32,15 @@ This workflow demonstrates synthetic data generation using the Gazebo simulator.
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/synthetic_data_generation/gazebo/sdg.py
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/synthetic_data_generation/gazebo/segmentation_world.sdf
-osmo workflow submit gazebo_sdg.yaml
+osmo workflow submit gazebo_sdg.yaml --set storage_url=s3://my-bucket/datasets
 ```
 
 ## Downloading Output Dataset
 
-Once the workflow is completed, download the generated dataset:
+Once the workflow is completed, download the generated data from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-osmo dataset download gazebo-sdg-sample <local_folder>
+osmo data download s3://my-bucket/datasets/gazebo-sdg-sample/<workflow-id>/ <local_folder>
 ```
 
 ## Example Output

--- a/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
+++ b/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit gazebo_sdg.yaml
+# osmo workflow submit gazebo_sdg.yaml --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: gazebo-sdg

--- a/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
+++ b/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
@@ -27,9 +27,7 @@ workflow:
     command: ["bash"]
     args: ["/tmp/entry.sh"]
     outputs:
-    # Dataset output
-    - dataset:
-        name: {{ dataset }}
+    - url: {{ storage_url }}/{{ dataset }}/{{ workflow_id }}/
     files:
     - path: /tmp/entry.sh
       contents: |
@@ -62,4 +60,4 @@ workflow:
 
 default-values:
   platform: ovx-a40
-  dataset: gazebo-sdg-sample
+  dataset: gazebo-sdg-sample  # Name of the output dataset under storage_url.

--- a/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
+++ b/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
@@ -27,7 +27,7 @@ workflow:
     command: ["bash"]
     args: ["/tmp/entry.sh"]
     outputs:
-    - url: {{ storage_url }}/{{ dataset }}/{{ workflow_id }}/
+    - url: {{ storage_url }}/{{ dataset }}/{{workflow_id}}/
     files:
     - path: /tmp/entry.sh
       contents: |

--- a/cookbook/synthetic_data_generation/isaac_sim/README.md
+++ b/cookbook/synthetic_data_generation/isaac_sim/README.md
@@ -31,5 +31,5 @@ networks. The workflow consists of one main task that launches Isaac Sim, and ge
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
-osmo workflow submit isaac_sim_sdg.yaml
+osmo workflow submit isaac_sim_sdg.yaml --set storage_url=s3://my-bucket/datasets
 ```

--- a/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
+++ b/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
@@ -41,7 +41,7 @@ workflow:
         }
       path: /tmp/config.json
     outputs:
-    - url: {{ storage_url }}/isaac-sim-sdg-sample/{{ workflow_id }}/
+    - url: {{ storage_url }}/isaac-sim-sdg-sample/{{workflow_id}}/
   resources:
     default:
       cpu: 4

--- a/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
+++ b/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
@@ -41,8 +41,7 @@ workflow:
         }
       path: /tmp/config.json
     outputs:
-    - dataset:
-        name: isaac-sim-sdg-sample
+    - url: {{ storage_url }}/isaac-sim-sdg-sample/{{ workflow_id }}/
   resources:
     default:
       cpu: 4

--- a/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
+++ b/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit isaac_sim_sdg.yaml
+# osmo workflow submit isaac_sim_sdg.yaml --set storage_url=s3://my-bucket/datasets
 
 workflow:
   name: isaac-sim-sdg

--- a/cookbook/tutorials/data_filter.yaml
+++ b/cookbook/tutorials/data_filter.yaml
@@ -14,6 +14,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# To submit:
+#   osmo workflow submit data_filter.yaml --set storage_url=s3://my-bucket
+
 workflow:
   name: filtered-io
 
@@ -24,11 +27,9 @@ workflow:
     args: ["ls -la {{input:0}}/"]
 
     inputs:
-    - dataset:
-        name: large_dataset
-        regex: .*\.txt$ # (1)
+    - url: {{ storage_url }}/large_dataset/
+      regex: .*\.txt$ # (1)
 
     outputs:
-    - dataset:
-        name: output_dataset
-        regex: .*\.(json|yaml)$ # (2)
+    - url: {{ storage_url }}/output_dataset/{{ workflow_id }}/
+      regex: .*\.(json|yaml)$ # (2)

--- a/cookbook/tutorials/data_filter.yaml
+++ b/cookbook/tutorials/data_filter.yaml
@@ -31,5 +31,5 @@ workflow:
       regex: .*\.txt$ # (1)
 
     outputs:
-    - url: {{ storage_url }}/output_dataset/{{ workflow_id }}/
+    - url: {{ storage_url }}/output_dataset/{{workflow_id}}/
       regex: .*\.(json|yaml)$ # (2)


### PR DESCRIPTION
## Description

Replaces deprecated `dataset:` I/O blocks with `url:` blocks in 24 cookbook YAMLs (dnn_training, groot, cosmos, RL, SDG/mobility, wandb, nut_pouring chain, plus the `data_filter` tutorial). Each migrated workflow takes a `{{ storage_url }}` Jinja variable that the submitter must provide via `--set storage_url=…`. No default is set, so omission produces a Jinja undefined error at submit time (fail fast). Per-run outputs use a `{{ workflow_id }}/` suffix for isolation. The 6-stage nut-pouring chain (`01_*` → `06_*`) deliberately omits the workflow_id segment so stages share a fixed URL under one shared `storage_url` override.

Schema is unchanged: `URLInputOutput` (`src/utils/job/task.py:483`) was already in place; this PR only edits cookbook YAMLs.

The 3 dataset-only tutorials (`dataset_upload.yaml`, `dataset_download.yaml`, `data_and_dataset_combined.yaml`) and the matching RST sections are deleted in companion PR #910 — the two PRs are independent and can land in either order.

Issue #911

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflows switched from internal dataset artifacts to emitting direct storage URLs for outputs; outputs now include the workflow run ID and tasks consume storage-backed URLs.
* **Documentation**
  * Updated example submission commands and READMEs to show passing storage_url at submit time and to download outputs from the generated storage URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->