### PR TITLE
Pre-render Jinja in osmo-ctrl resources for pool-quota accounting

### DIFF
--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -459,9 +459,13 @@ def _render_pod_template_for_accounting(
     and a representative one for those that do — close enough for the
     capacity-vs-overhead estimate this feeds into.
     """
-    if not default_variables:
-        return pod_template
+    # Always return a standalone dict — callers store this alongside
+    # parsed_pod_template, and the templated copy is mutated at workflow
+    # render time by substitute_pod_template_tokens. Aliasing would let
+    # those mutations corrupt the accounting copy.
     rendered = copy.deepcopy(pod_template)
+    if not default_variables:
+        return rendered
     containers = rendered.get('spec', {}).get('containers', [])
     for container in containers:
         if container.get('name') != 'osmo-ctrl':
@@ -479,10 +483,15 @@ def _render_pod_template_for_accounting(
                 try:
                     fields[key] = jinja_sandbox.sandboxed_jinja_substitute(
                         value, default_variables)
-                except osmo_errors.OSMOUsageError:
-                    # Leave the original template; accounting falls back
-                    # to convert_cpu_unit's zero-on-parse-failure path.
-                    pass
+                except osmo_errors.OSMOUsageError as exc:
+                    # Leave the original template in place; accounting
+                    # falls back to convert_cpu_unit's zero-on-parse
+                    # path. Log so operators see the bad template rather
+                    # than silently undercounting pool overhead.
+                    logging.warning(
+                        'Failed to pre-render osmo-ctrl %s.%s for '
+                        'accounting (template kept as-is): %s',
+                        kind, key, exc)
     return rendered
 
 

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -30,6 +30,7 @@ import pydantic
 import yaml
 from watchdog import events, observers
 
+from src.lib.utils import jinja_sandbox, osmo_errors
 from src.lib.utils.common import merge_lists_on_name, recursive_dict_update
 from src.service.core.config import configmap_events, configmap_guard
 from src.utils import connectors
@@ -442,6 +443,49 @@ def _resolve_pool_computed_fields(managed_configs: Dict[str, Any]) -> None:
             pool_data, pod_templates, resource_validations, group_templates)
 
 
+def _render_pod_template_for_accounting(
+    pod_template: Dict[str, Any],
+    default_variables: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Return a copy of `pod_template` with Jinja in osmo-ctrl resources
+    rendered using `default_variables` as sentinel inputs.
+
+    Pool-quota math reads osmo-ctrl request/limit fields as numeric K8s
+    resource values, but those fields can be Jinja templates that depend
+    on per-workflow variables (e.g. `{% if USER_CPU > 2 %}2{% else %}{{USER_CPU}}{% endif %}`).
+    Without rendering, the accounting code can't parse the value and
+    silently treats it as zero. Pre-rendering with the pool's defaults
+    gives an exact value for workflows that don't override these vars
+    and a representative one for those that do — close enough for the
+    capacity-vs-overhead estimate this feeds into.
+    """
+    if not default_variables:
+        return pod_template
+    rendered = copy.deepcopy(pod_template)
+    containers = rendered.get('spec', {}).get('containers', [])
+    for container in containers:
+        if container.get('name') != 'osmo-ctrl':
+            continue
+        resources = container.get('resources')
+        if not isinstance(resources, dict):
+            continue
+        for kind in ('requests', 'limits'):
+            fields = resources.get(kind)
+            if not isinstance(fields, dict):
+                continue
+            for key, value in fields.items():
+                if not isinstance(value, str) or '{' not in value:
+                    continue
+                try:
+                    fields[key] = jinja_sandbox.sandboxed_jinja_substitute(
+                        value, default_variables)
+                except osmo_errors.OSMOUsageError:
+                    # Leave the original template; accounting falls back
+                    # to convert_cpu_unit's zero-on-parse-failure path.
+                    pass
+    return rendered
+
+
 def _resolve_single_pool(
     pool_data: Dict[str, Any],
     pod_templates: Dict[str, Any],
@@ -470,6 +514,10 @@ def _resolve_single_pool(
             logging.warning(
                 'Pod template %r referenced by pool not found', template_name)
     pool_data['parsed_pod_template'] = base_pod_template
+    pool_data['parsed_pod_template_for_accounting'] = (
+        _render_pod_template_for_accounting(
+            base_pod_template,
+            pool_data.get('common_default_variables', {}) or {}))
 
     # Resolve common resource validations (pool-level base)
     common_resource_validation_names = pool_data.get(
@@ -511,12 +559,13 @@ def _resolve_single_pool(
 
     # Resolve per-platform computed fields
     platforms = pool_data.get('platforms', {})
+    pool_defaults = pool_data.get('common_default_variables', {}) or {}
     for platform_data in platforms.values():
         if not isinstance(platform_data, dict):
             continue
         _resolve_platform_fields(
             platform_data, base_pod_template, base_resource_validations,
-            pod_templates, resource_validations)
+            pod_templates, resource_validations, pool_defaults)
 
 
 def _get_default_mounts(pod_template: Dict[str, Any]) -> List[str]:
@@ -543,6 +592,7 @@ def _resolve_platform_fields(
     base_resource_validations: List[Any],
     pod_templates: Dict[str, Any],
     resource_validations: Dict[str, Any],
+    pool_default_variables: Dict[str, Any],
 ) -> None:
     """Resolve computed fields for a single platform within a pool.
 
@@ -567,6 +617,17 @@ def _resolve_platform_fields(
                 'Pod template %r referenced by platform not found',
                 template_name)
     platform_data['parsed_pod_template'] = platform_pod_template
+
+    # Accounting copy: render Jinja in osmo-ctrl resources using pool
+    # defaults overlaid by platform-specific defaults so the values are
+    # numeric for pool-quota math.
+    platform_defaults = {
+        **pool_default_variables,
+        **(platform_data.get('default_variables') or {}),
+    }
+    platform_data['parsed_pod_template_for_accounting'] = (
+        _render_pod_template_for_accounting(
+            platform_pod_template, platform_defaults))
 
     # Derive tolerations, labels, default_mounts from resolved template.
     # Unconditional assignment — always recompute from the resolved template

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -509,6 +509,8 @@ def _resolve_single_pool(
             pool_data[list_field] = []
     if not isinstance(pool_data.get('platforms'), dict):
         pool_data['platforms'] = {}
+    if not isinstance(pool_data.get('common_default_variables'), dict):
+        pool_data['common_default_variables'] = {}
 
     # Resolve common pod template (pool-level base)
     common_pod_template_names = pool_data.get('common_pod_template', [])
@@ -526,7 +528,7 @@ def _resolve_single_pool(
     pool_data['parsed_pod_template_for_accounting'] = (
         _render_pod_template_for_accounting(
             base_pod_template,
-            pool_data.get('common_default_variables', {}) or {}))
+            pool_data['common_default_variables']))
 
     # Resolve common resource validations (pool-level base)
     common_resource_validation_names = pool_data.get(
@@ -568,7 +570,7 @@ def _resolve_single_pool(
 
     # Resolve per-platform computed fields
     platforms = pool_data.get('platforms', {})
-    pool_defaults = pool_data.get('common_default_variables', {}) or {}
+    pool_defaults = pool_data['common_default_variables']
     for platform_data in platforms.values():
         if not isinstance(platform_data, dict):
             continue
@@ -608,10 +610,12 @@ def _resolve_platform_fields(
     Always resolves from source-of-truth references (template names),
     overwriting any pre-existing parsed_* fields.
     """
-    # Normalize list fields to prevent crashes on null/wrong types
+    # Normalize list/dict fields to prevent crashes on null/wrong types
     for list_field in ('override_pod_template', 'resource_validations'):
         if not isinstance(platform_data.get(list_field), list):
             platform_data[list_field] = []
+    if not isinstance(platform_data.get('default_variables'), dict):
+        platform_data['default_variables'] = {}
 
     # Pod template: start from pool common, merge platform overrides
     platform_pod_template = copy.deepcopy(base_pod_template)
@@ -632,7 +636,7 @@ def _resolve_platform_fields(
     # numeric for pool-quota math.
     platform_defaults = {
         **pool_default_variables,
-        **(platform_data.get('default_variables') or {}),
+        **platform_data['default_variables'],
     }
     platform_data['parsed_pod_template_for_accounting'] = (
         _render_pod_template_for_accounting(

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -1269,7 +1269,10 @@ class TestResolvePoolComputedFields(unittest.TestCase):
                                 'name': 'osmo-ctrl',
                                 'resources': {
                                     'requests': {
-                                        'cpu': '{% if USER_CPU > 2 %}2{% else %}{{USER_CPU}}{% endif %}',
+                                        'cpu': (
+                                            '{% if USER_CPU > 2 %}2'
+                                            '{% else %}{{USER_CPU}}'
+                                            '{% endif %}'),
                                         'memory': '{{USER_MEMORY}}',
                                     },
                                     'limits': {

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -1251,6 +1251,121 @@ class TestResolvePoolComputedFields(unittest.TestCase):
         self.assertEqual(
             platform['labels'], {'gpu': 'a100', 'arch': 'amd64'})
 
+    def test_pre_renders_jinja_in_ctrl_resources_for_accounting(self):
+        """parsed_pod_template_for_accounting must have Jinja in osmo-ctrl
+        resources rendered with default variables, leaving the original
+        parsed_pod_template templated for per-workflow rendering.
+        """
+        configs: Dict[str, Any] = {
+            'pod_templates': {
+                'default_ctrl': {
+                    'spec': {
+                        'containers': [
+                            {
+                                'name': 'osmo-ctrl',
+                                'resources': {
+                                    'requests': {
+                                        'cpu': '{% if USER_CPU > 2 %}2{% else %}{{USER_CPU}}{% endif %}',
+                                        'memory': '{{USER_MEMORY}}',
+                                    },
+                                    'limits': {
+                                        'cpu': '{{USER_CPU}}',
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+            'pools': {
+                'default': {
+                    'common_default_variables': {
+                        'USER_CPU': 1,
+                        'USER_MEMORY': '1Gi',
+                    },
+                    'common_pod_template': ['default_ctrl'],
+                    'common_resource_validations': [],
+                    'common_group_templates': [],
+                    'platforms': {
+                        'gpu': {
+                            'override_pod_template': [],
+                            'resource_validations': [],
+                        },
+                    },
+                },
+            },
+        }
+        configmap_loader._resolve_pool_computed_fields(configs)
+
+        pool = configs['pools']['default']
+        platform = pool['platforms']['gpu']
+
+        # Originals stay templated for substitute_pod_template_tokens.
+        ctrl_orig = pool['parsed_pod_template']['spec']['containers'][0]
+        self.assertIn(
+            '{% if', ctrl_orig['resources']['requests']['cpu'])
+
+        # Accounting copy is rendered with USER_CPU=1 → else-branch → '1'.
+        ctrl_acct = (pool['parsed_pod_template_for_accounting']
+                     ['spec']['containers'][0])
+        self.assertEqual(
+            ctrl_acct['resources']['requests']['cpu'], '1')
+        self.assertEqual(
+            ctrl_acct['resources']['requests']['memory'], '1Gi')
+        self.assertEqual(
+            ctrl_acct['resources']['limits']['cpu'], '1')
+
+        # Platform inherits the same accounting copy.
+        plat_acct = (platform['parsed_pod_template_for_accounting']
+                     ['spec']['containers'][0])
+        self.assertEqual(
+            plat_acct['resources']['requests']['cpu'], '1')
+
+    def test_pre_render_uses_platform_default_variables_overrides(self):
+        """Platform-level default_variables must override pool defaults
+        when rendering the accounting copy.
+        """
+        configs: Dict[str, Any] = {
+            'pod_templates': {
+                'default_ctrl': {
+                    'spec': {
+                        'containers': [
+                            {
+                                'name': 'osmo-ctrl',
+                                'resources': {
+                                    'requests': {
+                                        'cpu': '{% if USER_CPU > 2 %}2{% else %}{{USER_CPU}}{% endif %}',
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+            'pools': {
+                'default': {
+                    'common_default_variables': {'USER_CPU': 1},
+                    'common_pod_template': ['default_ctrl'],
+                    'common_resource_validations': [],
+                    'common_group_templates': [],
+                    'platforms': {
+                        'big': {
+                            'default_variables': {'USER_CPU': 8},
+                            'override_pod_template': [],
+                            'resource_validations': [],
+                        },
+                    },
+                },
+            },
+        }
+        configmap_loader._resolve_pool_computed_fields(configs)
+
+        platform = configs['pools']['default']['platforms']['big']
+        ctrl = (platform['parsed_pod_template_for_accounting']
+                ['spec']['containers'][0])
+        # USER_CPU=8 > 2 → if-branch → '2'.
+        self.assertEqual(ctrl['resources']['requests']['cpu'], '2')
+
     def test_load_and_apply_resolves_pool_fields(self):
         """End-to-end: _load_and_apply resolves pool computed fields."""
         config: Dict[str, Any] = {

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -1252,9 +1252,13 @@ class TestResolvePoolComputedFields(unittest.TestCase):
             platform['labels'], {'gpu': 'a100', 'arch': 'amd64'})
 
     def test_pre_renders_jinja_in_ctrl_resources_for_accounting(self):
-        """parsed_pod_template_for_accounting must have Jinja in osmo-ctrl
-        resources rendered with default variables, leaving the original
-        parsed_pod_template templated for per-workflow rendering.
+        """parsed_pod_template_for_accounting renders Jinja in osmo-ctrl
+        resources with the merged pool+platform default variables, while
+        parsed_pod_template stays templated for per-workflow rendering.
+
+        Two platforms exercise both invariants: 'default' inherits pool
+        defaults (USER_CPU=1 → else-branch); 'big' overrides via its own
+        default_variables (USER_CPU=8 → if-branch clamps to 2).
         """
         configs: Dict[str, Any] = {
             'pod_templates': {
@@ -1287,68 +1291,10 @@ class TestResolvePoolComputedFields(unittest.TestCase):
                     'common_resource_validations': [],
                     'common_group_templates': [],
                     'platforms': {
-                        'gpu': {
+                        'default': {
                             'override_pod_template': [],
                             'resource_validations': [],
                         },
-                    },
-                },
-            },
-        }
-        configmap_loader._resolve_pool_computed_fields(configs)
-
-        pool = configs['pools']['default']
-        platform = pool['platforms']['gpu']
-
-        # Originals stay templated for substitute_pod_template_tokens.
-        ctrl_orig = pool['parsed_pod_template']['spec']['containers'][0]
-        self.assertIn(
-            '{% if', ctrl_orig['resources']['requests']['cpu'])
-
-        # Accounting copy is rendered with USER_CPU=1 → else-branch → '1'.
-        ctrl_acct = (pool['parsed_pod_template_for_accounting']
-                     ['spec']['containers'][0])
-        self.assertEqual(
-            ctrl_acct['resources']['requests']['cpu'], '1')
-        self.assertEqual(
-            ctrl_acct['resources']['requests']['memory'], '1Gi')
-        self.assertEqual(
-            ctrl_acct['resources']['limits']['cpu'], '1')
-
-        # Platform inherits the same accounting copy.
-        plat_acct = (platform['parsed_pod_template_for_accounting']
-                     ['spec']['containers'][0])
-        self.assertEqual(
-            plat_acct['resources']['requests']['cpu'], '1')
-
-    def test_pre_render_uses_platform_default_variables_overrides(self):
-        """Platform-level default_variables must override pool defaults
-        when rendering the accounting copy.
-        """
-        configs: Dict[str, Any] = {
-            'pod_templates': {
-                'default_ctrl': {
-                    'spec': {
-                        'containers': [
-                            {
-                                'name': 'osmo-ctrl',
-                                'resources': {
-                                    'requests': {
-                                        'cpu': '{% if USER_CPU > 2 %}2{% else %}{{USER_CPU}}{% endif %}',
-                                    },
-                                },
-                            },
-                        ],
-                    },
-                },
-            },
-            'pools': {
-                'default': {
-                    'common_default_variables': {'USER_CPU': 1},
-                    'common_pod_template': ['default_ctrl'],
-                    'common_resource_validations': [],
-                    'common_group_templates': [],
-                    'platforms': {
                         'big': {
                             'default_variables': {'USER_CPU': 8},
                             'override_pod_template': [],
@@ -1360,11 +1306,36 @@ class TestResolvePoolComputedFields(unittest.TestCase):
         }
         configmap_loader._resolve_pool_computed_fields(configs)
 
-        platform = configs['pools']['default']['platforms']['big']
-        ctrl = (platform['parsed_pod_template_for_accounting']
-                ['spec']['containers'][0])
-        # USER_CPU=8 > 2 → if-branch → '2'.
-        self.assertEqual(ctrl['resources']['requests']['cpu'], '2')
+        pool = configs['pools']['default']
+
+        # Original stays templated for substitute_pod_template_tokens.
+        ctrl_orig = pool['parsed_pod_template']['spec']['containers'][0]
+        self.assertIn(
+            '{% if', ctrl_orig['resources']['requests']['cpu'])
+
+        # Pool-level accounting copy renders with pool defaults.
+        ctrl_pool = (pool['parsed_pod_template_for_accounting']
+                     ['spec']['containers'][0])
+        self.assertEqual(
+            ctrl_pool['resources']['requests']['cpu'], '1')
+        self.assertEqual(
+            ctrl_pool['resources']['requests']['memory'], '1Gi')
+        self.assertEqual(
+            ctrl_pool['resources']['limits']['cpu'], '1')
+
+        # Platform inheriting pool defaults gets the else-branch ('1').
+        ctrl_default = (pool['platforms']['default']
+                        ['parsed_pod_template_for_accounting']
+                        ['spec']['containers'][0])
+        self.assertEqual(
+            ctrl_default['resources']['requests']['cpu'], '1')
+
+        # Platform overriding USER_CPU=8 trips the if-branch ('2').
+        ctrl_big = (pool['platforms']['big']
+                    ['parsed_pod_template_for_accounting']
+                    ['spec']['containers'][0])
+        self.assertEqual(
+            ctrl_big['resources']['requests']['cpu'], '2')
 
     def test_load_and_apply_resolves_pool_fields(self):
         """End-to-end: _load_and_apply resolves pool computed fields."""

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -2188,8 +2188,15 @@ class BackendResource(pydantic.BaseModel):
                     if platform not in curr_pool_config.platforms:
                         continue
                     curr_platform_config = curr_pool_config.platforms[platform]
+                    # Prefer the accounting copy where osmo-ctrl resource
+                    # templates have been Jinja-rendered with default
+                    # variables; fall back to parsed_pod_template when
+                    # the loader didn't populate it (e.g. DB mode).
+                    accounting_template = (
+                        curr_platform_config.parsed_pod_template_for_accounting
+                        or curr_platform_config.parsed_pod_template)
                     resource_limits = \
-                        check_osmo_data_resource(curr_platform_config.parsed_pod_template)
+                        check_osmo_data_resource(accounting_template)
                     updated_allocatable_fields = copy.deepcopy(allocatable_fields)
                     if 'cpu' in updated_allocatable_fields:
                         updated_allocatable_fields['cpu'] = max(0,
@@ -3460,6 +3467,10 @@ class Platform(PlatformMinimal):
     parsed_resource_validations: List[ResourceAssertion] = []
     override_pod_template: List[str] = []
     parsed_pod_template: Dict = {}
+    # Pod template with Jinja in osmo-ctrl resources pre-rendered using
+    # pool/platform default variables. Populated by the ConfigMap loader;
+    # falls back to parsed_pod_template when absent (DB mode).
+    parsed_pod_template_for_accounting: Dict = {}
 
     def insert_into_db(self, database: PostgresConnector, pool_name: str, platform_name: str):
         """ Create/update an entry in the pools table """
@@ -3538,6 +3549,9 @@ class Pool(PoolBase, extra='ignore'):
     parsed_resource_validations: List[ResourceAssertion] = []
     common_pod_template: List[str] = []
     parsed_pod_template: Dict = {}
+    # Pod template with Jinja in osmo-ctrl resources pre-rendered using
+    # the pool's common_default_variables. See Platform for rationale.
+    parsed_pod_template_for_accounting: Dict = {}
     common_group_templates: List[str] = []
     parsed_group_templates: List[Dict] = []
     platforms: Dict[str, Platform] = {}

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1978,8 +1978,12 @@ class ResourceSpec(pydantic.BaseModel):
                      self.storage, self.memory, str(self.gpu)))
 
 class ResourceLimitationsField(ExtraArgBaseModel):
-    cpu: str
-    memory: str
+    # Defaults of '0' let pod templates omit individual fields without
+    # failing strict validation in pool-quota accounting. K8s itself
+    # treats an absent limit as "unbounded" — the pool-quota math here
+    # subtracts these as overhead, so '0' is the right neutral value.
+    cpu: str = '0'
+    memory: str = '0'
     ephemeral_storage: str = pydantic.Field('1Gi', alias='ephemeral-storage')
 
 

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1979,9 +1979,9 @@ class ResourceSpec(pydantic.BaseModel):
 
 class ResourceLimitationsField(ExtraArgBaseModel):
     # Defaults of '0' let pod templates omit individual fields without
-    # failing strict validation in pool-quota accounting. K8s itself
-    # treats an absent limit as "unbounded" — the pool-quota math here
-    # subtracts these as overhead, so '0' is the right neutral value.
+    # failing strict validation in pool-quota accounting. The math in
+    # check_osmo_data_resource subtracts requests as ctrl-pod overhead,
+    # so '0' is the right neutral value when fields are omitted.
     cpu: str = '0'
     memory: str = '0'
     ephemeral_storage: str = pydantic.Field('1Gi', alias='ephemeral-storage')


### PR DESCRIPTION
## Description

Pool-quota math reads osmo-ctrl request/limit fields as numeric K8s values, but those fields can be Jinja templates that depend on per-workflow variables (e.g. `{% if USER_CPU > 2 %}2{% else %}{{USER_CPU}}{% endif %}`). With no workflow context, the accounting code couldn't parse the template and silently treated it as zero — `/api/pool_quota` undercounted ctrl overhead and emitted `is not a valid value for CPU` warnings on every request.

The ConfigMap loader now pre-renders Jinja in osmo-ctrl resources once at config-load time using each pool/platform's `common_default_variables` / `default_variables`, stores the result in a new `parsed_pod_template_for_accounting` field, and `check_osmo_data_resource` reads from it. The original templated `parsed_pod_template` is unchanged for per-workflow rendering.

Also defaults `ResourceLimitationsField.cpu` and `.memory` to `'0'` so partial pod-template specs (e.g. `limits: {memory: 1Gi}` with no `limits.cpu`) don't 500 the pool-quota endpoint.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Resource limit configuration validation is now more flexible—CPU and memory constraints can be omitted without triggering validation errors.
  * Enhanced resource allocation and capacity calculation logic for improved quota and resource management accuracy.

* **Tests**
  * Added comprehensive unit tests validating resource configuration and capacity calculation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->