### PR TITLE
Fix CVE-2026-2673: Update web-ui base image to v4.0.5

### DIFF
--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -56,7 +56,7 @@
 # Stage 1: Dependencies (cached unless package.json/pnpm-lock.yaml change)
 # =============================================================================
 ARG NODE_BUILD_IMAGE=node:24-slim
-ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/node:24-v4.0.4
+ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/node:24-v4.0.5
 
 FROM ${NODE_BUILD_IMAGE} AS deps
 


### PR DESCRIPTION
## Description
Update NVIDIA distroless Node.js base image from v4.0.4 to v4.0.5 to address CVE-2026-2673, an OpenSSL vulnerability affecting TLS 1.3 key exchange in OpenSSL 3.5 and 3.6.

The vulnerability could cause TLS 1.3 servers to negotiate less preferred key exchange groups, particularly impacting hybrid post-quantum cryptography deployments.

This update ensures the web-ui container uses a patched OpenSSL version (3.6.2+ or 3.5.6+).

References:
- https://security-tracker.debian.org/tracker/CVE-2026-2673
- https://www.wiz.io/vulnerability-database/cve/cve-2026-2673

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production container base image to the latest version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->