### PR TITLE
testbot: require go_test BUILD targets for new Go test files

### DIFF
--- a/src/scripts/testbot/TESTBOT_PROMPT.md
+++ b/src/scripts/testbot/TESTBOT_PROMPT.md
@@ -29,10 +29,28 @@ The targets are appended below this prompt. For each target you receive:
    - Target: boundary values, empty/None inputs, error paths, off-by-one.
 5. Write (or extend) the test file targeting the uncovered line ranges.
    Place new test files in the same location convention as step 2.
-6. **Python only — BUILD file**:
-   - Check the `BUILD` file in the test directory for an existing `py_test()` entry.
-   - If missing, add a `py_test()` rule. Infer `deps` from other `py_test` entries
-     in the same BUILD file. Do NOT guess target names.
+6. **BUILD file** (Python and Go — TypeScript uses Vitest discovery, no BUILD edit):
+   - **Python**: check the `BUILD` file in the test directory for an existing
+     `py_test()` entry. If missing, add a `py_test()` rule. Infer `deps` from
+     other `py_test` entries in the same BUILD file. Do NOT guess target names.
+   - **Go**: the test file lives next to the source (`<name>_test.go`), so
+     check the source package's `BUILD` for an existing `go_test()` entry. If
+     the BUILD only has `go_library` and you added a `_test.go`, you MUST also
+     add a `go_test` rule referencing it. Without the rule the test file is
+     invisible to Bazel and `bazel coverage` will not run it. Pattern (verified
+     against `src/runtime/pkg/data/BUILD`):
+     ```
+     load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+     go_test(
+         name = "<pkg>_test",
+         srcs = ["<name>_test.go"],
+         embed = [":<pkg>"],   # the existing go_library target name
+         # add deps only if your test imports something the library doesn't
+     )
+     ```
+     Confirm the rule is loaded by running `bazel test <target>`; if you get
+     `ERROR: No test targets were found, yet testing was requested`, the
+     `go_test` rule is missing or misnamed.
 7. Run the test and verify code style per TESTBOT_RULES.md.
    If the test fails, follow the bug detection steps in TESTBOT_RULES.md.
 8. Move to the next target.
@@ -41,7 +59,8 @@ The targets are appended below this prompt. For each target you receive:
 
 - **Test files only**: You may ONLY create or modify test files (`test_*.py`,
   `*_test.go`, `*.test.ts`, `*.test.tsx`) and `BUILD` files (for `py_test`
-  entries). Do NOT modify source code, configuration, or other non-test files.
+  and `go_test` entries). Do NOT modify source code, configuration, or other
+  non-test files.
 - **No git or gh commands**: Do NOT run `git`, `gh`, or any commands that
   modify version control state. The harness script handles branch creation,
   committing, pushing, and PR creation.

--- a/src/scripts/testbot/TESTBOT_PROMPT.md
+++ b/src/scripts/testbot/TESTBOT_PROMPT.md
@@ -39,7 +39,7 @@ The targets are appended below this prompt. For each target you receive:
      add a `go_test` rule referencing it. Without the rule the test file is
      invisible to Bazel and `bazel coverage` will not run it. Pattern (verified
      against `src/runtime/pkg/data/BUILD`):
-     ```
+     ```bzl
      load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
      go_test(
          name = "<pkg>_test",

--- a/src/scripts/testbot/TESTBOT_RULES.md
+++ b/src/scripts/testbot/TESTBOT_RULES.md
@@ -53,7 +53,10 @@ When a test fails:
 > see both the failure and the output. Just run the command directly.
 
 1. **Run the test**:
-   - Python/Go: `bazel test <target>` (derive the Bazel target from the BUILD file)
+   - Python/Go: `bazel test <target>` (derive the Bazel target from the BUILD file).
+     If `bazel test` reports `ERROR: No test targets were found, yet testing
+     was requested`, the test file isn't wired into BUILD — see "BUILD wiring"
+     below before retrying.
    - TypeScript: `pnpm --dir src/ui test -- --run <test_file_path>`
 2. If the test fails, read the error and fix. Retry up to 3 times.
 3. **Verify code style** (same checks as PR CI). Fix and re-verify until clean:
@@ -62,6 +65,19 @@ When a test fails:
      format:check, tests, and build). If formatting fails, run
      `pnpm --dir src/ui format` to auto-fix.
    - Go: no additional checks beyond step 1.
+
+### BUILD wiring (Python + Go)
+
+A test file that isn't registered as a Bazel target is invisible to CI —
+`bazel coverage //...` won't run it and Codecov won't see the new coverage,
+defeating the whole point of the testbot run.
+
+- **Python** (`test_<name>.py`): the `BUILD` file in the test directory must
+  have a `py_test()` rule whose `srcs` includes the new file.
+- **Go** (`<name>_test.go`): the source package's `BUILD` file must load
+  `go_test` and declare a `go_test()` rule pointing at the new file. A
+  `go_library`-only BUILD file silently drops adjacent `_test.go` files
+  on the floor.
 
 ## Language Conventions
 


### PR DESCRIPTION
## Summary

PR #956 (testbot-generated) added `src/runtime/pkg/common/common_test.go` but didn't add a corresponding `go_test` rule to the package's `BUILD` file. The test file is invisible to Bazel:

```
$ bazel test //src/runtime/pkg/common:all
ERROR: No test targets were found, yet testing was requested
$ bazel query 'kind(go_test, //src/runtime/pkg/common/...)'
INFO: Empty results
```

Net effect: a testbot run that picked `common.go` because of "0% coverage" closed the gap with a PR that ships **zero new measured coverage** — `bazel coverage //...` won't run a test target it doesn't know about, and Codecov never sees the result.

This PR teaches the testbot to wire up Go tests properly going forward:

- **`TESTBOT_PROMPT.md` step 6**: generalized from "Python only" to cover Go. Includes the canonical pattern (`go_library` + `go_test` with `embed = [":<pkg>"]`) verified against `src/runtime/pkg/data/BUILD`, and a "check it worked" instruction — re-run `bazel test` and watch for `No test targets were found`.
- **`TESTBOT_RULES.md` verification step**: explicitly call out the "No test targets were found" failure mode and point at BUILD wiring. New "BUILD wiring (Python + Go)" subsection explains why a `go_library`-only BUILD silently drops adjacent `_test.go` files.
- **`TESTBOT_PROMPT.md` guardrails**: include `go_test` alongside `py_test` in the allowed BUILD edits.

Documentation-only change to the prompt files. No code paths or tests change.

Issue - None

## Files tested
- N/A — this updates the agent's instructions, not source code.

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes (14/14 testbot bazel tests still pass)
- [x] The documentation is up to date with these changes (this *is* the documentation)

## Test plan
- [x] `bazel test //src/scripts/testbot/tests/...` (still green)
- [ ] Next testbot generate run picks a Go target and produces a PR with both `_test.go` AND a `go_test` BUILD entry, then `bazel coverage //...` actually shows non-zero coverage on the targeted file.

## Follow-up

PR #956 itself still needs the `go_test` rule appended to `src/runtime/pkg/common/BUILD` to take effect. I'd suggest either pushing the fix to that branch directly or asking testbot to follow up via `/testbot add a go_test rule to BUILD for common_test.go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded test-generation guidance with detailed BUILD file handling and Bazel wiring instructions for Python and Go, including verification steps and a Bazel-specific test failure path.
  * Clarified that test-generation changes are restricted to test files and BUILD entries (py_test/go_test), with no modifications to source code or configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->