### PR TITLE
Add user context to frontend logs

### DIFF
--- a/src/lib/utils/logging.py
+++ b/src/lib/utils/logging.py
@@ -49,6 +49,53 @@ import pydantic
 
 logger = logging.getLogger(__name__)
 
+_user_id_context = contextvars.ContextVar('user_id', default='')
+_job_id_context = contextvars.ContextVar('job_id', default='')
+
+
+class UserLogContext:
+    """
+    Log context for adding user_id to JSON log records.
+    """
+
+    def __init__(self, user_id: str = ''):
+        self.user_id = user_id
+        self._token: contextvars.Token[str] | None = None
+
+    def __enter__(self):
+        # Always set the ContextVar — including to '' — so a nested context
+        # without a user_id masks any value from an outer scope rather than
+        # leaking it into logs emitted inside this block.
+        self._token = _user_id_context.set(self.user_id)
+        return self
+
+    def __exit__(self, ex_type, ex_value, ex_traceback):
+        # pylint: disable=unused-argument
+        if self._token is not None:
+            _user_id_context.reset(self._token)
+
+
+class JobLogContext:
+    """
+    Log context for adding job_id to JSON log records.
+    """
+
+    def __init__(self, job_id: str = ''):
+        self.job_id = job_id
+        self._token: contextvars.Token[str] | None = None
+
+    def __enter__(self):
+        # Always set the ContextVar — including to '' — so a nested context
+        # without a job_id masks any value from an outer scope rather than
+        # leaking it into logs emitted inside this block.
+        self._token = _job_id_context.set(self.job_id)
+        return self
+
+    def __exit__(self, ex_type, ex_value, ex_traceback):
+        # pylint: disable=unused-argument
+        if self._token is not None:
+            _job_id_context.reset(self._token)
+
 
 class LoggingLevel(enum.IntEnum):
     """
@@ -111,22 +158,28 @@ class WorkflowLogContext:
     All logging, even within subfunctions, inside this context will have the workflow ID
     attribute included with the log. Users should only use this for single threaded instances.
     If 'extra' parameter is used when using logging inside the context, the workflow_uuid attribute
-    will not be overridden.
+    will not be overridden. user_id and job_id are emitted only by JsonServiceFormatter.
     """
 
-    def __init__(self, workflow_uuid: str):
+    def __init__(self, workflow_uuid: str, user_id: str = '', job_id: str = ''):
         self.workflow_uuid = workflow_uuid
         self._filter = WorkflowLogFilter(workflow_uuid)
+        self._user_context = UserLogContext(user_id)
+        self._job_context = JobLogContext(job_id)
 
     def __enter__(self):
         if self.workflow_uuid:
             logging.getLogger().addFilter(self._filter)
+        self._user_context.__enter__()
+        self._job_context.__enter__()
         return self
 
     def __exit__(self, ex_type, ex_value, ex_traceback):
         # pylint: disable=unused-argument
         if self.workflow_uuid:
             logging.getLogger().removeFilter(self._filter)
+        self._job_context.__exit__(ex_type, ex_value, ex_traceback)
+        self._user_context.__exit__(ex_type, ex_value, ex_traceback)
 
 
 class LogFormat(str, enum.Enum):
@@ -235,6 +288,9 @@ class JsonServiceFormatter(logging.Formatter):
       message:       formatted message body
       backend:       set only for backend loggers (get_backend_logger)
       workflow_uuid: set only when the WorkflowLogFilter or extra= adds it
+      user_id:       set only in JSON logs when UserLogContext or extra= adds it
+      job_id:        set only in JSON logs when JobLogContext or extra= adds it
+      status_code:   set only in JSON logs when extra= adds it (HTTP responses)
       exception:     set only when exc_info is provided (formatted traceback)
       stack:         set only when stack_info is provided
     """
@@ -263,6 +319,19 @@ class JsonServiceFormatter(logging.Formatter):
         workflow_uuid = getattr(record, 'workflow_uuid', None)
         if workflow_uuid:
             payload['workflow_uuid'] = workflow_uuid
+        user_id = getattr(record, 'user_id', None)
+        if user_id is None:
+            user_id = _user_id_context.get()
+        if user_id:
+            payload['user_id'] = user_id
+        job_id = getattr(record, 'job_id', None)
+        if job_id is None:
+            job_id = _job_id_context.get()
+        if job_id:
+            payload['job_id'] = job_id
+        status_code = getattr(record, 'status_code', None)
+        if status_code is not None:
+            payload['status_code'] = status_code
         if record.exc_info:
             payload['exception'] = self.formatException(record.exc_info)
         if record.stack_info:

--- a/src/lib/utils/tests/test_logging.py
+++ b/src/lib/utils/tests/test_logging.py
@@ -28,6 +28,9 @@ def _make_record(
     level: int = logging.INFO,
     message: str = 'hello world',
     workflow_uuid: str | None = None,
+    user_id: str | None = None,
+    job_id: str | None = None,
+    status_code: int | None = None,
     exc_info=None,
 ) -> logging.LogRecord:
     record = logging.LogRecord(
@@ -42,6 +45,12 @@ def _make_record(
     record.module = 'test_logging'
     if workflow_uuid is not None:
         record.workflow_uuid = workflow_uuid
+    if user_id is not None:
+        record.user_id = user_id
+    if job_id is not None:
+        record.job_id = job_id
+    if status_code is not None:
+        record.status_code = status_code
     return record
 
 
@@ -92,6 +101,7 @@ class TestJsonServiceFormatter(unittest.TestCase):
         self.assertIn('timestamp', payload)
         self.assertNotIn('backend', payload)
         self.assertNotIn('workflow_uuid', payload)
+        self.assertNotIn('user_id', payload)
         self.assertNotIn('exception', payload)
 
     def test_backend_field_emitted_for_backend_loggers(self):
@@ -105,6 +115,66 @@ class TestJsonServiceFormatter(unittest.TestCase):
         formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
         payload = json.loads(formatter.format(_make_record(workflow_uuid='wf-123')))
         self.assertEqual(payload['workflow_uuid'], 'wf-123')
+
+    def test_user_id_propagated_when_present(self):
+        formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
+        payload = json.loads(formatter.format(_make_record(user_id='alice@example.com')))
+        self.assertEqual(payload['user_id'], 'alice@example.com')
+
+    def test_user_id_context_propagated_to_json(self):
+        formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
+        with logging_utils.UserLogContext('alice@example.com'):
+            payload = json.loads(formatter.format(_make_record()))
+        self.assertEqual(payload['user_id'], 'alice@example.com')
+
+    def test_empty_user_id_context_masks_outer_user_id(self):
+        formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
+        with logging_utils.UserLogContext('alice@example.com'):
+            with logging_utils.UserLogContext(''):
+                payload = json.loads(formatter.format(_make_record()))
+                self.assertNotIn('user_id', payload)
+            # Outer user_id is restored after the inner context exits.
+            payload = json.loads(formatter.format(_make_record()))
+            self.assertEqual(payload['user_id'], 'alice@example.com')
+
+    def test_job_id_propagated_when_present(self):
+        formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
+        payload = json.loads(formatter.format(_make_record(job_id='job-123')))
+        self.assertEqual(payload['job_id'], 'job-123')
+
+    def test_job_id_context_propagated_to_json(self):
+        formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
+        with logging_utils.JobLogContext('job-123'):
+            payload = json.loads(formatter.format(_make_record()))
+        self.assertEqual(payload['job_id'], 'job-123')
+
+    def test_empty_job_id_context_masks_outer_job_id(self):
+        formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
+        with logging_utils.JobLogContext('job-123'):
+            with logging_utils.JobLogContext(''):
+                payload = json.loads(formatter.format(_make_record()))
+                self.assertNotIn('job_id', payload)
+            payload = json.loads(formatter.format(_make_record()))
+            self.assertEqual(payload['job_id'], 'job-123')
+
+    def test_status_code_propagated_when_present(self):
+        formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
+        payload = json.loads(formatter.format(_make_record(status_code=404)))
+        self.assertEqual(payload['status_code'], 404)
+
+    def test_status_code_absent_when_not_provided(self):
+        formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
+        payload = json.loads(formatter.format(_make_record()))
+        self.assertNotIn('status_code', payload)
+
+    def test_workflow_log_context_propagates_job_id(self):
+        formatter = logging_utils.JsonServiceFormatter(service='osmo-test')
+        with logging_utils.WorkflowLogContext(
+            'wf-123', user_id='alice@example.com', job_id='job-123'
+        ):
+            payload = json.loads(formatter.format(_make_record()))
+        self.assertEqual(payload['user_id'], 'alice@example.com')
+        self.assertEqual(payload['job_id'], 'job-123')
 
     def test_exception_traceback_included(self):
         formatter = logging_utils.JsonServiceFormatter(service='osmo-test')

--- a/src/operator/backend_worker.py
+++ b/src/operator/backend_worker.py
@@ -134,36 +134,39 @@ class BackendWorker():
 
         workflow_uuid = job.workflow_uuid if \
             isinstance(job, backend_jobs.BackendWorkflowJob) else ''
-        logging.info('Starting job %s from the queue', job, extra={'workflow_uuid': workflow_uuid})
-        job_start_time = time.time()
-        try:
-            result = await asyncio.to_thread(
-                job.execute, context, self._progress_writer, self._progress_iter_freq)
-            if result.status != jobs_base.JobStatus.SUCCESS:
-                result.message = f'Backend execution failed: {result.message}'
-            message = backend_messages.MessageBody(
-                type=backend_messages.MessageType.JOB_STATUS, body=result)
-        except Exception as error:  # pylint: disable=broad-except
-            error_message = f'{type(error).__name__}: {error}'
-            logging.exception('Fatal exception of type %s when running job %s',
-                            error_message, job, extra={'workflow_uuid': workflow_uuid})
-            message = backend_messages.MessageBody(
-                type=backend_messages.MessageType.JOB_STATUS,
-                body=jobs_base.JobResult(
-                    status=jobs_base.JobStatus.FAILED_NO_RETRY,
-                    message=f'Got exception when running backend execute: {error_message}\n' + \
-                            f'Traceback: {traceback.format_exc()}'))
+        with src.lib.utils.logging.UserLogContext(job_spec.get('user', '')), \
+                src.lib.utils.logging.JobLogContext(job.job_id or ''):
+            logging.info(
+                'Starting job %s from the queue', job, extra={'workflow_uuid': workflow_uuid})
+            job_start_time = time.time()
+            try:
+                result = await asyncio.to_thread(
+                    job.execute, context, self._progress_writer, self._progress_iter_freq)
+                if result.status != jobs_base.JobStatus.SUCCESS:
+                    result.message = f'Backend execution failed: {result.message}'
+                message = backend_messages.MessageBody(
+                    type=backend_messages.MessageType.JOB_STATUS, body=result)
+            except Exception as error:  # pylint: disable=broad-except
+                error_message = f'{type(error).__name__}: {error}'
+                logging.exception('Fatal exception of type %s when running job %s',
+                                error_message, job, extra={'workflow_uuid': workflow_uuid})
+                message = backend_messages.MessageBody(
+                    type=backend_messages.MessageType.JOB_STATUS,
+                    body=jobs_base.JobResult(
+                        status=jobs_base.JobStatus.FAILED_NO_RETRY,
+                        message=f'Got exception when running backend execute: {error_message}\n' + \
+                                f'Traceback: {traceback.format_exc()}'))
 
-        await context.send_async_message(message)
+            await context.send_async_message(message)
 
-        logging.info('Completed job %s with status %s', job, message.body,
-                     extra={'workflow_uuid': workflow_uuid})
-        job_duration = time.time() - job_start_time
-        self.backend_metrics.send_histogram(
-            name='backend_job_execution_time', value=job_duration, unit='seconds',
-            description=f'Job execution time for {job.job_type}',
-            tags={'job_type': job.job_type, 'namespace': self.config.namespace}
-        )
+            logging.info('Completed job %s with status %s', job, message.body,
+                         extra={'workflow_uuid': workflow_uuid})
+            job_duration = time.time() - job_start_time
+            self.backend_metrics.send_histogram(
+                name='backend_job_execution_time', value=job_duration, unit='seconds',
+                description=f'Job execution time for {job.job_type}',
+                tags={'job_type': job.job_type, 'namespace': self.config.namespace}
+            )
         self._current_job = None
 
     def _monitor_progress(self):

--- a/src/service/agent/objects.py
+++ b/src/service/agent/objects.py
@@ -124,9 +124,11 @@ class WebsocketWorker(kombu.mixins.ConsumerMixin):
         extra = {}
         if 'workflow_uuid' in job_spec:
             extra['workflow_uuid'] = job_spec['workflow_uuid']
+        if 'user' in job_spec:
+            extra['user_id'] = job_spec['user']
         logging.info('Completed job (type=%s, id=%s) with status %s',
                      job_spec['job_type'], job_spec['job_id'],
-                     result,extra=extra)
+                     result, extra=extra)
 
     async def run_jobs(self, backend_name: str):
         worker_thread = threading.Thread(target=self.run, daemon=True)

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -59,6 +59,18 @@ curr_cli_config = connectors.CliConfig()
 
 @app.middleware('http')
 async def check_client_version(request: fastapi.Request, call_next):
+    user_id = request.headers.get(login.OSMO_USER_HEADER, '')
+    with src.lib.utils.logging.UserLogContext(user_id):
+        response = await _check_client_version(request, call_next)
+        logging.info(
+            '%s %s -> %d',
+            request.method, request.url.path, response.status_code,
+            extra={'status_code': response.status_code},
+        )
+        return response
+
+
+async def _check_client_version(request: fastapi.Request, call_next):
     client_version_str = request.headers.get(version.VERSION_HEADER)
     token_name = request.headers.get(login.OSMO_TOKEN_NAME_HEADER)
     if client_version_str is None:

--- a/src/service/core/workflow/objects.py
+++ b/src/service/core/workflow/objects.py
@@ -959,6 +959,7 @@ class WorkflowSubmitInfo(pydantic.BaseModel):
         upload_spec_job = jobs.UploadWorkflowFiles(
             workflow_id=workflow_id,
             workflow_uuid=self.base32_id,
+            user=self.user,
             files=files)
         upload_spec_job.send_job_to_queue()
 

--- a/src/service/logger/ctrl_websocket.py
+++ b/src/service/logger/ctrl_websocket.py
@@ -127,7 +127,9 @@ async def run_websocket(websocket: fastapi.WebSocket, name: str, task_name: str,
         workflow_obj = workflow.Workflow.fetch_from_db(database, name)
         group_name = task.Task.fetch_group_name(database, workflow_obj.workflow_id, task_name)
 
-        with src.lib.utils.logging.WorkflowLogContext(workflow_obj.workflow_uuid):
+        with src.lib.utils.logging.WorkflowLogContext(
+            workflow_obj.workflow_uuid, user_id=workflow_obj.user
+        ):
 
             task_cred_values = task.TaskGroup.fetch_task_secrets(database,
                                                                 workflow_obj.workflow_id,

--- a/src/service/worker/worker.py
+++ b/src/service/worker/worker.py
@@ -109,7 +109,11 @@ class Worker(kombu.mixins.ConsumerMixin):
         self._current_job = job
 
         workflow_uuid = job.workflow_uuid if isinstance(job, jobs.WorkflowJob) else ''
-        with src.lib.utils.logging.WorkflowLogContext(workflow_uuid):
+        with src.lib.utils.logging.WorkflowLogContext(
+            workflow_uuid,
+            user_id=getattr(job, 'user', ''),
+            job_id=job.job_id or '',
+        ):
             logging.info('Starting job %s from the queue', job)
             job_metadata = job.get_metadata()
 

--- a/src/ui/src/lib/auth/user-context.tsx
+++ b/src/ui/src/lib/auth/user-context.tsx
@@ -16,7 +16,8 @@
 
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useEffect, type ReactNode } from "react";
+import { setLogUserId } from "@/lib/logger";
 
 export interface User {
   id: string;
@@ -55,6 +56,11 @@ export function UserProvider({ children, initialUser }: UserProviderProps) {
   const logout = () => {
     window.location.href = getLogoutUrl();
   };
+
+  useEffect(() => {
+    setLogUserId(initialUser?.id ?? null);
+    return () => setLogUserId(null);
+  }, [initialUser?.id]);
 
   return (
     <UserContext.Provider value={{ user: initialUser, isLoading: false, logout }}>{children}</UserContext.Provider>

--- a/src/ui/src/lib/logger.ts
+++ b/src/ui/src/lib/logger.ts
@@ -17,17 +17,34 @@
 /**
  * Simple logger that can be configured for different environments.
  *
- * In production, errors are logged. Warnings are suppressed unless debug mode is enabled.
+ * In production, errors are logged. Warnings/info/debug are suppressed unless dev mode.
  * In development, all logs are shown.
+ *
+ * Module-level user context (mirrors backend WorkflowLogContext): once set via
+ * setLogUserId, every log line is prefixed with `[user=<id>]`.
  */
 
 const isDev = process.env.NODE_ENV === "development";
+
+let currentUserId: string | null = null;
+
+export function setLogUserId(userId: string | null): void {
+  currentUserId = userId;
+}
+
+export function clearLogUserId(): void {
+  currentUserId = null;
+}
+
+function buildPrefix(): string {
+  return currentUserId ? `[OSMO] [user=${currentUserId}]` : "[OSMO]";
+}
 
 /**
  * Log an error. Always logged.
  */
 export function logError(message: string, ...args: unknown[]): void {
-  console.error(`[OSMO] ${message}`, ...args);
+  console.error(`${buildPrefix()} ${message}`, ...args);
 }
 
 /**
@@ -35,6 +52,24 @@ export function logError(message: string, ...args: unknown[]): void {
  */
 export function logWarn(message: string, ...args: unknown[]): void {
   if (isDev) {
-    console.warn(`[OSMO] ${message}`, ...args);
+    console.warn(`${buildPrefix()} ${message}`, ...args);
+  }
+}
+
+/**
+ * Log an info message. Only logged in development.
+ */
+export function logInfo(message: string, ...args: unknown[]): void {
+  if (isDev) {
+    console.info(`${buildPrefix()} ${message}`, ...args);
+  }
+}
+
+/**
+ * Log a debug message. Only logged in development.
+ */
+export function logDebug(message: string, ...args: unknown[]): void {
+  if (isDev) {
+    console.debug(`${buildPrefix()} ${message}`, ...args);
   }
 }

--- a/src/utils/job/backend_jobs.py
+++ b/src/utils/job/backend_jobs.py
@@ -99,9 +99,15 @@ class BackendWorkflowJob(BackendJob):
     Represents some workflow task that needs to be executed by a backend worker.
     """
     workflow_uuid: str
+    user: str = ''
 
     def log_labels(self) -> Dict[str, str]:
-        return {'workflow_uuid': self.workflow_uuid}
+        labels = {'workflow_uuid': self.workflow_uuid}
+        if self.user:
+            labels['user_id'] = self.user
+        if self.job_id:
+            labels['job_id'] = self.job_id
+        return labels
 
 
 class BackendCreateGroup(backend_job_defs.BackendCreateGroupMixin, BackendWorkflowJob):

--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -63,7 +63,7 @@ class JobExecutionContext(pydantic.BaseModel):
 
 
 def cleanup_workflow_group(context: JobExecutionContext, workflow_id: str, workflow_uuid: str,
-                           group_name: str):
+                           group_name: str, user: str = ''):
     """
     Cleans up a workflow group and enqueues a workflow cleanup job if all groups are cleaned up.
 
@@ -76,6 +76,7 @@ def cleanup_workflow_group(context: JobExecutionContext, workflow_id: str, workf
         workflow_id: The ID of the workflow to clean up
         workflow_uuid: The UUID of the workflow to clean up
         group_name: The name of the group to mark as cleaned up
+        user: The user that owns the workflow; propagated onto CleanupWorkflow for log labels
 
     Returns:
         None
@@ -85,7 +86,8 @@ def cleanup_workflow_group(context: JobExecutionContext, workflow_id: str, workf
     if all_cleaned_up:
         cleanup_job = CleanupWorkflow(
             workflow_id=workflow_id,
-            workflow_uuid=workflow_uuid
+            workflow_uuid=workflow_uuid,
+            user=user,
         )
         cleanup_job.send_job_to_queue()
 
@@ -144,13 +146,19 @@ class WorkflowJob(FrontendJob):
     """
     workflow_id: task_common.NamePattern
     workflow_uuid: common.UuidPattern
+    user: str = ''
 
     def log_submission(self):
         logging.info('Submitted new job %s to the job queue', self,
-                     extra={'workflow_uuid': self.workflow_uuid})
+                     extra=self.log_labels())
 
     def log_labels(self) -> Dict[str, str]:
-        return {'workflow_uuid': self.workflow_uuid}
+        labels = {'workflow_uuid': self.workflow_uuid}
+        if self.user:
+            labels['user_id'] = self.user
+        if self.job_id:
+            labels['job_id'] = self.job_id
+        return labels
 
 
 class BackendJob(Job):
@@ -511,6 +519,7 @@ class CreateGroup(BackendJob, WorkflowJob, backend_job_defs.BackendCreateGroupMi
             upload_task = UploadWorkflowFiles(
                 workflow_id=workflow_obj.workflow_id,
                 workflow_uuid=self.workflow_uuid,
+                user=self.user,
                 files=[File(f'{task_name}.spec', yaml.dump(redact_pod_spec_env(pod_spec)))
                         for task_name, pod_spec in pod_specs.items()])
             upload_task.send_job_to_queue()
@@ -556,7 +565,8 @@ class CleanupGroup(BackendJob, WorkflowJob, backend_job_defs.BackendCleanupGroup
                 progress_writer: progress.ProgressWriter,
                 progress_iter_freq: datetime.timedelta = \
                     datetime.timedelta(seconds=15)) -> JobResult:
-        cleanup_workflow_group(context, self.workflow_id, self.workflow_uuid, self.group_name)
+        cleanup_workflow_group(context, self.workflow_id, self.workflow_uuid, self.group_name,
+                               user=self.user)
         return JobResult()
 
     def prepare_execute(self, context: JobExecutionContext,
@@ -814,7 +824,8 @@ class UpdateGroup(WorkflowJob):
 
             cleanup_workflow_group(context, workflow_obj.workflow_id,
                                     workflow_obj.workflow_uuid,
-                                    group_obj.name)
+                                    group_obj.name,
+                                    user=self.user)
         else:
             factory = group_obj.get_k8s_object_factory(backend)
             cleanup_specs = [
@@ -851,6 +862,7 @@ class UpdateGroup(WorkflowJob):
                 group_name=group_obj.name,
                 workflow_id=self.workflow_id,
                 workflow_uuid=self.workflow_uuid,
+                user=self.user,
                 force_delete=self.force_cancel,
                 cleanup_specs=cleanup_specs, error_log_spec=error_log_spec,
                 max_log_lines=workflow_config.max_error_log_lines)
@@ -968,6 +980,7 @@ class UpdateGroup(WorkflowJob):
                         else workflow_config.default_queue_timeout)
                 check_queue_timeout = CheckQueueTimeout(workflow_id=self.workflow_id,
                                                         workflow_uuid=self.workflow_uuid,
+                                                        user=self.user,
                                                         group_name=self.group_name)
                 check_queue_timeout.send_delayed_job_to_queue(queue_timeout)
 
@@ -982,6 +995,7 @@ class UpdateGroup(WorkflowJob):
                         else workflow_config.default_exec_timeout)
                 check_run_timeout = CheckRunTimeout(workflow_id=self.workflow_id,
                                                     workflow_uuid=self.workflow_uuid,
+                                                    user=self.user,
                                                     group_name=self.group_name)
                 check_run_timeout.send_delayed_job_to_queue(exec_timeout)
 
@@ -1178,6 +1192,7 @@ class UpdateGroup(WorkflowJob):
             group_name=group.name,
             workflow_id=self.workflow_id,
             workflow_uuid=self.workflow_uuid,
+            user=self.user,
             cleanup_specs=[error_log_spec], error_log_spec=error_log_spec,
             max_log_lines=workflow_config.max_error_log_lines)
 
@@ -1212,6 +1227,7 @@ class UpdateGroup(WorkflowJob):
             workflow_id=self.workflow_id,
             workflow_uuid=self.workflow_uuid,
             backend=spec.backend,
+            user=self.user,
             retry_id=new_task.retry_id,
             task_name=new_task.name,
             lead_task=self.lead_task,
@@ -1634,9 +1650,15 @@ class CancelWorkflow(WorkflowJob):
         Executes the job. Returns true if the workflow was canceled.
         """
 
-        # Indicate that the workflow is to be canceled
+        # Indicate that the workflow is to be canceled. Timeout-driven cancels are
+        # attributed to the 'osmo' system user so the UI can distinguish them from
+        # user-initiated cancels.
         workflow_obj = workflow.Workflow.fetch_from_db(context.postgres, self.workflow_id)
-        workflow_obj.update_cancelled_by(self.user)
+        cancelled_by = 'osmo' if self.workflow_status in (
+            workflow.WorkflowStatus.FAILED_EXEC_TIMEOUT,
+            workflow.WorkflowStatus.FAILED_QUEUE_TIMEOUT,
+        ) else self.user
+        workflow_obj.update_cancelled_by(cancelled_by)
 
         # Iterate through each group and create a task to mark it as failed
         for group_obj in workflow_obj.get_group_objs():
@@ -1733,6 +1755,7 @@ class CheckRunTimeout(WorkflowJob):
             CheckRunTimeout(
                 workflow_id=self.workflow_id,
                 workflow_uuid=self.workflow_uuid,
+                user=self.user,
                 group_name=group_name,
             ).send_delayed_job_to_queue(exec_timeout - time_elapsed)
             return JobResult()
@@ -1746,7 +1769,7 @@ class CheckRunTimeout(WorkflowJob):
             group_name=group_name,
             status=task.TaskGroupStatus.FAILED_EXEC_TIMEOUT,
             message=f'{limit_message}.',
-            user='osmo',
+            user=self.user,
         ).send_job_to_queue()
         return JobResult()
 
@@ -1770,11 +1793,12 @@ class CheckRunTimeout(WorkflowJob):
             CheckRunTimeout(
                 workflow_id=self.workflow_id,
                 workflow_uuid=self.workflow_uuid,
+                user=self.user,
             ).send_delayed_job_to_queue(exec_timeout - time_elapsed)
         else:
             CancelWorkflow(
                 workflow_id=self.workflow_id,
-                workflow_uuid=self.workflow_uuid, user='osmo',
+                workflow_uuid=self.workflow_uuid, user=self.user,
                 workflow_status=workflow.WorkflowStatus.FAILED_EXEC_TIMEOUT,
                 task_status=task.TaskGroupStatus.FAILED_EXEC_TIMEOUT,
             ).send_job_to_queue()
@@ -1848,6 +1872,7 @@ class CheckQueueTimeout(WorkflowJob):
             CheckQueueTimeout(
                 workflow_id=self.workflow_id,
                 workflow_uuid=self.workflow_uuid,
+                user=self.user,
                 group_name=group_name,
             ).send_delayed_job_to_queue(queue_timeout - time_elapsed)
             return JobResult()
@@ -1861,7 +1886,7 @@ class CheckQueueTimeout(WorkflowJob):
             group_name=group_name,
             status=task.TaskGroupStatus.FAILED_QUEUE_TIMEOUT,
             message=f'{limit_message}.',
-            user='osmo',
+            user=self.user,
         ).send_job_to_queue()
         return JobResult()
 
@@ -1887,11 +1912,12 @@ class CheckQueueTimeout(WorkflowJob):
             CheckQueueTimeout(
                 workflow_id=self.workflow_id,
                 workflow_uuid=self.workflow_uuid,
+                user=self.user,
             ).send_delayed_job_to_queue(queue_timeout - time_since_submission)
         else:
             CancelWorkflow(
                 workflow_id=self.workflow_id,
-                workflow_uuid=self.workflow_uuid, user='osmo',
+                workflow_uuid=self.workflow_uuid, user=self.user,
                 workflow_status=workflow.WorkflowStatus.FAILED_QUEUE_TIMEOUT,
                 task_status=task.TaskGroupStatus.FAILED_QUEUE_TIMEOUT,
             ).send_job_to_queue()

--- a/src/utils/logging/logging.go
+++ b/src/utils/logging/logging.go
@@ -295,6 +295,12 @@ func buildHandler(serviceName string, config Config, writer io.Writer) slog.Hand
 	case FormatJSON:
 		h := slog.NewJSONHandler(writer, &slog.HandlerOptions{
 			Level: config.Level,
+			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+				if len(groups) == 0 && a.Key == specialAttrKey {
+					a.Key = "user_id"
+				}
+				return a
+			},
 		})
 		return h.WithAttrs([]slog.Attr{slog.String("service", serviceName)})
 	default:

--- a/src/utils/logging/logging_test.go
+++ b/src/utils/logging/logging_test.go
@@ -369,6 +369,12 @@ func TestJSONHandlerServiceAttrAlwaysPresent(t *testing.T) {
 	if records[0]["service"] != "authz-sidecar" {
 		t.Errorf("service missing after WithGroup: %v", records[0])
 	}
+	if records[0]["user_id"] != "alice" {
+		t.Errorf("user should be emitted as user_id in JSON logs, got %v", records[0])
+	}
+	if _, ok := records[0]["user"]; ok {
+		t.Errorf("JSON logs should not emit user, got %v", records[0])
+	}
 }
 
 // TestInitLoggerJSONFormat is the end-to-end check: InitLogger with


### PR DESCRIPTION
## Description
Adds frontend user context to OSMO UI logs so log messages emitted during an authenticated `UserProvider` session include the active user ID.

  - Adds `setLogUserId` / `clearLogUserId` helpers in the UI logger.
  - Prefixes frontend log output with `[user=<id>]` when a user ID is available.
  - Wires `UserProvider` to set and clear the log user ID as the active user changes.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Diagnostics and logs now include per-user and per-job context (user_id/job_id) and emit richer JSON fields for easier troubleshooting.
  * Server requests and job lifecycles log request method/path and status, and background jobs/uploads are associated with the submitting user for clearer traceability.
  * Dev-mode debug/info logs added for more verbose local debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->