### PR TITLE
Increase service startup probe time to 2min

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -33,6 +33,7 @@ This Helm chart deploys the OSMO platform with its core services and an optional
 | `global.imagePullSecret` | Name of the Kubernetes secret containing Docker registry credentials | `null` |
 | `global.nodeSelector` | Global node selector | `{}` |
 | `global.hostname` | External DNS hostname this OSMO deployment serves on (e.g. `staging.osmo.nvidia.com`). Canonical fallback for `services.service.hostname`, `services.router.hostname`, and `gateway.envoy.hostname` — set this once at the top level instead of three times. | `""` |
+| `global.startupProbeFailureThreshold` | Single knob that drives every OSMO service's startup-probe `failureThreshold` (api, agent, logger, router, ui, worker, delayed-job-monitor). With `periodSeconds: 5`, the value × 5 is roughly the seconds of init slack the kubelet tolerates before declaring CrashLoopBackOff. Default tolerates ~2 minutes; bump it on slow-I/O clusters. Doesn't affect healthy startups — the first successful probe ends the startup phase. | `24` |
 
 ### Global Logging Settings
 

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -33,7 +33,8 @@ This Helm chart deploys the OSMO platform with its core services and an optional
 | `global.imagePullSecret` | Name of the Kubernetes secret containing Docker registry credentials | `null` |
 | `global.nodeSelector` | Global node selector | `{}` |
 | `global.hostname` | External DNS hostname this OSMO deployment serves on (e.g. `staging.osmo.nvidia.com`). Canonical fallback for `services.service.hostname`, `services.router.hostname`, and `gateway.envoy.hostname` — set this once at the top level instead of three times. | `""` |
-| `global.startupProbeFailureThreshold` | Single knob that drives every OSMO service's startup-probe `failureThreshold` (api, agent, logger, router, ui, worker, delayed-job-monitor). With `periodSeconds: 5`, the value × 5 is roughly the seconds of init slack the kubelet tolerates before declaring CrashLoopBackOff. Default tolerates ~2 minutes; bump it on slow-I/O clusters. Doesn't affect healthy startups — the first successful probe ends the startup phase. | `24` |
+
+> **Startup probe tuning.** Each service has its own `services.<svc>.startupProbe` block in `values.yaml` (api/agent/logger/router/ui/worker/delayedJobMonitor). To loosen tolerance on slow-I/O clusters, bump `failureThreshold` (with `periodSeconds: 5`, the value × 5 is roughly the seconds of init slack before CrashLoopBackOff). Defaults are 24 across the board — about 2 minutes — and don't affect healthy startups since the first successful probe ends the startup phase.
 
 ### Global Logging Settings
 

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -186,12 +186,10 @@ spec:
           failureThreshold: 3
           periodSeconds: 45
 
-        # Give the container 30 seconds to startup
         {{- with .Values.services.agent.startupProbe }}
         startupProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-          initialDelaySeconds: 10
 
         readinessProbe:
           httpGet:

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -187,17 +187,10 @@ spec:
           periodSeconds: 45
 
         # Give the container 30 seconds to startup
+        {{- with .Values.services.agent.startupProbe }}
         startupProbe:
-          exec:
-            command:
-            - progress_check
-            - --progress_interval
-            - "60"
-            - --progress_file
-            - /var/run/osmo/last_progress
-          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
-          periodSeconds: 5
-          timeoutSeconds: 15
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
           initialDelaySeconds: 10
 
         readinessProbe:

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -195,7 +195,7 @@ spec:
             - "60"
             - --progress_file
             - /var/run/osmo/last_progress
-          failureThreshold: 12
+          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
           periodSeconds: 5
           timeoutSeconds: 15
           initialDelaySeconds: 10

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -217,7 +217,7 @@ spec:
         {{- include "osmo.upstream-probe-yaml" (dict "probe" .Values.services.service.livenessProbe "context" .) | nindent 10 }}
 
 
-        # Give the container 30 seconds to startup
+        # Give the container 120 seconds to startup
         startupProbe:
           httpGet:
             port: 8000
@@ -225,7 +225,7 @@ spec:
             {{- if .Values.gateway.tls.enabled }}
             scheme: HTTPS
             {{- end }}
-          failureThreshold: 6
+          failureThreshold: 24
           periodSeconds: 5
           timeoutSeconds: 3
           initialDelaySeconds: 5

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -217,7 +217,10 @@ spec:
         {{- include "osmo.upstream-probe-yaml" (dict "probe" .Values.services.service.livenessProbe "context" .) | nindent 10 }}
 
 
-        # Give the container 120 seconds to startup
+        # Startup tolerance is governed by global.startupProbeFailureThreshold
+        # (period=5s, so the value ≈ seconds of init slack the kubelet will
+        # wait). Centralized so all services share the same tolerance and a
+        # slow-I/O cluster can bump it once.
         startupProbe:
           httpGet:
             port: 8000
@@ -225,7 +228,7 @@ spec:
             {{- if .Values.gateway.tls.enabled }}
             scheme: HTTPS
             {{- end }}
-          failureThreshold: 24
+          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
           periodSeconds: 5
           timeoutSeconds: 3
           initialDelaySeconds: 5

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -217,21 +217,10 @@ spec:
         {{- include "osmo.upstream-probe-yaml" (dict "probe" .Values.services.service.livenessProbe "context" .) | nindent 10 }}
 
 
-        # Startup tolerance is governed by global.startupProbeFailureThreshold
-        # (period=5s, so the value ≈ seconds of init slack the kubelet will
-        # wait). Centralized so all services share the same tolerance and a
-        # slow-I/O cluster can bump it once.
+        # Probe spec comes from values.yaml; the helper overlays
+        # `scheme: HTTPS` when gateway.tls.enabled is true.
         startupProbe:
-          httpGet:
-            port: 8000
-            path: /api/version
-            {{- if .Values.gateway.tls.enabled }}
-            scheme: HTTPS
-            {{- end }}
-          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
-          periodSeconds: 5
-          timeoutSeconds: 3
-          initialDelaySeconds: 5
+          {{- include "osmo.upstream-probe-yaml" (dict "probe" .Values.services.service.startupProbe "context" .) | nindent 10 }}
 
         # Do a basic database read operation to ensure the service is able to serve traffic
         readinessProbe:

--- a/deployments/charts/service/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/service/templates/delayed-job-monitor.yaml
@@ -167,7 +167,7 @@ spec:
             - progress_check
             - --progress_interval
             - "30"
-          failureThreshold: 12
+          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
           periodSeconds: 5
           timeoutSeconds: 15
           initialDelaySeconds: 10

--- a/deployments/charts/service/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/service/templates/delayed-job-monitor.yaml
@@ -161,14 +161,10 @@ spec:
           timeoutSeconds: 15
 
         # Give the container 60 seconds to startup
+        {{- with .Values.services.delayedJobMonitor.startupProbe }}
         startupProbe:
-          exec:
-            command:
-            - progress_check
-            - --progress_interval
-            - "30"
-          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
-          periodSeconds: 5
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
           timeoutSeconds: 15
           initialDelaySeconds: 10
 

--- a/deployments/charts/service/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/service/templates/delayed-job-monitor.yaml
@@ -160,13 +160,10 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 15
 
-        # Give the container 60 seconds to startup
         {{- with .Values.services.delayedJobMonitor.startupProbe }}
         startupProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-          timeoutSeconds: 15
-          initialDelaySeconds: 10
 
       {{- include "osmo.extra-sidecars" .Values.services.delayedJobMonitor | nindent 6 }}
       volumes:

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -186,7 +186,7 @@ spec:
             - "60"
             - --progress_file
             - /var/run/osmo/last_progress
-          failureThreshold: 12
+          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
           periodSeconds: 5
           timeoutSeconds: 15
           initialDelaySeconds: 10

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -178,17 +178,10 @@ spec:
           periodSeconds: 45
 
         # Give the container 30 seconds to startup
+        {{- with .Values.services.logger.startupProbe }}
         startupProbe:
-          exec:
-            command:
-            - progress_check
-            - --progress_interval
-            - "60"
-            - --progress_file
-            - /var/run/osmo/last_progress
-          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
-          periodSeconds: 5
-          timeoutSeconds: 15
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
           initialDelaySeconds: 10
 
         readinessProbe:

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -182,7 +182,6 @@ spec:
         startupProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-          initialDelaySeconds: 10
 
         readinessProbe:
           httpGet:

--- a/deployments/charts/service/templates/router-service.yaml
+++ b/deployments/charts/service/templates/router-service.yaml
@@ -188,9 +188,8 @@ spec:
         {{- end }}
 
         {{- with .Values.services.router.startupProbe }}
-        {{- $probe := mustMergeOverwrite (deepCopy .) (dict "failureThreshold" (int $.Values.global.startupProbeFailureThreshold)) }}
         startupProbe:
-          {{- include "osmo.upstream-probe-yaml" (dict "probe" $probe "context" $) | nindent 10 }}
+          {{- include "osmo.upstream-probe-yaml" (dict "probe" . "context" $) | nindent 10 }}
         {{- end }}
 
         {{- with .Values.services.router.readinessProbe }}

--- a/deployments/charts/service/templates/router-service.yaml
+++ b/deployments/charts/service/templates/router-service.yaml
@@ -188,8 +188,9 @@ spec:
         {{- end }}
 
         {{- with .Values.services.router.startupProbe }}
+        {{- $probe := mustMergeOverwrite (deepCopy .) (dict "failureThreshold" (int $.Values.global.startupProbeFailureThreshold)) }}
         startupProbe:
-          {{- include "osmo.upstream-probe-yaml" (dict "probe" . "context" $) | nindent 10 }}
+          {{- include "osmo.upstream-probe-yaml" (dict "probe" $probe "context" $) | nindent 10 }}
         {{- end }}
 
         {{- with .Values.services.router.readinessProbe }}

--- a/deployments/charts/service/templates/ui-service.yaml
+++ b/deployments/charts/service/templates/ui-service.yaml
@@ -164,7 +164,9 @@ spec:
         {{- end }}
 
         {{- with .Values.services.ui.startupProbe }}
-        # Give the container 30 seconds to startup
+        # failureThreshold comes from global.startupProbeFailureThreshold so
+        # all services share the same startup tolerance; everything else is
+        # taken from .Values.services.ui.startupProbe.
         startupProbe:
           {{- if .httpGet }}
           httpGet:
@@ -184,9 +186,7 @@ spec:
           exec:
             {{- toYaml .exec | nindent 12 }}
           {{- end }}
-          {{- with .failureThreshold }}
-          failureThreshold: {{ . }}
-          {{- end }}
+          failureThreshold: {{ $.Values.global.startupProbeFailureThreshold }}
           {{- with .periodSeconds }}
           periodSeconds: {{ . }}
           {{- end }}

--- a/deployments/charts/service/templates/ui-service.yaml
+++ b/deployments/charts/service/templates/ui-service.yaml
@@ -164,9 +164,6 @@ spec:
         {{- end }}
 
         {{- with .Values.services.ui.startupProbe }}
-        # failureThreshold comes from global.startupProbeFailureThreshold so
-        # all services share the same startup tolerance; everything else is
-        # taken from .Values.services.ui.startupProbe.
         startupProbe:
           {{- if .httpGet }}
           httpGet:
@@ -186,7 +183,9 @@ spec:
           exec:
             {{- toYaml .exec | nindent 12 }}
           {{- end }}
-          failureThreshold: {{ $.Values.global.startupProbeFailureThreshold }}
+          {{- with .failureThreshold }}
+          failureThreshold: {{ . }}
+          {{- end }}
           {{- with .periodSeconds }}
           periodSeconds: {{ . }}
           {{- end }}

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -174,16 +174,10 @@ spec:
           timeoutSeconds: 15
 
         # Give the container 60 seconds to startup
+        {{- with .Values.services.worker.startupProbe }}
         startupProbe:
-          exec:
-            command:
-            - progress_check
-            - --progress_interval
-            - "300"
-          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
-          periodSeconds: 5
-          timeoutSeconds: 15
-          initialDelaySeconds: 10
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
 
       {{- include "osmo.extra-sidecars" .Values.services.worker | nindent 6 }}
       volumes:

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -180,7 +180,7 @@ spec:
             - progress_check
             - --progress_interval
             - "300"
-          failureThreshold: 12
+          failureThreshold: {{ .Values.global.startupProbeFailureThreshold }}
           periodSeconds: 5
           timeoutSeconds: 15
           initialDelaySeconds: 10

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -53,15 +53,6 @@ global:
   ##
   hostname: ""
 
-  ## Startup-probe failureThreshold applied to every OSMO service that has
-  ## a hardcoded startup probe (api, agent, logger, worker, delayed-job-
-  ## monitor). With period=5s, the value is roughly the number of seconds
-  ## the kubelet will wait for slow init (configmap secret loads, table
-  ## warm-up, TLS listener bind) divided by 5. Default tolerates ~2 minutes;
-  ## bump it for slow-I/O clusters. Doesn't affect healthy startups, since
-  ## the first successful probe ends the startup phase.
-  startupProbeFailureThreshold: 24
-
   ## Logging configuration for all Osmo services
   ##
   logs:
@@ -283,12 +274,11 @@ services:
 
     ## Startup probe configuration
     ##
-    ## failureThreshold is set globally via global.startupProbeFailureThreshold
-    ## and any value here would be overridden, so it's omitted.
     startupProbe:
       httpGet:
         path: /health
         port: 8000
+      failureThreshold: 24
       periodSeconds: 5
       timeoutSeconds: 3
       initialDelaySeconds: 5
@@ -785,6 +775,20 @@ services:
     ##
     initContainers: []
 
+    ## Startup probe — runs progress_check until the delayed job monitor
+    ## has reported progress at least once. failureThreshold * periodSeconds
+    ## (default 24 * 5 = 120s) is how long the kubelet waits before declaring
+    ## CrashLoopBackOff.
+    ##
+    startupProbe:
+      exec:
+        command:
+        - progress_check
+        - --progress_interval
+        - "30"
+      failureThreshold: 24
+      periodSeconds: 5
+
     ## Node selector constraints for delayed job monitor pod scheduling
     ##
     nodeSelector: {}
@@ -896,6 +900,22 @@ services:
     ## Init containers for worker
     ##
     initContainers: []
+
+    ## Startup probe — runs progress_check until the worker has reported
+    ## progress at least once. failureThreshold * periodSeconds (default
+    ## 24 * 5 = 120s) is how long the kubelet waits before declaring
+    ## CrashLoopBackOff.
+    ##
+    startupProbe:
+      exec:
+        command:
+        - progress_check
+        - --progress_interval
+        - "300"
+      failureThreshold: 24
+      periodSeconds: 5
+      timeoutSeconds: 15
+      initialDelaySeconds: 10
 
     ## Node selector constraints for worker pod scheduling
     ##
@@ -1099,6 +1119,20 @@ services:
       ## How often to perform the probe
       ##
       periodSeconds: 45
+
+    ## Startup probe — kubelet waits up to failureThreshold * periodSeconds
+    ## (default 24 * 5 = 120s) for the API service to bind its TLS listener
+    ## after configmap/secret loads + task-metric registration. Once the
+    ## first probe succeeds, the startup phase ends and liveness takes over.
+    ##
+    startupProbe:
+      httpGet:
+        port: 8000
+        path: /api/version
+      failureThreshold: 24
+      periodSeconds: 5
+      timeoutSeconds: 3
+      initialDelaySeconds: 5
 
     ## Node selector constraints for API service pod scheduling
     ##
@@ -1317,12 +1351,11 @@ services:
       periodSeconds: 5
       timeoutSeconds: 30
 
-    ## failureThreshold is set globally via global.startupProbeFailureThreshold
-    ## and any value here would be overridden, so it's omitted.
     startupProbe:
       httpGet:
         port: 8000
         path: /api/router/version
+      failureThreshold: 24
       periodSeconds: 5
       timeoutSeconds: 3
       initialDelaySeconds: 30
@@ -1376,6 +1409,23 @@ services:
     ## Init containers for logger service
     ##
     initContainers: []
+
+    ## Startup probe — runs progress_check until the logger has reported
+    ## progress at least once. failureThreshold * periodSeconds (default
+    ## 24 * 5 = 120s) is how long the kubelet waits before declaring
+    ## CrashLoopBackOff.
+    ##
+    startupProbe:
+      exec:
+        command:
+        - progress_check
+        - --progress_interval
+        - "60"
+        - --progress_file
+        - /var/run/osmo/last_progress
+      failureThreshold: 24
+      periodSeconds: 5
+      timeoutSeconds: 15
 
     ## Node selector constraints for logger service pod scheduling
     ##
@@ -1494,6 +1544,23 @@ services:
     ## Init containers for agent service
     ##
     initContainers: []
+
+    ## Startup probe — runs progress_check until the agent has reported
+    ## progress at least once. failureThreshold * periodSeconds (default
+    ## 24 * 5 = 120s) is how long the kubelet waits before declaring
+    ## CrashLoopBackOff.
+    ##
+    startupProbe:
+      exec:
+        command:
+        - progress_check
+        - --progress_interval
+        - "60"
+        - --progress_file
+        - /var/run/osmo/last_progress
+      failureThreshold: 24
+      periodSeconds: 5
+      timeoutSeconds: 15
 
     ## Node selector constraints for agent service pod scheduling
     ##

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -53,6 +53,15 @@ global:
   ##
   hostname: ""
 
+  ## Startup-probe failureThreshold applied to every OSMO service that has
+  ## a hardcoded startup probe (api, agent, logger, worker, delayed-job-
+  ## monitor). With period=5s, the value is roughly the number of seconds
+  ## the kubelet will wait for slow init (configmap secret loads, table
+  ## warm-up, TLS listener bind) divided by 5. Default tolerates ~2 minutes;
+  ## bump it for slow-I/O clusters. Doesn't affect healthy startups, since
+  ## the first successful probe ends the startup phase.
+  startupProbeFailureThreshold: 24
+
   ## Logging configuration for all Osmo services
   ##
   logs:
@@ -274,11 +283,12 @@ services:
 
     ## Startup probe configuration
     ##
+    ## failureThreshold is set globally via global.startupProbeFailureThreshold
+    ## and any value here would be overridden, so it's omitted.
     startupProbe:
       httpGet:
         path: /health
         port: 8000
-      failureThreshold: 6
       periodSeconds: 5
       timeoutSeconds: 3
       initialDelaySeconds: 5
@@ -1307,11 +1317,12 @@ services:
       periodSeconds: 5
       timeoutSeconds: 30
 
+    ## failureThreshold is set globally via global.startupProbeFailureThreshold
+    ## and any value here would be overridden, so it's omitted.
     startupProbe:
       httpGet:
         port: 8000
         path: /api/router/version
-      failureThreshold: 6
       periodSeconds: 5
       timeoutSeconds: 3
       initialDelaySeconds: 30

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -788,6 +788,8 @@ services:
         - "30"
       failureThreshold: 24
       periodSeconds: 5
+      timeoutSeconds: 15
+      initialDelaySeconds: 10
 
     ## Node selector constraints for delayed job monitor pod scheduling
     ##
@@ -1426,6 +1428,7 @@ services:
       failureThreshold: 24
       periodSeconds: 5
       timeoutSeconds: 15
+      initialDelaySeconds: 10
 
     ## Node selector constraints for logger service pod scheduling
     ##
@@ -1561,6 +1564,7 @@ services:
       failureThreshold: 24
       periodSeconds: 5
       timeoutSeconds: 15
+      initialDelaySeconds: 10
 
     ## Node selector constraints for agent service pod scheduling
     ##


### PR DESCRIPTION
Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made startup probes configurable per service and moved probe definitions into values so teams can supply custom probe types and timings; increased default failure thresholds to allow longer, more tolerant startups for core components.
* **Documentation**
  * Added a "Startup probe tuning" note describing per-service probe blocks, recommended timings, and guidance for adjusting failureThreshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->