### PR TITLE
rsync: fix ValueError 'Invalid file descriptor: -1' on download shutdown

### DIFF
--- a/src/lib/rsync/rsync.py
+++ b/src/lib/rsync/rsync.py
@@ -569,7 +569,12 @@ class RsyncClient:
             task.cancel()
 
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception) and not isinstance(
+                    result, asyncio.CancelledError
+                ):
+                    logger.error('Unexpected error during task shutdown: %s', result)
 
         # Socket cleanup is owned by run_tcp_with_sock via asyncio.start_server.
 

--- a/src/lib/rsync/rsync.py
+++ b/src/lib/rsync/rsync.py
@@ -571,11 +571,7 @@ class RsyncClient:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Do not close self._sock here — asyncio.start_server takes ownership of the
-        # socket when run_tcp_with_sock registers it with the event loop. Closing it
-        # before the server's _stop_serving() runs causes sock.fileno() to return -1,
-        # which raises ValueError inside the selector cleanup.  The socket is closed
-        # either by asyncio's Server.close() path or by _port_forward()'s finally block.
+        # Socket cleanup is owned by run_tcp_with_sock via asyncio.start_server.
 
     async def upload(self) -> None:
         """

--- a/src/lib/rsync/rsync.py
+++ b/src/lib/rsync/rsync.py
@@ -559,17 +559,17 @@ class RsyncClient:
         self._stop_event.set()
         self._tcp_close.set()
 
-        if self._port_forward_task is not None:
-            try:
-                self._port_forward_task.cancel()
-            except Exception:  # pylint: disable=broad-except
-                pass
+        current_task = asyncio.current_task()
+        tasks = [
+            task for task in (self._port_forward_task, self._reconcile_upload_task)
+            if task is not None and task is not current_task and not task.done()
+        ]
 
-        if self._reconcile_upload_task is not None:
-            try:
-                self._reconcile_upload_task.cancel()
-            except Exception:  # pylint: disable=broad-except
-                pass
+        for task in tasks:
+            task.cancel()
+
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
         # Do not close self._sock here — asyncio.start_server takes ownership of the
         # socket when run_tcp_with_sock registers it with the event loop. Closing it

--- a/src/lib/rsync/rsync.py
+++ b/src/lib/rsync/rsync.py
@@ -571,9 +571,11 @@ class RsyncClient:
             except Exception:  # pylint: disable=broad-except
                 pass
 
-        if self._sock is not None:
-            self._sock.close()
-            self._sock = None
+        # Do not close self._sock here — asyncio.start_server takes ownership of the
+        # socket when run_tcp_with_sock registers it with the event loop. Closing it
+        # before the server's _stop_serving() runs causes sock.fileno() to return -1,
+        # which raises ValueError inside the selector cleanup.  The socket is closed
+        # either by asyncio's Server.close() path or by _port_forward()'s finally block.
 
     async def upload(self) -> None:
         """

--- a/src/lib/utils/port_forward.py
+++ b/src/lib/utils/port_forward.py
@@ -210,24 +210,22 @@ async def run_tcp_with_sock(
         if ready_event:
             ready_event.set()
 
-        async with server:
-            # Do not include server.serve_forever() here — first_completed cancels
-            # it without awaiting, leaking the task until asyncio.run() shutdown.
-            # The server is already active inside `async with server`; waiting on
-            # the close/ws signals is sufficient.
+        try:
+            # start_server() is already serving; wait for close signals.
             await common.first_completed([
                 close.wait(),
                 ctrl_ws.wait_closed(),
             ])
+        finally:
+            try:
+                server.close()
+                await server.wait_closed()
+            except ValueError as err:
+                if sock.fileno() != -1:
+                    raise
+                logger.debug('Server socket already closed on shutdown: %s', err)
     except (ConnectionRefusedError, websockets.exceptions.ConnectionClosedError) as err:
         logger.error(err)
-    except ValueError as err:
-        # "Invalid file descriptor: -1": raised by server.close() → _stop_serving()
-        # when the socket was closed externally before the server's own cleanup ran
-        # (e.g. the caller cancelled this coroutine without awaiting it and then
-        # closed the socket, leaving asyncio.run() shutdown to process the task).
-        # The transfer already completed; suppress the noisy shutdown artifact.
-        logger.debug('Server socket already closed on shutdown: %s', err)
     finally:
         if ctrl_ws:
             try:

--- a/src/lib/utils/port_forward.py
+++ b/src/lib/utils/port_forward.py
@@ -211,13 +211,23 @@ async def run_tcp_with_sock(
             ready_event.set()
 
         async with server:
+            # Do not include server.serve_forever() here — first_completed cancels
+            # it without awaiting, leaking the task until asyncio.run() shutdown.
+            # The server is already active inside `async with server`; waiting on
+            # the close/ws signals is sufficient.
             await common.first_completed([
-                server.serve_forever(),
                 close.wait(),
                 ctrl_ws.wait_closed(),
             ])
     except (ConnectionRefusedError, websockets.exceptions.ConnectionClosedError) as err:
         logger.error(err)
+    except ValueError as err:
+        # "Invalid file descriptor: -1": raised by server.close() → _stop_serving()
+        # when the socket was closed externally before the server's own cleanup ran
+        # (e.g. the caller cancelled this coroutine without awaiting it and then
+        # closed the socket, leaving asyncio.run() shutdown to process the task).
+        # The transfer already completed; suppress the noisy shutdown artifact.
+        logger.debug('Server socket already closed on shutdown: %s', err)
     finally:
         if ctrl_ws:
             try:

--- a/src/lib/utils/tests/BUILD
+++ b/src/lib/utils/tests/BUILD
@@ -34,6 +34,14 @@ osmo_py_test(
     ]
 )
 
+osmo_py_test(
+    name = "test_port_forward",
+    srcs = ["test_port_forward.py"],
+    deps = [
+        "//src/lib/utils:port_forward",
+    ]
+)
+
 
 osmo_py_test(
     name = "test_jinja_sandbox",

--- a/src/lib/utils/tests/test_port_forward.py
+++ b/src/lib/utils/tests/test_port_forward.py
@@ -1,0 +1,119 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import socket
+from typing import Any, cast
+import unittest
+from unittest import mock
+
+from src.lib.utils import port_forward
+
+
+class _FakeWebsocket:
+    def __init__(self):
+        self.closed = False
+
+    async def wait_closed(self):
+        await asyncio.Event().wait()
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeServiceClient:
+    def __init__(self, websocket: _FakeWebsocket):
+        self.websocket = websocket
+
+    async def create_websocket(self, *_args, **_kwargs):
+        return self.websocket
+
+
+class _SocketClosingEvent:
+    """Fake close event that closes the socket when awaited."""
+
+    def __init__(self, sock: socket.socket):
+        self._sock = sock
+
+    async def wait(self):
+        self._sock.close()
+
+
+class TestRunTcpWithSock(unittest.TestCase):
+    """Tests for run_tcp_with_sock shutdown error handling."""
+
+    def test_suppresses_server_shutdown_after_external_socket_close(self):
+        async def run_test():
+            ctrl_ws = _FakeWebsocket()
+            service_client = _FakeServiceClient(ctrl_ws)
+            ready_event = asyncio.Event()
+
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.bind(('127.0.0.1', 0))
+                await port_forward.run_tcp_with_sock(
+                    cast(Any, service_client),
+                    sock,
+                    'test port forward',
+                    'api/router/test',
+                    1,
+                    'ws://router',
+                    'key',
+                    'cookie=value',
+                    ready_event=ready_event,
+                    close_event=cast(Any, _SocketClosingEvent(sock)),
+                )
+
+            self.assertTrue(ready_event.is_set())
+            self.assertTrue(ctrl_ws.closed)
+
+        asyncio.run(run_test())
+
+    def test_reraises_value_error_when_socket_is_open(self):
+        async def raise_value_error(coroutines):
+            for coroutine in coroutines:
+                coroutine.close()
+            raise ValueError('unexpected value error')
+
+        async def run_test():
+            ctrl_ws = _FakeWebsocket()
+            service_client = _FakeServiceClient(ctrl_ws)
+
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.bind(('127.0.0.1', 0))
+                with mock.patch.object(
+                    port_forward.common,
+                    'first_completed',
+                    side_effect=raise_value_error,
+                ):
+                    with self.assertRaisesRegex(ValueError, 'unexpected value error'):
+                        await port_forward.run_tcp_with_sock(
+                            cast(Any, service_client),
+                            sock,
+                            'test port forward',
+                            'api/router/test',
+                            1,
+                            'ws://router',
+                            'key',
+                            'cookie=value',
+                        )
+
+        asyncio.run(run_test())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Fixes a spurious `unhandled exception during asyncio.run() shutdown -- ValueError: Invalid file descriptor: -1` printed after every successful `osmo workflow rsync download`. The download itself always succeeded (exit 0, file intact); the error was noise but alarming to users.

Three layered issues in the shutdown path:

1. `RsyncClient.stop()` closed `self._sock` while `asyncio.start_server(sock=sock)` still had the fd registered in the event loop selector. `server.close()` calling `_stop_serving()` then hit `sock.fileno() == -1`.

2. `run_tcp_with_sock` passed `server.serve_forever()` into `first_completed`, which cancels tasks without awaiting them. The leaked task fired during `asyncio.run()` shutdown and its CancelledError handler called `server.close()` on the already-closed socket.

3. `_port_forward()`'s `first_completed` similarly leaked the `run_tcp_with_sock` task. After `_port_forward`'s `finally` closed the socket, asyncio cleanup cancelled the task and hit the same dead fd.

Fix:
- `stop()`: cancel both background tasks in one pass, then `await asyncio.gather(*tasks, return_exceptions=True)` so port-forward cleanup finishes before `stop()` returns.
- `run_tcp_with_sock`: drop `server.serve_forever()` from `first_completed` (server is already active after `start_server`; that task was the original leak). Replace `async with server` with explicit `try/finally` calling `server.close()` + `await server.wait_closed()`. Suppress `ValueError` only when `sock.fileno() == -1`; re-raise otherwise.
- New `test_port_forward.py`: covers the suppressed-ValueError case and the re-raised case.

Reproduced and verified end-to-end on `isaac-nightly` pool -- 3x clean runs after the fix, no exception output.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for port forwarding shutdown behavior and error handling scenarios.

* **Refactor**
  * Improved async task cancellation logic in the rsync client.
  * Enhanced server shutdown handling in port forwarding to better manage socket lifecycle and resource cleanup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/987)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->