### PR TITLE
feat(rsync): expose --exclude/--include/--exclude-from/--include-from

### DIFF
--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -16,11 +16,16 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import argparse
+import dataclasses
+import json
+import os
+import tempfile
 import unittest
 from unittest import mock
 
 from src.cli import workflow
 from src.lib.rsync import rsync
+from src.lib.utils import osmo_errors
 
 class TestPortParse(unittest.TestCase):
     def test_port_parse(self):
@@ -155,6 +160,157 @@ class TestAsyncioEntrypoints(unittest.TestCase):
             )
 
         self.assertEqual(download_task.await_count, 1)
+
+
+class TestRsyncFilterCliParsing(unittest.TestCase):
+    """Tests for the rsync filter CLI parsing and spec construction."""
+
+    def _build_rsync_parser(self) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest='module')
+        workflow.setup_parser(subparsers)
+        return parser
+
+    def test_filter_rules_preserve_input_order(self):
+        """First-match-wins requires that --exclude/--include interleave is preserved."""
+        parser = self._build_rsync_parser()
+        args = parser.parse_args([
+            'workflow', 'rsync', 'upload', 'wf-1', 'task-1', '/tmp/a:/tmp/b',
+            '--include', '*.py',
+            '--exclude', '*.log',
+            '--include', 'README',
+            '--exclude', '*',
+        ])
+        self.assertEqual(args.filter_rules, [
+            (rsync.RsyncFilterRuleKind.INCLUDE, '*.py'),
+            (rsync.RsyncFilterRuleKind.EXCLUDE, '*.log'),
+            (rsync.RsyncFilterRuleKind.INCLUDE, 'README'),
+            (rsync.RsyncFilterRuleKind.EXCLUDE, '*'),
+        ])
+
+    def test_filter_rules_default_is_empty_list(self):
+        parser = self._build_rsync_parser()
+        args = parser.parse_args([
+            'workflow', 'rsync', 'upload', 'wf-1', 'task-1', '/tmp/a:/tmp/b',
+        ])
+        self.assertEqual(args.filter_rules, [])
+
+    def test_download_parser_accepts_filter_flags(self):
+        parser = self._build_rsync_parser()
+        args = parser.parse_args([
+            'workflow', 'rsync', 'download', 'wf-1', 'task-1', '/tmp/r:/tmp/l',
+            '--exclude', '*.tmp',
+        ])
+        self.assertEqual(args.filter_rules, [
+            (rsync.RsyncFilterRuleKind.EXCLUDE, '*.tmp'),
+        ])
+
+    def test_build_spec_validates_exclude_from_exists(self):
+        with self.assertRaises(osmo_errors.OSMOUserError):
+            workflow._build_rsync_filter_spec([
+                (rsync.RsyncFilterRuleKind.EXCLUDE_FROM, '/nonexistent/excludes.txt'),
+            ])
+
+    def test_build_spec_resolves_from_path_to_absolute(self):
+        with tempfile.NamedTemporaryFile(suffix='.excludes', delete=False) as f:
+            f.write(b'*.log\n')
+            tmp_path = f.name
+        try:
+            spec = workflow._build_rsync_filter_spec([
+                (rsync.RsyncFilterRuleKind.EXCLUDE_FROM, tmp_path),
+            ])
+            self.assertEqual(len(spec.rules), 1)
+            self.assertTrue(os.path.isabs(spec.rules[0].value))
+            self.assertEqual(spec.rules[0].kind, rsync.RsyncFilterRuleKind.EXCLUDE_FROM)
+        finally:
+            os.unlink(tmp_path)
+
+
+class TestRsyncFilterSpec(unittest.TestCase):
+    """Tests for the lib-level filter spec types."""
+
+    def test_build_filter_args_preserves_order(self):
+        spec = rsync.RsyncFilterSpec(rules=(
+            rsync.RsyncFilterRule(rsync.RsyncFilterRuleKind.INCLUDE, '*.py'),
+            rsync.RsyncFilterRule(rsync.RsyncFilterRuleKind.EXCLUDE, '*'),
+            rsync.RsyncFilterRule(rsync.RsyncFilterRuleKind.EXCLUDE_FROM, '/tmp/excl'),
+        ))
+        self.assertEqual(rsync._build_filter_args(spec), [
+            '--include', '*.py',
+            '--exclude', '*',
+            '--exclude-from', '/tmp/excl',
+        ])
+
+    def test_build_filter_args_empty_spec_is_empty_list(self):
+        self.assertEqual(rsync._build_filter_args(rsync.RsyncFilterSpec()), [])
+
+    def test_filter_spec_json_roundtrip(self):
+        spec = rsync.RsyncFilterSpec(rules=(
+            rsync.RsyncFilterRule(rsync.RsyncFilterRuleKind.EXCLUDE, '*.log'),
+            rsync.RsyncFilterRule(rsync.RsyncFilterRuleKind.INCLUDE, 'keep.txt'),
+        ))
+        as_dict = dataclasses.asdict(spec)
+        reloaded = rsync.RsyncFilterSpec.from_dict(json.loads(json.dumps(as_dict)))
+        self.assertEqual(reloaded, spec)
+
+    def test_daemon_metadata_backward_compat_no_filter_spec(self):
+        """Old PID files lacking filter_spec must still load with an empty spec."""
+        old_pid_data = {
+            'pid': 1234,
+            'rsync_request': {
+                'workflow_id': 'wf-1',
+                'task_name': 'task-1',
+                'direction': 'upload',
+                'local_path': '/tmp/local',
+                'remote_module': 'osmo',
+                'remote_path': 'sub',
+                'original_remote_path': '/osmo/run/workspace/sub',
+            },
+            'start_time': '2025-01-01T00:00:00',
+        }
+        metadata = rsync.RsyncDaemonMetadata.from_dict(old_pid_data)
+        self.assertEqual(metadata.rsync_request.filter_spec, rsync.RsyncFilterSpec())
+
+    def test_daemon_metadata_backward_compat_legacy_keys(self):
+        """Legacy schema with src/dst_module/dst_path keys must still load."""
+        legacy_pid_data = {
+            'pid': 1234,
+            'rsync_request': {
+                'workflow_id': 'wf-1',
+                'task_name': 'task-1',
+                'src': '/tmp/local',
+                'dst_module': 'osmo',
+                'dst_path': 'sub',
+                'original_dst_path': '/osmo/run/workspace/sub',
+            },
+            'start_time': '2025-01-01T00:00:00',
+        }
+        metadata = rsync.RsyncDaemonMetadata.from_dict(legacy_pid_data)
+        self.assertEqual(metadata.rsync_request.local_path, '/tmp/local')
+        self.assertEqual(metadata.rsync_request.filter_spec, rsync.RsyncFilterSpec())
+
+    def test_daemon_metadata_roundtrip_with_filter_spec(self):
+        """New PID files with a filter_spec must round-trip cleanly."""
+        original = rsync.RsyncDaemonMetadata(
+            pid=4321,
+            rsync_request=rsync.RsyncRequest(
+                workflow_id='wf-1',
+                task_name='task-1',
+                direction=rsync.RsyncDirection.UPLOAD,
+                local_path='/tmp/local',
+                remote_module='osmo',
+                remote_path='sub',
+                original_remote_path='/osmo/run/workspace/sub',
+                filter_spec=rsync.RsyncFilterSpec(rules=(
+                    rsync.RsyncFilterRule(rsync.RsyncFilterRuleKind.EXCLUDE, '*.log'),
+                )),
+            ),
+            start_time='2025-01-01T00:00:00',
+        )
+        reloaded = rsync.RsyncDaemonMetadata.from_dict(
+            json.loads(json.dumps(dataclasses.asdict(original))),
+        )
+        self.assertEqual(reloaded, original)
 
 
 if __name__ == "__main__":

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -72,6 +72,85 @@ class TemplateData(pydantic.BaseModel, extra='forbid'):
         }
 
 
+class _AppendFilterRule(argparse.Action):
+    """
+    Captures rsync filter rules into a single ordered list. Rsync uses first-match-wins
+    semantics across `--exclude`/`--include`, so we cannot use four separate `append`
+    dests — interleave order would be lost.
+    """
+    _OPTION_TO_KIND = {
+        '--exclude': rsync.RsyncFilterRuleKind.EXCLUDE,
+        '--include': rsync.RsyncFilterRuleKind.INCLUDE,
+        '--exclude-from': rsync.RsyncFilterRuleKind.EXCLUDE_FROM,
+        '--include-from': rsync.RsyncFilterRuleKind.INCLUDE_FROM,
+    }
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest, None) or []
+        kind = self._OPTION_TO_KIND[option_string]
+        items.append((kind, values))
+        setattr(namespace, self.dest, items)
+
+
+def _add_rsync_filter_args(subparser: argparse.ArgumentParser) -> None:
+    """
+    Adds the four rsync filter flags to the given subparser, all writing to a single
+    ordered `filter_rules` dest. Defined as a helper so upload and download share the
+    same surface.
+    """
+    subparser.add_argument('--exclude',
+                           metavar='PATTERN',
+                           dest='filter_rules',
+                           default=[],
+                           action=_AppendFilterRule,
+                           help='Skip files matching PATTERN. Repeatable. '
+                                'Patterns interleave with --include in input order '
+                                '(first-match-wins).')
+    subparser.add_argument('--include',
+                           metavar='PATTERN',
+                           dest='filter_rules',
+                           action=_AppendFilterRule,
+                           help='Include files matching PATTERN even if they would '
+                                'otherwise be excluded. Repeatable.')
+    subparser.add_argument('--exclude-from',
+                           metavar='FILE',
+                           dest='filter_rules',
+                           action=_AppendFilterRule,
+                           help='Read exclude patterns from FILE (one per line, '
+                                '# for comments). For --daemon, FILE is re-read on '
+                                'every reconnect, so it must remain readable.')
+    subparser.add_argument('--include-from',
+                           metavar='FILE',
+                           dest='filter_rules',
+                           action=_AppendFilterRule,
+                           help='Read include patterns from FILE (one per line, '
+                                '# for comments). For --daemon, FILE is re-read on '
+                                'every reconnect, so it must remain readable.')
+
+
+def _build_rsync_filter_spec(
+    filter_rules: List[Tuple[rsync.RsyncFilterRuleKind, str]],
+) -> rsync.RsyncFilterSpec:
+    """
+    Convert parsed CLI rules into an `RsyncFilterSpec`. For file-based rules
+    (`--exclude-from`/`--include-from`), resolve to absolute paths and verify the file
+    exists at parse time so daemon mode fails loudly upfront rather than at every
+    reconnect.
+    """
+    rules = []
+    for kind, value in filter_rules:
+        if kind in (rsync.RsyncFilterRuleKind.EXCLUDE_FROM,
+                    rsync.RsyncFilterRuleKind.INCLUDE_FROM):
+            resolved = os.path.abspath(os.path.expanduser(value))
+            if not os.path.isfile(resolved):
+                raise osmo_errors.OSMOUserError(
+                    f'--{kind.value} file does not exist: {value}')
+            rules.append(rsync.RsyncFilterRule(kind=kind, value=resolved))
+        else:
+            rules.append(rsync.RsyncFilterRule(kind=kind, value=value))
+    return rsync.RsyncFilterSpec(rules=tuple(rules))
+
+
 def setup_parser(parser: argparse._SubParsersAction):
     '''
     Workflow parser setup and run command based on parsing.
@@ -531,6 +610,7 @@ Stop a specific daemon::
                                  action='store_true',
                                  help='Suppress transfer progress output. By default, progress '
                                       'is shown for foreground transfers.')
+    _add_rsync_filter_args(rsync_up_parser)
     rsync_up_parser.set_defaults(func=_rsync_upload)
 
     # --- download subcommand ---
@@ -558,6 +638,7 @@ Stop a specific daemon::
                                    action='store_true',
                                    help='Suppress transfer progress output. By default, progress '
                                         'is shown.')
+    _add_rsync_filter_args(rsync_down_parser)
     rsync_down_parser.set_defaults(func=_rsync_download)
 
     # --- status subcommand ---
@@ -1707,6 +1788,7 @@ def _rsync_upload(service_client: client.ServiceClient, args: argparse.Namespace
         daemon_max_log_size=args.max_log_size,
         daemon_verbose_logging=args.verbose,
         show_progress=not args.daemon and not args.no_progress,
+        filter_spec=_build_rsync_filter_spec(args.filter_rules),
     )
 
 
@@ -1730,4 +1812,5 @@ def _rsync_download(service_client: client.ServiceClient, args: argparse.Namespa
         args.path,
         timeout=args.timeout,
         show_progress=not args.no_progress,
+        filter_spec=_build_rsync_filter_spec(args.filter_rules),
     )

--- a/src/go.mod
+++ b/src/go.mod
@@ -91,3 +91,5 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	kernel.org/pub/linux/libs/security/libcap/psx v1.2.70 // indirect
 )
+
+replace github.com/gokrazy/rsync => github.com/f-luo/rsync v0.0.0-20260422234135-c84164e0ea7d

--- a/src/go.sum
+++ b/src/go.sum
@@ -49,6 +49,8 @@ github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3re
 github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
 github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
+github.com/f-luo/rsync v0.0.0-20260422234135-c84164e0ea7d h1:FtJ4Q5dmm+5pZXRdztvjITeUbky8QIzzq4OhP4p40Sw=
+github.com/f-luo/rsync v0.0.0-20260422234135-c84164e0ea7d/go.mod h1:1R8gV3DX/cCc3DHWuUOobD7QONQHD7xRZqJE/b332Mo=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -58,8 +60,6 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
-github.com/gokrazy/rsync v0.3.1 h1:M6a725JXvpGLdVzNUDFBsm98qHIzVroSF9FogYSUsyA=
-github.com/gokrazy/rsync v0.3.1/go.mod h1:1R8gV3DX/cCc3DHWuUOobD7QONQHD7xRZqJE/b332Mo=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/src/lib/rsync/rsync.py
+++ b/src/lib/rsync/rsync.py
@@ -177,6 +177,58 @@ class RsyncDirection(str, enum.Enum):
     DOWNLOAD = 'download'
 
 
+class RsyncFilterRuleKind(str, enum.Enum):
+    """
+    Represents the kind of an rsync filter rule. Values match the rsync CLI flag names so
+    serialized rules round-trip cleanly through PID-file JSON.
+    """
+    EXCLUDE = 'exclude'
+    INCLUDE = 'include'
+    EXCLUDE_FROM = 'exclude-from'
+    INCLUDE_FROM = 'include-from'
+
+
+@dataclasses.dataclass(frozen=True)
+class RsyncFilterRule:
+    """
+    A single rsync filter rule. The pair (kind, value) is emitted on the rsync CLI as
+    `--<kind> <value>`.
+    """
+    kind: RsyncFilterRuleKind
+    value: str
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> 'RsyncFilterRule':
+        return cls(kind=RsyncFilterRuleKind(data['kind']), value=data['value'])
+
+
+@dataclasses.dataclass(frozen=True)
+class RsyncFilterSpec:
+    """
+    Ordered list of rsync filter rules. Rsync uses first-match-wins semantics, so order
+    across `--exclude`/`--include` is significant — store as a single ordered tuple.
+    """
+    rules: Tuple[RsyncFilterRule, ...] = ()
+
+    @classmethod
+    def from_dict(cls, data: Dict | None) -> 'RsyncFilterSpec':
+        if not data:
+            return cls()
+        return cls(rules=tuple(
+            RsyncFilterRule.from_dict(r) for r in data.get('rules', [])
+        ))
+
+
+def _build_filter_args(filter_spec: RsyncFilterSpec) -> List[str]:
+    """
+    Convert a filter spec into rsync CLI args, preserving rule order.
+    """
+    args: List[str] = []
+    for rule in filter_spec.rules:
+        args.extend([f'--{rule.kind.value}', rule.value])
+    return args
+
+
 @dataclasses.dataclass(frozen=True)
 class RsyncRequest:
     """
@@ -189,6 +241,7 @@ class RsyncRequest:
     remote_module: str
     remote_path: str
     original_remote_path: str
+    filter_spec: RsyncFilterSpec = dataclasses.field(default_factory=RsyncFilterSpec)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -233,7 +286,10 @@ class RsyncDaemonMetadata:
                 'remote_path': rsync_request_data['dst_path'],
                 'original_remote_path': rsync_request_data['original_dst_path'],
             }
-        rsync_request = RsyncRequest(**rsync_request_data)
+        # filter_spec is nested; rebuild explicitly. .pop() so the leftover dict can be
+        # passed to RsyncRequest via **kwargs without clashing on the field.
+        filter_spec = RsyncFilterSpec.from_dict(rsync_request_data.pop('filter_spec', None))
+        rsync_request = RsyncRequest(filter_spec=filter_spec, **rsync_request_data)
 
         return cls(
             pid=data['pid'],
@@ -616,6 +672,7 @@ class RsyncClient:
 
             try:
                 rsync_args = [self._rsync_bin_path, RSYNC_FLAGS]
+                rsync_args.extend(_build_filter_args(self._rsync_request.filter_spec))
                 if self._show_progress:
                     rsync_args.append('--progress')
                 rsync_args.extend([self._rsync_request.local_path, resolved_dst])
@@ -692,6 +749,7 @@ class RsyncClient:
             os.makedirs(resolved_dst, exist_ok=True)
 
             rsync_args = [self._rsync_bin_path, RSYNC_FLAGS]
+            rsync_args.extend(_build_filter_args(self._rsync_request.filter_spec))
             if self._show_progress:
                 rsync_args.append('--progress')
             rsync_args.extend([resolved_src, resolved_dst])
@@ -1773,6 +1831,7 @@ def parse_rsync_request(
     task_name: str,
     rsync_path: str,
     direction: RsyncDirection,
+    filter_spec: RsyncFilterSpec | None = None,
 ) -> RsyncRequest:
     """
     Parses a rsync path into a rsync request.
@@ -1785,6 +1844,7 @@ def parse_rsync_request(
     :param task_name: The task name.
     :param rsync_path: The rsync path.
     :param direction: The rsync direction.
+    :param filter_spec: Optional filter rules to apply to the transfer.
 
     :return: The rsync request.
     """
@@ -1824,6 +1884,7 @@ def parse_rsync_request(
         remote_module=remote_module,
         remote_path=remote_path,
         original_remote_path=original_remote_path,
+        filter_spec=filter_spec or RsyncFilterSpec(),
     )
 
 
@@ -1860,6 +1921,7 @@ def rsync_upload(
     daemon_verbose_logging: bool = False,
     quiet: bool = False,
     show_progress: bool = False,
+    filter_spec: RsyncFilterSpec | None = None,
 ):
     """
     Rsync uploads to a remote workflow task.
@@ -1880,11 +1942,16 @@ def rsync_upload(
     :param daemon_verbose_logging: Whether to enable verbose logging for the daemon.
     :param quiet: Whether to suppress the output.
     :param show_progress: Whether to show transfer progress for foreground uploads.
+    :param filter_spec: Optional rsync filter rules. Applies to both foreground and daemon
+        modes. For daemon mode, file-based rules (`--exclude-from`/`--include-from`) are
+        re-read by rsync on every reconnect, so the file must remain readable for the
+        daemon's lifetime.
     """
     rsync_config = get_rsync_config(service_client)
     task_name = task_name or get_lead_task_name(service_client, workflow_id)
     rsync_request = parse_rsync_request(
-        rsync_config, workflow_id, task_name, path, RsyncDirection.UPLOAD)
+        rsync_config, workflow_id, task_name, path, RsyncDirection.UPLOAD,
+        filter_spec=filter_spec)
 
     # Determine the rate limit to use.
     # If the server rate limit is not configured or is zero, default to user provided rate limit.
@@ -1945,6 +2012,7 @@ def rsync_download(
     *,
     timeout: int = 10,
     show_progress: bool = False,
+    filter_spec: RsyncFilterSpec | None = None,
 ):
     """
     Rsync downloads from a remote workflow task.
@@ -1957,11 +2025,13 @@ def rsync_download(
     :param path: The rsync path in <remote_path>:<local_path> format.
     :param timeout: The connection timeout.
     :param show_progress: Whether to show transfer progress.
+    :param filter_spec: Optional rsync filter rules to apply to the download.
     """
     rsync_config = get_rsync_config(service_client)
     task_name = task_name or get_lead_task_name(service_client, workflow_id)
     rsync_request = parse_rsync_request(
-        rsync_config, workflow_id, task_name, path, RsyncDirection.DOWNLOAD)
+        rsync_config, workflow_id, task_name, path, RsyncDirection.DOWNLOAD,
+        filter_spec=filter_spec)
 
     asyncio.run(
         rsync_download_task(


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->

Bumps the bundled `rsync_bin` to the [f-luo/rsync](https://github.com/f-luo/rsync/commit/c84164e0ea7dc69dac79fa4730216ecc4096d7e9) fork via a `go.mod` `replace` directive. The fork ports rsync's wildmatch algorithm and uncomments `--exclude-from` / `--include-from`, both of which were stubbed `errNotYetImplemented` in upstream `gokrazy/rsync v0.3.1` (the wildcard matcher also panicked on common patterns like `*.log`). The Bazel repo name `@com_github_gokrazy_rsync` is preserved because the fork keeps the original Go module path, so no BUILD changes are needed.

Adds an ordered `RsyncFilterSpec` carried on `RsyncRequest` and threaded through `parse_rsync_request` / `rsync_upload` / `rsync_download`. Filter rules apply to both foreground transfers and the watch-based upload daemon — they survive the `multiprocessing.spawn` boundary as a frozen dataclass with tuple fields, and `RsyncDaemonMetadata.from_dict` is updated with backward-compat handling so existing PID files (with or without legacy `src`/`dst_module` keys) still load. Subprocess builders inject filter args between `-av` and the source/dest paths.

Exposes four new flags on both `osmo workflow rsync upload` and `osmo workflow rsync download`:

- `--exclude PATTERN` (repeatable)
- `--include PATTERN` (repeatable)
- `--exclude-from FILE`
- `--include-from FILE`

A single `argparse.Action` dispatches by `option_string` so all four flags interleave into one ordered `filter_rules` list — this preserves rsync's first-match-wins semantics across `--exclude` and `--include` (e.g. `--include '*.py' --exclude '*'` to whitelist Python files). For `*-from` flags, file existence is validated and paths are resolved to absolute at parse time so daemon mode fails loudly upfront rather than at every reconnect.

**Cross-cutting risk:** `src/runtime/cmd/rsync/` resolves the same Go module, so runtime container images must roll out in lockstep with the client. Old-server binaries panic when a new client sends wildcard filter rules.

**Tests:** Added 10 unit tests covering CLI parse-order preservation, `*-from` file validation, abs-path resolution, `_build_filter_args` ordering, JSON roundtrip of the spec, and three `RsyncDaemonMetadata.from_dict` backward-compat scenarios (no filter_spec, legacy schema, full roundtrip). Manually smoke-tested `rsync_bin -av --exclude='*.log' src/ dst/` end-to-end and confirmed `*.log` was filtered.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rsync filter rule support to upload and download commands. Users can now specify file inclusion and exclusion patterns. Rules are processed in the order specified for precise control over which files are transferred during synchronization.

* **Chores**
  * Updated module dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->