### PR TITLE
fix(deploy): key GPU pool detection on the TF label, not NFD's

### DIFF
--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -875,7 +875,7 @@ extra_values_flags() {
 # was passed via NO_GPU=0 + force). Replaces the 6.2-era `osmo config update`
 # CLI dance — in 6.3 ConfigMap mode the pool definition lives in Helm values.
 #
-# To force-enable on a cluster without the gpu.present label, set
+# To force-enable on a cluster without the `nvidia.com/gpu=present` label, set
 # OSMO_GPU_POOL_ENABLED=true. To force-disable, set NO_GPU=1.
 render_gpu_pool_values() {
     GPU_POOL_VALUES_FILE=""
@@ -886,8 +886,12 @@ render_gpu_pool_values() {
 
     local force="${OSMO_GPU_POOL_ENABLED:-auto}"
     local detected="false"
-    # GPU Operator NFD labels GPU nodes with `nvidia.com/gpu.present=true`.
-    if [ "$($RUN_KUBECTL "get nodes -l nvidia.com/gpu.present=true --no-headers" 2>/dev/null | wc -l)" -gt 0 ]; then
+    # terraform/{azure,aws}/example/ labels GPU nodes with `nvidia.com/gpu=present`
+    # at provisioning time. Keying on the TF-provided label (rather than NFD's
+    # `nvidia.com/gpu.present=true`, which only appears after the GPU Operator
+    # finishes installing) means gpu-pool.yaml is layered as soon as the GPU
+    # node pool exists.
+    if [ "$($RUN_KUBECTL "get nodes -l nvidia.com/gpu=present --no-headers" 2>/dev/null | wc -l)" -gt 0 ]; then
         detected="true"
     fi
 

--- a/deployments/terraform/aws/example/example.tf
+++ b/deployments/terraform/aws/example/example.tf
@@ -139,8 +139,10 @@ module "eks" {
       }
     },
     # Optional GPU node group (gated on var.gpu_node_pool_enabled).
-    # Tainted with sku=gpu:NoSchedule so non-GPU pods don't schedule here;
-    # deploy-k8s.sh detects GPU nodes and renders a matching toleration.
+    # Labeled `nvidia.com/gpu=present` and tainted `nvidia.com/gpu=present:NoSchedule`
+    # (see `labels` / `taints` below) so non-GPU pods don't schedule here.
+    # deploy-k8s.sh detects the label and renders a matching nodeSelector +
+    # toleration into Helm values for the OSMO pool.
     var.gpu_node_pool_enabled ? {
       gpu = {
         name = "${local.name}-gpu"

--- a/deployments/terraform/azure/example/example.tf
+++ b/deployments/terraform/azure/example/example.tf
@@ -260,8 +260,8 @@ resource "azurerm_kubernetes_cluster" "main" {
 #
 # Adds a separate AKS node pool with `sku=gpu:NoSchedule` taint so non-GPU
 # workloads don't schedule there. deploy-k8s.sh detects nodes labeled
-# `nvidia.com/gpu.present` (set by the NVIDIA GPU Operator's device plugin)
-# and renders a matching toleration into Helm values for the OSMO pool.
+# `nvidia.com/gpu=present` (set below via `node_labels`) and renders a matching
+# nodeSelector + toleration into Helm values for the OSMO pool.
 ################################################################################
 
 resource "azurerm_kubernetes_cluster_node_pool" "gpu" {

--- a/deployments/values/gpu-pool.yaml
+++ b/deployments/values/gpu-pool.yaml
@@ -3,13 +3,19 @@
 #
 # Opt-in fragment that registers a GPU platform on the default OSMO pool.
 # Layered by deploy-osmo-minimal.sh when GPU nodes are detected
-# (`kubectl get nodes -l nvidia.com/gpu.present=true`).
+# (`kubectl get nodes -l nvidia.com/gpu=present`).
 #
-# Toleration matches the taint set by terraform/{azure,aws}/example/
-# (`nvidia.com/gpu=present:NoSchedule`). nodeSelector matches the label set
-# by GPU Operator NFD (`nvidia.com/gpu.present=true`). default_platform=gpu
-# routes workflow pods to GPU nodes — where the NVIDIA container runtime
-# (RuntimeClass `nvidia`) is registered.
+# Both the toleration and the nodeSelector key on the taint+label set by
+# terraform/{azure,aws}/example/ on the GPU node pool itself:
+#   taint:  nvidia.com/gpu=present:NoSchedule
+#   label:  nvidia.com/gpu=present
+# Using the TF-provided label (rather than NFD's `nvidia.com/gpu.present=true`,
+# which only appears after the GPU Operator finishes installing) avoids a race
+# where workflow pods are submitted before NFD has labelled the node and stay
+# stuck in scheduling. BYO clusters whose GPU nodes use a different label
+# should override `nodeSelector` here via a deployment-specific values file.
+# default_platform=gpu routes workflow pods to GPU nodes — where the NVIDIA
+# container runtime (RuntimeClass `nvidia`) is registered.
 
 services:
   configs:
@@ -22,7 +28,7 @@ services:
               operator: Exists
               effect: NoSchedule
           nodeSelector:
-            nvidia.com/gpu.present: "true"
+            nvidia.com/gpu: "present"
     pools:
       default:
         default_platform: gpu


### PR DESCRIPTION
## Description

Workflow pods stay stuck in `SCHEDULING` on a freshly-deployed cluster because [`gpu-pool.yaml`](deployments/values/gpu-pool.yaml) and [`deploy-k8s.sh:render_gpu_pool_values`](deployments/scripts/deploy-k8s.sh) key on the NFD-set `nvidia.com/gpu.present=true`, which only appears after the NVIDIA GPU Operator finishes installing. `deploy-osmo-minimal.sh` installs KAI + GPU Operator + OSMO and then submits `verify-gpu` in sequence — but NFD's labelling is async and can lag, so the smoke test gets submitted before the GPU node carries the label and sits stuck (no node matches its nodeSelector).

Switch both the detection check and the workflow-pod `nodeSelector` to `nvidia.com/gpu=present`, which `terraform/{azure,aws}/example/` already puts on the GPU node pool at provisioning time. No NFD timing dependency.

| Label | Set by | Available when |
|---|---|---|
| `nvidia.com/gpu=present` | TF `node_labels` on the GPU pool | Node creation (immediate) |
| `nvidia.com/gpu.present=true` | NFD DaemonSet (shipped with GPU Operator) | After GPU Operator install + NFD reconcile |

The pod toleration (`key: nvidia.com/gpu, operator: Exists, effect: NoSchedule`) already matches the TF-set taint `nvidia.com/gpu=present:NoSchedule` and is unchanged.

Also rewrites the stale comment in [`aws/example/example.tf`](deployments/terraform/aws/example/example.tf) that still referenced the old `sku=gpu:NoSchedule` taint (the resource hasn't used that key in some time).

### BYO behaviour change

BYO clusters whose GPU nodes use a different label (e.g. AKS Console default of `accelerator=nvidia`) will now silently skip GPU pool layering. The previous NFD label would also have failed there if GPU Operator wasn't installed, so this isn't a strict regression — but the contract shifts slightly toward "OSMO TF-style labelling required." `gpu-pool.yaml` carries an inline note telling BYO operators to override `nodeSelector` via a values file or to label their nodes `nvidia.com/gpu=present`. A follow-up could add an explicit `log_warning` in `render_gpu_pool_values` when GPUs are advertised on the cluster but no node carries the expected label.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved GPU node pool configuration documentation across AWS and Azure deployments

* **Chores**
  * Standardized GPU node detection and scheduling configuration across deployments for consistent behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->