### PR TITLE
service: default podMonitor.enabled to false

### DIFF
--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1565,7 +1565,7 @@ services:
 ## Set enabled: false if the PodMonitor CRD is not installed in your cluster.
 ##
 podMonitor:
-  enabled: true
+  enabled: false
 
 ## Global configuration for extra ConfigMaps
 ## These ConfigMaps can be used for custom configurations


### PR DESCRIPTION
## Description
Default to disabled so the chart works on clusters without the Prometheus Operator / monitoring.coreos.com PodMonitor CRD installed. Existing deployments set podMonitor.enabled=true in their values files to keep current behavior.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled PodMonitor resource generation by default. Users requiring Prometheus Operator integration will need to explicitly enable this functionality in their configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->