### PR TITLE
Add support for setting helm values in minimal

### DIFF
--- a/deployments/scripts/README.md
+++ b/deployments/scripts/README.md
@@ -121,6 +121,7 @@ When invoked, the entry-point runs these phases in order. Each is idempotent and
 4. **OSMO Helm install** (`deploy-k8s.sh`)
    - Creates namespaces, MEK ConfigMap, NGC pull secret
    - `helm upgrade --install` with chart + storage-values fragment + `--set global.osmoImageTag=$OSMO_IMAGE_TAG` + `--version $OSMO_CHART_VERSION` (when set)
+   - Optional user values files and simple `--set` overrides are layered last
    - Idempotent backend-operator token mint (re-uses existing if valid)
    - Waits for pods Running 1/1
 5. **Smoke test** (`verify.sh`) — submits `verify-hello.yaml`, polls until COMPLETED, dumps logs on failure. With GPU nodes, also runs `verify-gpu.yaml`.
@@ -146,10 +147,46 @@ Main entry point — see `--help` for the full flag list. Orchestrates all phase
 | `--skip-osmo` | Provision infrastructure only. |
 | `--destroy` | TF destroy (azure/aws) + cluster cleanup. |
 | `--ngc-api-key KEY` | Auth for `nvcr.io` images and `helm.ngc.nvidia.com` charts. Also `NGC_API_KEY` env var. |
+| `--helm-values FILE` | Repeatable values file layered into both the service and backend-operator Helm releases. |
+| `--service-helm-values FILE` | Repeatable values file layered only into the service Helm release. |
+| `--backend-operator-helm-values FILE` | Repeatable values file layered only into the backend-operator Helm release. |
+| `--helm-set KEY=VALUE` | Repeatable simple `--set` override for both Helm releases. Use a values file for nested or complex values. |
+| `--service-helm-set KEY=VALUE` | Repeatable simple `--set` override only for the service Helm release. |
+| `--backend-operator-helm-set KEY=VALUE` | Repeatable simple `--set` override only for the backend-operator Helm release. |
 | `--non-interactive` | Fail if required values are missing (CI mode). |
 | `--dry-run` | Print phases without making changes. |
 
 Full help: `./deploy-osmo-minimal.sh --help`.
+
+Extra values are applied after the built-in static, PodMonitor, GPU pool, storage values, and generated per-cluster overrides. That means an explicit caller value always wins, including image pull policy, resources, node selectors, tolerations, probes, image settings, database host, Redis host, and namespaces.
+
+For broad overrides, prefer a values file:
+
+```yaml
+# /tmp/osmo-overrides.yaml
+services:
+  ui:
+    imagePullPolicy: IfNotPresent
+  service:
+    imagePullPolicy: IfNotPresent
+
+gateway:
+  envoy:
+    imagePullPolicy: IfNotPresent
+
+backendTestRunner:
+  podTemplate:
+    image:
+      pullPolicy: IfNotPresent
+    initContainer:
+      imagePullPolicy: IfNotPresent
+```
+
+Then pass it to both OSMO charts:
+
+```bash
+./deploy-osmo-minimal.sh --provider azure --helm-values /tmp/osmo-overrides.yaml
+```
 
 ### `deploy-k8s.sh`
 

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -92,6 +92,28 @@ DRY_RUN="${DRY_RUN:-false}"
 POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}"
 REDIS_PASSWORD="${REDIS_PASSWORD:-}"
 
+# Optional user Helm overrides. deploy-osmo-minimal.sh sets these arrays before
+# sourcing this file; direct deploy-k8s.sh invocations can populate them through
+# parse_k8s_args below.
+if ! declare -p OSMO_HELM_VALUES_FILES >/dev/null 2>&1; then
+    declare -a OSMO_HELM_VALUES_FILES=()
+fi
+if ! declare -p OSMO_SERVICE_HELM_VALUES_FILES >/dev/null 2>&1; then
+    declare -a OSMO_SERVICE_HELM_VALUES_FILES=()
+fi
+if ! declare -p OSMO_BACKEND_OPERATOR_HELM_VALUES_FILES >/dev/null 2>&1; then
+    declare -a OSMO_BACKEND_OPERATOR_HELM_VALUES_FILES=()
+fi
+if ! declare -p OSMO_HELM_SET_VALUES >/dev/null 2>&1; then
+    declare -a OSMO_HELM_SET_VALUES=()
+fi
+if ! declare -p OSMO_SERVICE_HELM_SET_VALUES >/dev/null 2>&1; then
+    declare -a OSMO_SERVICE_HELM_SET_VALUES=()
+fi
+if ! declare -p OSMO_BACKEND_OPERATOR_HELM_SET_VALUES >/dev/null 2>&1; then
+    declare -a OSMO_BACKEND_OPERATOR_HELM_SET_VALUES=()
+fi
+
 # IS_PRIVATE_CLUSTER is set by azure/terraform.sh (when AKS is private) or by
 # preflight in the BYO provider. Default to false so non-azure / non-byo
 # providers (microk8s, aws) don't trip `set -u` later.
@@ -132,6 +154,30 @@ parse_k8s_args() {
                 ;;
             --ngc-api-key)
                 NGC_API_KEY="$2"
+                shift 2
+                ;;
+            --helm-values)
+                OSMO_HELM_VALUES_FILES+=("$2")
+                shift 2
+                ;;
+            --service-helm-values)
+                OSMO_SERVICE_HELM_VALUES_FILES+=("$2")
+                shift 2
+                ;;
+            --backend-operator-helm-values|--operator-helm-values)
+                OSMO_BACKEND_OPERATOR_HELM_VALUES_FILES+=("$2")
+                shift 2
+                ;;
+            --helm-set)
+                OSMO_HELM_SET_VALUES+=("$2")
+                shift 2
+                ;;
+            --service-helm-set)
+                OSMO_SERVICE_HELM_SET_VALUES+=("$2")
+                shift 2
+                ;;
+            --backend-operator-helm-set|--operator-helm-set)
+                OSMO_BACKEND_OPERATOR_HELM_SET_VALUES+=("$2")
                 shift 2
                 ;;
             *)
@@ -651,9 +697,95 @@ chart_version_flag() {
     fi
 }
 
+validate_user_helm_overrides() {
+    local value_file
+    for value_file in "${OSMO_HELM_VALUES_FILES[@]+"${OSMO_HELM_VALUES_FILES[@]}"}" \
+                      "${OSMO_SERVICE_HELM_VALUES_FILES[@]+"${OSMO_SERVICE_HELM_VALUES_FILES[@]}"}" \
+                      "${OSMO_BACKEND_OPERATOR_HELM_VALUES_FILES[@]+"${OSMO_BACKEND_OPERATOR_HELM_VALUES_FILES[@]}"}"; do
+        if [[ -z "$value_file" ]]; then
+            continue
+        fi
+        if [[ ! -f "$value_file" ]]; then
+            log_error "Helm values file not found: $value_file"
+            return 1
+        fi
+    done
+
+    local set_value
+    for set_value in "${OSMO_HELM_SET_VALUES[@]+"${OSMO_HELM_SET_VALUES[@]}"}" \
+                     "${OSMO_SERVICE_HELM_SET_VALUES[@]+"${OSMO_SERVICE_HELM_SET_VALUES[@]}"}" \
+                     "${OSMO_BACKEND_OPERATOR_HELM_SET_VALUES[@]+"${OSMO_BACKEND_OPERATOR_HELM_SET_VALUES[@]}"}"; do
+        if [[ -z "$set_value" ]]; then
+            continue
+        fi
+        if [[ "$set_value" != *=* ]]; then
+            log_error "Helm --set override must use KEY=VALUE form: $set_value"
+            return 1
+        fi
+    done
+}
+
+helm_user_values_flags() {
+    local chart_scope="$1"
+    local flags=""
+    local value_file
+
+    for value_file in "${OSMO_HELM_VALUES_FILES[@]+"${OSMO_HELM_VALUES_FILES[@]}"}"; do
+        [[ -n "$value_file" ]] && flags+=" -f $value_file"
+    done
+
+    case "$chart_scope" in
+        service)
+            for value_file in "${OSMO_SERVICE_HELM_VALUES_FILES[@]+"${OSMO_SERVICE_HELM_VALUES_FILES[@]}"}"; do
+                [[ -n "$value_file" ]] && flags+=" -f $value_file"
+            done
+            ;;
+        backend-operator)
+            for value_file in "${OSMO_BACKEND_OPERATOR_HELM_VALUES_FILES[@]+"${OSMO_BACKEND_OPERATOR_HELM_VALUES_FILES[@]}"}"; do
+                [[ -n "$value_file" ]] && flags+=" -f $value_file"
+            done
+            ;;
+        *)
+            log_error "Unknown Helm chart scope: $chart_scope"
+            return 1
+            ;;
+    esac
+
+    echo "$flags"
+}
+
+helm_user_set_flags() {
+    local chart_scope="$1"
+    local flags=""
+    local set_value
+
+    for set_value in "${OSMO_HELM_SET_VALUES[@]+"${OSMO_HELM_SET_VALUES[@]}"}"; do
+        [[ -n "$set_value" ]] && flags+=" --set $set_value"
+    done
+
+    case "$chart_scope" in
+        service)
+            for set_value in "${OSMO_SERVICE_HELM_SET_VALUES[@]+"${OSMO_SERVICE_HELM_SET_VALUES[@]}"}"; do
+                [[ -n "$set_value" ]] && flags+=" --set $set_value"
+            done
+            ;;
+        backend-operator)
+            for set_value in "${OSMO_BACKEND_OPERATOR_HELM_SET_VALUES[@]+"${OSMO_BACKEND_OPERATOR_HELM_SET_VALUES[@]}"}"; do
+                [[ -n "$set_value" ]] && flags+=" --set $set_value"
+            done
+            ;;
+        *)
+            log_error "Unknown Helm chart scope: $chart_scope"
+            return 1
+            ;;
+    esac
+
+    echo "$flags"
+}
+
 # Build extra helm `-f` flags for the service release. Layering order matters:
-# later files override earlier ones. The static service.yaml is passed as the
-# RUN_HELM_WITH_VALUES primary file (always first); these are appended after.
+# later files override earlier ones. The static service.yaml is passed first;
+# these are appended after.
 #
 #  1. PodMonitor on/off fragment (auto-detected via prometheus-operator CRDs)
 #  2. GPU pool fragment (when GPU nodes are detected)
@@ -727,12 +859,13 @@ deploy_osmo_service() {
     #   3. values/gpu-pool.yaml                    (if GPU nodes detected)
     #   4. .storage-values.yaml                    (from configure-storage.sh — overrides as needed)
     #   5. --set per-cluster overrides             (PG/Redis hosts, image tag, etc.)
+    #   6. user values files / --set overrides     (from deploy-osmo-minimal flags)
     # In 6.3 the service chart bundles router + UI, so this is the only release.
     # --timeout 15m by default — Azure Managed Redis cold start (~10-15 min)
     # + AKS image pulls (~3-5 min) + Postgres + service init can push past 10m
     # on a fresh cluster. Override via HELM_TIMEOUT_SERVICE for slower envs.
     $RUN_HELM \
-        "upgrade --install osmo-minimal $OSMO_HELM_REPO_NAME/service --namespace $OSMO_NAMESPACE --wait --timeout ${HELM_TIMEOUT_SERVICE:-15m}$(chart_version_flag) -f $STATIC_VALUES_DIR/service.yaml$(extra_values_flags)$(service_set_flags)"
+        "upgrade --install osmo-minimal $OSMO_HELM_REPO_NAME/service --namespace $OSMO_NAMESPACE --wait --timeout ${HELM_TIMEOUT_SERVICE:-15m}$(chart_version_flag) -f $STATIC_VALUES_DIR/service.yaml$(extra_values_flags)$(service_set_flags)$(helm_user_values_flags service)$(helm_user_set_flags service)"
 
     log_success "OSMO service deployed"
 }
@@ -764,10 +897,10 @@ setup_backend_operator() {
 
     # Phase 2: install/upgrade backend-operator chart unconditionally.
     log_info "Deploying Backend Operator..."
-    # backend-operator.yaml first, then --set overrides last (no per-cluster
-    # values fragment for backend-operator, so order is straightforward).
+    # backend-operator.yaml first, generated per-cluster overrides next, then
+    # user overrides last so an explicit caller value always wins.
     $RUN_HELM \
-        "upgrade --install osmo-operator $OSMO_HELM_REPO_NAME/backend-operator --namespace $OSMO_OPERATOR_NAMESPACE --wait --timeout ${HELM_TIMEOUT_OPERATOR:-10m}$(chart_version_flag) -f $STATIC_VALUES_DIR/backend-operator.yaml$(backend_operator_set_flags)"
+        "upgrade --install osmo-operator $OSMO_HELM_REPO_NAME/backend-operator --namespace $OSMO_OPERATOR_NAMESPACE --wait --timeout ${HELM_TIMEOUT_OPERATOR:-10m}$(chart_version_flag) -f $STATIC_VALUES_DIR/backend-operator.yaml$(backend_operator_set_flags)$(helm_user_values_flags backend-operator)$(helm_user_set_flags backend-operator)"
 
     log_success "Backend Operator deployed"
 }
@@ -972,6 +1105,7 @@ deploy_k8s_main() {
     # Layer values/gpu-pool.yaml when GPU nodes are detected.
     # 6.3 ConfigMap mode: pod template + pool defs go into Helm values, not CLI.
     render_gpu_pool_values
+    validate_user_helm_overrides
 
     deploy_osmo_service
     wait_for_pods "$OSMO_NAMESPACE" "${OSMO_WAIT_TIMEOUT_SERVICE:-300}" "" "$RUN_KUBECTL"

--- a/deployments/scripts/deploy-osmo-minimal.sh
+++ b/deployments/scripts/deploy-osmo-minimal.sh
@@ -80,6 +80,14 @@ NGC_API_KEY="${NGC_API_KEY:-}"
 TF_POSTGRES_PASSWORD="${TF_POSTGRES_PASSWORD:-}"
 TF_REDIS_PASSWORD="${TF_REDIS_PASSWORD:-}"
 
+# User-supplied Helm overrides for the OSMO service and backend-operator charts.
+declare -a OSMO_HELM_VALUES_FILES=()
+declare -a OSMO_SERVICE_HELM_VALUES_FILES=()
+declare -a OSMO_BACKEND_OPERATOR_HELM_VALUES_FILES=()
+declare -a OSMO_HELM_SET_VALUES=()
+declare -a OSMO_SERVICE_HELM_SET_VALUES=()
+declare -a OSMO_BACKEND_OPERATOR_HELM_SET_VALUES=()
+
 # New flags (cluster-agnostic OSMO deploy)
 GPU_NODE_POOL=false
 STORAGE_BACKEND="${STORAGE_BACKEND:-auto}"
@@ -129,6 +137,20 @@ General Options:
   --gpu-node-pool        Provision a GPU node pool (azure/aws only; requires TF variables)
   --no-gpu               Skip GPU Operator install + GPU smoke test
   --gpu                  microk8s only: enable the nvidia addon during bootstrap
+  --helm-values FILE     Extra Helm values file for both OSMO charts (repeatable)
+  --service-helm-values FILE
+                         Extra Helm values file for the service chart (repeatable)
+  --backend-operator-helm-values FILE
+                         Extra Helm values file for the backend-operator chart
+                         (repeatable)
+  --helm-set KEY=VALUE   Extra Helm --set override for both OSMO charts
+                         (repeatable; use values files for complex values)
+  --service-helm-set KEY=VALUE
+                         Extra Helm --set override for the service chart
+                         (repeatable)
+  --backend-operator-helm-set KEY=VALUE
+                         Extra Helm --set override for the backend-operator chart
+                         (repeatable)
   -h, --help             Show this help message
 
 Azure-specific Options:
@@ -181,6 +203,10 @@ Examples:
   # Only deploy OSMO (infrastructure exists)
   ./deploy-osmo-minimal.sh --provider azure --skip-terraform
 
+  # Deploy with extra Helm values, for example imagePullPolicy overrides
+  ./deploy-osmo-minimal.sh --provider azure \
+    --helm-values /path/to/osmo-overrides.yaml
+
   # Destroy everything
   ./deploy-osmo-minimal.sh --provider azure --destroy
 EOF
@@ -221,6 +247,18 @@ while [[ $# -gt 0 ]]; do
             ;;
         --ngc-api-key)
             NGC_API_KEY="$2"; shift 2 ;;
+        --helm-values)
+            OSMO_HELM_VALUES_FILES+=("$2"); shift 2 ;;
+        --service-helm-values)
+            OSMO_SERVICE_HELM_VALUES_FILES+=("$2"); shift 2 ;;
+        --backend-operator-helm-values|--operator-helm-values)
+            OSMO_BACKEND_OPERATOR_HELM_VALUES_FILES+=("$2"); shift 2 ;;
+        --helm-set)
+            OSMO_HELM_SET_VALUES+=("$2"); shift 2 ;;
+        --service-helm-set)
+            OSMO_SERVICE_HELM_SET_VALUES+=("$2"); shift 2 ;;
+        --backend-operator-helm-set|--operator-helm-set)
+            OSMO_BACKEND_OPERATOR_HELM_SET_VALUES+=("$2"); shift 2 ;;
         -h|--help)
             show_help
             exit 0
@@ -809,4 +847,3 @@ main() {
 
 # Run main function
 main
-

--- a/deployments/values/README.md
+++ b/deployments/values/README.md
@@ -36,7 +36,13 @@ In addition, the storage backend script ([`scripts/configure-storage.sh`](../scr
 --set services.postgres.serviceName=...
 --set services.redis.serviceName=...
 ... etc
+[-f user-provided-values.yaml]                 # --helm-values / --service-helm-values
+[--set user.provided=value]                    # --helm-set / --service-helm-set
 ```
+
+The backend-operator chart uses the same pattern: `values/backend-operator.yaml`,
+then generated per-cluster `--set` overrides, then `--helm-values` /
+`--backend-operator-helm-values`.
 
 ## Security note: minimal mode auth
 


### PR DESCRIPTION
## Description
Some environments need a tweak to the helm values, so support passing helm values to the minimal install script.

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repeatable command-line flags (`--helm-values`, `--service-helm-values`, `--backend-operator-helm-values`) for custom Helm values files
  * Added repeatable `--set` override flags for inline Helm value customization at the chart level

* **Documentation**
  * Updated deployment script help documentation with new flags and examples
  * Clarified Helm values layering precedence and override application order

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/993)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->