### PR TITLE
testbot: surface Stage-2 picker rationale in PR descriptions

### DIFF
--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -147,7 +147,8 @@ jobs:
           PYTHONPATH=. python src/scripts/testbot/select_targets_agent.py \
             --shortlist "$RUNNER_TEMP/shortlist.json" \
             --max-targets ${{ inputs.max_targets || '1' }} \
-            --output "$RUNNER_TEMP/targets.txt"
+            --output "$RUNNER_TEMP/targets.txt" \
+            --meta-output "$RUNNER_TEMP/targets_meta.json"
           echo "::group::Selected targets"
           cat "$RUNNER_TEMP/targets.txt"
           echo "::endgroup::"
@@ -243,6 +244,7 @@ jobs:
       - name: Create PR
         if: inputs.dry_run != true
         run: |
-          PYTHONPATH=src/scripts python -m testbot.create_pr
+          PYTHONPATH=src/scripts python -m testbot.create_pr \
+            --targets-meta "$RUNNER_TEMP/targets_meta.json"
         env:
           GH_TOKEN: ${{ secrets.SVC_OSMO_CI_TOKEN }}

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -19,7 +19,7 @@ filesystem ───┘                                                         
 | **Stage 2: LLM picker** | `select_targets_agent.py` + `SELECT_TARGETS_PROMPT.md` | A read-only Claude Code subagent (`Read,Glob,Grep` only) reads each candidate, rejects hard-to-test infra glue, and picks the 1-3 files where unit tests would have the highest ROI. Can return zero picks if nothing meets the bar. |
 | **Test generation** | Claude Code CLI | Reads source, writes test files and BUILD entries, runs tests, iterates on failures |
 | **Guardrails** | `guardrails.py` | Filters out any non-test file changes made by Claude |
-| **PR creation** | `create_pr.py` | Creates branch, commits test files, pushes, opens PR with `ai-generated` label |
+| **PR creation** | `create_pr.py` | Creates branch, commits test files, pushes, opens PR with `ai-generated` label. Reads the picker's `targets_meta.json` sidecar and renders a "Why this file was targeted" section so reviewers see the rationale alongside the test diff. |
 
 Claude Code is sandboxed: it can only read files, edit test files, and run test commands (`bazel test`, `pnpm test`). It cannot run `git`, `gh`, or modify source code. All git and GitHub operations are in deterministic harness scripts.
 

--- a/src/scripts/testbot/create_pr.py
+++ b/src/scripts/testbot/create_pr.py
@@ -131,9 +131,16 @@ def _build_rationale_section(
     blocks: list[str] = [heading, ""]
     for source in seen_sources:
         entry = meta[source]
-        coverage = entry.get("coverage_pct", 0.0)
-        uncovered = entry.get("uncovered_lines", 0)
-        reason = (entry.get("reason") or "").strip()
+        try:
+            coverage = float(entry.get("coverage_pct", 0.0))
+        except (TypeError, ValueError):
+            coverage = 0.0
+        try:
+            uncovered = int(entry.get("uncovered_lines", 0))
+        except (TypeError, ValueError):
+            uncovered = 0
+        raw_reason = entry.get("reason")
+        reason = raw_reason.strip() if isinstance(raw_reason, str) else ""
         blocks.append(
             f"**`{source}`** — {coverage:.1f}% coverage, "
             f"{uncovered} uncovered lines."

--- a/src/scripts/testbot/create_pr.py
+++ b/src/scripts/testbot/create_pr.py
@@ -13,10 +13,12 @@ Usage:
 
 import argparse
 import datetime
+import json
 import logging
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 from src.scripts.testbot.guardrails import get_changed_test_files
 
@@ -64,6 +66,84 @@ def has_open_testbot_pr() -> bool:
 
 _SUSPECTED_BUG_RE = re.compile(r"(?:#|//)\s*SUSPECTED BUG:\s*(.+)")
 
+# Map a generated test file back to the source file it covers, so the
+# Stage-2 picker rationale (keyed on source path) can be attached to the
+# right test in the PR body. Mirrors the conventions enforced by
+# TESTBOT_RULES.md and the basename-stripping in the title generator.
+_TEST_TO_SOURCE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(.*?)/tests/test_([^/]+\.py)$"), r"\1/\2"),
+    (re.compile(r"(.+)_test(\.go)$"), r"\1\2"),
+    (re.compile(r"(.+)\.test(\.tsx?)$"), r"\1\2"),
+)
+
+
+def _test_to_source_path(test_path: str) -> str | None:
+    """Return the source path a test file covers, or None if unknown."""
+    for pattern, replacement in _TEST_TO_SOURCE_PATTERNS:
+        match = pattern.fullmatch(test_path)
+        if match:
+            return pattern.sub(replacement, test_path)
+    return None
+
+
+def _load_targets_meta(path: str) -> dict[str, dict]:
+    """Read the picker sidecar JSON into a {source_path: meta} dict.
+
+    Missing or malformed files yield an empty map so the PR-creation
+    flow never blocks on a stale or absent meta file.
+    """
+    if not path:
+        return {}
+    try:
+        entries = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Could not read targets meta %s: %s", path, exc)
+        return {}
+    if not isinstance(entries, list):
+        logger.warning("targets meta is not a list: %r", entries)
+        return {}
+    return {
+        entry["file_path"]: entry
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("file_path")
+    }
+
+
+def _build_rationale_section(
+    changed_files: list[str],
+    meta: dict[str, dict],
+) -> str:
+    """Render the 'Why ... was targeted' section, or '' when no rationale."""
+    seen_sources: list[str] = []
+    seen_set: set[str] = set()
+    for test_path in changed_files:
+        source = _test_to_source_path(test_path)
+        if source and source in meta and source not in seen_set:
+            seen_set.add(source)
+            seen_sources.append(source)
+    if not seen_sources:
+        return ""
+    heading = (
+        "## Why this file was targeted"
+        if len(seen_sources) == 1
+        else "## Why these files were targeted"
+    )
+    blocks: list[str] = [heading, ""]
+    for source in seen_sources:
+        entry = meta[source]
+        coverage = entry.get("coverage_pct", 0.0)
+        uncovered = entry.get("uncovered_lines", 0)
+        reason = (entry.get("reason") or "").strip()
+        blocks.append(
+            f"**`{source}`** — {coverage:.1f}% coverage, "
+            f"{uncovered} uncovered lines."
+        )
+        if reason:
+            blocks.append("")
+            blocks.extend(f"> {line}" for line in reason.splitlines())
+        blocks.append("")
+    return "\n".join(blocks).rstrip() + "\n"
+
 
 def _scan_suspected_bugs(files: list[str]) -> list[str]:
     """Scan test files for SUSPECTED BUG markers left by Claude."""
@@ -92,6 +172,11 @@ def main() -> None:
     parser.add_argument(
         "--dry-run", action="store_true",
         help="Show what would be done without creating a PR",
+    )
+    parser.add_argument(
+        "--targets-meta", default="",
+        help="Optional path to the picker's JSON metadata; when provided, "
+             "the PR body includes the 'Why this file was targeted' section",
     )
     args = parser.parse_args()
 
@@ -140,6 +225,11 @@ def main() -> None:
         bugs_list = "\n".join(f"- {bug}" for bug in suspected_bugs)
         bugs_section = f"\n## Suspected bugs\n{bugs_list}\n"
 
+    targets_meta = _load_targets_meta(args.targets_meta)
+    rationale_section = _build_rationale_section(changed_files, targets_meta)
+    if rationale_section:
+        rationale_section = "\n" + rationale_section
+
     pr_body = f"""## Summary
 AI-generated tests targeting file(s) with low coverage.
 
@@ -147,7 +237,7 @@ Issue - None
 
 ## Files tested
 {files_list}
-{bugs_section}
+{rationale_section}{bugs_section}
 ## Checklist
 - [x] I am familiar with the Contributing Guidelines
 - [x] New or existing tests cover these changes

--- a/src/scripts/testbot/select_targets_agent.py
+++ b/src/scripts/testbot/select_targets_agent.py
@@ -313,6 +313,23 @@ SKIP_MESSAGE = (
 )
 
 
+def _build_meta(merged: list[dict]) -> list[dict]:
+    """Project the merged picks down to the fields create_pr.py uses.
+
+    Strips score breakdowns and uncovered_ranges — those belong in the
+    workflow log, not in the PR description.
+    """
+    return [
+        {
+            "file_path": entry["file_path"],
+            "coverage_pct": entry["coverage_pct"],
+            "uncovered_lines": entry["uncovered_lines"],
+            "reason": entry.get("reason", ""),
+        }
+        for entry in merged
+    ]
+
+
 def format_targets_markdown(picks: list[dict]) -> str:
     """Thin wrapper around ``coverage_targets.format_targets``.
 
@@ -337,12 +354,17 @@ def main() -> None:
                         ))
     parser.add_argument("--output", default="-",
                         help="Output path; '-' (default) writes to stdout")
+    parser.add_argument("--meta-output", default="",
+                        help="Optional path to dump structured target metadata "
+                             "(JSON list with file_path, coverage_pct, "
+                             "uncovered_lines, reason) for downstream "
+                             "consumers like create_pr.py")
     args = parser.parse_args()
 
     shortlist = json.loads(Path(args.shortlist).read_text(encoding="utf-8"))
     if not shortlist:
         logger.warning("Empty shortlist; nothing to pick")
-        markdown = format_targets_markdown([])
+        merged: list[dict] = []
     else:
         prompt = build_prompt(shortlist, args.max_targets)
         output = invoke_claude(
@@ -360,12 +382,17 @@ def main() -> None:
             picks = picks[:args.max_targets]
         logger.info("Agent picked %d target(s) of %d max", len(picks), args.max_targets)
         merged = merge_picks_with_shortlist(picks, shortlist)
-        markdown = format_targets_markdown(merged)
 
+    markdown = format_targets_markdown(merged)
     if args.output == "-":
         print(markdown)
     else:
         Path(args.output).write_text(markdown, encoding="utf-8")
+
+    if args.meta_output:
+        Path(args.meta_output).write_text(
+            json.dumps(_build_meta(merged), indent=2), encoding="utf-8",
+        )
 
 
 if __name__ == "__main__":

--- a/src/scripts/testbot/tests/test_create_pr.py
+++ b/src/scripts/testbot/tests/test_create_pr.py
@@ -310,6 +310,26 @@ class TestBuildRationaleSection(unittest.TestCase):
         )
         self.assertEqual(section.count("**`src/lib/foo.py`**"), 1)
 
+    def test_coerces_unexpected_field_types(self):
+        # Defensive: a malformed sidecar (string coverage, list uncovered,
+        # numeric reason) must not crash the rendering. Numbers fall back
+        # to 0 / 0.0 and reason becomes empty (no blockquote).
+        meta = {
+            "src/lib/foo.py": {
+                "file_path": "src/lib/foo.py",
+                "coverage_pct": "not a number",
+                "uncovered_lines": ["wrong", "type"],
+                "reason": 42,
+            },
+        }
+        section = _build_rationale_section(
+            ["src/lib/tests/test_foo.py"], meta,
+        )
+        self.assertIn("**`src/lib/foo.py`**", section)
+        self.assertIn("0.0% coverage", section)
+        self.assertIn("0 uncovered lines", section)
+        self.assertNotIn("> ", section)
+
     def test_omits_blockquote_when_reason_empty(self):
         meta = {
             "src/lib/foo.py": {

--- a/src/scripts/testbot/tests/test_create_pr.py
+++ b/src/scripts/testbot/tests/test_create_pr.py
@@ -8,8 +8,13 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-from src.scripts.testbot.create_pr import _scan_suspected_bugs
-from src.scripts.testbot.create_pr import has_open_testbot_pr
+from src.scripts.testbot.create_pr import (
+    _build_rationale_section,
+    _load_targets_meta,
+    _scan_suspected_bugs,
+    _test_to_source_path,
+    has_open_testbot_pr,
+)
 
 
 class TestHasOpenTestbotPr(unittest.TestCase):
@@ -147,6 +152,177 @@ class TestScanSuspectedBugs(unittest.TestCase):
         result = _scan_suspected_bugs([path])
         self.assertEqual(len(result), 1)
         self.assertIn("off-by-one month", result[0])
+
+
+class TestTestToSourcePath(unittest.TestCase):
+    """Tests for mapping a generated test file back to its source path."""
+
+    def test_python_test_in_tests_dir(self):
+        self.assertEqual(
+            _test_to_source_path("src/lib/utils/tests/test_common.py"),
+            "src/lib/utils/common.py",
+        )
+
+    def test_python_nested_tests_dir(self):
+        self.assertEqual(
+            _test_to_source_path("src/service/core/data/tests/test_data_service.py"),
+            "src/service/core/data/data_service.py",
+        )
+
+    def test_go_test_strips_test_suffix(self):
+        self.assertEqual(
+            _test_to_source_path("src/runtime/pkg/common/common_test.go"),
+            "src/runtime/pkg/common/common.go",
+        )
+
+    def test_typescript_test_strips_dot_test(self):
+        self.assertEqual(
+            _test_to_source_path("src/ui/src/lib/foo.test.ts"),
+            "src/ui/src/lib/foo.ts",
+        )
+
+    def test_typescript_tsx_test(self):
+        self.assertEqual(
+            _test_to_source_path("src/ui/src/components/Bar.test.tsx"),
+            "src/ui/src/components/Bar.tsx",
+        )
+
+    def test_unrecognized_pattern_returns_none(self):
+        self.assertIsNone(_test_to_source_path("README.md"))
+
+
+class TestLoadTargetsMeta(unittest.TestCase):
+    """Tests for picker-sidecar JSON loading."""
+
+    def test_loads_valid_meta(self):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8",
+        ) as fh:
+            fh.write('[{"file_path": "src/lib/foo.py", "reason": "ok"}]')
+            path = fh.name
+        try:
+            meta = _load_targets_meta(path)
+            self.assertEqual(meta["src/lib/foo.py"]["reason"], "ok")
+        finally:
+            os.unlink(path)
+
+    def test_missing_path_returns_empty(self):
+        self.assertEqual(_load_targets_meta(""), {})
+
+    def test_nonexistent_file_returns_empty(self):
+        self.assertEqual(_load_targets_meta("/no/such/file.json"), {})
+
+    def test_malformed_json_returns_empty(self):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8",
+        ) as fh:
+            fh.write("not json {{{")
+            path = fh.name
+        try:
+            self.assertEqual(_load_targets_meta(path), {})
+        finally:
+            os.unlink(path)
+
+    def test_non_list_payload_returns_empty(self):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8",
+        ) as fh:
+            fh.write('{"file_path": "x.py"}')
+            path = fh.name
+        try:
+            self.assertEqual(_load_targets_meta(path), {})
+        finally:
+            os.unlink(path)
+
+
+class TestBuildRationaleSection(unittest.TestCase):
+    """Tests for the 'Why this file was targeted' PR-body section."""
+
+    def test_empty_when_no_meta(self):
+        self.assertEqual(_build_rationale_section(["src/x/tests/test_y.py"], {}), "")
+
+    def test_singular_heading_for_one_target(self):
+        meta = {
+            "src/lib/utils/common.py": {
+                "file_path": "src/lib/utils/common.py",
+                "coverage_pct": 45.3,
+                "uncovered_lines": 332,
+                "reason": "Highest fan-in file packed with pure utilities.",
+            },
+        }
+        section = _build_rationale_section(
+            ["src/lib/utils/tests/test_common.py"], meta,
+        )
+        self.assertIn("## Why this file was targeted", section)
+        self.assertIn("**`src/lib/utils/common.py`**", section)
+        self.assertIn("45.3% coverage", section)
+        self.assertIn("332 uncovered lines", section)
+        self.assertIn("> Highest fan-in", section)
+
+    def test_plural_heading_for_multiple_targets(self):
+        meta = {
+            "src/a/foo.py": {
+                "file_path": "src/a/foo.py",
+                "coverage_pct": 10.0, "uncovered_lines": 50,
+                "reason": "first",
+            },
+            "src/b/bar.py": {
+                "file_path": "src/b/bar.py",
+                "coverage_pct": 20.0, "uncovered_lines": 80,
+                "reason": "second",
+            },
+        }
+        section = _build_rationale_section(
+            ["src/a/tests/test_foo.py", "src/b/tests/test_bar.py"],
+            meta,
+        )
+        self.assertIn("## Why these files were targeted", section)
+        self.assertIn("**`src/a/foo.py`**", section)
+        self.assertIn("**`src/b/bar.py`**", section)
+
+    def test_skips_test_with_no_meta(self):
+        meta = {
+            "src/lib/foo.py": {
+                "file_path": "src/lib/foo.py",
+                "coverage_pct": 10.0, "uncovered_lines": 5,
+                "reason": "covered",
+            },
+        }
+        section = _build_rationale_section(
+            ["src/lib/tests/test_foo.py", "src/lib/tests/test_unrelated.py"],
+            meta,
+        )
+        self.assertIn("**`src/lib/foo.py`**", section)
+        self.assertNotIn("test_unrelated", section)
+        self.assertNotIn("unrelated.py", section)
+
+    def test_dedupes_when_two_tests_map_to_same_source(self):
+        meta = {
+            "src/lib/foo.py": {
+                "file_path": "src/lib/foo.py",
+                "coverage_pct": 10.0, "uncovered_lines": 5,
+                "reason": "covered",
+            },
+        }
+        section = _build_rationale_section(
+            ["src/lib/tests/test_foo.py", "src/lib/tests/test_foo.py"],
+            meta,
+        )
+        self.assertEqual(section.count("**`src/lib/foo.py`**"), 1)
+
+    def test_omits_blockquote_when_reason_empty(self):
+        meta = {
+            "src/lib/foo.py": {
+                "file_path": "src/lib/foo.py",
+                "coverage_pct": 10.0, "uncovered_lines": 5,
+                "reason": "",
+            },
+        }
+        section = _build_rationale_section(
+            ["src/lib/tests/test_foo.py"], meta,
+        )
+        self.assertIn("**`src/lib/foo.py`**", section)
+        self.assertNotIn("> ", section)
 
 
 if __name__ == "__main__":

--- a/src/scripts/testbot/tests/test_select_targets_agent.py
+++ b/src/scripts/testbot/tests/test_select_targets_agent.py
@@ -7,6 +7,7 @@ import unittest
 from pathlib import Path
 
 from src.scripts.testbot.select_targets_agent import (
+    _build_meta,
     _stream_npx,
     build_prompt,
     format_candidate,
@@ -147,6 +148,43 @@ class TestFormatTargetsMarkdown(unittest.TestCase):
         # No 'reason' key on this entry
         output = format_targets_markdown([target])
         self.assertNotIn("Why this file:", output)
+
+
+class TestBuildMeta(unittest.TestCase):
+    """Tests for the picker's PR-description sidecar shape."""
+
+    def test_projects_only_pr_relevant_fields(self):
+        merged = [{
+            "file_path": "src/lib/foo.py",
+            "coverage_pct": 25.0,
+            "uncovered_lines": 50,
+            "uncovered_ranges": [(10, 20), (30, 40)],
+            "tier": 0,
+            "fan_in": 30,
+            "churn": 12,
+            "loc": 200,
+            "score": 8.5,
+            "score_breakdown": {"tier": 4.0},
+            "reason": "central API",
+        }]
+        meta = _build_meta(merged)
+        self.assertEqual(meta, [{
+            "file_path": "src/lib/foo.py",
+            "coverage_pct": 25.0,
+            "uncovered_lines": 50,
+            "reason": "central API",
+        }])
+
+    def test_empty_merged_produces_empty_list(self):
+        self.assertEqual(_build_meta([]), [])
+
+    def test_missing_reason_defaults_to_empty_string(self):
+        merged = [{
+            "file_path": "src/lib/foo.py",
+            "coverage_pct": 10.0,
+            "uncovered_lines": 5,
+        }]
+        self.assertEqual(_build_meta(merged)[0]["reason"], "")
 
 
 class TestStreamNpxTimeout(unittest.TestCase):


### PR DESCRIPTION
## Summary

Surface the Stage-2 picker's `Why this file:` rationale in the generated PR description. Previously the rationale lived only in `$RUNNER_TEMP/targets.txt` (test-generation prompt input) and was discarded before `create_pr.py` ran — so reviewers saw the test diff but had to guess why testbot picked that file.

## What it looks like

Reviewers now see a section between "Files tested" and the checklist:

```
### Files tested
- `src/lib/utils/tests/test_common.py`

### Why this file was targeted

**`src/lib/utils/common.py`** — 45.3% coverage, 332 uncovered lines.

> Highest fan-in file (45 reverse imports) packed with pure,
> easily-testable functions: docker_parse, LRUCache, TokenBucket,
> strategic_merge_patch, recursive_dict_update. Clear input/output
> contracts, no I/O required, and 55% of lines remain uncovered
> despite heavy downstream use.
```

(The actual generated PR uses `##` headings; demoted here to `###` so the
PR-description validator doesn't read this example as the "real" checklist.)

Heading is singular ("this file") for one target and plural ("these files") for many. The blockquote on the rationale visually separates it from the metadata one-liner.

## How the data flows

1. `select_targets_agent.py` gains `--meta-output PATH`. When provided, dumps a sidecar JSON:
   ```json
   [{"file_path": "src/lib/utils/common.py",
     "coverage_pct": 45.3,
     "uncovered_lines": 332,
     "reason": "..."}]
   ```
2. `create_pr.py` gains `--targets-meta PATH`. Maps each generated test file back to its source path (`tests/test_X.py` → `X.py`, `X_test.go` → `X.go`, `X.test.ts(x)` → `X.ts(x)`), looks up the rationale, renders the section.
3. `testbot.yaml` passes `$RUNNER_TEMP/targets_meta.json` to both.

Markdown output (`--output`) and the rest of the pipeline are unchanged — Stage-2 still emits the same `targets.txt` for the test-generation prompt.

## Edge cases

- Picker skipped the day → meta JSON is `[]` → `create_pr.py` exits early because `changed_files` is empty.
- Missing/malformed sidecar → logged warning, PR still created without the section.
- Test file's source not in meta (tests written outside the shortlist) → silently skipped in the section.
- Two test files mapping to the same source → rendered once.
- Empty `reason` string → metadata line rendered, blockquote omitted.

Issue - None

## Files tested
- N/A — selector infrastructure; tests live alongside in `src/scripts/testbot/tests/`.

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes (17/17 testbot bazel targets pass; new tests for `_build_meta`, `_test_to_source_path`, `_load_targets_meta`, `_build_rationale_section`)
- [x] The documentation is up to date with these changes (README updated)

## Test plan
- [x] `bazel test //src/scripts/testbot/...` passes locally
- [x] Trigger Testbot via `workflow_dispatch` on this branch and confirm the resulting PR description carries a "Why this file was targeted" section that matches the picker's rationale: https://github.com/NVIDIA/OSMO/pull/970


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PRs now include a "Why this file was targeted" section showing coverage %, uncovered lines, and optional rationale for changed tests.

* **Documentation**
  * Updated architecture docs to describe the PR creation flow and the added rationale/sidecar behavior.

* **Tests**
  * Added tests covering rationale rendering, sidecar metadata loading, mapping tests→sources, and meta projection for PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
