### PR TITLE
fix(operator): classify kubelet `OutOf*` admission rejection as `FAILED_BACKEND_ERROR`

### DIFF
--- a/src/operator/backend_listener.py
+++ b/src/operator/backend_listener.py
@@ -975,6 +975,28 @@ def calculate_pod_status(pod: Any) -> Tuple[task.TaskGroupStatus, str, Optional[
         # e.g. GPU drops
         status = task.TaskGroupStatus.FAILED_BACKEND_ERROR
         exit_code = task.ExitCode.FAILED_BACKEND_ERROR.value
+    elif (
+        (pod.status.reason and pod.status.reason.startswith('OutOf'))
+        or (
+            pod.status.message
+            and "Node didn't have enough resource" in pod.status.message
+        )
+    ):
+        # The kubelet admit predicates rejected the pod after the scheduler had
+        # already bound it to a node, because the node's actual available
+        # resources were insufficient at admit time (the scheduler decided
+        # against a slightly stale snapshot). Kubernetes sets ``reason`` to
+        # one of ``OutOfcpu`` / ``OutOfmemory`` / ``OutOfephemeral-storage`` /
+        # ``OutOf<extended-resource>`` (for example ``OutOfnvidia.com/gpu``)
+        # and writes ``"Pod was rejected: Node didn't have enough resource:
+        # <resource>, requested: ..., used: ..., capacity: ..."`` into
+        # ``pod.status.message``. The message-substring fallback also catches
+        # K8s variants that may not populate ``reason`` consistently.
+        # Semantically this matches ``UnexpectedAdmissionError`` (admission-
+        # time backend failure that the workload owner cannot fix) and is
+        # best handled by rescheduling the task onto a different node.
+        status = task.TaskGroupStatus.FAILED_BACKEND_ERROR
+        exit_code = task.ExitCode.FAILED_BACKEND_ERROR.value
     else:
         # Check if the pod conditions indicate a failure
         failure_found, failure_status, failure_exit_code = check_failure_pod_conditions(pod)

--- a/src/operator/tests/test_calculate_pod_status_cases.json
+++ b/src/operator/tests/test_calculate_pod_status_cases.json
@@ -429,6 +429,58 @@
       }
     },
     {
+      "name": "test_out_of_cpu_admission_rejection",
+      "description": "Pod rejected by kubelet at admit time because the node ran out of CPU (typical OutOfcpu pattern emitted by kubelet predicates).",
+      "input": {
+        "phase": "Failed",
+        "reason": "OutOfcpu",
+        "message": "Pod was rejected: Node didn't have enough resource: cpu, requested: 9000, used: 118020, capacity: 127000"
+      },
+      "expected": {
+        "status": "FAILED_BACKEND_ERROR",
+        "exit_code": 3001
+      }
+    },
+    {
+      "name": "test_out_of_memory_admission_rejection",
+      "description": "Pod rejected by kubelet at admit time because the node ran out of memory.",
+      "input": {
+        "phase": "Failed",
+        "reason": "OutOfmemory",
+        "message": "Pod was rejected: Node didn't have enough resource: memory, requested: 65000000000, used: 980000000000, capacity: 1037488000000"
+      },
+      "expected": {
+        "status": "FAILED_BACKEND_ERROR",
+        "exit_code": 3001
+      }
+    },
+    {
+      "name": "test_out_of_extended_resource_admission_rejection",
+      "description": "Pod rejected by kubelet at admit time because the node ran out of an extended resource (e.g., GPU).",
+      "input": {
+        "phase": "Failed",
+        "reason": "OutOfnvidia.com/gpu",
+        "message": "Pod was rejected: Node didn't have enough resource: nvidia.com/gpu, requested: 1, used: 8, capacity: 8"
+      },
+      "expected": {
+        "status": "FAILED_BACKEND_ERROR",
+        "exit_code": 3001
+      }
+    },
+    {
+      "name": "test_node_resource_rejection_message_only",
+      "description": "Pod rejected by kubelet with the 'Node didn't have enough resource' message but no structured reason field. Exercises the message-substring fallback.",
+      "input": {
+        "phase": "Failed",
+        "reason": null,
+        "message": "Pod was rejected: Node didn't have enough resource: cpu, requested: 9000, used: 118020, capacity: 127000"
+      },
+      "expected": {
+        "status": "FAILED_BACKEND_ERROR",
+        "exit_code": 3001
+      }
+    },
+    {
       "name": "test_disruption_target_condition",
       "description": "Pod with DisruptionTarget condition",
       "input": {


### PR DESCRIPTION
## Summary

When the kubelet rejects a pod **after** the scheduler has bound it to a
node — because the node's actual available resources turn out to be
insufficient at admit time — Kubernetes sets:

- `pod.status.reason` to one of the `OutOf*` family:
  - `OutOfcpu`, `OutOfmemory`, `OutOfephemeral-storage`
  - `OutOf<extended-resource>` (e.g. `OutOfnvidia.com/gpu`)
- `pod.status.message` to
  `"Pod was rejected: Node didn't have enough resource: <resource>, requested: ..., used: ..., capacity: ..."`

Today `calculate_pod_status` has no branch for this case, so it falls
through to the generic fallback and reports `exit_code = 4000
FAILED_UNKNOWN`. This is semantically identical to the existing
`UnexpectedAdmissionError` branch (an admission-time backend failure
the workload owner cannot fix), and the user-facing docs in
[`workflows/lifecycle/index.rst`](../docs/user_guide/workflows/lifecycle/index.rst)
already list `FAILED_BACKEND_ERROR` as a recommended `RESCHEDULE`
target. Routing both through `3001 FAILED_BACKEND_ERROR` lets pool
admins whitelist this transient class with the existing
`default_exit_actions` mechanism.

## What this PR does

- **`src/operator/backend_listener.py`**: add an `elif` branch in
  `calculate_pod_status` that fires when either
  - `pod.status.reason` starts with `OutOf`, or
  - `pod.status.message` contains
    `"Node didn't have enough resource"` (defensive fallback if a K8s
    version doesn't populate `reason` consistently).
  
  The branch sets `status = FAILED_BACKEND_ERROR`,
  `exit_code = FAILED_BACKEND_ERROR.value`.

- **`src/operator/tests/test_calculate_pod_status_cases.json`**: add
  four new JSON-driven test cases:
  - `test_out_of_cpu_admission_rejection`
  - `test_out_of_memory_admission_rejection`
  - `test_out_of_extended_resource_admission_rejection`
  - `test_node_resource_rejection_message_only` (exercises the
    message-substring fallback)

No other call sites or behaviors are touched.

## Why `FAILED_BACKEND_ERROR` rather than `FAILED_START_ERROR`?

We considered both:

| | `3003 FAILED_START_ERROR` | `3001 FAILED_BACKEND_ERROR` |
|---|---|---|
| Semantic fit | "Task failed to start execution" — the task never ran | "Backend error" — admission/cluster failure |
| OSMO precedent (`UnexpectedAdmissionError`) | not this | **this** |
| Listed in [user_guide/workflows/lifecycle/index.rst](../docs/user_guide/workflows/lifecycle/index.rst) under `RESCHEDULE` recommendations | no | **yes** |

Picked `FAILED_BACKEND_ERROR` to stay consistent with the existing
`UnexpectedAdmissionError` branch and the published RESCHEDULE guidance.

## Test plan

- **JSON fixture**: the four new entries follow the existing
  `test_calculate_pod_status_cases.json` format; the dynamic loader in
  `test_pod_status_calculator.py` picks them up automatically. CI runs
  them via `bazel test //src/operator/tests:test_pod_status_calculator`.
- **Local smoke test** (Bazel-free reproducer, shipped separately):
  - Part 1: positive cases (`OutOfcpu`, `OutOfmemory`,
    `OutOfnvidia.com/gpu`, the message-only fallback) and 7 regression
    guards (`Evicted` / `StartError` / `UnexpectedAdmissionError` /
    `None` / `""` / `Failed`+unrelated-message / Failed-but-no-message).
    **11 / 11 cases pass.**
  - Part 2 — **mathematical non-regression proof**: the smoke test
    iterates the entire `test_calculate_pod_status_cases.json`
    fixture and asserts the new branch's predicate evaluates `False`
    for every pre-existing case. Result:
    **0 / 35 pre-existing cases match the new predicate** → because
    this PR's only behavioral change is the addition of the new
    `elif` block (no existing branch is touched), the patch is
    provably non-regressive against the full upstream test fixture.

## Why the reason strings are canonical (not inferred)

The `pod.status.reason = "OutOfcpu" | "OutOfmemory" |
"OutOfephemeral-storage" | "OutOfpods" | "OutOf<extended-resource>"`
values come directly from kubelet upstream:

- **Constants** —
  [`pkg/kubelet/lifecycle/predicate.go` lines ~81–88](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/lifecycle/predicate.go#L81-L88):
  ```go
  InsufficientResourcePrefix = "OutOf"
  OutOfCPU              = "OutOfcpu"
  OutOfMemory           = "OutOfmemory"
  OutOfEphemeralStorage = "OutOfephemeral-storage"
  OutOfPods             = "OutOfpods"
  ```
- **Extended-resource branch** — same file, the
  `default` arm of the resource switch produces
  `fmt.Sprintf("%s%s", InsufficientResourcePrefix, re.ResourceName)`,
  e.g. `"OutOfnvidia.com/gpu"`.
- **Reason / Message propagation** —
  [`pkg/kubelet/kubelet.go::rejectPod`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet.go)
  ```go
  kl.statusManager.SetPodStatus(logger, pod, v1.PodStatus{
      Phase:   v1.PodFailed,
      Reason:  reason,
      Message: "Pod was rejected: " + message,
  })
  ```

So both detection paths in this patch (`reason.startswith('OutOf')`
and message contains `"Node didn't have enough resource"`) are
guaranteed by kubelet upstream rather than inferred from a single
field observation.

## Repro reference

Hit in the field on
[GR00T nightly metrics job `324186911`](https://gitlab-master.nvidia.com/gr00t-release/Isaac-GR00T/-/jobs/324186911):
19 sim tasks failed with `exit_code: 4000` and
`failure_message: "Pod was rejected: Node didn't have enough resource: cpu, requested: 9000, used: 118020, capacity: 127000"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pod failure detection to correctly classify resource exhaustion errors (out-of-CPU, out-of-memory, GPU unavailable).
  * System now accurately identifies and reports when pods fail due to insufficient cluster resources with specific error codes for improved troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->