### PR TITLE
fix(ui): route sign out through oauth2 proxy

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -368,6 +368,8 @@ Envoy uses filesystem-based dynamic configuration (LDS/CDS). When the ConfigMap 
 
 #### Gateway OAuth2 Proxy
 
+When enabled, the gateway exposes `/signout` and redirects it to `/oauth2/sign_out`. If `services.service.auth.logout_endpoint` is set, the gateway includes it as OAuth2 Proxy's `rd` target so logout clears both the local session cookie and the IDP SSO session. The IDP logout host must be allowed by `gateway.oauth2Proxy.extraArgs`, for example with `--whitelist-domain=<idp-domain>`.
+
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `gateway.oauth2Proxy.enabled` | Enable OAuth2 Proxy deployment | `true` |

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -189,6 +189,14 @@ data:
                 routes:
                 {{- if $gw.oauth2Proxy.enabled }}
                 - match:
+                    path: /signout
+                  redirect:
+                    {{- if .Values.services.service.auth.logout_endpoint }}
+                    path_redirect: "/oauth2/sign_out?rd={{ .Values.services.service.auth.logout_endpoint | urlquery }}"
+                    {{- else }}
+                    path_redirect: "/oauth2/sign_out"
+                    {{- end }}
+                - match:
                     prefix: /oauth2/
                   route:
                     cluster: oauth2-proxy

--- a/src/ui/src/lib/auth/README.md
+++ b/src/ui/src/lib/auth/README.md
@@ -46,7 +46,7 @@ export default async function Page() {
 
 ## Logout
 
-Redirect to `/oauth2/sign_out` which clears the session and redirects to IDP logout.
+Redirect to `/signout`. The gateway redirects that path to OAuth2 Proxy sign out and, when configured, the IDP logout endpoint.
 
 ## Local Development
 

--- a/src/ui/src/lib/auth/user-context.test.tsx
+++ b/src/ui/src/lib/auth/user-context.test.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ui/src/lib/auth/user-context.test.tsx
+++ b/src/ui/src/lib/auth/user-context.test.tsx
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getLogoutUrl } from "@/lib/auth/user-context";
+
+describe("getLogoutUrl", () => {
+  const originalBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
+
+  afterEach(() => {
+    if (originalBasePath === undefined) {
+      delete process.env.NEXT_PUBLIC_BASE_PATH;
+    } else {
+      process.env.NEXT_PUBLIC_BASE_PATH = originalBasePath;
+    }
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("returns the gateway sign-out path", () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+
+    expect(getLogoutUrl()).toBe("/signout");
+  });
+
+  it("ignores the configured base path because sign out is routed at the gateway root", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/v2";
+
+    expect(getLogoutUrl()).toBe("/signout");
+  });
+
+  it("ignores the detected base path because sign out is routed at the gateway root", () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    window.history.replaceState(null, "", "/v2/workflows");
+
+    expect(getLogoutUrl()).toBe("/signout");
+  });
+});

--- a/src/ui/src/lib/auth/user-context.tsx
+++ b/src/ui/src/lib/auth/user-context.tsx
@@ -17,7 +17,6 @@
 "use client";
 
 import { createContext, useContext, type ReactNode } from "react";
-import { getBasePathUrl } from "@/lib/config";
 
 export interface User {
   id: string;
@@ -36,6 +35,10 @@ interface UserContextType {
 
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
+export function getLogoutUrl(): string {
+  return "/signout";
+}
+
 interface UserProviderProps {
   children: ReactNode;
   initialUser: User | null;
@@ -50,7 +53,7 @@ interface UserProviderProps {
  */
 export function UserProvider({ children, initialUser }: UserProviderProps) {
   const logout = () => {
-    window.location.href = getBasePathUrl("/signout");
+    window.location.href = getLogoutUrl();
   };
 
   return (


### PR DESCRIPTION
Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Logout now consistently redirects to the gateway sign-out path (/signout), which forwards to the OAuth2 sign-out and includes the upstream IDP logout target when configured.
* **Tests**
  * Added tests to ensure logout URL generation always returns /signout and ignores base-path detection.
* **Documentation**
  * Updated docs to describe gateway logout behavior and upstream IDP logout configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/996)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->