### PR TITLE
rsync: error on download when remote source does not exist

### DIFF
--- a/src/lib/rsync/rsync.py
+++ b/src/lib/rsync/rsync.py
@@ -658,13 +658,13 @@ class RsyncClient:
                 logger.error('Error running rsync upload: %s', err)
                 raise
 
-    def _download_landed(self, resolved_dst: str, dest_before: Set[str]) -> bool:
+    def _download_landed(self, resolved_dst: str, dst_before: Set[str] | None) -> bool:
         """Returns True if the remote source appears to have landed in dst."""
         # Trailing-slash sources copy contents (no predictable basename); fall
         # back to "did anything new appear" for that case only.
         remote_path = self._rsync_request.original_remote_path
         if remote_path.endswith('/'):
-            return bool(set(os.listdir(resolved_dst)) - dest_before)
+            return bool(set(os.listdir(resolved_dst)) - (dst_before or set()))
         basename = os.path.basename(remote_path)
         return os.path.exists(os.path.join(resolved_dst, basename))
 
@@ -704,8 +704,11 @@ class RsyncClient:
             os.makedirs(resolved_dst, exist_ok=True)
 
             # gokrazy/rsync silently exits 0 when the source is missing; snapshot
-            # so we can detect that case after the transfer.
-            dest_before = set(os.listdir(resolved_dst))
+            # only for trailing-slash sources where we have no basename to check.
+            remote_path = self._rsync_request.original_remote_path
+            dst_before: Set[str] | None = (
+                set(os.listdir(resolved_dst)) if remote_path.endswith('/') else None
+            )
 
             rsync_args = [self._rsync_bin_path, RSYNC_FLAGS]
             if self._show_progress:
@@ -728,7 +731,7 @@ class RsyncClient:
             if process.returncode != 0:
                 raise osmo_errors.OSMOError(f'Rsync failed: {stderr.decode()}')
 
-            if not self._download_landed(resolved_dst, dest_before):
+            if not self._download_landed(resolved_dst, dst_before):
                 raise osmo_errors.OSMOError(
                     f'Source path does not exist on remote task: '
                     f'{self._rsync_request.original_remote_path}',

--- a/src/lib/rsync/rsync.py
+++ b/src/lib/rsync/rsync.py
@@ -115,12 +115,12 @@ async def _stream_progress(stdout: asyncio.StreamReader) -> None:
         cli/workflow.py  ████████████████████ 100%  71.8KB  199.31MB/s  0:00:00
     """
     current_file = ''
-    file_count = 0
     try:
         terminal_width = os.get_terminal_size().columns
     except OSError:
         terminal_width = 80
     bar_width = 20
+    rendered = False
 
     while True:
         line_bytes = await stdout.readline()
@@ -148,14 +148,13 @@ async def _stream_progress(stdout: asyncio.StreamReader) -> None:
             padding = max(0, terminal_width - len(display))
             sys.stdout.write(f'\r{display}{' ' * padding}')
             sys.stdout.flush()
+            rendered = True
         else:
-            file_count += 1
             current_file = line
 
-    # Final newline to move past the in-place line
-    if file_count > 0:
-        sys.stdout.write(f'\rSynced {file_count} file{'s' if file_count != 1 else ''}'
-                         f'{' ' * (terminal_width - 20)}\n')
+    # Clear the in-place line so subsequent output starts fresh.
+    if rendered:
+        sys.stdout.write(f'\r{' ' * terminal_width}\r')
         sys.stdout.flush()
 
 
@@ -659,6 +658,16 @@ class RsyncClient:
                 logger.error('Error running rsync upload: %s', err)
                 raise
 
+    def _download_landed(self, resolved_dst: str, dest_before: Set[str]) -> bool:
+        """Returns True if the remote source appears to have landed in dst."""
+        # Trailing-slash sources copy contents (no predictable basename); fall
+        # back to "did anything new appear" for that case only.
+        remote_path = self._rsync_request.original_remote_path
+        if remote_path.endswith('/'):
+            return bool(set(os.listdir(resolved_dst)) - dest_before)
+        basename = os.path.basename(remote_path)
+        return os.path.exists(os.path.join(resolved_dst, basename))
+
     async def download(self) -> None:
         """
         Downloads from the remote workflow task to the local path.
@@ -694,6 +703,10 @@ class RsyncClient:
                     f'{self._rsync_request.local_path}')
             os.makedirs(resolved_dst, exist_ok=True)
 
+            # gokrazy/rsync silently exits 0 when the source is missing; snapshot
+            # so we can detect that case after the transfer.
+            dest_before = set(os.listdir(resolved_dst))
+
             rsync_args = [self._rsync_bin_path, RSYNC_FLAGS]
             if self._show_progress:
                 rsync_args.append('--progress')
@@ -714,12 +727,19 @@ class RsyncClient:
             _, stderr = await process.communicate()
             if process.returncode != 0:
                 raise osmo_errors.OSMOError(f'Rsync failed: {stderr.decode()}')
-            else:
-                logger.info(
-                    'Rsync download completed successfully for %s/%s',
-                    self._rsync_request.workflow_id,
-                    self._rsync_request.task_name,
+
+            if not self._download_landed(resolved_dst, dest_before):
+                raise osmo_errors.OSMOError(
+                    f'Source path does not exist on remote task: '
+                    f'{self._rsync_request.original_remote_path}',
+                    workflow_id=self._rsync_request.workflow_id,
                 )
+
+            logger.info(
+                'Rsync download completed successfully for %s/%s',
+                self._rsync_request.workflow_id,
+                self._rsync_request.task_name,
+            )
         except (asyncio.CancelledError, InterruptedError, KeyboardInterrupt):
             if process is not None and process.returncode is None:
                 process.terminate()

--- a/src/lib/rsync/tests/BUILD
+++ b/src/lib/rsync/tests/BUILD
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bzl:py.bzl", "osmo_py_test")
+
+osmo_py_test(
+    name = "test_rsync_download",
+    srcs = ["test_rsync_download.py"],
+    deps = [
+        "//src/lib/rsync",
+        "//src/lib/utils:osmo_errors",
+    ],
+)

--- a/src/lib/rsync/tests/test_rsync_download.py
+++ b/src/lib/rsync/tests/test_rsync_download.py
@@ -53,12 +53,12 @@ class TestDownloadLanded(unittest.TestCase):
                 f.write('hello')
 
             client = _make_client('/osmo/run/workspace/foo.txt')
-            self.assertTrue(client._download_landed(dst, set()))
+            self.assertTrue(client._download_landed(dst, None))
 
     def test_file_missing_when_basename_not_present(self):
         with tempfile.TemporaryDirectory() as dst:
             client = _make_client('/osmo/run/workspace/no_such_file.txt')
-            self.assertFalse(client._download_landed(dst, set()))
+            self.assertFalse(client._download_landed(dst, None))
 
     def test_redownload_with_preexisting_file_succeeds(self):
         # In-sync re-download: no new entries, but basename still exists.
@@ -67,7 +67,7 @@ class TestDownloadLanded(unittest.TestCase):
                 f.write('previous run')
 
             client = _make_client('/osmo/run/workspace/foo.txt')
-            self.assertTrue(client._download_landed(dst, {'foo.txt'}))
+            self.assertTrue(client._download_landed(dst, None))
 
     def test_trailing_slash_directory_with_new_entries_succeeds(self):
         with tempfile.TemporaryDirectory() as dst:
@@ -86,12 +86,12 @@ class TestDownloadLanded(unittest.TestCase):
         with tempfile.TemporaryDirectory() as dst:
             os.makedirs(os.path.join(dst, 'some_dir'))
             client = _make_client('/osmo/run/workspace/some_dir')
-            self.assertTrue(client._download_landed(dst, set()))
+            self.assertTrue(client._download_landed(dst, None))
 
     def test_named_directory_missing_when_subdir_absent(self):
         with tempfile.TemporaryDirectory() as dst:
             client = _make_client('/osmo/run/workspace/no_such_dir')
-            self.assertFalse(client._download_landed(dst, set()))
+            self.assertFalse(client._download_landed(dst, None))
 
 
 class TestStreamProgressTail(unittest.IsolatedAsyncioTestCase):

--- a/src/lib/rsync/tests/test_rsync_download.py
+++ b/src/lib/rsync/tests/test_rsync_download.py
@@ -31,7 +31,7 @@ def _make_request(remote_path: str) -> rsync.RsyncRequest:
         workflow_id='wf-1',
         task_name='task-main',
         direction=rsync.RsyncDirection.DOWNLOAD,
-        local_path='/tmp/dst',
+        local_path='/local/dst',
         remote_module='osmo',
         remote_path='ignored',
         original_remote_path=remote_path,

--- a/src/lib/rsync/tests/test_rsync_download.py
+++ b/src/lib/rsync/tests/test_rsync_download.py
@@ -1,0 +1,126 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+# pylint: disable=protected-access
+
+import os
+import tempfile
+import unittest
+from typing import List
+from unittest import mock
+
+from src.lib.rsync import rsync
+
+
+def _make_request(remote_path: str) -> rsync.RsyncRequest:
+    return rsync.RsyncRequest(
+        workflow_id='wf-1',
+        task_name='task-main',
+        direction=rsync.RsyncDirection.DOWNLOAD,
+        local_path='/tmp/dst',
+        remote_module='osmo',
+        remote_path='ignored',
+        original_remote_path=remote_path,
+    )
+
+
+def _make_client(remote_path: str) -> rsync.RsyncClient:
+    client = rsync.RsyncClient.__new__(rsync.RsyncClient)
+    client._rsync_request = _make_request(remote_path)
+    return client
+
+
+class TestDownloadLanded(unittest.TestCase):
+    """Tests for RsyncClient._download_landed missing-source detection."""
+
+    def test_file_landed_when_basename_exists(self):
+        with tempfile.TemporaryDirectory() as dst:
+            with open(os.path.join(dst, 'foo.txt'), 'w', encoding='utf-8') as f:
+                f.write('hello')
+
+            client = _make_client('/osmo/run/workspace/foo.txt')
+            self.assertTrue(client._download_landed(dst, set()))
+
+    def test_file_missing_when_basename_not_present(self):
+        with tempfile.TemporaryDirectory() as dst:
+            client = _make_client('/osmo/run/workspace/no_such_file.txt')
+            self.assertFalse(client._download_landed(dst, set()))
+
+    def test_redownload_with_preexisting_file_succeeds(self):
+        # In-sync re-download: no new entries, but basename still exists.
+        with tempfile.TemporaryDirectory() as dst:
+            with open(os.path.join(dst, 'foo.txt'), 'w', encoding='utf-8') as f:
+                f.write('previous run')
+
+            client = _make_client('/osmo/run/workspace/foo.txt')
+            self.assertTrue(client._download_landed(dst, {'foo.txt'}))
+
+    def test_trailing_slash_directory_with_new_entries_succeeds(self):
+        with tempfile.TemporaryDirectory() as dst:
+            with open(os.path.join(dst, 'a.txt'), 'w', encoding='utf-8') as f:
+                f.write('a')
+
+            client = _make_client('/osmo/run/workspace/')
+            self.assertTrue(client._download_landed(dst, set()))
+
+    def test_trailing_slash_directory_with_no_new_entries_flagged(self):
+        with tempfile.TemporaryDirectory() as dst:
+            client = _make_client('/osmo/run/workspace/')
+            self.assertFalse(client._download_landed(dst, set()))
+
+    def test_named_directory_landed_when_subdir_exists(self):
+        with tempfile.TemporaryDirectory() as dst:
+            os.makedirs(os.path.join(dst, 'some_dir'))
+            client = _make_client('/osmo/run/workspace/some_dir')
+            self.assertTrue(client._download_landed(dst, set()))
+
+    def test_named_directory_missing_when_subdir_absent(self):
+        with tempfile.TemporaryDirectory() as dst:
+            client = _make_client('/osmo/run/workspace/no_such_dir')
+            self.assertFalse(client._download_landed(dst, set()))
+
+
+class TestStreamProgressTail(unittest.IsolatedAsyncioTestCase):
+    """The Synced-N-files tail line is gone; we just clean the cursor row."""
+
+    async def test_no_synced_files_summary(self):
+        # Verbose chatter for a missing source: two non-space lines, no progress.
+        stdout = mock.MagicMock()
+        lines = iter([
+            b'receiving incremental file list\n',
+            b'sent 8 bytes  received 9 bytes  3.40 bytes/sec\n',
+            b'',  # EOF
+        ])
+
+        async def readline():
+            return next(lines)
+
+        stdout.readline = readline
+
+        captured: List[str] = []
+        with mock.patch.object(rsync.sys.stdout, 'write',
+                               side_effect=captured.append):
+            with mock.patch.object(rsync.sys.stdout, 'flush'):
+                await rsync._stream_progress(stdout)
+
+        joined = ''.join(captured)
+        self.assertNotIn('Synced', joined)
+        self.assertNotIn('files', joined)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
<!-- Provide a standalone description of changes in this PR. See these rules: https://chris.beams.io/posts/git-commit/ -->

Fixes a silent-success bug where \`osmo workflow rsync download\` reports \`Rsync download completed successfully\` with exit 0 even when the requested remote path does not exist on the task pod.

Two cooperating issues produced the false success:

1. **gokrazy/rsync daemon returns exit 0 for missing sources.** Unlike upstream rsync (which exits 23), the daemon used by OSMO's runtime says "0 files matched, no error" and the local rsync client therefore exits 0. The CLI's \`if process.returncode != 0\` check at \`rsync.py:712\` never fired.

2. **\`_stream_progress\` counted rsync's verbose chatter as transferred files.** With \`-av --progress\` and a missing source, rsync still emits header + closing summary lines on stdout. The heuristic at \`rsync.py:151-153\` treated each non-space-prefixed line as a filename, so \`file_count\` reached 2 and the user saw "Synced 2 files".


Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Downloads now verify that the remote source actually landed in the destination and raise an error if missing despite a successful transfer exit.
  * Progress display uses a safer terminal-width lookup and no longer emits a final “Synced N file(s)” summary.

* **Tests**
  * Added unit tests for remote-source validation across path formats and re-downloads.
  * Added async tests for progress output rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1019)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->