### PR TITLE
Remove stale ingress in readme

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -273,24 +273,6 @@ The router was its own Helm chart prior to v6.3 and is now deployed as part of t
 
 The router reads the same `services.configFile.path` as the API service. When `services.configFile.enabled: false` (default), the router gets `--config <path>` as a CLI arg. The API service ignores `services.configFile.path` unless `services.configFile.enabled: true`, so setting just the path lets you point the router at a vault-injected config without affecting the API service.
 
-### Ingress Settings
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `services.service.ingress.enabled` | Enable ingress for external access | `true`|
-| `services.service.ingress.prefix` | URL path prefix | `/` |
-| `services.service.ingress.ingressClass` | Ingress controller class | `nginx` |
-| `services.service.ingress.sslEnabled` | Enable SSL | `true` |
-| `services.service.ingress.sslSecret` | Name of SSL secret | `osmo-tls` |
-| `services.service.ingress.annotations` | Additional custom annotations | `{}` |
-
-#### ALB Annotations Settings
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `services.service.ingress.albAnnotations.enabled` | Enable ALB annotations | `false` |
-| `services.service.ingress.albAnnotations.sslCertArn` | ARN of SSL certificate | `""` |
-
 ### Prometheus Metrics Settings
 
 | Parameter | Description | Default |


### PR DESCRIPTION
Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed service ingress configuration and ALB annotation documentation from the Helm chart README, streamlining the configuration guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1017)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->