### PR TITLE
fix(azure example): bring tfvars + README up to date (Managed Redis SKU + supported k8s version)

### DIFF
--- a/deployments/terraform/azure/example/README.md
+++ b/deployments/terraform/azure/example/README.md
@@ -80,9 +80,7 @@ All resources are deployed in the same VNet and properly networked together.
 | `aks_dns_service_ip` | Kubernetes DNS service IP | `192.168.0.10` | Must be within service CIDR |
 | `node_instance_type` | AKS node VM size | `Standard_D2s_v3` | `Standard_D4s_v3+` |
 | `postgres_sku_name` | PostgreSQL SKU | `GP_Standard_D2s_v3` | `GP_Standard_D4s_v3+` |
-| `redis_sku_name` | Redis SKU | `Standard` | Basic, Standard, or Premium |
-| `redis_family` | Redis family | `C` | C for Basic/Standard, P for Premium |
-| `redis_capacity` | Redis capacity | `1` | 0-6 for C family, 1-5 for P family |
+| `redis_sku_name` | Azure Managed Redis SKU | `Balanced_B0` | `Balanced_B*` / `ComputeOptimized_X*` / `MemoryOptimized_M*` / `FlashOptimized_A*` |
 
 ### Security Considerations
 

--- a/deployments/terraform/azure/example/README.md
+++ b/deployments/terraform/azure/example/README.md
@@ -80,7 +80,7 @@ All resources are deployed in the same VNet and properly networked together.
 | `aks_dns_service_ip` | Kubernetes DNS service IP | `192.168.0.10` | Must be within service CIDR |
 | `node_instance_type` | AKS node VM size | `Standard_D2s_v3` | `Standard_D4s_v3+` |
 | `postgres_sku_name` | PostgreSQL SKU | `GP_Standard_D2s_v3` | `GP_Standard_D4s_v3+` |
-| `redis_sku_name` | Azure Managed Redis SKU | `Balanced_B0` | `Balanced_B*` / `ComputeOptimized_X*` / `MemoryOptimized_M*` / `FlashOptimized_A*` |
+| `redis_sku_name` | Azure Managed Redis SKU | `ComputeOptimized_X3` | `Balanced_B*` / `ComputeOptimized_X*` / `MemoryOptimized_M*` / `FlashOptimized_A*` (X3 is the validated default; `Balanced_B0/B1/B3` have hit AllocationFailed in busy regions) |
 
 ### Security Considerations
 

--- a/deployments/terraform/azure/example/README.md
+++ b/deployments/terraform/azure/example/README.md
@@ -6,7 +6,7 @@ This Terraform configuration creates a complete Azure infrastructure using Azure
 - **Virtual Network (VNet)** with private and database subnets using Azure Verified Module
 - **AKS cluster** with auto-scaling node pools and Container Insights monitoring
 - **PostgreSQL Flexible Server** in private subnets with delegation
-- **Azure Cache for Redis** (Standard tier)
+- **Azure Managed Redis** (Redis 7+, `ComputeOptimized_X3` default)
 - **Log Analytics Workspace** with Container Insights solution for AKS monitoring
 
 All resources are deployed in the same VNet and properly networked together.
@@ -180,13 +180,13 @@ This configuration uses the following components:
 ### Development Environment
 - Use `Standard_D2s_v3` for AKS nodes
 - Use `GP_Standard_D2s_v3` for PostgreSQL
-- Use `Standard` Redis with capacity 1 (C1)
+- Use `ComputeOptimized_X3` Managed Redis (the validated default — see `variables.tf` for why `Balanced_B0/B1/B3` are not recommended despite being nominally cheaper)
 - Set `node_group_desired_size = 1`
 
 ### Production Environment
 - Use larger VM sizes (`Standard_D4s_v3+`, `GP_Standard_D4s_v3+`)
 - Enable geo-redundant backup for PostgreSQL
-- Use `Premium` Redis (P family) with higher capacity
+- Bump Managed Redis to `MemoryOptimized_M*` or larger `ComputeOptimized_X*` for higher throughput / RAM
 - Scale node pools based on workload
 - Enable availability zones
 

--- a/deployments/terraform/azure/example/terraform.tfvars.example
+++ b/deployments/terraform/azure/example/terraform.tfvars.example
@@ -41,10 +41,13 @@ postgres_backup_retention_days        = 7
 postgres_geo_redundant_backup_enabled = false  # Set to true for production
 postgres_extensions                   = ["hstore", "uuid-ossp", "pg_stat_statements"]  # Extensions to enable
 
-# Redis Cache Configuration
-redis_sku_name = "Standard"  # Basic, Standard, or Premium
-redis_family   = "C"         # C for Basic/Standard, P for Premium
-redis_capacity = 1           # 0-6 for C family, 1-5 for P family
+# Redis Configuration
+# Azure Managed Redis SKU. OSMO requires Redis 7+, which on Azure is only
+# available via azurerm_managed_redis (classic azurerm_redis_cache caps at
+# Redis 6; azurerm_redis_enterprise_cluster is retired). Valid SKU
+# families: Balanced_B*, ComputeOptimized_X*, MemoryOptimized_M*,
+# FlashOptimized_A*. Balanced_B0 is the smallest tier — bump up for prod.
+redis_sku_name = "Balanced_B0"
 
 # Log Analytics Configuration
 log_analytics_sku            = "PerGB2018"  # Standard pricing tier

--- a/deployments/terraform/azure/example/terraform.tfvars.example
+++ b/deployments/terraform/azure/example/terraform.tfvars.example
@@ -18,7 +18,10 @@ database_subnets = ["10.0.201.0/24", "10.0.202.0/24"]
 availability_zones = ["1", "2"]
 
 # AKS Configuration
-kubernetes_version              = "1.31.1"
+# Azure rolls AKS-supported Kubernetes versions forward and prunes older
+# ones — if `terraform apply` errors with "version not found", check
+# `az aks get-versions -l <region> -o table` for the current GA list.
+kubernetes_version              = "1.33.11"
 node_instance_type             = "Standard_D2s_v3"  # Use Standard_D4s_v3 or higher for production
 node_group_min_size            = 1
 node_group_max_size            = 5

--- a/deployments/terraform/azure/example/terraform.tfvars.example
+++ b/deployments/terraform/azure/example/terraform.tfvars.example
@@ -49,8 +49,10 @@ postgres_extensions                   = ["hstore", "uuid-ossp", "pg_stat_stateme
 # available via azurerm_managed_redis (classic azurerm_redis_cache caps at
 # Redis 6; azurerm_redis_enterprise_cluster is retired). Valid SKU
 # families: Balanced_B*, ComputeOptimized_X*, MemoryOptimized_M*,
-# FlashOptimized_A*. Balanced_B0 is the smallest tier — bump up for prod.
-redis_sku_name = "Balanced_B0"
+# FlashOptimized_A*. ComputeOptimized_X3 is the validated default — see
+# variables.tf for the empirical-allocation rationale; Balanced_B0/B1/B3
+# have hit AllocationFailed in capacity-constrained regions.
+redis_sku_name = "ComputeOptimized_X3"
 
 # Log Analytics Configuration
 log_analytics_sku            = "PerGB2018"  # Standard pricing tier

--- a/deployments/terraform/azure/example/variables.tf
+++ b/deployments/terraform/azure/example/variables.tf
@@ -83,9 +83,9 @@ variable "availability_zones" {
 
 # AKS Variables
 variable "kubernetes_version" {
-  description = "Kubernetes version"
+  description = "Kubernetes version. Azure rolls AKS-supported versions forward and prunes older ones; if apply fails with 'version not found' check `az aks get-versions -l <region>` for the current GA list."
   type        = string
-  default     = "1.31.1"
+  default     = "1.33.11"
 }
 
 variable "node_instance_type" {


### PR DESCRIPTION
## Description

Stale-default catch-up in `deployments/terraform/azure/example/`. Anyone copying `terraform.tfvars.example` verbatim today gets:

- `redis_sku_name = "Standard"` → validator regex rejection (classic-Redis tier; the module now uses `azurerm_managed_redis`).
- `redis_family = "C"` + `redis_capacity = 1` → two `undeclared input variable` warnings (variables were never declared after the switch to Managed Redis).
- `kubernetes_version = "1.31.1"` → no longer in Azure's regional GA list (`az aks get-versions` returns a moving window of supported versions and prunes old ones).

The module already uses `azurerm_managed_redis` and validates `redis_sku_name` against the Managed Redis SKU regex `^(Balanced_B|ComputeOptimized_X|MemoryOptimized_M|FlashOptimized_A)[0-9]+$` (see `variables.tf:233-235`). The example file and README just hadn't caught up.

### Changes by commit

- `9a30e57` — Redis schema. `terraform.tfvars.example`: `redis_sku_name = "Standard"` → `"Balanced_B0"`, drop `redis_family` + `redis_capacity`. `README.md`: variable reference table consolidated from 3 stale rows into 1 accurate row.
- `ac26813` — Kubernetes version bump. Both `terraform.tfvars.example` and the `variables.tf` default: `1.31.1` → `1.33.11` (validated working on a real AKS deploy 2026-05-21). Comment added pointing at `az aks get-versions -l <region> -o table` as source-of-truth for when this goes stale again.
- `609bd0ab1` — Per CodeRabbit + `variables.tf:222-227` empirical-allocation note: Redis SKU default `Balanced_B0` → `ComputeOptimized_X3`. The B0/B1/B3 tier hit `AllocationFailed` on `eastus2` 2026-05-01; X3/M10/A250 allocated cleanly. X3 is also what `variables.tf` already defaults to — the example was the only place steering new users toward B0.
- `42c8b80c7` — Per reviewer follow-up: two README prose spots also had classic-Redis terminology that the first commit missed:
  - Line 9 (Architecture overview): "Azure Cache for Redis (Standard tier)" → "Azure Managed Redis (Redis 7+, `ComputeOptimized_X3` default)"
  - Lines 181-189 (Cost Optimization dev/prod tiers): replaced `Standard ... C1` / `Premium (P family)` with Managed Redis families. Dev now recommends `ComputeOptimized_X3` (the validated default), not `Balanced_B0`.

### Scope

Pure docs/defaults catch-up. No TF module or code changes. The live `variables.tf` validators already encode the correct constraints; this PR just brings the example file + README in line with what those validators actually accept.

Net diff: ~14 LOC across 3 files (4 commits).

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes. _(N/A — docs/defaults only. The `variables.tf` validators already cover the schema; the bug was that the example + README contradicted them. Validator behavior verified locally against `eastus2`: `GP_Standard_D2s_v3` Postgres SKU and `ComputeOptimized_X3` Redis SKU both pass; the prior `Standard` value still hits the validator correctly.)_
- [x] The documentation is up to date with these changes. _(This PR **is** the doc update.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)