### PR TITLE
charts/backend-operator: configurable + relaxed startupProbe defaults

### DIFF
--- a/deployments/charts/backend-operator/templates/backend-listener.yaml
+++ b/deployments/charts/backend-operator/templates/backend-listener.yaml
@@ -167,10 +167,10 @@ spec:
             - "300:300:300:300"
             - --progress_file
             - /var/run/osmo/last_progress_websocket:/var/run/osmo/last_progress_pod:/var/run/osmo/last_progress_node:/var/run/osmo/last_progress_event
-          failureThreshold: 12
-          periodSeconds: 5
-          timeoutSeconds: 15
-          initialDelaySeconds: 10
+          failureThreshold: {{ .Values.services.backendListener.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.services.backendListener.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.services.backendListener.startupProbe.timeoutSeconds }}
+          initialDelaySeconds: {{ .Values.services.backendListener.startupProbe.initialDelaySeconds }}
 
       {{- with .Values.services.backendListener.extraSidecarContainers }}
       {{- toYaml . | nindent 6 }}

--- a/deployments/charts/backend-operator/templates/backend-worker.yaml
+++ b/deployments/charts/backend-operator/templates/backend-worker.yaml
@@ -171,10 +171,10 @@ spec:
             - "300:300"
             - --progress_file
             - /var/run/osmo/last_progress_worker_job:/var/run/osmo/last_progress_worker_heartbeat
-          failureThreshold: 12
-          periodSeconds: 5
-          timeoutSeconds: 15
-          initialDelaySeconds: 10
+          failureThreshold: {{ .Values.services.backendWorker.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.services.backendWorker.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.services.backendWorker.startupProbe.timeoutSeconds }}
+          initialDelaySeconds: {{ .Values.services.backendWorker.startupProbe.initialDelaySeconds }}
 
       {{- with .Values.services.backendWorker.extraSidecarContainers }}
       {{- toYaml . | nindent 6 }}

--- a/deployments/charts/backend-operator/values.yaml
+++ b/deployments/charts/backend-operator/values.yaml
@@ -335,6 +335,17 @@ services:
     ##
     apiBurst: 30
 
+    ## Startup probe tuning. Defaults sized for managed K8s (AKS/EKS) where
+    ## progress_check (PyInstaller-bundled Python) cold-starts past 15s on
+    ## small system-pool nodes. 60s timeout × 30 attempts = 150s tolerance.
+    ## Harmless on fast clusters (probe stops at first success).
+    ##
+    startupProbe:
+      failureThreshold: 30
+      periodSeconds: 5
+      timeoutSeconds: 60
+      initialDelaySeconds: 10
+
   ## Backend worker configuration
   ## Executes jobs received from the backend listener
   ##
@@ -445,6 +456,17 @@ services:
         memory: "1Gi"
       limits:
         memory: "1Gi"
+
+    ## Startup probe tuning. Defaults sized for managed K8s (AKS/EKS) where
+    ## progress_check (PyInstaller-bundled Python) cold-starts past 15s on
+    ## small system-pool nodes. 60s timeout × 30 attempts = 150s tolerance.
+    ## Harmless on fast clusters (probe stops at first success).
+    ##
+    startupProbe:
+      failureThreshold: 30
+      periodSeconds: 5
+      timeoutSeconds: 60
+      initialDelaySeconds: 10
 
 
 ## Backend Test Runner CronJob Configuration


### PR DESCRIPTION
## Description

Two changes to backend-operator startup probes:

1. **Make the probe configurable.** Drop the hardcoded `failureThreshold` / `periodSeconds` / `timeoutSeconds` / `initialDelaySeconds` on `backendListener` + `backendWorker`; pull each through `services.{backendListener,backendWorker}.startupProbe.*` values. Same pattern as #5247b44f8 on the service-side chart.

2. **Relax the defaults.** `failureThreshold: 12 → 30`, `timeoutSeconds: 15 → 60` (others unchanged). The previous defaults assumed fast-bootstrap = 60s tolerance; managed K8s (AKS/EKS) cold-starts blow past that. New tolerance is 150s, harmless on fast clusters because the probe stops at first success — extra threshold/timeout has no overhead unless the service is actually broken. Only downside on a genuinely-broken pod is slower kubelet kill (~2.5 min vs ~60s); that's fine for a startup probe.

**Why.** Surfaced during full bring-up on Azure. On 2-CPU AKS system-pool VMs, `progress_check` (PyInstaller-bundled Python) cold-starts past the 15s `timeoutSeconds` on every invocation. Every probe times out, kubelet kills the container, the cycle repeats until helm `--wait` deadline fires — despite the listener/worker being functionally healthy and watching events the whole time.

**Verification.**
- `helm template` with no overrides → renders new defaults: 30 / 5 / 60 / 10
- `helm template --set services.backendListener.startupProbe.failureThreshold=12 ...` → overrides flow through correctly; backendWorker stays at defaults
- Live cluster: pod-level patch with same numbers (60 / 30) made backend-listener + backend-worker Ready in 2m20s on cold AKS nodes; they CrashLoopBackOff'd indefinitely with the previous defaults

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Externalized startup probe configuration for backend services, enabling flexible tuning of health check parameters (failure thresholds, probe intervals, timeouts, and initial delays) through configurable values instead of hard-coded settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->