### PR TITLE
build: bump rules_distroless 0.5.1 -> 0.6.1 to fix builder image build

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -322,7 +322,7 @@ http_archive(
 ################
 
 bazel_dep(name = "rules_oci", version = "2.2.3")
-bazel_dep(name = "rules_distroless", version = "0.5.1")
+bazel_dep(name = "rules_distroless", version = "0.6.1")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 


### PR DESCRIPTION
## Description

After #572 bumped `aspect_bazel_lib` from `2.14.0` → `2.19.3`, `lib/tar.bzl` in `aspect_bazel_lib` became a shim that re-exports symbols from a separate `@tar.bzl` module:

```python
# external/aspect_bazel_lib+/lib/tar.bzl
load("@tar.bzl//tar:mtree.bzl", _mtree_mutate = "mtree_mutate", ...)
load("@tar.bzl//tar:tar.bzl", _tar = "tar", _tar_lib = "tar_lib", ...)
```

`rules_distroless` 0.5.1 loads `@aspect_bazel_lib//lib:tar.bzl` from its `distroless/private/tar.bzl` but does not declare `tar.bzl` as a `bazel_dep`. Under bzlmod, `@tar.bzl` is therefore not visible from `@@rules_distroless+`, and toolchain resolution for `dpkg_status` (used by the apt-generated `dev_builder_debian_packages_*` repos) fails:

```
ERROR: no such package '@@[unknown repo 'tar.bzl' requested from @@rules_distroless+]//tar/toolchain':
The repository '@@[unknown repo 'tar.bzl' requested from @@rules_distroless+]' could not be resolved:
No repository visible as '@tar.bzl' from repository '@@rules_distroless+'
```

This breaks `bazel run //run:builder_image_load_{x86_64,arm64}` and any other target that pulls in the distroless apt repos, blocking the [Build & Test guide](../blob/main/BUILD_AND_TEST.md) flow.

`rules_distroless` 0.6.0 added `bazel_dep(name = "tar.bzl", ...)` to its `MODULE.bazel`, which makes the load resolve correctly. This PR bumps to 0.6.1 (smallest 0.6.x available on BCR with the fix). The `apt` extension API and `apt.install(...)` calls in `MODULE.bazel` are unchanged; transitive deps (`bazel_lib`, `gawk`, `tar.bzl`, `yq.bzl`) are pulled in automatically by the resolver.

Issue #None

## Test plan

Verified locally on darwin/arm64:

- [x] `bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //run:builder_image_load_arm64` — succeeded, `osmo-builder:latest-arm64` loaded into Docker
- [x] `bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //run:builder_image_load_x86_64` — succeeded
- [ ] CI runs the existing Bazel test suite to confirm no regression in unrelated apt/distroless consumers

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (No new tests; the existing build targets exercise the apt/distroless toolchain resolution path that was broken.)
- [x] The documentation is up to date with these changes. (No doc changes — `BUILD_AND_TEST.md` commands are unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated build system dependency to a newer stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->