### PR TITLE
deploy-script: idempotent token mint + AWS S3 storage backend wiring

### DIFF
--- a/deployments/scripts/aws/terraform.sh
+++ b/deployments/scripts/aws/terraform.sh
@@ -214,6 +214,12 @@ rds_password       = "$TF_POSTGRES_PASSWORD"
 redis_node_type       = "cache.t3.micro"
 redis_num_cache_nodes = 1
 redis_auth_token      = "$TF_REDIS_PASSWORD"
+
+# Optional S3 bucket for OSMO workflow data
+# Triggered by --storage-backend s3 on deploy-osmo-minimal.sh
+# (the storage backend script reads s3_bucket / s3_access_key_id /
+# s3_secret_access_key TF outputs)
+s3_bucket_enabled = ${TF_S3_BUCKET_ENABLED:-false}
 EOF
 
     log_success "terraform.tfvars generated for AWS"

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -812,14 +812,39 @@ mint_backend_operator_token() {
         log_info "Service-account user '$sa_user' already exists"
     fi
 
+    # `osmo token set` is create-only — if a `backend-token` already exists
+    # for this user (from a previous deploy run, partial failure, or PVC
+    # carryover on in-cluster postgres), the next `set` call returns 400
+    # "Token name already exists" and the deploy stalls. Delete first so
+    # re-runs always reconcile to a fresh secret.
+    #
+    # Use the JSON output + the same pre-JSON banner strip we apply on
+    # `osmo token set` below — text-format parsing was brittle (row indexing
+    # changes when the CLI prints a "New client X.Y.Z available" banner on
+    # version skew, and the preamble line count depends on whether --user
+    # is passed). The JSON `token_name` field name is stable.
+    local token_name="backend-token"
+    if osmo token list --user "$sa_user" -t json 2>/dev/null \
+        | sed -n '/^\[/,/^\]/p' \
+        | jq -e --arg n "$token_name" 'any(.[]; .token_name == $n)' >/dev/null; then
+        log_info "  $token_name already exists for $sa_user — deleting before re-mint"
+        osmo token delete "$token_name" --user "$sa_user" >/dev/null 2>&1 || true
+    fi
+
     log_info "Generating backend operator token for $sa_user..."
     local backend_token
-    backend_token=$(osmo token set backend-token \
+    # Strip pre-JSON banner lines before piping to jq. OSMO CLI versions
+    # older than the server emit `WARNING: New client X.Y.Z available` to
+    # stdout above the JSON body; without the sed filter, `jq -r '.token'`
+    # errors with "parse error: Invalid numeric literal" and the script
+    # treats the mint as failed.
+    backend_token=$(osmo token set "$token_name" \
         --expires-at "$BACKEND_TOKEN_EXPIRY" \
         --description "Backend Operator Token" \
         --user "$sa_user" \
         --roles osmo-backend \
-        -t json 2>/tmp/osmo-token-set.log | jq -r '.token' || echo "")
+        -t json 2>/tmp/osmo-token-set.log | sed -n '/^{/,/^}/p' \
+        | jq -r '.token' || echo "")
 
     if [[ -z "$backend_token" || "$backend_token" == "null" ]]; then
         log_error "Failed to mint backend-operator token (osmo CLI returned empty)"

--- a/deployments/scripts/deploy-osmo-minimal.sh
+++ b/deployments/scripts/deploy-osmo-minimal.sh
@@ -348,6 +348,13 @@ setup_provider_env() {
           && -z "${STORAGE_ACCOUNT:-}" ]]; then
         export TF_STORAGE_ACCOUNT_ENABLED=true
     fi
+    # Symmetric to the Azure block above: the S3 storage backend reads bucket
+    # creds from AWS TF outputs when STORAGE_BUCKET isn't set, so flip the
+    # AWS-side toggle when the caller picks --storage-backend s3.
+    if [[ "$PROVIDER" == "aws" && "$STORAGE_BACKEND" == "s3" \
+          && -z "${STORAGE_BUCKET:-}" ]]; then
+        export TF_S3_BUCKET_ENABLED=true
+    fi
 
     # Set output file paths
     OUTPUTS_FILE="$SCRIPT_DIR/.${PROVIDER}_outputs.env"


### PR DESCRIPTION
## Description

Three small defects observed on real clean deploys after PR #979 (consolidation) merged:

**`deploy-k8s.sh` — `mint_backend_operator_token`**
- `osmo token set` is create-only — if a `backend-token` already exists for the user (partial prior run, in-cluster postgres PVC carryover, etc.), the next set call returns `400 Token name already exists` and the deploy stalls. Pre-delete the token so re-runs reconcile.
- Pipe `osmo token list -t json` and `osmo token set -t json` through `sed -n '/^{/,/^}/p'` (and the \`^[\`/\`^]\` variant for the list array) before `jq`. CLI versions older than the server emit `WARNING: New client X.Y.Z available` to stdout above the JSON body; without the strip, `jq` errors with `parse error: Invalid numeric literal` and the script reports the mint as failed. The list parsing also moves from text-row indexing (`awk 'NR>3'`) to `jq -e 'any(.[]; .token_name == \$n)'` — banner-tolerant and not dependent on the table preamble shape.

**`deploy-osmo-minimal.sh` — `setup_provider_env`**
- Auto-set `TF_S3_BUCKET_ENABLED=true` when `--provider aws --storage-backend s3` and `STORAGE_BUCKET` is unset. Symmetric to the existing Azure block that auto-flips `TF_STORAGE_ACCOUNT_ENABLED=true` for `--storage-backend azure-blob`. Without this, an AWS S3 deploy aborts at `configure-storage.sh` with "AWS TF s3_bucket output is empty."

**`aws/terraform.sh` — `aws_generate_tfvars`**
- Emit `s3_bucket_enabled = ${TF_S3_BUCKET_ENABLED:-false}` in the generated tfvars so the env-var toggle above actually reaches Terraform. Matches the existing Azure tfvars line for `storage_account_enabled`.

**Verification:** end-to-end clean deploys with `verify-hello: COMPLETED` on all three paths today:
- microk8s + minio
- AWS + s3 (this PR's S3 toggle wired into a fresh `terraform apply`)
- Azure + azure-blob

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.