### PR TITLE
BYO/Azure deploy: bash3 array, dead NGC block + MEK guard, GPU label, smoke-test failure exit code, single-pool auto-pick

### DIFF
--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -138,6 +138,13 @@ RUN_KUBECTL_APPLY_STDIN=""
 RUN_HELM="helm"
 RUN_HELM_WITH_VALUES=""
 
+# Populated by create_database() from the in-pod psql probe. Used by
+# create_secrets() to refuse a fresh MEK against a populated DB. Values:
+#   ""        — probe didn't run (in-cluster DB mode, or BYO without PG creds)
+#   <int>     — number of user tables in public schema (0 = empty DB)
+#   "UNKNOWN" — probe ran but result couldn't be parsed (treat as unsafe)
+DB_TABLE_COUNT=""
+
 ###############################################################################
 # Parse Arguments
 ###############################################################################
@@ -350,6 +357,8 @@ spec:
           psql -h \$PGHOST -U \$PGUSER -d postgres -c 'CREATE DATABASE \"${POSTGRES_DB_NAME:-osmo}\";' 2>&1 || echo 'Database may already exist (this is OK)'
           echo 'Verifying database connection...'
           psql -h \$PGHOST -U \$PGUSER -d ${POSTGRES_DB_NAME:-osmo} -c 'SELECT 1 as connected;' && echo 'SUCCESS: Database ${POSTGRES_DB_NAME:-osmo} is ready!'
+          COUNT=\$(psql -h \$PGHOST -U \$PGUSER -d ${POSTGRES_DB_NAME:-osmo} -tAc \"SELECT count(*) FROM information_schema.tables WHERE table_schema='public';\")
+          echo \"OSMO_DB_TABLE_COUNT=\$COUNT\"
   restartPolicy: Never"
 
     log_info "Creating database initialization pod..."
@@ -366,14 +375,21 @@ spec:
         if [[ "$status" == "Succeeded" ]]; then
             log_success "Database created successfully"
             echo "--- Database creation logs ---"
-            $RUN_KUBECTL "logs $OSMO_DB_OPS_POD --namespace $OSMO_NAMESPACE" 2>/dev/null || true
+            local pod_logs
+            pod_logs=$($RUN_KUBECTL "logs $OSMO_DB_OPS_POD --namespace $OSMO_NAMESPACE" 2>/dev/null || true)
+            echo "$pod_logs"
             echo "---"
+            DB_TABLE_COUNT=$(echo "$pod_logs" | sed -n 's/^OSMO_DB_TABLE_COUNT=\([0-9][0-9]*\)$/\1/p' | tail -1)
+            if [[ -z "$DB_TABLE_COUNT" ]]; then
+                DB_TABLE_COUNT="UNKNOWN"
+            fi
             $RUN_KUBECTL "delete pod $OSMO_DB_OPS_POD --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
             return 0
         elif [[ "$status" == "Failed" ]]; then
             log_warning "Database creation pod failed, checking logs..."
             $RUN_KUBECTL "logs $OSMO_DB_OPS_POD --namespace $OSMO_NAMESPACE" 2>/dev/null || true
             $RUN_KUBECTL "delete pod $OSMO_DB_OPS_POD --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
+            DB_TABLE_COUNT="UNKNOWN"
             return 0
         fi
 
@@ -385,77 +401,7 @@ spec:
 
     log_warning "Timeout waiting for database creation, continuing anyway..."
     $RUN_KUBECTL "delete pod $OSMO_DB_OPS_POD --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
-}
-
-# Returns:
-#   0 - DB has user tables (caller must block destructive ops).
-#   1 - DB verified empty, OR check is not applicable (in-cluster DB not yet
-#       up, no PG creds in env — both are normal first-install states).
-#   2 - Probe failed/timed out. Caller cannot prove safety; should block.
-db_has_existing_data() {
-    if [[ "${OSMO_IN_CLUSTER_DB:-false}" == "true" ]]; then
-        return 1
-    fi
-    if [[ -z "${POSTGRES_HOST:-}" || -z "${POSTGRES_PASSWORD:-}" || -z "${POSTGRES_USERNAME:-}" ]]; then
-        return 1
-    fi
-
-    local probe_pod="${OSMO_DB_OPS_POD}-mek-check"
-    $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
-
-    local escaped_password
-    escaped_password=$(printf '%s' "$POSTGRES_PASSWORD" | sed "s/'/'\\\\''/g")
-    local probe_manifest="apiVersion: v1
-kind: Pod
-metadata:
-  name: $probe_pod
-  namespace: $OSMO_NAMESPACE
-spec:
-  containers:
-    - name: $probe_pod
-      image: $POSTGRES_OPS_IMAGE
-      env:
-        - name: PGPASSWORD
-          value: '$escaped_password'
-        - name: PGHOST
-          value: '$POSTGRES_HOST'
-        - name: PGUSER
-          value: '$POSTGRES_USERNAME'
-        - name: PGDATABASE
-          value: '${POSTGRES_DB_NAME:-osmo}'
-      command:
-        - /bin/bash
-        - -c
-        - |
-          psql -tAc \"SELECT count(*) FROM information_schema.tables WHERE table_schema='public';\"
-  restartPolicy: Never"
-
-    $RUN_KUBECTL_APPLY_STDIN "$probe_manifest" > /dev/null 2>&1 || return 1
-
-    local max_wait=60
-    local waited=0
-    while [[ $waited -lt $max_wait ]]; do
-        local phase
-        phase=$($RUN_KUBECTL "get pod $probe_pod --namespace $OSMO_NAMESPACE -o jsonpath={.status.phase}" 2>/dev/null)
-        if [[ "$phase" == "Succeeded" ]]; then
-            local table_count
-            table_count=$($RUN_KUBECTL "logs $probe_pod --namespace $OSMO_NAMESPACE" 2>/dev/null | grep -oE '^[0-9]+$' | head -1)
-            $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
-            if [[ -n "$table_count" && "$table_count" -gt 0 ]]; then
-                return 0
-            fi
-            return 1
-        elif [[ "$phase" == "Failed" ]]; then
-            $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
-            return 2
-        fi
-        sleep 2
-        waited=$((waited + 2))
-    done
-
-    log_warning "MEK probe pod did not complete within ${max_wait}s (phase=${phase:-unknown})"
-    $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
-    return 2
+    DB_TABLE_COUNT="UNKNOWN"
 }
 
 ###############################################################################
@@ -517,25 +463,24 @@ create_secrets() {
         log_info "MEK ConfigMap already present in $OSMO_NAMESPACE — preserving (re-using existing key)"
         log_info "  Pass RESET_MEK=true (or --reset-mek) to force a fresh key — DESTRUCTIVE if DB has encrypted data"
     else
-        if [[ "$mek_exists" == "true" && "$RESET_MEK" == "true" ]]; then
-            log_warning "RESET_MEK=true — replacing existing MEK. Data encrypted with the previous key will be unreadable."
+        if [[ "$RESET_MEK" == "true" ]]; then
+            log_warning "RESET_MEK=true — minting a fresh MEK. Data encrypted with any previous key will be unreadable."
         else
-            # Refuse to mint a new MEK if the DB still has encrypted data from a previous install.
-            db_has_existing_data
-            local probe_result=$?
-            if [[ "$probe_result" == "0" ]]; then
-                log_error "MEK ConfigMap 'mek-config' not found in $OSMO_NAMESPACE, but the database '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST already has user tables."
+            # Refuse to mint a new MEK if the DB still has encrypted data from a
+            # previous install. $DB_TABLE_COUNT is populated by create_database.
+            if [[ "$DB_TABLE_COUNT" == "UNKNOWN" ]]; then
+                log_error "Could not verify whether '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST has existing data (db-ops probe failed or timed out)."
+                log_error "Refusing to mint a fresh MEK without confirmation — minting against a populated DB silently orphans encrypted columns."
+                log_error "Retry once Postgres connectivity is healthy, or pass RESET_MEK=true to acknowledge data loss and proceed."
+                exit 1
+            elif [[ -n "$DB_TABLE_COUNT" && "$DB_TABLE_COUNT" -gt 0 ]]; then
+                log_error "MEK ConfigMap 'mek-config' not found in $OSMO_NAMESPACE, but the database '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST already has $DB_TABLE_COUNT user table(s)."
                 log_error "Generating a new MEK now would orphan every encrypted column (service_auth.private_key, workflow secrets, ...). To resolve:"
                 log_error "  - Restore the previous 'mek-config' ConfigMap from backup, OR"
                 log_error "  - Wipe the database before re-running:"
                 log_error "      psql -h $POSTGRES_HOST -U ${POSTGRES_USERNAME} -d postgres \\"
                 log_error "        -c 'DROP DATABASE IF EXISTS ${POSTGRES_DB_NAME:-osmo}; CREATE DATABASE ${POSTGRES_DB_NAME:-osmo};'"
                 log_error "  - Pass RESET_MEK=true to acknowledge data loss and proceed."
-                exit 1
-            elif [[ "$probe_result" == "2" ]]; then
-                log_error "Could not verify whether '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST has existing data (probe pod failed or timed out)."
-                log_error "Refusing to mint a fresh MEK without confirmation — minting against a populated DB silently orphans encrypted columns."
-                log_error "Retry once Postgres connectivity is healthy, or pass RESET_MEK=true to acknowledge data loss and proceed."
                 exit 1
             fi
             log_info "Generating Master Encryption Key (MEK) — first install"

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -387,6 +387,74 @@ spec:
     $RUN_KUBECTL "delete pod $OSMO_DB_OPS_POD --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
 }
 
+# Returns 0 if the OSMO database has user tables in the public schema,
+# 1 otherwise (incl. probe failure — caller treats unknown as empty).
+db_has_existing_data() {
+    if [[ "${OSMO_IN_CLUSTER_DB:-false}" == "true" ]]; then
+        return 1
+    fi
+    if [[ -z "${POSTGRES_HOST:-}" || -z "${POSTGRES_PASSWORD:-}" || -z "${POSTGRES_USERNAME:-}" ]]; then
+        return 1
+    fi
+
+    local probe_pod="${OSMO_DB_OPS_POD}-mek-check"
+    $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
+
+    local escaped_password
+    escaped_password=$(printf '%s' "$POSTGRES_PASSWORD" | sed "s/'/'\\\\''/g")
+    local probe_manifest="apiVersion: v1
+kind: Pod
+metadata:
+  name: $probe_pod
+  namespace: $OSMO_NAMESPACE
+spec:
+  containers:
+    - name: $probe_pod
+      image: $POSTGRES_OPS_IMAGE
+      env:
+        - name: PGPASSWORD
+          value: '$escaped_password'
+        - name: PGHOST
+          value: '$POSTGRES_HOST'
+        - name: PGUSER
+          value: '$POSTGRES_USERNAME'
+        - name: PGDATABASE
+          value: '${POSTGRES_DB_NAME:-osmo}'
+      command:
+        - /bin/bash
+        - -c
+        - |
+          psql -tAc \"SELECT count(*) FROM information_schema.tables WHERE table_schema='public';\"
+  restartPolicy: Never"
+
+    $RUN_KUBECTL_APPLY_STDIN "$probe_manifest" > /dev/null 2>&1 || return 1
+
+    local max_wait=60
+    local waited=0
+    while [[ $waited -lt $max_wait ]]; do
+        local phase
+        phase=$($RUN_KUBECTL "get pod $probe_pod --namespace $OSMO_NAMESPACE -o jsonpath={.status.phase}" 2>/dev/null)
+        if [[ "$phase" == "Succeeded" ]]; then
+            local table_count
+            table_count=$($RUN_KUBECTL "logs $probe_pod --namespace $OSMO_NAMESPACE" 2>/dev/null | grep -oE '^[0-9]+$' | head -1)
+            $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
+            if [[ -n "$table_count" && "$table_count" -gt 0 ]]; then
+                return 0
+            fi
+            return 1
+        elif [[ "$phase" == "Failed" ]]; then
+            $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
+            return 1
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
+
+    log_warning "MEK probe pod did not complete within ${max_wait}s (phase=${phase:-unknown}) — proceeding without DB check"
+    $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
+    return 1
+}
+
 ###############################################################################
 # Secrets Functions
 ###############################################################################
@@ -449,6 +517,17 @@ create_secrets() {
         if [[ "$mek_exists" == "true" && "$RESET_MEK" == "true" ]]; then
             log_warning "RESET_MEK=true — replacing existing MEK. Data encrypted with the previous key will be unreadable."
         else
+            # Refuse to mint a new MEK if the DB still has encrypted data from a previous install.
+            if db_has_existing_data; then
+                log_error "MEK ConfigMap 'mek-config' not found in $OSMO_NAMESPACE, but the database '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST already has user tables."
+                log_error "Generating a new MEK now would orphan every encrypted column (service_auth.private_key, workflow secrets, ...). To resolve:"
+                log_error "  - Restore the previous 'mek-config' ConfigMap from backup, OR"
+                log_error "  - Wipe the database before re-running:"
+                log_error "      psql -h $POSTGRES_HOST -U ${POSTGRES_USERNAME} -d postgres \\"
+                log_error "        -c 'DROP DATABASE IF EXISTS ${POSTGRES_DB_NAME:-osmo}; CREATE DATABASE ${POSTGRES_DB_NAME:-osmo};'"
+                log_error "  - Pass RESET_MEK=true to acknowledge data loss and proceed."
+                exit 1
+            fi
             log_info "Generating Master Encryption Key (MEK) — first install"
         fi
         local random_key=$(openssl rand -base64 32 | tr -d '\n')
@@ -632,10 +711,8 @@ service_set_flags() {
     # No kubectl-existence probe — that path caused stale-secret confusion
     # where a pre-existing nvcr-secret in the namespace silently re-engaged
     # plumbing the caller hadn't asked for.
-    local has_pull_secret=false
     if [[ -n "$NGC_SECRET_NAME" ]]; then
         sets+=" --set global.imagePullSecret=${NGC_SECRET_NAME}"
-        has_pull_secret=true
     fi
 
     sets+=" --set services.postgres.serviceName=${POSTGRES_HOST}"
@@ -698,15 +775,6 @@ service_set_flags() {
     sets+=" --set services.configs.workflow.backend_images.init=${OSMO_IMAGE_REGISTRY}/init-container:${OSMO_IMAGE_TAG}"
     sets+=" --set services.configs.workflow.backend_images.client=${OSMO_IMAGE_REGISTRY}/client:${OSMO_IMAGE_TAG}"
 
-    # NGC pull-secret plumbing in the rendered configmap. Gated on
-    # has_pull_secret (= NGC_SECRET_NAME non-empty); service.yaml ships
-    # without these defaults so the no-opt-in path leaves both empty and
-    # the chart's secretRefs range iterates nothing.
-    if [[ "$has_pull_secret" == "true" ]]; then
-        sets+=" --set services.configs.secretRefs[0].secretName=${NGC_SECRET_NAME}"
-        sets+=" --set services.configs.workflow.backend_images.credential.secretName=${NGC_SECRET_NAME}"
-        sets+=" --set services.configs.workflow.backend_images.credential.secretKey=.dockerconfigjson"
-    fi
 
     echo "$sets"
 }
@@ -863,13 +931,8 @@ render_gpu_pool_values() {
 
     local force="${OSMO_GPU_POOL_ENABLED:-auto}"
     local detected="false"
-    # GPU Operator labels GPU nodes with `nvidia.com/gpu=present` (key/value),
-    # not `nvidia.com/gpu.present` (which doesn't exist as a label name). Use
-    # the value-bearing label selector and count rows — `kubectl get nodes -l`
-    # output doesn't include the label NAME in any column, so grepping the
-    # output for the selector string would always return no match. Route
-    # through $RUN_KUBECTL so private/provider-routed flows honor the wrapper.
-    if [ "$($RUN_KUBECTL "get nodes -l nvidia.com/gpu=present --no-headers" 2>/dev/null | wc -l)" -gt 0 ]; then
+    # GPU Operator NFD labels GPU nodes with `nvidia.com/gpu.present=true`.
+    if [ "$($RUN_KUBECTL "get nodes -l nvidia.com/gpu.present=true --no-headers" 2>/dev/null | wc -l)" -gt 0 ]; then
         detected="true"
     fi
 

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -387,8 +387,11 @@ spec:
     $RUN_KUBECTL "delete pod $OSMO_DB_OPS_POD --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
 }
 
-# Returns 0 if the OSMO database has user tables in the public schema,
-# 1 otherwise (incl. probe failure — caller treats unknown as empty).
+# Returns:
+#   0 - DB has user tables (caller must block destructive ops).
+#   1 - DB verified empty, OR check is not applicable (in-cluster DB not yet
+#       up, no PG creds in env — both are normal first-install states).
+#   2 - Probe failed/timed out. Caller cannot prove safety; should block.
 db_has_existing_data() {
     if [[ "${OSMO_IN_CLUSTER_DB:-false}" == "true" ]]; then
         return 1
@@ -444,15 +447,15 @@ spec:
             return 1
         elif [[ "$phase" == "Failed" ]]; then
             $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
-            return 1
+            return 2
         fi
         sleep 2
         waited=$((waited + 2))
     done
 
-    log_warning "MEK probe pod did not complete within ${max_wait}s (phase=${phase:-unknown}) — proceeding without DB check"
+    log_warning "MEK probe pod did not complete within ${max_wait}s (phase=${phase:-unknown})"
     $RUN_KUBECTL "delete pod $probe_pod --namespace $OSMO_NAMESPACE --ignore-not-found=true" > /dev/null 2>&1 || true
-    return 1
+    return 2
 }
 
 ###############################################################################
@@ -518,7 +521,9 @@ create_secrets() {
             log_warning "RESET_MEK=true — replacing existing MEK. Data encrypted with the previous key will be unreadable."
         else
             # Refuse to mint a new MEK if the DB still has encrypted data from a previous install.
-            if db_has_existing_data; then
+            db_has_existing_data
+            local probe_result=$?
+            if [[ "$probe_result" == "0" ]]; then
                 log_error "MEK ConfigMap 'mek-config' not found in $OSMO_NAMESPACE, but the database '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST already has user tables."
                 log_error "Generating a new MEK now would orphan every encrypted column (service_auth.private_key, workflow secrets, ...). To resolve:"
                 log_error "  - Restore the previous 'mek-config' ConfigMap from backup, OR"
@@ -526,6 +531,11 @@ create_secrets() {
                 log_error "      psql -h $POSTGRES_HOST -U ${POSTGRES_USERNAME} -d postgres \\"
                 log_error "        -c 'DROP DATABASE IF EXISTS ${POSTGRES_DB_NAME:-osmo}; CREATE DATABASE ${POSTGRES_DB_NAME:-osmo};'"
                 log_error "  - Pass RESET_MEK=true to acknowledge data loss and proceed."
+                exit 1
+            elif [[ "$probe_result" == "2" ]]; then
+                log_error "Could not verify whether '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST has existing data (probe pod failed or timed out)."
+                log_error "Refusing to mint a fresh MEK without confirmation — minting against a populated DB silently orphans encrypted columns."
+                log_error "Retry once Postgres connectivity is healthy, or pass RESET_MEK=true to acknowledge data loss and proceed."
                 exit 1
             fi
             log_info "Generating Master Encryption Key (MEK) — first install"

--- a/deployments/scripts/deploy-osmo-minimal.sh
+++ b/deployments/scripts/deploy-osmo-minimal.sh
@@ -867,8 +867,14 @@ main() {
 
         local skip_gpu=0
         [[ "$NO_GPU" == "1" ]] && skip_gpu=1
-        SKIP_GPU="$skip_gpu" OSMO_NAMESPACE="$osmo_ns" \
-            bash "$SCRIPT_DIR/verify.sh" || log_warning "Smoke tests reported failures"
+        if ! SKIP_GPU="$skip_gpu" OSMO_NAMESPACE="$osmo_ns" bash "$SCRIPT_DIR/verify.sh"; then
+            if [[ "${OSMO_TOLERATE_VERIFY_FAILURE:-0}" == "1" ]]; then
+                log_warning "Smoke tests failed but OSMO_TOLERATE_VERIFY_FAILURE=1 — continuing"
+            else
+                log_error "Smoke tests failed. Set OSMO_TOLERATE_VERIFY_FAILURE=1 to continue anyway, or SKIP_VERIFY=1 to skip the phase."
+                exit 1
+            fi
+        fi
 
         # Bring up the UI watchdog too for convenience
         bash "$SCRIPT_DIR/port-forward.sh" --watchdog osmo-ui 3000 "$osmo_ns" || true

--- a/deployments/scripts/storage/common.sh
+++ b/deployments/scripts/storage/common.sh
@@ -36,7 +36,7 @@ create_workflow_cred_secrets() {
             --from-literal=endpoint="$endpoint" \
             --from-literal=region="$region" \
             --from-literal=override_url="$override_url" \
-            "${addressing_style_arg[@]}" \
+            ${addressing_style_arg[@]+"${addressing_style_arg[@]}"} \
             --dry-run=client -o yaml | $KUBECTL apply -f -
     done
 }

--- a/deployments/values/gpu-pool.yaml
+++ b/deployments/values/gpu-pool.yaml
@@ -3,15 +3,13 @@
 #
 # Opt-in fragment that registers a GPU platform on the default OSMO pool.
 # Layered by deploy-osmo-minimal.sh when GPU nodes are detected
-# (`kubectl get nodes -l nvidia.com/gpu=present`).
+# (`kubectl get nodes -l nvidia.com/gpu.present=true`).
 #
-# Replaces the 6.2-era `osmo config update POD_TEMPLATE` + `osmo config update
-# POOL` CLI dance — in 6.3 ConfigMap mode the pool definition lives in values.
-#
-# Taint matches the NVIDIA-standard GPU pool taint set by the TF resources in
-# terraform/{azure,aws}/example/ (`nvidia.com/gpu=present:NoSchedule`). If you
-# customize the taint, override here AND update GPU Operator + NFD + every
-# downstream NVIDIA-stack daemonset's tolerations to match.
+# Toleration matches the taint set by terraform/{azure,aws}/example/
+# (`nvidia.com/gpu=present:NoSchedule`). nodeSelector matches the label set
+# by GPU Operator NFD (`nvidia.com/gpu.present=true`). default_platform=gpu
+# routes workflow pods to GPU nodes — where the NVIDIA container runtime
+# (RuntimeClass `nvidia`) is registered.
 
 services:
   configs:
@@ -24,9 +22,10 @@ services:
               operator: Exists
               effect: NoSchedule
           nodeSelector:
-            nvidia.com/gpu: "present"
+            nvidia.com/gpu.present: "true"
     pools:
       default:
+        default_platform: gpu
         platforms:
           system: {}
           gpu:

--- a/src/cli/pool.py
+++ b/src/cli/pool.py
@@ -78,12 +78,17 @@ def fetch_default_pool(service_client: client.ServiceClient) -> str:
     if default_pool:
         return default_pool
     # No profile default. If the backend exposes exactly one pool, auto-pick it.
-    pool_response = list_pools(service_client)
-    pool_names = {pool['name']
-                  for nodeset in pool_response.get('node_sets', [])
-                  for pool in nodeset.get('pools', [])}
-    if len(pool_names) == 1:
-        return next(iter(pool_names))
+    # Swallow probe errors so the user-facing message stays "no default pool set"
+    # rather than a transport stack trace.
+    try:
+        pool_response = list_pools(service_client)
+        pool_names = {pool['name']
+                      for nodeset in pool_response.get('node_sets', [])
+                      for pool in nodeset.get('pools', [])}
+        if len(pool_names) == 1:
+            return next(iter(pool_names))
+    except Exception:  # pylint: disable=broad-except
+        pass
     raise osmo_errors.OSMOUserError('No default pool set. Set a default pool using '
                                     '"osmo profile set pool <profile_name>" '
                                     'or specify a pool using --pool or -p.')

--- a/src/cli/pool.py
+++ b/src/cli/pool.py
@@ -75,11 +75,18 @@ def setup_parser(parser: argparse._SubParsersAction):
 def fetch_default_pool(service_client: client.ServiceClient) -> str:
     profile_result = service_client.request(client.RequestMethod.GET, 'api/profile/settings')
     default_pool = profile_result.get('profile', {}).get('pool', None)
-    if not default_pool:
-        raise osmo_errors.OSMOUserError('No default pool set. Set a default pool using '
-                                        '"osmo profile set pool <profile_name>" '
-                                        'or specify a pool using --pool or -p.')
-    return default_pool
+    if default_pool:
+        return default_pool
+    # No profile default. If the backend exposes exactly one pool, auto-pick it.
+    pool_response = list_pools(service_client)
+    pool_names = {pool['name']
+                  for nodeset in pool_response.get('node_sets', [])
+                  for pool in nodeset.get('pools', [])}
+    if len(pool_names) == 1:
+        return next(iter(pool_names))
+    raise osmo_errors.OSMOUserError('No default pool set. Set a default pool using '
+                                    '"osmo profile set pool <profile_name>" '
+                                    'or specify a pool using --pool or -p.')
 
 
 def list_pools(service_client: client.ServiceClient,

--- a/src/cli/tests/BUILD
+++ b/src/cli/tests/BUILD
@@ -77,3 +77,13 @@ py_test(
         "//src/cli:cli_lib",
     ]
 )
+
+py_test(
+    name = "test_pool",
+    srcs = [
+        "test_pool.py"
+    ],
+    deps = [
+        "//src/cli:cli_lib",
+    ]
+)

--- a/src/cli/tests/test_pool.py
+++ b/src/cli/tests/test_pool.py
@@ -1,0 +1,88 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+from unittest import mock
+
+from src.cli import pool
+from src.lib.utils import osmo_errors
+
+
+class TestFetchDefaultPool(unittest.TestCase):
+    """fetch_default_pool: profile default wins; otherwise auto-pick the only pool."""
+
+    def _client_with(self, profile_pool, pools_response=None, pools_raises=None):
+        client = mock.MagicMock()
+
+        def request(_method, path, *_args, **_kwargs):
+            if path == 'api/profile/settings':
+                return {'profile': {'pool': profile_pool}}
+            if path == '/api/pool':
+                if pools_raises is not None:
+                    raise pools_raises
+                return pools_response
+            raise AssertionError(f'unexpected path {path}')
+
+        client.request.side_effect = request
+        return client
+
+    def test_profile_default_wins(self):
+        client = self._client_with(profile_pool='my-pool')
+        self.assertEqual(pool.fetch_default_pool(client), 'my-pool')
+
+    def test_auto_pick_single_pool(self):
+        client = self._client_with(
+            profile_pool=None,
+            pools_response={'node_sets': [{'pools': [{'name': 'only-pool'}]}]})
+        self.assertEqual(pool.fetch_default_pool(client), 'only-pool')
+
+    def test_auto_pick_dedupes_across_nodesets(self):
+        client = self._client_with(
+            profile_pool=None,
+            pools_response={'node_sets': [
+                {'pools': [{'name': 'shared'}]},
+                {'pools': [{'name': 'shared'}]},
+            ]})
+        self.assertEqual(pool.fetch_default_pool(client), 'shared')
+
+    def test_multiple_pools_raises(self):
+        client = self._client_with(
+            profile_pool=None,
+            pools_response={'node_sets': [
+                {'pools': [{'name': 'one'}, {'name': 'two'}]},
+            ]})
+        with self.assertRaises(osmo_errors.OSMOUserError):
+            pool.fetch_default_pool(client)
+
+    def test_no_pools_raises(self):
+        client = self._client_with(
+            profile_pool=None,
+            pools_response={'node_sets': []})
+        with self.assertRaises(osmo_errors.OSMOUserError):
+            pool.fetch_default_pool(client)
+
+    def test_list_pools_failure_preserves_user_error(self):
+        client = self._client_with(
+            profile_pool=None,
+            pools_raises=RuntimeError('transport blew up'))
+        with self.assertRaises(osmo_errors.OSMOUserError):
+            pool.fetch_default_pool(client)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Six fixes to make \`deploy-osmo-minimal.sh --provider byo\` work end-to-end on Azure AKS with a managed Postgres/Redis backend. All bugs hit on the same fresh-cluster bring-up; each commit is independently revertable.

Issue #None

### Commits

1. **\`storage/common.sh\`** — guard empty-array expansion under bash 3.2 (macOS default). \`\"\${addressing_style_arg[@]}\"\` errored \`unbound variable\` whenever the backend (azure-blob, gcs, swift) didn't pass an addressing_style. Replaced with the \`\${arr[@]+\"\${arr[@]}\"}\` idiom — no semantic change on bash 4+.

2. **\`deploy-k8s.sh\`** (three things, same file):
   - Remove the dead NGC pull-secret block in \`service_set_flags()\`. The workflow \`init-container\` + \`client\` images at \`\$OSMO_IMAGE_REGISTRY\` are public, so \`backend_images.credential\` is unused. Worse, the unconditional \`secretRefs[0]\` \`--set\` clobbered whatever the storage-values fragment put at index 0 (\`osmo-workflow-data-cred\`) — silently dropping it from the rendered pod spec. osmo-service then crashed with \`Failed to read secret directory /etc/osmo/secrets/osmo-workflow-data-cred\`.
   - Add \`db_has_existing_data()\` probe and use it to guard MEK regeneration. The existing logic preserved \`mek-config\` only when the K8s ConfigMap was present. When the namespace gets deleted but the managed Postgres database persists (common BYO cloud pattern), the script silently minted a fresh MEK against existing encrypted data — orphaning every encrypted column. Result: osmo-service / backend-operator crashed with \`jwcrypto.jwk.InvalidJWKValue\` on \`service_auth.private_key\` read. The probe is fail-closed on probe failure (return 2) so a transient PG outage during deploy doesn't authorize a fresh MEK.
   - Fix GPU detection label selector. GPU Operator NFD labels GPU nodes with \`nvidia.com/gpu.present=true\` (dotted key, boolean value); the previous selector \`nvidia.com/gpu=present\` was the taint shape and matched zero nodes, so \`render_gpu_pool_values\` always skipped the fragment.

3. **\`values/gpu-pool.yaml\`** — fix nodeSelector to use the real label (\`nvidia.com/gpu.present=true\`) and add \`default_platform: gpu\`. Without the latter, default-platform workflow pods land on system nodes that lack the \`nvidia\` RuntimeClass (GPU Operator's container-toolkit DaemonSet only deploys on labeled GPU nodes), failing at sandbox creation with \`no runtime for nvidia is configured\`.

4. **\`deploy-osmo-minimal.sh\`** — \`verify.sh\` failure was swallowed into \`log_warning\`; the script then printed \"OSMO deploy complete\" and exited 0 even when verify-hello CrashLoopBackOff'd. Now exits non-zero on smoke-test failure; opt-out with \`OSMO_TOLERATE_VERIFY_FAILURE=1\` or skip the phase entirely with \`SKIP_VERIFY=1\`.

5. **\`cli/pool.py\`** — \`fetch_default_pool()\` previously required \`osmo profile set pool <name>\` before any pool-dependent command worked. On clusters with exactly one pool (common fresh-deploy state) it now auto-picks. \`list_pools()\` is wrapped in try/except so a transport error during the fallback doesn't replace the user-facing message with a stack trace. New tests in \`src/cli/tests/test_pool.py\`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes (\`src/cli/tests/test_pool.py\` for the CLI fix; deploy-script changes have no unit-test home and were verified by the live BYO/Azure bring-up that produced these fixes).
- [x] The documentation is up to date with these changes (inline help text on smoke-test failure includes the opt-out env vars).

## Test plan

- [x] \`storage/common.sh\` fix: re-ran \`deploy-osmo-minimal.sh --provider byo --storage-backend azure-blob --non-interactive\` on bash 3.2.57 (macOS) — previous \`unbound variable\` abort no longer reproduces.
- [x] Dead NGC block removal: re-ran the deploy; pod spec now mounts all three workflow-cred volumes (data/log/app) instead of dropping data-cred.
- [x] MEK guard: simulated the dangerous case by deleting \`osmo-minimal\` namespace while Postgres persisted; script now aborts with the documented remediation message instead of minting a fresh MEK.
- [x] GPU label fix: \`render_gpu_pool_values\` now detects GPU nodes on AKS with stock GPU Operator NFD labels. \`gpu_toleration\` pod template's nodeSelector matches.
- [x] \`default_platform: gpu\` in gpu-pool.yaml: \`verify-hello\` workflow now schedules on GPU nodes (where the \`nvidia\` RuntimeClass exists) instead of failing with \`no runtime for nvidia is configured\` on system nodes.
- [x] Smoke-test-fail-exit: tested by injecting a failing verify-hello — script now exits 1.
- [x] CLI single-pool auto-pick: ran \`osmo workflow submit\` against a single-pool cluster without setting \`osmo profile set pool\` — submit succeeds; new \`test_pool.py\` covers the 6 cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-deploy safety probe that blocks minting of cluster keys when the database appears populated or probe status is uncertain and required config is missing.
  * Default pool is auto-selected when exactly one pool exists in the backend.

* **Bug Fixes**
  * Corrected GPU node detection to use the updated node label format.
  * Fixed optional argument expansion in secret creation.
  * Simplified image-pull secret handling and related service credential wiring.

* **Tests**
  * Added unit tests covering pool selection and related error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->