### PR TITLE
Enable ConfigMap mode for worker, agent, and logger services

### DIFF
--- a/deployments/charts/service/templates/_helpers.tpl
+++ b/deployments/charts/service/templates/_helpers.tpl
@@ -151,3 +151,56 @@ data:
 {{- end }}
 {{- end }}
 
+{{/*
+ConfigMap-mode mounts (shared by api-service, worker, agent, logger).
+All four services need the same configs ConfigMap and its referenced
+secrets so they can read the in-memory snapshot via ConfigMapWatcher
+instead of falling back to Postgres.
+
+OSMO_CONFIGMAP_NAME deliberately references services.service.serviceName
+(the API service) because the API owns the shared configs ConfigMap.
+*/}}
+{{- define "osmo.configmap-args" -}}
+{{- if .Values.services.configs.enabled }}
+- --config_file
+- /etc/osmo/configs/config.yaml
+{{- end }}
+{{- end -}}
+
+{{- define "osmo.configmap-env" -}}
+{{- if .Values.services.configs.enabled }}
+- name: POD_NAMESPACE
+  valueFrom:
+    fieldRef:
+      fieldPath: metadata.namespace
+- name: OSMO_CONFIGMAP_NAME
+  value: {{ .Values.services.service.serviceName }}-configs
+{{- end }}
+{{- end -}}
+
+{{- define "osmo.configmap-volume-mounts" -}}
+{{- if .Values.services.configs.enabled }}
+- name: configs
+  mountPath: /etc/osmo/configs
+  readOnly: true
+{{- range .Values.services.configs.secretRefs }}
+- name: secret-{{ .secretName }}
+  mountPath: /etc/osmo/secrets/{{ .secretName }}
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "osmo.configmap-volumes" -}}
+{{- if .Values.services.configs.enabled }}
+- name: configs
+  configMap:
+    name: {{ .Values.services.service.serviceName }}-configs
+{{- range .Values.services.configs.secretRefs }}
+- name: secret-{{ .secretName }}
+  secret:
+    secretName: {{ .secretName }}
+{{- end }}
+{{- end }}
+{{- end -}}
+

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -124,6 +124,7 @@ spec:
         - --log_name
         - agent_service
         {{- end }}
+        {{- include "osmo.configmap-args" . | nindent 8 }}
         {{- range $arg := .Values.services.agent.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
@@ -132,6 +133,7 @@ spec:
         - name: OSMO_SCHEMA_VERSION
           value: {{ .Values.services.migration.targetSchema }}
         {{- end }}
+        {{- include "osmo.configmap-env" . | nindent 8 }}
         {{- include "osmo.extra-env" .Values.services.agent | nindent 8 }}
         {{- if .Values.services.postgres.password }}
         - name: OSMO_POSTGRES_PASSWORD
@@ -150,7 +152,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.services.agent.imagePullPolicy }}
         ports:
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.agent.extraVolumeMounts }}
+        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.configs.enabled .Values.services.agent.extraVolumeMounts }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
@@ -158,6 +160,7 @@ spec:
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
+        {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
         {{- if .Values.global.logs.enabled }}
         - name: logs
           mountPath: /logs
@@ -218,6 +221,7 @@ spec:
             name: mek-config
           name: mek-volume
         {{- end}}
+        {{- include "osmo.configmap-volumes" . | nindent 8 }}
 
 ---
 

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -31,9 +31,6 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
-        {{- if .Values.services.configs.enabled }}
-        checksum/configs: {{ .Values.services.configs | toYaml | sha256sum }}
-        {{- end }}
         {{- include "osmo.extra-annotations" .Values.services.service | nindent 8 }}
     spec:
       {{- with .Values.services.service.hostAliases }}

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -149,24 +149,14 @@ spec:
         - --default_admin_username
         - {{ .Values.services.defaultAdmin.username | quote }}
         {{- end }}
-        {{- if .Values.services.configs.enabled }}
-        - --config_file
-        - /etc/osmo/configs/config.yaml
-        {{- end }}
+        {{- include "osmo.configmap-args" . | nindent 8 }}
         {{- range $arg := .Values.services.service.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
         env:
         - name: OSMO_DISABLE_TASK_METRICS
           value: {{ .Values.services.service.disableTaskMetrics | quote }}
-        {{- if .Values.services.configs.enabled }}
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: OSMO_CONFIGMAP_NAME
-          value: {{ .Values.services.service.serviceName }}-configs
-        {{- end }}
+        {{- include "osmo.configmap-env" . | nindent 8 }}
         {{- if .Values.services.migration.enabled }}
         - name: OSMO_SCHEMA_VERSION
           value: {{ .Values.services.migration.targetSchema }}
@@ -212,16 +202,7 @@ spec:
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
-        {{- if .Values.services.configs.enabled }}
-        - name: configs
-          mountPath: /etc/osmo/configs
-          readOnly: true
-        {{- range .Values.services.configs.secretRefs }}
-        - name: secret-{{ .secretName }}
-          mountPath: /etc/osmo/secrets/{{ .secretName }}
-          readOnly: true
-        {{- end }}
-        {{- end }}
+        {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
         {{- if .Values.global.logs.enabled }}
         - name: logs
           mountPath: /logs
@@ -273,16 +254,7 @@ spec:
             name: mek-config
           name: mek-volume
         {{- end}}
-        {{- if .Values.services.configs.enabled }}
-        - name: configs
-          configMap:
-            name: {{ .Values.services.service.serviceName }}-configs
-        {{- range .Values.services.configs.secretRefs }}
-        - name: secret-{{ .secretName }}
-          secret:
-            secretName: {{ .secretName }}
-        {{- end }}
-        {{- end }}
+        {{- include "osmo.configmap-volumes" . | nindent 8 }}
 ---
 
 apiVersion: v1

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -119,10 +119,12 @@ spec:
         - --log_name
         - logger_service
         {{- end }}
+        {{- include "osmo.configmap-args" . | nindent 8 }}
         {{- range $arg := .Values.services.logger.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
         env:
+        {{- include "osmo.configmap-env" . | nindent 8 }}
         {{- include "osmo.extra-env" .Values.services.logger | nindent 8 }}
         {{- if .Values.services.postgres.password }}
         - name: OSMO_POSTGRES_PASSWORD
@@ -141,7 +143,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.services.logger.imagePullPolicy }}
         ports:
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.logger.extraVolumeMounts }}
+        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.configs.enabled .Values.services.logger.extraVolumeMounts }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
@@ -149,6 +151,7 @@ spec:
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
+        {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
         {{- if .Values.global.logs.enabled }}
         - name: logs
           mountPath: /logs
@@ -209,6 +212,7 @@ spec:
             name: mek-config
           name: mek-volume
         {{- end}}
+        {{- include "osmo.configmap-volumes" . | nindent 8 }}
 
 ---
 

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -117,6 +117,7 @@ spec:
         - --log_name
         - worker
         {{- end }}
+        {{- include "osmo.configmap-args" . | nindent 8 }}
         {{- range $arg := .Values.services.worker.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
@@ -125,6 +126,7 @@ spec:
         - name: OSMO_SCHEMA_VERSION
           value: {{ .Values.services.migration.targetSchema }}
         {{- end }}
+        {{- include "osmo.configmap-env" . | nindent 8 }}
         {{- include "osmo.extra-env" .Values.services.worker | nindent 8 }}
         {{- if .Values.services.postgres.password }}
         - name: OSMO_POSTGRES_PASSWORD
@@ -141,7 +143,7 @@ spec:
               name: redis-secret
               key: redis-password
         {{- end }}
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.worker.extraVolumeMounts }}
+        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.configs.enabled .Values.services.worker.extraVolumeMounts }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
@@ -149,6 +151,7 @@ spec:
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
+        {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
         {{- if .Values.global.logs.enabled }}
         - name: logs
           mountPath: /logs
@@ -196,6 +199,7 @@ spec:
             name: mek-config
           name: mek-volume
         {{- end}}
+        {{- include "osmo.configmap-volumes" . | nindent 8 }}
 
 ---
 

--- a/src/lib/utils/credentials.py
+++ b/src/lib/utils/credentials.py
@@ -29,11 +29,16 @@ get_static_data_credential_from_config = credentials.get_static_data_credential_
 CREDNAMEREGEX = r'^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$'
 
 
-class RegistryCredential(pydantic.BaseModel, extra='forbid'):
+class RegistryCredential(pydantic.BaseModel, extra='forbid', populate_by_name=True):
     """ Authentication information for a Docker registry. """
     registry: str = pydantic.Field('', description='The Docker registry URL')
     username: str = pydantic.Field('', description='The username for the Docker registry')
+    # Accepts both `auth` (legacy field name) and `password` (matches the
+    # K8s Secret convention `kubectl create secret generic --from-literal=password=...`).
+    # Internally always stored as `auth`; the worker base64s `username:auth`
+    # to build the dockerconfigjson auth header at pod-creation time.
     auth: pydantic.SecretStr = pydantic.Field(
         pydantic.SecretStr(''),
-        description='The authentication token for the Docker registry',
+        description='The authentication token (raw password) for the Docker registry',
+        validation_alias=pydantic.AliasChoices('auth', 'password'),
     )

--- a/src/service/agent/agent_service.py
+++ b/src/service/agent/agent_service.py
@@ -29,13 +29,16 @@ import src.lib.utils.logging
 from src.utils.metrics import metrics
 from src.service.agent import helpers
 from src.service.core.auth import auth_service
+from src.service.core.config import configmap_loader
+from src.service.core.config.configmap_loader import ConfigFileMixin
 from src.service.core.workflow import objects
 from src.utils import connectors, static_config
 from src.utils.progress_check import progress
 
 
 class BackendServiceConfig(connectors.RedisConfig, connectors.PostgresConfig,
-                           src.lib.utils.logging.LoggingConfig, static_config.StaticConfig):
+                           src.lib.utils.logging.LoggingConfig,
+                           static_config.StaticConfig, ConfigFileMixin):
     """Config settings for the backend service"""
     progress_period: int = pydantic.Field(
         default=30,
@@ -112,6 +115,10 @@ def main():
     connectors.RedisConnector(config)
     agent_metrics = metrics.MetricCreator(config=config).get_meter_instance()
     agent_metrics.start_server()
+    # Pin the watcher on app.state so the daemon Observer thread isn't GC'd.
+    app.state.config_watcher = configmap_loader.start_config_watcher(
+        config.config_file, postgres,
+        emit_events=False, inject_runtime=False)
     objects.WorkflowServiceContext.set(
         objects.WorkflowServiceContext(config=config, database=postgres))
     parsed_url = urlparse(config.host)

--- a/src/service/agent/agent_service.py
+++ b/src/service/agent/agent_service.py
@@ -36,6 +36,10 @@ from src.utils import connectors, static_config
 from src.utils.progress_check import progress
 
 
+# ConfigFileMixin is required even though we read config.config_file from
+# WorkflowServiceConfig: the chart adds --config_file to argv, and
+# StaticConfig.load() does a strict parse_args() per class — without the
+# mixin BackendServiceConfig.load() would reject the unknown flag and crash.
 class BackendServiceConfig(connectors.RedisConfig, connectors.PostgresConfig,
                            src.lib.utils.logging.LoggingConfig,
                            static_config.StaticConfig, ConfigFileMixin):
@@ -117,8 +121,7 @@ def main():
     agent_metrics.start_server()
     # Pin the watcher on app.state so the daemon Observer thread isn't GC'd.
     app.state.config_watcher = configmap_loader.start_config_watcher(
-        config.config_file, postgres,
-        emit_events=False, inject_runtime=False)
+        config.config_file, postgres)
     objects.WorkflowServiceContext.set(
         objects.WorkflowServiceContext(config=config, database=postgres))
     parsed_url = urlparse(config.host)

--- a/src/service/core/config/BUILD
+++ b/src/service/core/config/BUILD
@@ -21,22 +21,36 @@ load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 
 osmo_py_library(
-    name = "config",
+    name = "configmap_loader_lib",
     srcs = [
-        "config_history_helpers.py",
-        "config_service.py",
         "configmap_events.py",
         "configmap_guard.py",
         "configmap_loader.py",
-        "helpers.py",
-        "objects.py",
     ],
     deps = [
-        requirement("fastapi"),
         requirement("kubernetes"),
         requirement("pydantic"),
         requirement("pyyaml"),
         requirement("watchdog"),
+        "//src/lib/utils:common",
+        "//src/utils:configmap_state",
+        "//src/utils/connectors",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "config",
+    srcs = [
+        "config_history_helpers.py",
+        "config_service.py",
+        "helpers.py",
+        "objects.py",
+    ],
+    deps = [
+        ":configmap_loader_lib",
+        requirement("fastapi"),
+        requirement("pydantic"),
         "//src/lib/utils:common",
         "//src/lib/utils:osmo_errors",
         "//src/lib/utils:config_history",

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -123,25 +123,38 @@ class ConfigMapWatcher:
         # Only emit "reload succeeded" events when recovering from a
         # previous failure — successful reloads on their own are noise.
         self._last_reload_failed = False
+        # 'transient' means the file isn't readable yet (kubelet projection
+        # in progress); 'permanent' means the file exists but is unparseable
+        # or invalid. start() retries on transient and fails fast on
+        # permanent so a bad ConfigMap surfaces immediately instead of
+        # spinning for the full retry deadline.
+        self._last_failure_kind: str | None = None
 
     def start(self) -> None:
         """Load configs, activate ConfigMap mode, start file watcher.
 
-        Retries the initial load for up to _STARTUP_RETRY_DEADLINE_S so a
-        pod scheduled before kubelet finishes projecting the ConfigMap
-        volume doesn't immediately CrashLoopBackoff. After the deadline,
-        a load failure raises RuntimeError; K8s stalls the rolling update
-        at the bad revision and old pods keep serving.
+        Retries the initial load on transient failures (file missing
+        because kubelet hasn't finished projecting the ConfigMap volume)
+        for up to _STARTUP_RETRY_DEADLINE_S. Permanent failures (bad
+        YAML / failed validation) fail fast — operator gets the signal
+        immediately and old pods keep serving via the rolling-update
+        stall.
         """
         deadline = time.monotonic() + _STARTUP_RETRY_DEADLINE_S
         while True:
             if self._load_and_apply():
                 break
+            if self._last_failure_kind == 'permanent':
+                raise RuntimeError(
+                    f'ConfigMap load failed at startup '
+                    f'({self._config_file_path}): malformed or invalid '
+                    f'config file. Refusing to serve.')
             if time.monotonic() >= deadline:
                 raise RuntimeError(
                     f'ConfigMap load failed at startup after '
                     f'{_STARTUP_RETRY_DEADLINE_S:.0f}s '
-                    f'({self._config_file_path}). Refusing to serve.')
+                    f'({self._config_file_path}): file never became '
+                    f'readable. Refusing to serve.')
             time.sleep(_STARTUP_RETRY_INTERVAL_S)
 
         configmap_guard.set_configmap_mode(True)
@@ -180,18 +193,28 @@ class ConfigMapWatcher:
     def _load_and_apply(self) -> bool:
         """Parse, resolve secrets, validate, and swap the in-memory config dict.
 
-        Returns True if configs were successfully loaded.
+        Returns True if configs were successfully loaded. Sets
+        self._last_failure_kind to 'transient' (file not yet readable)
+        or 'permanent' (file exists but unparseable / invalid) on failure.
         """
         try:
             with open(self._config_file_path, encoding='utf-8') as f:
                 raw_config = yaml.safe_load(f)
-        except (OSError, yaml.YAMLError) as error:
+        except OSError as error:
+            self._last_failure_kind = 'transient'
             self._record_failure(
-                f'Failed to read/parse config file '
+                f'Failed to read config file '
+                f'{self._config_file_path}: {error}')
+            return False
+        except yaml.YAMLError as error:
+            self._last_failure_kind = 'permanent'
+            self._record_failure(
+                f'Failed to parse config file '
                 f'{self._config_file_path}: {error}')
             return False
 
         if not raw_config or not isinstance(raw_config, dict):
+            self._last_failure_kind = 'permanent'
             self._record_failure(
                 f'Config file {self._config_file_path} is empty or invalid')
             return False
@@ -213,6 +236,7 @@ class ConfigMapWatcher:
         # by configure_app().
         validation_errors = _validate_configs(managed_configs)
         if validation_errors:
+            self._last_failure_kind = 'permanent'
             joined_errors = '; '.join(validation_errors)
             self._record_failure(
                 f'ConfigMap validation failed, keeping previous config: '
@@ -242,6 +266,7 @@ class ConfigMapWatcher:
         logging.info(
             'ConfigMap configs loaded from %s', self._config_file_path)
         self._record_success()
+        self._last_failure_kind = None
 
         return True
 

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -17,6 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import copy
+import enum
 import json
 import logging
 import os
@@ -39,15 +40,27 @@ _STARTUP_RETRY_DEADLINE_S = 30.0
 _STARTUP_RETRY_INTERVAL_S = 1.0
 
 
+class LoadResult(enum.Enum):
+    """Outcome of a ConfigMapWatcher load attempt.
+
+    TRANSIENT means retrying may succeed (file isn't readable yet —
+    kubelet projection in progress). PERMANENT means the file is there
+    but malformed or invalid; retrying won't help so cold-start fails
+    fast and operators see the bad ConfigMap immediately.
+    """
+    SUCCESS = 'success'
+    TRANSIENT_FAILURE = 'transient'
+    PERMANENT_FAILURE = 'permanent'
+
+
 class ConfigFileMixin(pydantic.BaseModel):
     """Pydantic mixin adding `--config_file` to a service config class.
 
     Inherited by every service binary that wants ConfigMap mode (api,
-    worker, agent, logger). Centralizing the field keeps the flag name
-    (`--config_file`) and env var (`OSMO_CONFIG_FILE`) consistent across
-    services and avoids argparse divergence when one binary loads more
-    than one config class (e.g. agent loads both WorkflowServiceConfig
-    and BackendServiceConfig).
+    worker, logger, and the WorkflowServiceConfig that the agent loads
+    alongside its BackendServiceConfig). Centralizing the field keeps
+    the flag name (`--config_file`) and env var (`OSMO_CONFIG_FILE`)
+    consistent and avoids argparse divergence.
     """
     config_file: str | None = pydantic.Field(
         default=None,
@@ -123,12 +136,6 @@ class ConfigMapWatcher:
         # Only emit "reload succeeded" events when recovering from a
         # previous failure — successful reloads on their own are noise.
         self._last_reload_failed = False
-        # 'transient' means the file isn't readable yet (kubelet projection
-        # in progress); 'permanent' means the file exists but is unparseable
-        # or invalid. start() retries on transient and fails fast on
-        # permanent so a bad ConfigMap surfaces immediately instead of
-        # spinning for the full retry deadline.
-        self._last_failure_kind: str | None = None
 
     def start(self) -> None:
         """Load configs, activate ConfigMap mode, start file watcher.
@@ -142,9 +149,10 @@ class ConfigMapWatcher:
         """
         deadline = time.monotonic() + _STARTUP_RETRY_DEADLINE_S
         while True:
-            if self._load_and_apply():
+            result = self._load_and_apply()
+            if result == LoadResult.SUCCESS:
                 break
-            if self._last_failure_kind == 'permanent':
+            if result == LoadResult.PERMANENT_FAILURE:
                 raise RuntimeError(
                     f'ConfigMap load failed at startup '
                     f'({self._config_file_path}): malformed or invalid '
@@ -190,34 +198,31 @@ class ConfigMapWatcher:
                 'ConfigMap reload succeeded after previous failure')
         self._last_reload_failed = False
 
-    def _load_and_apply(self) -> bool:
+    def _load_and_apply(self) -> LoadResult:
         """Parse, resolve secrets, validate, and swap the in-memory config dict.
 
-        Returns True if configs were successfully loaded. Sets
-        self._last_failure_kind to 'transient' (file not yet readable)
-        or 'permanent' (file exists but unparseable / invalid) on failure.
+        TRANSIENT_FAILURE means retrying may succeed (file not yet
+        readable). PERMANENT_FAILURE means the file exists but is
+        unparseable / invalid; retrying won't help.
         """
         try:
             with open(self._config_file_path, encoding='utf-8') as f:
                 raw_config = yaml.safe_load(f)
         except OSError as error:
-            self._last_failure_kind = 'transient'
             self._record_failure(
                 f'Failed to read config file '
                 f'{self._config_file_path}: {error}')
-            return False
+            return LoadResult.TRANSIENT_FAILURE
         except yaml.YAMLError as error:
-            self._last_failure_kind = 'permanent'
             self._record_failure(
                 f'Failed to parse config file '
                 f'{self._config_file_path}: {error}')
-            return False
+            return LoadResult.PERMANENT_FAILURE
 
         if not raw_config or not isinstance(raw_config, dict):
-            self._last_failure_kind = 'permanent'
             self._record_failure(
                 f'Config file {self._config_file_path} is empty or invalid')
-            return False
+            return LoadResult.PERMANENT_FAILURE
 
         managed_configs = raw_config
 
@@ -236,12 +241,11 @@ class ConfigMapWatcher:
         # by configure_app().
         validation_errors = _validate_configs(managed_configs)
         if validation_errors:
-            self._last_failure_kind = 'permanent'
             joined_errors = '; '.join(validation_errors)
             self._record_failure(
                 f'ConfigMap validation failed, keeping previous config: '
                 f'{joined_errors}')
-            return False
+            return LoadResult.PERMANENT_FAILURE
 
         # Resolve pool computed fields (parsed_pod_template, etc.) from
         # template/validation name references. This allows compact ConfigMap
@@ -255,8 +259,6 @@ class ConfigMapWatcher:
         if self._inject_runtime:
             self._inject_runtime_fields(managed_configs)
 
-        # Atomic swap — in-flight requests holding a reference to the old
-        # dict continue using it; new requests get the new dict.
         configmap_guard.set_parsed_configs(managed_configs)
         if not configmap_guard.is_configmap_mode():
             configmap_guard.set_configmap_mode(True)
@@ -266,9 +268,8 @@ class ConfigMapWatcher:
         logging.info(
             'ConfigMap configs loaded from %s', self._config_file_path)
         self._record_success()
-        self._last_failure_kind = None
 
-        return True
+        return LoadResult.SUCCESS
 
     def _inject_runtime_fields(
         self, managed_configs: Dict[str, Any],
@@ -301,8 +302,7 @@ def start_config_watcher(
     config_file: str | None,
     postgres: connectors.PostgresConnector,
     *,
-    emit_events: bool = False,
-    inject_runtime: bool = False,
+    is_api_service: bool = False,
 ) -> 'ConfigMapWatcher | None':
     """Initialize and start a ConfigMapWatcher when `config_file` is set.
 
@@ -310,21 +310,18 @@ def start_config_watcher(
     Observer thread is daemonic; without a live reference the watcher may
     be GC'd while the process is still alive).
 
-    Args:
-        emit_events: Pass True only for the API service. Worker/agent/logger
-            run with multiple replicas and N replicas racing on the same K8s
-            Event object produces 409 Conflict storms; let them log to stderr
-            instead.
-        inject_runtime: Pass True only for the API service. service_auth
-            and service_base_url are runtime-generated fields meaningful
-            only for the API; injecting them in non-API services adds an
-            unnecessary DB round-trip and confuses readers.
+    The API service has two extra responsibilities tied to it being the
+    primary reader and writer of configs: it emits K8s Events on reload
+    failures, and it injects runtime-generated fields (service_auth,
+    service_base_url) into the snapshot. Worker/agent/logger don't do
+    either — they'd race on the same Event object across replicas, and
+    they don't generate the runtime fields.
     """
     if not config_file:
         return None
 
     event_recorder: configmap_events.EventRecorder | None = None
-    if emit_events:
+    if is_api_service:
         pod_namespace = os.environ.get('POD_NAMESPACE')
         configmap_name = os.environ.get('OSMO_CONFIGMAP_NAME')
         if pod_namespace and configmap_name:
@@ -338,7 +335,7 @@ def start_config_watcher(
     watcher = ConfigMapWatcher(
         config_file, postgres,
         event_recorder=event_recorder,
-        inject_runtime=inject_runtime,
+        inject_runtime=is_api_service,
     )
     watcher.start()
     return watcher

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import threading
+import time
 from typing import Any, Callable, Dict, List
 
 import pydantic
@@ -30,6 +31,31 @@ from watchdog import events, observers
 from src.lib.utils.common import merge_lists_on_name, recursive_dict_update
 from src.service.core.config import configmap_events, configmap_guard
 from src.utils import connectors
+
+
+# Cold-start retry: kubelet may take up to ~60s to project a freshly-created
+# ConfigMap volume on a new pod, so we retry the initial load before giving up.
+_STARTUP_RETRY_DEADLINE_S = 30.0
+_STARTUP_RETRY_INTERVAL_S = 1.0
+
+
+class ConfigFileMixin(pydantic.BaseModel):
+    """Pydantic mixin adding `--config_file` to a service config class.
+
+    Inherited by every service binary that wants ConfigMap mode (api,
+    worker, agent, logger). Centralizing the field keeps the flag name
+    (`--config_file`) and env var (`OSMO_CONFIG_FILE`) consistent across
+    services and avoids argparse divergence when one binary loads more
+    than one config class (e.g. agent loads both WorkflowServiceConfig
+    and BackendServiceConfig).
+    """
+    config_file: str | None = pydantic.Field(
+        default=None,
+        description='Path to ConfigMap YAML file to load configs from.',
+        json_schema_extra={
+            'command_line': 'config_file',
+            'env': 'OSMO_CONFIG_FILE',
+        })
 
 
 # ---------------------------------------------------------------------------
@@ -83,11 +109,14 @@ class ConfigMapWatcher:
         self,
         config_file_path: str,
         postgres: connectors.PostgresConnector | None = None,
+        *,
         event_recorder: configmap_events.EventRecorder | None = None,
+        inject_runtime: bool = True,
     ):
         self._config_file_path = config_file_path
         self._postgres = postgres
         self._event_recorder = event_recorder
+        self._inject_runtime = inject_runtime
         self._watch_directory = os.path.dirname(config_file_path)
         self._config_filename = os.path.basename(config_file_path)
         self._observer: Any = None
@@ -98,15 +127,22 @@ class ConfigMapWatcher:
     def start(self) -> None:
         """Load configs, activate ConfigMap mode, start file watcher.
 
-        A startup load failure raises RuntimeError so the pod crashes
-        and K8s stalls the rolling update at the bad revision; old
-        pods keep serving. Same behavior as CoreDNS / NGINX Ingress
-        with a bad config file at startup.
+        Retries the initial load for up to _STARTUP_RETRY_DEADLINE_S so a
+        pod scheduled before kubelet finishes projecting the ConfigMap
+        volume doesn't immediately CrashLoopBackoff. After the deadline,
+        a load failure raises RuntimeError; K8s stalls the rolling update
+        at the bad revision and old pods keep serving.
         """
-        if not self._load_and_apply():
-            raise RuntimeError(
-                f'ConfigMap load failed at startup '
-                f'({self._config_file_path}). Refusing to serve.')
+        deadline = time.monotonic() + _STARTUP_RETRY_DEADLINE_S
+        while True:
+            if self._load_and_apply():
+                break
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f'ConfigMap load failed at startup after '
+                    f'{_STARTUP_RETRY_DEADLINE_S:.0f}s '
+                    f'({self._config_file_path}). Refusing to serve.')
+            time.sleep(_STARTUP_RETRY_INTERVAL_S)
 
         configmap_guard.set_configmap_mode(True)
         logging.info(
@@ -190,7 +226,10 @@ class ConfigMapWatcher:
 
         # Inject runtime-generated fields (service_auth, service_base_url)
         # that are not in the ConfigMap but are needed by the service.
-        self._inject_runtime_fields(managed_configs)
+        # Only the API service generates these; non-API services (worker,
+        # agent, logger) skip the injection and the unnecessary DB read.
+        if self._inject_runtime:
+            self._inject_runtime_fields(managed_configs)
 
         # Atomic swap — in-flight requests holding a reference to the old
         # dict continue using it; new requests get the new dict.
@@ -231,6 +270,53 @@ class ConfigMapWatcher:
         for field in ('service_auth', 'service_base_url'):
             if field not in service_config and field in prev_service:
                 service_config[field] = prev_service[field]
+
+
+def start_config_watcher(
+    config_file: str | None,
+    postgres: connectors.PostgresConnector,
+    *,
+    emit_events: bool = False,
+    inject_runtime: bool = False,
+) -> 'ConfigMapWatcher | None':
+    """Initialize and start a ConfigMapWatcher when `config_file` is set.
+
+    Returns the watcher so the caller can keep a reference (the watchdog
+    Observer thread is daemonic; without a live reference the watcher may
+    be GC'd while the process is still alive).
+
+    Args:
+        emit_events: Pass True only for the API service. Worker/agent/logger
+            run with multiple replicas and N replicas racing on the same K8s
+            Event object produces 409 Conflict storms; let them log to stderr
+            instead.
+        inject_runtime: Pass True only for the API service. service_auth
+            and service_base_url are runtime-generated fields meaningful
+            only for the API; injecting them in non-API services adds an
+            unnecessary DB round-trip and confuses readers.
+    """
+    if not config_file:
+        return None
+
+    event_recorder: configmap_events.EventRecorder | None = None
+    if emit_events:
+        pod_namespace = os.environ.get('POD_NAMESPACE')
+        configmap_name = os.environ.get('OSMO_CONFIGMAP_NAME')
+        if pod_namespace and configmap_name:
+            event_recorder = configmap_events.ConfigMapEventRecorder(
+                namespace=pod_namespace, configmap_name=configmap_name)
+        else:
+            logging.warning(
+                'POD_NAMESPACE or OSMO_CONFIGMAP_NAME unset; '
+                'ConfigMap reload events will not be emitted')
+
+    watcher = ConfigMapWatcher(
+        config_file, postgres,
+        event_recorder=event_recorder,
+        inject_runtime=inject_runtime,
+    )
+    watcher.start()
+    return watcher
 
 
 # ---------------------------------------------------------------------------

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -16,6 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import base64
 import copy
 import enum
 import json
@@ -599,6 +600,31 @@ def _resolve_platform_fields(
 SECRETS_ROOT = '/etc/osmo/secrets'
 
 
+def _decode_dockerconfig_auth(auth_b64: str, username: str) -> str:
+    """Recover the raw password from a `.dockerconfigjson` `auth` field.
+
+    The `auth` field is base64(`username:password`); strip the username
+    prefix and a single ':' to get the password back. Returns '' on any
+    decode failure — caller logs and proceeds with empty credentials.
+    """
+    if not auth_b64:
+        return ''
+    try:
+        decoded = base64.b64decode(auth_b64).decode('utf-8')
+    except (ValueError, UnicodeDecodeError):
+        logging.warning(
+            'Could not base64-decode dockerconfigjson auth field; '
+            'returning empty password')
+        return ''
+    prefix = f'{username}:'
+    if username and decoded.startswith(prefix):
+        return decoded[len(prefix):]
+    # No username, or auth doesn't start with username: — just split on
+    # first ':' as a best effort.
+    _, sep, password = decoded.partition(':')
+    return password if sep else ''
+
+
 def _resolve_secret_file_references(config_data: Dict[str, Any],
                                      parent_key: str = '') -> None:
     """Recursively resolve secret_file / secretName references in a config dict.
@@ -696,10 +722,22 @@ def _resolve_single_secret(parent_dict: Dict[str, Any], key: str,
         if isinstance(auths, dict) and auths:
             registry_url = next(iter(auths))
             registry_data = auths[registry_url]
+            # RegistryCredential.auth is the raw password/token; the worker
+            # base64s `username:auth` to build the dockerconfigjson auth
+            # header at pod-creation time. Source files store either
+            # `password` (raw, what we want) or `auth` (already
+            # base64(username:password)). Prefer password; fall back to
+            # decoding auth and stripping the username prefix so we always
+            # land in the model with a raw token.
+            password = registry_data.get('password')
+            if not password:
+                password = _decode_dockerconfig_auth(
+                    registry_data.get('auth', ''),
+                    registry_data.get('username', ''))
             extracted = {
                 'registry': registry_url,
                 'username': registry_data.get('username', ''),
-                'auth': registry_data.get('auth', ''),
+                'auth': password,
             }
             current_value.pop('secret_file', None)
             current_value.pop('secretName', None)

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -21,6 +21,8 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 import os
 import tempfile
+import threading
+import time
 import unittest
 from typing import Any, Dict
 from unittest import mock
@@ -1273,6 +1275,103 @@ class TestConfigFileEventHandler(unittest.TestCase):
         handler.on_any_event(event)
 
         self.assertIsNotNone(handler._debounce_timer)
+
+
+class TestStartConfigWatcher(unittest.TestCase):
+    """Tests for the start_config_watcher convenience helper."""
+
+    def setUp(self):
+        configmap_state.set_configmap_mode(False)
+        configmap_state.set_parsed_configs(None)
+
+    def tearDown(self):
+        configmap_state.set_configmap_mode(False)
+        configmap_state.set_parsed_configs(None)
+
+    def test_returns_none_when_config_file_unset(self):
+        watcher = configmap_loader.start_config_watcher(
+            None, mock.MagicMock(), emit_events=True, inject_runtime=True)
+        self.assertIsNone(watcher)
+        self.assertFalse(configmap_state.is_configmap_mode())
+
+    def test_emit_events_false_skips_event_recorder(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = os.path.join(tmp_dir, 'config.yaml')
+            with open(config_path, 'w', encoding='utf-8') as f:
+                yaml.dump({'service': {}}, f)
+
+            with mock.patch.object(
+                configmap_events, 'ConfigMapEventRecorder',
+            ) as mock_recorder:
+                watcher = configmap_loader.start_config_watcher(
+                    config_path, mock.MagicMock(),
+                    emit_events=False, inject_runtime=False)
+                assert watcher is not None
+                try:
+                    self.assertIsNone(watcher._event_recorder)
+                    mock_recorder.assert_not_called()
+                finally:
+                    watcher.stop()
+
+    def test_inject_runtime_false_skips_db_read(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = os.path.join(tmp_dir, 'config.yaml')
+            with open(config_path, 'w', encoding='utf-8') as f:
+                yaml.dump({'service': {}}, f)
+
+            postgres = mock.MagicMock()
+            watcher = configmap_loader.start_config_watcher(
+                config_path, postgres,
+                emit_events=False, inject_runtime=False)
+            assert watcher is not None
+            try:
+                # _inject_runtime_fields was not invoked, so no DB read.
+                postgres.get_service_configs.assert_not_called()
+            finally:
+                watcher.stop()
+
+    def test_cold_start_retry_succeeds_when_file_appears(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = os.path.join(tmp_dir, 'config.yaml')
+
+            def write_file_late():
+                time.sleep(0.15)
+                with open(config_path, 'w', encoding='utf-8') as f:
+                    yaml.dump({'service': {}}, f)
+
+            # Speed up the retry loop so the test runs in <1s.
+            with mock.patch.object(
+                configmap_loader, '_STARTUP_RETRY_DEADLINE_S', 5.0,
+            ), mock.patch.object(
+                configmap_loader, '_STARTUP_RETRY_INTERVAL_S', 0.05,
+            ):
+                writer = threading.Thread(target=write_file_late)
+                writer.start()
+                watcher = None
+                try:
+                    watcher = configmap_loader.start_config_watcher(
+                        config_path, mock.MagicMock(),
+                        emit_events=False, inject_runtime=False)
+                    self.assertIsNotNone(watcher)
+                finally:
+                    writer.join()
+                    if watcher is not None:
+                        watcher.stop()
+
+    def test_cold_start_raises_after_deadline(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            missing_path = os.path.join(tmp_dir, 'never-appears.yaml')
+
+            with mock.patch.object(
+                configmap_loader, '_STARTUP_RETRY_DEADLINE_S', 0.2,
+            ), mock.patch.object(
+                configmap_loader, '_STARTUP_RETRY_INTERVAL_S', 0.05,
+            ):
+                with self.assertRaises(RuntimeError) as ctx:
+                    configmap_loader.start_config_watcher(
+                        missing_path, mock.MagicMock(),
+                        emit_events=False, inject_runtime=False)
+                self.assertIn('failed at startup', str(ctx.exception))
 
 
 if __name__ == '__main__':

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -1344,7 +1344,12 @@ class TestStartConfigWatcher(unittest.TestCase):
                 configmap_loader, '_STARTUP_RETRY_DEADLINE_S', 5.0,
             ), mock.patch.object(
                 configmap_loader, '_STARTUP_RETRY_INTERVAL_S', 0.05,
-            ):
+            ), mock.patch.object(
+                configmap_loader.ConfigMapWatcher,
+                '_load_and_apply',
+                autospec=True,
+                wraps=configmap_loader.ConfigMapWatcher._load_and_apply,
+            ) as load_spy:
                 writer = threading.Thread(target=write_file_late)
                 writer.start()
                 watcher = None
@@ -1353,6 +1358,11 @@ class TestStartConfigWatcher(unittest.TestCase):
                         config_path, mock.MagicMock(),
                         emit_events=False, inject_runtime=False)
                     self.assertIsNotNone(watcher)
+                    # First call(s) must fail (file not yet present), then
+                    # the writer thread creates the file and a later call
+                    # succeeds. Anything less than 2 invocations means the
+                    # retry path was never exercised.
+                    self.assertGreaterEqual(load_spy.call_count, 2)
                 finally:
                     writer.join()
                     if watcher is not None:
@@ -1372,6 +1382,31 @@ class TestStartConfigWatcher(unittest.TestCase):
                         missing_path, mock.MagicMock(),
                         emit_events=False, inject_runtime=False)
                 self.assertIn('failed at startup', str(ctx.exception))
+                self.assertIn('never became readable', str(ctx.exception))
+
+    def test_cold_start_fails_fast_on_permanent_error(self):
+        """Bad YAML must not consume the full retry deadline."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = os.path.join(tmp_dir, 'config.yaml')
+            with open(config_path, 'w', encoding='utf-8') as f:
+                f.write('not: [valid: yaml')
+
+            with mock.patch.object(
+                configmap_loader, '_STARTUP_RETRY_DEADLINE_S', 60.0,
+            ), mock.patch.object(
+                configmap_loader, '_STARTUP_RETRY_INTERVAL_S', 1.0,
+            ):
+                start = time.monotonic()
+                with self.assertRaises(RuntimeError) as ctx:
+                    configmap_loader.start_config_watcher(
+                        config_path, mock.MagicMock(),
+                        emit_events=False, inject_runtime=False)
+                elapsed = time.monotonic() - start
+                # Should bail out essentially immediately (single attempt).
+                # Bound generously to absorb CI jitter; the point is that
+                # we don't sit through the 60s deadline.
+                self.assertLess(elapsed, 5.0)
+                self.assertIn('malformed or invalid', str(ctx.exception))
 
 
 if __name__ == '__main__':

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -550,7 +550,7 @@ class TestConfigMapWatcherEvents(unittest.TestCase):
             watcher = configmap_loader.ConfigMapWatcher(
                 good_path, self.mock_postgres, event_recorder=recorder)
             result = watcher._load_and_apply()
-            self.assertTrue(result)
+            self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
             self.assertEqual(recorder.failures, [])
             self.assertEqual(recorder.successes, [])
         finally:
@@ -582,7 +582,8 @@ class TestConfigMapWatcherEvents(unittest.TestCase):
             watcher = configmap_loader.ConfigMapWatcher(
                 bad_path, self.mock_postgres, event_recorder=None)
             # Must not raise despite the failure
-            self.assertFalse(watcher._load_and_apply())
+            result = watcher._load_and_apply()
+            self.assertNotEqual(result, configmap_loader.LoadResult.SUCCESS)
         finally:
             os.unlink(bad_path)
 
@@ -786,7 +787,8 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         watcher = configmap_loader.ConfigMapWatcher(
             '/nonexistent/path.yaml', self.mock_postgres)
         result = watcher._load_and_apply()
-        self.assertFalse(result)
+        self.assertEqual(
+            result, configmap_loader.LoadResult.TRANSIENT_FAILURE)
         self.assertIsNone(configmap_state.get_snapshot())
 
     def test_load_empty_file(self):
@@ -798,7 +800,8 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             watcher = configmap_loader.ConfigMapWatcher(
                 path, self.mock_postgres)
             result = watcher._load_and_apply()
-            self.assertFalse(result)
+            self.assertEqual(
+                result, configmap_loader.LoadResult.PERMANENT_FAILURE)
         finally:
             os.unlink(path)
 
@@ -821,7 +824,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             watcher = configmap_loader.ConfigMapWatcher(
                 path, self.mock_postgres)
             result = watcher._load_and_apply()
-            self.assertTrue(result)
+            self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
 
             snapshot = configmap_state.get_snapshot()
             assert snapshot is not None
@@ -849,7 +852,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             watcher = configmap_loader.ConfigMapWatcher(
                 path, self.mock_postgres)
             result = watcher._load_and_apply()
-            self.assertTrue(result)
+            self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
 
             snapshot = configmap_state.get_snapshot()
             assert snapshot is not None
@@ -888,7 +891,8 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             watcher2 = configmap_loader.ConfigMapWatcher(
                 bad_path, self.mock_postgres)
             result = watcher2._load_and_apply()
-            self.assertFalse(result)
+            self.assertEqual(
+                result, configmap_loader.LoadResult.PERMANENT_FAILURE)
 
             # Previous snapshot preserved
             self.assertIs(configmap_state.get_snapshot(), old_snapshot)
@@ -1223,7 +1227,7 @@ class TestResolvePoolComputedFields(unittest.TestCase):
             configmap_state.set_parsed_configs(None)
             watcher = configmap_loader.ConfigMapWatcher(path, mock_postgres)
             result = watcher._load_and_apply()
-            self.assertTrue(result)
+            self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
 
             snapshot = configmap_state.get_snapshot()
             assert snapshot is not None
@@ -1290,45 +1294,30 @@ class TestStartConfigWatcher(unittest.TestCase):
 
     def test_returns_none_when_config_file_unset(self):
         watcher = configmap_loader.start_config_watcher(
-            None, mock.MagicMock(), emit_events=True, inject_runtime=True)
+            None, mock.MagicMock(), is_api_service=True)
         self.assertIsNone(watcher)
         self.assertFalse(configmap_state.is_configmap_mode())
 
-    def test_emit_events_false_skips_event_recorder(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            config_path = os.path.join(tmp_dir, 'config.yaml')
-            with open(config_path, 'w', encoding='utf-8') as f:
-                yaml.dump({'service': {}}, f)
-
-            with mock.patch.object(
-                configmap_events, 'ConfigMapEventRecorder',
-            ) as mock_recorder:
-                watcher = configmap_loader.start_config_watcher(
-                    config_path, mock.MagicMock(),
-                    emit_events=False, inject_runtime=False)
-                assert watcher is not None
-                try:
-                    self.assertIsNone(watcher._event_recorder)
-                    mock_recorder.assert_not_called()
-                finally:
-                    watcher.stop()
-
-    def test_inject_runtime_false_skips_db_read(self):
+    def test_non_api_service_skips_event_recorder_and_db_read(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             config_path = os.path.join(tmp_dir, 'config.yaml')
             with open(config_path, 'w', encoding='utf-8') as f:
                 yaml.dump({'service': {}}, f)
 
             postgres = mock.MagicMock()
-            watcher = configmap_loader.start_config_watcher(
-                config_path, postgres,
-                emit_events=False, inject_runtime=False)
-            assert watcher is not None
-            try:
-                # _inject_runtime_fields was not invoked, so no DB read.
-                postgres.get_service_configs.assert_not_called()
-            finally:
-                watcher.stop()
+            with mock.patch.object(
+                configmap_events, 'ConfigMapEventRecorder',
+            ) as mock_recorder:
+                watcher = configmap_loader.start_config_watcher(
+                    config_path, postgres, is_api_service=False)
+                assert watcher is not None
+                try:
+                    # No K8s Event recorder, no DB read for runtime fields.
+                    self.assertIsNone(watcher._event_recorder)
+                    mock_recorder.assert_not_called()
+                    postgres.get_service_configs.assert_not_called()
+                finally:
+                    watcher.stop()
 
     def test_cold_start_retry_succeeds_when_file_appears(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1356,7 +1345,7 @@ class TestStartConfigWatcher(unittest.TestCase):
                 try:
                     watcher = configmap_loader.start_config_watcher(
                         config_path, mock.MagicMock(),
-                        emit_events=False, inject_runtime=False)
+                        is_api_service=False)
                     self.assertIsNotNone(watcher)
                     # First call(s) must fail (file not yet present), then
                     # the writer thread creates the file and a later call
@@ -1380,7 +1369,7 @@ class TestStartConfigWatcher(unittest.TestCase):
                 with self.assertRaises(RuntimeError) as ctx:
                     configmap_loader.start_config_watcher(
                         missing_path, mock.MagicMock(),
-                        emit_events=False, inject_runtime=False)
+                        is_api_service=False)
                 self.assertIn('failed at startup', str(ctx.exception))
                 self.assertIn('never became readable', str(ctx.exception))
 
@@ -1400,7 +1389,7 @@ class TestStartConfigWatcher(unittest.TestCase):
                 with self.assertRaises(RuntimeError) as ctx:
                     configmap_loader.start_config_watcher(
                         config_path, mock.MagicMock(),
-                        emit_events=False, inject_runtime=False)
+                        is_api_service=False)
                 elapsed = time.monotonic() - start
                 # Should bail out essentially immediately (single attempt).
                 # Bound generously to absorb CI jitter; the point is that

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -18,6 +18,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # pylint: disable=protected-access
 
+import base64
+import json
 import logging
 import os
 import tempfile
@@ -172,6 +174,69 @@ class TestResolveSecretFileReferences(unittest.TestCase):
         }
         with self.assertLogs(level=logging.ERROR):
             configmap_loader._resolve_secret_file_references(config_data)
+
+    def test_resolve_dockerconfigjson_prefers_password(self):
+        """The worker treats RegistryCredential.auth as the raw password
+        and re-encodes username:auth. If the loader fed it the
+        already-base64-encoded composite, the resulting pull-secret
+        would be double-encoded and registries reject it.
+        """
+        secret_data = {
+            'auths': {
+                'nvcr.io': {
+                    'username': '$oauthtoken',
+                    'password': 'raw-token-value',
+                    'auth': base64.b64encode(
+                        b'$oauthtoken:raw-token-value').decode(),
+                },
+            },
+        }
+        with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.json', delete=False) as secret_file:
+            json.dump(secret_data, secret_file)
+            secret_path = secret_file.name
+        try:
+            config_data: Dict[str, Any] = {
+                'backend_images': {
+                    'credential': {'secret_file': secret_path},
+                },
+            }
+            configmap_loader._resolve_secret_file_references(config_data)
+
+            credential = config_data['backend_images']['credential']
+            self.assertEqual(credential['registry'], 'nvcr.io')
+            self.assertEqual(credential['username'], '$oauthtoken')
+            self.assertEqual(credential['auth'], 'raw-token-value')
+        finally:
+            os.unlink(secret_path)
+
+    def test_resolve_dockerconfigjson_falls_back_to_decoding_auth(self):
+        """When `password` is missing, decode `auth` and strip username."""
+        secret_data = {
+            'auths': {
+                'nvcr.io': {
+                    'username': '$oauthtoken',
+                    'auth': base64.b64encode(
+                        b'$oauthtoken:fallback-token').decode(),
+                },
+            },
+        }
+        with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.json', delete=False) as secret_file:
+            json.dump(secret_data, secret_file)
+            secret_path = secret_file.name
+        try:
+            config_data: Dict[str, Any] = {
+                'backend_images': {
+                    'credential': {'secret_file': secret_path},
+                },
+            }
+            configmap_loader._resolve_secret_file_references(config_data)
+
+            credential = config_data['backend_images']['credential']
+            self.assertEqual(credential['auth'], 'fallback-token')
+        finally:
+            os.unlink(secret_path)
 
 
 class TestResolveSecretDirectory(unittest.TestCase):

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -485,10 +485,7 @@ def configure_app(target_app: fastapi.FastAPI, config: objects.WorkflowServiceCo
 
     # Store on app state to prevent GC from killing the watcher thread.
     target_app.state.config_watcher = configmap_loader.start_config_watcher(
-        config.config_file, postgres,
-        emit_events=True,
-        inject_runtime=True,
-    )
+        config.config_file, postgres, is_api_service=True)
 
     # Instantiate QueryParser
     query.QueryParser()

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -19,7 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 import base64
 import datetime
 import logging
-import os
 from pathlib import Path
 import sys
 from typing import Dict, List
@@ -38,7 +37,7 @@ from src.service.agent import helpers as backend_helpers
 from src.service.core.app import app_service
 from src.service.core.auth import auth_service, objects as auth_objects
 from src.service.core.config import (
-    config_service, configmap_events, configmap_loader,
+    config_service, configmap_loader,
     helpers as config_helpers, objects as config_objects,
 )
 from src.service.core.data import data_service, query
@@ -471,28 +470,21 @@ def configure_app(target_app: fastapi.FastAPI, config: objects.WorkflowServiceCo
         )
 
     create_default_pool(postgres)
-    set_default_backend_images(postgres)
+    # In ConfigMap mode, backend_images comes from the YAML snapshot.
+    # Skip the DB seed so the configs table doesn't accumulate values
+    # that are invisible to readers (the snapshot wins in get_configs).
+    if not config.config_file:
+        set_default_backend_images(postgres)
     set_default_service_url(postgres)
     set_client_install_url(postgres, config)
     setup_default_admin(postgres, config)
 
-    if config.config_file:
-        event_recorder: configmap_events.EventRecorder | None = None
-        pod_namespace = os.environ.get('POD_NAMESPACE')
-        configmap_name = os.environ.get('OSMO_CONFIGMAP_NAME')
-        if pod_namespace and configmap_name:
-            event_recorder = configmap_events.ConfigMapEventRecorder(
-                namespace=pod_namespace, configmap_name=configmap_name)
-        else:
-            logging.warning(
-                'POD_NAMESPACE or OSMO_CONFIGMAP_NAME unset; '
-                'ConfigMap reload events will not be emitted')
-
-        watcher = configmap_loader.ConfigMapWatcher(
-            config.config_file, postgres, event_recorder=event_recorder)
-        watcher.start()
-        # Store on app state to prevent GC from killing the watcher
-        target_app.state.config_watcher = watcher
+    # Store on app state to prevent GC from killing the watcher thread.
+    target_app.state.config_watcher = configmap_loader.start_config_watcher(
+        config.config_file, postgres,
+        emit_events=True,
+        inject_runtime=True,
+    )
 
     # Instantiate QueryParser
     query.QueryParser()

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -469,14 +469,18 @@ def configure_app(target_app: fastapi.FastAPI, config: objects.WorkflowServiceCo
             username='',
         )
 
-    create_default_pool(postgres)
-    # In ConfigMap mode, backend_images comes from the YAML snapshot.
-    # Skip the DB seed so the configs table doesn't accumulate values
-    # that are invisible to readers (the snapshot wins in get_configs).
+    # In ConfigMap mode, the YAML snapshot is authoritative for these fields,
+    # so DB writes here are invisible to readers (the snapshot wins in
+    # get_configs) and just bloat the configs/pools tables on every restart.
+    # set_default_service_url is kept unconditionally because it seeds
+    # service_base_url, which _inject_runtime_fields reads from DB on first
+    # cold-start when the ConfigMap omits it. setup_default_admin writes a
+    # user record, not a config row, so it stays unconditional too.
     if not config.config_file:
+        create_default_pool(postgres)
         set_default_backend_images(postgres)
+        set_client_install_url(postgres, config)
     set_default_service_url(postgres)
-    set_client_install_url(postgres, config)
     setup_default_admin(postgres, config)
 
     # Store on app state to prevent GC from killing the watcher thread.

--- a/src/service/core/tests/test_asyncio_startup.py
+++ b/src/service/core/tests/test_asyncio_startup.py
@@ -83,6 +83,7 @@ class AsyncioStartupTestCase(unittest.TestCase):
             host='http://127.0.0.1:8000',
             progress_file='/tmp/logger-progress',
             progress_period=60,
+            config_file=None,
         )
 
         with (
@@ -104,6 +105,7 @@ class AsyncioStartupTestCase(unittest.TestCase):
         workflow_config = types.SimpleNamespace(
             host='http://127.0.0.1:8000',
             progress_file='/tmp/agent-progress',
+            config_file=None,
         )
         agent_config = types.SimpleNamespace(progress_period=60)
 

--- a/src/service/core/workflow/BUILD
+++ b/src/service/core/workflow/BUILD
@@ -40,6 +40,7 @@ osmo_py_library(
         "//src/lib/utils:priority",
         "//src/lib/utils:osmo_errors",
         "//src/lib/utils:redact",
+        "//src/service/core/config:configmap_loader_lib",
         "//src/utils:static_config",
         "//src/utils/job:job",
         "//src/utils:yaml",

--- a/src/service/core/workflow/objects.py
+++ b/src/service/core/workflow/objects.py
@@ -30,6 +30,7 @@ from src.lib.data.storage.credentials import credentials as data_credentials
 from src.lib.utils import credentials, common, osmo_errors, priority as wf_priority
 from src.lib.utils.redact import redact_secrets
 import src.lib.utils.logging
+from src.service.core.config.configmap_loader import ConfigFileMixin
 from src.utils.job import app, common as task_common, jobs, kb_objects, task, workflow
 from src.utils.job.task import _encode_hstore
 from src.utils import connectors, static_config, yaml as util_yaml
@@ -38,7 +39,9 @@ from src.utils.metrics import metrics
 
 class WorkflowServiceConfig(connectors.RedisConfig, connectors.PostgresConfig,
                             src.lib.utils.logging.LoggingConfig,
-                            static_config.StaticConfig, metrics.MetricsCreatorConfig):
+                            static_config.StaticConfig,
+                            metrics.MetricsCreatorConfig,
+                            ConfigFileMixin):
     """ Manages configuration specific to the workflow service. """
     host: str = pydantic.Field(
         default='http://0.0.0.0:8000',
@@ -102,14 +105,6 @@ class WorkflowServiceConfig(connectors.RedisConfig, connectors.PostgresConfig,
             'command_line': 'default_admin_password',
             'env': 'OSMO_DEFAULT_ADMIN_PASSWORD'
         })
-    config_file: str | None = pydantic.Field(
-        default=None,
-        description='Path to ConfigMap YAML file to load configs from.',
-        json_schema_extra={
-            'command_line': 'config_file',
-            'env': 'OSMO_CONFIG_FILE'
-        })
-
     @pydantic.model_validator(mode='before')
     @classmethod
     def validate_default_admin(cls, values):

--- a/src/service/logger/BUILD
+++ b/src/service/logger/BUILD
@@ -47,6 +47,7 @@ osmo_py_library(
         "//src/lib/utils:logging",
         "//src/utils/progress_check:progress_check_lib",
         "//src/service/core/auth",
+        "//src/service/core/config:configmap_loader_lib",
         "//src/service/core/workflow",
         "//src/utils:static_config",
         "//src/utils/job",

--- a/src/service/logger/logger.py
+++ b/src/service/logger/logger.py
@@ -26,12 +26,15 @@ import uvicorn  # type: ignore
 import src.lib.utils.logging
 from src.service.logger import ctrl_websocket
 from src.service.core.auth import auth_service
+from src.service.core.config import configmap_loader
+from src.service.core.config.configmap_loader import ConfigFileMixin
 from src.utils import connectors, static_config
 from src.utils.progress_check import progress
 
 
 class LoggerServiceConfig(connectors.RedisConfig, connectors.PostgresConfig,
-                          src.lib.utils.logging.LoggingConfig, static_config.StaticConfig):
+                          src.lib.utils.logging.LoggingConfig,
+                          static_config.StaticConfig, ConfigFileMixin):
     """Config settings for the logger service"""
     host: str = pydantic.Field(
         default='http://0.0.0.0:8000',
@@ -68,7 +71,11 @@ async def put_workflow_logs(websocket: fastapi.WebSocket, name: str, task_name: 
 def main():
     config = LoggerServiceConfig.load()
     src.lib.utils.logging.init_logger('logger', config)
-    _ = connectors.PostgresConnector(config)
+    postgres = connectors.PostgresConnector(config)
+    # Pin the watcher on app.state so the daemon Observer thread isn't GC'd.
+    app.state.config_watcher = configmap_loader.start_config_watcher(
+        config.config_file, postgres,
+        emit_events=False, inject_runtime=False)
     parsed_url = urlparse(config.host)
     host = parsed_url.hostname if parsed_url.hostname else ''
     if parsed_url.port:

--- a/src/service/logger/logger.py
+++ b/src/service/logger/logger.py
@@ -74,8 +74,7 @@ def main():
     postgres = connectors.PostgresConnector(config)
     # Pin the watcher on app.state so the daemon Observer thread isn't GC'd.
     app.state.config_watcher = configmap_loader.start_config_watcher(
-        config.config_file, postgres,
-        emit_events=False, inject_runtime=False)
+        config.config_file, postgres)
     parsed_url = urlparse(config.host)
     host = parsed_url.hostname if parsed_url.hostname else ''
     if parsed_url.port:

--- a/src/service/worker/BUILD
+++ b/src/service/worker/BUILD
@@ -35,6 +35,7 @@ osmo_py_library(
         "//src/utils/metrics",
         "//src/lib/utils:common",
         "//src/lib/utils:logging",
+        "//src/service/core/config:configmap_loader_lib",
         "//src/utils:static_config",
         "//src/utils/job",
         "//src/utils/progress_check:progress_check_lib",

--- a/src/service/worker/worker.py
+++ b/src/service/worker/worker.py
@@ -22,7 +22,7 @@ import sys
 import threading
 import time
 import traceback
-from typing import Callable, Dict, Iterable, Optional
+from typing import Any, Callable, Dict, Iterable, Optional
 
 import kombu  # type: ignore
 import kombu.mixins  # type: ignore
@@ -43,6 +43,14 @@ from src.utils.progress_check import progress
 
 # How long to keep uuids for deduplicating jobs
 UNIQUE_JOB_TTL = 5 * 24 * 60 * 60
+
+# Module-level pin for the ConfigMap watcher's daemon Observer thread.
+# A local in main() works today (worker.run() blocks for the process
+# lifetime) but is fragile to refactors that move the call into a
+# returning helper — silently dropping the reference would let the GC
+# stop the watcher mid-flight. The agent and logger pin to app.state for
+# the same reason; worker has no FastAPI app to use.
+_active_config_watcher: Any = None
 
 class WorkerConfig(connectors.RedisConfig, connectors.PostgresConfig,
                    src.lib.utils.logging.LoggingConfig, static_config.StaticConfig,
@@ -221,9 +229,10 @@ def main():
     worker_metrics.start_server()
     connectors.RedisConnector(config)
     postgres = connectors.PostgresConnector(config)
-    # Bind to a local so the watchdog Observer thread isn't GC'd; only the
-    # API service emits K8s Events / injects runtime fields.
-    _config_watcher = configmap_loader.start_config_watcher(  # noqa: F841
+    # Pin to module-level global so the daemon Observer thread isn't GC'd;
+    # only the API service emits K8s Events / injects runtime fields.
+    global _active_config_watcher  # noqa: PLW0603
+    _active_config_watcher = configmap_loader.start_config_watcher(
         config.config_file, postgres,
         emit_events=False, inject_runtime=False)
 

--- a/src/service/worker/worker.py
+++ b/src/service/worker/worker.py
@@ -229,12 +229,10 @@ def main():
     worker_metrics.start_server()
     connectors.RedisConnector(config)
     postgres = connectors.PostgresConnector(config)
-    # Pin to module-level global so the daemon Observer thread isn't GC'd;
-    # only the API service emits K8s Events / injects runtime fields.
+    # Pin to module-level global so the daemon Observer thread isn't GC'd.
     global _active_config_watcher  # noqa: PLW0603
     _active_config_watcher = configmap_loader.start_config_watcher(
-        config.config_file, postgres,
-        emit_events=False, inject_runtime=False)
+        config.config_file, postgres)
 
     if config.method != 'dev':
         worker_metrics.send_observable_gauge(

--- a/src/service/worker/worker.py
+++ b/src/service/worker/worker.py
@@ -33,6 +33,8 @@ import pydantic
 
 from src.lib.utils import common, osmo_errors
 import src.lib.utils.logging
+from src.service.core.config import configmap_loader
+from src.service.core.config.configmap_loader import ConfigFileMixin
 from src.utils.job import jobs, jobs_base
 from src.utils.metrics import metrics
 from src.utils import connectors, static_config
@@ -44,7 +46,7 @@ UNIQUE_JOB_TTL = 5 * 24 * 60 * 60
 
 class WorkerConfig(connectors.RedisConfig, connectors.PostgresConfig,
                    src.lib.utils.logging.LoggingConfig, static_config.StaticConfig,
-                   metrics.MetricsCreatorConfig):
+                   metrics.MetricsCreatorConfig, ConfigFileMixin):
     progress_file: str = pydantic.Field(
         default='/var/run/osmo/last_progress',
         description='The file to write progress timestamps to (For liveness/startup probes)',
@@ -68,7 +70,7 @@ class Worker(kombu.mixins.ConsumerMixin):
         self.config = config
         self.connection = connection
         self.context = jobs.JobExecutionContext(
-            postgres=connectors.PostgresConnector(self.config),
+            postgres=connectors.PostgresConnector.get_instance(),
             redis=self.config)
         self.redis_client = connectors.RedisConnector.get_instance().client
         self._worker_metrics = metrics.MetricCreator.get_meter_instance()
@@ -218,6 +220,12 @@ def main():
     worker_metrics = metrics.MetricCreator(config=config).get_meter_instance()
     worker_metrics.start_server()
     connectors.RedisConnector(config)
+    postgres = connectors.PostgresConnector(config)
+    # Bind to a local so the watchdog Observer thread isn't GC'd; only the
+    # API service emits K8s Events / injects runtime fields.
+    _config_watcher = configmap_loader.start_config_watcher(  # noqa: F841
+        config.config_file, postgres,
+        emit_events=False, inject_runtime=False)
 
     if config.method != 'dev':
         worker_metrics.send_observable_gauge(


### PR DESCRIPTION
## Summary

OSMO has a "ConfigMap mode" where in-cluster service configs come from a YAML file projected from a K8s ConfigMap, with a `ConfigMapWatcher` that hot-reloads the in-memory snapshot via watchdog inotify. **Until this PR, only the API service started the watcher** — worker, agent, and logger fell back to Postgres reads, so they served stale values from the `configs` table even when the ConfigMap was up to date.

User-visible symptom: workflow pods built by the worker used image tags from a months-old DB seed (e.g. `client:v6.2-rc8`) even though the ConfigMap had `6.3.0-prerelease-rc1`. The worker is what builds workflow pod manifests; without a watcher in its process, `get_snapshot()` returned `None` and `get_workflow_configs()` fell through to `SELECT * FROM configs`.

This PR:

- Wires `ConfigMapWatcher` into worker, agent, and logger via a new `start_config_watcher(config_file, postgres, *, is_api_service)` helper extracted from the inline init in `service.py`.
- Adds a 30s cold-start retry that distinguishes transient (kubelet projection in progress) from permanent (bad YAML / failed validation) failures via a `LoadResult` enum — bad ConfigMaps fail fast instead of spinning the full window.
- Adds `ConfigFileMixin` (pydantic) so all four service configs declare `--config_file` consistently, avoiding argparse divergence when the agent loads two config classes.
- Worker uses `PostgresConnector.get_instance()` so `main()` and `Worker.__init__` share a single connection pool.
- Splits the Bazel `:config` target into a lighter `:configmap_loader_lib` so worker/logger don't drag in fastapi/job/workflow deps.
- Chart: extracts `osmo.configmap-{args,env,volume-mounts,volumes}` partials in `_helpers.tpl`, mounts the configs ConfigMap and `secretRefs` on api/worker/agent/logger.
- Drops the `checksum/configs` annotation from `api-service.yaml` — it forced a rolling restart on every ConfigMap edit, defeating the watcher's hot-reload path.
- Gates `set_default_backend_images`, `set_client_install_url`, and `create_default_pool` on `config.config_file` so they no-op in ConfigMap mode (the snapshot wins; DB writes were invisible bloat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Services can load configuration from a shared file-backed source (ConfigMap) mounted into pods.
  * Automatic config watcher with retry semantics for transient read failures and controlled runtime injection.
  * Unified config wiring across agent, API, logger, and worker services.

* **Bug Fixes / Improvements**
  * More robust secret credential handling (prefers explicit password, decodes legacy tokens).
  * Startup now respects config-file mode when seeding certain DB defaults.

* **Tests**
  * Expanded unit tests covering config loading, secret resolution, and watcher behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->