### PR TITLE
service/agent: always sync KAI queues on backend registration

### DIFF
--- a/src/service/agent/helpers.py
+++ b/src/service/agent/helpers.py
@@ -116,8 +116,9 @@ def create_backend(postgres: connectors.PostgresConnector,
         raise osmo_errors.OSMOBackendError(f'Backend {name} is already being used by a '
                                            'different cluster')
 
-    if k8s_info[0].is_new:
-        config_helpers.update_backend_queues(connectors.Backend.fetch_from_db(postgres, name))
+    # Snapshot pre-UPDATE; passed to update_backend_queues below so it can
+    # clean up old scheduler resources on scheduler_type / namespace changes.
+    previous_backend = connectors.Backend.fetch_from_db(postgres, name)
 
     # Update node_conditions column to set the prefix while preserving existing values
     update_cmd = '''
@@ -150,6 +151,17 @@ def create_backend(postgres: connectors.PostgresConnector,
                                                     name,
                                                     message.k8s_namespace,
                                                     message.version, message.node_condition_prefix))
+
+    # MUST run after the UPDATE above: queue names embed k8s_namespace
+    # (`osmo-pool-<ns>-<pool>`), so the fetched backend has to reflect the
+    # just-written namespace. previous_backend (snapshot pre-UPDATE) lets
+    # update_backend_queues clean up old scheduler resources on
+    # scheduler_type / namespace transitions. Idempotent on every reconnect:
+    # the worker no-ops unchanged specs.
+    config_helpers.update_backend_queues(
+        connectors.Backend.fetch_from_db(postgres, name),
+        previous_backend,
+    )
 
     # Only create a single history entry for the backend creation or update
     if k8s_info[0].is_new:

--- a/src/utils/job/backend_jobs.py
+++ b/src/utils/job/backend_jobs.py
@@ -444,6 +444,34 @@ class LabelNode(BackendWorkflowJob):
         return JobResult()
 
 
+def _immutable_target_already_current(target: Dict, existing: Dict) -> bool:
+    """Return True iff `existing`'s meaningful content already matches `target`.
+
+    Used by BackendSynchronizeQueues to skip the delete+recreate cycle on
+    immutable CRDs (e.g. KAI Topology) when the spec hasn't changed.
+
+    Compared: `apiVersion` + `kind` + `spec` (deep equal) plus
+    `metadata.labels` (each target label must be present and equal in
+    existing). Server-managed metadata (resourceVersion, uid, generation,
+    managedFields, creationTimestamp, selfLink) and `status` are ignored.
+    `apiVersion` is included as a hedge against API version bumps (e.g.
+    scheduling.run.ai/v2 -> v3): without it the helper would say "current"
+    even though the resource needs to be migrated.
+    """
+    if target.get('apiVersion') != existing.get('apiVersion'):
+        return False
+    if target.get('kind') != existing.get('kind'):
+        return False
+    if target.get('spec') != existing.get('spec'):
+        return False
+    target_labels = (target.get('metadata') or {}).get('labels') or {}
+    existing_labels = (existing.get('metadata') or {}).get('labels') or {}
+    for key, value in target_labels.items():
+        if existing_labels.get(key) != value:
+            return False
+    return True
+
+
 class BackendSynchronizeQueues(backend_job_defs.BackendSynchronizeQueuesMixin, BackendJob):
     """Synchronizes scheduler K8s objects (queues, topologies, etc.)
     in the backend to match configuration"""
@@ -528,10 +556,28 @@ class BackendSynchronizeQueues(backend_job_defs.BackendSynchronizeQueuesMixin, B
             if obj_name in all_objects:
                 # Object exists - check if it needs to be recreated (immutable) or updated
                 if obj_kind in self.immutable_kinds:
-                    # Delete and recreate for immutable kinds
-                    logging.info('Recreating immutable %s object: %s', obj_kind, obj_name)
-                    self._delete_object(context, cleanup_spec, obj_name)
-                    self._apply_object(context, cleanup_spec, obj, resource_version=None)
+                    # Skip the delete+recreate when the existing object's spec
+                    # already matches the target. Without this guard, every
+                    # backend re-registration churned every immutable CRD
+                    # (e.g. KAI Topology) — the brief gap between delete and
+                    # recreate makes pods that reference the CRD error with
+                    # "topology not found" while the new resource is being
+                    # written. Idempotent re-syncs (same spec) should no-op.
+                    existing = all_objects[obj_name]
+                    if _immutable_target_already_current(obj, existing):
+                        # Info-level (not debug): the no-op path is now the
+                        # steady-state on reconnects, and visibility into
+                        # "did the sync run, did it find the spec current?"
+                        # matters for triaging "are queues up-to-date?"
+                        # without redeploying with --log-level=debug.
+                        logging.info(
+                            'Immutable %s %s already current — skipping recreate',
+                            obj_kind, obj_name)
+                    else:
+                        logging.info(
+                            'Recreating immutable %s object: %s', obj_kind, obj_name)
+                        self._delete_object(context, cleanup_spec, obj_name)
+                        self._apply_object(context, cleanup_spec, obj, resource_version=None)
                 else:
                     # Update existing object
                     original = all_objects[obj_name]

--- a/src/utils/job/tests/BUILD
+++ b/src/utils/job/tests/BUILD
@@ -85,6 +85,16 @@ py_test(
 )
 
 py_test(
+    name = "test_backend_jobs",
+    srcs = [
+        "test_backend_jobs.py"
+    ],
+    deps = [
+        "//src/utils/job:backend_job",
+    ]
+)
+
+py_test(
     name = "test_topology",
     srcs = [
         "test_topology.py"

--- a/src/utils/job/tests/test_backend_jobs.py
+++ b/src/utils/job/tests/test_backend_jobs.py
@@ -1,0 +1,192 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+from unittest import mock
+
+from src.utils.job import backend_job_defs, backend_jobs
+
+
+class ImmutableTargetAlreadyCurrentTest(unittest.TestCase):
+    """Pure unit tests for backend_jobs._immutable_target_already_current.
+
+    Regression guard for the KAI Topology churn fix: BackendSynchronizeQueues
+    must skip the delete+recreate when an immutable CRD's spec is unchanged.
+    """
+
+    def _topology(self, *, levels=None, labels=None,
+                  api_version='kai.scheduler/v1alpha1', kind='Topology'):
+        """Build a minimal Topology-shaped dict for comparison tests."""
+        return {
+            'apiVersion': api_version,
+            'kind': kind,
+            'metadata': {
+                'name': 'osmo-pool-osmo-workflows-default-topology',
+                'labels': labels or {'osmo.namespace': 'osmo-workflows'},
+            },
+            'spec': {'topologyKeys': levels or ['zone', 'rack', 'hostname']},
+        }
+
+    def test_identical_specs_match(self):
+        target = self._topology()
+        existing = self._topology()
+        self.assertTrue(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+    def test_existing_with_extra_server_metadata_still_matches(self):
+        """existing carries server-set fields that target doesn't — should match."""
+        target = self._topology()
+        existing = self._topology()
+        existing['metadata'].update({
+            'resourceVersion': '12345',
+            'uid': 'abc-def',
+            'creationTimestamp': '2026-05-01T00:00:00Z',
+            'generation': 1,
+            'managedFields': [{'manager': 'kai'}],
+            'selfLink': '/apis/...',
+        })
+        existing['status'] = {'phase': 'Ready'}
+        self.assertTrue(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+    def test_differing_spec_does_not_match(self):
+        target = self._topology(levels=['zone', 'rack'])
+        existing = self._topology(levels=['zone', 'rack', 'hostname'])
+        self.assertFalse(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+    def test_differing_topology_key_order_does_not_match(self):
+        """Topology level order is semantically meaningful (coarse -> fine)."""
+        target = self._topology(levels=['zone', 'rack', 'hostname'])
+        existing = self._topology(levels=['hostname', 'rack', 'zone'])
+        self.assertFalse(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+    def test_target_label_subset_of_existing_matches(self):
+        """Existing may carry extra labels (operator-added); target subset is fine."""
+        target = self._topology(labels={'osmo.namespace': 'osmo-workflows'})
+        existing = self._topology(
+            labels={'osmo.namespace': 'osmo-workflows',
+                    'kai.scheduler/managed': 'true'})
+        self.assertTrue(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+    def test_target_label_missing_in_existing_does_not_match(self):
+        target = self._topology(
+            labels={'osmo.namespace': 'osmo-workflows', 'env': 'prod'})
+        existing = self._topology(labels={'osmo.namespace': 'osmo-workflows'})
+        self.assertFalse(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+    def test_target_label_value_differs_does_not_match(self):
+        target = self._topology(labels={'osmo.namespace': 'osmo-workflows'})
+        existing = self._topology(labels={'osmo.namespace': 'osmo-other'})
+        self.assertFalse(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+    def test_api_version_bump_does_not_match(self):
+        """Hedge against scheduling.run.ai/v2 -> v3 mid-deploy: must recreate."""
+        target = self._topology(api_version='kai.scheduler/v1beta1')
+        existing = self._topology(api_version='kai.scheduler/v1alpha1')
+        self.assertFalse(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+    def test_kind_mismatch_does_not_match(self):
+        target = self._topology(kind='Topology')
+        existing = self._topology(kind='Queue')
+        self.assertFalse(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+    def test_missing_metadata_labels_treated_as_empty(self):
+        """A target with no labels declared matches any existing."""
+        target = self._topology()
+        target['metadata'].pop('labels')
+        existing = self._topology()
+        self.assertTrue(
+            backend_jobs._immutable_target_already_current(target, existing))
+
+
+class SyncObjectsForSpecImmutableShortCircuitTest(unittest.TestCase):
+    """Regression guard for BackendSynchronizeQueues._sync_objects_for_spec.
+
+    The two scenarios that matter for the KAI Topology churn fix:
+      - existing object's spec matches target -> do NOT delete+recreate
+      - existing object's spec differs        -> DO delete+recreate
+    """
+
+    def _make_job(self, k8s_resources):
+        """Construct a BackendSynchronizeQueues without going through pydantic
+        full validation — fields exercised by _sync_objects_for_spec only."""
+        job = backend_jobs.BackendSynchronizeQueues.model_construct(
+            backend='default',
+            type='BackendSynchronizeQueues',
+            super_type='backend',
+            k8s_resources=k8s_resources,
+            cleanup_specs=[],
+            immutable_kinds=['Topology'],
+        )
+        return job
+
+    def _topology(self, levels):
+        return {
+            'apiVersion': 'kai.scheduler/v1alpha1',
+            'kind': 'Topology',
+            'metadata': {
+                'name': 'osmo-pool-osmo-workflows-default-topology',
+                'labels': {'osmo.namespace': 'osmo-workflows'},
+            },
+            'spec': {'topologyKeys': levels},
+        }
+
+    def _cleanup_spec(self):
+        return backend_job_defs.BackendCleanupSpec(
+            generic_api=backend_job_defs.BackendGenericApi(
+                api_version='kai.scheduler/v1alpha1', kind='Topology'),
+            labels={'osmo.namespace': 'osmo-workflows'})
+
+    def test_unchanged_immutable_target_is_not_deleted(self):
+        target = self._topology(levels=['zone', 'rack', 'hostname'])
+        existing = self._topology(levels=['zone', 'rack', 'hostname'])
+        # existing carries server-managed fields that the helper must ignore
+        existing['metadata']['resourceVersion'] = '99'
+
+        job = self._make_job([target])
+        with mock.patch.object(job, '_get_objects', return_value=[existing]), \
+             mock.patch.object(job, '_delete_object') as mock_delete, \
+             mock.patch.object(job, '_apply_object') as mock_apply:
+            job._sync_objects_for_spec(mock.Mock(), self._cleanup_spec())
+
+        mock_delete.assert_not_called()
+        mock_apply.assert_not_called()
+
+    def test_changed_immutable_target_triggers_recreate(self):
+        target = self._topology(levels=['zone', 'rack', 'hostname'])
+        existing = self._topology(levels=['hostname'])  # stale shape
+
+        job = self._make_job([target])
+        with mock.patch.object(job, '_get_objects', return_value=[existing]), \
+             mock.patch.object(job, '_delete_object') as mock_delete, \
+             mock.patch.object(job, '_apply_object') as mock_apply:
+            job._sync_objects_for_spec(mock.Mock(), self._cleanup_spec())
+
+        mock_delete.assert_called_once()
+        mock_apply.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Surfaced by full Azure deploy. Workflow submit reached PENDING, backend-worker created PodGroup + Pod, but the workflow Pod sat in Pending forever with:

  Warning  Unschedulable  ... QueueDoesNotExist: Queue
  'osmo-pool-osmo-workflows-default' does not exist.

Root cause: `agent.helpers.create_backend` only invoked `config_helpers.update_backend_queues(...)` when the backend was *new* in postgres (`if k8s_info[0].is_new:`). The premise of that guard — that queues only need to be created on first registration — is broken:

1. Subsequent registrations (e.g. backend-operator restart, k8s_namespace change, scheduler_type switch) don't re-sync queues, so config drift between the configmap/DB and KAI silently breaks scheduling.
2. ConfigMap mode + agent-registration ordering can race in surprising ways (the snapshot has pools but the BackendSynchronizeQueues job may not have made it through, etc.) — the original guard makes the error mode "queues missing forever" instead of "re-sync on next reconnect."

`update_backend_queues` sends a `BackendSynchronizeQueues` job which the worker handles idempotently (kubectl-style apply against scheduling.run.ai/v2 Queue CRDs), so dropping the guard adds at most one redis enqueue per backend reconnect — negligible cost, much better failure mode.

Validated downstream on a fresh Azure deploy: same registration path without this guard correctly creates `osmo-default-osmo-workflows` + `osmo-pool-osmo-workflows-default` so workflows can schedule from first deploy. Without the fix the deploy script needs an out-of-band queue-bootstrap step (which the consolidation branch had to add as a workaround before reverting to wait for this upstream fix).

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Always run queue synchronization during backend (re)registration so queues and resources reflect namespace changes; backend config history logging unchanged.
  * Skip needless delete-and-recreate for immutable cluster objects when an existing object already matches the desired apiVersion/kind/spec and label subset, reducing churn.

* **Tests**
  * Added unit tests covering immutable-object matching and sync behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->