### PR TITLE
Better errors when setting up storage credentials

### DIFF
--- a/docs/deployment_guide/getting_started/create_storage/s3/index.rst
+++ b/docs/deployment_guide/getting_started/create_storage/s3/index.rst
@@ -135,4 +135,12 @@ OSMO supports MinIO, Ceph, LocalStack, and S3 API-compatible services. Storage U
 the same S3 URI format (``s3://<bucket>``). To connect OSMO to an S3-compatible service,
 set the ``override_url`` credential field to the service's HTTP endpoint (e.g., ``http://minio:9000``).
 
+.. warning::
+
+   If your provider gave you a URL like ``https://s3.example.com/my-bucket/path``,
+   **don't paste it directly into** ``endpoint``. Split it:
+
+   - ``endpoint=s3://my-bucket/path``
+   - ``override_url=https://s3.example.com``
+
 Follow :ref:`configure_data` for full credential setup instructions.

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -595,38 +595,24 @@ class EndpointValidationErrorTest(unittest.TestCase):
             )
         return ctx.exception
 
-    def test_path_style_https_includes_canonical_split(self):
-        err = str(self._build_with('https://s3-compat.example.com/my-bucket/workflows'))
-        self.assertIn("endpoint='s3://my-bucket/workflows'", err)
-        self.assertIn("override_url='https://s3-compat.example.com'", err)
-
-    def test_path_style_http_with_port_preserves_port(self):
+    def test_http_url_with_port_directs_operator_to_override_url(self):
         err = str(self._build_with('http://minio.local:9000/bucket'))
-        self.assertIn("endpoint='s3://bucket'", err)
-        self.assertIn("override_url='http://minio.local:9000'", err)
+        self.assertIn("override_url=http://minio.local:9000", err)
 
-    def test_https_no_path_suggests_override_url(self):
+    def test_https_no_path_directs_operator_to_override_url(self):
         err = str(self._build_with('https://host.example'))
         self.assertIn('override_url', err)
         self.assertIn("'https://host.example'", err)
 
-    def test_https_root_path_treated_as_no_path(self):
-        err = str(self._build_with('https://host.example/'))
-        self.assertIn('override_url', err)
-        self.assertNotIn('Did you mean', err)
-
-    def test_non_url_falls_back_to_generic_message(self):
+    def test_non_url_value_is_quoted_in_message(self):
         err = str(self._build_with('not-a-url'))
         self.assertIn("'not-a-url'", err)
-        self.assertNotIn('Did you mean', err)
 
     def test_error_lists_every_registered_scheme(self):
-        """If a backend is added, this test guards the error against drift."""
+        """Drift guard: adding a new backend must surface in operator-facing errors."""
         err = str(self._build_with('not-a-url'))
         for scheme in constants.STORAGE_BACKEND_SCHEMES:
             self.assertIn(f'{scheme}://', err)
-        # Sanity: the registry isn't empty.
-        self.assertGreater(len(constants.STORAGE_BACKEND_SCHEMES), 0)
 
     def test_valid_endpoint_still_accepted(self):
         cred = credentials.StaticDataCredential(

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -597,7 +597,7 @@ class EndpointValidationErrorTest(unittest.TestCase):
 
     def test_http_url_with_port_directs_operator_to_override_url(self):
         err = str(self._build_with('http://minio.local:9000/bucket'))
-        self.assertIn("override_url=http://minio.local:9000", err)
+        self.assertIn('override_url=http://minio.local:9000', err)
 
     def test_https_no_path_directs_operator_to_override_url(self):
         err = str(self._build_with('https://host.example'))

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -22,6 +22,7 @@ import unittest
 from typing import cast
 from unittest import mock
 
+from src.lib.data.storage import constants
 from src.lib.data.storage.backends import azure, backends, s3
 from src.lib.data.storage.credentials import credentials
 from src.lib.data.storage.core import header
@@ -580,6 +581,60 @@ class WorkflowConfigCredentialTest(unittest.TestCase):
         self.assertEqual(result['region'], 'us-west-2')
         self.assertNotIn('access_key_id', result)
         self.assertNotIn('access_key', result)
+
+
+class EndpointValidationErrorTest(unittest.TestCase):
+    """Tests for the helpful error message produced by validate_endpoint."""
+
+    def _build_with(self, endpoint: str) -> osmo_errors.OSMOUserError:
+        with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+            credentials.StaticDataCredential(
+                endpoint=endpoint,
+                access_key_id='k',
+                access_key='s',
+            )
+        return ctx.exception
+
+    def test_path_style_https_includes_canonical_split(self):
+        err = str(self._build_with('https://s3-compat.example.com/my-bucket/workflows'))
+        self.assertIn("endpoint='s3://my-bucket/workflows'", err)
+        self.assertIn("override_url='https://s3-compat.example.com'", err)
+
+    def test_path_style_http_with_port_preserves_port(self):
+        err = str(self._build_with('http://minio.local:9000/bucket'))
+        self.assertIn("endpoint='s3://bucket'", err)
+        self.assertIn("override_url='http://minio.local:9000'", err)
+
+    def test_https_no_path_suggests_override_url(self):
+        err = str(self._build_with('https://host.example'))
+        self.assertIn('override_url', err)
+        self.assertIn("'https://host.example'", err)
+
+    def test_https_root_path_treated_as_no_path(self):
+        err = str(self._build_with('https://host.example/'))
+        self.assertIn('override_url', err)
+        self.assertNotIn('Did you mean', err)
+
+    def test_non_url_falls_back_to_generic_message(self):
+        err = str(self._build_with('not-a-url'))
+        self.assertIn("'not-a-url'", err)
+        self.assertNotIn('Did you mean', err)
+
+    def test_error_lists_every_registered_scheme(self):
+        """If a backend is added, this test guards the error against drift."""
+        err = str(self._build_with('not-a-url'))
+        for scheme in constants.STORAGE_BACKEND_SCHEMES:
+            self.assertIn(f'{scheme}://', err)
+        # Sanity: the registry isn't empty.
+        self.assertGreater(len(constants.STORAGE_BACKEND_SCHEMES), 0)
+
+    def test_valid_endpoint_still_accepted(self):
+        cred = credentials.StaticDataCredential(
+            endpoint='s3://bucket/prefix',
+            access_key_id='k',
+            access_key='s',
+        )
+        self.assertEqual(cred.endpoint, 's3://bucket/prefix')
 
 
 if __name__ == '__main__':

--- a/src/lib/data/storage/constants/constants.py
+++ b/src/lib/data/storage/constants/constants.py
@@ -18,6 +18,7 @@
 Constants for the data module.
 """
 
+import re
 from typing import Annotated
 
 import pydantic
@@ -39,6 +40,13 @@ TOS_REGEX = fr'^tos://{URI_COMPONENT}(/{URI_COMPONENT})+/*$'
 AZURE_REGEX = fr'^azure://{URI_COMPONENT}(/{URI_COMPONENT})+/*$'
 STORAGE_BACKEND_REGEX = fr'({SWIFT_REGEX}|{S3_REGEX}|{GS_REGEX}|{TOS_REGEX}|{AZURE_REGEX})'
 StorageBackendPattern = Annotated[str, pydantic.Field(pattern=STORAGE_BACKEND_REGEX)]
+
+# Schemes are derived from STORAGE_BACKEND_REGEX so adding a new backend
+# (e.g., a new *_REGEX included in the union above) auto-propagates here
+# and to any consumer that lists supported schemes (e.g., error messages).
+STORAGE_BACKEND_SCHEMES: tuple[str, ...] = tuple(
+    re.findall(r'\^(\w+)://', STORAGE_BACKEND_REGEX)
+)
 
 
 # Regex rules for storage profiles

--- a/src/lib/data/storage/credentials/credentials.py
+++ b/src/lib/data/storage/credentials/credentials.py
@@ -24,6 +24,7 @@ import abc
 import os
 import re
 from typing import Union
+from urllib.parse import urlparse
 
 import pydantic
 import yaml
@@ -32,13 +33,49 @@ from .. import constants
 from ....utils import client_configs, osmo_errors
 
 
+def _format_invalid_endpoint_error(value: str) -> str:
+    """
+    Build a helpful error message for an invalid endpoint.
+
+    When the value parses as an http(s) URL, include a concrete
+    `endpoint`/`override_url` split the operator can copy-paste.
+    """
+    schemes = ', '.join(f'{s}://' for s in constants.STORAGE_BACKEND_SCHEMES)
+    parsed = urlparse(value)
+    if parsed.scheme in ('http', 'https') and parsed.netloc:
+        override = f'{parsed.scheme}://{parsed.netloc}'
+        path = parsed.path.strip('/')
+        if path:
+            bucket, _, prefix = path.partition('/')
+            canonical = f's3://{bucket}/{prefix}' if prefix else f's3://{bucket}'
+            return (
+                f'Invalid endpoint: {value!r}. Endpoint must use one of: '
+                f'{schemes} (e.g., {canonical!r}). Did you mean: '
+                f'endpoint={canonical!r}, override_url={override!r}?'
+            )
+        return (
+            f'Invalid endpoint: {value!r}. Endpoint must use one of: '
+            f"{schemes} (e.g., 's3://my-bucket/prefix'). For HTTP service "
+            f"URL {override!r}, set 'override_url' separately."
+        )
+    return (
+        f'Invalid endpoint: {value!r}. Endpoint must use one of: {schemes} '
+        f"(e.g., 's3://my-bucket/prefix'). For HTTP service URLs, set "
+        f"'override_url' separately."
+    )
+
+
 class DataCredentialBase(pydantic.BaseModel, abc.ABC, extra='forbid'):
     """
     Base class for data credentials (i.e. credentials with endpoint and region).
     """
     endpoint: str = pydantic.Field(
         ...,
-        description='The OSMO storage URI for the data service (e.g., s3://bucket)',
+        description=(
+            'The OSMO storage URI for the data service (e.g., s3://bucket). '
+            "For S3-compatible services with HTTP endpoints, set 'override_url' "
+            'separately rather than pasting the full HTTPS URL here.'
+        ),
     )
     region: str | None = pydantic.Field(
         default=None,
@@ -46,7 +83,11 @@ class DataCredentialBase(pydantic.BaseModel, abc.ABC, extra='forbid'):
     )
     override_url: str | None = pydantic.Field(
         default=None,
-        description='HTTP endpoint URL override the storage URI (e.g., http://minio:9000)',
+        description=(
+            'HTTP service URL for S3-compatible providers '
+            '(e.g., http://minio:9000, https://s3-compat.example.com). '
+            'Leave unset for native AWS S3, GCS, Azure, etc.'
+        ),
     )
 
     @pydantic.field_validator('endpoint')
@@ -56,7 +97,7 @@ class DataCredentialBase(pydantic.BaseModel, abc.ABC, extra='forbid'):
         Validates endpoint. Returns the value of parsed job_id if valid.
         """
         if not re.fullmatch(constants.STORAGE_CREDENTIAL_REGEX, value):
-            raise osmo_errors.OSMOUserError(f'Invalid endpoint: {value}')
+            raise osmo_errors.OSMOUserError(_format_invalid_endpoint_error(value))
         return value.rstrip('/')
 
 

--- a/src/lib/data/storage/credentials/credentials.py
+++ b/src/lib/data/storage/credentials/credentials.py
@@ -36,32 +36,19 @@ from ....utils import client_configs, osmo_errors
 def _format_invalid_endpoint_error(value: str) -> str:
     """
     Build a helpful error message for an invalid endpoint.
-
-    When the value parses as an http(s) URL, include a concrete
-    `endpoint`/`override_url` split the operator can copy-paste.
     """
     schemes = ', '.join(f'{s}://' for s in constants.STORAGE_BACKEND_SCHEMES)
     parsed = urlparse(value)
     if parsed.scheme in ('http', 'https') and parsed.netloc:
         override = f'{parsed.scheme}://{parsed.netloc}'
-        path = parsed.path.strip('/')
-        if path:
-            bucket, _, prefix = path.partition('/')
-            canonical = f's3://{bucket}/{prefix}' if prefix else f's3://{bucket}'
-            return (
-                f'Invalid endpoint: {value!r}. Endpoint must use one of: '
-                f'{schemes} (e.g., {canonical!r}). Did you mean: '
-                f'endpoint={canonical!r}, override_url={override!r}?'
-            )
         return (
             f'Invalid endpoint: {value!r}. Endpoint must use one of: '
-            f"{schemes} (e.g., 's3://my-bucket/prefix'). For HTTP service "
-            f"URL {override!r}, set 'override_url' separately."
+            f"{schemes}. The value looks like an HTTP service URL — set "
+            f"'override_url={override}' and put the storage URI in 'endpoint'."
         )
     return (
-        f'Invalid endpoint: {value!r}. Endpoint must use one of: {schemes} '
-        f"(e.g., 's3://my-bucket/prefix'). For HTTP service URLs, set "
-        f"'override_url' separately."
+        f'Invalid endpoint: {value!r}. Endpoint must use one of: {schemes}. '
+        f"For HTTP service URLs, set 'override_url' separately."
     )
 
 


### PR DESCRIPTION
## Description
More user friendly error messages when working with storage credentials

Issue #934 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified S3-compatible guidance: show how to split a full provider URL into a storage endpoint and a separate override URL, with copy-pastable examples.

* **Bug Fixes**
  * Improved invalid-endpoint errors to give tailored guidance (including quoting non-URL inputs) and to list supported storage schemes so users can fix configuration issues more easily.

* **Tests**
  * Added tests verifying improved endpoint validation messages and acceptance of valid storage URIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->