### PR TITLE
testbot: rank coverage targets by criticality x coverage gap

### DIFF
--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -128,13 +128,16 @@ jobs:
         run: |
           # PYTHONPATH=. so the namespace-package import
           # `from src.scripts.testbot.coverage_targets import ...` resolves.
+          # criticality_scorer logs the ranked shortlist itself; we just
+          # dump the JSON in a foldable group so reviewers can see the full
+          # per-signal breakdown when debugging a pick.
           PYTHONPATH=. python src/scripts/testbot/criticality_scorer.py \
             --repo-root . \
             --shortlist-size 20 \
             --max-uncovered ${{ inputs.max_uncovered || '300' }} \
             --output "$RUNNER_TEMP/shortlist.json"
-          echo "::group::Criticality shortlist"
-          python -c 'import json,sys; data=json.load(open(sys.argv[1])); [print(f"{i+1:2d}. score={t[\"score\"]:6.2f} cov={t[\"coverage_pct\"]:5.1f}%  fan_in={t[\"fan_in\"]:3d} churn={t[\"churn\"]:3d}  {t[\"file_path\"]}") for i,t in enumerate(data)]' "$RUNNER_TEMP/shortlist.json"
+          echo "::group::Shortlist JSON (full per-signal breakdown)"
+          cat "$RUNNER_TEMP/shortlist.json"
           echo "::endgroup::"
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -28,7 +28,7 @@ on:
         default: '1'
       max_uncovered:
         description: 'Max uncovered lines per target (0 = no cap)'
-        default: '300'
+        default: '500'
       max_turns:
         description: 'Max Claude Code agent turns'
         default: '100'
@@ -134,7 +134,7 @@ jobs:
           PYTHONPATH=. python src/scripts/testbot/criticality_scorer.py \
             --repo-root . \
             --shortlist-size 20 \
-            --max-uncovered ${{ inputs.max_uncovered || '300' }} \
+            --max-uncovered ${{ inputs.max_uncovered || '500' }} \
             --output "$RUNNER_TEMP/shortlist.json"
           echo "::group::Shortlist JSON (full per-signal breakdown)"
           cat "$RUNNER_TEMP/shortlist.json"

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -126,7 +126,9 @@ jobs:
       # and picks the 1-3 best test targets by ROI.
       - name: Score criticality (Stage 1)
         run: |
-          python src/scripts/testbot/criticality_scorer.py \
+          # PYTHONPATH=. so the namespace-package import
+          # `from src.scripts.testbot.coverage_targets import ...` resolves.
+          PYTHONPATH=. python src/scripts/testbot/criticality_scorer.py \
             --repo-root . \
             --shortlist-size 20 \
             --max-uncovered ${{ inputs.max_uncovered || '300' }} \
@@ -139,7 +141,7 @@ jobs:
 
       - name: Pick targets via subagent (Stage 2)
         run: |
-          python src/scripts/testbot/select_targets_agent.py \
+          PYTHONPATH=. python src/scripts/testbot/select_targets_agent.py \
             --shortlist "$RUNNER_TEMP/shortlist.json" \
             --max-targets ${{ inputs.max_targets || '1' }} \
             --output "$RUNNER_TEMP/targets.txt"

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -120,17 +120,38 @@ jobs:
           git config user.name "testbot[bot]"
           git config user.email "testbot[bot]@users.noreply.github.com"
 
-      - name: Select coverage targets
+      # Two-stage target selection: a heuristic scorer narrows the candidate
+      # pool to ~20 critical-but-undertested files (using fan-in, churn, and
+      # path-tier signals), then a small Claude subagent reads each candidate
+      # and picks the 1-3 best test targets by ROI.
+      - name: Score criticality (Stage 1)
         run: |
-          python src/scripts/testbot/coverage_targets.py \
-            --max-targets ${{ inputs.max_targets || '1' }} \
+          python src/scripts/testbot/criticality_scorer.py \
+            --repo-root . \
+            --shortlist-size 20 \
             --max-uncovered ${{ inputs.max_uncovered || '300' }} \
-            > "$RUNNER_TEMP/targets.txt"
+            --output "$RUNNER_TEMP/shortlist.json"
+          echo "::group::Criticality shortlist"
+          python -c 'import json,sys; data=json.load(open(sys.argv[1])); [print(f"{i+1:2d}. score={t[\"score\"]:6.2f} cov={t[\"coverage_pct\"]:5.1f}%  fan_in={t[\"fan_in\"]:3d} churn={t[\"churn\"]:3d}  {t[\"file_path\"]}") for i,t in enumerate(data)]' "$RUNNER_TEMP/shortlist.json"
+          echo "::endgroup::"
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Pick targets via subagent (Stage 2)
+        run: |
+          python src/scripts/testbot/select_targets_agent.py \
+            --shortlist "$RUNNER_TEMP/shortlist.json" \
+            --max-targets ${{ inputs.max_targets || '1' }} \
+            --output "$RUNNER_TEMP/targets.txt"
           echo "::group::Selected targets"
           cat "$RUNNER_TEMP/targets.txt"
           echo "::endgroup::"
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
+          ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
+          ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/bedrock-claude-opus-4-7' }}
+          DISABLE_PROMPT_CACHING: "1"
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
 
       - name: Generate tests
         run: |

--- a/src/scripts/testbot/BUILD
+++ b/src/scripts/testbot/BUILD
@@ -1,11 +1,29 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bzl:py.bzl", "osmo_py_library")
+load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library")
 
 osmo_py_library(
     name = "testbot",
     srcs = glob(["*.py"]),
-    data = ["TESTBOT_PROMPT.md"],
+    data = [
+        "SELECT_TARGETS_PROMPT.md",
+        "TESTBOT_PROMPT.md",
+    ],
     visibility = ["//visibility:public"],
+)
+
+osmo_py_binary(
+    name = "criticality_scorer",
+    srcs = ["criticality_scorer.py"],
+    main = "criticality_scorer.py",
+    deps = [":testbot"],
+)
+
+osmo_py_binary(
+    name = "select_targets_agent",
+    srcs = ["select_targets_agent.py"],
+    main = "select_targets_agent.py",
+    data = ["SELECT_TARGETS_PROMPT.md"],
+    deps = [":testbot"],
 )

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -135,10 +135,14 @@ The selector runs in two stages. Tunables live in `criticality_scorer.py`
 Score formula (per file):
 
 ```
-                       ┌──────────── criticality ────────────┐   ┌── coverage gap ──┐
-score   =   w_tier · (DEFAULT_TIER − tier)                       (1 − coverage_pct/100)
-          + w_fan_in · log(fan_in + 1) / log(max_fan_in + 1)   ×  · log(min(uncovered, 500) + 1)
-          + w_churn  · log(churn + 1)  / log(max_churn  + 1)
+criticality   =   w_tier   · (DEFAULT_TIER − tier)
+                + w_fan_in · log(fan_in + 1) / log(max_fan_in + 1)
+                + w_churn  · log(churn  + 1) / log(max_churn  + 1)
+
+coverage_gap  =   (1 − coverage_pct / 100)
+                × log(min(uncovered_lines, 500) + 1)
+
+score         =   criticality × coverage_gap
 ```
 
 Each term:

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -132,15 +132,30 @@ The selector runs in two stages. Tunables live in `criticality_scorer.py`
 | `MIN_LOC` | `30` | Skip files smaller than this — too small to give useful coverage gain. |
 | `--shortlist-size` | `20` | Number of candidates handed to the Stage-2 picker. |
 
-Score formula:
+Score formula (per file):
+
 ```
-criticality = w_tier·(4 - tier) + w_fan_in·log(fan_in+1)/log(peak+1) + w_churn·log(churn+1)/log(peak+1)
-gap         = (1 - coverage) · log(min(uncovered_lines, 500) + 1)
-score       = criticality · gap
+                       ┌──────────── criticality ────────────┐   ┌── coverage gap ──┐
+score   =   w_tier · (DEFAULT_TIER − tier)                       (1 − coverage_pct/100)
+          + w_fan_in · log(fan_in + 1) / log(max_fan_in + 1)   ×  · log(min(uncovered, 500) + 1)
+          + w_churn  · log(churn + 1)  / log(max_churn  + 1)
 ```
 
-Log normalization keeps a single mega-hub from swamping the rest of the
-signals. Used together with the existing `IGNORE_PATTERNS` /
+Each term:
+
+| Term | Meaning | Range with defaults |
+|------|---------|---------------------|
+| `w_tier · (DEFAULT_TIER − tier)` | Path-prefix bonus. `DEFAULT_TIER = 4`, so `lib/`/`utils/`/`runtime/pkg/` (tier 0) get +4.0 here, fall-through paths (tier 4) get 0. | `[0, 4.0]` |
+| `w_fan_in · log_norm(fan_in)` | Log-normalized reverse-import count. `log_norm(x) = log(x+1)/log(peak+1)` lives in `[0, 1]`, so this term saturates at `w_fan_in` for the most-imported file in the corpus. | `[0, 2.5]` |
+| `w_churn · log_norm(churn)` | Log-normalized commit count over the last 6 months, same shape as `fan_in`. | `[0, 0.8]` |
+| `(1 − coverage_pct/100)` | Linear coverage gap. A 10%-covered file scales the criticality 9× more than a 90%-covered one. | `[0, 1.0]` |
+| `log(min(uncovered, 500) + 1)` | Log-scaled uncovered surface area. Cap means a 5000-line uncovered file doesn't dwarf a 500-line one infinitely. | `[0, log(501) ≈ 6.22]` |
+
+Why **multiplication**, not addition: a perfectly-covered hub scores `0` (nothing to test) and a 0%-covered trivial file scores low (criticality term is small). Both signals must be present for a file to rank high.
+
+Why **log normalization** on `fan_in` and `churn`: without it, OSMO's `lib/utils/common.py` (fan_in=222) would single-handedly drown out everything else. With it, each of those two terms is bounded at its weight.
+
+Used together with the existing `IGNORE_PATTERNS` /
 `SKIP_BASENAME_PATTERNS` from `coverage_targets.py` plus extra skips for
 generated barrels and vendored code.
 

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -7,14 +7,16 @@ Testbot analyzes coverage gaps, generates tests using Claude Code, validates the
 ### Test Generation (`testbot.yaml`)
 
 ```text
-Codecov API → coverage_targets.py → Claude Code CLI → guardrails → create_pr.py
-                                      |         ↑
-                                      └─────────┘ (agent retries on test failures)
+Codecov API ──┐
+              ├─► criticality_scorer.py ──► select_targets_agent.py ──► Claude Code CLI ──► guardrails ──► create_pr.py
+git log ──────┤    (heuristic shortlist)       (LLM target picker)         |          ↑
+filesystem ───┘                                                            └──────────┘ (agent retries on test failures)
 ```
 
 | Stage | Component | Description |
 |-------|-----------|-------------|
-| **Coverage analysis** | `coverage_targets.py` | Fetches Codecov report, selects lowest-coverage files |
+| **Stage 1: Heuristic** | `criticality_scorer.py` | Combines Codecov coverage with static fan-in (Python AST + Go scan), 6-month git churn, and a path-tier classification to rank candidates by `criticality * coverage_gap`. Outputs a top-20 JSON shortlist. |
+| **Stage 2: LLM picker** | `select_targets_agent.py` + `SELECT_TARGETS_PROMPT.md` | A read-only Claude Code subagent (`Read,Glob,Grep` only) reads each candidate, rejects hard-to-test infra glue, and picks the 1-3 files where unit tests would have the highest ROI. Can return zero picks if nothing meets the bar. |
 | **Test generation** | Claude Code CLI | Reads source, writes test files and BUILD entries, runs tests, iterates on failures |
 | **Guardrails** | `guardrails.py` | Filters out any non-test file changes made by Claude |
 | **PR creation** | `create_pr.py` | Creates branch, commits test files, pushes, opens PR with `ai-generated` label |
@@ -115,19 +117,54 @@ Then post a new `/testbot` comment with clearer instructions.
 | `--timeout` | `720` | Claude Code CLI timeout in seconds |
 | `--model` | `aws/anthropic/bedrock-claude-opus-4-7` | LLM model |
 
-### Coverage target selection (constants in `coverage_targets.py`)
+### Coverage target selection
+
+The selector runs in two stages. Tunables live in `criticality_scorer.py`
+(Stage 1) and `select_targets_agent.py` (Stage 2).
+
+**Stage 1 — heuristic (`criticality_scorer.py`):**
 
 | Constant | Value | Description |
 |----------|-------|-------------|
-| `MIN_FILE_LINES` | `10` | Skip files smaller than this |
-| `MAX_FILE_LINES` | `0` | Skip files larger than this (0 = no cap) |
-| `LANGUAGE_PRIORITY` | `.py`/`.go` = 0, `.ts`/`.tsx` = 1 | Backend code is prioritized over UI; lower bucket picked first, ties broken by coverage % asc |
+| `TIER_PREFIXES` | `lib/`, `utils/`, `runtime/pkg/` = 0; `service/core/` = 1; `cli/`, `runtime/cmd/` = 2; supporting services + `operator/` = 3 | Path-prefix tier (lower = more critical). |
+| `Weights` | tier=1.0, fan_in=1.5, churn=0.8 | Default weights for the criticality score. |
+| `CHURN_SINCE` | `6 months ago` | Window for the `git log` churn count. |
+| `MIN_LOC` | `30` | Skip files smaller than this — too small to give useful coverage gain. |
+| `--shortlist-size` | `20` | Number of candidates handed to the Stage-2 picker. |
+
+Score formula:
+```
+criticality = w_tier·(4 - tier) + w_fan_in·log(fan_in+1)/log(peak+1) + w_churn·log(churn+1)/log(peak+1)
+gap         = (1 - coverage) · log(min(uncovered_lines, 300) + 1)
+score       = criticality · gap
+```
+
+Log normalization keeps a single mega-hub from swamping the rest of the
+signals. Used together with the existing `IGNORE_PATTERNS` /
+`SKIP_BASENAME_PATTERNS` from `coverage_targets.py` plus extra skips for
+generated barrels and vendored code.
+
+**Stage 2 — LLM picker (`select_targets_agent.py`):**
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| `ALLOWED_TOOLS` | `Read,Glob,Grep` | Read-only — the picker can never modify anything. |
+| `DEFAULT_MAX_TURNS` | `30` | Hard turn cap for the picker subagent. |
+| Output contract | JSON `{targets: [{file_path, reason}]}` in a fenced block | Picker can return `[]` to skip a day. |
+
+The picker rejects heavy I/O glue, long-running orchestration, and SDK-call
+delegators where unit-test coverage gain would be shallow. When picks are
+made, the rationale is surfaced in the resulting PR description so reviewers
+can see *why* a file was chosen.
 
 ## File Structure
 
 ```text
 src/scripts/testbot/
-├── coverage_targets.py         # Codecov API → select low-coverage targets
+├── coverage_targets.py         # Codecov API client + filtering helpers
+├── criticality_scorer.py       # Stage 1: heuristic shortlist (fan-in × churn × tier × coverage gap)
+├── select_targets_agent.py     # Stage 2: Claude subagent that picks the best test targets
+├── SELECT_TARGETS_PROMPT.md    # System prompt for the Stage-2 picker
 ├── create_pr.py                # Branch, commit, push, open PR
 ├── guardrails.py               # Test-file-only filter, shared by all scripts
 ├── respond.py                  # Review response: Claude Code CLI + GitHub API
@@ -138,8 +175,10 @@ src/scripts/testbot/
 └── tests/
     ├── test_coverage_targets.py
     ├── test_create_pr.py
+    ├── test_criticality_scorer.py
     ├── test_guardrails.py
-    └── test_respond.py
+    ├── test_respond.py
+    └── test_select_targets_agent.py
 
 .github/workflows/
 ├── testbot.yaml                    # Scheduled test generation

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -63,7 +63,7 @@ Claude Code is sandboxed: it can only read files, edit test files, and run test 
 ```bash
 gh workflow run testbot.yaml --ref <branch> \
   -f max_targets=1 \
-  -f max_uncovered=300 \
+  -f max_uncovered=500 \
   -f max_turns=100 \
   -f model=aws/anthropic/bedrock-claude-opus-4-7
 ```
@@ -102,7 +102,7 @@ Then post a new `/testbot` comment with clearer instructions.
 | Input | Default | Description |
 |-------|---------|-------------|
 | `max_targets` | `1` | Files to target per run |
-| `max_uncovered` | `300` | Uncovered lines cap per target (0 = no cap) |
+| `max_uncovered` | `500` | Uncovered lines cap per target (0 = no cap) |
 | `max_turns` | `100` | Claude Code agent turns |
 | `timeout_minutes` | `30` | Workflow timeout |
 | `model` | `aws/anthropic/bedrock-claude-opus-4-7` | LLM model on API gateway |
@@ -127,7 +127,7 @@ The selector runs in two stages. Tunables live in `criticality_scorer.py`
 | Constant | Value | Description |
 |----------|-------|-------------|
 | `TIER_PREFIXES` | `lib/`, `utils/`, `runtime/pkg/` = 0; `service/core/` = 1; `cli/`, `runtime/cmd/` = 2; supporting services + `operator/` = 3 | Path-prefix tier (lower = more critical). |
-| `Weights` | tier=1.0, fan_in=1.5, churn=0.8 | Default weights for the criticality score. |
+| `Weights` | tier=1.0, fan_in=2.5, churn=0.8 | Default weights for the criticality score. fan_in dominates because dependency centrality is the most durable signal — a hub stays a hub for years, while coverage and churn shift week to week. |
 | `CHURN_SINCE` | `6 months ago` | Window for the `git log` churn count. |
 | `MIN_LOC` | `30` | Skip files smaller than this — too small to give useful coverage gain. |
 | `--shortlist-size` | `20` | Number of candidates handed to the Stage-2 picker. |
@@ -135,7 +135,7 @@ The selector runs in two stages. Tunables live in `criticality_scorer.py`
 Score formula:
 ```
 criticality = w_tier·(4 - tier) + w_fan_in·log(fan_in+1)/log(peak+1) + w_churn·log(churn+1)/log(peak+1)
-gap         = (1 - coverage) · log(min(uncovered_lines, 300) + 1)
+gap         = (1 - coverage) · log(min(uncovered_lines, 500) + 1)
 score       = criticality · gap
 ```
 

--- a/src/scripts/testbot/SELECT_TARGETS_PROMPT.md
+++ b/src/scripts/testbot/SELECT_TARGETS_PROMPT.md
@@ -1,0 +1,75 @@
+You are the **target picker** for OSMO's testbot. A heuristic upstream of you
+has produced a shortlist of {shortlist_count} files ranked by
+
+    criticality_score = tier + log(fan_in) + log(churn)
+    coverage_gap      = (1 - coverage) * log(uncovered_lines)
+    final             = criticality_score * coverage_gap
+
+Your job: choose **at most {max_targets}** files from this shortlist where new
+unit tests would yield the highest ROI. The downstream test-generation agent
+will write tests against the file's *public API* — you are picking what the
+tests will cover, not writing them.
+
+## Hard rules
+
+1. Pick files where good unit tests are *feasible* without spinning up real
+   infrastructure. Reading the file is the only way to tell.
+2. **Reject the entire shortlist** (return an empty list) if none of the files
+   meet the bar. Skipping a day is fine — burning the budget on low-ROI work
+   is not.
+3. Output **valid JSON** in a fenced ```json``` block. No prose outside the
+   block. Use exactly this shape:
+
+   ```json
+   {{
+     "targets": [
+       {{
+         "file_path": "src/lib/utils/...",
+         "reason": "1-2 sentence explanation"
+       }}
+     ]
+   }}
+   ```
+
+## Prefer
+
+- **Pure functions / data transformations** with clear inputs and outputs
+  (validators, parsers, formatters, score/quota math, path/URL helpers).
+- **Public API surfaces** that other modules depend on — files in `src/lib/`,
+  `src/utils/`, FastAPI route handlers in `src/service/core/`, CLI commands.
+- **High-fan-in AND high-churn** files — actively-evolving hubs where bugs
+  cause wide blowback.
+- **Clearly-scoped error paths** that are easy to exercise — argument
+  validation, schema checks, retry/backoff logic.
+
+## Avoid
+
+- Heavy I/O glue: database connectors, K8s API wrappers, raw network code.
+  Tests need testcontainers or mocks-of-mocks; coverage gain is shallow.
+- Long-running orchestration: background workers, lifecycle controllers,
+  WebSocket servers. Hard to unit test, easy to write tests that don't catch
+  real regressions.
+- Code dominated by SDK calls (boto3, kubernetes client, FastAPI internals).
+- Files where most uncovered lines are simple delegation/re-export.
+- Anything where you can't articulate a concrete public function whose
+  contract a test would lock down.
+
+## How to decide
+
+For each candidate (in the order given — they are pre-ranked):
+
+1. `Read` the file.
+2. Spot the public functions/classes the file exports. Count those whose
+   inputs/outputs you can describe in one sentence each.
+3. If you can describe at least one such contract, the file is a candidate.
+4. If the file is mostly I/O glue, orchestration, or thin wrappers around an
+   SDK, drop it.
+5. Stop reading once you have {max_targets} good picks.
+
+## Shortlist (pre-ranked, highest score first)
+
+{candidates}
+
+## Now decide
+
+Pick at most {max_targets} files and emit the JSON block.

--- a/src/scripts/testbot/coverage_targets.py
+++ b/src/scripts/testbot/coverage_targets.py
@@ -46,6 +46,10 @@ SKIP_BASENAME_PATTERNS = [
 MIN_FILE_LINES = 10
 MAX_FILE_LINES = 0  # 0 = no cap
 
+# Codecov line_coverage format: [[line_num, status], ...]
+CODECOV_LINE_HIT = 0
+CODECOV_LINE_MISS = 1
+
 # Language priority bucket — lower value picked first within a target run.
 # Backend code (Python, Go) gets the limited test-generation budget before
 # frontend (TS/TSX) at the same coverage level; UI files are still eligible
@@ -152,30 +156,24 @@ def fetch_codecov_report(
         sys.exit(1)
 
 
-def select_targets(
+def parse_coverage_entries(
     report: dict,
-    max_targets: int,
     max_uncovered: int,
 ) -> list[dict]:
-    """Parse the Codecov report and return the lowest-coverage targets.
+    """Convert a Codecov report into per-file coverage entries.
 
-    Args:
-        report: Raw JSON response from the Codecov API.
-        max_targets: Maximum number of files to return.
-        max_uncovered: Cap on uncovered lines per target (0 = no cap).
-
-    Returns:
-        A list of target dicts with keys: file_path, coverage_pct,
-        uncovered_lines, uncovered_ranges.
+    Returns a list of dicts with keys: ``file_path``, ``coverage_pct``,
+    ``uncovered_lines``, ``uncovered_ranges``, ``loc``. No ranking or
+    truncation — callers (``select_targets``, ``criticality_scorer``)
+    apply their own ordering and slicing.
     """
     entries = []
     for file_report in report.get("files", []):
         file_path = file_report["name"]
-
         if _is_ignored(file_path):
             continue
 
-        line_coverage = file_report.get("line_coverage", [])
+        line_coverage = file_report.get("line_coverage") or []
         if not line_coverage:
             continue
 
@@ -185,14 +183,12 @@ def select_targets(
         if 0 < MAX_FILE_LINES < total_lines:
             continue
 
-        # Codecov line_coverage format: [[line_num, status], ...]
-        # where 0 = hit (covered), 1 = miss (uncovered)
         covered = 0
-        uncovered_numbers = []
+        uncovered_numbers: list[int] = []
         for line, status in line_coverage:
-            if status == 0:
+            if status == CODECOV_LINE_HIT:
                 covered += 1
-            elif status == 1:
+            elif status == CODECOV_LINE_MISS:
                 uncovered_numbers.append(line)
         uncovered_numbers.sort()
         coverage_pct = (covered / total_lines * 100) if total_lines else 0.0
@@ -210,10 +206,22 @@ def select_targets(
             "coverage_pct": coverage_pct,
             "uncovered_lines": uncovered_line_count,
             "uncovered_ranges": uncovered_ranges,
+            "loc": total_lines,
         })
+    return entries
 
-    # Primary: language priority (backend before frontend).
-    # Secondary: coverage_pct ascending (worst coverage first within bucket).
+
+def select_targets(
+    report: dict,
+    max_targets: int,
+    max_uncovered: int,
+) -> list[dict]:
+    """Return the lowest-coverage Codecov files for test generation.
+
+    Primary sort: language priority (backend before frontend).
+    Secondary: coverage_pct ascending (worst coverage first).
+    """
+    entries = parse_coverage_entries(report, max_uncovered)
     entries.sort(key=lambda entry: (
         _language_priority(entry["file_path"]),
         entry["coverage_pct"],
@@ -221,10 +229,17 @@ def select_targets(
     return entries[:max_targets]
 
 
-def format_targets(targets: list[dict]) -> str:
-    """Format targets as structured text for the Claude Code prompt."""
+def format_targets(
+    targets: list[dict],
+    empty_message: str = "No coverage targets found.",
+) -> str:
+    """Format targets as structured text for the Claude Code prompt.
+
+    A ``reason`` string on a target (set by the Stage-2 picker) is rendered
+    as a ``Why this file:`` line so the rationale lands in the PR description.
+    """
     if not targets:
-        return "No coverage targets found."
+        return empty_message
 
     lines: list[str] = []
     for i, target in enumerate(targets, start=1):
@@ -238,6 +253,8 @@ def format_targets(targets: list[dict]) -> str:
             f"({target["uncovered_lines"]} uncovered lines)"
         )
         lines.append(f"Uncovered ranges: {ranges_str}")
+        if target.get("reason"):
+            lines.append(f"Why this file: {target["reason"]}")
         lines.append("")
     return "\n".join(lines)
 

--- a/src/scripts/testbot/criticality_scorer.py
+++ b/src/scripts/testbot/criticality_scorer.py
@@ -1,0 +1,465 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+# SPDX-License-Identifier: Apache-2.0
+"""Rank OSMO files by criticality x coverage gap.
+
+The "select coverage targets" step in testbot used to sort files purely by
+coverage percentage, which let trivial low-coverage files dominate the budget
+(a one-off handler at 0% would beat a heavily-imported public API at 30%).
+
+This module enriches each candidate with three cheap static signals:
+
+  * **tier**       — path-prefix bucket (lib/utils > service/core > scripts)
+  * **fan_in**     — repo-internal reverse imports (Python AST + Go scan)
+  * **churn**      — git commits touching the file in the last 6 months
+
+and combines them with the coverage gap into a single score so the heuristic
+short-list passed to the LLM target picker is biased toward the files whose
+under-coverage actually matters.
+
+Output: JSON list of the top N candidates with a per-signal breakdown so the
+LLM picker (and humans reviewing the workflow log) can see *why* each was
+ranked where it was.
+
+Usage:
+    python criticality_scorer.py \
+        --token $CODECOV_TOKEN \
+        --repo-root . \
+        --shortlist-size 20 \
+        --output /tmp/shortlist.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import dataclasses
+import json
+import logging
+import math
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from src.scripts.testbot.coverage_targets import (
+    _cap_ranges,
+    _is_ignored,
+    _lines_to_ranges,
+    fetch_codecov_report,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Path-prefix tiers. Lower = more critical. Matches the AGENTS.md categorization
+# (lib/ and utils/ are widely-imported foundations; service/core is the FastAPI
+# core; cli + runtime are user/runtime-facing; supporting services and the
+# operator land in tier 3; everything else falls through to 4).
+TIER_PREFIXES: list[tuple[str, int]] = [
+    ("src/lib/", 0),
+    ("src/utils/", 0),
+    ("src/runtime/pkg/", 0),
+    ("src/service/core/", 1),
+    ("src/cli/", 2),
+    ("src/runtime/cmd/", 2),
+    ("src/service/router/", 3),
+    ("src/service/worker/", 3),
+    ("src/service/agent/", 3),
+    ("src/service/logger/", 3),
+    ("src/service/delayed_job_monitor/", 3),
+    ("src/service/authz_sidecar/", 3),
+    ("src/operator/", 3),
+]
+DEFAULT_TIER = 4
+
+# Files that pass _is_ignored but are still poor test targets:
+# - generated barrels and trivial wrappers
+# - vendored third-party code
+# - docs / type-only files
+EXTRA_SKIP_PATTERNS: tuple[str, ...] = (
+    "src/ui/src/lib/api/generated.ts",
+    "vendor/",
+    "node_modules/",
+)
+
+MIN_LOC = 30  # Skip trivial files; tiny modules give shallow coverage gain.
+
+CHURN_SINCE = "6 months ago"
+
+# Match Go imports inside the `import (...)` block (whitespace + quoted path)
+# or single-line `import "fmt"` (any preceding text + quoted path).
+GO_BLOCK_IMPORT_RE = re.compile(r'^\s*(?:[a-zA-Z_][\w]*\s+)?"([^"]+)"', re.MULTILINE)
+GO_INLINE_IMPORT_RE = re.compile(r'"([^"]+)"')
+GO_PACKAGE_PREFIX = "go.corp.nvidia.com/osmo/"
+
+
+@dataclasses.dataclass(frozen=True)
+class Weights:
+    """Tunable weights for the criticality score."""
+    tier: float = 1.0
+    fan_in: float = 1.5
+    churn: float = 0.8
+
+
+@dataclasses.dataclass
+class RankedTarget:
+    """One file's full score breakdown for the LLM picker."""
+    file_path: str
+    coverage_pct: float
+    uncovered_lines: int
+    uncovered_ranges: list[tuple[int, int]]
+    tier: int
+    fan_in: int
+    churn: int
+    loc: int
+    score: float
+    score_breakdown: dict[str, float]
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+
+def classify_tier(file_path: str) -> int:
+    """Return the criticality tier (lower = more critical) for a path."""
+    for prefix, tier in TIER_PREFIXES:
+        if file_path.startswith(prefix):
+            return tier
+    return DEFAULT_TIER
+
+
+def _extra_skip(file_path: str) -> bool:
+    return any(token in file_path for token in EXTRA_SKIP_PATTERNS)
+
+
+def _python_module_name(path: Path, repo_root: Path) -> str:
+    """Convert ``src/lib/utils/client.py`` to ``src.lib.utils.client``."""
+    rel = path.relative_to(repo_root).with_suffix("")
+    return ".".join(rel.parts)
+
+
+def _walk_files(repo_root: Path, suffixes: tuple[str, ...]) -> list[Path]:
+    """List repo files matching any of the suffixes, excluding ignored paths."""
+    results: list[Path] = []
+    for path in repo_root.rglob("*"):
+        if not path.is_file() or path.suffix not in suffixes:
+            continue
+        try:
+            rel = str(path.relative_to(repo_root))
+        except ValueError:
+            continue
+        if _is_ignored(rel) or _extra_skip(rel):
+            continue
+        results.append(path)
+    return results
+
+
+def _python_imports(path: Path) -> set[str]:
+    """Return the set of dotted module names imported by a Python file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except SyntaxError:
+        return set()
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                modules.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            modules.add(node.module)
+    return modules
+
+
+def build_python_fan_in(repo_root: Path) -> dict[str, int]:
+    """Walk all repo Python files and count repo-internal reverse imports.
+
+    Returns a dict from relative file path (e.g. ``src/lib/utils/client.py``)
+    to the number of *other* repo files that import that module. Imports that
+    don't resolve to a file in the repo (third-party, stdlib) are dropped.
+    """
+    files = _walk_files(repo_root, (".py",))
+    module_to_path: dict[str, str] = {}
+    for path in files:
+        module_to_path[_python_module_name(path, repo_root)] = str(
+            path.relative_to(repo_root)
+        )
+    counts: dict[str, int] = {p: 0 for p in module_to_path.values()}
+    for path in files:
+        for module in _python_imports(path):
+            target = module_to_path.get(module)
+            if target is None or target == str(path.relative_to(repo_root)):
+                continue
+            counts[target] = counts.get(target, 0) + 1
+    return counts
+
+
+def _go_package_for_file(path: Path, repo_root: Path) -> str:
+    """Return ``go.corp.nvidia.com/osmo/<dir>`` for a Go source file."""
+    rel = path.relative_to(repo_root).parent
+    return GO_PACKAGE_PREFIX + str(rel).replace(os.sep, "/").removeprefix("src/")
+
+
+def _go_imports(path: Path) -> set[str]:
+    """Pull import paths out of a Go file via regex (no full parser needed)."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return set()
+    in_block = False
+    imports: set[str] = set()
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("import ("):
+            in_block = True
+            continue
+        if in_block:
+            if stripped == ")":
+                in_block = False
+                continue
+            match = GO_BLOCK_IMPORT_RE.match(line)
+            if match:
+                imports.add(match.group(1))
+        elif stripped.startswith("import "):
+            match = GO_INLINE_IMPORT_RE.search(stripped)
+            if match:
+                imports.add(match.group(1))
+    return imports
+
+
+def build_go_fan_in(repo_root: Path) -> dict[str, int]:
+    """Count repo-internal Go reverse package imports, distributed across files.
+
+    A package's fan-in is shared equally across the files in that package, so
+    a leaf file in a popular package gets credit for the package's imports.
+    """
+    files = _walk_files(repo_root, (".go",))
+    package_files: dict[str, list[Path]] = {}
+    for path in files:
+        pkg = _go_package_for_file(path, repo_root)
+        package_files.setdefault(pkg, []).append(path)
+    package_imports: dict[str, set[str]] = {}
+    for path in files:
+        pkg = _go_package_for_file(path, repo_root)
+        package_imports.setdefault(pkg, set()).update(_go_imports(path))
+    package_fan_in: dict[str, int] = {pkg: 0 for pkg in package_files}
+    for pkg, imports in package_imports.items():
+        for imp in imports:
+            if imp in package_fan_in and imp != pkg:
+                package_fan_in[imp] += 1
+    file_fan_in: dict[str, int] = {}
+    for pkg, paths in package_files.items():
+        share = package_fan_in[pkg] // max(len(paths), 1)
+        for path in paths:
+            file_fan_in[str(path.relative_to(repo_root))] = share
+    return file_fan_in
+
+
+def compute_churn(
+    repo_root: Path,
+    since: str = CHURN_SINCE,
+) -> dict[str, int]:
+    """Return per-file commit count for the time window via ``git log``."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "log",
+             f"--since={since}", "--pretty=format:", "--name-only"],
+            capture_output=True, text=True, check=True, timeout=120,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        logger.warning("git log failed: %s; churn will be zero everywhere", exc)
+        return {}
+    counts: dict[str, int] = {}
+    for line in result.stdout.splitlines():
+        path = line.strip()
+        if path:
+            counts[path] = counts.get(path, 0) + 1
+    return counts
+
+
+def _normalize(value: int, peak: int) -> float:
+    """Log-normalize so one mega-hub doesn't swamp every other signal."""
+    if peak <= 0:
+        return 0.0
+    return math.log(value + 1) / math.log(peak + 1)
+
+
+def score_entry(
+    *,
+    tier: int,
+    fan_in: int,
+    churn: int,
+    coverage_pct: float,
+    uncovered_lines: int,
+    peak_fan_in: int,
+    peak_churn: int,
+    weights: Weights,
+) -> tuple[float, dict[str, float]]:
+    """Compute the final score and per-component breakdown."""
+    tier_term = weights.tier * (DEFAULT_TIER - tier)
+    fan_in_term = weights.fan_in * _normalize(fan_in, peak_fan_in)
+    churn_term = weights.churn * _normalize(churn, peak_churn)
+    criticality = tier_term + fan_in_term + churn_term
+    gap = (1.0 - coverage_pct / 100.0) * math.log(min(uncovered_lines, 300) + 1)
+    final = criticality * gap
+    breakdown = {
+        "tier": round(tier_term, 4),
+        "fan_in": round(fan_in_term, 4),
+        "churn": round(churn_term, 4),
+        "criticality": round(criticality, 4),
+        "gap": round(gap, 4),
+    }
+    return final, breakdown
+
+
+def _coverage_entries(report: dict, max_uncovered: int) -> list[dict]:
+    """Mirror coverage_targets.select_targets but return *all* candidates."""
+    entries: list[dict] = []
+    for file_report in report.get("files", []):
+        file_path = file_report["name"]
+        if _is_ignored(file_path) or _extra_skip(file_path):
+            continue
+        line_coverage = file_report.get("line_coverage") or []
+        if not line_coverage:
+            continue
+        total_lines = len(line_coverage)
+        if total_lines < MIN_LOC:
+            continue
+        covered = 0
+        uncovered_numbers: list[int] = []
+        for line, status in line_coverage:
+            if status == 0:
+                covered += 1
+            elif status == 1:
+                uncovered_numbers.append(line)
+        uncovered_numbers.sort()
+        coverage_pct = (covered / total_lines * 100) if total_lines else 0.0
+        ranges = _lines_to_ranges(uncovered_numbers)
+        if max_uncovered > 0:
+            ranges = _cap_ranges(ranges, max_uncovered)
+        uncovered_count = sum(e - s + 1 for s, e in ranges)
+        if uncovered_count == 0:
+            continue
+        entries.append({
+            "file_path": file_path,
+            "coverage_pct": coverage_pct,
+            "uncovered_lines": uncovered_count,
+            "uncovered_ranges": ranges,
+            "loc": total_lines,
+        })
+    return entries
+
+
+def rank_targets(
+    report: dict,
+    repo_root: Path,
+    *,
+    shortlist_size: int,
+    max_uncovered: int,
+    weights: Weights,
+    fan_in: dict[str, int] | None = None,
+    churn: dict[str, int] | None = None,
+) -> list[RankedTarget]:
+    """Build the ranked shortlist."""
+    entries = _coverage_entries(report, max_uncovered)
+    if fan_in is None:
+        py_fan_in = build_python_fan_in(repo_root)
+        go_fan_in = build_go_fan_in(repo_root)
+        fan_in = {**py_fan_in, **go_fan_in}
+    if churn is None:
+        churn = compute_churn(repo_root)
+
+    peak_fan_in = max(fan_in.values(), default=0)
+    peak_churn = max(churn.values(), default=0)
+
+    ranked: list[RankedTarget] = []
+    for entry in entries:
+        path = entry["file_path"]
+        tier = classify_tier(path)
+        file_fan_in = fan_in.get(path, 0)
+        file_churn = churn.get(path, 0)
+        score, breakdown = score_entry(
+            tier=tier,
+            fan_in=file_fan_in,
+            churn=file_churn,
+            coverage_pct=entry["coverage_pct"],
+            uncovered_lines=entry["uncovered_lines"],
+            peak_fan_in=peak_fan_in,
+            peak_churn=peak_churn,
+            weights=weights,
+        )
+        ranked.append(RankedTarget(
+            file_path=path,
+            coverage_pct=entry["coverage_pct"],
+            uncovered_lines=entry["uncovered_lines"],
+            uncovered_ranges=entry["uncovered_ranges"],
+            tier=tier,
+            fan_in=file_fan_in,
+            churn=file_churn,
+            loc=entry["loc"],
+            score=round(score, 4),
+            score_breakdown=breakdown,
+        ))
+    ranked.sort(key=lambda r: r.score, reverse=True)
+    return ranked[:shortlist_size]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--token", default="",
+                        help="Codecov API token (or set CODECOV_TOKEN env var)")
+    parser.add_argument("--repo-root", default=".",
+                        help="Path to the OSMO repo root (default: cwd)")
+    parser.add_argument("--shortlist-size", type=int, default=20)
+    parser.add_argument("--max-uncovered", type=int, default=300,
+                        help="Cap uncovered lines per target (0 = no cap)")
+    parser.add_argument("--output", default="-",
+                        help="Output path; '-' (default) writes to stdout")
+    parser.add_argument("--weight-tier", type=float, default=Weights.tier)
+    parser.add_argument("--weight-fan-in", type=float, default=Weights.fan_in)
+    parser.add_argument("--weight-churn", type=float, default=Weights.churn)
+    args = parser.parse_args()
+
+    token = args.token or os.environ.get("CODECOV_TOKEN", "")
+    if not token:
+        logger.error("No Codecov token. Use --token or set CODECOV_TOKEN.")
+        sys.exit(1)
+
+    repo_root = Path(args.repo_root).resolve()
+    weights = Weights(
+        tier=args.weight_tier,
+        fan_in=args.weight_fan_in,
+        churn=args.weight_churn,
+    )
+
+    report = fetch_codecov_report(token)
+    logger.info("Codecov: %d files, %.1f%% overall coverage",
+                report["totals"]["files"], report["totals"]["coverage"])
+
+    ranked = rank_targets(
+        report,
+        repo_root,
+        shortlist_size=args.shortlist_size,
+        max_uncovered=args.max_uncovered,
+        weights=weights,
+    )
+    logger.info("Top %d shortlist:", len(ranked))
+    for rank, target in enumerate(ranked, start=1):
+        logger.info(
+            "  %2d. score=%.2f tier=%d fan_in=%d churn=%d cov=%.1f%% %s",
+            rank, target.score, target.tier, target.fan_in,
+            target.churn, target.coverage_pct, target.file_path,
+        )
+
+    payload = json.dumps(
+        [target.to_dict() for target in ranked],
+        indent=2,
+        default=list,
+    )
+    if args.output == "-":
+        print(payload)
+    else:
+        Path(args.output).write_text(payload, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/testbot/criticality_scorer.py
+++ b/src/scripts/testbot/criticality_scorer.py
@@ -41,6 +41,7 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 from src.scripts.testbot.coverage_targets import (
@@ -146,41 +147,59 @@ def _python_module_name(path: Path, repo_root: Path) -> str:
     return ".".join(rel.parts)
 
 
+# Directory subtrees we never want to descend into. Pruning at os.walk time
+# avoids stat'ing every file in heavy trees like src/ui/node_modules (~645MB
+# of npm packages on the OSMO repo). The names mirror IGNORE_PATTERNS /
+# EXTRA_SKIP_PATTERNS but applied as directory prunes instead of per-file
+# filters.
+PRUNE_DIR_NAMES = frozenset({
+    "node_modules", "vendor", "tests", "__pycache__", ".git",
+})
+PRUNE_ROOTED_DIRS = frozenset({"src/scripts", "bzl", "run", "deployments"})
+
+
+def _iter_repo_files(repo_root: Path) -> Iterator[tuple[Path, str]]:
+    """Walk the repo, pruning ignored subtrees, yielding (path, rel_str)."""
+    for root, dirnames, filenames in os.walk(repo_root):
+        rel_root = os.path.relpath(root, repo_root)
+        rel_root_norm = "" if rel_root == "." else rel_root.replace(os.sep, "/")
+        kept: list[str] = []
+        for dirname in dirnames:
+            if dirname in PRUNE_DIR_NAMES or dirname.startswith("."):
+                continue
+            sub = f"{rel_root_norm}/{dirname}" if rel_root_norm else dirname
+            if sub in PRUNE_ROOTED_DIRS:
+                continue
+            kept.append(dirname)
+        dirnames[:] = kept
+        for filename in filenames:
+            rel = f"{rel_root_norm}/{filename}" if rel_root_norm else filename
+            yield Path(root) / filename, rel
+
+
 def _walk_files(repo_root: Path, suffixes: tuple[str, ...]) -> list[Path]:
     """List repo files matching any of the suffixes, excluding ignored paths."""
-    results: list[Path] = []
-    for path in repo_root.rglob("*"):
-        if not path.is_file() or path.suffix not in suffixes:
-            continue
-        try:
-            rel = str(path.relative_to(repo_root))
-        except ValueError:
-            continue
-        if _is_ignored(rel) or _extra_skip(rel):
-            continue
-        results.append(path)
-    return results
+    return [
+        path for path, rel in _iter_repo_files(repo_root)
+        if path.suffix in suffixes
+        and not _is_ignored(rel)
+        and not _extra_skip(rel)
+    ]
 
 
 def _walk_init_files(repo_root: Path) -> list[Path]:
     """List ``__init__.py`` files for re-export resolution.
 
     Unlike ``_walk_files``, this keeps ``__init__.py`` through the filter —
-    we still apply ``IGNORE_PATTERNS`` (skip tests, scripts, deployments)
-    but ignore ``SKIP_BASENAME_PATTERNS`` since ``__init__.py`` is exactly
-    what we want to read here.
+    ``IGNORE_PATTERNS`` still applies but ``SKIP_BASENAME_PATTERNS`` doesn't
+    since ``__init__.py`` is exactly what we want to read here.
     """
-    results: list[Path] = []
-    for path in repo_root.rglob("__init__.py"):
-        if not path.is_file():
-            continue
-        rel = str(path.relative_to(repo_root))
-        if any(fnmatch.fnmatch(rel, pattern) for pattern in IGNORE_PATTERNS):
-            continue
-        if _extra_skip(rel):
-            continue
-        results.append(path)
-    return results
+    return [
+        path for path, rel in _iter_repo_files(repo_root)
+        if path.name == "__init__.py"
+        and not any(fnmatch.fnmatch(rel, pattern) for pattern in IGNORE_PATTERNS)
+        and not _extra_skip(rel)
+    ]
 
 
 def _python_imports(path: Path) -> set[str]:
@@ -247,8 +266,17 @@ def _re_export_targets(
             if node.level != 1 or not node.module:
                 continue
             sub_parts = node.module.split(".")
-            target_file = package_dir.joinpath(*sub_parts).with_suffix(".py")
-            target_str = str(target_file).replace(os.sep, "/")
+            # Try `<sub>.py` first; if that doesn't exist, fall back to
+            # `<sub>/__init__.py` so `from .backends import X` resolves to
+            # backends/__init__.py instead of a phantom backends.py.
+            module_target = package_dir.joinpath(*sub_parts).with_suffix(".py")
+            package_target = package_dir.joinpath(*sub_parts, "__init__.py")
+            if (repo_root / module_target).exists():
+                target_str = str(module_target).replace(os.sep, "/")
+            elif (repo_root / package_target).exists():
+                target_str = str(package_target).replace(os.sep, "/")
+            else:
+                continue
             files_in_init.add(target_str)
             for alias in node.names:
                 if alias.name == "*":

--- a/src/scripts/testbot/criticality_scorer.py
+++ b/src/scripts/testbot/criticality_scorer.py
@@ -550,9 +550,11 @@ def main() -> None:
     logger.info("Top %d shortlist:", len(ranked))
     for rank, target in enumerate(ranked, start=1):
         logger.info(
-            "  %2d. score=%.2f tier=%d fan_in=%d churn=%d cov=%.1f%% %s",
+            "  %2d. score=%.2f tier=%d fan_in=%d churn=%d "
+            "cov=%.1f%% uncov=%d %s",
             rank, target.score, target.tier, target.fan_in,
-            target.churn, target.coverage_pct, target.file_path,
+            target.churn, target.coverage_pct, target.uncovered_lines,
+            target.file_path,
         )
 
     payload = json.dumps(

--- a/src/scripts/testbot/criticality_scorer.py
+++ b/src/scripts/testbot/criticality_scorer.py
@@ -45,10 +45,9 @@ from pathlib import Path
 
 from src.scripts.testbot.coverage_targets import (
     IGNORE_PATTERNS,
-    _cap_ranges,
     _is_ignored,
-    _lines_to_ranges,
     fetch_codecov_report,
+    parse_coverage_entries,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -85,7 +84,7 @@ EXTRA_SKIP_PATTERNS: tuple[str, ...] = (
     "node_modules/",
 )
 
-MIN_LOC = 30  # Skip trivial files; tiny modules give shallow coverage gain.
+MIN_LOC = 30
 
 CHURN_SINCE = "6 months ago"
 
@@ -245,9 +244,6 @@ def _re_export_targets(
         for node in ast.walk(tree):
             if not isinstance(node, ast.ImportFrom):
                 continue
-            # 1-level relative imports only (``from .X import Y``).
-            # Higher levels (``from ..pkg import Z``) need parent-traversal
-            # logic that hasn't been worth the complexity yet.
             if node.level != 1 or not node.module:
                 continue
             sub_parts = node.module.split(".")
@@ -277,21 +273,21 @@ def build_python_fan_in(repo_root: Path) -> dict[str, int]:
          credit every file that ``storage/__init__.py`` imports from)
     """
     files = _walk_files(repo_root, (".py",))
-    module_to_path: dict[str, str] = {}
-    for path in files:
-        module_to_path[_python_module_name(path, repo_root)] = str(
-            path.relative_to(repo_root)
-        )
+    rel_for: dict[Path, str] = {
+        path: str(path.relative_to(repo_root)) for path in files
+    }
+    module_to_path: dict[str, str] = {
+        _python_module_name(path, repo_root): rel_for[path] for path in files
+    }
     aliases, package_re_exports = _re_export_targets(repo_root)
     for alias_module, alias_target in aliases.items():
         module_to_path.setdefault(alias_module, alias_target)
     counts: dict[str, int] = {p: 0 for p in module_to_path.values()}
     for path in files:
-        importer_rel = str(path.relative_to(repo_root))
-        # Dedup: a file that imports both `Client` and `SingleObjectClient`
-        # from the same package (both resolving to client.py) should add
-        # exactly 1 to client.py's fan-in, not 2. The same set also collapses
-        # the overlap between alias resolution and package expansion.
+        importer_rel = rel_for[path]
+        # Dedup so a file that imports both `Client` and `SingleObjectClient`
+        # adds 1 to client.py, not 2 — also collapses the alias/package
+        # expansion overlap.
         resolved: set[str] = set()
         for module in _python_imports(path):
             target = module_to_path.get(module)
@@ -346,12 +342,10 @@ def build_go_fan_in(repo_root: Path) -> dict[str, int]:
     """
     files = _walk_files(repo_root, (".go",))
     package_files: dict[str, list[Path]] = {}
-    for path in files:
-        pkg = _go_package_for_file(path, repo_root)
-        package_files.setdefault(pkg, []).append(path)
     package_imports: dict[str, set[str]] = {}
     for path in files:
         pkg = _go_package_for_file(path, repo_root)
+        package_files.setdefault(pkg, []).append(path)
         package_imports.setdefault(pkg, set()).update(_go_imports(path))
     package_fan_in: dict[str, int] = {pkg: 0 for pkg in package_files}
     for pkg, imports in package_imports.items():
@@ -423,44 +417,6 @@ def score_entry(
     return final, breakdown
 
 
-def _coverage_entries(report: dict, max_uncovered: int) -> list[dict]:
-    """Mirror coverage_targets.select_targets but return *all* candidates."""
-    entries: list[dict] = []
-    for file_report in report.get("files", []):
-        file_path = file_report["name"]
-        if _is_ignored(file_path) or _extra_skip(file_path):
-            continue
-        line_coverage = file_report.get("line_coverage") or []
-        if not line_coverage:
-            continue
-        total_lines = len(line_coverage)
-        if total_lines < MIN_LOC:
-            continue
-        covered = 0
-        uncovered_numbers: list[int] = []
-        for line, status in line_coverage:
-            if status == 0:
-                covered += 1
-            elif status == 1:
-                uncovered_numbers.append(line)
-        uncovered_numbers.sort()
-        coverage_pct = (covered / total_lines * 100) if total_lines else 0.0
-        ranges = _lines_to_ranges(uncovered_numbers)
-        if max_uncovered > 0:
-            ranges = _cap_ranges(ranges, max_uncovered)
-        uncovered_count = sum(e - s + 1 for s, e in ranges)
-        if uncovered_count == 0:
-            continue
-        entries.append({
-            "file_path": file_path,
-            "coverage_pct": coverage_pct,
-            "uncovered_lines": uncovered_count,
-            "uncovered_ranges": ranges,
-            "loc": total_lines,
-        })
-    return entries
-
-
 def rank_targets(
     report: dict,
     repo_root: Path,
@@ -472,7 +428,10 @@ def rank_targets(
     churn: dict[str, int] | None = None,
 ) -> list[RankedTarget]:
     """Build the ranked shortlist."""
-    entries = _coverage_entries(report, max_uncovered)
+    entries = [
+        entry for entry in parse_coverage_entries(report, max_uncovered)
+        if not _extra_skip(entry["file_path"]) and entry["loc"] >= MIN_LOC
+    ]
     if fan_in is None:
         py_fan_in = build_python_fan_in(repo_root)
         go_fan_in = build_go_fan_in(repo_root)

--- a/src/scripts/testbot/criticality_scorer.py
+++ b/src/scripts/testbot/criticality_scorer.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import ast
 import dataclasses
+import fnmatch
 import json
 import logging
 import math
@@ -43,6 +44,7 @@ import sys
 from pathlib import Path
 
 from src.scripts.testbot.coverage_targets import (
+    IGNORE_PATTERNS,
     _cap_ranges,
     _is_ignored,
     _lines_to_ranges,
@@ -154,8 +156,40 @@ def _walk_files(repo_root: Path, suffixes: tuple[str, ...]) -> list[Path]:
     return results
 
 
+def _walk_init_files(repo_root: Path) -> list[Path]:
+    """List ``__init__.py`` files for re-export resolution.
+
+    Unlike ``_walk_files``, this keeps ``__init__.py`` through the filter —
+    we still apply ``IGNORE_PATTERNS`` (skip tests, scripts, deployments)
+    but ignore ``SKIP_BASENAME_PATTERNS`` since ``__init__.py`` is exactly
+    what we want to read here.
+    """
+    results: list[Path] = []
+    for path in repo_root.rglob("__init__.py"):
+        if not path.is_file():
+            continue
+        rel = str(path.relative_to(repo_root))
+        if any(fnmatch.fnmatch(rel, pattern) for pattern in IGNORE_PATTERNS):
+            continue
+        if _extra_skip(rel):
+            continue
+        results.append(path)
+    return results
+
+
 def _python_imports(path: Path) -> set[str]:
-    """Return the set of dotted module names imported by a Python file."""
+    """Return the set of dotted module names imported by a Python file.
+
+    OSMO uses ``from src.utils.job import jobs, workflow, task`` style heavily.
+    For those, we record both the source package (``src.utils.job``) and each
+    imported name as a candidate submodule (``src.utils.job.jobs``,
+    ``src.utils.job.workflow``, etc.). The fan-in resolver only counts the
+    candidates that resolve to an actual file in the repo, so this is safe
+    even when the imported name is a symbol rather than a submodule —
+    ``from src.lib.utils.redact import redact_secrets`` records both
+    ``src.lib.utils.redact`` (which resolves to a file) and
+    ``src.lib.utils.redact.redact_secrets`` (which doesn't, so it's dropped).
+    """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
     except SyntaxError:
@@ -167,7 +201,59 @@ def _python_imports(path: Path) -> set[str]:
                 modules.add(alias.name)
         elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
             modules.add(node.module)
+            for alias in node.names:
+                if alias.name != "*":
+                    modules.add(f"{node.module}.{alias.name}")
     return modules
+
+
+def _re_export_targets(
+    repo_root: Path,
+) -> tuple[dict[str, str], dict[str, set[str]]]:
+    """Parse every ``__init__.py`` for relative-import re-exports.
+
+    Returns two maps:
+
+    * ``aliases`` — ``<package>.<symbol>`` → implementing file, so a caller's
+      ``from src.lib.data.storage import Client`` credits ``client.py``.
+    * ``package_re_exports`` — ``<package>`` → set of files referenced by the
+      package's ``__init__.py``. The dominant OSMO pattern is
+      ``from src.lib.data import storage``: the importer pulls in the
+      package as a name, Python runs ``storage/__init__.py``, and every
+      file it imports from is part of the effective surface. Crediting all
+      of them is more accurate than crediting nothing.
+    """
+    aliases: dict[str, str] = {}
+    package_re_exports: dict[str, set[str]] = {}
+    for init_path in _walk_init_files(repo_root):
+        package_dir = init_path.parent.relative_to(repo_root)
+        if str(package_dir) == ".":
+            continue
+        package_module = ".".join(package_dir.parts)
+        try:
+            tree = ast.parse(init_path.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        files_in_init: set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            # 1-level relative imports only (``from .X import Y``).
+            # Higher levels (``from ..pkg import Z``) need parent-traversal
+            # logic that hasn't been worth the complexity yet.
+            if node.level != 1 or not node.module:
+                continue
+            sub_parts = node.module.split(".")
+            target_file = package_dir.joinpath(*sub_parts).with_suffix(".py")
+            target_str = str(target_file).replace(os.sep, "/")
+            files_in_init.add(target_str)
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                aliases[f"{package_module}.{alias.name}"] = target_str
+        if files_in_init:
+            package_re_exports[package_module] = files_in_init
+    return aliases, package_re_exports
 
 
 def build_python_fan_in(repo_root: Path) -> dict[str, int]:
@@ -176,6 +262,12 @@ def build_python_fan_in(repo_root: Path) -> dict[str, int]:
     Returns a dict from relative file path (e.g. ``src/lib/utils/client.py``)
     to the number of *other* repo files that import that module. Imports that
     don't resolve to a file in the repo (third-party, stdlib) are dropped.
+
+    Resolution order for each imported name:
+      1. Direct submodule (``from src.utils.job import jobs`` -> ``src/utils/job/jobs.py``)
+      2. ``__init__.py`` re-export alias (``from src.lib.data.storage import Client`` -> ``src/lib/data/storage/client.py``)
+      3. Package re-export expansion (``from src.lib.data import storage`` ->
+         credit every file that ``storage/__init__.py`` imports from)
     """
     files = _walk_files(repo_root, (".py",))
     module_to_path: dict[str, str] = {}
@@ -183,12 +275,25 @@ def build_python_fan_in(repo_root: Path) -> dict[str, int]:
         module_to_path[_python_module_name(path, repo_root)] = str(
             path.relative_to(repo_root)
         )
+    aliases, package_re_exports = _re_export_targets(repo_root)
+    for alias_module, alias_target in aliases.items():
+        module_to_path.setdefault(alias_module, alias_target)
     counts: dict[str, int] = {p: 0 for p in module_to_path.values()}
     for path in files:
+        importer_rel = str(path.relative_to(repo_root))
+        # Dedup: a file that imports both `Client` and `SingleObjectClient`
+        # from the same package (both resolving to client.py) should add
+        # exactly 1 to client.py's fan-in, not 2. The same set also collapses
+        # the overlap between alias resolution and package expansion.
+        resolved: set[str] = set()
         for module in _python_imports(path):
             target = module_to_path.get(module)
-            if target is None or target == str(path.relative_to(repo_root)):
-                continue
+            if target is not None and target != importer_rel:
+                resolved.add(target)
+            for pkg_target in package_re_exports.get(module, ()):
+                if pkg_target != importer_rel:
+                    resolved.add(pkg_target)
+        for target in resolved:
             counts[target] = counts.get(target, 0) + 1
     return counts
 

--- a/src/scripts/testbot/criticality_scorer.py
+++ b/src/scripts/testbot/criticality_scorer.py
@@ -202,34 +202,46 @@ def _walk_init_files(repo_root: Path) -> list[Path]:
     ]
 
 
-def _python_imports(path: Path) -> set[str]:
-    """Return the set of dotted module names imported by a Python file.
+def _python_imports(path: Path) -> tuple[set[str], set[str]]:
+    """Classify dotted module names imported by a Python file.
 
-    OSMO uses ``from src.utils.job import jobs, workflow, task`` style heavily.
-    For those, we record both the source package (``src.utils.job``) and each
-    imported name as a candidate submodule (``src.utils.job.jobs``,
-    ``src.utils.job.workflow``, etc.). The fan-in resolver only counts the
-    candidates that resolve to an actual file in the repo, so this is safe
-    even when the imported name is a symbol rather than a submodule —
-    ``from src.lib.utils.redact import redact_secrets`` records both
-    ``src.lib.utils.redact`` (which resolves to a file) and
-    ``src.lib.utils.redact.redact_secrets`` (which doesn't, so it's dropped).
+    Returns ``(direct, package_use)``:
+
+    * ``direct`` — every dotted name that *might* resolve to a single file.
+      Includes both the source of an ``ImportFrom`` (``X`` in
+      ``from X import Y``) and each composed candidate (``X.Y``), plus the
+      target of a plain ``import X.Y.Z``.
+    * ``package_use`` — names the importer binds *as a value* and may
+      access attributes of, so a change anywhere the package's
+      ``__init__.py`` re-exports from could affect the importer.
+      Populated by ``import X.Y.Z`` (top-level package binding) and the
+      composed ``X.Y`` from ``from X import Y`` (since Y could be a
+      sub-package the importer will use as ``Y.something``).
+      Crucially **not** the source ``X`` of ``from X import Y, Z``: in
+      that form the importer never references ``X`` as a value, so the
+      package-expansion fan-in credit for ``X``'s re-export set would be
+      noise.
     """
     try:
         tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
     except SyntaxError:
-        return set()
-    modules: set[str] = set()
+        return set(), set()
+    direct: set[str] = set()
+    package_use: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                modules.add(alias.name)
+                direct.add(alias.name)
+                package_use.add(alias.name)
         elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
-            modules.add(node.module)
+            direct.add(node.module)
             for alias in node.names:
-                if alias.name != "*":
-                    modules.add(f"{node.module}.{alias.name}")
-    return modules
+                if alias.name == "*":
+                    continue
+                composed = f"{node.module}.{alias.name}"
+                direct.add(composed)
+                package_use.add(composed)
+    return direct, package_use
 
 
 def _re_export_targets(
@@ -317,10 +329,20 @@ def build_python_fan_in(repo_root: Path) -> dict[str, int]:
         # adds 1 to client.py, not 2 — also collapses the alias/package
         # expansion overlap.
         resolved: set[str] = set()
-        for module in _python_imports(path):
+        direct, package_use = _python_imports(path)
+        for module in direct:
             target = module_to_path.get(module)
             if target is not None and target != importer_rel:
                 resolved.add(target)
+        # Only expand package re-exports for modules the importer
+        # actually binds as a value (`import X.Y` or `from X import Y`),
+        # and only when the module isn't already a single-file hit.
+        # This avoids over-crediting siblings of a named symbol, e.g.
+        # `from src.lib.data.storage import Client` should credit only
+        # client.py — not every other file storage/__init__.py exports.
+        for module in package_use:
+            if module in module_to_path:
+                continue
             for pkg_target in package_re_exports.get(module, ()):
                 if pkg_target != importer_rel:
                     resolved.add(pkg_target)

--- a/src/scripts/testbot/criticality_scorer.py
+++ b/src/scripts/testbot/criticality_scorer.py
@@ -98,9 +98,16 @@ GO_PACKAGE_PREFIX = "go.corp.nvidia.com/osmo/"
 
 @dataclasses.dataclass(frozen=True)
 class Weights:
-    """Tunable weights for the criticality score."""
+    """Tunable weights for the criticality score.
+
+    fan_in is weighted highest because dependency centrality is the most
+    durable signal of criticality — a hub stays a hub for years, while
+    coverage gaps and recent churn shift week to week. Both fan_in and
+    churn are log-normalized in score_entry so the heaviest hub's
+    contribution is bounded at the weight value itself.
+    """
     tier: float = 1.0
-    fan_in: float = 1.5
+    fan_in: float = 2.5
     churn: float = 0.8
 
 
@@ -404,7 +411,7 @@ def score_entry(
     fan_in_term = weights.fan_in * _normalize(fan_in, peak_fan_in)
     churn_term = weights.churn * _normalize(churn, peak_churn)
     criticality = tier_term + fan_in_term + churn_term
-    gap = (1.0 - coverage_pct / 100.0) * math.log(min(uncovered_lines, 300) + 1)
+    gap = (1.0 - coverage_pct / 100.0) * math.log(min(uncovered_lines, 500) + 1)
     final = criticality * gap
     breakdown = {
         "tier": round(tier_term, 4),
@@ -515,7 +522,7 @@ def main() -> None:
     parser.add_argument("--repo-root", default=".",
                         help="Path to the OSMO repo root (default: cwd)")
     parser.add_argument("--shortlist-size", type=int, default=20)
-    parser.add_argument("--max-uncovered", type=int, default=300,
+    parser.add_argument("--max-uncovered", type=int, default=500,
                         help="Cap uncovered lines per target (0 = no cap)")
     parser.add_argument("--output", default="-",
                         help="Output path; '-' (default) writes to stdout")

--- a/src/scripts/testbot/select_targets_agent.py
+++ b/src/scripts/testbot/select_targets_agent.py
@@ -31,6 +31,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 from pathlib import Path
 
 from src.scripts.testbot.coverage_targets import format_targets
@@ -111,16 +112,27 @@ def _stream_npx(cmd: list[str], stream_log_path: Path, timeout_sec: int) -> int:
                 stdout = proc.stdout
                 if stdout is None:
                     raise RuntimeError("subprocess.Popen returned no stdout")
-                try:
+
+                # Drain stdout from a background thread so proc.wait() can
+                # actually enforce the timeout — a synchronous for-loop
+                # would block until the agent closes its pipe and would
+                # mask a hang where the agent stops writing entirely.
+                def _drain() -> None:
                     for line in stdout:
                         sys.stdout.write(line)
                         logf.write(line)
+
+                drain = threading.Thread(target=_drain, daemon=True)
+                drain.start()
+                try:
                     proc.wait(timeout=timeout_sec)
                 except subprocess.TimeoutExpired:
                     proc.kill()
                     proc.wait()
+                    drain.join(timeout=2.0)
                     logger.error("Claude CLI timed out after %ds", timeout_sec)
                     return 124
+                drain.join(timeout=2.0)
                 return proc.returncode
     finally:
         print("::endgroup::", flush=True)

--- a/src/scripts/testbot/select_targets_agent.py
+++ b/src/scripts/testbot/select_targets_agent.py
@@ -33,6 +33,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+from src.scripts.testbot.coverage_targets import format_targets
+
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -106,9 +108,11 @@ def _stream_npx(cmd: list[str], stream_log_path: Path, timeout_sec: int) -> int:
                 text=True,
                 bufsize=1,
             ) as proc:
-                assert proc.stdout is not None  # bound by stdout=PIPE
+                stdout = proc.stdout
+                if stdout is None:
+                    raise RuntimeError("subprocess.Popen returned no stdout")
                 try:
-                    for line in proc.stdout:
+                    for line in stdout:
                         sys.stdout.write(line)
                         logf.write(line)
                     proc.wait(timeout=timeout_sec)
@@ -272,32 +276,20 @@ def merge_picks_with_shortlist(
     return merged
 
 
+SKIP_MESSAGE = (
+    "No coverage targets selected — shortlist did not contain any "
+    "high-ROI candidates today."
+)
+
+
 def format_targets_markdown(picks: list[dict]) -> str:
-    """Render the final target list in the format coverage_targets.py emits.
+    """Thin wrapper around ``coverage_targets.format_targets``.
 
-    Identical to ``coverage_targets.format_targets`` but with an extra
-    ``Why this file:`` line carrying the LLM's rationale so reviewers can
-    see why it was chosen.
+    Kept as a named symbol so existing tests and imports continue to work;
+    delegates to the shared formatter (which renders ``Why this file:``
+    when a pick carries a ``reason``).
     """
-    if not picks:
-        return "No coverage targets selected — shortlist did not contain any high-ROI candidates today."
-
-    lines: list[str] = []
-    for index, target in enumerate(picks, start=1):
-        ranges_str = ", ".join(
-            f"{s}-{e}" if s != e else str(s)
-            for s, e in target["uncovered_ranges"]
-        )
-        lines.append(f"## Target {index}: {target["file_path"]}")
-        lines.append(
-            f"Coverage: {target["coverage_pct"]:.1f}% "
-            f"({target["uncovered_lines"]} uncovered lines)"
-        )
-        lines.append(f"Uncovered ranges: {ranges_str}")
-        if target.get("reason"):
-            lines.append(f"Why this file: {target["reason"]}")
-        lines.append("")
-    return "\n".join(lines)
+    return format_targets(picks, empty_message=SKIP_MESSAGE)
 
 
 def main() -> None:

--- a/src/scripts/testbot/select_targets_agent.py
+++ b/src/scripts/testbot/select_targets_agent.py
@@ -261,6 +261,9 @@ def merge_picks_with_shortlist(
     by_path = {entry["file_path"]: entry for entry in shortlist}
     merged: list[dict] = []
     for pick in picks:
+        if not isinstance(pick, dict):
+            logger.warning("Skipping non-dict pick: %r", pick)
+            continue
         path = pick.get("file_path")
         if not path:
             logger.warning("Skipping pick with no file_path: %r", pick)
@@ -321,6 +324,12 @@ def main() -> None:
             timeout_sec=args.timeout_sec,
         )
         picks = parse_agent_output(output)
+        if len(picks) > args.max_targets:
+            logger.warning(
+                "Agent returned %d picks; truncating to --max-targets=%d",
+                len(picks), args.max_targets,
+            )
+            picks = picks[:args.max_targets]
         logger.info("Agent picked %d target(s) of %d max", len(picks), args.max_targets)
         merged = merge_picks_with_shortlist(picks, shortlist)
         markdown = format_targets_markdown(merged)

--- a/src/scripts/testbot/select_targets_agent.py
+++ b/src/scripts/testbot/select_targets_agent.py
@@ -107,20 +107,29 @@ def _stream_npx(cmd: list[str], stream_log_path: Path, timeout_sec: int) -> int:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 bufsize=1,
             ) as proc:
                 stdout = proc.stdout
                 if stdout is None:
-                    raise RuntimeError("subprocess.Popen returned no stdout")
+                    # Unreachable when stdout=PIPE; return a sentinel so
+                    # callers still emit diagnostics instead of crashing.
+                    logger.error("subprocess.Popen returned no stdout")
+                    return 1
 
                 # Drain stdout from a background thread so proc.wait() can
                 # actually enforce the timeout — a synchronous for-loop
                 # would block until the agent closes its pipe and would
                 # mask a hang where the agent stops writing entirely.
                 def _drain() -> None:
-                    for line in stdout:
-                        sys.stdout.write(line)
-                        logf.write(line)
+                    try:
+                        for line in stdout:
+                            sys.stdout.write(line)
+                            logf.write(line)
+                    except (ValueError, OSError):
+                        # stdout closed by teardown after a timeout; stop.
+                        pass
 
                 drain = threading.Thread(target=_drain, daemon=True)
                 drain.start()
@@ -129,10 +138,17 @@ def _stream_npx(cmd: list[str], stream_log_path: Path, timeout_sec: int) -> int:
                 except subprocess.TimeoutExpired:
                     proc.kill()
                     proc.wait()
+                    # Pipe is now closed by the OS; the drain loop will
+                    # see EOF and exit. Bound the join in case the
+                    # reader is wedged in some other call.
                     drain.join(timeout=2.0)
                     logger.error("Claude CLI timed out after %ds", timeout_sec)
                     return 124
-                drain.join(timeout=2.0)
+                # Process exited cleanly; the for-loop in _drain has
+                # observed EOF and is about to return. Wait for it
+                # (no timeout) so the final lines flush before we close
+                # logf in the surrounding `with`.
+                drain.join()
                 return proc.returncode
     finally:
         print("::endgroup::", flush=True)

--- a/src/scripts/testbot/select_targets_agent.py
+++ b/src/scripts/testbot/select_targets_agent.py
@@ -26,9 +26,11 @@ import json
 import logging
 import os
 import re
+import secrets
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -77,6 +79,98 @@ def build_prompt(shortlist: list[dict], max_targets: int) -> str:
     )
 
 
+DIAGNOSTIC_KEYS = (
+    "subtype",
+    "is_error",
+    "num_turns",
+    "duration_ms",
+    "duration_api_ms",
+    "total_cost_usd",
+)
+
+
+def _stream_npx(cmd: list[str], stream_log_path: Path, timeout_sec: int) -> int:
+    """Run ``cmd`` streaming stdout into both the workflow log and a JSONL file.
+
+    Returns the subprocess exit code. Wraps the live stream in a foldable
+    ``::group::`` so the per-turn JSON doesn't spam the default workflow view.
+    """
+    print("::group::Claude Code stream — target picker (click to expand)",
+          flush=True)
+    try:
+        with open(stream_log_path, "w", encoding="utf-8") as logf:
+            with subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            ) as proc:
+                assert proc.stdout is not None  # bound by stdout=PIPE
+                try:
+                    for line in proc.stdout:
+                        sys.stdout.write(line)
+                        logf.write(line)
+                    proc.wait(timeout=timeout_sec)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                    logger.error("Claude CLI timed out after %ds", timeout_sec)
+                    return 124
+                return proc.returncode
+    finally:
+        print("::endgroup::", flush=True)
+
+
+def _load_final_result(stream_log_path: Path) -> dict | None:
+    """Pull the final stream-json ``result`` event out of the JSONL log.
+
+    Iterates the file in reverse so we stop at the first match instead of
+    parsing every assistant turn and tool-use line.
+    """
+    if not stream_log_path.exists():
+        return None
+    with open(stream_log_path, encoding="utf-8") as logf:
+        lines = logf.readlines()
+    for line in reversed(lines):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if event.get("type") == "result":
+            return event
+    return None
+
+
+def _emit_diagnostics(final: dict | None, exit_status: int) -> None:
+    """Print a foldable diagnostics block, stop-command-protected.
+
+    Mirrors the ``Claude Code diagnostics`` block on the generate step in
+    testbot.yaml: untrusted ``result`` text is wrapped in
+    ``::stop-commands::`` so it can't inject ``::warning::``,
+    ``::add-mask::``, etc. into the workflow.
+    """
+    stop_token = secrets.token_hex(16)
+    print("::group::Claude Code diagnostics — target picker", flush=True)
+    print(f"::stop-commands::{stop_token}", flush=True)
+    print(f"exit_status: {exit_status}")
+    if final is None:
+        print("no final result message captured")
+    else:
+        for key in DIAGNOSTIC_KEYS:
+            if key in final:
+                print(f"{key}: {final[key]}")
+        result_text = final.get("result")
+        if isinstance(result_text, str) and result_text:
+            print("result:")
+            print(result_text[:2000])
+    print(f"::{stop_token}::", flush=True)
+    print("::endgroup::", flush=True)
+
+
 def invoke_claude(
     prompt: str,
     *,
@@ -84,12 +178,16 @@ def invoke_claude(
     max_turns: int,
     timeout_sec: int,
 ) -> str:
-    """Run ``claude --print`` and return its stdout.
+    """Run the picker subagent and return its final assistant text.
 
-    The same NVIDIA-gateway env (``ANTHROPIC_API_KEY``, ``ANTHROPIC_BASE_URL``,
+    Streams the per-turn stream-json events live into a foldable workflow
+    group, then prints a diagnostics summary (turns, duration, cost, exit
+    status) modelled on the generate step in ``testbot.yaml``.
+
+    The NVIDIA-gateway env (``ANTHROPIC_API_KEY``, ``ANTHROPIC_BASE_URL``,
     ``ANTHROPIC_MODEL``, ``DISABLE_PROMPT_CACHING``,
     ``CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS``) is inherited from the calling
-    workflow step, so this function doesn't manage credentials itself.
+    workflow step.
     """
     npx = shutil.which("npx")
     if npx is None:
@@ -99,21 +197,36 @@ def invoke_claude(
         "--model", model,
         "--allowedTools", ALLOWED_TOOLS,
         "--max-turns", str(max_turns),
+        "--output-format", "stream-json",
+        "--verbose",
         prompt,
     ]
-    logger.info("Invoking Claude CLI (model=%s, max_turns=%d)", model, max_turns)
-    result = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        timeout=timeout_sec,
-        check=False,
-    )
-    if result.returncode != 0:
-        logger.error("Claude CLI exited %d", result.returncode)
-        logger.error("stderr: %s", result.stderr[:1000])
-        sys.exit(result.returncode)
-    return result.stdout
+    logger.info("Invoking Claude CLI (model=%s, max_turns=%d)",
+                model, max_turns)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+    ) as tmp:
+        stream_log_path = Path(tmp.name)
+    try:
+        exit_status = _stream_npx(cmd, stream_log_path, timeout_sec)
+        final = _load_final_result(stream_log_path)
+        _emit_diagnostics(final, exit_status)
+
+        if exit_status != 0:
+            sys.exit(exit_status)
+        if final is None:
+            raise RuntimeError(
+                "Claude CLI exited 0 but no final result event was captured"
+            )
+        result_text = final.get("result")
+        if not isinstance(result_text, str):
+            raise RuntimeError(
+                f"Final event missing string 'result' field: {final!r}"
+            )
+        return result_text
+    finally:
+        stream_log_path.unlink(missing_ok=True)
 
 
 def parse_agent_output(output: str) -> list[dict]:

--- a/src/scripts/testbot/select_targets_agent.py
+++ b/src/scripts/testbot/select_targets_agent.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+# SPDX-License-Identifier: Apache-2.0
+"""Stage-2 target picker: a small Claude Code subagent with read-only access.
+
+The criticality scorer (Stage 1) produces a heuristic shortlist of ~20
+candidates. This script wraps a separate ``claude --print`` invocation to let
+the model **read** each candidate's source and pick the 1-3 best test targets
+based on whether good unit tests are actually feasible — something a static
+heuristic can't tell.
+
+Output is a markdown block in the same shape ``coverage_targets.format_targets``
+emits, so the downstream prompt assembly in the testbot workflow doesn't care
+which selector produced it.
+
+Usage:
+    python select_targets_agent.py \
+        --shortlist /tmp/shortlist.json \
+        --max-targets 1 \
+        --output /tmp/targets.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+CLAUDE_CLI_VERSION = "2.1.116"
+DEFAULT_MAX_TURNS = 30
+DEFAULT_TIMEOUT_SEC = 600
+ALLOWED_TOOLS = "Read,Glob,Grep"
+PROMPT_TEMPLATE_PATH = Path(__file__).parent / "SELECT_TARGETS_PROMPT.md"
+
+# Match a fenced JSON block (```json ... ```). The prompt instructs the agent
+# to emit exactly this shape; we don't try to recover from arbitrary prose.
+JSON_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+def format_candidate(rank: int, target: dict) -> str:
+    """Render one shortlist entry for the agent's prompt."""
+    breakdown = target.get("score_breakdown", {})
+    return (
+        f"### {rank}. `{target["file_path"]}` "
+        f"(score={target["score"]:.2f})\n"
+        f"- Coverage: {target["coverage_pct"]:.1f}% "
+        f"({target["uncovered_lines"]} uncovered lines, {target["loc"]} LoC)\n"
+        f"- Tier: {target["tier"]} (0=lib/utils, 4=other)\n"
+        f"- Fan-in: {target["fan_in"]} reverse imports\n"
+        f"- Churn (6mo): {target["churn"]} commits\n"
+        f"- Score breakdown: tier={breakdown.get("tier", 0):.2f} "
+        f"fan_in={breakdown.get("fan_in", 0):.2f} "
+        f"churn={breakdown.get("churn", 0):.2f} "
+        f"gap={breakdown.get("gap", 0):.2f}\n"
+    )
+
+
+def build_prompt(shortlist: list[dict], max_targets: int) -> str:
+    """Render the agent prompt with the shortlist spliced in."""
+    template = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    candidates_md = "\n".join(
+        format_candidate(rank, target)
+        for rank, target in enumerate(shortlist, start=1)
+    )
+    return template.format(
+        shortlist_count=len(shortlist),
+        max_targets=max_targets,
+        candidates=candidates_md,
+    )
+
+
+def invoke_claude(
+    prompt: str,
+    *,
+    model: str,
+    max_turns: int,
+    timeout_sec: int,
+) -> str:
+    """Run ``claude --print`` and return its stdout.
+
+    The same NVIDIA-gateway env (``ANTHROPIC_API_KEY``, ``ANTHROPIC_BASE_URL``,
+    ``ANTHROPIC_MODEL``, ``DISABLE_PROMPT_CACHING``,
+    ``CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS``) is inherited from the calling
+    workflow step, so this function doesn't manage credentials itself.
+    """
+    npx = shutil.which("npx")
+    if npx is None:
+        raise RuntimeError("npx not found on PATH; cannot invoke Claude CLI")
+    cmd = [
+        npx, f"@anthropic-ai/claude-code@{CLAUDE_CLI_VERSION}", "--print",
+        "--model", model,
+        "--allowedTools", ALLOWED_TOOLS,
+        "--max-turns", str(max_turns),
+        prompt,
+    ]
+    logger.info("Invoking Claude CLI (model=%s, max_turns=%d)", model, max_turns)
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout_sec,
+        check=False,
+    )
+    if result.returncode != 0:
+        logger.error("Claude CLI exited %d", result.returncode)
+        logger.error("stderr: %s", result.stderr[:1000])
+        sys.exit(result.returncode)
+    return result.stdout
+
+
+def parse_agent_output(output: str) -> list[dict]:
+    """Extract the ``targets`` array from the agent's fenced JSON block."""
+    match = JSON_BLOCK_RE.search(output)
+    if not match:
+        raise ValueError(
+            "Agent output did not contain a ```json``` block — refusing to "
+            "guess. Raw output (truncated): " + output[:500]
+        )
+    payload = json.loads(match.group(1))
+    targets = payload.get("targets", [])
+    if not isinstance(targets, list):
+        raise ValueError(f"Expected list under 'targets', got {type(targets)}")
+    return targets
+
+
+def merge_picks_with_shortlist(
+    picks: list[dict],
+    shortlist: list[dict],
+) -> list[dict]:
+    """Re-attach uncovered_ranges/coverage data to each picked file.
+
+    The agent only emits ``file_path`` + ``reason``; the downstream prompt
+    needs the full per-target shape (uncovered ranges, etc.) so it can tell
+    the test-generation agent *which lines* to focus on.
+    """
+    by_path = {entry["file_path"]: entry for entry in shortlist}
+    merged: list[dict] = []
+    for pick in picks:
+        path = pick.get("file_path")
+        if not path:
+            logger.warning("Skipping pick with no file_path: %r", pick)
+            continue
+        entry = by_path.get(path)
+        if entry is None:
+            logger.warning("Pick %r not in shortlist; ignoring", path)
+            continue
+        merged.append({
+            **entry,
+            "reason": pick.get("reason", ""),
+        })
+    return merged
+
+
+def format_targets_markdown(picks: list[dict]) -> str:
+    """Render the final target list in the format coverage_targets.py emits.
+
+    Identical to ``coverage_targets.format_targets`` but with an extra
+    ``Why this file:`` line carrying the LLM's rationale so reviewers can
+    see why it was chosen.
+    """
+    if not picks:
+        return "No coverage targets selected — shortlist did not contain any high-ROI candidates today."
+
+    lines: list[str] = []
+    for index, target in enumerate(picks, start=1):
+        ranges_str = ", ".join(
+            f"{s}-{e}" if s != e else str(s)
+            for s, e in target["uncovered_ranges"]
+        )
+        lines.append(f"## Target {index}: {target["file_path"]}")
+        lines.append(
+            f"Coverage: {target["coverage_pct"]:.1f}% "
+            f"({target["uncovered_lines"]} uncovered lines)"
+        )
+        lines.append(f"Uncovered ranges: {ranges_str}")
+        if target.get("reason"):
+            lines.append(f"Why this file: {target["reason"]}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shortlist", required=True,
+                        help="Path to the JSON shortlist from criticality_scorer")
+    parser.add_argument("--max-targets", type=int, default=1)
+    parser.add_argument("--max-turns", type=int, default=DEFAULT_MAX_TURNS)
+    parser.add_argument("--timeout-sec", type=int, default=DEFAULT_TIMEOUT_SEC)
+    parser.add_argument("--model",
+                        default=os.environ.get(
+                            "ANTHROPIC_MODEL",
+                            "aws/anthropic/bedrock-claude-opus-4-7",
+                        ))
+    parser.add_argument("--output", default="-",
+                        help="Output path; '-' (default) writes to stdout")
+    args = parser.parse_args()
+
+    shortlist = json.loads(Path(args.shortlist).read_text(encoding="utf-8"))
+    if not shortlist:
+        logger.warning("Empty shortlist; nothing to pick")
+        markdown = format_targets_markdown([])
+    else:
+        prompt = build_prompt(shortlist, args.max_targets)
+        output = invoke_claude(
+            prompt,
+            model=args.model,
+            max_turns=args.max_turns,
+            timeout_sec=args.timeout_sec,
+        )
+        picks = parse_agent_output(output)
+        logger.info("Agent picked %d target(s) of %d max", len(picks), args.max_targets)
+        merged = merge_picks_with_shortlist(picks, shortlist)
+        markdown = format_targets_markdown(merged)
+
+    if args.output == "-":
+        print(markdown)
+    else:
+        Path(args.output).write_text(markdown, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/testbot/tests/BUILD
+++ b/src/scripts/testbot/tests/BUILD
@@ -28,6 +28,18 @@ osmo_py_test(
 )
 
 osmo_py_test(
+    name = "test_criticality_scorer",
+    srcs = ["test_criticality_scorer.py"],
+    deps = ["//src/scripts/testbot"],
+)
+
+osmo_py_test(
+    name = "test_select_targets_agent",
+    srcs = ["test_select_targets_agent.py"],
+    deps = ["//src/scripts/testbot"],
+)
+
+osmo_py_test(
     name = "test_workflow_python_version",
     srcs = ["test_workflow_python_version.py"],
     data = [

--- a/src/scripts/testbot/tests/test_criticality_scorer.py
+++ b/src/scripts/testbot/tests/test_criticality_scorer.py
@@ -130,36 +130,53 @@ class TestPythonImports(unittest.TestCase):
             f.write("import json\nimport os\n")
             path = Path(f.name)
         try:
-            self.assertEqual(_python_imports(path), {"json", "os"})
+            direct, package_use = _python_imports(path)
+            self.assertEqual(direct, {"json", "os"})
+            # `import X` binds X as a value, so package_use mirrors direct.
+            self.assertEqual(package_use, {"json", "os"})
         finally:
             path.unlink()
 
     def test_extracts_from_import(self):
-        # ``from X.Y import Z`` records both X.Y (the source) and X.Y.Z
-        # (a possible submodule). The submodule candidate is dropped later
-        # if it doesn't resolve to a file, so this is safe.
+        # `from X.Y import Z` records X.Y (source) and X.Y.Z (composed).
+        # Only the composed name goes into package_use — the source is
+        # not bound as a value in the importer.
         with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
             f.write("from src.lib.utils.client import ServiceClient\n")
             path = Path(f.name)
         try:
+            direct, package_use = _python_imports(path)
             self.assertEqual(
-                _python_imports(path),
+                direct,
                 {"src.lib.utils.client", "src.lib.utils.client.ServiceClient"},
+            )
+            self.assertEqual(
+                package_use, {"src.lib.utils.client.ServiceClient"},
             )
         finally:
             path.unlink()
 
     def test_records_each_submodule_in_multi_name_from_import(self):
-        # The OSMO-prevalent pattern: ``from src.utils.job import a, b, c``
-        # must register fan-in against a, b, and c — each of which is a file.
+        # `from src.utils.job import a, b, c` — direct must include the
+        # source plus each composed candidate so per-file lookups succeed;
+        # package_use carries only the composed names.
         with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
             f.write("from src.utils.job import jobs, workflow, task\n")
             path = Path(f.name)
         try:
+            direct, package_use = _python_imports(path)
             self.assertEqual(
-                _python_imports(path),
+                direct,
                 {
                     "src.utils.job",
+                    "src.utils.job.jobs",
+                    "src.utils.job.workflow",
+                    "src.utils.job.task",
+                },
+            )
+            self.assertEqual(
+                package_use,
+                {
                     "src.utils.job.jobs",
                     "src.utils.job.workflow",
                     "src.utils.job.task",
@@ -173,7 +190,9 @@ class TestPythonImports(unittest.TestCase):
             f.write("from src.lib.utils import *\n")
             path = Path(f.name)
         try:
-            self.assertEqual(_python_imports(path), {"src.lib.utils"})
+            direct, package_use = _python_imports(path)
+            self.assertEqual(direct, {"src.lib.utils"})
+            self.assertEqual(package_use, set())
         finally:
             path.unlink()
 
@@ -182,7 +201,7 @@ class TestPythonImports(unittest.TestCase):
             f.write("from . import sibling\nfrom ..lib import utils\n")
             path = Path(f.name)
         try:
-            self.assertEqual(_python_imports(path), set())
+            self.assertEqual(_python_imports(path), (set(), set()))
         finally:
             path.unlink()
 
@@ -191,7 +210,7 @@ class TestPythonImports(unittest.TestCase):
             f.write("def broken(:\n")
             path = Path(f.name)
         try:
-            self.assertEqual(_python_imports(path), set())
+            self.assertEqual(_python_imports(path), (set(), set()))
         finally:
             path.unlink()
 
@@ -265,6 +284,38 @@ class TestBuildPythonFanIn(unittest.TestCase):
             )
             counts = build_python_fan_in(root)
             self.assertEqual(counts.get("src/lib/data/storage/client.py"), 1)
+
+    def test_named_import_does_not_overcredit_package_siblings(self):
+        # `from src.lib.data.storage import StorageBackend` should credit
+        # ONLY backends/common.py (where StorageBackend is implemented),
+        # NOT every other file storage/__init__.py re-exports from. The
+        # importer never references storage as a value, so package
+        # expansion of storage's full re-export set would be noise.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            backends = root / "src" / "lib" / "data" / "storage" / "backends"
+            backends.mkdir(parents=True)
+            (root / "src" / "service").mkdir(parents=True)
+            (root / "src" / "lib" / "data" / "storage" / "__init__.py").write_text(
+                "from .client import Client\n"
+                "from .backends.common import StorageBackend\n"
+            )
+            (root / "src" / "lib" / "data" / "storage" / "client.py").write_text(
+                "class Client: pass\n"
+            )
+            (backends / "common.py").write_text(
+                "class StorageBackend: pass\n"
+            )
+            (root / "src" / "service" / "main.py").write_text(
+                "from src.lib.data.storage import StorageBackend\n"
+            )
+            counts = build_python_fan_in(root)
+            self.assertEqual(
+                counts.get("src/lib/data/storage/backends/common.py"), 1,
+            )
+            # client.py is a sibling re-export of storage/__init__.py but
+            # the named-symbol import never used it — must stay at 0.
+            self.assertEqual(counts.get("src/lib/data/storage/client.py"), 0)
 
     def test_credits_package_import_to_full_re_export_set(self):
         # The dominant OSMO pattern is `from src.lib.data import storage`

--- a/src/scripts/testbot/tests/test_criticality_scorer.py
+++ b/src/scripts/testbot/tests/test_criticality_scorer.py
@@ -135,11 +135,45 @@ class TestPythonImports(unittest.TestCase):
             path.unlink()
 
     def test_extracts_from_import(self):
+        # ``from X.Y import Z`` records both X.Y (the source) and X.Y.Z
+        # (a possible submodule). The submodule candidate is dropped later
+        # if it doesn't resolve to a file, so this is safe.
         with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
             f.write("from src.lib.utils.client import ServiceClient\n")
             path = Path(f.name)
         try:
-            self.assertEqual(_python_imports(path), {"src.lib.utils.client"})
+            self.assertEqual(
+                _python_imports(path),
+                {"src.lib.utils.client", "src.lib.utils.client.ServiceClient"},
+            )
+        finally:
+            path.unlink()
+
+    def test_records_each_submodule_in_multi_name_from_import(self):
+        # The OSMO-prevalent pattern: ``from src.utils.job import a, b, c``
+        # must register fan-in against a, b, and c — each of which is a file.
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("from src.utils.job import jobs, workflow, task\n")
+            path = Path(f.name)
+        try:
+            self.assertEqual(
+                _python_imports(path),
+                {
+                    "src.utils.job",
+                    "src.utils.job.jobs",
+                    "src.utils.job.workflow",
+                    "src.utils.job.task",
+                },
+            )
+        finally:
+            path.unlink()
+
+    def test_skips_star_import_name(self):
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("from src.lib.utils import *\n")
+            path = Path(f.name)
+        try:
+            self.assertEqual(_python_imports(path), {"src.lib.utils"})
         finally:
             path.unlink()
 
@@ -209,6 +243,103 @@ class TestBuildPythonFanIn(unittest.TestCase):
             counts = build_python_fan_in(root)
             self.assertEqual(counts.get("src/service/core/helpers.py"), 1)
             self.assertEqual(counts.get("src/service/core/service.py"), 0)
+
+    def test_credits_init_py_re_exports_to_implementing_file(self):
+        # `from .client import Client` in storage/__init__.py + caller's
+        # `from src.lib.data.storage import Client` should credit
+        # `src/lib/data/storage/client.py` with fan-in, not the package
+        # directory and not __init__.py.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "src" / "lib" / "data" / "storage").mkdir(parents=True)
+            (root / "src" / "service").mkdir(parents=True)
+            (root / "src" / "lib" / "data" / "storage" / "__init__.py").write_text(
+                "from .client import Client, SingleObjectClient\n"
+            )
+            (root / "src" / "lib" / "data" / "storage" / "client.py").write_text(
+                "class Client: pass\nclass SingleObjectClient: pass\n"
+            )
+            (root / "src" / "service" / "main.py").write_text(
+                "from src.lib.data.storage import Client\n"
+                "from src.lib.data.storage import SingleObjectClient as SOC\n"
+            )
+            counts = build_python_fan_in(root)
+            self.assertEqual(counts.get("src/lib/data/storage/client.py"), 1)
+
+    def test_credits_package_import_to_full_re_export_set(self):
+        # The dominant OSMO pattern is `from src.lib.data import storage`
+        # (importing the package as a name). Python runs storage/__init__.py
+        # which imports from client.py and backends/common.py — both files
+        # should get fan-in credit because the importer's behavior is
+        # tied to anything the __init__ surfaces.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            backends = root / "src" / "lib" / "data" / "storage" / "backends"
+            backends.mkdir(parents=True)
+            (root / "src" / "service").mkdir(parents=True)
+            (root / "src" / "lib" / "data" / "__init__.py").write_text("")
+            (root / "src" / "lib" / "data" / "storage" / "__init__.py").write_text(
+                "from .client import Client\n"
+                "from .backends.common import StorageBackend\n"
+            )
+            (root / "src" / "lib" / "data" / "storage" / "client.py").write_text(
+                "class Client: pass\n"
+            )
+            (backends / "common.py").write_text(
+                "class StorageBackend: pass\n"
+            )
+            (root / "src" / "service" / "main.py").write_text(
+                "from src.lib.data import storage\n"
+            )
+            counts = build_python_fan_in(root)
+            self.assertEqual(counts.get("src/lib/data/storage/client.py"), 1)
+            self.assertEqual(
+                counts.get("src/lib/data/storage/backends/common.py"), 1,
+            )
+
+    def test_credits_nested_init_re_export_to_target_file(self):
+        # `from .backends.common import StorageBackend` should credit
+        # `src/lib/data/storage/backends/common.py` for callers that say
+        # `from src.lib.data.storage import StorageBackend`.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            backends = root / "src" / "lib" / "data" / "storage" / "backends"
+            backends.mkdir(parents=True)
+            (root / "src" / "service").mkdir(parents=True)
+            (root / "src" / "lib" / "data" / "storage" / "__init__.py").write_text(
+                "from .backends.common import StorageBackend\n"
+            )
+            (backends / "common.py").write_text(
+                "class StorageBackend: pass\n"
+            )
+            (root / "src" / "service" / "main.py").write_text(
+                "from src.lib.data.storage import StorageBackend\n"
+            )
+            counts = build_python_fan_in(root)
+            self.assertEqual(
+                counts.get("src/lib/data/storage/backends/common.py"), 1,
+            )
+
+    def test_counts_from_package_import_submodule(self):
+        # The OSMO-prevalent pattern: importer says
+        # ``from src.utils.job import jobs`` — the file we want fan-in
+        # credited to is ``src/utils/job/jobs.py``, not the directory.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "src" / "utils" / "job").mkdir(parents=True)
+            (root / "src" / "service").mkdir(parents=True)
+            (root / "src" / "utils" / "job" / "jobs.py").write_text(
+                "def run():\n    return 1\n"
+            )
+            (root / "src" / "utils" / "job" / "task.py").write_text(
+                "def go():\n    return 1\n"
+            )
+            (root / "src" / "service" / "main.py").write_text(
+                "from src.utils.job import jobs, task\n"
+            )
+            counts = build_python_fan_in(root)
+            self.assertEqual(counts.get("src/utils/job/jobs.py"), 1)
+            self.assertEqual(counts.get("src/utils/job/task.py"), 1)
 
     def test_ignores_third_party_imports(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/src/scripts/testbot/tests/test_criticality_scorer.py
+++ b/src/scripts/testbot/tests/test_criticality_scorer.py
@@ -297,6 +297,32 @@ class TestBuildPythonFanIn(unittest.TestCase):
                 counts.get("src/lib/data/storage/backends/common.py"), 1,
             )
 
+    def test_resolves_re_export_to_package_init_when_module_missing(self):
+        # `from .backends import construct_storage_backend` in
+        # storage/__init__.py: there is no `backends.py`, only
+        # `backends/__init__.py`. The resolver must fall back to the
+        # package's __init__.py instead of pointing at a phantom file.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            backends = root / "src" / "lib" / "data" / "storage" / "backends"
+            backends.mkdir(parents=True)
+            (root / "src" / "service").mkdir(parents=True)
+            (root / "src" / "lib" / "data" / "storage" / "__init__.py").write_text(
+                "from .backends import construct_storage_backend\n"
+            )
+            (backends / "__init__.py").write_text(
+                "def construct_storage_backend(): pass\n"
+            )
+            (root / "src" / "service" / "main.py").write_text(
+                "from src.lib.data.storage import construct_storage_backend\n"
+            )
+            counts = build_python_fan_in(root)
+            self.assertEqual(
+                counts.get("src/lib/data/storage/backends/__init__.py"), 1,
+            )
+            # Phantom path must not appear in the counts dict.
+            self.assertNotIn("src/lib/data/storage/backends.py", counts)
+
     def test_credits_nested_init_re_export_to_target_file(self):
         # `from .backends.common import StorageBackend` should credit
         # `src/lib/data/storage/backends/common.py` for callers that say

--- a/src/scripts/testbot/tests/test_criticality_scorer.py
+++ b/src/scripts/testbot/tests/test_criticality_scorer.py
@@ -1,0 +1,338 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for criticality_scorer."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+from src.scripts.testbot.criticality_scorer import (
+    DEFAULT_TIER,
+    Weights,
+    _go_imports,
+    _normalize,
+    _python_imports,
+    build_go_fan_in,
+    build_python_fan_in,
+    classify_tier,
+    rank_targets,
+    score_entry,
+)
+
+
+class TestClassifyTier(unittest.TestCase):
+    """Tests for path-prefix tier classification."""
+
+    def test_lib_is_tier_zero(self):
+        self.assertEqual(classify_tier("src/lib/utils/client.py"), 0)
+
+    def test_utils_is_tier_zero(self):
+        self.assertEqual(classify_tier("src/utils/job/task.py"), 0)
+
+    def test_runtime_pkg_is_tier_zero(self):
+        self.assertEqual(classify_tier("src/runtime/pkg/data/upload.go"), 0)
+
+    def test_service_core_is_tier_one(self):
+        self.assertEqual(classify_tier("src/service/core/service.py"), 1)
+
+    def test_cli_is_tier_two(self):
+        self.assertEqual(classify_tier("src/cli/workflow.py"), 2)
+
+    def test_runtime_cmd_is_tier_two(self):
+        self.assertEqual(classify_tier("src/runtime/cmd/ctrl/main.go"), 2)
+
+    def test_supporting_service_is_tier_three(self):
+        self.assertEqual(classify_tier("src/service/router/router.py"), 3)
+        self.assertEqual(classify_tier("src/service/worker/job.py"), 3)
+        self.assertEqual(classify_tier("src/operator/backend_listener.py"), 3)
+
+    def test_unknown_path_falls_through_to_default(self):
+        self.assertEqual(classify_tier("src/random/path.py"), DEFAULT_TIER)
+
+
+class TestNormalize(unittest.TestCase):
+    """Tests for log normalization helper."""
+
+    def test_zero_returns_zero(self):
+        self.assertEqual(_normalize(0, 100), 0.0)
+
+    def test_peak_returns_one(self):
+        self.assertEqual(_normalize(100, 100), 1.0)
+
+    def test_log_normalization_compresses_outliers(self):
+        # Halfway in raw count is well above halfway in log space.
+        mid = _normalize(50, 100)
+        self.assertGreater(mid, 0.5)
+
+    def test_zero_peak_returns_zero(self):
+        self.assertEqual(_normalize(5, 0), 0.0)
+
+
+class TestScoreEntry(unittest.TestCase):
+    """Tests for the per-file scoring formula."""
+
+    def test_high_criticality_outscores_low_at_same_coverage(self):
+        weights = Weights()
+        high, _ = score_entry(
+            tier=0, fan_in=50, churn=20,
+            coverage_pct=20.0, uncovered_lines=100,
+            peak_fan_in=50, peak_churn=20, weights=weights,
+        )
+        low, _ = score_entry(
+            tier=DEFAULT_TIER, fan_in=0, churn=0,
+            coverage_pct=20.0, uncovered_lines=100,
+            peak_fan_in=50, peak_churn=20, weights=weights,
+        )
+        self.assertGreater(high, low)
+
+    def test_lower_coverage_increases_score(self):
+        weights = Weights()
+        worse, _ = score_entry(
+            tier=0, fan_in=10, churn=5,
+            coverage_pct=10.0, uncovered_lines=100,
+            peak_fan_in=10, peak_churn=5, weights=weights,
+        )
+        better, _ = score_entry(
+            tier=0, fan_in=10, churn=5,
+            coverage_pct=80.0, uncovered_lines=100,
+            peak_fan_in=10, peak_churn=5, weights=weights,
+        )
+        self.assertGreater(worse, better)
+
+    def test_breakdown_sums_to_criticality(self):
+        weights = Weights(tier=1.0, fan_in=1.5, churn=0.8)
+        _, breakdown = score_entry(
+            tier=0, fan_in=10, churn=5,
+            coverage_pct=20.0, uncovered_lines=100,
+            peak_fan_in=10, peak_churn=5, weights=weights,
+        )
+        self.assertAlmostEqual(
+            breakdown["tier"] + breakdown["fan_in"] + breakdown["churn"],
+            breakdown["criticality"],
+            places=3,
+        )
+
+    def test_full_coverage_yields_zero_score(self):
+        score, _ = score_entry(
+            tier=0, fan_in=100, churn=100,
+            coverage_pct=100.0, uncovered_lines=0,
+            peak_fan_in=100, peak_churn=100, weights=Weights(),
+        )
+        self.assertEqual(score, 0.0)
+
+
+class TestPythonImports(unittest.TestCase):
+    """Tests for AST-based Python import extraction."""
+
+    def test_extracts_simple_import(self):
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("import json\nimport os\n")
+            path = Path(f.name)
+        try:
+            self.assertEqual(_python_imports(path), {"json", "os"})
+        finally:
+            path.unlink()
+
+    def test_extracts_from_import(self):
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("from src.lib.utils.client import ServiceClient\n")
+            path = Path(f.name)
+        try:
+            self.assertEqual(_python_imports(path), {"src.lib.utils.client"})
+        finally:
+            path.unlink()
+
+    def test_skips_relative_imports(self):
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("from . import sibling\nfrom ..lib import utils\n")
+            path = Path(f.name)
+        try:
+            self.assertEqual(_python_imports(path), set())
+        finally:
+            path.unlink()
+
+    def test_handles_syntax_error(self):
+        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+            f.write("def broken(:\n")
+            path = Path(f.name)
+        try:
+            self.assertEqual(_python_imports(path), set())
+        finally:
+            path.unlink()
+
+
+class TestGoImports(unittest.TestCase):
+    """Tests for regex-based Go import extraction."""
+
+    def test_extracts_block_imports(self):
+        with tempfile.NamedTemporaryFile(suffix=".go", mode="w", delete=False) as f:
+            f.write(
+                "package main\n\n"
+                "import (\n"
+                "    \"fmt\"\n"
+                "    \"go.corp.nvidia.com/osmo/lib/data/storage\"\n"
+                ")\n"
+            )
+            path = Path(f.name)
+        try:
+            imports = _go_imports(path)
+            self.assertIn("fmt", imports)
+            self.assertIn("go.corp.nvidia.com/osmo/lib/data/storage", imports)
+        finally:
+            path.unlink()
+
+    def test_extracts_single_line_import(self):
+        with tempfile.NamedTemporaryFile(suffix=".go", mode="w", delete=False) as f:
+            f.write("package main\nimport \"fmt\"\n")
+            path = Path(f.name)
+        try:
+            self.assertEqual(_go_imports(path), {"fmt"})
+        finally:
+            path.unlink()
+
+
+class TestBuildPythonFanIn(unittest.TestCase):
+    """Tests for the Python repo-internal fan-in counter."""
+
+    def test_counts_internal_imports_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src_dir = root / "src" / "service" / "core"
+            src_dir.mkdir(parents=True)
+            (src_dir / "service.py").write_text(
+                "from src.service.core.helpers import helper\nimport json\n"
+            )
+            (src_dir / "helpers.py").write_text(
+                "def helper():\n    return 1\n"
+            )
+            counts = build_python_fan_in(root)
+            self.assertEqual(counts.get("src/service/core/helpers.py"), 1)
+            self.assertEqual(counts.get("src/service/core/service.py"), 0)
+
+    def test_ignores_third_party_imports(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src_dir = root / "src"
+            src_dir.mkdir()
+            (src_dir / "a.py").write_text("import requests\nimport boto3\n")
+            counts = build_python_fan_in(root)
+            self.assertEqual(counts.get("src/a.py", 0), 0)
+
+
+class TestBuildGoFanIn(unittest.TestCase):
+    """Tests for the Go repo-internal fan-in counter."""
+
+    def test_distributes_package_fan_in_across_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "src" / "lib" / "shared").mkdir(parents=True)
+            (root / "src" / "cmd").mkdir(parents=True)
+            (root / "src" / "lib" / "shared" / "a.go").write_text(
+                "package shared\nfunc A() {}\n"
+            )
+            (root / "src" / "lib" / "shared" / "b.go").write_text(
+                "package shared\nfunc B() {}\n"
+            )
+            (root / "src" / "cmd" / "main.go").write_text(
+                "package main\nimport \"go.corp.nvidia.com/osmo/lib/shared\"\n"
+                "func main() { shared.A() }\n"
+            )
+            counts = build_go_fan_in(root)
+            # Package has 1 importer, 2 files -> each file gets 0
+            # (integer division). At least the package path is present.
+            self.assertIn("src/lib/shared/a.go", counts)
+
+
+class TestRankTargets(unittest.TestCase):
+    """Tests for the end-to-end ranker."""
+
+    def test_ranks_high_criticality_above_low(self):
+        report: dict[str, Any] = {
+            "files": [
+                {
+                    "name": "src/lib/utils/critical.py",
+                    "line_coverage": [[i, 1] for i in range(50)],
+                },
+                {
+                    "name": "src/random/trivial.py",
+                    "line_coverage": [[i, 1] for i in range(50)],
+                },
+            ]
+        }
+        ranked = rank_targets(
+            report,
+            Path("/nonexistent"),
+            shortlist_size=10,
+            max_uncovered=300,
+            weights=Weights(),
+            fan_in={"src/lib/utils/critical.py": 30, "src/random/trivial.py": 0},
+            churn={"src/lib/utils/critical.py": 12, "src/random/trivial.py": 0},
+        )
+        self.assertEqual(len(ranked), 2)
+        self.assertEqual(ranked[0].file_path, "src/lib/utils/critical.py")
+
+    def test_respects_shortlist_size(self):
+        report = {
+            "files": [
+                {
+                    "name": f"src/lib/file{i}.py",
+                    "line_coverage": [[j, 1] for j in range(50)],
+                }
+                for i in range(5)
+            ]
+        }
+        ranked = rank_targets(
+            report,
+            Path("/nonexistent"),
+            shortlist_size=3,
+            max_uncovered=300,
+            weights=Weights(),
+            fan_in={},
+            churn={},
+        )
+        self.assertEqual(len(ranked), 3)
+
+    def test_skips_ignored_paths(self):
+        report = {
+            "files": [
+                {
+                    "name": "src/scripts/testbot/foo.py",
+                    "line_coverage": [[i, 1] for i in range(50)],
+                },
+            ]
+        }
+        ranked = rank_targets(
+            report,
+            Path("/nonexistent"),
+            shortlist_size=10,
+            max_uncovered=300,
+            weights=Weights(),
+            fan_in={},
+            churn={},
+        )
+        self.assertEqual(ranked, [])
+
+    def test_skips_files_below_min_loc(self):
+        report = {
+            "files": [
+                {
+                    "name": "src/lib/tiny.py",
+                    "line_coverage": [[i, 1] for i in range(10)],
+                },
+            ]
+        }
+        ranked = rank_targets(
+            report,
+            Path("/nonexistent"),
+            shortlist_size=10,
+            max_uncovered=300,
+            weights=Weights(),
+            fan_in={},
+            churn={},
+        )
+        self.assertEqual(ranked, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/scripts/testbot/tests/test_select_targets_agent.py
+++ b/src/scripts/testbot/tests/test_select_targets_agent.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for select_targets_agent."""
 
+import tempfile
 import unittest
+from pathlib import Path
 
 from src.scripts.testbot.select_targets_agent import (
+    _stream_npx,
     build_prompt,
     format_candidate,
     format_targets_markdown,
@@ -144,6 +147,29 @@ class TestFormatTargetsMarkdown(unittest.TestCase):
         # No 'reason' key on this entry
         output = format_targets_markdown([target])
         self.assertNotIn("Why this file:", output)
+
+
+class TestStreamNpxTimeout(unittest.TestCase):
+    """End-to-end test of _stream_npx's timeout enforcement.
+
+    Uses a real subprocess (sleep) — no Claude CLI dependency. The earlier
+    synchronous-drain implementation would hang here despite timeout_sec=1
+    because the for-loop blocked on the pipe; this test pins the
+    background-thread-drain fix in place.
+    """
+
+    def test_timeout_kills_process_and_returns_124(self):
+        with tempfile.NamedTemporaryFile(
+            suffix=".jsonl", delete=False, mode="w",
+        ) as tmp:
+            log_path = Path(tmp.name)
+        try:
+            exit_code = _stream_npx(
+                ["sleep", "30"], log_path, timeout_sec=1,
+            )
+            self.assertEqual(exit_code, 124)
+        finally:
+            log_path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/src/scripts/testbot/tests/test_select_targets_agent.py
+++ b/src/scripts/testbot/tests/test_select_targets_agent.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for select_targets_agent."""
+
+import unittest
+
+from src.scripts.testbot.select_targets_agent import (
+    build_prompt,
+    format_candidate,
+    format_targets_markdown,
+    merge_picks_with_shortlist,
+    parse_agent_output,
+)
+
+
+def _shortlist_entry(file_path: str, **overrides) -> dict:
+    base = {
+        "file_path": file_path,
+        "coverage_pct": 25.0,
+        "uncovered_lines": 50,
+        "uncovered_ranges": [(10, 20), (30, 40)],
+        "tier": 0,
+        "fan_in": 30,
+        "churn": 12,
+        "loc": 200,
+        "score": 8.5,
+        "score_breakdown": {
+            "tier": 4.0, "fan_in": 2.0, "churn": 1.5,
+            "criticality": 7.5, "gap": 1.13,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+class TestFormatCandidate(unittest.TestCase):
+    """Tests for format_candidate prompt rendering."""
+
+    def test_includes_path_and_score(self):
+        rendered = format_candidate(1, _shortlist_entry("src/lib/foo.py"))
+        self.assertIn("src/lib/foo.py", rendered)
+        self.assertIn("8.50", rendered)
+        self.assertIn("Coverage: 25.0%", rendered)
+        self.assertIn("Tier: 0", rendered)
+
+
+class TestBuildPrompt(unittest.TestCase):
+    """Tests for build_prompt template substitution."""
+
+    def test_inlines_candidates_and_max_targets(self):
+        shortlist = [
+            _shortlist_entry("src/lib/a.py"),
+            _shortlist_entry("src/lib/b.py"),
+        ]
+        prompt = build_prompt(shortlist, max_targets=2)
+        self.assertIn("at most 2", prompt)
+        self.assertIn("src/lib/a.py", prompt)
+        self.assertIn("src/lib/b.py", prompt)
+        self.assertIn("shortlist of 2", prompt)
+
+
+class TestParseAgentOutput(unittest.TestCase):
+    """Tests for extracting JSON picks from raw agent output."""
+
+    def test_parses_fenced_json(self):
+        output = (
+            "Here are my picks:\n\n"
+            "```json\n"
+            '{"targets": [{"file_path": "src/lib/foo.py", "reason": "good"}]}\n'
+            "```\n"
+        )
+        picks = parse_agent_output(output)
+        self.assertEqual(len(picks), 1)
+        self.assertEqual(picks[0]["file_path"], "src/lib/foo.py")
+
+    def test_parses_empty_targets(self):
+        output = '```json\n{"targets": []}\n```'
+        self.assertEqual(parse_agent_output(output), [])
+
+    def test_raises_on_missing_block(self):
+        with self.assertRaises(ValueError):
+            parse_agent_output("Sorry, I can't help with that.")
+
+    def test_raises_on_non_list_targets(self):
+        output = '```json\n{"targets": "src/lib/foo.py"}\n```'
+        with self.assertRaises(ValueError):
+            parse_agent_output(output)
+
+
+class TestMergePicksWithShortlist(unittest.TestCase):
+    """Tests for merging agent picks with full shortlist entries."""
+
+    def test_attaches_uncovered_ranges_from_shortlist(self):
+        shortlist = [_shortlist_entry("src/lib/foo.py")]
+        picks = [{"file_path": "src/lib/foo.py", "reason": "central API"}]
+        merged = merge_picks_with_shortlist(picks, shortlist)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["uncovered_ranges"], [(10, 20), (30, 40)])
+        self.assertEqual(merged[0]["reason"], "central API")
+
+    def test_drops_picks_not_in_shortlist(self):
+        shortlist = [_shortlist_entry("src/lib/foo.py")]
+        picks = [
+            {"file_path": "src/lib/foo.py", "reason": "ok"},
+            {"file_path": "src/lib/hallucinated.py", "reason": "made up"},
+        ]
+        merged = merge_picks_with_shortlist(picks, shortlist)
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["file_path"], "src/lib/foo.py")
+
+    def test_skips_pick_without_file_path(self):
+        shortlist = [_shortlist_entry("src/lib/foo.py")]
+        picks = [{"reason": "missing path"}]
+        merged = merge_picks_with_shortlist(picks, shortlist)
+        self.assertEqual(merged, [])
+
+
+class TestFormatTargetsMarkdown(unittest.TestCase):
+    """Tests for the final markdown rendering of selected targets."""
+
+    def test_empty_picks_emits_skip_message(self):
+        output = format_targets_markdown([])
+        self.assertIn("No coverage targets selected", output)
+
+    def test_renders_target_with_reason(self):
+        target = _shortlist_entry("src/lib/foo.py")
+        target["reason"] = "Central error formatter"
+        output = format_targets_markdown([target])
+        self.assertIn("## Target 1: src/lib/foo.py", output)
+        self.assertIn("Coverage: 25.0%", output)
+        self.assertIn("10-20, 30-40", output)
+        self.assertIn("Why this file: Central error formatter", output)
+
+    def test_omits_why_line_when_no_reason(self):
+        target = _shortlist_entry("src/lib/foo.py")
+        # No 'reason' key on this entry
+        output = format_targets_markdown([target])
+        self.assertNotIn("Why this file:", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/scripts/testbot/tests/test_select_targets_agent.py
+++ b/src/scripts/testbot/tests/test_select_targets_agent.py
@@ -114,6 +114,14 @@ class TestMergePicksWithShortlist(unittest.TestCase):
         merged = merge_picks_with_shortlist(picks, shortlist)
         self.assertEqual(merged, [])
 
+    def test_skips_non_dict_pick(self):
+        # Defensive: the agent could emit a list of strings or other
+        # non-object entries. Don't crash on `.get(...)`.
+        shortlist = [_shortlist_entry("src/lib/foo.py")]
+        picks: list = ["src/lib/foo.py", 42, None]
+        merged = merge_picks_with_shortlist(picks, shortlist)
+        self.assertEqual(merged, [])
+
 
 class TestFormatTargetsMarkdown(unittest.TestCase):
     """Tests for the final markdown rendering of selected targets."""


### PR DESCRIPTION
## Summary

Pure-coverage ranking let trivial low-coverage files dominate the testbot budget (e.g. PR #939 picked a one-off file at 0% over heavily-imported public APIs at 30%). Replace the single-pass selector with a two-stage criticality-aware pipeline.

- **Stage 1** (`criticality_scorer.py`): Python AST + Go reverse imports for fan-in, six-month git churn, path-tier from AGENTS.md, and Codecov coverage gap. Scores `criticality × (1 − coverage) × log(uncovered_lines)`, log-normalized so one mega-hub can't swamp the rest. Emits a top-20 JSON shortlist with per-signal breakdown.
- **Stage 2** (`select_targets_agent.py` + `SELECT_TARGETS_PROMPT.md`): read-only Claude subagent (`Read,Glob,Grep`, 30-turn cap) reads each candidate and picks 1–3 files by ROI. Rejects heavy I/O glue, orchestration, SDK delegators. Can return zero picks rather than burn budget. Streams turn-by-turn into a foldable workflow group with a diagnostics block (exit_status, num_turns, duration_ms, total_cost_usd) wrapped in `::stop-commands::` for safety.

Final picks + LLM rationale flow into the existing `TESTBOT_PROMPT.md` / `create_pr.py` contract — no downstream changes.

## Scoring formula

```
criticality   =   w_tier   · (DEFAULT_TIER − tier)
                + w_fan_in · log(fan_in + 1) / log(max_fan_in + 1)
                + w_churn  · log(churn  + 1) / log(max_churn  + 1)

coverage_gap  =   (1 − coverage_pct / 100)
                × log(min(uncovered_lines, 500) + 1)

score         =   criticality × coverage_gap
```

| Term | What it captures | Bound with defaults |
|------|------------------|---------------------|
| `w_tier · (DEFAULT_TIER − tier)` | Path-prefix bonus. `DEFAULT_TIER = 4`. `lib/`/`utils/`/`runtime/pkg/` (tier 0) → +4.0; everything else → less. | `[0, 4.0]` |
| `w_fan_in · log_norm(fan_in)` | Reverse-import centrality, log-normalized so `[0, 1]`. Term saturates at `w_fan_in` for the most-imported file in the corpus. | `[0, 2.5]` |
| `w_churn · log_norm(churn)` | 6-month commit count, same shape. | `[0, 0.8]` |
| `(1 − coverage_pct/100)` | Linear coverage gap. | `[0, 1.0]` |
| `log(min(uncovered, 500) + 1)` | Uncovered surface area, log-scaled and capped. | `[0, ~6.22]` |

Why **multiplication**, not addition: a perfectly-covered hub scores `0` (nothing to test); a 0%-covered trivial file scores low (criticality is small). Both signals must be present.

Why **log normalization** on `fan_in` and `churn`: without it, OSMO's `lib/utils/common.py` (fan_in=222) would single-handedly drown every other signal. With it, each term is bounded at its weight.

## Defaults

| Knob | Value | Why |
|------|------:|-----|
| `w_tier` | 1.0 | Path tier is a coarse, durable proxy for "this is foundation code." |
| `w_fan_in` | 2.5 | Dependency centrality is the most durable signal — a hub stays a hub for years, while coverage gaps and churn shift week to week. |
| `w_churn` | 0.8 | Recent activity nudges the score but shouldn't dominate it. |
| `--max-uncovered` | 500 | Was 300; under-weighted big files like `lib/utils/common.py` at 1266 LoC. |
| `--shortlist-size` | 20 | Top-20 candidates handed to the Stage-2 picker. |
| `--max-targets` | 1 | Final picks per workflow run. |

## Dry-run on main

Codecov: 211 files, 44.5% overall coverage.

| # | Score | Tier | Fan-in | Churn | Cov% | Uncov | File |
|---|--:|--:|--:|--:|--:|--:|---|
| 1 | 26.60 | 0 | 4 | 7 | 18.8 | 403 | `utils/job/backend_jobs.py` |
| 2 | 25.90 | 0 | 7 | 19 | 30.0 | 500 | `utils/job/jobs.py` |
| 3 | 25.45 | 0 | 14 | 4 | 21.9 | 217 | `lib/data/storage/client.py` |
| 4 | 25.35 | 0 | 17 | 11 | 23.8 | 186 | `lib/utils/client.py` |
| 5 | 24.68 | 0 | 1 | 4 | 16.9 | 500 | `lib/rsync/rsync.py` |
| 6 | 22.13 | 0 | 45 | 12 | 45.3 | 332 | `lib/utils/common.py` |
| 7 | 21.51 | 1 | 1 | 10 | 10.7 | 444 | `service/core/data/data_service.py` |
| 8 | 21.38 | 1 | 5 | 3 | 11.9 | 238 | `service/core/workflow/helpers.py` |
| 9 | 19.58 | 0 | 3 | 4 | 13.6 | 76 | `utils/postgres/postgres_client.go` |
| 10 | 19.13 | 0 | 1 | 2 | 16.7 | 135 | `lib/utils/port_forward.py` |

These are the files we want testbot writing tests for — `lib/`, `utils/`, `service/core/`. Not the `cli/` one-offs the old selector kept picking.

## Python import resolution

OSMO uses three import patterns the naive AST scan missed (all caused `fan_in=0` for genuinely heavily-imported files); resolved in this PR:

1. `from src.utils.job import jobs, workflow, task` — record each imported name as a candidate submodule, not just the source package.
2. `from src.lib.data.storage import Client` — follow `__init__.py` re-exports (`from .client import Client`) so `Client` aliases to `client.py`.
3. `from src.lib.data import storage` — credit every file `storage/__init__.py` imports from (Python runs `__init__.py` on package import, so the importer's fate is tied to all of them).

`lib/utils/client.py` was reading `fan_in=0` before this PR; it's actually 17 (the most-imported `Client` SDK in the codebase).

## Simplify pass

After three review agents flagged duplication, consolidated:
- Extracted `parse_coverage_entries()` in `coverage_targets.py`; criticality_scorer layers its own filter+rank on top instead of re-implementing the Codecov parser.
- Extended `coverage_targets.format_targets()` to render `Why this file:` from a `reason` field; `select_targets_agent.format_targets_markdown` collapsed to a one-line wrapper.
- Added `CODECOV_LINE_HIT` / `CODECOV_LINE_MISS` constants.
- Cached `path → rel_str` in `build_python_fan_in`'s inner loop; single-pass classification in `build_go_fan_in`.

Net diff after simplify: −32 lines, identical top-5 ranking.

Issue #760

## Files tested
- N/A — selector infrastructure; new tests live alongside in `src/scripts/testbot/tests/`.

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes (17/17 testbot bazel targets pass — unit + pylint + mypy)
- [x] The documentation is up to date with these changes (README diagram + tunable tables updated)

## Test plan
- [x] `bazel test //src/scripts/testbot/...` passes locally
- [x] Dry-run via `bazel run //src/scripts/testbot:criticality_scorer` against live Codecov produces the table above
- [x] Trigger Testbot via `workflow_dispatch` on this branch and verify the resulting PR description carries the LLM rationale and targets a high-criticality file
   - https://github.com/NVIDIA/OSMO/actions/runs/25351113018/job/74330690236
