### PR TITLE
feat: support quick-start object storage secret refs

### DIFF
--- a/deployments/charts/quick-start/README.md
+++ b/deployments/charts/quick-start/README.md
@@ -70,6 +70,9 @@ This chart installs and configures:
 | `global.objectStorage.overrideUrl`      | Object storage override URL (changed for localstack-s3)                 | `"http://localstack-s3.osmo:4566"` |
 | `global.objectStorage.accessKeyId`      | Object storage access key ID for authentication                         | `"test"`                           |
 | `global.objectStorage.accessKey`        | Object storage access key for authentication                            | `"test"`                           |
+| `global.objectStorage.existingSecret.name` | Existing Secret containing object storage credentials                 | `""`                               |
+| `global.objectStorage.existingSecret.accessKeyIdKey` | Secret key for the object storage access key ID              | `"access_key_id"`                  |
+| `global.objectStorage.existingSecret.accessKeyKey` | Secret key for the object storage access key                    | `"access_key"`                     |
 | `global.objectStorage.region`           | Object storage region where the bucket is located                       | `"us-east-1"`                      |
 
 ### Gateway Configuration

--- a/deployments/charts/quick-start/templates/config-setup.yaml
+++ b/deployments/charts/quick-start/templates/config-setup.yaml
@@ -256,10 +256,23 @@ spec:
           value: {{ .Values.global.objectStorage.endpoint | quote }}
         - name: OBJECT_STORAGE_OVERRIDE_URL
           value: {{ .Values.global.objectStorage.overrideUrl | quote }}
+        {{- if .Values.global.objectStorage.existingSecret.name }}
+        - name: OBJECT_STORAGE_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.objectStorage.existingSecret.name | quote }}
+              key: {{ .Values.global.objectStorage.existingSecret.accessKeyIdKey | quote }}
+        - name: OBJECT_STORAGE_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.global.objectStorage.existingSecret.name | quote }}
+              key: {{ .Values.global.objectStorage.existingSecret.accessKeyKey | quote }}
+        {{- else }}
         - name: OBJECT_STORAGE_ACCESS_KEY_ID
           value: {{ .Values.global.objectStorage.accessKeyId | quote }}
         - name: OBJECT_STORAGE_ACCESS_KEY
           value: {{ .Values.global.objectStorage.accessKey | quote }}
+        {{- end }}
         - name: OBJECT_STORAGE_REGION
           value: {{ .Values.global.objectStorage.region | quote }}
         - name: CONTAINER_REGISTRY

--- a/deployments/charts/quick-start/values.yaml
+++ b/deployments/charts/quick-start/values.yaml
@@ -66,6 +66,14 @@ global:
     ## Object storage access key for authentication
     ##
     accessKey: "test"
+    ## Existing Kubernetes Secret for object storage credentials.
+    ## When name is set, config-setup reads accessKeyId/accessKey from this Secret
+    ## instead of rendering the plain values above into the Job manifest.
+    ##
+    existingSecret:
+      name: ""
+      accessKeyIdKey: "access_key_id"
+      accessKeyKey: "access_key"
     ## Object storage region where the bucket is located
     ##
     region: "us-east-1"


### PR DESCRIPTION
## Description

Fixes #723.

Adds quick-start chart support for sourcing object storage access keys from an existing Kubernetes Secret instead of rendering them as plain Helm values in the `config-setup` Job manifest.

New values:

```yaml
global:
  objectStorage:
    existingSecret:
      name: my-s3-secret
      accessKeyIdKey: access-key-id
      accessKeyKey: access-key
```

When `existingSecret.name` is set, `OBJECT_STORAGE_ACCESS_KEY_ID` and `OBJECT_STORAGE_ACCESS_KEY` use `valueFrom.secretKeyRef`. When it is unset, the chart preserves the existing `value:` behavior for backward compatibility.

## Why

The quick-start chart previously required object storage secrets to be stored directly in values files. That exposes credentials in rendered manifests and Helm release secrets. This keeps the existing simple local defaults while allowing production deployments to provide credentials through Kubernetes Secrets.

## Validation

- `helm lint deployments/charts/quick-start`
- `helm template osmo deployments/charts/quick-start --show-only templates/config-setup.yaml`
- `helm template osmo deployments/charts/quick-start --show-only templates/config-setup.yaml --set global.objectStorage.existingSecret.name=my-s3-secret --set global.objectStorage.existingSecret.accessKeyIdKey=access-key-id --set global.objectStorage.existingSecret.accessKeyKey=access-key`
- Rendered the secret-backed config-setup Job and validated it against an EKS API server dry-run three times:
  - `kubectl apply --dry-run=server -f <rendered-config-setup>` x3
- Rendered the default config-setup Job and validated it once with EKS API server dry-run to confirm backward-compatible plain-value manifests remain valid.
- Created a temporary Kubernetes Secret and pod on EKS using the same `secretKeyRef` shape; the pod verified both object storage environment variables and exited successfully. Temporary validation resources were deleted afterward.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick Start Helm Chart now supports sourcing object storage credentials from existing Kubernetes Secrets, offering an alternative to direct configuration values.

* **Documentation**
  * Updated configuration documentation to describe the new secret-based credential option and its setup parameters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/982)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->