### PR TITLE
backend-operator: default podMonitor.enabled to false

### DIFF
--- a/deployments/charts/backend-operator/values.yaml
+++ b/deployments/charts/backend-operator/values.yaml
@@ -216,7 +216,7 @@ global:
 ## Set enabled: false if the PodMonitor CRD is not installed in your cluster.
 ##
 podMonitor:
-  enabled: true
+  enabled: false
 
 ## Configuration for individual backend operators
 ##


### PR DESCRIPTION

## Description
Default to disabled so the chart works on clusters without the Prometheus Operator / monitoring.coreos.com PodMonitor CRD installed. Existing deployments set podMonitor.enabled=true in their values files to keep current behavior.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to disable monitoring by default, allowing operators to explicitly enable it for their infrastructure setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->