### PR TITLE
ci(release-notes): bump to opus 4.7, rename env to nim-env, unwrap line wraps

### DIFF
--- a/.github/release-notes-prompt.md
+++ b/.github/release-notes-prompt.md
@@ -124,13 +124,11 @@ read as "added entries for new commits" — not as a wholesale rewrite.
 
 ### Helm Charts and Containers
 
-Helm charts and container images are available on
-[NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/containers/osmo).
+Helm charts and container images are available on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/containers/osmo).
 
 ### CLI Client
 
-Installers for the CLI client for macOS (Apple Silicon), x86-64 Linux, and
-ARM64 Linux are attached as assets to this release.
+Installers for the CLI client for macOS (Apple Silicon), x86-64 Linux, and ARM64 Linux are attached as assets to this release.
 ```
 
 **Always include the exact Getting OSMO section** above (heading, both
@@ -149,6 +147,9 @@ notes file. Do not paraphrase, condense, or omit it.
   change gets one terse bullet. A release with 3 user-facing changes is short.
   A release with 50 is long. Don't pad. Don't truncate. Don't omit changes to
   hit a length, and don't invent filler to fill space.
+- **No hard line wraps.** Each bullet and each paragraph stays on a single
+  line in the file — no mid-sentence newlines. The GitHub releases UI renders
+  soft breaks as visible breaks, so wrapping at ~80 chars produces ragged output.
 
 ## Voice
 

--- a/.github/workflows/draft-release-notes.yaml
+++ b/.github/workflows/draft-release-notes.yaml
@@ -31,7 +31,7 @@ on:
         required: true
       model:
         description: 'LLM model name on NVIDIA gateway'
-        default: 'aws/anthropic/claude-opus-4-5'
+        default: 'aws/anthropic/bedrock-claude-opus-4-7'
 
 permissions:
   contents: write
@@ -45,7 +45,7 @@ concurrency:
 
 jobs:
   draft:
-    environment: testbot-generate
+    environment: nim-env
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -198,7 +198,7 @@ jobs:
           stream_log="$RUNNER_TEMP/claude-stream.jsonl"
           stderr_log="$RUNNER_TEMP/claude-stderr.log"
           set +e
-          npx @anthropic-ai/claude-code@2.1.91 --print --verbose \
+          npx @anthropic-ai/claude-code@2.1.116 --print --verbose \
             --output-format stream-json \
             --model "$ANTHROPIC_MODEL" \
             --allowedTools "Read,Glob,Grep,WebFetch(domain:raw.githubusercontent.com),WebFetch(domain:nvidia.github.io),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git tag:*),Bash(git rev-parse:*)" \

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -53,7 +53,7 @@ concurrency:
 
 jobs:
   generate-tests:
-    environment: testbot-generate
+    environment: nim-env
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes || '30') }}
     runs-on: ubuntu-latest
     steps:

--- a/releases/6.3.0.md
+++ b/releases/6.3.0.md
@@ -70,10 +70,8 @@
 
 ### Helm Charts and Containers
 
-Helm charts and container images are available on
-[NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/containers/osmo).
+Helm charts and container images are available on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/containers/osmo).
 
 ### CLI Client
 
-Installers for the CLI client for macOS (Apple Silicon), x86-64 Linux, and
-ARM64 Linux are attached as assets to this release.
+Installers for the CLI client for macOS (Apple Silicon), x86-64 Linux, and ARM64 Linux are attached as assets to this release.


### PR DESCRIPTION
## Description

Follow-ups to #920 / #919:

- Unwrap mid-sentence line breaks in `releases/6.3.0.md` Getting OSMO section so they render cleanly on the GitHub release page.
- Unwrap the Getting OSMO example in `.github/release-notes-prompt.md` (the source of the wrapped output) and add an explicit "no hard line wraps" rule for future runs.
- Rename the `testbot-generate` GitHub Actions environment to `nim-env` in `draft-release-notes.yaml` and `testbot.yaml` — the env now serves more than just testbot. The `nim-env` environment is being created in repo settings with `NVIDIA_NIM_KEY` ahead of merge; `testbot-generate` will be deleted after this lands and any open branches are rebased.
- Bump release-notes generation to `aws/anthropic/bedrock-claude-opus-4-7` and `@anthropic-ai/claude-code@2.1.116`, matching the testbot upgrade in #914.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release notes generation tooling and infrastructure configuration to ensure consistent formatting standards across release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->