### PR TITLE
deployments: pin AKS 1.33 + GPU Operator v25.10.1, standardize GPU pool taint

### DIFF
--- a/deployments/scripts/azure/terraform.sh
+++ b/deployments/scripts/azure/terraform.sh
@@ -57,7 +57,13 @@ TF_CLUSTER_NAME="${TF_CLUSTER_NAME:-osmo-cluster}"
 TF_REGION="${TF_REGION:-East US 2}"
 TF_ENVIRONMENT="${TF_ENVIRONMENT:-dev}"
 TF_PROJECT_NAME="${TF_PROJECT_NAME:-osmo}"
-TF_K8S_VERSION="${TF_K8S_VERSION:-1.35.3}"
+# Pin to AKS 1.33.x — the most recent minor with Ubuntu 22.04 + containerd 1.7.x
+# defaults, validated against GPU Operator v25.10.1 and KAI Scheduler v0.14.0.
+# AKS 1.34+ on Ubuntu 24.04 nodes ships containerd 2.x which the current
+# NVIDIA toolchain in install-gpu-operator.sh has not been validated against.
+# AKS 1.32 and older are LTS-only as of 2026-03-31 and cannot be used to
+# create new standard-tier clusters.
+TF_K8S_VERSION="${TF_K8S_VERSION:-1.33.11}"
 
 # Private cluster detection
 IS_PRIVATE_CLUSTER=false

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -867,8 +867,9 @@ render_gpu_pool_values() {
     # not `nvidia.com/gpu.present` (which doesn't exist as a label name). Use
     # the value-bearing label selector and count rows — `kubectl get nodes -l`
     # output doesn't include the label NAME in any column, so grepping the
-    # output for the selector string would always return no match.
-    if [ "$(kubectl get nodes -l nvidia.com/gpu=present --no-headers 2>/dev/null | wc -l)" -gt 0 ]; then
+    # output for the selector string would always return no match. Route
+    # through $RUN_KUBECTL so private/provider-routed flows honor the wrapper.
+    if [ "$($RUN_KUBECTL get nodes -l nvidia.com/gpu=present --no-headers 2>/dev/null | wc -l)" -gt 0 ]; then
         detected="true"
     fi
 

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -863,8 +863,12 @@ render_gpu_pool_values() {
 
     local force="${OSMO_GPU_POOL_ENABLED:-auto}"
     local detected="false"
-    if kubectl get nodes -l nvidia.com/gpu.present 2>/dev/null \
-        | grep -q "nvidia.com/gpu.present"; then
+    # GPU Operator labels GPU nodes with `nvidia.com/gpu=present` (key/value),
+    # not `nvidia.com/gpu.present` (which doesn't exist as a label name). Use
+    # the value-bearing label selector and count rows — `kubectl get nodes -l`
+    # output doesn't include the label NAME in any column, so grepping the
+    # output for the selector string would always return no match.
+    if [ "$(kubectl get nodes -l nvidia.com/gpu=present --no-headers 2>/dev/null | wc -l)" -gt 0 ]; then
         detected="true"
     fi
 

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -869,7 +869,7 @@ render_gpu_pool_values() {
     # output doesn't include the label NAME in any column, so grepping the
     # output for the selector string would always return no match. Route
     # through $RUN_KUBECTL so private/provider-routed flows honor the wrapper.
-    if [ "$($RUN_KUBECTL get nodes -l nvidia.com/gpu=present --no-headers 2>/dev/null | wc -l)" -gt 0 ]; then
+    if [ "$($RUN_KUBECTL "get nodes -l nvidia.com/gpu=present --no-headers" 2>/dev/null | wc -l)" -gt 0 ]; then
         detected="true"
     fi
 

--- a/deployments/scripts/deploy-osmo-minimal.sh
+++ b/deployments/scripts/deploy-osmo-minimal.sh
@@ -167,7 +167,7 @@ Azure-specific Options:
   --cluster-name NAME    AKS cluster name (default: osmo-cluster)
   --region REGION        Azure region (default: East US 2)
   --environment ENV      Environment name (default: dev)
-  --k8s-version VER      Kubernetes version (default: 1.32.9)
+  --k8s-version VER      Kubernetes version (default: 1.33.11)
 
 AWS-specific Options:
   --aws-region REGION    AWS region (default: us-west-2)

--- a/deployments/scripts/install-gpu-operator.sh
+++ b/deployments/scripts/install-gpu-operator.sh
@@ -35,7 +35,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
-GPU_OPERATOR_VERSION="${GPU_OPERATOR_VERSION:-v25.3.4}"
+# v25.10.1 is the first release containing PR #1757, which fixes the
+# ClusterPolicy validator.plugin null-rendering bug (NVIDIA/gpu-operator#1745)
+# that breaks chart install on K8s 1.33+ schema validation. Earlier v25.3.x
+# releases fail with "spec.validator.plugin: Invalid value: 'null'" on install.
+GPU_OPERATOR_VERSION="${GPU_OPERATOR_VERSION:-v25.10.1}"
 GPU_OPERATOR_NAMESPACE="${GPU_OPERATOR_NAMESPACE:-gpu-operator}"
 GPU_OPERATOR_RELEASE="${GPU_OPERATOR_RELEASE:-gpu-operator}"
 NO_GPU="${NO_GPU:-0}"

--- a/deployments/terraform/aws/example/example.tf
+++ b/deployments/terraform/aws/example/example.tf
@@ -155,13 +155,18 @@ module "eks" {
 
         labels = {
           "nvidia.com/gpu" = "present"
-          "sku"            = "gpu"
         }
 
+        # Use the NVIDIA-standard taint key. GPU Operator, NFD worker, NIM
+        # Operator's NIMService pods, and KAI Scheduler's mutating webhook
+        # all default-tolerate `nvidia.com/gpu:NoSchedule`. Non-standard taint
+        # keys (e.g. `sku=gpu`) require extending tolerations across every
+        # NVIDIA chart and break the GPU Operator's GPU-detection cascade
+        # when the NFD worker can't land on the GPU node.
         taints = {
           gpu = {
-            key    = "sku"
-            value  = "gpu"
+            key    = "nvidia.com/gpu"
+            value  = "present"
             effect = "NO_SCHEDULE"
           }
         }

--- a/deployments/terraform/azure/example/example.tf
+++ b/deployments/terraform/azure/example/example.tf
@@ -252,7 +252,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "gpu" {
   max_count             = var.gpu_node_pool_max_size
   auto_scaling_enabled  = true
   vnet_subnet_id        = azurerm_subnet.private[0].id
-  zones                 = ["1", "3"]
+  zones                 = var.availability_zones
   os_disk_size_gb       = 100
   priority              = var.gpu_node_pool_priority
   eviction_policy       = var.gpu_node_pool_priority == "Spot" ? "Delete" : null

--- a/deployments/terraform/azure/example/example.tf
+++ b/deployments/terraform/azure/example/example.tf
@@ -252,16 +252,22 @@ resource "azurerm_kubernetes_cluster_node_pool" "gpu" {
   max_count             = var.gpu_node_pool_max_size
   auto_scaling_enabled  = true
   vnet_subnet_id        = azurerm_subnet.private[0].id
-  zones                 = var.availability_zones
+  zones                 = ["1", "3"]
   os_disk_size_gb       = 100
   priority              = var.gpu_node_pool_priority
   eviction_policy       = var.gpu_node_pool_priority == "Spot" ? "Delete" : null
   spot_max_price        = var.gpu_node_pool_priority == "Spot" ? -1 : null
 
-  node_taints = ["sku=gpu:NoSchedule"]
+  # Use the NVIDIA-standard taint key. GPU Operator (clusterpolicy.spec.
+  # daemonsets.tolerations), NFD worker DaemonSet, NIM Operator's NIMService
+  # pods, and KAI Scheduler's mutating webhook all default-tolerate
+  # `nvidia.com/gpu:NoSchedule`. Non-standard taint keys (e.g. `sku=gpu`)
+  # require extending tolerations across every NVIDIA chart and break the
+  # GPU Operator's GPU-detection cascade when the NFD worker can't land on
+  # the GPU node.
+  node_taints = ["nvidia.com/gpu=present:NoSchedule"]
   node_labels = {
     "nvidia.com/gpu" = "present"
-    "sku"            = "gpu"
   }
 
   tags = local.tags

--- a/deployments/values/gpu-pool.yaml
+++ b/deployments/values/gpu-pool.yaml
@@ -3,13 +3,15 @@
 #
 # Opt-in fragment that registers a GPU platform on the default OSMO pool.
 # Layered by deploy-osmo-minimal.sh when GPU nodes are detected
-# (`kubectl get nodes -l nvidia.com/gpu.present`).
+# (`kubectl get nodes -l nvidia.com/gpu=present`).
 #
 # Replaces the 6.2-era `osmo config update POD_TEMPLATE` + `osmo config update
 # POOL` CLI dance — in 6.3 ConfigMap mode the pool definition lives in values.
 #
-# The taint key/value here matches the GPU node pool TF resources in
-# terraform/{azure,aws}/example/. If you customize the taint, override here.
+# Taint matches the NVIDIA-standard GPU pool taint set by the TF resources in
+# terraform/{azure,aws}/example/ (`nvidia.com/gpu=present:NoSchedule`). If you
+# customize the taint, override here AND update GPU Operator + NFD + every
+# downstream NVIDIA-stack daemonset's tolerations to match.
 
 services:
   configs:
@@ -18,15 +20,15 @@ services:
       gpu_toleration:
         spec:
           tolerations:
-            - key: sku
-              operator: Equal
-              value: gpu
+            - key: nvidia.com/gpu
+              operator: Exists
               effect: NoSchedule
           nodeSelector:
-            nvidia.com/gpu.present: "true"
+            nvidia.com/gpu: "present"
     pools:
       default:
         platforms:
           system: {}
           gpu:
-            override_pod_template: gpu_toleration
+            override_pod_template:
+              - gpu_toleration


### PR DESCRIPTION
## Description

Pins the deploy toolchain to a validated combo and fixes three GPU-pool wiring bugs that silently broke fresh installs on the prior defaults.

- `scripts/azure/terraform.sh`: bump `TF_K8S_VERSION` default `1.35.3` → `1.33.11`. AKS 1.34+ nodes default to Ubuntu 24.04 + containerd 2.x, which the GPU Operator's v25.x toolkit installer doesn't add a `nvidia` runtime alias to. AKS 1.32 and older are LTS-only as of 2026-03-31 (fail to create on standard tier with `K8sVersionNotSupported`).

- `scripts/install-gpu-operator.sh`: bump `GPU_OPERATOR_VERSION` default `v25.3.4` → `v25.10.1`. v25.3.x hits NVIDIA/gpu-operator#1745 — `validator.plugin.env: []` renders `plugin:` as null, which fails K8s 1.25+ CRD schema validation. PR #1757 (in v25.10.0+) fixes it.

- `scripts/deploy-k8s.sh`: fix `render_gpu_pool_values` GPU-node detection. Previous selector `nvidia.com/gpu.present` (with a dot) doesn't match GPU Operator's actual label `nvidia.com/gpu=present` (key/value), and the `grep` over `kubectl get nodes` output for the selector string always returned no match. Replaced with a value-bearing selector + row count.

- `terraform/{azure,aws}/example/example.tf`: change GPU pool `node_taints` from `sku=gpu:NoSchedule` to `nvidia.com/gpu=present:NoSchedule`. GPU Operator daemonsets, NFD worker, NIM Operator NIMService pods, and KAI Scheduler's mutating webhook all default-tolerate the standard NVIDIA taint. The `sku=gpu` taint required extending tolerations across every NVIDIA chart, and a missing NFD-worker toleration broke the entire GPU-detection cascade.

- `values/gpu-pool.yaml`: align `gpu_toleration` pod template to the new taint and update header comment. Switch the toleration to `(key=nvidia.com/gpu, operator=Exists)`.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Kubernetes default bumped to 1.33.11 for AKS/containerd compatibility
  * GPU Operator default upgraded to v25.10.1 to address installer validation on newer Kubernetes
  * GPU pool values restructured for clearer pod-template overrides
* **Bug Fixes**
  * Reliable GPU node detection and standardized NVIDIA taint/label handling so GPU pools are recognized consistently
* **Docs**
  * Help text and inline docs updated to reflect new defaults and taint/label behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->