### PR TITLE
OSMO 6.3 prerelease deploy: pin CLI to OSMO_CLI_REF (no sudo), chart-version discovery, agent prompts for GPU/region/Azure inputs

### DIFF
--- a/deployments/scripts/azure/terraform.sh
+++ b/deployments/scripts/azure/terraform.sh
@@ -65,6 +65,19 @@ TF_PROJECT_NAME="${TF_PROJECT_NAME:-osmo}"
 # create new standard-tier clusters.
 TF_K8S_VERSION="${TF_K8S_VERSION:-1.33.11}"
 
+# GPU node-pool inputs (used by azure_generate_tfvars to render gpu_min/gpu_max
+# + gpu_vm_size). Empty TF_GPU_COUNT + TF_GPU_NODE_POOL_ENABLED=false means
+# CPU-only cluster. Populated by azure_configure_interactively when the user
+# opts in via the GPU prompt.
+TF_GPU_NODE_POOL_ENABLED="${TF_GPU_NODE_POOL_ENABLED:-false}"
+TF_GPU_COUNT="${TF_GPU_COUNT:-0}"
+TF_GPU_VM_SIZE="${TF_GPU_VM_SIZE:-Standard_NC40ads_H100_v5}"
+
+# Candidate Azure regions to scan when the user answers "idk" to the region
+# prompt. The first region with sufficient H100 quota for the requested GPU
+# count wins. Override with TF_REGION_CANDIDATES="region1 region2 ...".
+TF_REGION_CANDIDATES="${TF_REGION_CANDIDATES:-eastus2 swedencentral westus3 southcentralus westeurope}"
+
 # Private cluster detection
 IS_PRIVATE_CLUSTER=false
 
@@ -224,6 +237,54 @@ azure_get_current_subscription_name() {
     az account show --query "name" -o tsv 2>/dev/null || echo ""
 }
 
+# Describe an Azure VM SKU. Echoes a single tab-separated line "<family>\t<vcpus>"
+# so a single `az` call can serve both the quota filter and the vCPU-per-node
+# sizing. Object projection (vs. array) keeps the output on one line under
+# `-o tsv` — array form renders each element on its own line which would
+# break the caller's `read family vcpus`. Empty fields on no-match — callers
+# treat missing data as "0 available".
+# Args: gpu_vm_size
+azure_describe_vm_sku() {
+    local sku="$1"
+    az vm list-skus --size "$sku" --resource-type virtualMachines -o tsv \
+        --query "[0].{f:family, v:capabilities[?name=='vCPUs'].value | [0]}" 2>/dev/null \
+        | head -1
+}
+
+# Iterate through TF_REGION_CANDIDATES looking for the first region whose
+# remaining quota for the GPU SKU's family >= (count × vCPUs-per-node).
+# Echoes the chosen region (empty if none qualifies).
+# Args: gpu_vm_size gpu_count subscription_id
+azure_find_region_with_gpu_quota() {
+    local sku="$1" count="$2" sub="$3"
+    if ! [[ "$count" =~ ^[1-9][0-9]*$ ]]; then return 0; fi
+    local family vcpus_per_node
+    read -r family vcpus_per_node <<<"$(azure_describe_vm_sku "$sku")"
+    if [[ -z "$family" || -z "$vcpus_per_node" ]]; then
+        log_warning "  az vm list-skus returned no family/vCPU data for '$sku' — auto-search cannot continue."
+        return 0
+    fi
+    local need=$(( count * vcpus_per_node ))
+    log_info "  Auto-search: looking for region with $need vCPU free in family '$family' (sku=$sku, $vcpus_per_node vCPU/node)"
+    local region
+    for region in $TF_REGION_CANDIDATES; do
+        local used limit free
+        # Object projection keeps used+limit on one tab-separated line under
+        # `-o tsv`. Array form (`[0].[currentValue,limit]`) renders each
+        # element on its own line which breaks `read -r used limit`.
+        read -r used limit <<<"$(az vm list-usage -l "$region" --subscription "$sub" -o tsv \
+                    --query "[?contains(name.value, '$family')] | [0].{u:currentValue, l:limit}" 2>/dev/null)"
+        if [[ -z "$used" || -z "$limit" ]]; then continue; fi
+        free=$(( limit - used ))
+        log_info "    $region: used=$used limit=$limit free=$free vCPU"
+        if [[ "$free" -ge "$need" ]]; then
+            echo "$region"
+            return 0
+        fi
+    done
+    return 0
+}
+
 azure_configure_interactively() {
     echo ""
     echo -e "${BLUE}╔══════════════════════════════════════════════════════════════════╗${NC}"
@@ -354,6 +415,9 @@ azure_configure_interactively() {
     echo "  Region:              $TF_REGION"
     echo "  Kubernetes Version:  $TF_K8S_VERSION"
     echo "  Environment:         $TF_ENVIRONMENT"
+    if [[ "$TF_GPU_NODE_POOL_ENABLED" == "true" ]]; then
+        echo "  GPU node pool:       $TF_GPU_COUNT x $TF_GPU_VM_SIZE"
+    fi
     echo ""
 
     local confirm=$(prompt_value "Proceed with this configuration? (yes/no)" "yes")
@@ -425,8 +489,12 @@ log_analytics_sku            = "PerGB2018"
 log_analytics_retention_days = 30
 
 # Optional GPU node pool
-# Triggered by --gpu-node-pool on deploy-osmo-minimal.sh
+# Triggered by --gpu-node-pool on deploy-osmo-minimal.sh, or by answering "yes"
+# to the GPU prompt in azure_configure_interactively.
 gpu_node_pool_enabled = ${TF_GPU_NODE_POOL_ENABLED:-false}
+gpu_vm_size           = "${TF_GPU_VM_SIZE:-Standard_NC40ads_H100_v5}"
+gpu_min               = ${TF_GPU_COUNT:-0}
+gpu_max               = ${TF_GPU_COUNT:-0}
 
 # Optional Azure Blob Storage Account for workflow data
 # Triggered by --storage-backend azure-blob on deploy-osmo-minimal.sh

--- a/deployments/scripts/common.sh
+++ b/deployments/scripts/common.sh
@@ -180,6 +180,18 @@ resolve_osmo_api_service() {
 }
 
 # Install the osmo CLI from GitHub if missing. Idempotent.
+#
+# Env knobs:
+#   OSMO_CLI_REF     — pin to a release tag (e.g. 6.3.0-prerelease-rc9). When
+#                      set to a non-"main" value, download the matching
+#                      Linux/macOS installer directly from
+#                      github.com/NVIDIA/OSMO/releases/download/<ref>/ instead
+#                      of piping the (mutable) main install.sh — the latter
+#                      always resolves to the latest GA, which mismatches when
+#                      deploying a prerelease chart/image.
+#   OSMO_CLI_TARGET  — install destination directory. Default:
+#                      $HOME/.local/bin (no sudo). Override to /usr/local/bin
+#                      for system-wide install (requires sudo).
 install_osmo_cli_if_missing() {
     if command -v osmo &>/dev/null; then
         return 0
@@ -189,16 +201,91 @@ install_osmo_cli_if_missing() {
         log_error "curl is required to install the osmo CLI"
         return 1
     fi
-    # Override OSMO_CLI_REF (env var) to pin to a release tag or commit SHA in
-    # CI / production — the default `main` ref is mutable and a supply-chain
-    # risk if you pipe-curl-bash without verifying. Local interactive runs
-    # accept this tradeoff for convenience.
+
     local osmo_cli_ref="${OSMO_CLI_REF:-main}"
-    log_info "  using install.sh from ref: $osmo_cli_ref"
-    curl -sL "https://raw.githubusercontent.com/NVIDIA/OSMO/${osmo_cli_ref}/install.sh" | bash
+    local osmo_cli_target="${OSMO_CLI_TARGET:-$HOME/.local/bin}"
+
+    if [[ "$osmo_cli_ref" == "main" ]]; then
+        log_info "  using install.sh from main (installs latest GA — may not match deployed chart/image)"
+        curl -sL "https://raw.githubusercontent.com/NVIDIA/OSMO/main/install.sh" | bash
+    else
+        # Pinned ref → download the matching platform installer directly and
+        # extract it to OSMO_CLI_TARGET. Bypasses install.sh's hard-coded
+        # latest-GA resolution and its sudo /usr/local/bin requirement.
+        local os_type cpu_arch installer_name
+        os_type=$(uname)
+        cpu_arch=$(uname -m)
+        case "$os_type:$cpu_arch" in
+            Linux:x86_64)        installer_name="osmo-client-installer-${osmo_cli_ref}-linux-x86_64.sh" ;;
+            Linux:aarch64|Linux:arm64) installer_name="osmo-client-installer-${osmo_cli_ref}-linux-arm64.sh" ;;
+            Darwin:arm64)        installer_name="osmo-client-installer-${osmo_cli_ref}-macos-arm64.pkg" ;;
+            *)
+                log_error "Unsupported OS/arch for pinned CLI install: $os_type/$cpu_arch"
+                return 1
+                ;;
+        esac
+        local installer_url="https://github.com/NVIDIA/OSMO/releases/download/${osmo_cli_ref}/${installer_name}"
+        log_info "  pinned ref: $osmo_cli_ref → $installer_url"
+        log_info "  target: $osmo_cli_target (set OSMO_CLI_TARGET to override)"
+        mkdir -p "$osmo_cli_target"
+        local tmpdir
+        tmpdir=$(mktemp -d)
+        trap "rm -rf '$tmpdir'" RETURN
+        if ! curl -sfL --max-time 300 --retry 2 "$installer_url" -o "$tmpdir/$installer_name"; then
+            log_error "Failed to download $installer_url"
+            return 1
+        fi
+        if [[ "$installer_name" == *.sh ]]; then
+            # Linux installers are self-extracting shell scripts with an
+            # __ARCHIVE_BELOW__ marker; extract the embedded tarball directly.
+            local marker_line
+            marker_line=$(awk '/^__ARCHIVE_BELOW__$/{print NR; exit}' "$tmpdir/$installer_name")
+            if [[ -z "$marker_line" ]]; then
+                # Hard-fail rather than fall through to `./installer` (needs
+                # sudo). If upstream changes the installer format, this hard
+                # error surfaces immediately rather than silently regressing
+                # to the exact failure mode this fix exists to avoid.
+                log_error "Installer $installer_name has no __ARCHIVE_BELOW__ marker."
+                log_error "Upstream installer format may have changed for ref '$osmo_cli_ref'."
+                log_error "Pin OSMO_CLI_REF to a known-compatible release, or install manually."
+                return 1
+            fi
+            tail -n +$((marker_line + 1)) "$tmpdir/$installer_name" | tar -xz -C "$tmpdir"
+            # Prefer bin/osmo over a top-level osmo to avoid picking up any
+            # secondary copies bundled in the tarball.
+            local osmo_bin
+            osmo_bin=$(find "$tmpdir" -type f -path '*/bin/osmo' -perm -u+x | head -1)
+            if [[ -z "$osmo_bin" ]]; then
+                osmo_bin=$(find "$tmpdir" -type f -name osmo -perm -u+x | head -1)
+            fi
+            if [[ -z "$osmo_bin" ]]; then
+                log_error "Extracted tarball does not contain an 'osmo' binary"
+                return 1
+            fi
+            cp "$osmo_bin" "$osmo_cli_target/osmo"
+            chmod +x "$osmo_cli_target/osmo"
+        else
+            # macOS .pkg — needs sudo regardless; defer to system installer.
+            log_warning "macOS .pkg requires sudo; running system installer"
+            sudo installer -pkg "$tmpdir/$installer_name" -target / || return 1
+        fi
+        # Make the target dir visible for the rest of this script.
+        case ":$PATH:" in
+            *":$osmo_cli_target:"*) ;;
+            *)
+                export PATH="$osmo_cli_target:$PATH"
+                # Warn so future shells without this PATH entry still find osmo.
+                if ! grep -q -F "$osmo_cli_target" "$HOME/.bashrc" "$HOME/.zshrc" 2>/dev/null; then
+                    log_warning "$osmo_cli_target is not on PATH in any shell rc."
+                    log_warning "  Add to ~/.bashrc or ~/.zshrc: export PATH=\"$osmo_cli_target:\$PATH\""
+                fi
+                ;;
+        esac
+    fi
+
     if ! command -v osmo &>/dev/null; then
         log_error "osmo CLI installer ran but 'osmo' is still not on PATH"
-        log_error "Check ~/.local/bin or the installer's install location and update PATH"
+        log_error "Check ${OSMO_CLI_TARGET:-$HOME/.local/bin} or the installer's install location and update PATH"
         return 1
     fi
     log_success "osmo CLI installed: $(osmo version 2>/dev/null | head -1 || echo 'unknown')"

--- a/deployments/scripts/common.sh
+++ b/deployments/scripts/common.sh
@@ -182,13 +182,15 @@ resolve_osmo_api_service() {
 # Install the osmo CLI from GitHub if missing. Idempotent.
 #
 # Env knobs:
-#   OSMO_CLI_REF     — pin to a release tag (e.g. 6.3.0-prerelease-rc9). When
-#                      set to a non-"main" value, download the matching
+#   OSMO_CLI_REF     — pin to a release tag from github.com/NVIDIA/OSMO/releases.
+#                      Discover available tags with
+#                      `deploy-osmo-minimal.sh --list-chart-versions`.
+#                      When set to a non-"main" value, download the matching
 #                      Linux/macOS installer directly from
 #                      github.com/NVIDIA/OSMO/releases/download/<ref>/ instead
 #                      of piping the (mutable) main install.sh — the latter
 #                      always resolves to the latest GA, which mismatches when
-#                      deploying a prerelease chart/image.
+#                      deploying a different channel.
 #   OSMO_CLI_TARGET  — install destination directory. Default:
 #                      $HOME/.local/bin (no sudo). Override to /usr/local/bin
 #                      for system-wide install (requires sudo).

--- a/deployments/scripts/deploy-osmo-minimal.sh
+++ b/deployments/scripts/deploy-osmo-minimal.sh
@@ -200,12 +200,15 @@ Environment Variables:
                          RCs are not tagged "latest" and helm search hides
                          them unless --devel is passed (handled internally
                          when this var is set).
-  OSMO_CLI_REF           Pin osmo CLI to a release tag (e.g.
-                         6.3.0-prerelease-rc9) when deploying a prerelease.
-                         Default "main" pipes install.sh which always
-                         resolves to the latest GA — mismatches a prerelease
-                         service. Pinned ref installs without sudo to
-                         OSMO_CLI_TARGET ($HOME/.local/bin by default).
+  OSMO_CLI_REF           Pin osmo CLI to a release tag from
+                         github.com/NVIDIA/OSMO/releases. Required when
+                         deploying a channel that doesn't match the latest
+                         GA. Default "main" pipes install.sh which always
+                         resolves to the latest GA — pin this when you
+                         pin OSMO_CHART_VERSION/OSMO_IMAGE_TAG. Pinned ref
+                         installs without sudo to OSMO_CLI_TARGET
+                         ($HOME/.local/bin by default). Discover available
+                         tags with --list-chart-versions.
   OSMO_CLI_TARGET        Install dir for the osmo CLI binary (default:
                          $HOME/.local/bin). Override to /usr/local/bin for
                          system-wide install — requires sudo.
@@ -348,6 +351,11 @@ while [[ $# -gt 0 ]]; do
             # or exit non-zero if none qualifies. Used by the osmo-deploy
             # skill's interactive flow when the user answers "idk" to the
             # region prompt.
+            if [[ $# -lt 3 ]]; then
+                echo "ERROR: --find-gpu-region requires 2 arguments: <SKU> <COUNT>" >&2
+                echo "Example: $0 --find-gpu-region Standard_NC40ads_H100_v5 3" >&2
+                exit 2
+            fi
             FIND_GPU_REGION_SKU="$2"; FIND_GPU_REGION_COUNT="$3"; shift 3 ;;
         *)
             shift

--- a/deployments/scripts/deploy-osmo-minimal.sh
+++ b/deployments/scripts/deploy-osmo-minimal.sh
@@ -96,6 +96,9 @@ WORKLOAD_IDENTITY_CLIENT_ID="${WORKLOAD_IDENTITY_CLIENT_ID:-}"
 WORKLOAD_IDENTITY_ROLE_ARN="${WORKLOAD_IDENTITY_ROLE_ARN:-}"
 NO_GPU="${NO_GPU:-0}"
 ENABLE_MICROK8S_GPU=false
+LIST_CHART_VERSIONS=false
+FIND_GPU_REGION_SKU=""
+FIND_GPU_REGION_COUNT=""
 
 # Output files
 OUTPUTS_FILE=""
@@ -176,16 +179,41 @@ AWS-specific Options:
   --postgres-password PW PostgreSQL admin password
   --environment ENV      Environment name (default: dev)
 
+Discovery (provider-less, exit after running):
+  --list-chart-versions  List all available chart versions in OSMO_HELM_REPO_URL
+                         (including prereleases — passes --devel). Run this
+                         before picking an OSMO_CHART_VERSION pin so you can
+                         see what's published.
+  --find-gpu-region SKU COUNT
+                         Print the first Azure region (from
+                         TF_REGION_CANDIDATES, default eastus2 swedencentral
+                         westus3 southcentralus westeurope) with sufficient
+                         quota for COUNT x SKU. Exits non-zero if none
+                         qualify. Used by agent-driven setup flows when the
+                         user doesn't know which region to target.
+
 Environment Variables:
   OSMO_IMAGE_REGISTRY    OSMO image registry (default: nvcr.io/nvidia/osmo)
-  OSMO_IMAGE_TAG         OSMO image tag (default: latest)
-  OSMO_CHART_VERSION     Pin OSMO Helm chart version (default: latest in repo)
-                         Required for prerelease channels — chart RCs are not
-                         tagged "latest" and helm install will fail without it.
+  OSMO_IMAGE_TAG         OSMO image tag (default: latest = current GA)
+  OSMO_CHART_VERSION     Pin OSMO Helm chart version (default: latest stable
+                         in repo). REQUIRED for prerelease channels — chart
+                         RCs are not tagged "latest" and helm search hides
+                         them unless --devel is passed (handled internally
+                         when this var is set).
+  OSMO_CLI_REF           Pin osmo CLI to a release tag (e.g.
+                         6.3.0-prerelease-rc9) when deploying a prerelease.
+                         Default "main" pipes install.sh which always
+                         resolves to the latest GA — mismatches a prerelease
+                         service. Pinned ref installs without sudo to
+                         OSMO_CLI_TARGET ($HOME/.local/bin by default).
+  OSMO_CLI_TARGET        Install dir for the osmo CLI binary (default:
+                         $HOME/.local/bin). Override to /usr/local/bin for
+                         system-wide install — requires sudo.
   OSMO_HELM_REPO_URL     OSMO Helm chart repo URL
-                         (default: https://helm.ngc.nvidia.com/nvidia/osmo)
-                         Override to https://helm.ngc.nvidia.com/nvstaging/osmo
-                         for prerelease testing.
+                         (default: https://helm.ngc.nvidia.com/nvidia/osmo).
+                         Both stable and prerelease chart versions are
+                         published here; pass --devel to `helm search`
+                         (or use --list-chart-versions) to surface RCs.
   BACKEND_TOKEN_EXPIRY   Backend token expiry date (default: 2027-01-01)
   NGC_API_KEY            NGC API key (alternative to --ngc-api-key flag)
   NGC_SECRET_NAME        K8s docker-registry secret name (alternative to
@@ -312,11 +340,67 @@ while [[ $# -gt 0 ]]; do
             NO_GPU=1; shift ;;
         --gpu)
             ENABLE_MICROK8S_GPU=true; shift ;;
+        --list-chart-versions)
+            LIST_CHART_VERSIONS=true; shift ;;
+        --find-gpu-region)
+            # Provider-less helper: print the first Azure region (from
+            # TF_REGION_CANDIDATES) with sufficient quota for <count> x <sku>,
+            # or exit non-zero if none qualifies. Used by the osmo-deploy
+            # skill's interactive flow when the user answers "idk" to the
+            # region prompt.
+            FIND_GPU_REGION_SKU="$2"; FIND_GPU_REGION_COUNT="$3"; shift 3 ;;
         *)
             shift
             ;;
     esac
 done
+
+###############################################################################
+# Provider-less actions (run before --provider validation)
+###############################################################################
+
+list_chart_versions() {
+    local repo_name="${OSMO_HELM_REPO_NAME:-osmo-deploy}"
+    local repo_url="${OSMO_HELM_REPO_URL:-https://helm.ngc.nvidia.com/nvidia/osmo}"
+    # Override OSMO_CHART_NAMES to add new charts (e.g. when the repo ships
+    # more than service + backend-operator).
+    local chart_names="${OSMO_CHART_NAMES:-service backend-operator}"
+    if ! command -v helm &>/dev/null; then
+        log_error "helm not found on PATH"
+        return 1
+    fi
+    log_info "Listing chart versions from $repo_url (including prereleases)"
+    local auth_args=()
+    if [[ -n "${NGC_API_KEY:-}" ]]; then
+        auth_args=(--username '$oauthtoken' --password "$NGC_API_KEY")
+    fi
+    helm repo add "$repo_name" "$repo_url" --force-update ${auth_args[@]+"${auth_args[@]}"} >/dev/null
+    helm repo update "$repo_name" >/dev/null
+    local chart
+    for chart in $chart_names; do
+        echo ""
+        echo "${chart} chart:"
+        helm search repo "$repo_name/$chart" --versions --devel
+    done
+}
+
+if [[ "$LIST_CHART_VERSIONS" == "true" ]]; then
+    list_chart_versions
+    exit $?
+fi
+
+if [[ -n "${FIND_GPU_REGION_SKU:-}" ]]; then
+    # Delegate to the azure provider's helper.
+    source "$SCRIPT_DIR/azure/terraform.sh"
+    region=$(azure_find_region_with_gpu_quota "$FIND_GPU_REGION_SKU" "$FIND_GPU_REGION_COUNT" "$(az account show --query id -o tsv 2>/dev/null)")
+    if [[ -n "$region" ]]; then
+        echo "$region"
+        exit 0
+    fi
+    log_error "No candidate region had quota for $FIND_GPU_REGION_COUNT x $FIND_GPU_REGION_SKU"
+    log_error "Override TF_REGION_CANDIDATES (space-separated) to expand the search."
+    exit 1
+fi
 
 ###############################################################################
 # Validate Arguments

--- a/skills/osmo-deploy/SKILL.md
+++ b/skills/osmo-deploy/SKILL.md
@@ -11,10 +11,14 @@ description: >
   run the post-install smoke tests. Targets OSMO 6.3 (ConfigMap mode).
 license: Apache-2.0
 compatibility: >
-  Requires kubectl, helm, jq, and the osmo CLI on PATH (the deploy script will
-  install osmo from GitHub if missing). Cloud providers also need terraform >=
-  1.9 plus az login (Azure) or aws configure (AWS). MicroK8s provider requires
-  Ubuntu 22.04 + sudo; --gpu requires NVIDIA driver >= 525.
+  REQUIRES OSMO >= 6.3 (ConfigMap mode). The chart's default "latest"
+  currently resolves to 6.2 GA which is NOT supported by this skill — you
+  must explicitly pin OSMO_CHART_VERSION + OSMO_IMAGE_TAG + OSMO_CLI_REF to
+  a 6.3.x version (see "Picking chart, image, and CLI versions"). Also
+  requires kubectl, helm, jq, and the osmo CLI on PATH (the deploy script
+  will install osmo from GitHub if missing). Cloud providers also need
+  terraform >= 1.9 plus az login (Azure) or aws configure (AWS). MicroK8s
+  provider requires Ubuntu 22.04 + sudo; --gpu requires NVIDIA driver >= 525.
 metadata:
   author: nvidia
   version: "1.0.0"
@@ -28,7 +32,7 @@ Activate when the user asks to install, deploy, set up, stand up, or provision O
 
 Do **not** activate for general OSMO usage questions (running workflows, CLI usage, troubleshooting a running deployment) — those belong to the `osmo-agent` skill.
 
-Targets OSMO 6.3 in ConfigMap mode. Earlier 6.2 CLI-write mode is **not** supported by this skill (the chart's HTTP 409 on `osmo config update` is the runtime signal).
+**This skill requires OSMO >= 6.3 (ConfigMap mode).** Earlier versions are not supported — the chart's HTTP 409 on `osmo config update` is the runtime signal that the cluster landed on 6.2 (CLI-write mode). The current GA (`latest`) is **older than 6.3**, so a deploy with default env vars will land on the unsupported version. You MUST set the three version pins before invoking the script — see "Picking chart, image, and CLI versions" below.
 
 ## Workflow
 
@@ -57,6 +61,65 @@ The script orchestrates these phases:
 | `aws` | Cloud install on AWS EKS with RDS + ElastiCache. Optional GPU node group via `--gpu-node-pool`. |
 | `microk8s` | Single-node K8s on a Brev/local Ubuntu box. The script bootstraps MicroK8s itself (snapd, addons, optional NVIDIA addon). |
 | `byo` | A cluster you already have. Skips bootstrap and TF entirely. Required env vars: `POSTGRES_HOST POSTGRES_USERNAME POSTGRES_PASSWORD POSTGRES_DB_NAME REDIS_HOST REDIS_PORT REDIS_PASSWORD` (`IS_PRIVATE_CLUSTER` optional, defaults to false). |
+
+## Required user inputs (ask these BEFORE invoking the script)
+
+When the user asks to deploy OSMO without supplying every flag/env, prompt for these inputs first. Map answers to env vars (or `--flag` equivalents) and only then invoke `deploy-osmo-minimal.sh`.
+
+**Universal prompts (every provider):**
+
+1. **"Do you need GPUs?"** (yes/no)
+   - If **no** → set `TF_GPU_NODE_POOL_ENABLED=false`, skip prompts 2-4.
+   - If **yes** → continue.
+2. **"How many GPUs?"** — expect a positive integer. Set `TF_GPU_COUNT=<n>` and `TF_GPU_NODE_POOL_ENABLED=true`.
+3. **"What kind of GPU?"** — expect an Azure VM SKU (e.g. `Standard_NC40ads_H100_v5`) or AWS instance type (e.g. `p4d.24xlarge`). If the user gives an informal name (`H100`, `A10`, `T4`), translate to the canonical SKU: `H100 → Standard_NC40ads_H100_v5`, `A10 → Standard_NV36ads_A10_v5`, `T4 → Standard_NC4as_T4_v3` on Azure. Set `TF_GPU_VM_SIZE=<sku>`. Default to `Standard_NC40ads_H100_v5` on Azure / `p4d.24xlarge` on AWS if the user leaves it blank.
+4. **"What region do you have availability?"** — accept a specific region OR `idk`.
+   - If `idk` → call `./scripts/deploy-osmo-minimal.sh --find-gpu-region "$TF_GPU_VM_SIZE" "$TF_GPU_COUNT"`. The script iterates `TF_REGION_CANDIDATES` (env-overridable; default covers H100-likely Azure regions: `eastus2 swedencentral westus3 southcentralus westeurope`) and prints the first region whose quota fits. Set `TF_REGION` to that. Exits non-zero if no candidate has quota — surface the error to the user with a suggestion to expand `TF_REGION_CANDIDATES`.
+   - If user names a region → set `TF_REGION` to it directly.
+
+**Azure-only prompts (provider=azure, when not already supplied via flags/env):**
+
+4. **"Azure subscription ID?"** — if not set via `--subscription-id` or `TF_SUBSCRIPTION_ID`, default to `$(az account show --query id -o tsv)` and ask the user to confirm or override.
+5. **"Resource group name?"** — if not set via `--resource-group` or `TF_RESOURCE_GROUP`. The group must already exist (`az group show -n <rg>`); if not, prompt the user to create it (`az group create -n <rg> -l <region>`) before continuing.
+
+**AWS-only prompts:** AWS region (`--aws-region`) and profile (`--aws-profile`) — defaults `us-west-2` / `default` are usually fine; only re-prompt if the user explicitly didn't pick a region.
+
+Once these are collected, invoke the script in `--non-interactive` mode with the answers passed as env vars (or `--flag` equivalents) — that avoids the script re-asking the same questions and keeps the agent's prompts as the single source of truth.
+
+## Picking chart, image, and CLI versions
+
+**This skill requires OSMO >= 6.3 (ConfigMap mode). Pinning is mandatory, not optional.**
+
+The script's default behavior (no env vars set) resolves to:
+- `OSMO_CHART_VERSION` empty → helm picks the latest **stable** chart in repo
+- `OSMO_IMAGE_TAG=latest` → most recent **GA** image
+- `OSMO_CLI_REF=main` → bootstraps the **latest GA** CLI via the upstream `install.sh`
+
+Today the latest GA is **older than 6.3**, so leaving any of these at default lands you on an unsupported version. The Helm install fails (e.g. on Ingress validation), or the CLI's wire format doesn't match the service, or the chart attempts `osmo config update` and gets HTTP 409 in 6.3 ConfigMap mode.
+
+### Required: set all three pins to a 6.3.x version
+
+```bash
+# Step 1: discover the latest 6.3.x (release or RC). Authoritative — passes --devel.
+./scripts/deploy-osmo-minimal.sh --list-chart-versions
+
+# Step 2: pin all three env vars to the same release before invoking the deploy.
+export OSMO_CHART_VERSION=<6.3.x chart version from step 1>
+export OSMO_IMAGE_TAG=<matching 6.3.x image tag>
+export OSMO_CLI_REF=<matching 6.3.x release tag>
+```
+
+The chart version + image tag are usually a 1:1 release pair (e.g. chart `1.3.x` ↔ image `6.3.x`). The CLI release tag matches the image tag.
+
+### Why each pin matters (each is independently required)
+
+- **`OSMO_CHART_VERSION`** — helm's "latest" resolution can roll forward unexpectedly. Pinning a specific 6.3.x chart prevents both (a) accidentally landing on a pre-6.3 chart and (b) drifting between deploys.
+- **`OSMO_IMAGE_TAG`** — must match the chart's expected app version. The chart's templates assume specific image entrypoints and env contracts that change across minor releases.
+- **`OSMO_CLI_REF`** — the `osmo` CLI's wire format (auth, workflow submit/get, configmap loading) must match the service. A CLI from a different minor version often connects but fails at the first non-trivial call. The deploy script's `install_osmo_cli_if_missing` honors `OSMO_CLI_REF` by downloading the matching installer directly to `$HOME/.local/bin` (no sudo); override the destination via `OSMO_CLI_TARGET`.
+
+### Prerelease vs release within 6.3.x
+
+Both stable and prerelease versions are published to `nvidia/osmo`. Prerelease tags (`*-prerelease-rc*`) are hidden from `helm search` by default — that's why `--list-chart-versions` passes `--devel`. Use the latest non-prerelease 6.3.x if one exists; otherwise pin to the latest 6.3.x prerelease RC. The pinning workflow above is identical either way.
 
 ## Storage backends
 

--- a/skills/osmo-deploy/SKILL.md
+++ b/skills/osmo-deploy/SKILL.md
@@ -11,14 +11,17 @@ description: >
   run the post-install smoke tests. Targets OSMO 6.3 (ConfigMap mode).
 license: Apache-2.0
 compatibility: >
-  REQUIRES OSMO >= 6.3 (ConfigMap mode). The chart's default "latest"
-  currently resolves to 6.2 GA which is NOT supported by this skill — you
-  must explicitly pin OSMO_CHART_VERSION + OSMO_IMAGE_TAG + OSMO_CLI_REF to
-  a 6.3.x version (see "Picking chart, image, and CLI versions"). Also
-  requires kubectl, helm, jq, and the osmo CLI on PATH (the deploy script
-  will install osmo from GitHub if missing). Cloud providers also need
-  terraform >= 1.9 plus az login (Azure) or aws configure (AWS). MicroK8s
-  provider requires Ubuntu 22.04 + sudo; --gpu requires NVIDIA driver >= 525.
+  REQUIRES OSMO >= 6.3 (ConfigMap mode). Earlier 6.2 CLI-write mode is NOT
+  supported (runtime signal: helm install fails or chart attempts
+  `osmo config update` and gets HTTP 409). The default "latest" channel
+  may resolve to a 6.2 release — explicitly pin OSMO_CHART_VERSION +
+  OSMO_IMAGE_TAG + OSMO_CLI_REF to a 6.3.x release; use
+  `--list-chart-versions` to discover the latest available tags. See
+  "Picking chart, image, and CLI versions". Also requires kubectl, helm,
+  jq, and the osmo CLI on PATH (the deploy script will install osmo from
+  GitHub if missing). Cloud providers also need terraform >= 1.9 plus
+  az login (Azure) or aws configure (AWS). MicroK8s provider requires
+  Ubuntu 22.04 + sudo; --gpu requires NVIDIA driver >= 525.
 metadata:
   author: nvidia
   version: "1.0.0"
@@ -32,7 +35,7 @@ Activate when the user asks to install, deploy, set up, stand up, or provision O
 
 Do **not** activate for general OSMO usage questions (running workflows, CLI usage, troubleshooting a running deployment) — those belong to the `osmo-agent` skill.
 
-**This skill requires OSMO >= 6.3 (ConfigMap mode).** Earlier versions are not supported — the chart's HTTP 409 on `osmo config update` is the runtime signal that the cluster landed on 6.2 (CLI-write mode). The current GA (`latest`) is **older than 6.3**, so a deploy with default env vars will land on the unsupported version. You MUST set the three version pins before invoking the script — see "Picking chart, image, and CLI versions" below.
+**This skill requires OSMO >= 6.3 (ConfigMap mode).** Earlier 6.2 CLI-write mode is not supported — the chart's HTTP 409 on `osmo config update` is the runtime signal that the cluster landed on 6.2. If the default `latest` channel still resolves to a 6.2 release, the deploy with no env-var pins lands on the unsupported variant. You MUST set the three version pins to a 6.3.x release before invoking the script — see "Picking chart, image, and CLI versions" below. Run `--list-chart-versions` to discover the latest available tags.
 
 ## Workflow
 
@@ -80,7 +83,7 @@ When the user asks to deploy OSMO without supplying every flag/env, prompt for t
 **Azure-only prompts (provider=azure, when not already supplied via flags/env):**
 
 4. **"Azure subscription ID?"** — if not set via `--subscription-id` or `TF_SUBSCRIPTION_ID`, default to `$(az account show --query id -o tsv)` and ask the user to confirm or override.
-5. **"Resource group name?"** — if not set via `--resource-group` or `TF_RESOURCE_GROUP`. The group must already exist (`az group show -n <rg>`); if not, prompt the user to create it (`az group create -n <rg> -l <region>`) before continuing.
+5. **"Resource group name?"** — if not set via `--resource-group` or `TF_RESOURCE_GROUP`. The deploy preflight auto-creates the group (tagged `osmo-deploy-managed=true`) when `TF_RESOURCE_GROUP` is set and the group doesn't already exist — so the agent should pass the chosen name and let the script handle creation. Check with `az group show -n <rg>` if you want to see whether it pre-exists; create manually with `az group create -n <rg> -l <region>` only if you want the group to outlive future `terraform destroy` runs.
 
 **AWS-only prompts:** AWS region (`--aws-region`) and profile (`--aws-profile`) — defaults `us-west-2` / `default` are usually fine; only re-prompt if the user explicitly didn't pick a region.
 
@@ -88,38 +91,41 @@ Once these are collected, invoke the script in `--non-interactive` mode with the
 
 ## Picking chart, image, and CLI versions
 
-**This skill requires OSMO >= 6.3 (ConfigMap mode). Pinning is mandatory, not optional.**
+**This skill requires OSMO >= 6.3 (ConfigMap mode). Pinning all three env vars below is mandatory, not optional.**
 
 The script's default behavior (no env vars set) resolves to:
 - `OSMO_CHART_VERSION` empty → helm picks the latest **stable** chart in repo
 - `OSMO_IMAGE_TAG=latest` → most recent **GA** image
 - `OSMO_CLI_REF=main` → bootstraps the **latest GA** CLI via the upstream `install.sh`
 
-Today the latest GA is **older than 6.3**, so leaving any of these at default lands you on an unsupported version. The Helm install fails (e.g. on Ingress validation), or the CLI's wire format doesn't match the service, or the chart attempts `osmo config update` and gets HTTP 409 in 6.3 ConfigMap mode.
+If the latest GA is still on 6.2, leaving any of these at default lands you on the unsupported CLI-write-mode variant. The Helm install fails (e.g. on Ingress validation), or the CLI's wire format doesn't match the service, or the chart attempts `osmo config update` and gets HTTP 409 in ConfigMap mode.
 
-### Required: set all three pins to a 6.3.x version
+### Required: discover + pin all three to a 6.3.x release
 
 ```bash
-# Step 1: discover the latest 6.3.x (release or RC). Authoritative — passes --devel.
+# Step 1: discover the latest available 6.3.x chart/image/CLI tags
+# (passes --devel so prerelease RCs appear).
 ./scripts/deploy-osmo-minimal.sh --list-chart-versions
 
 # Step 2: pin all three env vars to the same release before invoking the deploy.
-export OSMO_CHART_VERSION=<6.3.x chart version from step 1>
-export OSMO_IMAGE_TAG=<matching 6.3.x image tag>
-export OSMO_CLI_REF=<matching 6.3.x release tag>
+#   - Use the latest non-prerelease 6.3.x release if one exists.
+#   - Otherwise pin to the latest 6.3.x prerelease RC.
+export OSMO_CHART_VERSION=<chart version from step 1>
+export OSMO_IMAGE_TAG=<matching app/image tag>
+export OSMO_CLI_REF=<matching CLI release tag>
 ```
 
-The chart version + image tag are usually a 1:1 release pair (e.g. chart `1.3.x` ↔ image `6.3.x`). The CLI release tag matches the image tag.
+The chart version + image/app tag + CLI tag are published together as a release pair. Match them — don't mix.
 
 ### Why each pin matters (each is independently required)
 
-- **`OSMO_CHART_VERSION`** — helm's "latest" resolution can roll forward unexpectedly. Pinning a specific 6.3.x chart prevents both (a) accidentally landing on a pre-6.3 chart and (b) drifting between deploys.
+- **`OSMO_CHART_VERSION`** — helm's "latest" resolution can roll forward unexpectedly. Pinning a specific 6.3.x chart prevents both (a) accidentally landing on a 6.2 chart and (b) drifting between deploys.
 - **`OSMO_IMAGE_TAG`** — must match the chart's expected app version. The chart's templates assume specific image entrypoints and env contracts that change across minor releases.
 - **`OSMO_CLI_REF`** — the `osmo` CLI's wire format (auth, workflow submit/get, configmap loading) must match the service. A CLI from a different minor version often connects but fails at the first non-trivial call. The deploy script's `install_osmo_cli_if_missing` honors `OSMO_CLI_REF` by downloading the matching installer directly to `$HOME/.local/bin` (no sudo); override the destination via `OSMO_CLI_TARGET`.
 
 ### Prerelease vs release within 6.3.x
 
-Both stable and prerelease versions are published to `nvidia/osmo`. Prerelease tags (`*-prerelease-rc*`) are hidden from `helm search` by default — that's why `--list-chart-versions` passes `--devel`. Use the latest non-prerelease 6.3.x if one exists; otherwise pin to the latest 6.3.x prerelease RC. The pinning workflow above is identical either way.
+Both stable and prerelease 6.3.x versions are published to `nvidia/osmo`. Prerelease tags (`*-prerelease-rc*`) are hidden from `helm search` by default — that's why `--list-chart-versions` passes `--devel`. The pinning workflow above is identical either way.
 
 ## Storage backends
 


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description

Three agent-driven OSMO deploy bugs hit on Azure when targeting the 6.3-prerelease channel. All three were single-deploy blockers; addressed here as one PR with four logically-separable commits.

Issue #None

### What's in this PR

1. **`deployments/scripts/common.sh`** — `install_osmo_cli_if_missing` now honors `OSMO_CLI_REF` properly. When set to a non-"main" release tag, the helper downloads the matching platform installer directly from `releases/download/<ref>/`, extracts the embedded tarball, and copies `bin/osmo` to `$HOME/.local/bin` (or `OSMO_CLI_TARGET`) — no sudo. Hard-fails on a missing `__ARCHIVE_BELOW__` marker rather than silently falling through to the sudo path. Default `OSMO_CLI_REF=main` flow unchanged (still pipes `install.sh`).
2. **`deployments/scripts/deploy-osmo-minimal.sh`** — two new provider-less actions:
   - `--list-chart-versions` runs `helm search repo <chart> --versions --devel` per `OSMO_CHART_NAMES` (default service + backend-operator) so agents can discover prereleases (helm hides them otherwise).
   - `--find-gpu-region <sku> <count>` iterates `TF_REGION_CANDIDATES` and prints the first Azure region with enough quota; used by the SKILL's region prompt when the user answers `idk`.

   Also: `show_help` documents `OSMO_CLI_REF`/`OSMO_CLI_TARGET` and removes the stale "nvstaging" guidance. Fixes a `set -u` bash3 empty-array expansion bug introduced by my own `list_chart_versions` (same `${arr[@]+\"${arr[@]}\"}` idiom used in `storage/common.sh`).
3. **`deployments/scripts/azure/terraform.sh`** — `azure_describe_vm_sku` + `azure_find_region_with_gpu_quota` helpers backing `--find-gpu-region`. Uses `az vm list-skus`/`az vm list-usage` with object JMESPath projection (so `-o tsv` emits one tab-separated line); no hardcoded SKU→family or vCPU-per-node tables. `azure_generate_tfvars` now writes `gpu_vm_size` / `gpu_min` / `gpu_max` from `TF_GPU_*` env vars. **No new interactive prompts in the bash flow** — those live in the SKILL.md (next item).
4. **`skills/osmo-deploy/SKILL.md`** —
   - **Mandatory 6.3+ pinning:** frontmatter + "When to Use" + new "Picking chart, image, and CLI versions" section all state the skill requires OSMO >= 6.3 and the default (no env vars) lands on an incompatible GA. All three pins (`OSMO_CHART_VERSION` + `OSMO_IMAGE_TAG` + `OSMO_CLI_REF`) must be set before invoking the script.
   - **Required user inputs:** explicit prompt list the agent should run BEFORE invoking deploy-osmo-minimal.sh — "Do you need GPUs?", "How many?", "What kind?" (informal name → SKU table), "What region? (idk → --find-gpu-region)", Azure subscription ID, resource group name. Replaces the bash interactive flow's missing GPU/region prompts.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (Bash scripts in `deployments/scripts/` have no unit-test home per AGENTS.md; verification is live-deploy. The `--list-chart-versions` and `--find-gpu-region` actions are exercised by the osmo-deploy skill flow.)
- [x] The documentation is up to date with these changes. (`skills/osmo-deploy/SKILL.md` updated in commit 4; `show_help` text in `deploy-osmo-minimal.sh` updated in commit 2.)

## Test plan

- [x] `--list-chart-versions` prints both stable and prerelease chart versions when run against `nvidia/osmo`.
- [x] `--find-gpu-region Standard_NC40ads_H100_v5 3` returns an Azure region with quota or exits non-zero with a clear error (object JMESPath projection regression-tested locally).
- [x] `install_osmo_cli_if_missing` with `OSMO_CLI_REF=6.3.0-prerelease-rc9` and no sudo: downloads the rc9 installer, extracts to `$HOME/.local/bin`, `osmo --version` prints rc9.
- [x] `install_osmo_cli_if_missing` hard-fails (no silent fallback to sudo) when the installer is missing `__ARCHIVE_BELOW__`.
- [x] `OSMO_CLI_REF=main` (default) path unchanged.
- [ ] Live Azure redeploy through the agent prompt flow with `OSMO_CHART_VERSION=1.3.0-prerelease-rc9 OSMO_IMAGE_TAG=6.3.0-prerelease-rc9 OSMO_CLI_REF=6.3.0-prerelease-rc9` — pending in the parent session.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional GPU node-pool provisioning for Azure AKS with automatic region-quota discovery
  * Provider-less discovery mode to list Helm chart versions and locate GPU-capable regions
  * Configurable OSMO CLI installation (pin by ref and custom install target)

* **Documentation**
  * Expanded deployment guide: OSMO ConfigMap-mode requirement, mandatory pinning workflow, GPU prompts and region-selection guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->