### PR TITLE
Testbot: backend-first targets, retry-on-error, opus 4.7 upgrade

### DIFF
--- a/.github/workflows/testbot-respond.yaml
+++ b/.github/workflows/testbot-respond.yaml
@@ -105,7 +105,7 @@ jobs:
             --max-responses 10 \
             --max-turns 200 \
             --timeout 900 \
-            --model aws/anthropic/claude-opus-4-5
+            --model aws/anthropic/bedrock-claude-opus-4-7
         env:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -158,7 +158,7 @@ jobs:
           npx @anthropic-ai/claude-code@2.1.116 --print \
             --model "$ANTHROPIC_MODEL" \
             --output-format stream-json --verbose \
-            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cd *),Bash(mv *),Bash(bazel test *),Bash(bazel build *),Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *)" \
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cd *),Bash(mv *),Bash(rm *),Bash(bazel test *),Bash(bazel build *),Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *)" \
             --max-turns "$MAX_TURNS" \
             "$PROMPT" | tee "$STREAM_LOG"
           # PIPESTATUS[0] is the npx exit code; $? would be tee's, masking

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -37,7 +37,7 @@ on:
         default: '30'
       model:
         description: 'LLM model name on NVIDIA gateway'
-        default: 'aws/anthropic/claude-opus-4-5'
+        default: 'aws/anthropic/bedrock-claude-opus-4-7'
       dry_run:
         description: 'Generate but do not create PR'
         type: boolean
@@ -155,7 +155,7 @@ jobs:
           # block runs even when Claude exits non-zero.
           set +e
           echo "::group::Claude Code stream (click to expand turn-by-turn log)"
-          npx @anthropic-ai/claude-code@2.1.91 --print \
+          npx @anthropic-ai/claude-code@2.1.116 --print \
             --model "$ANTHROPIC_MODEL" \
             --output-format stream-json --verbose \
             --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cd *),Bash(mv *),Bash(bazel test *),Bash(bazel build *),Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *)" \
@@ -209,7 +209,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
-          ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/claude-opus-4-5' }}
+          ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/bedrock-claude-opus-4-7' }}
           MAX_TURNS: ${{ inputs.max_turns || '200' }}
           DISABLE_PROMPT_CACHING: "1"  # NVIDIA gateway rejects cache_control.ephemeral.scope
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"  # NVIDIA gateway rejects context_management

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -121,6 +121,7 @@ Then post a new `/testbot` comment with clearer instructions.
 |----------|-------|-------------|
 | `MIN_FILE_LINES` | `10` | Skip files smaller than this |
 | `MAX_FILE_LINES` | `0` | Skip files larger than this (0 = no cap) |
+| `LANGUAGE_PRIORITY` | `.py`/`.go` = 0, `.ts`/`.tsx` = 1 | Backend code is prioritized over UI; lower bucket picked first, ties broken by coverage % asc |
 
 ## File Structure
 

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -63,7 +63,7 @@ gh workflow run testbot.yaml --ref <branch> \
   -f max_targets=1 \
   -f max_uncovered=300 \
   -f max_turns=100 \
-  -f model=aws/anthropic/claude-opus-4-5
+  -f model=aws/anthropic/bedrock-claude-opus-4-7
 ```
 
 ### Schedule
@@ -103,7 +103,7 @@ Then post a new `/testbot` comment with clearer instructions.
 | `max_uncovered` | `300` | Uncovered lines cap per target (0 = no cap) |
 | `max_turns` | `100` | Claude Code agent turns |
 | `timeout_minutes` | `30` | Workflow timeout |
-| `model` | `aws/anthropic/claude-opus-4-5` | LLM model on API gateway |
+| `model` | `aws/anthropic/bedrock-claude-opus-4-7` | LLM model on API gateway |
 | `dry_run` | `false` | Generate without creating PR |
 
 ### Review response (CLI args in `testbot-respond.yaml`)
@@ -113,7 +113,7 @@ Then post a new `/testbot` comment with clearer instructions.
 | `--max-turns` | `200` | Claude Code agent turns |
 | `--max-responses` | `10` | Max threads to address per trigger |
 | `--timeout` | `720` | Claude Code CLI timeout in seconds |
-| `--model` | `aws/anthropic/claude-opus-4-5` | LLM model |
+| `--model` | `aws/anthropic/bedrock-claude-opus-4-7` | LLM model |
 
 ### Coverage target selection (constants in `coverage_targets.py`)
 

--- a/src/scripts/testbot/coverage_targets.py
+++ b/src/scripts/testbot/coverage_targets.py
@@ -46,6 +46,26 @@ SKIP_BASENAME_PATTERNS = [
 MIN_FILE_LINES = 10
 MAX_FILE_LINES = 0  # 0 = no cap
 
+# Language priority bucket — lower value picked first within a target run.
+# Backend code (Python, Go) gets the limited test-generation budget before
+# frontend (TS/TSX) at the same coverage level; UI files are still eligible
+# but only after backend gaps are addressed.
+LANGUAGE_PRIORITY = {
+    ".py": 0,
+    ".go": 0,
+    ".ts": 1,
+    ".tsx": 1,
+}
+DEFAULT_LANGUAGE_PRIORITY = 2
+
+
+def _language_priority(file_path: str) -> int:
+    """Return the language priority bucket for a file path."""
+    if "." not in file_path:
+        return DEFAULT_LANGUAGE_PRIORITY
+    ext = "." + file_path.rsplit(".", maxsplit=1)[-1]
+    return LANGUAGE_PRIORITY.get(ext, DEFAULT_LANGUAGE_PRIORITY)
+
 
 def _is_ignored(file_path: str) -> bool:
     """Check if a file path matches ignore patterns.
@@ -192,7 +212,12 @@ def select_targets(
             "uncovered_ranges": uncovered_ranges,
         })
 
-    entries.sort(key=lambda entry: entry["coverage_pct"])
+    # Primary: language priority (backend before frontend).
+    # Secondary: coverage_pct ascending (worst coverage first within bucket).
+    entries.sort(key=lambda entry: (
+        _language_priority(entry["file_path"]),
+        entry["coverage_pct"],
+    ))
     return entries[:max_targets]
 
 

--- a/src/scripts/testbot/respond.py
+++ b/src/scripts/testbot/respond.py
@@ -308,7 +308,7 @@ def build_prompt(threads: list[dict], pr_number: int) -> str:
 
 def run_claude(
     prompt: str,
-    model: str = "aws/anthropic/claude-opus-4-5",
+    model: str = "aws/anthropic/bedrock-claude-opus-4-7",
     max_turns: int = 50,
     timeout: int = 720,
 ) -> dict:
@@ -317,7 +317,7 @@ def run_claude(
     Returns a dict with 'structured_output' and/or 'result' fields.
     Returns empty dict on failure.
     """
-    claude_bin = os.environ.get("CLAUDE_CODE_BIN", "npx @anthropic-ai/claude-code@2.1.91")
+    claude_bin = os.environ.get("CLAUDE_CODE_BIN", "npx @anthropic-ai/claude-code@2.1.116")
     cmd = [
         *shlex.split(claude_bin), "--print",
         "--model", model,
@@ -485,8 +485,8 @@ def main() -> None:
                         help="Max Claude Code agent turns (default: 50)")
     parser.add_argument("--timeout", type=int, default=720,
                         help="Claude Code CLI timeout in seconds (default: 720)")
-    parser.add_argument("--model", default="aws/anthropic/claude-opus-4-5",
-                        help="LLM model name (default: aws/anthropic/claude-opus-4-5)")
+    parser.add_argument("--model", default="aws/anthropic/bedrock-claude-opus-4-7",
+                        help="LLM model name (default: aws/anthropic/bedrock-claude-opus-4-7)")
     args = parser.parse_args()
 
     github_repository = os.environ.get("GITHUB_REPOSITORY", "NVIDIA/OSMO")

--- a/src/scripts/testbot/respond.py
+++ b/src/scripts/testbot/respond.py
@@ -29,10 +29,16 @@ logger = logging.getLogger(__name__)
 MAX_PUSH_RETRIES = 3
 SELF_AUTHORS = frozenset({"github-actions[bot]", "svc-osmo-ci"})
 ALLOWED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
+# Hidden trailer appended to every failure reply (max-turns, timeout, generic
+# error). filter_actionable treats bot replies bearing this marker as
+# non-terminal so the user's /testbot is still eligible for retry on the next
+# event without having to repost the comment.
+ERROR_REPLY_MARKER = "<!-- testbot-status: error -->"
 # Shared with testbot.yaml — update both when changing the tool allowlist.
 ALLOWED_TOOLS = (
     "Read,Edit,Write,Glob,Grep,"
-    "Bash(cd *),Bash(mv *),Bash(bazel test *),Bash(bazel build *),"
+    "Bash(cd *),Bash(mv *),Bash(rm *),"
+    "Bash(bazel test *),Bash(bazel build *),"
     "Bash(pnpm *),Bash(npx vitest *),Bash(npx tsc *),"
     "Bash(./node_modules/.bin/vitest *),Bash(./node_modules/.bin/tsc *),"
     "Bash(gh pr view *),Bash(gh pr diff *),Bash(gh pr checks *)"
@@ -221,13 +227,17 @@ def filter_actionable(
             continue
 
         # Find the latest authorized /testbot comment that hasn't been
-        # replied to by the bot. Walk backwards: stop at bot replies (prior
-        # triggers already handled), skip unauthorized triggers so an earlier
-        # authorized one can still be found.
+        # replied to (successfully) by the bot. Walk backwards: stop at a
+        # successful bot reply (prior triggers handled), but skip past
+        # error replies so the user's /testbot is still actionable on
+        # retry. Skip unauthorized triggers so an earlier authorized one
+        # can still be found.
         trigger_comment = None
         for comment in reversed(comments):
             if comment["author"] in SELF_AUTHORS:
-                break  # Bot already replied — all prior triggers handled
+                if ERROR_REPLY_MARKER in comment.get("body", ""):
+                    continue  # Failure reply — keep walking, retry is allowed
+                break  # Successful reply — prior triggers handled
             if not _has_trigger(comment["body"], trigger_phrase):
                 continue
             if comment.get("association", "NONE") not in ALLOWED_ASSOCIATIONS:
@@ -515,12 +525,15 @@ def main() -> None:
         for comment in actionable:
             reply_to_comment(
                 owner, repo, args.pr_number, comment,
-                "I encountered an error processing this request. Please retry or handle manually.",
+                "I encountered an error processing this request. "
+                "Please retry or handle manually.\n\n"
+                + ERROR_REPLY_MARKER,
             )
         return
 
     # On timeout or max-turns, discard partial file changes (may be incomplete)
-    # and post an informative reply.
+    # and post an informative reply with the error marker so the user can
+    # retry without having to repost the /testbot comment.
     subtype = claude_output.get("subtype")
     if subtype in ("timeout", "error_max_turns"):
         reason = "timed out" if subtype == "timeout" else "hit the max-turns limit"
@@ -529,7 +542,8 @@ def main() -> None:
         discard_changes()
         status_msg = (
             f"I {reason} after {turns_used} turns. "
-            f"Try breaking this into smaller requests, or handle manually."
+            f"Try breaking this into smaller requests, or handle manually.\n\n"
+            + ERROR_REPLY_MARKER
         )
         for comment in actionable:
             reply_to_comment(owner, repo, args.pr_number, comment, status_msg)
@@ -574,7 +588,8 @@ def main() -> None:
         per_thread_replies = {}
         fallback_message = (
             "I prepared a fix but could not push it. "
-            "Please retry or push manually."
+            "Please retry or push manually.\n\n"
+            + ERROR_REPLY_MARKER
         )
     elif not modified_files:
         fallback_message = (

--- a/src/scripts/testbot/respond.py
+++ b/src/scripts/testbot/respond.py
@@ -34,7 +34,10 @@ ALLOWED_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 # non-terminal so the user's /testbot is still eligible for retry on the next
 # event without having to repost the comment.
 ERROR_REPLY_MARKER = "<!-- testbot-status: error -->"
-# Shared with testbot.yaml — update both when changing the tool allowlist.
+# Mostly mirrored in testbot.yaml's `--allowedTools` — keep the shared
+# entries (Read/Edit/Write/Glob/Grep, cd/mv/rm, bazel/pnpm/npx/vitest/tsc)
+# in sync. The `gh pr view/diff/checks` entries are respond-only because
+# generate runs before any PR exists.
 ALLOWED_TOOLS = (
     "Read,Edit,Write,Glob,Grep,"
     "Bash(cd *),Bash(mv *),Bash(rm *),"

--- a/src/scripts/testbot/tests/test_coverage_targets.py
+++ b/src/scripts/testbot/tests/test_coverage_targets.py
@@ -193,6 +193,44 @@ class TestSelectTargets(unittest.TestCase):
         result = select_targets(report, max_targets=1, max_uncovered=10)
         self.assertEqual(result[0]["uncovered_lines"], 10)
 
+    def test_prefers_backend_over_frontend_at_same_coverage(self):
+        # Frontend file at 0% coverage but a higher-coverage backend file
+        # is picked first because language priority dominates.
+        report = {"files": [
+            {"name": "src/ui/foo.ts", "line_coverage": [[i, 1] for i in range(20)]},
+            {"name": "src/service/bar.py",
+             "line_coverage": [[i, 0] for i in range(15)] + [[i, 1] for i in range(15, 20)]},
+        ]}
+        result = select_targets(report, max_targets=2, max_uncovered=0)
+        self.assertEqual(result[0]["file_path"], "src/service/bar.py")
+        self.assertEqual(result[1]["file_path"], "src/ui/foo.ts")
+
+    def test_prefers_go_over_tsx_at_same_coverage(self):
+        report = {"files": [
+            {"name": "src/ui/page.tsx", "line_coverage": [[i, 1] for i in range(20)]},
+            {"name": "src/runtime/cmd/main.go", "line_coverage": [[i, 1] for i in range(20)]},
+        ]}
+        result = select_targets(report, max_targets=1, max_uncovered=0)
+        self.assertEqual(result[0]["file_path"], "src/runtime/cmd/main.go")
+
+    def test_falls_back_to_frontend_when_backend_fully_covered(self):
+        report = {"files": [
+            {"name": "src/service/done.py", "line_coverage": [[i, 0] for i in range(20)]},
+            {"name": "src/ui/foo.ts", "line_coverage": [[i, 1] for i in range(20)]},
+        ]}
+        result = select_targets(report, max_targets=1, max_uncovered=0)
+        self.assertEqual(result[0]["file_path"], "src/ui/foo.ts")
+
+    def test_within_backend_sorts_by_coverage_ascending(self):
+        report = {"files": [
+            {"name": "src/a.py",
+             "line_coverage": [[i, 0] for i in range(15)] + [[i, 1] for i in range(15, 20)]},
+            {"name": "src/b.py", "line_coverage": [[i, 1] for i in range(20)]},
+        ]}
+        result = select_targets(report, max_targets=2, max_uncovered=0)
+        self.assertEqual(result[0]["file_path"], "src/b.py")  # 0% covered
+        self.assertEqual(result[1]["file_path"], "src/a.py")  # 75% covered
+
 
 class TestFormatTargets(unittest.TestCase):
     """Tests for format_targets output formatting."""

--- a/src/scripts/testbot/tests/test_respond.py
+++ b/src/scripts/testbot/tests/test_respond.py
@@ -107,6 +107,33 @@ class TestFilterActionable(unittest.TestCase):
         result = filter_actionable(threads, "/testbot")
         self.assertEqual(result, [])
 
+    def test_actionable_after_bot_error_reply(self):
+        # A bot reply bearing the error marker is non-terminal: the user's
+        # /testbot stays actionable so a retry on the next event proceeds.
+        comments = [
+            {"id": 100, "body": "/testbot fix this", "author": "jiaenren", "association": "MEMBER"},
+            {"id": 200,
+             "body": "I hit the max-turns limit after 201 turns.\n\n<!-- testbot-status: error -->",
+             "author": "svc-osmo-ci", "association": "NONE"},
+        ]
+        threads = [self._make_thread(comments=comments)]
+        result = filter_actionable(threads, "/testbot")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["reply_comment_id"], 100)
+
+    def test_skips_thread_after_bot_error_then_success(self):
+        # Error → user followup → bot success: no retry
+        comments = [
+            {"id": 100, "body": "/testbot fix this", "author": "jiaenren", "association": "MEMBER"},
+            {"id": 200, "body": "Error.\n\n<!-- testbot-status: error -->",
+             "author": "svc-osmo-ci", "association": "NONE"},
+            {"id": 300, "body": "/testbot retry", "author": "jiaenren", "association": "MEMBER"},
+            {"id": 400, "body": "Fix applied.", "author": "svc-osmo-ci", "association": "NONE"},
+        ]
+        threads = [self._make_thread(comments=comments)]
+        result = filter_actionable(threads, "/testbot")
+        self.assertEqual(result, [])
+
     def test_skips_thread_without_trigger(self):
         comments = [{"id": 100, "body": "please fix this", "author": "jiaenren", "association": "MEMBER"}]
         threads = [self._make_thread(comments=comments)]


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description

Three related testbot improvements bundled together.

### 1. Prioritize backend (Python/Go) over UI in target selection

`coverage_targets.py` sorted purely by `coverage_pct asc`, which let small
UI files at 0% coverage win every run even when backend modules had the
same or worse absolute test gap. Recent runs spent the budget on
`src/ui/src/lib/api/adapter/datasets-hooks.ts` instead of business-critical
Python/Go in `service/`, `lib/`, `runtime/`.

Add a **language-priority bucket** as the primary sort key:

| Bucket | Extensions | Effect |
|---|---|---|
| 0 | `.py`, `.go` | Picked first |
| 1 | `.ts`, `.tsx` | Picked only after bucket 0 has no candidates |
| 2 | other | After 0 and 1 |

Within a bucket, `coverage_pct asc` tiebreaker is preserved (worst-covered
file still wins among same-language candidates). UI files are not
excluded — just queued after backend. Override is a one-line edit to
`LANGUAGE_PRIORITY` / `DEFAULT_LANGUAGE_PRIORITY`.

### 2. testbot respond: allow `rm` and let users retry after a bot failure

Two bugs surfaced on PR #913, comment
[r3157976896](https://github.com/NVIDIA/OSMO/pull/913#discussion_r3157976896):

**(a) Allowlist gap.** User asked "is it okay to not include this
placeholder file?" — Claude's natural action is to delete it, but `rm` /
`git rm` were blocked. Same loop pattern as the earlier `mv` case: Claude
tried variants until max-turns hit, ~$80 spent for nothing. Add
`Bash(rm *)` to both respond's `ALLOWED_TOOLS` and the generate workflow's
`--allowedTools`. Risk stays bounded: ephemeral runner, and
`get_changed_files()` / `get_changed_test_files()` already filter
post-run so guardrails remain in effect. The `gh pr view/diff/checks`
entries stay respond-only because generate runs before any PR exists.

**(b) Failure replies poisoned the dedup walk.** `filter_actionable`
walked thread comments newest→oldest and broke on any `SELF_AUTHORS`
reply, treating it as "all prior triggers handled". A max-turns / timeout
/ generic-error reply blocked the original `/testbot` from retrying, even
though the request was never actually processed — the user had to delete
and repost the comment.

Add a hidden HTML-comment marker `<!-- testbot-status: error -->` to every
failure-reply path (Claude error, timeout/max-turns, push failure). The
filter now skips past bot replies bearing the marker instead of breaking,
so a follow-up event re-triggers the original request without manual
intervention.

### 3. Upgrade Claude Code CLI to 2.1.116 and switch default model to opus 4.7

Claude Code 2.1.91 (current pin) sends `thinking.type.enabled` in the
request body, which Bedrock rejects for Opus 4.7:

```
"thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

Claude Code **2.1.111** (released 2026-04-16) fixed this by emitting
`thinking.type.adaptive` for the affected models. Bumping the pinned
version to **2.1.116** (current `stable` channel) gets us past that fix
across both workflows and `respond.py`'s `CLAUDE_CODE_BIN` default.

Default model switches from `aws/anthropic/claude-opus-4-5` to
`aws/anthropic/bedrock-claude-opus-4-7` (note the new `bedrock-` prefix
in the gateway's namespace for newer models). `workflow_dispatch`
inputs still let operators override per-run.

### Tests

- 4 new cases in `test_coverage_targets.py` covering backend>frontend
  ordering, Go>TSX, frontend-still-picked-when-backend-done, within-bucket
  tiebreaker.
- 2 new cases in `test_respond.TestFilterActionable` covering
  actionable-after-error and skip-after-error-then-success.

`bazel test //src/scripts/testbot/tests/...` passes (10/10 incl. pylint).

Issue #720

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced test target selection now prioritizes backend files over UI files for more balanced coverage.
  * Improved error handling allows failed bot replies to be retried.

* **Chores**
  * Updated Claude model to bedrock-claude-opus-4-7 for improved AI capabilities.
  * Upgraded Claude Code tool to version 2.1.116.
  * Expanded workflow tool capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->