### PR TITLE
Update distroless image

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -356,8 +356,8 @@ apt.install(
 
 oci.pull(
     name = "distroless_python3_14",
-    digest = "sha256:ec7cb9d99f7aca022f228c1be9740ec77441e9235c92840a05bc9dc0a3fe1fe3",
-    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.5",
+    digest = "sha256:fb2b71e7a05688113e12607dc8ae127c3e00bf8af8c28a6a9a2626ad673c789e",
+    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.6",
     platforms = [
         "linux/arm64/v8",
         "linux/amd64",
@@ -367,12 +367,12 @@ oci.pull(
 # Used for local debugging
 # oci.pull(
 #     name = "distroless_python3_14_dev",
-#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.5-dev",
+#     digest = "sha256:af6955568168aa9e9056926929608a730bc7b55ae0c00f0e46e2d33bbd4ce244",
+#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.6-dev",
 #     platforms = [
 #          "linux/amd64",
 #          "linux/arm64/v8"
 #     ],
-#     digest = "sha256:af6955568168aa9e9056926929608a730bc7b55ae0c00f0e46e2d33bbd4ce244",
 # )
 
 oci.pull(


### PR DESCRIPTION

## Description
Update distroless python to 4.0.6 

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated distroless Python 3.14 base image to version 4.0.6.
  * Updated local debug reference to the corresponding 3.14-dev image (remains disabled).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1007)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->