### PR TITLE
ci: upgrade label external action to node24

### DIFF
--- a/.github/workflows/label-external.yaml
+++ b/.github/workflows/label-external.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Check if author is in osmo-dev
         id: team-check
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662
+        uses: tspascoal/get-user-teams-membership@b2546c5affc730fd8e3d8483ae9ad3621938c2f9 # v4.0.2
         with:
           # Use a PAT or org-level token with read:org / members:read
           GITHUB_TOKEN: ${{ secrets.NVIDIA_ORG_MEMBER_READ_TOKEN }}


### PR DESCRIPTION
## Description
Upgrade the `label-external` workflow's `tspascoal/get-user-teams-membership` action pin from the Node.js 20 `v3.0.0` SHA to the Node.js 24 `v4.0.2` SHA.

Issue #None

Testing:
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/label-external.yaml"); puts "yaml ok"'`
- `git diff --check origin/main...HEAD`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned version of a third-party GitHub Actions step used in CI workflows.
  * Change is limited to the workflow pin; no other workflow steps, inputs, conditions, or labels were modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->