### PR TITLE
Apply exec_timeout and queue_timeout per-group instead of per-workflow

### DIFF
--- a/docs/deployment_guide/references/configs_definitions/pool.rst
+++ b/docs/deployment_guide/references/configs_definitions/pool.rst
@@ -75,19 +75,19 @@ Pool
      - ``None``
    * - ``default_exec_timeout``
      - String
-     - Default execution timeout for tasks. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
+     - Default per-group execution timeout, applied independently to each group's RUNNING phase. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
      - Inherited from ``default_exec_timeout`` workflow config
    * - ``default_queue_timeout``
      - String
-     - Default queue timeout for tasks. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
+     - Default per-group queue timeout, measured from when each group enters ``SCHEDULING`` until it is assigned a node (enters ``INITIALIZING``). Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
      - Inherited from ``default_queue_timeout`` workflow config
    * - ``max_exec_timeout``
      - String
-     - Maximum allowed execution timeout for tasks. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
+     - Maximum allowed per-group execution timeout. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
      - Inherited from ``max_exec_timeout`` workflow config
    * - ``max_queue_timeout``
      - String
-     - Maximum allowed queue timeout for tasks. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
+     - Maximum allowed per-group queue timeout. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
      - Inherited from ``max_queue_timeout`` workflow config
    * - ``default_exit_actions``
      - Dict[String, Integer]

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -92,19 +92,19 @@ Top-Level Configuration
      - ``30``
    * - ``default_exec_timeout``
      - String
-     - Default timeout for task execution. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
+     - Default per-group execution timeout, applied independently to each group's RUNNING phase. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
      - ``60d``
    * - ``default_queue_timeout``
      - String
-     - Default timeout for tasks in queue. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
+     - Default per-group queue timeout, measured from when each group enters ``SCHEDULING`` until it is assigned a node (enters ``INITIALIZING``). Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
      - ``60d``
    * - ``max_exec_timeout``
      - String
-     - Maximum allowed execution timeout. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
+     - Maximum allowed per-group execution timeout. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
      - ``60d``
    * - ``max_queue_timeout``
      - String
-     - Maximum allowed queue timeout. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
+     - Maximum allowed per-group queue timeout. Must be in the format of <integer><unit> (for example, 10m, 1h, 1d).
      - ``60d``
    * - ``force_cleanup_delay``
      - String

--- a/docs/user_guide/workflows/lifecycle/index.rst
+++ b/docs/user_guide/workflows/lifecycle/index.rst
@@ -340,9 +340,9 @@ Status Reference
       * - :bdg-failed:`FAILED`
         - Workflow failed to complete. One or more tasks have failed
       * - :bdg-failed:`FAILED_EXEC_TIMEOUT`
-        - Workflow was running longer than the set execution timeout (see :ref:`workflow_spec_timeouts`)
+        - At least one group ran longer than its per-group execution timeout, and all groups have finished (see :ref:`workflow_spec_timeouts`)
       * - :bdg-failed:`FAILED_QUEUE_TIMEOUT`
-        - Workflow was queued longer than the set queue timeout (see :ref:`workflow_spec_timeouts`)
+        - At least one group sat in ``SCHEDULING`` (waiting for a node assignment) longer than the per-group queue timeout, and all groups have finished (see :ref:`workflow_spec_timeouts`)
       * - :bdg-failed:`FAILED_SUBMISSION`
         - Workflow failed to submit due to resource or credential validation failure
       * - :bdg-failed:`FAILED_SERVER_ERROR`
@@ -386,9 +386,9 @@ Status Reference
       * - :bdg-failed:`FAILED_BACKEND_ERROR`
         - Task has failed due to some backend error like the node entering a Not Ready state
       * - :bdg-failed:`FAILED_EXEC_TIMEOUT`
-        - Workflow ran longer than the set execution timeout (see :ref:`workflow_spec_timeouts`)
+        - The group containing this task ran longer than the execution timeout (see :ref:`workflow_spec_timeouts`)
       * - :bdg-failed:`FAILED_QUEUE_TIMEOUT`
-        - Workflow was queued longer than the set queue timeout (see :ref:`workflow_spec_timeouts`)
+        - The group containing this task sat in ``SCHEDULING`` longer than the queue timeout while waiting for a node assignment (see :ref:`workflow_spec_timeouts`)
       * - :bdg-failed:`FAILED_IMAGE_PULL`
         - Task has failed to pull Docker image
       * - :bdg-failed:`FAILED_UPSTREAM`

--- a/docs/user_guide/workflows/specification/timeouts.rst
+++ b/docs/user_guide/workflows/specification/timeouts.rst
@@ -29,12 +29,16 @@ UI pool information.
   * - **Field**
     - **Description**
   * - ``exec_timeout``
-    - Maximum execution time for a workflow before the service cleans it up. This is the time since
-      the **workflow status** is set to ``READY``.
+    - Maximum execution time for **each group** in the workflow. The clock starts when a group's
+      status transitions to ``RUNNING`` and applies independently per group, so a long-running
+      group does not affect the budget of other groups in the same workflow.
   * - ``queue_timeout``
-    - Maximum queue time for a workflow in the workflow queue before the service cleans it up.
-      This is the time calculated after the **workflow status** is set to ``PENDING`` and until
-      the **workflow status** is set to ``READY``.
+    - Maximum queue time for **each group**, measured from when the group enters
+      ``SCHEDULING`` (submitted to the backend k8s queue) until it is assigned a
+      node and enters ``INITIALIZING``. A group still in ``SCHEDULING`` past this
+      window is marked ``FAILED_QUEUE_TIMEOUT``. Image pull and preflight time in
+      ``INITIALIZING`` is governed separately by the start timeout, not this one.
+      Each group has its own clock.
 
 .. note::
 
@@ -53,9 +57,15 @@ For example:
       queue_timeout: 6h
     ...
 
-If a running workflow is timed out, the workflow status is set to ``FAILED_EXEC_TIMEOUT``.
-If a workflow stays in the pending state it is timed out and the workflow status is set to
-``FAILED_QUEUE_TIMEOUT``.
+If a running group exceeds ``exec_timeout``, that group is marked ``FAILED_EXEC_TIMEOUT`` and
+its downstream groups cascade to ``FAILED_UPSTREAM``. Sibling groups that are still within their
+own ``exec_timeout`` window continue running. The workflow status aggregates to
+``FAILED_EXEC_TIMEOUT`` once all groups have finished and at least one timed out.
+
+If a group stays in ``SCHEDULING`` (waiting for a node assignment) longer than
+``queue_timeout``, that group is marked ``FAILED_QUEUE_TIMEOUT``. The workflow status
+aggregates to ``FAILED_QUEUE_TIMEOUT`` once all groups have finished and at least one
+hit the queue timeout.
 
 The timeout values are defined in the format ``<integer><unit>``. The units supported are:
 

--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -959,10 +959,13 @@ class UpdateGroup(WorkflowJob):
             # enters the backend k8s queue (SCHEDULING) and ends when it reaches RUNNING.
             if group_obj.status.prescheduling() and \
                     self.status == task.TaskGroupStatus.SCHEDULING:
-                queue_timeout = workflow_obj.timeout.queue_timeout or \
-                    common.to_timedelta(pool_info.default_queue_timeout
-                                        if pool_info.default_queue_timeout else
-                                        workflow_config.default_queue_timeout)
+                if workflow_obj.timeout.queue_timeout is not None:
+                    queue_timeout = workflow_obj.timeout.queue_timeout
+                else:
+                    queue_timeout = common.to_timedelta(
+                        pool_info.default_queue_timeout
+                        if pool_info.default_queue_timeout
+                        else workflow_config.default_queue_timeout)
                 check_queue_timeout = CheckQueueTimeout(workflow_id=self.workflow_id,
                                                         workflow_uuid=self.workflow_uuid,
                                                         group_name=self.group_name)
@@ -970,10 +973,13 @@ class UpdateGroup(WorkflowJob):
 
             # Is the status being updated to running? If so, schedule a CheckRunTimeout task
             if group_obj.status.prerunning() and self.status == task.TaskGroupStatus.RUNNING:
-                exec_timeout = workflow_obj.timeout.exec_timeout or \
-                    common.to_timedelta(pool_info.default_exec_timeout
-                                        if pool_info.default_exec_timeout else
-                                        workflow_config.default_exec_timeout)
+                if workflow_obj.timeout.exec_timeout is not None:
+                    exec_timeout = workflow_obj.timeout.exec_timeout
+                else:
+                    exec_timeout = common.to_timedelta(
+                        pool_info.default_exec_timeout
+                        if pool_info.default_exec_timeout
+                        else workflow_config.default_exec_timeout)
                 check_run_timeout = CheckRunTimeout(workflow_id=self.workflow_id,
                                                     workflow_uuid=self.workflow_uuid,
                                                     group_name=self.group_name)
@@ -1644,13 +1650,13 @@ class CancelWorkflow(WorkflowJob):
                 message += f' {self.message}'
             if self.workflow_status == workflow.WorkflowStatus.FAILED_EXEC_TIMEOUT:
                 limit_message = 'Task ran longer than the set limit'
-                if workflow_obj.timeout.exec_timeout:
+                if workflow_obj.timeout.exec_timeout is not None:
                     limit_message += \
                         f' of {common.readable_timedelta(workflow_obj.timeout.exec_timeout)}'
                 message = f'{limit_message}.'
             elif self.workflow_status == workflow.WorkflowStatus.FAILED_QUEUE_TIMEOUT:
                 limit_message = 'Task stayed in queue longer than the set limit'
-                if workflow_obj.timeout.queue_timeout:
+                if workflow_obj.timeout.queue_timeout is not None:
                     limit_message += \
                         f' of {common.readable_timedelta(workflow_obj.timeout.queue_timeout)}'
                 message = f'{limit_message}.'
@@ -1696,7 +1702,7 @@ class CheckRunTimeout(WorkflowJob):
     def _resolve_exec_timeout(self,
                               context: JobExecutionContext,
                               workflow_obj: workflow.Workflow) -> datetime.timedelta:
-        if workflow_obj.timeout.exec_timeout:
+        if workflow_obj.timeout.exec_timeout is not None:
             return workflow_obj.timeout.exec_timeout
         if not workflow_obj.pool:
             raise osmo_errors.OSMOUserError('No Pool Specified')
@@ -1732,7 +1738,7 @@ class CheckRunTimeout(WorkflowJob):
             return JobResult()
 
         limit_message = 'Task ran longer than the set limit'
-        if workflow_obj.timeout.exec_timeout:
+        if workflow_obj.timeout.exec_timeout is not None:
             limit_message += f' of {common.readable_timedelta(workflow_obj.timeout.exec_timeout)}'
         UpdateGroup(
             workflow_id=self.workflow_id,
@@ -1810,7 +1816,7 @@ class CheckQueueTimeout(WorkflowJob):
     def _resolve_queue_timeout(self,
                                context: JobExecutionContext,
                                workflow_obj: workflow.Workflow) -> datetime.timedelta:
-        if workflow_obj.timeout.queue_timeout:
+        if workflow_obj.timeout.queue_timeout is not None:
             return workflow_obj.timeout.queue_timeout
         if not workflow_obj.pool:
             raise osmo_errors.OSMOUserError('No Pool Specified')
@@ -1847,7 +1853,7 @@ class CheckQueueTimeout(WorkflowJob):
             return JobResult()
 
         limit_message = 'Task stayed in queue longer than the set limit'
-        if workflow_obj.timeout.queue_timeout:
+        if workflow_obj.timeout.queue_timeout is not None:
             limit_message += f' of {common.readable_timedelta(workflow_obj.timeout.queue_timeout)}'
         UpdateGroup(
             workflow_id=self.workflow_id,

--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -263,10 +263,6 @@ class SubmitWorkflow(WorkflowJob):
         # Fetch workflow_obj to get latest info
         workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, workflow_obj.workflow_id)
 
-        # Per-group queue timeout enforcement: CheckQueueTimeout is now scheduled
-        # in UpdateGroup.execute() when a group transitions into SCHEDULING, using
-        # group.scheduling_start_time as the clock. No workflow-level enqueue here.
-
         # Check if workflow has been canceled.
         # If it hasn't, mark all the groups as WAITING
         # If this is false, the workflow has been canceled
@@ -1710,9 +1706,10 @@ class CheckRunTimeout(WorkflowJob):
                                    if pool_info.default_exec_timeout
                                    else workflow_config.default_exec_timeout)
 
-    def _execute_per_group(self, context: JobExecutionContext) -> JobResult:
+    def _execute_per_group(self, context: JobExecutionContext,
+                           group_name: task_common.NamePattern) -> JobResult:
         group_obj = task.TaskGroup.fetch_from_db(
-            context.postgres, self.workflow_id, self.group_name)
+            context.postgres, self.workflow_id, group_name)
         if group_obj.status.finished():
             return JobResult()
         if not group_obj.start_time:
@@ -1725,12 +1722,12 @@ class CheckRunTimeout(WorkflowJob):
         if exec_timeout > time_elapsed:
             logging.info('Execution timeout for workflow %s group %s increased from %s to %s, '
                          'resubmitting it back to delayed job queue.',
-                         self.workflow_id, self.group_name, time_elapsed, exec_timeout,
+                         self.workflow_id, group_name, time_elapsed, exec_timeout,
                          extra={'workflow_uuid': self.workflow_uuid})
             CheckRunTimeout(
                 workflow_id=self.workflow_id,
                 workflow_uuid=self.workflow_uuid,
-                group_name=self.group_name,
+                group_name=group_name,
             ).send_delayed_job_to_queue(exec_timeout - time_elapsed)
             return JobResult()
 
@@ -1740,7 +1737,7 @@ class CheckRunTimeout(WorkflowJob):
         UpdateGroup(
             workflow_id=self.workflow_id,
             workflow_uuid=self.workflow_uuid,
-            group_name=self.group_name,
+            group_name=group_name,
             status=task.TaskGroupStatus.FAILED_EXEC_TIMEOUT,
             message=f'{limit_message}.',
             user='osmo',
@@ -1786,7 +1783,7 @@ class CheckRunTimeout(WorkflowJob):
         FAILED_EXEC_TIMEOUT; without it (legacy payload), enforces workflow-level.
         """
         if self.group_name:
-            return self._execute_per_group(context)
+            return self._execute_per_group(context, self.group_name)
         return self._execute_legacy_workflow_level(context)
 
 class CheckQueueTimeout(WorkflowJob):
@@ -1823,9 +1820,10 @@ class CheckQueueTimeout(WorkflowJob):
                                    if pool_info.default_queue_timeout
                                    else workflow_config.default_queue_timeout)
 
-    def _execute_per_group(self, context: JobExecutionContext) -> JobResult:
+    def _execute_per_group(self, context: JobExecutionContext,
+                           group_name: task_common.NamePattern) -> JobResult:
         group_obj = task.TaskGroup.fetch_from_db(
-            context.postgres, self.workflow_id, self.group_name)
+            context.postgres, self.workflow_id, group_name)
         # Queue clock stops once a node is assigned (INITIALIZING) or beyond.
         if group_obj.status != task.TaskGroupStatus.SCHEDULING:
             return JobResult()
@@ -1839,12 +1837,12 @@ class CheckQueueTimeout(WorkflowJob):
         if queue_timeout > time_elapsed:
             logging.info('Queue timeout for workflow %s group %s increased from %s to %s, '
                          'resubmitting it back to delayed job queue.',
-                         self.workflow_id, self.group_name, time_elapsed, queue_timeout,
+                         self.workflow_id, group_name, time_elapsed, queue_timeout,
                          extra={'workflow_uuid': self.workflow_uuid})
             CheckQueueTimeout(
                 workflow_id=self.workflow_id,
                 workflow_uuid=self.workflow_uuid,
-                group_name=self.group_name,
+                group_name=group_name,
             ).send_delayed_job_to_queue(queue_timeout - time_elapsed)
             return JobResult()
 
@@ -1854,7 +1852,7 @@ class CheckQueueTimeout(WorkflowJob):
         UpdateGroup(
             workflow_id=self.workflow_id,
             workflow_uuid=self.workflow_uuid,
-            group_name=self.group_name,
+            group_name=group_name,
             status=task.TaskGroupStatus.FAILED_QUEUE_TIMEOUT,
             message=f'{limit_message}.',
             user='osmo',
@@ -1903,7 +1901,7 @@ class CheckQueueTimeout(WorkflowJob):
         (legacy payload), enforces the workflow-level PENDING timeout.
         """
         if self.group_name:
-            return self._execute_per_group(context)
+            return self._execute_per_group(context, self.group_name)
         return self._execute_legacy_workflow_level(context)
 
 

--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -1690,7 +1690,7 @@ class CheckRunTimeout(WorkflowJob):
     @classmethod
     def _get_job_id(cls, values):
         group_name = values.get('group_name') or 'workflow'
-        return (f'{values["workflow_uuid"]}-{group_name}'
+        return (f'{values['workflow_uuid']}-{group_name}'
                 f'-{common.generate_unique_id(5)}-check_run_timeout')
 
     def _resolve_exec_timeout(self,
@@ -1804,7 +1804,7 @@ class CheckQueueTimeout(WorkflowJob):
     @classmethod
     def _get_job_id(cls, values):
         group_name = values.get('group_name') or 'workflow'
-        return (f'{values["workflow_uuid"]}-{group_name}'
+        return (f'{values['workflow_uuid']}-{group_name}'
                 f'-{common.generate_unique_id(5)}-check_queue_timeout')
 
     def _resolve_queue_timeout(self,

--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -263,18 +263,9 @@ class SubmitWorkflow(WorkflowJob):
         # Fetch workflow_obj to get latest info
         workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, workflow_obj.workflow_id)
 
-        # Enqueue a delayed job to check the queue timeout
-        if not workflow_obj.pool:
-            raise osmo_errors.OSMOUserError('No Pool Specified')
-        pool_info = connectors.Pool.fetch_from_db(context.postgres, workflow_obj.pool)
-        workflow_config = context.postgres.get_workflow_configs()
-        queue_timeout = workflow_obj.timeout.queue_timeout or \
-            common.to_timedelta(pool_info.default_queue_timeout
-                                if pool_info.default_queue_timeout else
-                                workflow_config.default_queue_timeout)
-        check_queue_timeout = CheckQueueTimeout(workflow_id=workflow_obj.workflow_id,
-                                                workflow_uuid=self.workflow_uuid)
-        check_queue_timeout.send_delayed_job_to_queue(queue_timeout)
+        # Per-group queue timeout enforcement: CheckQueueTimeout is now scheduled
+        # in UpdateGroup.execute() when a group transitions into SCHEDULING, using
+        # group.scheduling_start_time as the clock. No workflow-level enqueue here.
 
         # Check if workflow has been canceled.
         # If it hasn't, mark all the groups as WAITING
@@ -967,6 +958,20 @@ class UpdateGroup(WorkflowJob):
             if self.status == task.TaskGroupStatus.RESCHEDULED:
                 self.status = task.TaskGroupStatus.RUNNING
 
+            # Is the status being updated to scheduling? If so, schedule a per-group
+            # CheckQueueTimeout — the clock for queue_timeout starts when the group
+            # enters the backend k8s queue (SCHEDULING) and ends when it reaches RUNNING.
+            if group_obj.status.prescheduling() and \
+                    self.status == task.TaskGroupStatus.SCHEDULING:
+                queue_timeout = workflow_obj.timeout.queue_timeout or \
+                    common.to_timedelta(pool_info.default_queue_timeout
+                                        if pool_info.default_queue_timeout else
+                                        workflow_config.default_queue_timeout)
+                check_queue_timeout = CheckQueueTimeout(workflow_id=self.workflow_id,
+                                                        workflow_uuid=self.workflow_uuid,
+                                                        group_name=self.group_name)
+                check_queue_timeout.send_delayed_job_to_queue(queue_timeout)
+
             # Is the status being updated to running? If so, schedule a CheckRunTimeout task
             if group_obj.status.prerunning() and self.status == task.TaskGroupStatus.RUNNING:
                 exec_timeout = workflow_obj.timeout.exec_timeout or \
@@ -974,7 +979,8 @@ class UpdateGroup(WorkflowJob):
                                         if pool_info.default_exec_timeout else
                                         workflow_config.default_exec_timeout)
                 check_run_timeout = CheckRunTimeout(workflow_id=self.workflow_id,
-                                                    workflow_uuid=self.workflow_uuid)
+                                                    workflow_uuid=self.workflow_uuid,
+                                                    group_name=self.group_name)
                 check_run_timeout.send_delayed_job_to_queue(exec_timeout)
 
         group_obj.update_status_to_db(update_time, self.status, self.message)
@@ -1674,106 +1680,231 @@ class CancelWorkflow(WorkflowJob):
 
 class CheckRunTimeout(WorkflowJob):
     """
-    CheckRunTimeout job. When executed, it should create a CancelWorkflow job if the
-    target workflow is still running.
+    CheckRunTimeout job. When executed, it should mark the target group as
+    FAILED_EXEC_TIMEOUT if it has been running longer than the workflow's
+    exec_timeout. Per-group: each group has its own clock starting from when
+    that group entered RUNNING, and only that group is canceled on expiry
+    (downstream groups cascade via FAILED_UPSTREAM as usual).
+
+    Legacy: jobs serialized before group_name existed deserialize with
+    group_name=None and fall back to workflow-level enforcement.
     """
+    group_name: task_common.NamePattern | None = None
 
     @classmethod
     def _get_job_id(cls, values):
-        return f'{values['workflow_uuid']}-{common.generate_unique_id(5)}-check_run_timeout'
+        group_name = values.get('group_name') or 'workflow'
+        return (f'{values["workflow_uuid"]}-{group_name}'
+                f'-{common.generate_unique_id(5)}-check_run_timeout')
+
+    def _resolve_exec_timeout(self,
+                              context: JobExecutionContext,
+                              workflow_obj: workflow.Workflow) -> datetime.timedelta:
+        if workflow_obj.timeout.exec_timeout:
+            return workflow_obj.timeout.exec_timeout
+        if not workflow_obj.pool:
+            raise osmo_errors.OSMOUserError('No Pool Specified')
+        pool_info = connectors.Pool.fetch_from_db(context.postgres, workflow_obj.pool)
+        workflow_config = context.postgres.get_workflow_configs()
+        return common.to_timedelta(pool_info.default_exec_timeout
+                                   if pool_info.default_exec_timeout
+                                   else workflow_config.default_exec_timeout)
+
+    def _execute_per_group(self, context: JobExecutionContext) -> JobResult:
+        group_obj = task.TaskGroup.fetch_from_db(
+            context.postgres, self.workflow_id, self.group_name)
+        if group_obj.status.finished():
+            return JobResult()
+        if not group_obj.start_time:
+            return JobResult()
+
+        workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, self.workflow_id)
+        exec_timeout = self._resolve_exec_timeout(context, workflow_obj)
+        time_elapsed = datetime.datetime.now() - group_obj.start_time
+
+        if exec_timeout > time_elapsed:
+            logging.info('Execution timeout for workflow %s group %s increased from %s to %s, '
+                         'resubmitting it back to delayed job queue.',
+                         self.workflow_id, self.group_name, time_elapsed, exec_timeout,
+                         extra={'workflow_uuid': self.workflow_uuid})
+            CheckRunTimeout(
+                workflow_id=self.workflow_id,
+                workflow_uuid=self.workflow_uuid,
+                group_name=self.group_name,
+            ).send_delayed_job_to_queue(exec_timeout - time_elapsed)
+            return JobResult()
+
+        limit_message = 'Task ran longer than the set limit'
+        if workflow_obj.timeout.exec_timeout:
+            limit_message += f' of {common.readable_timedelta(workflow_obj.timeout.exec_timeout)}'
+        UpdateGroup(
+            workflow_id=self.workflow_id,
+            workflow_uuid=self.workflow_uuid,
+            group_name=self.group_name,
+            status=task.TaskGroupStatus.FAILED_EXEC_TIMEOUT,
+            message=f'{limit_message}.',
+            user='osmo',
+        ).send_job_to_queue()
+        return JobResult()
+
+    def _execute_legacy_workflow_level(self, context: JobExecutionContext) -> JobResult:
+        logging.warning(
+            'CheckRunTimeout for workflow %s has no group_name; falling back to legacy '
+            'workflow-level timeout enforcement. This payload predates the per-group change.',
+            self.workflow_id, extra={'workflow_uuid': self.workflow_uuid})
+
+        workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, self.workflow_id)
+        if workflow_obj.status.finished() or not workflow_obj.start_time:
+            return JobResult()
+
+        exec_timeout = self._resolve_exec_timeout(context, workflow_obj)
+        time_elapsed = datetime.datetime.now() - workflow_obj.start_time
+        if exec_timeout > time_elapsed:
+            logging.info('Execution timeout for workflow %s increased from %s to %s, '
+                         'resubmitting it back to delayed job queue.',
+                         self.workflow_id, time_elapsed, exec_timeout,
+                         extra={'workflow_uuid': self.workflow_uuid})
+            CheckRunTimeout(
+                workflow_id=self.workflow_id,
+                workflow_uuid=self.workflow_uuid,
+            ).send_delayed_job_to_queue(exec_timeout - time_elapsed)
+        else:
+            CancelWorkflow(
+                workflow_id=self.workflow_id,
+                workflow_uuid=self.workflow_uuid, user='osmo',
+                workflow_status=workflow.WorkflowStatus.FAILED_EXEC_TIMEOUT,
+                task_status=task.TaskGroupStatus.FAILED_EXEC_TIMEOUT,
+            ).send_job_to_queue()
+        return JobResult()
 
     def execute(self, context: JobExecutionContext,
                 progress_writer: progress.ProgressWriter,
                 progress_iter_freq: datetime.timedelta = \
                     datetime.timedelta(seconds=15)) -> JobResult:
         """
-        Executes the job. Return true if the CancelWorkflow job is submitted.
+        Executes the job. With group_name, marks just that group as
+        FAILED_EXEC_TIMEOUT; without it (legacy payload), enforces workflow-level.
         """
-        workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, self.workflow_id)
-        if not workflow_obj.status.finished():
-            if workflow_obj.start_time:
-                time_elapsed = datetime.datetime.now() - workflow_obj.start_time
-
-                if not workflow_obj.pool:
-                    raise osmo_errors.OSMOUserError('No Pool Specified')
-                pool_info = connectors.Pool.fetch_from_db(context.postgres, workflow_obj.pool)
-                workflow_config = context.postgres.get_workflow_configs()
-                exec_timeout = workflow_obj.timeout.exec_timeout or \
-                    common.to_timedelta(pool_info.default_exec_timeout
-                                        if pool_info.default_exec_timeout else
-                                        workflow_config.default_exec_timeout)
-                # Comparing two timedelta objects
-                if exec_timeout > time_elapsed:
-                    logging.info('Execution timeout for workflow %s increased from %s to %s, '
-                                'resubmitting it back to delayed job queue.',
-                                self.workflow_id, time_elapsed, exec_timeout,
-                                extra={'workflow_uuid': self.workflow_uuid})
-                    check_queue_timeout = CheckRunTimeout(workflow_id=self.workflow_id,
-                                                        workflow_uuid=self.workflow_uuid)
-                    # The amount of time left before hitting the new expiration timestamp
-                    delta = exec_timeout - time_elapsed
-                    check_queue_timeout.send_delayed_job_to_queue(delta)
-                else:
-                    cancel_job = CancelWorkflow(
-                        workflow_id=self.workflow_id,
-                        workflow_uuid=self.workflow_uuid, user='osmo',
-                        workflow_status=workflow.WorkflowStatus.FAILED_EXEC_TIMEOUT,
-                        task_status=task.TaskGroupStatus.FAILED_EXEC_TIMEOUT
-                    )
-                    cancel_job.send_job_to_queue()
-
-        return JobResult()
+        if self.group_name:
+            return self._execute_per_group(context)
+        return self._execute_legacy_workflow_level(context)
 
 class CheckQueueTimeout(WorkflowJob):
     """
-    CheckQueueTimeout job. When executed, it should create a CancelWorkflow job if the
-    target workflow is still pending (stuck in queue).
+    CheckQueueTimeout job. Per-group: queue_timeout measures how long a group
+    waits in the backend k8s queue for a node assignment — the window is just
+    the SCHEDULING phase. Once the group reaches INITIALIZING (node assigned,
+    image pulling starts) or beyond, the queue clock has stopped. If the group
+    is still in SCHEDULING after queue_timeout, mark it FAILED_QUEUE_TIMEOUT.
+
+    Legacy: jobs serialized before group_name existed deserialize with
+    group_name=None and fall back to workflow-level enforcement (cancels the
+    workflow if it has stayed in PENDING longer than queue_timeout from
+    submit_time).
     """
+    group_name: task_common.NamePattern | None = None
 
     @classmethod
     def _get_job_id(cls, values):
-        return f'{values['workflow_uuid']}-{common.generate_unique_id(5)}-check_queue_timeout'
+        group_name = values.get('group_name') or 'workflow'
+        return (f'{values["workflow_uuid"]}-{group_name}'
+                f'-{common.generate_unique_id(5)}-check_queue_timeout')
+
+    def _resolve_queue_timeout(self,
+                               context: JobExecutionContext,
+                               workflow_obj: workflow.Workflow) -> datetime.timedelta:
+        if workflow_obj.timeout.queue_timeout:
+            return workflow_obj.timeout.queue_timeout
+        if not workflow_obj.pool:
+            raise osmo_errors.OSMOUserError('No Pool Specified')
+        pool_info = connectors.Pool.fetch_from_db(context.postgres, workflow_obj.pool)
+        workflow_config = context.postgres.get_workflow_configs()
+        return common.to_timedelta(pool_info.default_queue_timeout
+                                   if pool_info.default_queue_timeout
+                                   else workflow_config.default_queue_timeout)
+
+    def _execute_per_group(self, context: JobExecutionContext) -> JobResult:
+        group_obj = task.TaskGroup.fetch_from_db(
+            context.postgres, self.workflow_id, self.group_name)
+        # Queue clock stops once a node is assigned (INITIALIZING) or beyond.
+        if group_obj.status != task.TaskGroupStatus.SCHEDULING:
+            return JobResult()
+        if not group_obj.scheduling_start_time:
+            return JobResult()
+
+        workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, self.workflow_id)
+        queue_timeout = self._resolve_queue_timeout(context, workflow_obj)
+        time_elapsed = datetime.datetime.now() - group_obj.scheduling_start_time
+
+        if queue_timeout > time_elapsed:
+            logging.info('Queue timeout for workflow %s group %s increased from %s to %s, '
+                         'resubmitting it back to delayed job queue.',
+                         self.workflow_id, self.group_name, time_elapsed, queue_timeout,
+                         extra={'workflow_uuid': self.workflow_uuid})
+            CheckQueueTimeout(
+                workflow_id=self.workflow_id,
+                workflow_uuid=self.workflow_uuid,
+                group_name=self.group_name,
+            ).send_delayed_job_to_queue(queue_timeout - time_elapsed)
+            return JobResult()
+
+        limit_message = 'Task stayed in queue longer than the set limit'
+        if workflow_obj.timeout.queue_timeout:
+            limit_message += f' of {common.readable_timedelta(workflow_obj.timeout.queue_timeout)}'
+        UpdateGroup(
+            workflow_id=self.workflow_id,
+            workflow_uuid=self.workflow_uuid,
+            group_name=self.group_name,
+            status=task.TaskGroupStatus.FAILED_QUEUE_TIMEOUT,
+            message=f'{limit_message}.',
+            user='osmo',
+        ).send_job_to_queue()
+        return JobResult()
+
+    def _execute_legacy_workflow_level(self, context: JobExecutionContext) -> JobResult:
+        logging.warning(
+            'CheckQueueTimeout for workflow %s has no group_name; falling back to legacy '
+            'workflow-level timeout enforcement. This payload predates the per-group change.',
+            self.workflow_id, extra={'workflow_uuid': self.workflow_uuid})
+
+        workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, self.workflow_id)
+        if workflow_obj.status != workflow.WorkflowStatus.PENDING:
+            return JobResult()
+        if not workflow_obj.submit_time:
+            return JobResult()
+
+        queue_timeout = self._resolve_queue_timeout(context, workflow_obj)
+        time_since_submission = datetime.datetime.now() - workflow_obj.submit_time
+        if queue_timeout > time_since_submission:
+            logging.info('Queue timeout for workflow %s increased from %s to %s, '
+                         'resubmitting it back to delayed job queue.',
+                         self.workflow_id, time_since_submission, queue_timeout,
+                         extra={'workflow_uuid': self.workflow_uuid})
+            CheckQueueTimeout(
+                workflow_id=self.workflow_id,
+                workflow_uuid=self.workflow_uuid,
+            ).send_delayed_job_to_queue(queue_timeout - time_since_submission)
+        else:
+            CancelWorkflow(
+                workflow_id=self.workflow_id,
+                workflow_uuid=self.workflow_uuid, user='osmo',
+                workflow_status=workflow.WorkflowStatus.FAILED_QUEUE_TIMEOUT,
+                task_status=task.TaskGroupStatus.FAILED_QUEUE_TIMEOUT,
+            ).send_job_to_queue()
+        return JobResult()
 
     def execute(self, context: JobExecutionContext,
                 progress_writer: progress.ProgressWriter,
                 progress_iter_freq: datetime.timedelta = \
                     datetime.timedelta(seconds=15)) -> JobResult:
         """
-        Executes the job. Return true if the CancelWorkflow job is submitted.
+        Executes the job. With group_name, marks just that group as
+        FAILED_QUEUE_TIMEOUT if it has been queueing too long; without it
+        (legacy payload), enforces the workflow-level PENDING timeout.
         """
-        workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, self.workflow_id)
-        if workflow_obj.status == workflow.WorkflowStatus.PENDING:
-            if workflow_obj.submit_time:
-                time_since_submission = datetime.datetime.now() - workflow_obj.submit_time
-
-                if not workflow_obj.pool:
-                    raise osmo_errors.OSMOUserError('No Pool Specified')
-                pool_info = connectors.Pool.fetch_from_db(context.postgres, workflow_obj.pool)
-                workflow_config = context.postgres.get_workflow_configs()
-                queue_timeout = workflow_obj.timeout.queue_timeout or \
-                    common.to_timedelta(pool_info.default_queue_timeout
-                                        if pool_info.default_queue_timeout else
-                                        workflow_config.default_queue_timeout)
-                if queue_timeout > time_since_submission:
-                    logging.info('Queue timeout for workflow %s increased from %s to %s, '
-                                'resubmitting it back to delayed job queue.',
-                                self.workflow_id, time_since_submission, queue_timeout,
-                                extra={'workflow_uuid': self.workflow_uuid})
-                    check_queue_timeout = CheckQueueTimeout(workflow_id=self.workflow_id,
-                                                            workflow_uuid=self.workflow_uuid)
-                    # The amount of time left before hitting the new expiration timestamp
-                    delta = queue_timeout - time_since_submission
-                    check_queue_timeout.send_delayed_job_to_queue(delta)
-                else:
-                    cancel_job = CancelWorkflow(
-                        workflow_id=self.workflow_id,
-                        workflow_uuid=self.workflow_uuid, user='osmo',
-                        workflow_status=workflow.WorkflowStatus.FAILED_QUEUE_TIMEOUT,
-                        task_status=task.TaskGroupStatus.FAILED_QUEUE_TIMEOUT
-                    )
-                    cancel_job.send_job_to_queue()
-
-        return JobResult()
+        if self.group_name:
+            return self._execute_per_group(context)
+        return self._execute_legacy_workflow_level(context)
 
 
 class UploadApp(FrontendJob):

--- a/src/utils/job/tests/test_task_db.py
+++ b/src/utils/job/tests/test_task_db.py
@@ -815,9 +815,11 @@ class CheckRunTimeoutDbTest(TaskDbFixture):
 class CheckQueueTimeoutDbTest(TaskDbFixture):
     """DB-backed integration tests for CheckQueueTimeout per-group queue_timeout enforcement.
 
-    Per-group semantics: the clock starts when a group enters SCHEDULING and runs until the
-    group reaches RUNNING. If the group is still in SCHEDULING/INITIALIZING after queue_timeout,
-    just that group is marked FAILED_QUEUE_TIMEOUT.
+    Per-group semantics: the clock starts when a group enters SCHEDULING and stops when the
+    group is assigned a node and enters INITIALIZING. If the group is still in SCHEDULING
+    after queue_timeout, just that group is marked FAILED_QUEUE_TIMEOUT. Once the group has
+    progressed to INITIALIZING (or beyond) the queue clock has stopped — image-pull and
+    preflight time is governed separately by the start timeout.
     """
 
     QUEUE_TIMEOUT_SECONDS = 100

--- a/src/utils/job/tests/test_task_db.py
+++ b/src/utils/job/tests/test_task_db.py
@@ -730,7 +730,10 @@ class CheckRunTimeoutDbTest(TaskDbFixture):
         self.assertIsInstance(update, jobs.UpdateGroup)
         self.assertEqual(update.group_name, 'group1')
         self.assertEqual(update.status, task.TaskGroupStatus.FAILED_EXEC_TIMEOUT)
-        self.assertIn(str(self.EXEC_TIMEOUT_SECONDS), update.message)
+        self.assertIn(
+            common.readable_timedelta(
+                datetime.timedelta(seconds=self.EXEC_TIMEOUT_SECONDS)),
+            update.message)
         self.assertEqual(self.delayed, [])
 
     def test_per_group_within_window_reschedules(self):
@@ -904,7 +907,10 @@ class CheckQueueTimeoutDbTest(TaskDbFixture):
         self.assertIsInstance(update, jobs.UpdateGroup)
         self.assertEqual(update.group_name, 'group1')
         self.assertEqual(update.status, task.TaskGroupStatus.FAILED_QUEUE_TIMEOUT)
-        self.assertIn(str(self.QUEUE_TIMEOUT_SECONDS), update.message)
+        self.assertIn(
+            common.readable_timedelta(
+                datetime.timedelta(seconds=self.QUEUE_TIMEOUT_SECONDS)),
+            update.message)
         self.assertEqual(self.delayed, [])
 
     def test_per_group_queue_within_window_reschedules(self):

--- a/src/utils/job/tests/test_task_db.py
+++ b/src/utils/job/tests/test_task_db.py
@@ -17,6 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 import datetime
 import json
+from typing import Any, List
 from unittest import mock
 
 from src.lib.utils import common, osmo_errors
@@ -665,7 +666,7 @@ class CheckRunTimeoutDbTest(TaskDbFixture):
         def _capture_delayed(captured_self, delay):
             self.delayed.append((captured_self, delay))
 
-        self._patches = [
+        self._patches: List[Any] = [
             mock.patch.object(jobs.UpdateGroup, 'send_job_to_queue', _capture_send),
             mock.patch.object(jobs.CancelWorkflow, 'send_job_to_queue', _capture_send),
             mock.patch.object(
@@ -832,7 +833,7 @@ class CheckQueueTimeoutDbTest(TaskDbFixture):
         def _capture_delayed(captured_self, delay):
             self.delayed.append((captured_self, delay))
 
-        self._patches = [
+        self._patches: List[Any] = [
             mock.patch.object(jobs.UpdateGroup, 'send_job_to_queue', _capture_send),
             mock.patch.object(jobs.CancelWorkflow, 'send_job_to_queue', _capture_send),
             mock.patch.object(

--- a/src/utils/job/tests/test_task_db.py
+++ b/src/utils/job/tests/test_task_db.py
@@ -17,11 +17,13 @@ SPDX-License-Identifier: Apache-2.0
 """
 import datetime
 import json
+from unittest import mock
 
 from src.lib.utils import common, osmo_errors
 from src.tests.common import fixtures
+from src.utils import connectors
 from src.utils.connectors import postgres
-from src.utils.job import task
+from src.utils.job import jobs, task, workflow
 from src.tests.common import runner
 
 
@@ -640,6 +642,357 @@ class PreloadedTasksDbTest(TaskDbFixture):
             group_rows[0], self._get_db(), load_tasks=True, preloaded_tasks=[])
 
         self.assertEqual(group.tasks, [])
+
+
+class CheckRunTimeoutDbTest(TaskDbFixture):
+    """DB-backed integration tests for CheckRunTimeout per-group exec_timeout enforcement.
+
+    Redis is mocked: these tests exercise the real Postgres queries used to fetch
+    Workflow/TaskGroup state, but capture the jobs CheckRunTimeout dispatches in
+    memory rather than enqueuing them.
+    """
+
+    EXEC_TIMEOUT_SECONDS = 100
+
+    def setUp(self):
+        super().setUp()
+        self.dispatched: list = []
+        self.delayed: list = []
+
+        def _capture_send(captured_self):
+            self.dispatched.append(captured_self)
+
+        def _capture_delayed(captured_self, delay):
+            self.delayed.append((captured_self, delay))
+
+        self._patches = [
+            mock.patch.object(jobs.UpdateGroup, 'send_job_to_queue', _capture_send),
+            mock.patch.object(jobs.CancelWorkflow, 'send_job_to_queue', _capture_send),
+            mock.patch.object(
+                jobs.CheckRunTimeout, 'send_delayed_job_to_queue', _capture_delayed),
+        ]
+        for patcher in self._patches:
+            patcher.start()
+        self.addCleanup(self._stop_patches)
+
+    def _stop_patches(self):
+        for patcher in self._patches:
+            patcher.stop()
+
+    def _insert_workflow_running(self, exec_timeout_seconds: int = EXEC_TIMEOUT_SECONDS,
+                                 start_time: datetime.datetime | None = None,
+                                 status: str = 'RUNNING') -> None:
+        submit_time = start_time or datetime.datetime.now()
+        self._get_db().execute_commit_command(
+            '''INSERT INTO workflows
+               (workflow_id, workflow_name, workflow_uuid, submitted_by,
+                backend, logs, exec_timeout, queue_timeout, plugins, status,
+                start_time, submit_time)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)''',
+            (WORKFLOW_ID, 'test-wf', WORKFLOW_UUID, 'user@nvidia.com',
+             'default', '', exec_timeout_seconds, 100, '{}', status,
+             start_time, submit_time))
+
+    def _insert_group_running(self, group_name: str,
+                              start_time: datetime.datetime,
+                              status: str = 'RUNNING') -> None:
+        group_uuid = common.generate_unique_id()
+        self._insert_group(group_name=group_name, group_uuid=group_uuid, status=status)
+        self._get_db().execute_commit_command(
+            'UPDATE groups SET start_time = %s WHERE workflow_id = %s AND name = %s',
+            (start_time, WORKFLOW_ID, group_name))
+
+    def _make_context(self) -> jobs.JobExecutionContext:
+        return jobs.JobExecutionContext(
+            postgres=self._get_db(), redis=connectors.RedisConfig())
+
+    def _run_check(self, group_name: str | None = None) -> None:
+        check = jobs.CheckRunTimeout(
+            workflow_id=WORKFLOW_ID, workflow_uuid=WORKFLOW_UUID, group_name=group_name)
+        check.execute(self._make_context(), mock.Mock())
+
+    def test_per_group_expiry_marks_only_that_group(self):
+        """A group whose elapsed time exceeds exec_timeout enqueues an UpdateGroup
+        with FAILED_EXEC_TIMEOUT for that group only — sibling groups are untouched.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow_running(start_time=now - datetime.timedelta(seconds=400))
+        self._insert_group_running('group1', start_time=now - datetime.timedelta(seconds=300))
+        self._insert_group_running('group2', start_time=now - datetime.timedelta(seconds=10))
+
+        self._run_check(group_name='group1')
+
+        self.assertEqual(len(self.dispatched), 1)
+        update = self.dispatched[0]
+        self.assertIsInstance(update, jobs.UpdateGroup)
+        self.assertEqual(update.group_name, 'group1')
+        self.assertEqual(update.status, task.TaskGroupStatus.FAILED_EXEC_TIMEOUT)
+        self.assertIn(str(self.EXEC_TIMEOUT_SECONDS), update.message)
+        self.assertEqual(self.delayed, [])
+
+    def test_per_group_within_window_reschedules(self):
+        """A group within the timeout window reschedules a fresh CheckRunTimeout
+        with the remaining delta and does not enqueue any UpdateGroup.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow_running(start_time=now - datetime.timedelta(seconds=20))
+        self._insert_group_running('group1', start_time=now - datetime.timedelta(seconds=10))
+
+        self._run_check(group_name='group1')
+
+        self.assertEqual(self.dispatched, [])
+        self.assertEqual(len(self.delayed), 1)
+        rescheduled, delta = self.delayed[0]
+        self.assertIsInstance(rescheduled, jobs.CheckRunTimeout)
+        self.assertEqual(rescheduled.group_name, 'group1')
+        self.assertGreater(delta.total_seconds(), 0)
+        self.assertLess(delta.total_seconds(), self.EXEC_TIMEOUT_SECONDS)
+
+    def test_per_group_skips_already_finished_group(self):
+        """If the target group has already reached a terminal status (e.g. COMPLETED),
+        CheckRunTimeout is a no-op even if start_time would otherwise be expired.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow_running(start_time=now - datetime.timedelta(seconds=400))
+        self._insert_group_running(
+            'group1', start_time=now - datetime.timedelta(seconds=300), status='COMPLETED')
+
+        self._run_check(group_name='group1')
+
+        self.assertEqual(self.dispatched, [])
+        self.assertEqual(self.delayed, [])
+
+    def test_per_group_skips_group_without_start_time(self):
+        """If the group has no start_time yet (still in queue), CheckRunTimeout is a no-op.
+        Belt-and-suspenders against scheduling timing.
+        """
+        self._insert_workflow_running()
+        self._insert_group(group_name='group1', status='SCHEDULING')
+
+        self._run_check(group_name='group1')
+
+        self.assertEqual(self.dispatched, [])
+        self.assertEqual(self.delayed, [])
+
+    def test_legacy_payload_without_group_name_falls_back_to_workflow_cancel(self):
+        """Delayed jobs serialized before group_name was added deserialize with
+        group_name=None; they must still trigger workflow-level cancellation when expired.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow_running(start_time=now - datetime.timedelta(seconds=400))
+        self._insert_group_running('group1', start_time=now - datetime.timedelta(seconds=300))
+
+        self._run_check(group_name=None)
+
+        self.assertEqual(len(self.dispatched), 1)
+        cancel = self.dispatched[0]
+        self.assertIsInstance(cancel, jobs.CancelWorkflow)
+        self.assertEqual(cancel.workflow_status, workflow.WorkflowStatus.FAILED_EXEC_TIMEOUT)
+        self.assertEqual(cancel.task_status, task.TaskGroupStatus.FAILED_EXEC_TIMEOUT)
+        self.assertEqual(self.delayed, [])
+
+    def test_legacy_payload_within_window_reschedules_workflow_level(self):
+        """Legacy payload (no group_name) within the window reschedules itself without
+        a group_name, preserving the legacy enforcement path until the queue drains.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow_running(start_time=now - datetime.timedelta(seconds=20))
+        self._insert_group_running('group1', start_time=now - datetime.timedelta(seconds=10))
+
+        self._run_check(group_name=None)
+
+        self.assertEqual(self.dispatched, [])
+        self.assertEqual(len(self.delayed), 1)
+        rescheduled, _ = self.delayed[0]
+        self.assertIsInstance(rescheduled, jobs.CheckRunTimeout)
+        self.assertIsNone(rescheduled.group_name)
+
+
+class CheckQueueTimeoutDbTest(TaskDbFixture):
+    """DB-backed integration tests for CheckQueueTimeout per-group queue_timeout enforcement.
+
+    Per-group semantics: the clock starts when a group enters SCHEDULING and runs until the
+    group reaches RUNNING. If the group is still in SCHEDULING/INITIALIZING after queue_timeout,
+    just that group is marked FAILED_QUEUE_TIMEOUT.
+    """
+
+    QUEUE_TIMEOUT_SECONDS = 100
+
+    def setUp(self):
+        super().setUp()
+        self.dispatched: list = []
+        self.delayed: list = []
+
+        def _capture_send(captured_self):
+            self.dispatched.append(captured_self)
+
+        def _capture_delayed(captured_self, delay):
+            self.delayed.append((captured_self, delay))
+
+        self._patches = [
+            mock.patch.object(jobs.UpdateGroup, 'send_job_to_queue', _capture_send),
+            mock.patch.object(jobs.CancelWorkflow, 'send_job_to_queue', _capture_send),
+            mock.patch.object(
+                jobs.CheckQueueTimeout, 'send_delayed_job_to_queue', _capture_delayed),
+        ]
+        for patcher in self._patches:
+            patcher.start()
+        self.addCleanup(self._stop_patches)
+
+    def _stop_patches(self):
+        for patcher in self._patches:
+            patcher.stop()
+
+    def _insert_workflow(self, queue_timeout_seconds: int = QUEUE_TIMEOUT_SECONDS,
+                         submit_time: datetime.datetime | None = None,
+                         status: str = 'PENDING') -> None:
+        # Override TaskDbFixture's helper so we control queue_timeout, status, submit_time.
+        if submit_time is None:
+            submit_time = datetime.datetime.now()
+        self._get_db().execute_commit_command(
+            '''INSERT INTO workflows
+               (workflow_id, workflow_name, workflow_uuid, submitted_by,
+                backend, logs, exec_timeout, queue_timeout, plugins, status,
+                submit_time)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)''',
+            (WORKFLOW_ID, 'test-wf', WORKFLOW_UUID, 'user@nvidia.com',
+             'default', '', 100, queue_timeout_seconds, '{}', status, submit_time))
+
+    def _insert_group_scheduling(self, group_name: str,
+                                 scheduling_start_time: datetime.datetime,
+                                 status: str = 'SCHEDULING') -> None:
+        group_uuid = common.generate_unique_id()
+        self._insert_group(group_name=group_name, group_uuid=group_uuid, status=status)
+        self._get_db().execute_commit_command(
+            'UPDATE groups SET scheduling_start_time = %s '
+            'WHERE workflow_id = %s AND name = %s',
+            (scheduling_start_time, WORKFLOW_ID, group_name))
+
+    def _make_context(self) -> jobs.JobExecutionContext:
+        return jobs.JobExecutionContext(
+            postgres=self._get_db(), redis=connectors.RedisConfig())
+
+    def _run_check(self, group_name: str | None = None) -> None:
+        check = jobs.CheckQueueTimeout(
+            workflow_id=WORKFLOW_ID, workflow_uuid=WORKFLOW_UUID, group_name=group_name)
+        check.execute(self._make_context(), mock.Mock())
+
+    def test_per_group_queue_expiry_marks_only_that_group(self):
+        """When a group has been queueing longer than queue_timeout, an UpdateGroup
+        with FAILED_QUEUE_TIMEOUT is enqueued for just that group.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow()
+        self._insert_group_scheduling(
+            'group1', scheduling_start_time=now - datetime.timedelta(seconds=300))
+        self._insert_group_scheduling(
+            'group2', scheduling_start_time=now - datetime.timedelta(seconds=10))
+
+        self._run_check(group_name='group1')
+
+        self.assertEqual(len(self.dispatched), 1)
+        update = self.dispatched[0]
+        self.assertIsInstance(update, jobs.UpdateGroup)
+        self.assertEqual(update.group_name, 'group1')
+        self.assertEqual(update.status, task.TaskGroupStatus.FAILED_QUEUE_TIMEOUT)
+        self.assertIn(str(self.QUEUE_TIMEOUT_SECONDS), update.message)
+        self.assertEqual(self.delayed, [])
+
+    def test_per_group_queue_within_window_reschedules(self):
+        """A group within the queue_timeout window reschedules a fresh CheckQueueTimeout
+        with the remaining delta, preserving dynamic-timeout-update support.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow()
+        self._insert_group_scheduling(
+            'group1', scheduling_start_time=now - datetime.timedelta(seconds=10))
+
+        self._run_check(group_name='group1')
+
+        self.assertEqual(self.dispatched, [])
+        self.assertEqual(len(self.delayed), 1)
+        rescheduled, delta = self.delayed[0]
+        self.assertIsInstance(rescheduled, jobs.CheckQueueTimeout)
+        self.assertEqual(rescheduled.group_name, 'group1')
+        self.assertGreater(delta.total_seconds(), 0)
+        self.assertLess(delta.total_seconds(), self.QUEUE_TIMEOUT_SECONDS)
+
+    def test_per_group_queue_skips_running_group(self):
+        """If the group has reached RUNNING, the queue clock has already stopped — no-op."""
+        now = datetime.datetime.now()
+        self._insert_workflow()
+        self._insert_group_scheduling(
+            'group1', scheduling_start_time=now - datetime.timedelta(seconds=300),
+            status='RUNNING')
+
+        self._run_check(group_name='group1')
+
+        self.assertEqual(self.dispatched, [])
+        self.assertEqual(self.delayed, [])
+
+    def test_per_group_queue_skips_finished_group(self):
+        """If the group is already finished, CheckQueueTimeout is a no-op."""
+        now = datetime.datetime.now()
+        self._insert_workflow()
+        self._insert_group_scheduling(
+            'group1', scheduling_start_time=now - datetime.timedelta(seconds=300),
+            status='COMPLETED')
+
+        self._run_check(group_name='group1')
+
+        self.assertEqual(self.dispatched, [])
+        self.assertEqual(self.delayed, [])
+
+    def test_per_group_queue_skips_initializing_group(self):
+        """The queue_timeout window stops once the group is assigned a node and enters
+        INITIALIZING. Even if the group sat in SCHEDULING + INITIALIZING longer than
+        queue_timeout, the queue clock has stopped and CheckQueueTimeout is a no-op.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow()
+        self._insert_group_scheduling(
+            'group1', scheduling_start_time=now - datetime.timedelta(seconds=300),
+            status='INITIALIZING')
+
+        self._run_check(group_name='group1')
+
+        self.assertEqual(self.dispatched, [])
+        self.assertEqual(self.delayed, [])
+
+    def test_legacy_queue_payload_falls_back_to_workflow_cancel(self):
+        """A legacy CheckQueueTimeout (no group_name) on a workflow stuck in PENDING
+        beyond queue_timeout still triggers CancelWorkflow with FAILED_QUEUE_TIMEOUT.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow(submit_time=now - datetime.timedelta(seconds=300))
+        self._insert_group_scheduling(
+            'group1', scheduling_start_time=now - datetime.timedelta(seconds=10))
+
+        self._run_check(group_name=None)
+
+        self.assertEqual(len(self.dispatched), 1)
+        cancel = self.dispatched[0]
+        self.assertIsInstance(cancel, jobs.CancelWorkflow)
+        self.assertEqual(cancel.workflow_status, workflow.WorkflowStatus.FAILED_QUEUE_TIMEOUT)
+        self.assertEqual(cancel.task_status, task.TaskGroupStatus.FAILED_QUEUE_TIMEOUT)
+        self.assertEqual(self.delayed, [])
+
+    def test_legacy_queue_payload_no_op_when_workflow_no_longer_pending(self):
+        """A legacy CheckQueueTimeout fires only if the workflow is still PENDING; once
+        any group has reached RUNNING the workflow is past PENDING and the legacy path
+        is a no-op.
+        """
+        now = datetime.datetime.now()
+        self._insert_workflow(submit_time=now - datetime.timedelta(seconds=300),
+                              status='RUNNING')
+        self._insert_group_scheduling(
+            'group1', scheduling_start_time=now - datetime.timedelta(seconds=10),
+            status='RUNNING')
+
+        self._run_check(group_name=None)
+
+        self.assertEqual(self.dispatched, [])
+        self.assertEqual(self.delayed, [])
 
 
 if __name__ == '__main__':

--- a/src/utils/job/tests/test_task_db.py
+++ b/src/utils/job/tests/test_task_db.py
@@ -687,17 +687,19 @@ class CheckRunTimeoutDbTest(TaskDbFixture):
             '''INSERT INTO workflows
                (workflow_id, workflow_name, workflow_uuid, submitted_by,
                 backend, logs, exec_timeout, queue_timeout, plugins, status,
-                start_time, submit_time)
-               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)''',
+                start_time, submit_time, outputs, priority)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)''',
             (WORKFLOW_ID, 'test-wf', WORKFLOW_UUID, 'user@nvidia.com',
              'default', '', exec_timeout_seconds, 100, '{}', status,
-             start_time, submit_time))
+             start_time, submit_time, '', 'NORMAL'))
 
     def _insert_group_running(self, group_name: str,
                               start_time: datetime.datetime,
                               status: str = 'RUNNING') -> None:
         group_uuid = common.generate_unique_id()
         self._insert_group(group_name=group_name, group_uuid=group_uuid, status=status)
+        # TaskGroup.fetch_from_db loads tasks by group name and raises if none exist.
+        self._insert_task(f'{group_name}-lead', group_name=group_name, lead=True, status=status)
         self._get_db().execute_commit_command(
             'UPDATE groups SET start_time = %s WHERE workflow_id = %s AND name = %s',
             (start_time, WORKFLOW_ID, group_name))
@@ -768,6 +770,7 @@ class CheckRunTimeoutDbTest(TaskDbFixture):
         """
         self._insert_workflow_running()
         self._insert_group(group_name='group1', status='SCHEDULING')
+        self._insert_task('group1-lead', group_name='group1', lead=True, status='SCHEDULING')
 
         self._run_check(group_name='group1')
 
@@ -853,16 +856,19 @@ class CheckQueueTimeoutDbTest(TaskDbFixture):
             '''INSERT INTO workflows
                (workflow_id, workflow_name, workflow_uuid, submitted_by,
                 backend, logs, exec_timeout, queue_timeout, plugins, status,
-                submit_time)
-               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)''',
+                submit_time, outputs, priority)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)''',
             (WORKFLOW_ID, 'test-wf', WORKFLOW_UUID, 'user@nvidia.com',
-             'default', '', 100, queue_timeout_seconds, '{}', status, submit_time))
+             'default', '', 100, queue_timeout_seconds, '{}', status, submit_time,
+             '', 'NORMAL'))
 
     def _insert_group_scheduling(self, group_name: str,
                                  scheduling_start_time: datetime.datetime,
                                  status: str = 'SCHEDULING') -> None:
         group_uuid = common.generate_unique_id()
         self._insert_group(group_name=group_name, group_uuid=group_uuid, status=status)
+        # TaskGroup.fetch_from_db loads tasks by group name and raises if none exist.
+        self._insert_task(f'{group_name}-lead', group_name=group_name, lead=True, status=status)
         self._get_db().execute_commit_command(
             'UPDATE groups SET scheduling_start_time = %s '
             'WHERE workflow_id = %s AND name = %s',


### PR DESCRIPTION
Both timeouts previously fired against workflow-level state. exec_timeout used workflow.start_time and cancelled the entire workflow on expiry; queue_timeout used workflow.submit_time and ran while workflow.status == PENDING. Each group is now metered independently:

  exec_timeout
    Clock starts when a group enters RUNNING (group.start_time). Only the
    expired group is marked FAILED_EXEC_TIMEOUT; downstream groups cascade
    via FAILED_UPSTREAM, sibling groups continue. The workflow status
    aggregates to FAILED_EXEC_TIMEOUT only once all groups have finished.

  queue_timeout
    Clock starts when a group enters SCHEDULING (group.scheduling_start_time)
    and stops when the group is assigned a node and enters INITIALIZING.
    Only the expired group is marked FAILED_QUEUE_TIMEOUT. INITIALIZING
    (image pull / preflight) is governed separately by the start timeout.

CheckRunTimeout and CheckQueueTimeout each gained an optional group_name field. When set, execute() takes the per-group path. When None — which only happens for delayed jobs serialized before this change — execute() falls back to the previous workflow-level enforcement with a WARNING log, so any in-flight payloads in the Redis ZSET drain cleanly under the old semantics.

Scheduling sites:
  - CheckRunTimeout is enqueued in UpdateGroup.execute() on the prerunning -> RUNNING transition (already group-scoped; just adds group_name to the payload).
  - CheckQueueTimeout is enqueued in UpdateGroup.execute() on the prescheduling -> SCHEDULING transition. The previous workflow-level enqueue at SubmitWorkflow.execute() is removed.

Other changes:
  - _resolve_exec_timeout / _resolve_queue_timeout short-circuit on an explicit workflow.timeout.* before fetching pool config — strict optimization, also lets tests skip the pool fixture.
  - test_task_db.py adds CheckRunTimeoutDbTest and CheckQueueTimeoutDbTest (Postgres testcontainer; Redis enqueue mocked to capture jobs). Coverage: per-group expiry hits only that group, within-window reschedules with the remaining delta, COMPLETED / RUNNING / pre-window groups are no-ops, INITIALIZING is a no-op for queue_timeout, legacy payloads (no group_name) use the workflow-level fallback.
  - Docs updated in user_guide/workflows/specification/timeouts.rst, user_guide/workflows/lifecycle/index.rst, and deployment_guide/references/configs_definitions/{pool,workflow}.rst to describe the per-group semantics.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified timeout fields as per-group timeouts and specified measurement windows: execution = group RUNNING; queue = group SCHEDULING→INITIALIZING. Updated lifecycle/status wording to reflect group-scoped semantics.

* **Bug Fixes**
  * Enforced timeouts per group so a timed-out group is marked without cancelling unaffected sibling groups; prior workflow-level enforcement remains as a fallback for legacy cases.

* **Tests**
  * Added DB-backed tests validating per-group timeout marking, rescheduling behavior, and legacy fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->