### PR TITLE
fix(storage): default S3 addressing_style to virtual for custom endpoints

### DIFF
--- a/src/cli/credential.py
+++ b/src/cli/credential.py
@@ -50,6 +50,8 @@ def _save_config(data_cred: credentials.StaticDataCredential):
     }
     if data_cred.override_url:
         cred_data['override_url'] = data_cred.override_url
+    if data_cred.addressing_style:
+        cred_data['addressing_style'] = data_cred.addressing_style
     config['auth']['data'][data_cred.endpoint] = cred_data
     with open(password_file, 'w', encoding='utf-8') as file:
         yaml.dump(config, file)
@@ -224,7 +226,7 @@ def setup_parser(parser: argparse._SubParsersAction):
             '+-----------------+-------------------------------------+--------------------------------------+\n'
             '| REGISTRY        | auth                                | registry, username                   |\n'
             '+-----------------+-------------------------------------+--------------------------------------+\n'
-            '| DATA            | access_key_id, access_key, endpoint | region, override_url                 |\n'
+            '| DATA            | access_key_id, access_key, endpoint | region, override_url, addressing_style |\n'
             '+-----------------+-------------------------------------+--------------------------------------+\n'
             '| GENERIC         |                                     |                                      |\n'
             '+-----------------+-------------------------------------+--------------------------------------+\n'

--- a/src/cli/tests/test_credential.py
+++ b/src/cli/tests/test_credential.py
@@ -36,6 +36,7 @@ def _make_static_data_credential(
     access_key: str = 'secret',
     region: str | None = None,
     override_url: str | None = None,
+    addressing_style: str | None = None,
 ) -> credentials.StaticDataCredential:
     return credentials.StaticDataCredential(
         endpoint=endpoint,
@@ -43,6 +44,7 @@ def _make_static_data_credential(
         access_key=pydantic.SecretStr(access_key),
         region=region,
         override_url=override_url,
+        addressing_style=addressing_style,
     )
 
 
@@ -89,6 +91,20 @@ class TestSaveConfig(unittest.TestCase):
         self.assertEqual(
             config['auth']['data']['s3://test-bucket']['override_url'],
             'http://minio:9000',
+        )
+
+    def test_save_config_with_addressing_style(self):
+        """Test that _save_config persists addressing_style when set."""
+        data_cred = _make_static_data_credential(addressing_style='virtual')
+
+        credential._save_config(data_cred)
+
+        config_path = os.path.join(self.tmp_dir, 'config.yaml')
+        with open(config_path, 'r', encoding='utf-8') as file:
+            config = yaml.safe_load(file.read())
+        self.assertEqual(
+            config['auth']['data']['s3://test-bucket']['addressing_style'],
+            'virtual',
         )
 
     def test_save_config_appends_to_existing_file(self):

--- a/src/lib/data/storage/backends/backends.py
+++ b/src/lib/data/storage/backends/backends.py
@@ -572,9 +572,12 @@ class S3Backend(Boto3Backend):
         if data_cred.region is not None:
             return data_cred.region
 
+        # Route the precheck to the credential's endpoint so it actually targets
+        # the bucket's backend (CAIOS, MinIO, etc.) rather than AWS S3.
         s3_client = s3.create_client(
             data_cred=data_cred,
             scheme=self.scheme,
+            endpoint_url=data_cred.override_url,
         )
 
         def _get_region() -> str:

--- a/src/lib/data/storage/backends/s3.py
+++ b/src/lib/data/storage/backends/s3.py
@@ -122,9 +122,9 @@ def _get_s3_addressing_style(
         return addressing_style
     if scheme != common.StorageBackendType.S3.value:
         return None
-    override = os.getenv(OSMO_S3_ADDRESSING_STYLE)
-    if override:
-        return override
+    osmo_override = os.getenv(OSMO_S3_ADDRESSING_STYLE)
+    if osmo_override:
+        return osmo_override
     if os.getenv('AWS_S3_FORCE_PATH_STYLE', '').lower() in ('true', '1'):
         return 'path'
     if endpoint_url is None:

--- a/src/lib/data/storage/backends/s3.py
+++ b/src/lib/data/storage/backends/s3.py
@@ -104,10 +104,19 @@ def _get_s3_addressing_style(endpoint_url: str | None) -> str | None:
     path-style requests on operations like HeadBucket and GetBucketLocation.
     Boto3's 'auto' default picks path-style whenever endpoint_url is set, which
     breaks those backends.
+
+    Resolution order:
+      1. OSMO_S3_ADDRESSING_STYLE env var (explicit operator override).
+      2. AWS_S3_FORCE_PATH_STYLE env var (the convention chart deployments and
+         localstack/MinIO setups already use to signal "path-style required";
+         boto3 does not honor it natively, so we honor it here).
+      3. 'virtual' for custom endpoints, None (boto3 default) for AWS.
     """
     override = os.getenv(OSMO_S3_ADDRESSING_STYLE)
     if override:
         return override
+    if os.getenv('AWS_S3_FORCE_PATH_STYLE', '').lower() in ('true', '1'):
+        return 'path'
     if endpoint_url is None:
         return None
     return 'virtual'

--- a/src/lib/data/storage/backends/s3.py
+++ b/src/lib/data/storage/backends/s3.py
@@ -94,24 +94,34 @@ def _get_s3_timeout() -> datetime.timedelta:
     return utils_common.to_timedelta(os.getenv(OSMO_S3_TIMEOUT, '24h'))
 
 
-def _get_s3_addressing_style(endpoint_url: str | None) -> str | None:
+def _get_s3_addressing_style(
+    scheme: str,
+    endpoint_url: str | None,
+    addressing_style: str | None = None,
+) -> str | None:
     """
     Returns the S3 addressing style to pass to boto3, or None to defer to its
     default resolver.
 
-    For custom (non-AWS) endpoints we default to 'virtual' because several
+    For S3 custom (non-AWS) endpoints we default to 'virtual' because several
     S3-compatible providers (CAIOS, Cloudflare R2 strict, Wasabi strict) reject
     path-style requests on operations like HeadBucket and GetBucketLocation.
     Boto3's 'auto' default picks path-style whenever endpoint_url is set, which
     breaks those backends.
 
     Resolution order:
-      1. OSMO_S3_ADDRESSING_STYLE env var (explicit operator override).
-      2. AWS_S3_FORCE_PATH_STYLE env var (the convention chart deployments and
+      1. Credential addressing_style (explicit per-endpoint override).
+      2. OSMO_S3_ADDRESSING_STYLE env var (explicit operator override).
+      3. AWS_S3_FORCE_PATH_STYLE env var (the convention chart deployments and
          localstack/MinIO setups already use to signal "path-style required";
          boto3 does not honor it natively, so we honor it here).
-      3. 'virtual' for custom endpoints, None (boto3 default) for AWS.
+      4. 'virtual' for S3 custom endpoints, None (boto3 default) for AWS and
+         other S3-API backends.
     """
+    if addressing_style:
+        return addressing_style
+    if scheme != common.StorageBackendType.S3.value:
+        return None
     override = os.getenv(OSMO_S3_ADDRESSING_STYLE)
     if override:
         return override
@@ -125,6 +135,7 @@ def _get_s3_addressing_style(endpoint_url: str | None) -> str | None:
 def _get_boto_config(
     scheme: str,
     endpoint_url: str | None = None,
+    addressing_style: str | None = None,
 ) -> botocore.config.Config:
     """
     Returns the boto3 configuration for the given scheme and endpoint.
@@ -137,7 +148,11 @@ def _get_boto_config(
         # TOS only supports virtual-hosted style.
         s3_config['addressing_style'] = 'virtual'
     else:
-        addressing_style = _get_s3_addressing_style(endpoint_url)
+        addressing_style = _get_s3_addressing_style(
+            scheme,
+            endpoint_url,
+            addressing_style=addressing_style,
+        )
         if addressing_style is not None:
             s3_config['addressing_style'] = addressing_style
 
@@ -577,7 +592,11 @@ def create_client(
         mypy_boto3_s3.S3Client
     """
     def _get_client() -> mypy_boto3_s3.S3Client:
-        config = _get_boto_config(scheme, endpoint_url=endpoint_url)
+        config = _get_boto_config(
+            scheme,
+            endpoint_url=endpoint_url,
+            addressing_style=data_cred.addressing_style,
+        )
 
         session = boto3.Session()
         _add_request_headers(session, extra_headers)

--- a/src/lib/data/storage/backends/s3.py
+++ b/src/lib/data/storage/backends/s3.py
@@ -70,6 +70,12 @@ OSMO_S3_PAGINATOR_SIZE = 'OSMO_S3_PAGINATOR_SIZE'
 # Delete objects batch size for S3 delete objects.
 OSMO_S3_DELETE_OBJECTS_BATCH_SIZE = 'OSMO_S3_DELETE_OBJECTS_BATCH_SIZE'
 
+# Override for the S3 addressing style. One of: 'virtual', 'path', 'auto'.
+# When unset, defaults to 'virtual' for custom (non-AWS) endpoints and defers to
+# boto3's resolver for AWS S3. Set to 'path' for legacy buckets whose names are
+# not DNS-compliant under virtual-hosted style.
+OSMO_S3_ADDRESSING_STYLE = 'OSMO_S3_ADDRESSING_STYLE'
+
 
 ##################################
 
@@ -88,35 +94,57 @@ def _get_s3_timeout() -> datetime.timedelta:
     return utils_common.to_timedelta(os.getenv(OSMO_S3_TIMEOUT, '24h'))
 
 
-def _get_boto_config(scheme: str) -> botocore.config.Config:
+def _get_s3_addressing_style(endpoint_url: str | None) -> str | None:
     """
-    Returns the boto3 configuration for the given scheme.
+    Returns the S3 addressing style to pass to boto3, or None to defer to its
+    default resolver.
+
+    For custom (non-AWS) endpoints we default to 'virtual' because several
+    S3-compatible providers (CAIOS, Cloudflare R2 strict, Wasabi strict) reject
+    path-style requests on operations like HeadBucket and GetBucketLocation.
+    Boto3's 'auto' default picks path-style whenever endpoint_url is set, which
+    breaks those backends.
+    """
+    override = os.getenv(OSMO_S3_ADDRESSING_STYLE)
+    if override:
+        return override
+    if endpoint_url is None:
+        return None
+    return 'virtual'
+
+
+def _get_boto_config(
+    scheme: str,
+    endpoint_url: str | None = None,
+) -> botocore.config.Config:
+    """
+    Returns the boto3 configuration for the given scheme and endpoint.
     """
     max_attempts = _get_s3_max_retry_count()
     max_pool_connections = max(10, int(os.getenv(OSMO_S3_MAX_POOL_CONNECTIONS, '160')))
 
+    s3_config: Dict[str, Any] = {}
     if scheme == common.StorageBackendType.TOS.value:
-        # TOS requires additional configurations.
-        return botocore.config.Config(
-            retries={
-                'max_attempts': max_attempts,
-                'mode': 'standard',
-            },
-            max_pool_connections=max_pool_connections,
-            s3={'addressing_style': 'virtual'},
-            request_checksum_calculation='when_required',
-            response_checksum_validation='when_required',
-        )
+        # TOS only supports virtual-hosted style.
+        s3_config['addressing_style'] = 'virtual'
+    else:
+        addressing_style = _get_s3_addressing_style(endpoint_url)
+        if addressing_style is not None:
+            s3_config['addressing_style'] = addressing_style
 
-    return botocore.config.Config(
-        retries={
+    config_kwargs: Dict[str, Any] = {
+        'retries': {
             'max_attempts': max_attempts,
             'mode': 'standard',
         },
-        max_pool_connections=max_pool_connections,
-        request_checksum_calculation='when_required',
-        response_checksum_validation='when_required',
-    )
+        'max_pool_connections': max_pool_connections,
+        'request_checksum_calculation': 'when_required',
+        'response_checksum_validation': 'when_required',
+    }
+    if s3_config:
+        config_kwargs['s3'] = s3_config
+
+    return botocore.config.Config(**config_kwargs)
 
 
 def _get_s3_transfer_config() -> boto3.s3.transfer.TransferConfig:
@@ -540,7 +568,7 @@ def create_client(
         mypy_boto3_s3.S3Client
     """
     def _get_client() -> mypy_boto3_s3.S3Client:
-        config = _get_boto_config(scheme)
+        config = _get_boto_config(scheme, endpoint_url=endpoint_url)
 
         session = boto3.Session()
         _add_request_headers(session, extra_headers)

--- a/src/lib/data/storage/backends/s3.py
+++ b/src/lib/data/storage/backends/s3.py
@@ -94,6 +94,28 @@ def _get_s3_timeout() -> datetime.timedelta:
     return utils_common.to_timedelta(os.getenv(OSMO_S3_TIMEOUT, '24h'))
 
 
+_VALID_S3_ADDRESSING_STYLES = ('virtual', 'path', 'auto')
+
+
+def _normalize_env_addressing_style(raw: str) -> str:
+    """
+    Normalizes and validates an OSMO_S3_ADDRESSING_STYLE env var value.
+
+    Trims whitespace and lowercases the value, then verifies it's one of the
+    supported addressing styles. Raises ValueError with the offending raw
+    value on miss, so a typo surfaces immediately instead of silently flowing
+    into botocore's Config.
+    """
+    normalized = raw.strip().lower()
+    if normalized not in _VALID_S3_ADDRESSING_STYLES:
+        supported = ', '.join(_VALID_S3_ADDRESSING_STYLES)
+        raise ValueError(
+            f'Invalid {OSMO_S3_ADDRESSING_STYLE} value {raw!r}; '
+            f'expected one of: {supported}'
+        )
+    return normalized
+
+
 def _get_s3_addressing_style(
     scheme: str,
     endpoint_url: str | None,
@@ -124,7 +146,7 @@ def _get_s3_addressing_style(
         return None
     osmo_override = os.getenv(OSMO_S3_ADDRESSING_STYLE)
     if osmo_override:
-        return osmo_override
+        return _normalize_env_addressing_style(osmo_override)
     if os.getenv('AWS_S3_FORCE_PATH_STYLE', '').lower() in ('true', '1'):
         return 'path'
     if endpoint_url is None:

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -548,6 +548,20 @@ class GetS3AddressingStyleTest(unittest.TestCase):
                 'virtual',
             )
 
+    def test_env_override_normalizes_case_and_whitespace(self):
+        """OSMO_S3_ADDRESSING_STYLE is trimmed and lowercased before use."""
+        with mock.patch.dict('os.environ', {s3.OSMO_S3_ADDRESSING_STYLE: '  Virtual  '}):
+            self.assertEqual(s3._get_s3_addressing_style('s3', None), 'virtual')
+
+    def test_env_override_invalid_raises(self):
+        """An unsupported OSMO_S3_ADDRESSING_STYLE value surfaces a clear error
+        rather than silently flowing into botocore."""
+        with mock.patch.dict('os.environ', {s3.OSMO_S3_ADDRESSING_STYLE: 'virtua'}):
+            with self.assertRaises(ValueError) as ctx:
+                s3._get_s3_addressing_style('s3', 'https://cwobject.com')
+        self.assertIn(s3.OSMO_S3_ADDRESSING_STYLE, str(ctx.exception))
+        self.assertIn("'virtua'", str(ctx.exception))
+
 
 class S3BackendRegionTest(unittest.TestCase):
     """Tests for S3Backend.region() endpoint routing."""

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -511,25 +511,28 @@ class GetS3AddressingStyleTest(unittest.TestCase):
     def test_no_endpoint_returns_none(self):
         """AWS S3 (no custom endpoint): defer to boto3 default."""
         with mock.patch.dict('os.environ', {}, clear=True):
-            self.assertIsNone(s3._get_s3_addressing_style(None))
+            self.assertIsNone(s3._get_s3_addressing_style('s3', None))
 
     def test_custom_endpoint_returns_virtual(self):
         """Custom endpoint defaults to virtual-hosted style."""
         with mock.patch.dict('os.environ', {}, clear=True):
-            self.assertEqual(s3._get_s3_addressing_style('https://cwobject.com'), 'virtual')
+            self.assertEqual(
+                s3._get_s3_addressing_style('s3', 'https://cwobject.com'),
+                'virtual',
+            )
 
     def test_env_override_wins(self):
         """OSMO_S3_ADDRESSING_STYLE overrides the default for both endpoint cases."""
         with mock.patch.dict('os.environ', {s3.OSMO_S3_ADDRESSING_STYLE: 'path'}):
-            self.assertEqual(s3._get_s3_addressing_style('https://cwobject.com'), 'path')
-            self.assertEqual(s3._get_s3_addressing_style(None), 'path')
+            self.assertEqual(s3._get_s3_addressing_style('s3', 'https://cwobject.com'), 'path')
+            self.assertEqual(s3._get_s3_addressing_style('s3', None), 'path')
 
     def test_aws_s3_force_path_style_returns_path(self):
         """AWS_S3_FORCE_PATH_STYLE=true preserves localstack/MinIO chart deployments."""
         for value in ('true', 'True', 'TRUE', '1'):
             with mock.patch.dict('os.environ', {'AWS_S3_FORCE_PATH_STYLE': value}, clear=True):
                 self.assertEqual(
-                    s3._get_s3_addressing_style('http://localstack-s3.osmo:4566'),
+                    s3._get_s3_addressing_style('s3', 'http://localstack-s3.osmo:4566'),
                     'path',
                     value,
                 )
@@ -541,7 +544,7 @@ class GetS3AddressingStyleTest(unittest.TestCase):
             'AWS_S3_FORCE_PATH_STYLE': 'true',
         }):
             self.assertEqual(
-                s3._get_s3_addressing_style('http://localstack-s3.osmo:4566'),
+                s3._get_s3_addressing_style('s3', 'http://localstack-s3.osmo:4566'),
                 'virtual',
             )
 
@@ -600,6 +603,28 @@ class GetBotoConfigTest(unittest.TestCase):
             config = s3._get_boto_config('s3', endpoint_url='https://cwobject.com')
         self.assertEqual(self._s3_options(config).get('addressing_style'), 'virtual')
 
+    def test_swift_endpoint_keeps_boto_default(self):
+        """Swift uses path-style S3 API paths and should not inherit S3 virtual defaults."""
+        with mock.patch.dict('os.environ', {}, clear=True):
+            config = s3._get_boto_config('swift', endpoint_url='https://swift.example.com')
+        self.assertNotIn('addressing_style', self._s3_options(config))
+
+    def test_gs_endpoint_keeps_boto_default(self):
+        """GS should not inherit the S3 custom-endpoint virtual default."""
+        with mock.patch.dict('os.environ', {}, clear=True):
+            config = s3._get_boto_config('gs', endpoint_url='https://storage.googleapis.com')
+        self.assertNotIn('addressing_style', self._s3_options(config))
+
+    def test_credential_addressing_style_overrides_default(self):
+        """Credential-level addressing_style is passed to botocore config."""
+        with mock.patch.dict('os.environ', {}, clear=True):
+            config = s3._get_boto_config(
+                's3',
+                endpoint_url='https://cwobject.com',
+                addressing_style='path',
+            )
+        self.assertEqual(self._s3_options(config).get('addressing_style'), 'path')
+
     def test_tos_unchanged(self):
         """TOS still hardcodes virtual regardless of endpoint."""
         with mock.patch.dict('os.environ', {}, clear=True):
@@ -611,6 +636,24 @@ class GetBotoConfigTest(unittest.TestCase):
         with mock.patch.dict('os.environ', {s3.OSMO_S3_ADDRESSING_STYLE: 'path'}):
             config = s3._get_boto_config('s3', endpoint_url='https://cwobject.com')
         self.assertEqual(self._s3_options(config).get('addressing_style'), 'path')
+
+
+class CredentialAddressingStyleTest(unittest.TestCase):
+    """Tests for carrying S3 addressing style through data credentials."""
+
+    def test_static_credential_to_decrypted_dict_includes_addressing_style(self):
+        data_cred = credentials.StaticDataCredential(
+            endpoint='s3://bucket',
+            access_key_id='ak',
+            access_key='sk',
+            region='us-east-1',
+            override_url='https://cwobject.com',
+            addressing_style='virtual',
+        )
+
+        result = data_cred.to_decrypted_dict()
+
+        self.assertEqual(result['addressing_style'], 'virtual')
 
 
 class WorkflowConfigCredentialTest(unittest.TestCase):

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -503,6 +503,64 @@ class IsAwsEndpointTest(unittest.TestCase):
             self.assertFalse(backends._is_aws_endpoint(url), url)
 
 
+class GetS3AddressingStyleTest(unittest.TestCase):
+    """Tests for _get_s3_addressing_style helper."""
+
+    # pylint: disable=protected-access
+
+    def test_no_endpoint_returns_none(self):
+        """AWS S3 (no custom endpoint): defer to boto3 default."""
+        with mock.patch.dict('os.environ', {}, clear=True):
+            self.assertIsNone(s3._get_s3_addressing_style(None))
+
+    def test_custom_endpoint_returns_virtual(self):
+        """Custom endpoint defaults to virtual-hosted style."""
+        with mock.patch.dict('os.environ', {}, clear=True):
+            self.assertEqual(s3._get_s3_addressing_style('https://cwobject.com'), 'virtual')
+
+    def test_env_override_wins(self):
+        """OSMO_S3_ADDRESSING_STYLE overrides the default for both endpoint cases."""
+        with mock.patch.dict('os.environ', {s3.OSMO_S3_ADDRESSING_STYLE: 'path'}):
+            self.assertEqual(s3._get_s3_addressing_style('https://cwobject.com'), 'path')
+            self.assertEqual(s3._get_s3_addressing_style(None), 'path')
+
+
+class GetBotoConfigTest(unittest.TestCase):
+    """Tests for _get_boto_config addressing_style selection."""
+
+    # pylint: disable=protected-access
+
+    @staticmethod
+    def _s3_options(config) -> dict:
+        # botocore.config.Config exposes 's3' as an instance attribute when set,
+        # but it's not in the type stubs — read defensively.
+        return getattr(config, 's3', None) or {}
+
+    def test_aws_s3_no_addressing_style(self):
+        """AWS S3 (no endpoint): no addressing_style is set, boto3 picks the default."""
+        with mock.patch.dict('os.environ', {}, clear=True):
+            config = s3._get_boto_config('s3')
+        self.assertNotIn('addressing_style', self._s3_options(config))
+
+    def test_custom_endpoint_uses_virtual(self):
+        """Custom endpoint sets addressing_style=virtual."""
+        with mock.patch.dict('os.environ', {}, clear=True):
+            config = s3._get_boto_config('s3', endpoint_url='https://cwobject.com')
+        self.assertEqual(self._s3_options(config).get('addressing_style'), 'virtual')
+
+    def test_tos_unchanged(self):
+        """TOS still hardcodes virtual regardless of endpoint."""
+        with mock.patch.dict('os.environ', {}, clear=True):
+            config = s3._get_boto_config('tos')
+        self.assertEqual(self._s3_options(config).get('addressing_style'), 'virtual')
+
+    def test_env_override_to_path(self):
+        """OSMO_S3_ADDRESSING_STYLE=path reverts custom endpoints to path-style."""
+        with mock.patch.dict('os.environ', {s3.OSMO_S3_ADDRESSING_STYLE: 'path'}):
+            config = s3._get_boto_config('s3', endpoint_url='https://cwobject.com')
+        self.assertEqual(self._s3_options(config).get('addressing_style'), 'path')
+
+
 class WorkflowConfigCredentialTest(unittest.TestCase):
     """Tests for WorkflowConfig credential type support."""
 

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -524,6 +524,58 @@ class GetS3AddressingStyleTest(unittest.TestCase):
             self.assertEqual(s3._get_s3_addressing_style('https://cwobject.com'), 'path')
             self.assertEqual(s3._get_s3_addressing_style(None), 'path')
 
+    def test_aws_s3_force_path_style_returns_path(self):
+        """AWS_S3_FORCE_PATH_STYLE=true preserves localstack/MinIO chart deployments."""
+        for value in ('true', 'True', 'TRUE', '1'):
+            with mock.patch.dict('os.environ', {'AWS_S3_FORCE_PATH_STYLE': value}, clear=True):
+                self.assertEqual(
+                    s3._get_s3_addressing_style('http://localstack-s3.osmo:4566'),
+                    'path',
+                    value,
+                )
+
+    def test_osmo_override_beats_aws_force_path(self):
+        """OSMO_S3_ADDRESSING_STYLE takes precedence over AWS_S3_FORCE_PATH_STYLE."""
+        with mock.patch.dict('os.environ', {
+            s3.OSMO_S3_ADDRESSING_STYLE: 'virtual',
+            'AWS_S3_FORCE_PATH_STYLE': 'true',
+        }):
+            self.assertEqual(
+                s3._get_s3_addressing_style('http://localstack-s3.osmo:4566'),
+                'virtual',
+            )
+
+
+class S3BackendRegionTest(unittest.TestCase):
+    """Tests for S3Backend.region() endpoint routing."""
+
+    @mock.patch('src.lib.data.storage.backends.s3.create_client')
+    def test_region_inference_targets_override_url(self, mock_create_client):
+        """When the credential has override_url but no region, the precheck must
+        target that endpoint — not AWS S3 — so GetBucketLocation actually hits
+        the right backend (e.g., CAIOS, MinIO)."""
+        mock_s3_client = mock.Mock()
+        mock_s3_client.get_bucket_location.return_value = {'LocationConstraint': 'us-east-1'}
+        mock_create_client.return_value = mock_s3_client
+
+        s3_backend = cast(backends.S3Backend, backends.construct_storage_backend(
+            uri='s3://my-caios-bucket/data',
+        ))
+        data_cred = credentials.StaticDataCredential(
+            endpoint='s3://my-caios-bucket',
+            access_key_id='ak',
+            access_key='sk',
+            override_url='https://cwobject.com',
+            # region intentionally not set: forces the GetBucketLocation path.
+        )
+
+        result = s3_backend.region(data_cred=data_cred)
+
+        self.assertEqual(result, 'us-east-1')
+        mock_create_client.assert_called_once()
+        call_kwargs = mock_create_client.call_args.kwargs
+        self.assertEqual(call_kwargs.get('endpoint_url'), 'https://cwobject.com')
+
 
 class GetBotoConfigTest(unittest.TestCase):
     """Tests for _get_boto_config addressing_style selection."""

--- a/src/lib/data/storage/credentials/credentials.py
+++ b/src/lib/data/storage/credentials/credentials.py
@@ -23,7 +23,7 @@ Credentials for the data module.
 import abc
 import os
 import re
-from typing import Union
+from typing import Literal, Union
 from urllib.parse import urlparse
 
 import pydantic
@@ -76,6 +76,14 @@ class DataCredentialBase(pydantic.BaseModel, abc.ABC, extra='forbid'):
             'Leave unset for native AWS S3, GCS, Azure, etc.'
         ),
     )
+    addressing_style: Literal['virtual', 'path', 'auto'] | None = pydantic.Field(
+        default=None,
+        description=(
+            'S3 request addressing style for S3-compatible providers. '
+            "Use 'virtual' for providers such as CoreWeave CAIOS that reject "
+            "path-style requests, or 'path' for localstack/MinIO-style endpoints."
+        ),
+    )
 
     @pydantic.field_validator('endpoint')
     @classmethod
@@ -115,6 +123,9 @@ class StaticDataCredential(DataCredentialBase, abc.ABC, extra='forbid'):
         if self.override_url:
             output['override_url'] = self.override_url
 
+        if self.addressing_style:
+            output['addressing_style'] = self.addressing_style
+
         return output
 
 
@@ -145,6 +156,9 @@ class DefaultDataCredential(DataCredentialBase, extra='forbid'):
 
         if self.override_url:
             output['override_url'] = self.override_url
+
+        if self.addressing_style:
+            output['addressing_style'] = self.addressing_style
 
         return output
 
@@ -187,6 +201,7 @@ def get_static_data_credential_from_config(
                 endpoint=url,
                 region=data_cred_dict.get('region'),
                 override_url=data_cred_dict.get('override_url'),
+                addressing_style=data_cred_dict.get('addressing_style'),
             )
 
             return data_cred

--- a/src/runtime/pkg/data/BUILD
+++ b/src/runtime/pkg/data/BUILD
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "data",
@@ -30,4 +30,10 @@ go_library(
         "//src/runtime/pkg/metrics",
         "//src/runtime/pkg/osmo_errors:osmo_errors",
     ]
+)
+
+go_test(
+    name = "data_test",
+    srcs = ["data_test.go"],
+    embed = [":data"],
 )

--- a/src/runtime/pkg/data/data.go
+++ b/src/runtime/pkg/data/data.go
@@ -60,6 +60,7 @@ const (
 const (
 	s3AddressingStylePath    string = "path"
 	s3AddressingStyleVirtual string = "virtual"
+	s3AddressingStyleAuto    string = "auto"
 	osmoS3AddressingStyle    string = "OSMO_S3_ADDRESSING_STYLE"
 	awsS3ForcePathStyle      string = "AWS_S3_FORCE_PATH_STYLE"
 )
@@ -96,6 +97,13 @@ func shouldForcePathStyle(storageBackend StorageBackend, dataCredential DataCred
 			return false
 		case s3AddressingStylePath:
 			return true
+		case s3AddressingStyleAuto:
+			// 'auto' is accepted by the credential schema for parity with
+			// boto3, but mount-s3 has no auto-detect knob. We deliberately
+			// diverge from boto3's 'auto' (which picks path-style for custom
+			// endpoints — the very behavior that breaks CAIOS) and instead
+			// fall through to OSMO's heuristic: AWS_S3_FORCE_PATH_STYLE,
+			// then OverrideUrl presence.
 		}
 		if awsForcePathStyleEnabled() {
 			return true

--- a/src/runtime/pkg/data/data.go
+++ b/src/runtime/pkg/data/data.go
@@ -58,6 +58,13 @@ const (
 )
 
 const (
+	s3AddressingStylePath    string = "path"
+	s3AddressingStyleVirtual string = "virtual"
+	osmoS3AddressingStyle    string = "OSMO_S3_ADDRESSING_STYLE"
+	awsS3ForcePathStyle      string = "AWS_S3_FORCE_PATH_STYLE"
+)
+
+const (
 	URLOperation     string = "Url"
 	DatasetOperation string = "Dataset"
 )
@@ -68,6 +75,77 @@ func setOrUnsetEnv(key, value string) {
 	} else {
 		os.Unsetenv(key)
 	}
+}
+
+func awsForcePathStyleEnabled() bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(awsS3ForcePathStyle)))
+	return value == "true" || value == "1"
+}
+
+func shouldForcePathStyle(storageBackend StorageBackend, dataCredential DataCredential) bool {
+	switch storageBackend.GetScheme() {
+	case TOS:
+		return false
+	case S3:
+		addressingStyle := strings.ToLower(strings.TrimSpace(dataCredential.AddressingStyle))
+		if addressingStyle == "" {
+			addressingStyle = strings.ToLower(strings.TrimSpace(os.Getenv(osmoS3AddressingStyle)))
+		}
+		switch addressingStyle {
+		case s3AddressingStyleVirtual:
+			return false
+		case s3AddressingStylePath:
+			return true
+		}
+		if awsForcePathStyleEnabled() {
+			return true
+		}
+		return dataCredential.OverrideUrl == ""
+	default:
+		return true
+	}
+}
+
+func buildMountCommandArgs(
+	storageBackend StorageBackend,
+	dataCredential DataCredential,
+	localPath string,
+	cachePath string,
+	cacheSize int,
+) []string {
+	commandArgs := []string{storageBackend.GetBucket(), localPath,
+		"--read-only", "--auto-unmount", "--allow-other"}
+	if shouldForcePathStyle(storageBackend, dataCredential) {
+		commandArgs = append(commandArgs, "--force-path-style")
+	}
+	// Specify cache only if the size is greater than 0
+	if cacheSize > 0 {
+		log.Printf("Path %s has cache size %dMiB", localPath, cacheSize)
+		cacheSlice := []string{
+			"--cache", cachePath,
+			"--metadata-ttl", "indefinite",
+			"--max-cache-size", strconv.Itoa(cacheSize)}
+		commandArgs = append(commandArgs, cacheSlice...)
+	} else {
+		log.Printf("Path %s has no cache", localPath)
+	}
+
+	endpointUrl := dataCredential.OverrideUrl
+	if endpointUrl == "" {
+		endpointUrl = storageBackend.GetAuthEndpoint()
+	}
+	if endpointUrl != "" {
+		commandArgs = append(commandArgs, "--endpoint-url", endpointUrl)
+	}
+	path := storageBackend.GetPath()
+	if path != "" {
+		if !strings.HasSuffix(path, "/") {
+			path += "/"
+		}
+		path = strings.Join([]string{"--prefix", path}, "=")
+		commandArgs = append(commandArgs, path)
+	}
+	return commandArgs
 }
 
 type VersionInfo struct {
@@ -434,34 +512,13 @@ func MountURL(downloadType string, credentialInfo ConfigInfo, urlPath string,
 	var commandArgs []string
 
 	if downloadType == Mountpoint {
-		commandArgs = []string{storageBackend.GetBucket(), localPath,
-			"--read-only", "--auto-unmount", "--allow-other"}
-		if storageBackend.GetScheme() != TOS {
-			commandArgs = append(commandArgs, "--force-path-style")
-		}
-		// Specify cache only if the size is greater than 0
-		if cacheSize > 0 {
-			log.Printf("Path %s has cache size %dMiB", localPath, cacheSize)
-			cacheSlice := []string{
-				"--cache", cachePath,
-				"--metadata-ttl", "indefinite",
-				"--max-cache-size", strconv.Itoa(cacheSize)}
-			commandArgs = append(commandArgs, cacheSlice...)
-		} else {
-			log.Printf("Path %s has no cache", localPath)
-		}
-
-		if storageBackend.GetAuthEndpoint() != "" {
-			commandArgs = append(commandArgs, "--endpoint-url", storageBackend.GetAuthEndpoint())
-		}
-		path := storageBackend.GetPath()
-		if path != "" {
-			if !strings.HasSuffix(path, "/") {
-				path += "/"
-			}
-			path = strings.Join([]string{"--prefix", path}, "=")
-			commandArgs = append(commandArgs, path)
-		}
+		commandArgs = buildMountCommandArgs(
+			storageBackend,
+			dataCredential,
+			localPath,
+			cachePath,
+			cacheSize,
+		)
 	} else {
 		osmoChan <- fmt.Sprintf("Mounting type %s is not supported.", downloadType)
 		return isEmpty

--- a/src/runtime/pkg/data/data_test.go
+++ b/src/runtime/pkg/data/data_test.go
@@ -157,6 +157,26 @@ func TestBuildMountCommandArgsOsmoEnvVarSelectsVirtual(t *testing.T) {
 	}
 }
 
+func TestBuildMountCommandArgsAutoFallsThroughToHeuristic(t *testing.T) {
+	// 'auto' is accepted by the credential schema (Literal['virtual','path','auto'])
+	// but the runtime intentionally does NOT mirror boto3's 'auto', which would
+	// pick path-style for any custom endpoint and re-break CAIOS. Treat 'auto'
+	// as "use OSMO's heuristic" — same as an unset value.
+	t.Setenv(osmoS3AddressingStyle, "")
+	t.Setenv(awsS3ForcePathStyle, "")
+	backend := ParseStorageBackend("s3://coreweave-bucket/data")
+	credential := DataCredential{
+		OverrideUrl:     "https://cwobject.com",
+		AddressingStyle: "auto",
+	}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if slices.Contains(args, "--force-path-style") {
+		t.Fatalf("'auto' with override_url must fall through to virtual-host: %v", args)
+	}
+}
+
 func TestBuildMountCommandArgsCredentialBeatsEnv(t *testing.T) {
 	// Per-credential addressing_style takes precedence over both env vars.
 	t.Setenv(osmoS3AddressingStyle, "path")

--- a/src/runtime/pkg/data/data_test.go
+++ b/src/runtime/pkg/data/data_test.go
@@ -1,0 +1,175 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package data
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestBuildMountCommandArgsS3VirtualCustomEndpoint(t *testing.T) {
+	backend := ParseStorageBackend("s3://coreweave-bucket/datasets")
+	credential := DataCredential{
+		OverrideUrl:     "https://cwobject.com",
+		AddressingStyle: "virtual",
+	}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if !slices.Contains(args, "--endpoint-url") {
+		t.Fatalf("expected endpoint URL flag in args: %v", args)
+	}
+	if !slices.Contains(args, "https://cwobject.com") {
+		t.Fatalf("expected CoreWeave endpoint URL in args: %v", args)
+	}
+	if slices.Contains(args, "--force-path-style") {
+		t.Fatalf("virtual addressing must not force path style: %v", args)
+	}
+	if !slices.Contains(args, "--prefix=datasets/") {
+		t.Fatalf("expected S3 prefix in args: %v", args)
+	}
+}
+
+func TestBuildMountCommandArgsS3CustomEndpointDefaultsVirtual(t *testing.T) {
+	t.Setenv(osmoS3AddressingStyle, "")
+	t.Setenv(awsS3ForcePathStyle, "")
+	backend := ParseStorageBackend("s3://coreweave-bucket/datasets")
+	credential := DataCredential{
+		OverrideUrl: "https://cwobject.com",
+	}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if slices.Contains(args, "--force-path-style") {
+		t.Fatalf("custom S3 endpoint should default to virtual addressing: %v", args)
+	}
+	if !slices.Contains(args, "https://cwobject.com") {
+		t.Fatalf("expected CoreWeave endpoint URL in args: %v", args)
+	}
+}
+
+func TestBuildMountCommandArgsS3PathCustomEndpoint(t *testing.T) {
+	backend := ParseStorageBackend("s3://localstack-bucket/datasets")
+	credential := DataCredential{
+		OverrideUrl:     "http://localstack-s3.osmo:4566",
+		AddressingStyle: "path",
+	}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if !slices.Contains(args, "--endpoint-url") {
+		t.Fatalf("expected endpoint URL flag in args: %v", args)
+	}
+	if !slices.Contains(args, "http://localstack-s3.osmo:4566") {
+		t.Fatalf("expected localstack endpoint URL in args: %v", args)
+	}
+	if !slices.Contains(args, "--force-path-style") {
+		t.Fatalf("path addressing must force path style: %v", args)
+	}
+}
+
+func TestBuildMountCommandArgsS3CustomEndpointRespectsForcePathEnv(t *testing.T) {
+	t.Setenv(osmoS3AddressingStyle, "")
+	t.Setenv(awsS3ForcePathStyle, "true")
+	backend := ParseStorageBackend("s3://localstack-bucket/datasets")
+	credential := DataCredential{
+		OverrideUrl: "http://localstack-s3.osmo:4566",
+	}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if !slices.Contains(args, "--force-path-style") {
+		t.Fatalf("AWS_S3_FORCE_PATH_STYLE must force path style: %v", args)
+	}
+}
+
+func TestBuildMountCommandArgsTOSDoesNotForcePathStyle(t *testing.T) {
+	// Regression guard: TOS only supports virtual-hosted style.
+	backend := ParseStorageBackend("tos://tos.example.com/my-bucket/data")
+	credential := DataCredential{}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if slices.Contains(args, "--force-path-style") {
+		t.Fatalf("TOS must not force path style: %v", args)
+	}
+}
+
+func TestBuildMountCommandArgsAwsS3WithoutOverrideForcesPathStyle(t *testing.T) {
+	// Preserved behavior: plain AWS S3 (no override_url, no env hints) still gets
+	// --force-path-style. Codex's refactor intentionally kept this.
+	t.Setenv(osmoS3AddressingStyle, "")
+	t.Setenv(awsS3ForcePathStyle, "")
+	backend := ParseStorageBackend("s3://aws-bucket/data")
+	credential := DataCredential{}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if !slices.Contains(args, "--force-path-style") {
+		t.Fatalf("AWS S3 without override_url must force path style (preserved): %v", args)
+	}
+	if slices.Contains(args, "--endpoint-url") {
+		t.Fatalf("AWS S3 with no override_url must not pass --endpoint-url: %v", args)
+	}
+}
+
+func TestBuildMountCommandArgsSwiftForcesPathStyle(t *testing.T) {
+	// Preserved behavior: Swift's S3 API uses path-style addressing.
+	t.Setenv(osmoS3AddressingStyle, "")
+	t.Setenv(awsS3ForcePathStyle, "")
+	backend := ParseStorageBackend("swift://swift.example.com/AUTH_ns/my-bucket/data")
+	credential := DataCredential{}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if !slices.Contains(args, "--force-path-style") {
+		t.Fatalf("Swift must force path style: %v", args)
+	}
+}
+
+func TestBuildMountCommandArgsOsmoEnvVarSelectsVirtual(t *testing.T) {
+	// OSMO_S3_ADDRESSING_STYLE=virtual flips even no-override AWS S3 to virtual.
+	t.Setenv(osmoS3AddressingStyle, "virtual")
+	t.Setenv(awsS3ForcePathStyle, "")
+	backend := ParseStorageBackend("s3://aws-bucket/data")
+	credential := DataCredential{}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if slices.Contains(args, "--force-path-style") {
+		t.Fatalf("OSMO_S3_ADDRESSING_STYLE=virtual must override the default: %v", args)
+	}
+}
+
+func TestBuildMountCommandArgsCredentialBeatsEnv(t *testing.T) {
+	// Per-credential addressing_style takes precedence over both env vars.
+	t.Setenv(osmoS3AddressingStyle, "path")
+	t.Setenv(awsS3ForcePathStyle, "true")
+	backend := ParseStorageBackend("s3://coreweave-bucket/data")
+	credential := DataCredential{
+		OverrideUrl:     "https://cwobject.com",
+		AddressingStyle: "virtual",
+	}
+
+	args := buildMountCommandArgs(backend, credential, "/mnt/input", "/mnt/cache", 0)
+
+	if slices.Contains(args, "--force-path-style") {
+		t.Fatalf("credential addressing_style=virtual must override env vars: %v", args)
+	}
+}

--- a/src/runtime/pkg/data/input_output.go
+++ b/src/runtime/pkg/data/input_output.go
@@ -34,9 +34,11 @@ import (
 )
 
 type DataCredential struct {
-	AccessKey   string `yaml:"access_key"`
-	AccessKeyId string `yaml:"access_key_id"`
-	Region      string `yaml:"region"`
+	AccessKey       string `yaml:"access_key"`
+	AccessKeyId     string `yaml:"access_key_id"`
+	Region          string `yaml:"region"`
+	OverrideUrl     string `yaml:"override_url"`
+	AddressingStyle string `yaml:"addressing_style"`
 }
 
 type DataConfig struct {

--- a/src/service/core/workflow/objects.py
+++ b/src/service/core/workflow/objects.py
@@ -671,6 +671,9 @@ class UserDataCredential(
         if self.override_url:
             payload['override_url'] = self.override_url
 
+        if self.addressing_style:
+            payload['addressing_style'] = self.addressing_style
+
         payload = postgres.encrypt_dict(payload, user)
 
         return CredentialRecord(
@@ -690,6 +693,7 @@ class UserDataCredential(
             access_key=pydantic.SecretStr(self.access_key),
             region=self.region,
             override_url=self.override_url,
+            addressing_style=self.addressing_style,
         )
 
         storage_info.data_auth(data_cred)

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -2742,6 +2742,7 @@ def _resolve_bucket_credential(
         access_key_id=credential.access_key_id,
         access_key=credential.access_key,
         override_url=credential.override_url,
+        addressing_style=credential.addressing_style,
     )
 
 


### PR DESCRIPTION
Boto3's 'auto' default picks path-style addressing whenever endpoint_url is set, which breaks S3-compatible providers that require virtual-hosted style. On CAIOS (CoreWeave Object Storage), R2-strict, and Wasabi-strict, this caused HeadBucket and GetBucketLocation to fail with 400, blocking osmo credential set, dataset/data uploads, and the upload preflight check.

In _get_boto_config, set addressing_style='virtual' whenever endpoint_url is provided. AWS S3 (no endpoint_url) is unaffected. The TOS branch is folded into the same shape (still hardcoded virtual). An OSMO_S3_ADDRESSING_STYLE env var is provided as an escape hatch for legacy buckets whose names are not DNS-compliant under virtual-hosted addressing.

Verified against a real CAIOS bucket via aws s3api head-bucket: path-style returned 400, virtual-hosted returned 200 with BucketRegion populated.

<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->

Issue #940

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global and per-credential S3 addressing-style (virtual/path/auto) with env var support and CLI/config persistence; mount tooling and runtime honor addressing-style when building S3 mount commands.
* **Bug Fixes**
  * Region lookup now targets a credential’s configured endpoint, fixing lookups for non-AWS S3-compatible backends.
* **Tests**
  * Added comprehensive tests for addressing-style precedence, validation, config persistence, client config behavior, and mount command argument generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->