### PR TITLE
build: bump rules_distroless to 0.6.1 and add docker-buildx-plugin to builder images

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -322,7 +322,7 @@ http_archive(
 ################
 
 bazel_dep(name = "rules_oci", version = "2.2.3")
-bazel_dep(name = "rules_distroless", version = "0.5.1")
+bazel_dep(name = "rules_distroless", version = "0.6.1")
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 

--- a/bzl/debian_packages/dev_builder_debian_packages_arm64.lock.json
+++ b/bzl/debian_packages/dev_builder_debian_packages_arm64.lock.json
@@ -308,13 +308,24 @@
 					"version": "12-20220319-1ubuntu1"
 				}
 			],
-			"key": "docker-ce-cli_5-28.4.0-1_ubuntu.22.04_jammy_arm64",
+			"key": "docker-ce-cli_5-29.4.1-1_ubuntu.22.04_jammy_arm64",
 			"name": "docker-ce-cli",
-			"sha256": "3849c29faffe055dd5e0e6385432f3b384c3785426d040533537baa45067c2b3",
+			"sha256": "8d16c0f9f699451fe028359770f542193723bacd334d10b2feea4e7254521ad0",
 			"urls": [
-				"https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/arm64/docker-ce-cli_28.4.0-1~ubuntu.22.04~jammy_arm64.deb"
+				"https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/arm64/docker-ce-cli_29.4.1-1~ubuntu.22.04~jammy_arm64.deb"
 			],
-			"version": "5:28.4.0-1~ubuntu.22.04~jammy"
+			"version": "5:29.4.1-1~ubuntu.22.04~jammy"
+		},
+		{
+			"arch": "arm64",
+			"dependencies": [],
+			"key": "docker-buildx-plugin_0.33.0-1_ubuntu.22.04_jammy_arm64",
+			"name": "docker-buildx-plugin",
+			"sha256": "b772de2b5a67370b5bf6b56656cf01c0818a4f059546a107ceaab882bd299a4c",
+			"urls": [
+				"https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/arm64/docker-buildx-plugin_0.33.0-1~ubuntu.22.04~jammy_arm64.deb"
+			],
+			"version": "0.33.0-1~ubuntu.22.04~jammy"
 		},
 		{
 			"arch": "arm64",

--- a/bzl/debian_packages/dev_builder_debian_packages_arm64.yaml
+++ b/bzl/debian_packages/dev_builder_debian_packages_arm64.yaml
@@ -29,6 +29,7 @@ archs:
 packages:
   - ca-certificates
   - docker-ce-cli
+  - docker-buildx-plugin
   - build-essential
   - libenchant-2-2
   - bash

--- a/bzl/debian_packages/dev_builder_debian_packages_x86_64.lock.json
+++ b/bzl/debian_packages/dev_builder_debian_packages_x86_64.lock.json
@@ -308,13 +308,24 @@
 					"version": "12-20220319-1ubuntu1"
 				}
 			],
-			"key": "docker-ce-cli_5-28.4.0-1_ubuntu.22.04_jammy_amd64",
+			"key": "docker-ce-cli_5-29.4.1-1_ubuntu.22.04_jammy_amd64",
 			"name": "docker-ce-cli",
-			"sha256": "7dad219d0e2f25912621f73b8a03b4af321f293961d0e5c1ddc321f408571ca8",
+			"sha256": "a64ebead73cd139fe7f6a98d1c19816b49ecd12d9af35199ef5aeecd0d39d87d",
 			"urls": [
-				"https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-ce-cli_28.4.0-1~ubuntu.22.04~jammy_amd64.deb"
+				"https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-ce-cli_29.4.1-1~ubuntu.22.04~jammy_amd64.deb"
 			],
-			"version": "5:28.4.0-1~ubuntu.22.04~jammy"
+			"version": "5:29.4.1-1~ubuntu.22.04~jammy"
+		},
+		{
+			"arch": "amd64",
+			"dependencies": [],
+			"key": "docker-buildx-plugin_0.33.0-1_ubuntu.22.04_jammy_amd64",
+			"name": "docker-buildx-plugin",
+			"sha256": "608bb1e6403fd056727be03bbc5a0be429263012ec2f6b0c8b1850341fdae2bd",
+			"urls": [
+				"https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-buildx-plugin_0.33.0-1~ubuntu.22.04~jammy_amd64.deb"
+			],
+			"version": "0.33.0-1~ubuntu.22.04~jammy"
 		},
 		{
 			"arch": "amd64",

--- a/bzl/debian_packages/dev_builder_debian_packages_x86_64.yaml
+++ b/bzl/debian_packages/dev_builder_debian_packages_x86_64.yaml
@@ -29,6 +29,7 @@ archs:
 packages:
   - ca-certificates
   - docker-ce-cli
+  - docker-buildx-plugin
   - build-essential
   - libenchant-2-2
   - bash


### PR DESCRIPTION
## Description

Two related fixes for the OSMO builder image flow documented in [`BUILD_AND_TEST.md`](../blob/main/BUILD_AND_TEST.md).

### 1. Bump `rules_distroless` 0.5.1 → 0.6.1 (fixes `tar.bzl` visibility)

After #572 bumped `aspect_bazel_lib` from `2.14.0` → `2.19.3`, `lib/tar.bzl` in `aspect_bazel_lib` became a shim that re-exports symbols from a separate `@tar.bzl` module:

```python
# external/aspect_bazel_lib+/lib/tar.bzl
load("@tar.bzl//tar:mtree.bzl", _mtree_mutate = "mtree_mutate", ...)
load("@tar.bzl//tar:tar.bzl", _tar = "tar", _tar_lib = "tar_lib", ...)
```

`rules_distroless` 0.5.1 loads `@aspect_bazel_lib//lib:tar.bzl` from its `distroless/private/tar.bzl` but does not declare `tar.bzl` as a `bazel_dep`. Under bzlmod, `@tar.bzl` is therefore not visible from `@@rules_distroless+`, and toolchain resolution for `dpkg_status` (used by the apt-generated `dev_builder_debian_packages_*` repos) fails:

```
ERROR: no such package '@@[unknown repo 'tar.bzl' requested from @@rules_distroless+]//tar/toolchain':
The repository '@@[unknown repo 'tar.bzl' requested from @@rules_distroless+]' could not be resolved:
No repository visible as '@tar.bzl' from repository '@@rules_distroless+'
```

This breaks `bazel run //run:builder_image_load_{x86_64,arm64}` and any other target that pulls in the distroless apt repos.

`rules_distroless` 0.6.0 added `bazel_dep(name = "tar.bzl", ...)` to its `MODULE.bazel`, which makes the load resolve correctly. This PR bumps to 0.6.1 (smallest 0.6.x available on BCR with the fix). The `apt` extension API and `apt.install(...)` calls in `MODULE.bazel` are unchanged; transitive deps (`bazel_lib`, `gawk`, `tar.bzl`, `yq.bzl`) are pulled in automatically by the resolver.

### 2. Add `docker-buildx-plugin` to dev builder images

The UI image build script `src/ui/scripts/build_push_web_ui_*.sh` runs `docker buildx build --platform "$PLATFORM"` from inside the `osmo-builder` container. The container's docker CLI didn't ship the buildx plugin, so cross-arch flows (e.g. building `linux/amd64` images from a `darwin/arm64` host through the `linux/amd64` builder image) failed with `unknown command: docker buildx` / `unknown flag: --platform`.

This adds `docker-buildx-plugin` to both `dev_builder_debian_packages_{x86_64,arm64}.yaml` (alongside the existing `docker-ce-cli` entry, served by the same Docker apt source) and regenerates the lock files via `bazel run @dev_builder_debian_packages_{x86_64,arm64}//:lock`. Lock regeneration also rolled `docker-ce-cli` forward `28.4.0` → `29.4.1` against the current Docker apt index — incidental but expected when re-resolving.

Discovered while verifying the OETF dev-instance deploy adapter from a Mac arm64 host targeting `linux/x86_64`. The internal-repo workaround (downloading a Linux buildx binary on the host and bind-mounting it into `/usr/libexec/docker/cli-plugins/docker-buildx`) can be removed once this lands and the submodule pin is updated.

Issue #None

## Test plan

Verified locally on darwin/arm64:

- [x] `bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //run:builder_image_load_arm64` — succeeded; `osmo-builder:latest-arm64` loaded into Docker
- [x] `bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //run:builder_image_load_x86_64` — succeeded; `osmo-builder:latest-amd64` loaded into Docker
- [x] `docker run --rm --entrypoint /bin/sh osmo-builder:latest-amd64 -c "docker buildx version"` → `github.com/docker/buildx v0.33.0 f7897eba028583e0071642db3c011e860444f8cf`
- [x] `docker run --rm --entrypoint /bin/sh osmo-builder:latest-arm64 -c "docker buildx version"` → `github.com/docker/buildx v0.33.0 f7897eba028583e0071642db3c011e860444f8cf`
- [ ] `bazel run @osmo_workspace//src/ui:build_push_web_ui_x86_64` end-to-end from inside the builder container (requires registry creds / network — covered by CI)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a build tool dependency to a newer version.
  * Bumped docker-ce-cli to a newer release in dev builder package locks (arm64 & x86_64).
  * Added docker-buildx-plugin to dev builder package manifests and lockfiles (arm64 & x86_64).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->