### PR TITLE
build: register Linux x86_64 + aarch64 wheels for osmo_python_deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -198,6 +198,11 @@ pip.parse(
     hub_name = "osmo_python_deps",
     python_version = "3.14.2",
     requirements_lock = "//src:locked_requirements.txt",
+    target_platforms = [
+        "{os}_{arch}",
+        "linux_x86_64",
+        "linux_aarch64",
+    ],
 )
 use_repo(pip, "osmo_python_deps")
 


### PR DESCRIPTION
## Description

Adds `target_platforms` to the `osmo_python_deps` `pip.parse` call so rules_python registers wheel repos for Linux x86_64 and aarch64 from the existing universal-hash lock file.

Without this, rules_python registers wheel repos only for the host arch. `bazel cquery deps(target) --platforms=linux_aarch64` from an x86_64 host then silently picks x86_64 wheels — the cross-arch query "succeeds" but resolves to wrong-arch wheels. With `target_platforms`, both arches' wheels are registered, the `select()` macro that `requirement(...)` already emits picks the right one based on `--platforms`, and cross-arch dep traversal resolves correctly.

The lock file at `src/locked_requirements.txt` already contains hashes for both arches (universal-hash output from `pip-compile --generate-hashes`), so no regeneration is needed. `MODULE.bazel.lock` is gitignored and regenerates on the next `bazel build`.

Other pip hubs (`osmo_mypy_deps`, `pylint_python_deps`, `osmo_tests_python_deps`) are dev-only and stay host-arch.

### Bonus capability

This change incidentally enables host-direct cross-compile (e.g., `bazel build --platforms=//bzl/platforms:linux_x86_64 //src/service/core:service_image_x86_64` from a macOS arm64 host) and running the resulting images under Docker emulation. The current BUILD_AND_TEST.md still requires a containerized builder for cross-arch; this change makes that step optional. Independently validated against a hello_world workflow bringup; details out of scope for this PR.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to add platform-specific targets, including support for multiple Linux architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->