### PR TITLE
Associate default pod templates with default pool

### DIFF
--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -601,6 +601,9 @@ services:
       default:
         description: "Default pool"
         backend: default
+        common_pod_template:
+          - default_user
+          - default_ctrl
         default_platform: default
         platforms:
           default: {}


### PR DESCRIPTION


<!-- Title should be "#<issue number> - <commit title>"-->

## Description
Without common_pod_template set, the default pool doesn't apply the default_ctrl/default_user pod templates to workflow containers.

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service deployment configuration to include pod template composition settings for the default pool.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1010)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->