### PR TITLE
scheduler: add 'none' scheduler_type to skip PodGroup creation

### DIFF
--- a/src/ui/openapi.json
+++ b/src/ui/openapi.json
@@ -8759,7 +8759,8 @@
       "BackendSchedulerType": {
         "type": "string",
         "enum": [
-          "kai"
+          "kai",
+          "none"
         ],
         "title": "BackendSchedulerType",
         "description": "Defines the type of scheduler used by the backend "

--- a/src/ui/src/lib/api/generated.ts
+++ b/src/ui/src/lib/api/generated.ts
@@ -105,6 +105,7 @@ export type BackendSchedulerType = typeof BackendSchedulerType[keyof typeof Back
 
 export const BackendSchedulerType = {
   kai: 'kai',
+  none: 'none',
 } as const;
 
 /**

--- a/src/ui/src/mocks/generated-mocks.ts
+++ b/src/ui/src/mocks/generated-mocks.ts
@@ -88,6 +88,7 @@ export type BackendSchedulerType = (typeof BackendSchedulerType)[keyof typeof Ba
 
 export const BackendSchedulerType = {
   kai: "kai",
+  none: "none",
 } as const;
 
 /**

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -2478,6 +2478,11 @@ class BackendResource(pydantic.BaseModel):
 class BackendSchedulerType(enum.Enum):
     """ Defines the type of scheduler used by the backend """
     KAI = 'kai'
+    # No gang-scheduler integration — pods are scheduled by `scheduler_name`
+    # (typically the K8s default scheduler). Skips PodGroup CR creation, which
+    # removes the kai-scheduler dependency for workflows that don't need
+    # gang scheduling. See NVIDIA/OSMO#936.
+    NONE = 'none'
 
 
 class BackendSchedulerSettings(pydantic.BaseModel):

--- a/src/utils/job/kb_objects.py
+++ b/src/utils/job/kb_objects.py
@@ -608,8 +608,12 @@ def get_k8s_object_factory(backend: connectors.Backend) -> K8sObjectFactory:
     scheduler_type = scheduler_settings.scheduler_type
     if scheduler_type == connectors.BackendSchedulerType.KAI:
         return KaiK8sObjectFactory(backend)
-    else:
-        raise osmo_errors.OSMOServerError(f'Unsupported scheduler type: {scheduler_type}')
+    if scheduler_type == connectors.BackendSchedulerType.NONE:
+        # Base K8sObjectFactory does exactly what 'none' needs: no PodGroup CR,
+        # `scheduler_name` written to pod.spec.schedulerName, no scheduler
+        # CRDs (queues/topologies), no priority/topology features. See #936.
+        return K8sObjectFactory(scheduler_settings.scheduler_name)
+    raise osmo_errors.OSMOServerError(f'Unsupported scheduler type: {scheduler_type}')
 
 
 class FileMount(pydantic.BaseModel):


### PR DESCRIPTION
## Summary

Implements Option C from #936: a new `BackendSchedulerType.NONE` that skips PodGroup CR creation and runs pods on the K8s default scheduler — removing the kai-scheduler hard dependency for workflows that don't need gang scheduling.

- `BackendSchedulerType` accepts `'none'` in addition to `'kai'`.
- `get_k8s_object_factory()` returns the base `K8sObjectFactory(scheduler_name)` for `NONE`. The base class already does what 'none' needs:
  - no PodGroup CR (just pods)
  - `scheduler_name` written to `pod.spec.schedulerName`
  - no scheduler resource CRDs (queues, topologies)
  - `priority_supported` / `topology_supported` return `False`
- `openapi.json` + UI generated types mirror the new enum value.

15 lines of code change across 5 files. The default behavior (`scheduler_type='kai'`) is unchanged.

## Test plan

OETF scenario test (in the internal harness, not part of this PR) exercises the path end-to-end on KIND:

1. POST `/api/configs/backend/default` with `scheduler_type='none'`, `scheduler_name='default-scheduler'`.
2. Submit `validation/workflow/serial_workflow.yaml`.
3. Expect `COMPLETED`.
4. `addCleanup` restores the original backend config.

TDD verification on `oetf:deploy --env kind --build-local`:

| Run | State | Result |
|-----|-------|--------|
| pass-on-good | full Option C | **PASS** (workflow completes; no PodGroup CR is created) |
| fail-on-bad | enum + factory branch reverted | **FAIL** with `422 Input should be 'kai'` (the exact symptom from #936) |
| pass-on-good (re-verify) | fix restored | **PASS** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a "none" backend scheduler option. When selected, pod scheduling uses the Kubernetes default scheduler instead of gang-scheduling, allowing for more flexible resource allocation configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->