### PR TITLE
Add cli config version validation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -93,3 +93,4 @@ build:ci --test_env=TESTCONTAINERS_HOST_OVERRIDE=docker
 # Coverage: use with `bazel coverage`
 coverage --combined_report=lcov
 coverage --test_tag_filters=-nocoverage
+coverage --build_tests_only

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -79,7 +79,7 @@ jobs:
       env:
         DOCKER_HOST: "tcp://docker:2375"
         DOCKER_TLS_CERTDIR: ""
-      options: --memory=8g --cpus=4 --memory-swap=8g --pids-limit=4096 -v /var/run/docker.sock:/var/run/docker.sock
+      options: --memory=16g --cpus=4 --memory-swap=16g --pids-limit=4096 -v /var/run/docker.sock:/var/run/docker.sock
     services:
       docker:
         # docker:29.2.1-dind pinned to digest for security

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -138,6 +138,11 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.fork == false
       )
+    # Serialize across PRs on the self-hosted runner: 16 GB main + 4 GB DinD
+    # leaves no room for two concurrent runs on a 24 GB host.
+    concurrency:
+      group: ci-internal-self-hosted
+      cancel-in-progress: false
     runs-on: self-hosted
     environment:
       name: internal-ci
@@ -151,7 +156,7 @@ jobs:
       env:
         DOCKER_HOST: "tcp://docker:2375"
         DOCKER_TLS_CERTDIR: ""
-      options: --memory=8g --cpus=4 --memory-swap=8g --pids-limit=4096 -v /var/run/docker.sock:/var/run/docker.sock
+      options: --memory=16g --cpus=4 --memory-swap=16g --pids-limit=4096 -v /var/run/docker.sock:/var/run/docker.sock
     services:
       docker:
         # docker:29.2.1-dind pinned to digest for security

--- a/src/service/core/config/tests/test_config_history.py
+++ b/src/service/core/config/tests/test_config_history.py
@@ -81,7 +81,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         # Test first service config update
         first_service_config = {
             'cli_config': {
-                'latest_version': 'test-cli',
+                'latest_version': '1.0.0',
                 'min_supported_version': '1.0.0',
             }
         }
@@ -98,7 +98,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         # Test second service config update
         second_service_config = {
             'cli_config': {
-                'latest_version': 'updated-cli',
+                'latest_version': '2.0.0',
                 'min_supported_version': '2.0.0',
             }
         }
@@ -122,7 +122,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
             expected_tags=first_tags,
         )
         config = history['configs'][-2]['data']
-        self.assertEqual(config['cli_config']['latest_version'], 'test-cli')
+        self.assertEqual(config['cli_config']['latest_version'], '1.0.0')
         self.assertEqual(config['cli_config']
                          ['min_supported_version'], '1.0.0')
         self._verify_history_entry(
@@ -133,7 +133,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
             expected_tags=second_tags,
         )
         config = history['configs'][-1]['data']
-        self.assertEqual(config['cli_config']['latest_version'], 'updated-cli')
+        self.assertEqual(config['cli_config']['latest_version'], '2.0.0')
         self.assertEqual(config['cli_config']
                          ['min_supported_version'], '2.0.0')
 
@@ -159,7 +159,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
             expected_tags=rollback_tags,
         )
         config = history['configs'][-1]['data']
-        self.assertEqual(config['cli_config']['latest_version'], 'test-cli')
+        self.assertEqual(config['cli_config']['latest_version'], '1.0.0')
         self.assertEqual(config['cli_config']['min_supported_version'], '1.0.0')
 
     def test_workflow_config_history(self):
@@ -1004,7 +1004,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         # Create multiple service config updates to have multiple revisions
         config_service.patch_service_configs(
             request=objects.PatchConfigRequest(
-                configs_dict={'cli_config': {'latest_version': 'test-cli-v1'}},
+                configs_dict={'cli_config': {'latest_version': '1.0.1'}},
                 description='First service update',
                 tags=['first-update']
             ),
@@ -1013,7 +1013,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
 
         config_service.patch_service_configs(
             request=objects.PatchConfigRequest(
-                configs_dict={'cli_config': {'latest_version': 'test-cli-v2'}},
+                configs_dict={'cli_config': {'latest_version': '1.0.2'}},
                 description='Second service update',
                 tags=['second-update']
             ),
@@ -1022,7 +1022,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
 
         config_service.patch_service_configs(
             request=objects.PatchConfigRequest(
-                configs_dict={'cli_config': {'latest_version': 'test-cli-v3'}},
+                configs_dict={'cli_config': {'latest_version': '1.0.3'}},
                 description='Third service update',
                 tags=['third-update']
             ),
@@ -1137,7 +1137,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         initial_tags = ['initial-tag', 'service-tag']
         config_service.patch_service_configs(
             request=objects.PatchConfigRequest(
-                configs_dict={'cli_config': {'latest_version': 'test-cli-v1'}},
+                configs_dict={'cli_config': {'latest_version': '1.0.1'}},
                 description='Initial service update',
                 tags=initial_tags
             ),

--- a/src/utils/connectors/BUILD
+++ b/src/utils/connectors/BUILD
@@ -22,6 +22,7 @@ osmo_py_library(
         "//src/lib/utils:osmo_errors",
         "//src/lib/utils:role",
         "//src/lib/utils:validation",
+        "//src/lib/utils:version",
         "//src/utils:auth",
         "//src/utils:configmap_state",
         "//src/utils:notify",

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -46,7 +46,7 @@ from src.utils import configmap_state
 from src.lib.data import storage
 from src.lib.data.storage import constants
 from src.lib.utils import (common, credentials, jinja_sandbox, login,
-                           osmo_errors, role)
+                           osmo_errors, role, version)
 from src.utils import auth, notify
 from src.utils.secret_manager import Encrypted, SecretManager
 
@@ -2928,6 +2928,24 @@ class CliConfig(ExtraArgBaseModel):
     latest_version: str | None = None
     min_supported_version: str | None = None
     client_install_url: str | None = None
+
+    @pydantic.field_validator('latest_version', 'min_supported_version')
+    @classmethod
+    def validate_version_format(
+            cls, v: str | None, info: pydantic.ValidationInfo) -> str | None:
+        """ Reject malformed version strings at write time so the version-check
+        middleware can trust the persisted value. None and empty pass through
+        unchanged (treated as "not configured" by callers). """
+        if not v:
+            return v
+        try:
+            version.Version.from_string(v)
+        except osmo_errors.OSMOError as exc:
+            raise osmo_errors.OSMOUserError(
+                f'Invalid {info.field_name} "{v}": '
+                'must be of the format major.minor.revision'
+            ) from exc
+        return v
 
 
 class ServiceConfig(DynamicConfig):

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -30,3 +30,17 @@ py_test(
     ],
     size = "small"
 )
+
+py_test(
+    name = "test_cli_config",
+    srcs = [
+        "test_cli_config.py"
+        ],
+    deps = [
+        "//src/utils/connectors:connectors",
+    ],
+    tags = [
+        "exclusive"
+    ],
+    size = "small"
+)

--- a/src/utils/connectors/tests/test_cli_config.py
+++ b/src/utils/connectors/tests/test_cli_config.py
@@ -1,0 +1,50 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import unittest
+
+from src.lib.utils import osmo_errors
+from src.utils import connectors
+
+
+class TestCliConfig(unittest.TestCase):
+    """ Validation tests for the CliConfig pydantic model. """
+
+    def test_accepts_valid_versions(self):
+        connectors.CliConfig()
+        connectors.CliConfig(latest_version='1.2.3')
+        connectors.CliConfig(latest_version='1.2.3.abc123')
+        connectors.CliConfig(min_supported_version='0.0.1')
+        connectors.CliConfig(latest_version='1.2.3', min_supported_version='1.0.0')
+
+    def test_accepts_none_and_empty(self):
+        connectors.CliConfig(latest_version=None, min_supported_version=None)
+        connectors.CliConfig(latest_version='', min_supported_version='')
+
+    def test_rejects_malformed_latest_version(self):
+        for bad in ['test-cli', 'v1.2.3', '1.2.3-rc1', '1.2', 'latest', '1.2.3.4.5']:
+            with self.subTest(bad=bad), self.assertRaises(osmo_errors.OSMOUserError):
+                connectors.CliConfig(latest_version=bad)
+
+    def test_rejects_malformed_min_supported_version(self):
+        for bad in ['test-cli', 'v1.2.3', '1.2.3-rc1', '1.2', 'latest']:
+            with self.subTest(bad=bad), self.assertRaises(osmo_errors.OSMOUserError):
+                connectors.CliConfig(min_supported_version=bad)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
- Rejects bad cli version str
- Prevents bad cli version str from failing API calls due to API version middleware check
- Adjust CI to prevent Bazel JVM OOM

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version configuration fields now validate format and reject invalid version strings with clear errors.

* **Tests**
  * Added and expanded tests covering version-field validation and malformed-value handling.

* **Chores**
  * Updated build/test configuration and coverage settings; CI runner container memory limits increased to improve test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->