### PR TITLE
Upgrade urllib3 to 2.7.0

### DIFF
--- a/src/locked_requirements.txt
+++ b/src/locked_requirements.txt
@@ -1107,10 +1107,11 @@ tzdata==2026.1 \
     --hash=sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9 \
     --hash=sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98
     # via kombu
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
+    #   -r requirements.txt
     #   botocore
     #   kubernetes
     #   requests

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -47,6 +47,7 @@ pyjwt==2.12.0
 
 # Requests
 requests==2.32.4
+urllib3==2.7.0
 
 # Jinja
 jinja2==3.1.6

--- a/src/tests/locked_requirements.txt
+++ b/src/tests/locked_requirements.txt
@@ -196,10 +196,11 @@ typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
     # via testcontainers
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
+    #   -r requirements.txt
     #   docker
     #   requests
     #   testcontainers

--- a/src/tests/requirements.txt
+++ b/src/tests/requirements.txt
@@ -22,3 +22,4 @@
 bcrypt==4.2.1
 httpx==0.28.1
 testcontainers==4.13.2
+urllib3==2.7.0


### PR DESCRIPTION
## Description
Pin urllib3 directly to 2.7.0 in runtime and test requirements, then refresh the generated lockfiles with the new hashes. This addresses the urllib3 advisory at https://github.com/advisories/GHSA-mf9v-mfxr-j63j.

Issue - None

## Verification
- Regenerated `src/locked_requirements.txt` from `src/requirements.txt` with `pip-compile --allow-unsafe --generate-hashes --output-file=locked_requirements.txt ./requirements.txt`.
- Regenerated `src/tests/locked_requirements.txt` from `src/tests/requirements.txt` with `pip-compile --allow-unsafe --generate-hashes --output-file=locked_requirements.txt ./requirements.txt`.
- Ran `git diff --check`.
- Bazel tests were not run locally because this checkout requires Bazel 8.5.1, which is missing from the installed Bazel wrapper path.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.