### PR TITLE
fix: match distroless arm64 variant

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -356,10 +356,10 @@ apt.install(
 
 oci.pull(
     name = "distroless_python3_14",
-    digest = "sha256:fb2b71e7a05688113e12607dc8ae127c3e00bf8af8c28a6a9a2626ad673c789e",
+    digest = "sha256:ec7cb9d99f7aca022f228c1be9740ec77441e9235c92840a05bc9dc0a3fe1fe3",
     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.5",
     platforms = [
-        "linux/arm64",
+        "linux/arm64/v8",
         "linux/amd64",
     ],
 )
@@ -388,7 +388,7 @@ use_repo(
     oci,
     "distroless_python3_14",
     "distroless_python3_14_linux_amd64",
-    "distroless_python3_14_linux_arm64",
+    "distroless_python3_14_linux_arm64_v8",
     # "distroless_python3_14_dev",
     # "distroless_python3_14_dev_linux_amd64",
     # "distroless_python3_14_dev_linux_arm64_v8",

--- a/src/BUILD
+++ b/src/BUILD
@@ -121,7 +121,7 @@ oci_image(
 
 oci_image(
     name = "osmo_docker_distroless_image_arm64",
-    base = "@distroless_python3_14_linux_arm64",
+    base = "@distroless_python3_14_linux_arm64_v8",
     tars = [
         "//src:group_tar",
         "//src:passwd_tar",
@@ -177,7 +177,7 @@ oci_image(
 
 oci_image(
     name = "osmo_docker_client_image_arm64",
-    base = "@distroless_python3_14_linux_arm64",
+    base = "@distroless_python3_14_linux_arm64_v8",
     tars = [
         # Client base packages (tree, ca-certificates, /osmo dir)
         "@debian_packages_arm64//tree/arm64:data",


### PR DESCRIPTION
## Description
Fixes the distroless Python arm64 image pull after the v4.0.5 update. That tag publishes arm as linux/arm64/v8, so the Bazel oci_pull platform and generated repository references now use that variant. The digest is pinned to the current v4.0.5 manifest list.

Issue #None

Testing:
- docker buildx imagetools inspect nvcr.io/nvidia/distroless/python:3.14-v4.0.5
- docker buildx imagetools inspect nvcr.io/nvidia/distroless/python@sha256:ec7cb9d99f7aca022f228c1be9740ec77441e9235c92840a05bc9dc0a3fe1fe3
- bazel build --nobuild --platforms=//bzl/platforms:linux_arm64 //src:osmo_docker_distroless_image_arm64 //src:osmo_docker_client_image_arm64
- bazel build --platforms=//bzl/platforms:linux_arm64 //src:osmo_docker_distroless_image_arm64 //src:osmo_docker_client_image_arm64
- bazel build --nobuild --platforms=//bzl/platforms:linux_x86_64 //src:osmo_docker_distroless_image_amd64 //src:osmo_docker_client_image_amd64
- bazel build --platforms=//bzl/platforms:linux_x86_64 //src:osmo_docker_distroless_image_amd64 //src:osmo_docker_client_image_amd64

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.