### PR TITLE
feat: add gateway envoy extension hooks

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -328,7 +328,12 @@ Benefits of the separate gateway model:
 | `gateway.envoy.idp.host` | IDP host for JWKS (e.g. `login.microsoftonline.com`) | `""` |
 | `gateway.envoy.jwt.providers` | JWT provider configurations | `[]` |
 | `gateway.envoy.skipAuthPaths` | Paths that bypass authentication | See values.yaml |
+| `gateway.envoy.extraSkipAuthPaths` | Additional paths that bypass authentication, appended to `skipAuthPaths` | `[]` |
 | `gateway.envoy.serviceRoutes` | Custom Envoy routes for osmo-service upstream | `[]` |
+| `gateway.envoy.extraRoutes` | Extra Envoy routes inserted before default service/UI routes | `[]` |
+| `gateway.envoy.extraClusters` | Extra Envoy clusters appended to CDS | `[]` |
+| `gateway.envoy.extraVolumeMounts` | Extra Envoy container volume mounts | `[]` |
+| `gateway.envoy.extraVolumes` | Extra Envoy pod volumes | `[]` |
 | `gateway.envoy.routerRoute.cookie.name` | Cookie name for router session affinity | `_osmo_router_affinity` |
 | `gateway.envoy.routerRoute.cookie.ttl` | Cookie TTL for router affinity | `60s` |
 | `gateway.envoy.ingress.enabled` | Enable Ingress for the gateway | `false` |

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -232,6 +232,10 @@ data:
                     timeout: 0s
                 {{- end }}
 
+                {{- with $envoy.extraRoutes }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+
                 {{- if $envoy.serviceRoutes }}
                 {{- toYaml $envoy.serviceRoutes | nindent 16 }}
                 {{- else }}
@@ -885,6 +889,10 @@ data:
                     path: /var/config
             {{- end }}
       {{- end }}
+    {{- end }}
+
+    {{- with $envoy.extraClusters }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 
 {{- end }}

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -28,6 +28,7 @@ setting detects this rotation and triggers Envoy to reload.
 {{- define "osmo.gateway-envoy-config" -}}
 {{- $gw := .Values.gateway }}
 {{- $envoy := $gw.envoy }}
+{{- $skipAuthPaths := concat (default (list) $envoy.skipAuthPaths) (default (list) $envoy.extraSkipAuthPaths) }}
 {{- $gwName := include "osmo.gateway-name" . }}
 {{- if $envoy.enabled }}
 apiVersion: v1
@@ -338,7 +339,7 @@ data:
 
                     function envoy_on_request(request_handle)
                       skip = false
-                      {{- range $envoy.skipAuthPaths }}
+                      {{- range $skipAuthPaths }}
                       if (starts_with(request_handle:headers():get(':path'), '{{.}}')) then
                         skip = true
                       end

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -517,20 +517,41 @@ data:
                     end
 
             {{- if $gw.authz.enabled }}
-            - name: envoy.filters.http.ext_authz
+            - name: authz-with-matcher
               typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
-                transport_api_version: V3
-                with_request_body:
-                  max_request_bytes: 8192
-                  allow_partial_message: true
-                failure_mode_allow: false
-                grpc_service:
-                  envoy_grpc:
-                    cluster_name: authz
-                  timeout: 1s
-                metadata_context_namespaces:
-                  - envoy.filters.http.jwt_authn
+                "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+                xds_matcher:
+                  matcher_list:
+                    matchers:
+                    - predicate:
+                        single_predicate:
+                          input:
+                            name: request-headers
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                              header_name: x-osmo-auth-skip
+                          value_match:
+                            exact: "true"
+                      on_match:
+                        action:
+                          name: skip
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
+                extension_config:
+                  name: envoy.filters.http.ext_authz
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                    transport_api_version: V3
+                    with_request_body:
+                      max_request_bytes: 8192
+                      allow_partial_message: true
+                    failure_mode_allow: false
+                    grpc_service:
+                      envoy_grpc:
+                        cluster_name: authz
+                      timeout: 1s
+                    metadata_context_namespaces:
+                      - envoy.filters.http.jwt_authn
             {{- end }}
 
             {{- if $gw.rateLimit.enabled }}

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -94,6 +94,9 @@ spec:
             mountPath: /etc/ssl/envoy-certs
             readOnly: true
           {{- end }}
+          {{- with $gw.envoy.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
         resources:
           {{- toYaml $gw.envoy.resources | nindent 10 }}
         {{- with $gw.envoy.livenessProbe }}
@@ -124,6 +127,9 @@ spec:
         - name: ssl-cert
           secret:
             secretName: {{ $gw.envoy.ssl.secretName | default "envoy-ssl-cert" }}
+        {{- end }}
+        {{- with $gw.envoy.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
 
 ---
@@ -729,4 +735,3 @@ spec:
       protocol: TCP
 {{- end }}
 {{- end }}
-

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1891,6 +1891,16 @@ gateway:
     ##
     tolerations: []
 
+    ## Extra volume mounts for the Envoy container.
+    ## Use this for namespace-local Secrets or ConfigMaps required by custom
+    ## gateway routes.
+    ##
+    extraVolumeMounts: []
+
+    ## Extra volumes for the Envoy pod.
+    ##
+    extraVolumes: []
+
     ## Identity Provider for JWKS discovery (e.g. login.microsoftonline.com)
     ##
     idp:
@@ -1938,6 +1948,17 @@ gateway:
     ## When empty, default routes for /api/ and /client/ are used.
     ##
     serviceRoutes: []
+
+    ## Extra routes inserted before the default osmo-service and osmo-ui routes.
+    ## Each item is rendered as an Envoy route. Use this for narrow external
+    ## upstream paths such as artifact download routes.
+    ##
+    extraRoutes: []
+
+    ## Extra clusters appended to Envoy CDS. Each item is rendered as an Envoy
+    ## Cluster resource and can be targeted by extraRoutes.
+    ##
+    extraClusters: []
 
     ## Circuit breaker — max concurrent requests to the osmo-service upstream
     ##

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1933,6 +1933,10 @@ gateway:
     - /api/router/version
     - /client/version
 
+    ## Additional paths that bypass authentication, appended to skipAuthPaths.
+    ##
+    extraSkipAuthPaths: []
+
     ## Route configuration for the osmo-router upstream.
     ## Uses RING_HASH lb_policy with a cookie for session affinity.
     ##


### PR DESCRIPTION
## Description

Adds lightweight extension hooks to the service chart gateway Envoy:

- extra Envoy routes rendered before the default service/UI routes
- extra Envoy clusters appended to CDS
- extra Envoy pod volumes and volume mounts

This keeps the chart generic; the Artifactory credential injector wiring lives in the internal validation values branch.

Issue #None

## Validation

- `helm lint deployments/charts/service`
- `helm template test deployments/charts/service`
- `helm template osmo ... -f charts_value/osmo/dev/elookpotts_stg_values.yaml`
- `envoyproxy/envoy:v1.35.10 envoy --mode validate -c /var/config/bootstrap.yaml`

Jenkins validation is running separately against `elookpotts-dev` with this branch as `EXTERNAL_REF`.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Envoy gateway: consolidated auth-bypass paths (base + extras) and conditional authorization so requests matching bypass paths skip external auth.
  * Support injecting custom HTTP routes ahead of defaults and appending extra service clusters.
  * Allow adding additional Envoy container volume mounts and pod volumes.

* **Documentation**
  * README updated to document the new auth-bypass paths option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1009)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->