### PR TITLE
fix: minio s3 addressing

### DIFF
--- a/deployments/scripts/configure-storage.sh
+++ b/deployments/scripts/configure-storage.sh
@@ -37,6 +37,7 @@
 #                                                     (default: $SCRIPT_DIR/values/.storage-values.yaml)
 #   --workload-identity-client-id ID                  Azure UAMI client ID (WI + azure-blob)
 #   --workload-identity-role-arn ARN                  AWS IAM role ARN (WI + byo)
+#   --storage-addressing-style {virtual|path|auto}    S3-compatible addressing style
 #   -h, --help                                        Show this help
 #
 # Backend selection:
@@ -65,12 +66,18 @@
 #   STORAGE_ENDPOINT        — required, e.g. s3://my-bucket
 #   STORAGE_REGION          — optional (default us-east-1)
 #   STORAGE_OVERRIDE_URL    — optional (e.g. https://s3.us-east-1.amazonaws.com)
+#   STORAGE_ADDRESSING_STYLE — optional (virtual|path|auto)
 #
 # BYO env vars (--auth-method workload-identity, AWS IRSA):
 #   WORKLOAD_IDENTITY_ROLE_ARN — required, e.g. arn:aws:iam::123:role/osmo-data-access
 #   STORAGE_ENDPOINT           — required, e.g. s3://my-bucket
 #   STORAGE_REGION             — optional (default us-east-1)
 #   STORAGE_OVERRIDE_URL       — optional
+#   STORAGE_ADDRESSING_STYLE   — optional (virtual|path|auto)
+#
+# MinIO env vars:
+#   MINIO_ADDRESSING_STYLE   — optional (default path; virtual|path|auto)
+#                              STORAGE_ADDRESSING_STYLE is also honored.
 #
 # Azure-blob env vars (--auth-method static):
 #   STORAGE_ACCOUNT         — Azure Storage Account name
@@ -109,6 +116,8 @@ while [[ $# -gt 0 ]]; do
             WORKLOAD_IDENTITY_CLIENT_ID="$2"; shift 2 ;;
         --workload-identity-role-arn)
             WORKLOAD_IDENTITY_ROLE_ARN="$2"; shift 2 ;;
+        --storage-addressing-style)
+            STORAGE_ADDRESSING_STYLE="$2"; shift 2 ;;
         --non-interactive)
             NON_INTERACTIVE=true; shift ;;
         -h|--help)
@@ -132,6 +141,8 @@ esac
 
 KUBECTL="${KUBECTL:-kubectl}"
 export KUBECTL NAMESPACE OUTPUT_VALUES AUTH_METHOD
+[[ -n "${STORAGE_ADDRESSING_STYLE:-}" ]] && export STORAGE_ADDRESSING_STYLE
+[[ -n "${MINIO_ADDRESSING_STYLE:-}" ]] && export MINIO_ADDRESSING_STYLE
 [[ -n "${WORKLOAD_IDENTITY_CLIENT_ID:-}" ]] && export WORKLOAD_IDENTITY_CLIENT_ID
 [[ -n "${WORKLOAD_IDENTITY_ROLE_ARN:-}" ]] && export WORKLOAD_IDENTITY_ROLE_ARN
 

--- a/deployments/scripts/storage/azure-blob.sh
+++ b/deployments/scripts/storage/azure-blob.sh
@@ -166,7 +166,7 @@ else
 fi
 
 create_workflow_cred_secrets \
-    "$STORAGE_ACCOUNT" "$CONN_STR" "$ENDPOINT" "${STORAGE_LOCATION:-eastus2}" ""
+    "$STORAGE_ACCOUNT" "$CONN_STR" "$ENDPOINT" "${STORAGE_LOCATION:-eastus2}" "" ""
 
 emit_static_values_fragment azure-blob "$ENDPOINT"
 

--- a/deployments/scripts/storage/byo.sh
+++ b/deployments/scripts/storage/byo.sh
@@ -9,7 +9,7 @@
 #     User has access keys. Script registers them as K8s Secrets and emits a
 #     values fragment with `secretName` references. Required env:
 #       STORAGE_ACCESS_KEY_ID, STORAGE_ACCESS_KEY, STORAGE_ENDPOINT
-#     Optional: STORAGE_REGION, STORAGE_OVERRIDE_URL
+#     Optional: STORAGE_REGION, STORAGE_OVERRIDE_URL, STORAGE_ADDRESSING_STYLE
 #
 #   --auth-method workload-identity (AWS IRSA)
 #     User has provisioned an IAM role with S3 access + an EKS OIDC trust
@@ -18,7 +18,7 @@
 #     DefaultDataCredential shape (just `endpoint`) and the
 #     `eks.amazonaws.com/role-arn` SA annotation. Required env:
 #       WORKLOAD_IDENTITY_ROLE_ARN, STORAGE_ENDPOINT
-#     Optional: STORAGE_REGION, STORAGE_OVERRIDE_URL
+#     Optional: STORAGE_REGION, STORAGE_OVERRIDE_URL, STORAGE_ADDRESSING_STYLE
 #
 # In both modes the user pre-provisions the bucket — this script never creates
 # storage resources.
@@ -36,6 +36,8 @@ NGC_SECRET_NAME="${NGC_SECRET_NAME:-nvcr-secret}"
 
 REGION="${STORAGE_REGION:-us-east-1}"
 OVERRIDE_URL="${STORAGE_OVERRIDE_URL:-}"
+ADDRESSING_STYLE="${STORAGE_ADDRESSING_STYLE:-}"
+validate_addressing_style "$ADDRESSING_STYLE"
 
 if [[ "$AUTH_METHOD" == "workload-identity" ]]; then
     # IRSA path — only need the bucket endpoint + the role ARN.
@@ -48,6 +50,7 @@ if [[ "$AUTH_METHOD" == "workload-identity" ]]; then
 Optional:
   STORAGE_REGION              (default: us-east-1)
   STORAGE_OVERRIDE_URL        (e.g. for non-AWS S3-compatible endpoints)
+  STORAGE_ADDRESSING_STYLE    (virtual|path|auto)
 MSG
         exit 1
     fi
@@ -78,23 +81,27 @@ services:
           endpoint: "$STORAGE_ENDPOINT"
           region: "$REGION"
 $([[ -n "$OVERRIDE_URL" ]] && echo "          override_url: \"$OVERRIDE_URL\"")
+$([[ -n "$ADDRESSING_STYLE" ]] && echo "          addressing_style: \"$ADDRESSING_STYLE\"")
         base_url: "$STORAGE_ENDPOINT"
       workflow_log:
         credential:
           endpoint: "$STORAGE_ENDPOINT"
           region: "$REGION"
 $([[ -n "$OVERRIDE_URL" ]] && echo "          override_url: \"$OVERRIDE_URL\"")
+$([[ -n "$ADDRESSING_STYLE" ]] && echo "          addressing_style: \"$ADDRESSING_STYLE\"")
       workflow_app:
         credential:
           endpoint: "$STORAGE_ENDPOINT"
           region: "$REGION"
 $([[ -n "$OVERRIDE_URL" ]] && echo "          override_url: \"$OVERRIDE_URL\"")
+$([[ -n "$ADDRESSING_STYLE" ]] && echo "          addressing_style: \"$ADDRESSING_STYLE\"")
 EOF
 
     echo "[INFO] BYO storage configured (AWS IRSA / workload-identity):"
     echo "       role ARN:    $WORKLOAD_IDENTITY_ROLE_ARN"
     echo "       endpoint:    $STORAGE_ENDPOINT"
     echo "       region:      $REGION"
+    echo "       addressing:  ${ADDRESSING_STYLE:-<default>}"
     echo "       SA mode:     chart creates SA with eks.amazonaws.com/role-arn annotation"
     echo "       values:      $OUTPUT_VALUES"
     exit 0
@@ -111,6 +118,7 @@ if [[ -z "${STORAGE_ACCESS_KEY_ID:-}" || -z "${STORAGE_ACCESS_KEY:-}" || -z "${S
 Optional:
   STORAGE_REGION       (default: us-east-1)
   STORAGE_OVERRIDE_URL (e.g. https://s3.us-east-1.amazonaws.com)
+  STORAGE_ADDRESSING_STYLE (virtual|path|auto)
 
 For workload-identity / IRSA mode, set --auth-method workload-identity and
 provide WORKLOAD_IDENTITY_ROLE_ARN instead of access keys.
@@ -119,7 +127,8 @@ MSG
 fi
 
 create_workflow_cred_secrets \
-    "$STORAGE_ACCESS_KEY_ID" "$STORAGE_ACCESS_KEY" "$STORAGE_ENDPOINT" "$REGION" "$OVERRIDE_URL"
+    "$STORAGE_ACCESS_KEY_ID" "$STORAGE_ACCESS_KEY" "$STORAGE_ENDPOINT" "$REGION" "$OVERRIDE_URL" \
+    "$ADDRESSING_STYLE"
 
 emit_static_values_fragment byo "$STORAGE_ENDPOINT"
 
@@ -127,5 +136,6 @@ echo "[INFO] BYO storage configured (static auth):"
 echo "       endpoint:    $STORAGE_ENDPOINT"
 echo "       region:      $REGION"
 echo "       override:    ${OVERRIDE_URL:-<none>}"
+echo "       addressing:  ${ADDRESSING_STYLE:-<default>}"
 echo "       secrets:     osmo-workflow-{data,log,app}-cred in $NAMESPACE"
 echo "       values:      $OUTPUT_VALUES"

--- a/deployments/scripts/storage/common.sh
+++ b/deployments/scripts/storage/common.sh
@@ -8,9 +8,26 @@
 
 # Create the three K8s Secrets the OSMO storage SDK reads via
 # services.configs.workflow.workflow_*.credential.secretName.
-# Args: access_key_id access_key endpoint region override_url
+# Args: access_key_id access_key endpoint region override_url [addressing_style]
+validate_addressing_style() {
+    local addressing_style="${1:-}"
+    case "$addressing_style" in
+        ""|virtual|path|auto) ;;
+        *)
+            echo "[ERROR] Invalid addressing style '$addressing_style' (expected: virtual, path, or auto)" >&2
+            exit 1
+            ;;
+    esac
+}
+
 create_workflow_cred_secrets() {
     local access_key_id="$1" access_key="$2" endpoint="$3" region="$4" override_url="$5"
+    local addressing_style="${6:-}"
+    validate_addressing_style "$addressing_style"
+    local addressing_style_arg=()
+    if [[ -n "$addressing_style" ]]; then
+        addressing_style_arg=(--from-literal=addressing_style="$addressing_style")
+    fi
     local name
     for name in osmo-workflow-data-cred osmo-workflow-log-cred osmo-workflow-app-cred; do
         $KUBECTL create secret generic "$name" -n "$NAMESPACE" \
@@ -19,6 +36,7 @@ create_workflow_cred_secrets() {
             --from-literal=endpoint="$endpoint" \
             --from-literal=region="$region" \
             --from-literal=override_url="$override_url" \
+            "${addressing_style_arg[@]}" \
             --dry-run=client -o yaml | $KUBECTL apply -f -
     done
 }

--- a/deployments/scripts/storage/minio.sh
+++ b/deployments/scripts/storage/minio.sh
@@ -40,6 +40,8 @@ fi
 
 MINIO_BUCKET="${MINIO_BUCKET:-${OSMO_WORKFLOW_BUCKET:-osmo-workflows}}"
 MINIO_NAMESPACE="${MINIO_NAMESPACE:-minio-operator}"
+MINIO_ADDRESSING_STYLE="${MINIO_ADDRESSING_STYLE:-${STORAGE_ADDRESSING_STYLE:-path}}"
+validate_addressing_style "$MINIO_ADDRESSING_STYLE"
 MINIO_SVC_DNS="minio.${MINIO_NAMESPACE}.svc.cluster.local"
 # Detect the actual Service port. The microk8s `minio` addon exposes the API on
 # Service port 80 (targetPort 9000); install-minio.sh / bitnami chart uses 9000
@@ -114,7 +116,8 @@ timeout "$BUCKET_SETUP_TIMEOUT" \
 
 # 3. Create 3 K8s Secrets, one per workflow_* credential reference.
 create_workflow_cred_secrets \
-    "$MINIO_USER" "$MINIO_PASS" "s3://$MINIO_BUCKET" "us-east-1" "$MINIO_ENDPOINT_URL"
+    "$MINIO_USER" "$MINIO_PASS" "s3://$MINIO_BUCKET" "us-east-1" "$MINIO_ENDPOINT_URL" \
+    "$MINIO_ADDRESSING_STYLE"
 
 # 4. Emit Helm values fragment.
 emit_static_values_fragment minio "s3://$MINIO_BUCKET"
@@ -122,5 +125,6 @@ emit_static_values_fragment minio "s3://$MINIO_BUCKET"
 echo "[INFO] MinIO storage configured:"
 echo "       bucket:      s3://$MINIO_BUCKET"
 echo "       endpoint:    $MINIO_ENDPOINT_URL"
+echo "       addressing:  $MINIO_ADDRESSING_STYLE"
 echo "       secrets:     osmo-workflow-{data,log,app}-cred in $NAMESPACE"
 echo "       values:      $OUTPUT_VALUES"

--- a/deployments/scripts/storage/s3.sh
+++ b/deployments/scripts/storage/s3.sh
@@ -74,6 +74,7 @@ else
 
 Optional:
   STORAGE_REGION       (default: $AWS_REGION or us-west-2)
+  STORAGE_ADDRESSING_STYLE (virtual|path|auto)
 
 or run osmo AWS terraform with `s3_bucket_enabled = true` and let the script
 read its outputs from terraform/aws/example/.
@@ -84,6 +85,8 @@ MSG
 fi
 
 ENDPOINT="s3://${BUCKET}"
+ADDRESSING_STYLE="${STORAGE_ADDRESSING_STYLE:-}"
+validate_addressing_style "$ADDRESSING_STYLE"
 
 # 2. Best-effort bucket reachability check via aws CLI when available.
 #    Skip silently if the IAM user's keys haven't propagated yet (eventually
@@ -102,7 +105,7 @@ fi
 
 # 3. Create 3 K8s Secrets, one per workflow_* credential reference.
 create_workflow_cred_secrets \
-    "$ACCESS_KEY_ID" "$SECRET_ACCESS_KEY" "$ENDPOINT" "$REGION" ""
+    "$ACCESS_KEY_ID" "$SECRET_ACCESS_KEY" "$ENDPOINT" "$REGION" "" "$ADDRESSING_STYLE"
 
 # 4. Emit Helm values fragment.
 emit_static_values_fragment s3 "$ENDPOINT"
@@ -111,5 +114,6 @@ echo "[INFO] S3 storage configured (static auth):"
 echo "       bucket:     $BUCKET"
 echo "       endpoint:   $ENDPOINT"
 echo "       region:     $REGION"
+echo "       addressing: ${ADDRESSING_STYLE:-<default>}"
 echo "       secrets:    osmo-workflow-{data,log,app}-cred in $NAMESPACE"
 echo "       values:     $OUTPUT_VALUES"


### PR DESCRIPTION


<!-- Title should be "#<issue number> - <commit title>"-->

## Description
Fix regression in MinIO S3 addressing after the default was changed to to virtual host style for non AWS S3 endpoints.

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced configurable storage addressing style (virtual, path, auto) across CLI and env, honored by all storage backends and shown in setup output.
  * Backends now validate the chosen addressing style and include it in generated credentials/values.

* **Documentation**
  * Updated help and informational messages to document the addressing-style option and display the resolved value during configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/991)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->