### PR TITLE
testbot: allow source-package BUILD edits paired with a Go test file

### DIFF
--- a/src/scripts/testbot/guardrails.py
+++ b/src/scripts/testbot/guardrails.py
@@ -24,12 +24,44 @@ def is_test_file(file_path: str) -> bool:
     """Check if a file path matches known test file patterns.
 
     BUILD files are only allowed inside /tests/ directories to prevent
-    modifications to source-package BUILD files.
+    modifications to source-package BUILD files. Use ``is_allowed_change``
+    when contextual signals (e.g. a sibling ``*_test.go`` in the same
+    change set) should also let a source-package ``BUILD`` through —
+    that's the Go convention because Go tests live next to their source.
     """
     basename = file_path.rsplit("/", maxsplit=1)[-1]
     if basename == "BUILD" and "/tests/" in file_path:
         return True
     return any(fnmatch.fnmatch(basename, pattern) for pattern in TEST_FILE_PATTERNS)
+
+
+def _has_sibling_go_test(build_path: str, change_set: set[str]) -> bool:
+    """Return True when ``build_path``'s directory contains a Go test in change_set."""
+    if "/" not in build_path:
+        return False
+    package_dir = build_path.rsplit("/", maxsplit=1)[0] + "/"
+    return any(
+        path.startswith(package_dir)
+        and "/" not in path[len(package_dir):]
+        and path.endswith("_test.go")
+        for path in change_set
+    )
+
+
+def is_allowed_change(file_path: str, change_set: set[str]) -> bool:
+    """Like ``is_test_file`` but also allows source-package BUILD edits paired with a Go test.
+
+    Go tests live next to their source (no ``/tests/`` segment), so adding
+    ``*_test.go`` requires editing the source package's ``BUILD`` to declare
+    a ``go_test`` rule. We let that BUILD edit through when a sibling
+    ``_test.go`` is part of the same change set.
+    """
+    if is_test_file(file_path):
+        return True
+    basename = file_path.rsplit("/", maxsplit=1)[-1]
+    if basename == "BUILD" and _has_sibling_go_test(file_path, change_set):
+        return True
+    return False
 
 
 def _detect_changes() -> tuple[set[str], set[str]]:
@@ -96,7 +128,7 @@ def get_changed_test_files() -> list[str]:
     non_test_tracked = []
     non_test_untracked = []
     for file_path in sorted(all_files):
-        if is_test_file(file_path):
+        if is_allowed_change(file_path, all_files):
             test_files.append(file_path)
         elif file_path in untracked:
             non_test_untracked.append(file_path)

--- a/src/scripts/testbot/tests/test_guardrails.py
+++ b/src/scripts/testbot/tests/test_guardrails.py
@@ -6,7 +6,12 @@ import subprocess
 import unittest
 from unittest.mock import patch
 
-from src.scripts.testbot.guardrails import get_changed_files, get_changed_test_files, is_test_file
+from src.scripts.testbot.guardrails import (
+    get_changed_files,
+    get_changed_test_files,
+    is_allowed_change,
+    is_test_file,
+)
 
 
 class TestIsTestFile(unittest.TestCase):
@@ -50,6 +55,55 @@ class TestIsTestFile(unittest.TestCase):
 
     def test_case_sensitive_no_match(self):
         self.assertFalse(is_test_file("src/foo/test_bar.PY"))
+
+
+class TestIsAllowedChange(unittest.TestCase):
+    """Contextual filter — Go tests live next to source, so a paired
+    BUILD edit must travel with the *_test.go file."""
+
+    def test_test_file_alone_is_allowed(self):
+        self.assertTrue(
+            is_allowed_change("src/utils/tests/test_task.py", set()),
+        )
+
+    def test_python_tests_dir_build_is_allowed(self):
+        self.assertTrue(
+            is_allowed_change("src/utils/tests/BUILD", set()),
+        )
+
+    def test_source_package_build_with_sibling_go_test_is_allowed(self):
+        change_set = {
+            "src/runtime/pkg/data/BUILD",
+            "src/runtime/pkg/data/data_test.go",
+        }
+        self.assertTrue(
+            is_allowed_change("src/runtime/pkg/data/BUILD", change_set),
+        )
+
+    def test_source_package_build_without_sibling_go_test_is_blocked(self):
+        change_set = {"src/runtime/pkg/data/BUILD"}
+        self.assertFalse(
+            is_allowed_change("src/runtime/pkg/data/BUILD", change_set),
+        )
+
+    def test_go_test_in_subdir_does_not_authorize_parent_build(self):
+        # _test.go must be a *direct* sibling, not nested deeper.
+        change_set = {
+            "src/runtime/pkg/data/BUILD",
+            "src/runtime/pkg/data/sub/sub_test.go",
+        }
+        self.assertFalse(
+            is_allowed_change("src/runtime/pkg/data/BUILD", change_set),
+        )
+
+    def test_source_file_remains_blocked_even_with_test_sibling(self):
+        change_set = {
+            "src/runtime/pkg/data/data.go",
+            "src/runtime/pkg/data/data_test.go",
+        }
+        self.assertFalse(
+            is_allowed_change("src/runtime/pkg/data/data.go", change_set),
+        )
 
 
 class TestGetChangedTestFiles(unittest.TestCase):
@@ -134,6 +188,40 @@ class TestGetChangedTestFiles(unittest.TestCase):
         result = get_changed_test_files()
         self.assertEqual(result, ["src/utils/tests/test_new.py"])
         mock_remove.assert_called_once_with("src/malicious.py")
+
+    @patch("src.scripts.testbot.guardrails.subprocess.run")
+    def test_keeps_go_build_edit_paired_with_test_file(self, mock_run):
+        # Go's go_test rule must be added to the source-package BUILD,
+        # which has no /tests/ segment. Pair it with the _test.go file
+        # in the change set and the BUILD edit is allowed through.
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(
+                [], 0, stdout="src/runtime/pkg/data/BUILD\n",
+            ),
+            subprocess.CompletedProcess(
+                [], 0, stdout="src/runtime/pkg/data/data_test.go\n",
+            ),
+        ]
+        result = get_changed_test_files()
+        self.assertEqual(
+            result,
+            [
+                "src/runtime/pkg/data/BUILD",
+                "src/runtime/pkg/data/data_test.go",
+            ],
+        )
+
+    @patch("src.scripts.testbot.guardrails.subprocess.run")
+    def test_reverts_orphan_go_build_edit_without_test_sibling(self, mock_run):
+        mock_run.side_effect = [
+            subprocess.CompletedProcess(
+                [], 0, stdout="src/runtime/pkg/data/BUILD\n",
+            ),
+            subprocess.CompletedProcess([], 0, stdout=""),
+            subprocess.CompletedProcess([], 0, stdout=""),  # git checkout
+        ]
+        result = get_changed_test_files()
+        self.assertEqual(result, [])
 
     @patch("src.scripts.testbot.guardrails.os.remove")
     @patch("src.scripts.testbot.guardrails.subprocess.run")


### PR DESCRIPTION
## Summary

Today's testbot generate run logged:

```
2026-05-08 06:38:40,046 [src.scripts.testbot.guardrails] WARNING:
Reverting 1 non-test tracked file(s): ['src/runtime/pkg/data/BUILD']
```

PR #959 taught the bot to add a `go_test` rule to the source package's `BUILD` when it writes a `*_test.go`. Without that rule, the test file is invisible to Bazel and `bazel coverage`. But the harness then reverted the BUILD edit because `is_test_file()` only allowed `BUILD` files inside `/tests/` directories — fine for Python (tests live in a sibling `tests/` dir), wrong for Go (tests live next to source).

This PR teaches the guardrail the Go convention.

## Change

New helper `is_allowed_change(path, change_set)`:

- `is_test_file(path)` cases pass through unchanged (test files; `BUILD` inside any `/tests/` directory).
- Plus: basename `BUILD` is allowed when a sibling `*_test.go` is in the same change set.

Sibling check is strict — the `_test.go` must be a **direct** child of the BUILD's directory. A `_test.go` nested deeper does not authorize the parent's BUILD edit, so a stray BUILD touch can't ride along on an unrelated deep test.

`get_changed_test_files` now uses the contextual check. `get_changed_files` (used by the respond workflow, which already permits source edits) is unaffected.

## Tests

Six new tests. Notable ones:

- `test_source_package_build_with_sibling_go_test_is_allowed` — the case that was failing in production.
- `test_source_package_build_without_sibling_go_test_is_blocked` — orphan BUILD touches still get reverted.
- `test_go_test_in_subdir_does_not_authorize_parent_build` — strict sibling check holds.
- `test_keeps_go_build_edit_paired_with_test_file` (integration via `get_changed_test_files`) — end-to-end with mocked git.

`bazel test //src/scripts/testbot/...` — 17/17 targets pass (unit + pylint + mypy).

Issue - None

## Files tested
- N/A — guardrail infrastructure; tests live alongside in `src/scripts/testbot/tests/test_guardrails.py`.

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes (six new tests)
- [x] The documentation is up to date with these changes (no doc impact — `TESTBOT_PROMPT.md` already documents the `go_test` BUILD edit; this PR makes the harness honor it)

## Test plan
- [x] `bazel test //src/scripts/testbot/...` passes locally
- [x] Trigger the daily testbot run on a Go target and confirm the resulting PR includes both the `*_test.go` AND the `go_test` BUILD entry, and that `bazel coverage //...` actually reports non-zero coverage on the targeted file afterward: https://github.com/NVIDIA/OSMO/pull/980


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test automation validation to allow coordinated modifications of build configuration files when paired with test files in the same package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->