### PR TITLE
Conditionally set backendImages credentials

### DIFF
--- a/deployments/BUILD
+++ b/deployments/BUILD
@@ -15,3 +15,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+
+filegroup(
+    name = "values",
+    srcs = glob(["values/**"]),
+    visibility = ["//visibility:public"],
+)

--- a/deployments/charts/BUILD
+++ b/deployments/charts/BUILD
@@ -32,3 +32,12 @@ filegroup(
     srcs = glob(["quick-start/**"]),
     visibility = ["//visibility:public"],
 )
+
+sh_test(
+    name = "service_public_registry_secret_render_test",
+    srcs = ["service/tests/public_registry_secret_render_test.sh"],
+    data = [
+        ":service",
+        "//deployments:values",
+    ],
+)

--- a/deployments/charts/service/templates/_helpers.tpl
+++ b/deployments/charts/service/templates/_helpers.tpl
@@ -178,15 +178,34 @@ OSMO_CONFIGMAP_NAME deliberately references services.service.serviceName
 {{- end }}
 {{- end -}}
 
+{{/*
+The minimal deploy values keep nvcr-secret as the private-registry default for
+existing deployments. Public installs can omit that Secret; in that case, do
+not render references that make pods wait on or configs load a missing Secret.
+*/}}
+{{- define "osmo.config-secret-ref-enabled" -}}
+{{- $secretName := .secretName | default "" -}}
+{{- $root := .root -}}
+{{- $imagePullSecret := $root.Values.global.imagePullSecret | default "" -}}
+{{- if and (eq $secretName "nvcr-secret") (ne $imagePullSecret $secretName) (not (lookup "v1" "Secret" $root.Release.Namespace $secretName)) -}}
+false
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{- define "osmo.configmap-volume-mounts" -}}
 {{- if .Values.services.configs.enabled }}
 - name: configs
   mountPath: /etc/osmo/configs
   readOnly: true
 {{- range .Values.services.configs.secretRefs }}
+{{- $secretName := .secretName | default "" }}
+{{- if and $secretName (eq (include "osmo.config-secret-ref-enabled" (dict "root" $ "secretName" $secretName) | trim) "true") }}
 - name: secret-{{ .secretName }}
   mountPath: /etc/osmo/secrets/{{ .secretName }}
   readOnly: true
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -197,10 +216,12 @@ OSMO_CONFIGMAP_NAME deliberately references services.service.serviceName
   configMap:
     name: {{ .Values.services.service.serviceName }}-configs
 {{- range .Values.services.configs.secretRefs }}
+{{- $secretName := .secretName | default "" }}
+{{- if and $secretName (eq (include "osmo.config-secret-ref-enabled" (dict "root" $ "secretName" $secretName) | trim) "true") }}
 - name: secret-{{ .secretName }}
   secret:
     secretName: {{ .secretName }}
 {{- end }}
 {{- end }}
+{{- end }}
 {{- end -}}
-

--- a/deployments/charts/service/templates/configs.yaml
+++ b/deployments/charts/service/templates/configs.yaml
@@ -33,7 +33,19 @@ data:
     {{- end }}
     {{- if $cfg.workflow }}
     workflow:
-      {{- toYaml $cfg.workflow | nindent 6 }}
+      {{- $workflow := deepCopy $cfg.workflow }}
+      {{- $backendImages := get $workflow "backend_images" | default dict }}
+      {{- if kindIs "map" $backendImages }}
+      {{- $credential := get $backendImages "credential" | default dict }}
+      {{- if kindIs "map" $credential }}
+      {{- $secretName := get $credential "secretName" | default "" }}
+      {{- if and $secretName (eq (include "osmo.config-secret-ref-enabled" (dict "root" $ "secretName" $secretName) | trim) "false") }}
+      {{- $_ := set $backendImages "credential" dict }}
+      {{- $_ := set $workflow "backend_images" $backendImages }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- toYaml $workflow | nindent 6 }}
     {{- end }}
     {{- if $cfg.dataset }}
     dataset:

--- a/deployments/charts/service/templates/configs.yaml
+++ b/deployments/charts/service/templates/configs.yaml
@@ -33,19 +33,7 @@ data:
     {{- end }}
     {{- if $cfg.workflow }}
     workflow:
-      {{- $workflow := deepCopy $cfg.workflow }}
-      {{- $backendImages := get $workflow "backend_images" | default dict }}
-      {{- if kindIs "map" $backendImages }}
-      {{- $credential := get $backendImages "credential" | default dict }}
-      {{- if kindIs "map" $credential }}
-      {{- $secretName := get $credential "secretName" | default "" }}
-      {{- if and $secretName (eq (include "osmo.config-secret-ref-enabled" (dict "root" $ "secretName" $secretName) | trim) "false") }}
-      {{- $_ := set $backendImages "credential" dict }}
-      {{- $_ := set $workflow "backend_images" $backendImages }}
-      {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- toYaml $workflow | nindent 6 }}
+      {{- toYaml $cfg.workflow | nindent 6 }}
     {{- end }}
     {{- if $cfg.dataset }}
     dataset:


### PR DESCRIPTION
## Description
For deployments that only use public images, and forego a key for NGC, it was difficuly to avoid image pull secrets.

Even if a secret was not specified the config map would still contain

```
apiVersion: v1
data:
  config.yaml: |
    workflow:
      backend_images:
        credential:
          secretKey: .dockerconfigjson
          secretName: nvcr-secret
```

With the default values it was not easy to remove that configuration due to how Helm patches values.

You would need to first set credential: null to delete the inherited map, then a second later file sets credential: {}

Instead of changing the default values, which would be a breaking change, add a template that only adds the credential structure when needed.

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conditional rendering of secret configurations and credentials in deployments based on environment settings.
  * Improved secret management for public registry configurations with dynamic validation.

* **Tests**
  * Added test coverage for public registry secret rendering scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->