### PR TITLE
deploy-minimal: harden deployment and verification script

### DIFF
--- a/deployments/scripts/README.md
+++ b/deployments/scripts/README.md
@@ -322,6 +322,8 @@ Pre-create the IAM role with the OSMO service-account trust, then:
 | `OSMO_HELM_REPO_URL` | OSMO Helm chart repo URL. Override to `https://helm.ngc.nvidia.com/nvstaging/osmo` for prerelease testing. | `https://helm.ngc.nvidia.com/nvidia/osmo` |
 | `OSMO_HELM_REPO_NAME` | Local helm repo alias | `osmo` |
 | `BACKEND_TOKEN_EXPIRY` | Backend operator token expiry | `2027-01-01` |
+| `OSMO_REACHABILITY_PATH` | Lightweight unauthenticated path used by `verify.sh` for the pre-login reachability probe | `/api/version` |
+| `OSMO_REACHABILITY_TIMEOUT_SECONDS` | Curl timeout for the `verify.sh` reachability probe | `5` |
 | `NGC_API_KEY` | NGC API key for `nvcr.io` images and chart pulls | — |
 | `AZURE_ENDPOINT_SUFFIX` | Azure Storage endpoint suffix (sovereign clouds) | `core.windows.net` |
 | `TF_SUBSCRIPTION_ID` | Azure subscription ID | — |

--- a/deployments/scripts/README.md
+++ b/deployments/scripts/README.md
@@ -206,7 +206,7 @@ Each is idempotent — safe to invoke on a cluster where the target component al
 | `install-gpu-operator.sh` | NVIDIA GPU Operator (drivers + container toolkit) | microk8s `nvidia` addon, helm release in any ns, `clusterpolicies.nvidia.com` CR (covers NVAIE), or `nvidia-device-plugin` DaemonSet |
 | `install-minio.sh` | Bitnami MinIO chart | microk8s `minio` addon or existing `minio` service in `minio-operator` ns |
 | `configure-storage.sh` | 6.3 storage wiring: K8s Secrets + helm values fragment for `services.configs.workflow.workflow_*.credential.secretName`. Dispatcher → `storage/{minio,azure-blob,s3,byo}.sh`. | n/a — backend chosen via `--backend` |
-| `port-forward.sh` | One-shot or `--watchdog` PF, tagged `osmo-pf-watchdog:<svc>` for cleanup with `pkill -f 'osmo-pf-watchdog:'` | Reuses live PF if context+namespace match |
+| `port-forward.sh` | One-shot or `--watchdog` PF, tagged `osmo-pf-watchdog:<svc>` for cleanup with `pkill -f 'osmo-pf-watchdog:'`. Watchdog readiness waits up to `OSMO_PF_HEALTH_TIMEOUT_SECONDS` (default 300). | Reuses live PF if context+namespace match |
 | `verify.sh` | Submits `workflows/verify-hello.yaml` + `verify-gpu.yaml`; polls until terminal state, dumps logs on failure. `SKIP_GPU=1` to skip GPU test. | n/a |
 
 ### `microk8s/install.sh`
@@ -375,7 +375,7 @@ osmo workflow submit ../workflows/verify-hello.yaml
 osmo workflow list
 ```
 
-To stop the watchdogs: `pkill -f 'osmo-pf-watchdog:'`. They're restarted by re-running `deploy-osmo-minimal.sh`.
+To stop the watchdogs: `pkill -f 'osmo-pf-watchdog:'`. They're restarted by re-running `deploy-osmo-minimal.sh`, which also replaces stale watchdogs on the same local port.
 
 ## Troubleshooting
 

--- a/deployments/scripts/port-forward.sh
+++ b/deployments/scripts/port-forward.sh
@@ -49,26 +49,44 @@ PORT="${2:?usage: $0 [--watchdog] <svc> <port> [namespace]}"
 NS="${3:-osmo-minimal}"
 TARGET_PORT="${TARGET_PORT:-80}"
 URL="http://localhost:${PORT}"
+WATCHDOG_HEALTH_TIMEOUT_SECONDS="${OSMO_PF_HEALTH_TIMEOUT_SECONDS:-300}"
 
 KUBECTL="${KUBECTL:-kubectl}"
 
 WATCHDOG_TAG="osmo-pf-watchdog:${SVC}"
 PGREP_ONESHOT="${KUBECTL} port-forward svc/${SVC} ${PORT}:.* -n ${NS}"
+PGREP_WATCHDOG_PORT_FORWARD="port-forward svc/[^ ]+ ${PORT}:.* -n ${NS}"
+
+kill_processes_matching() {
+    local pattern="$1"
+    local pid
+    local current_bash_pid="${BASHPID:-}"
+    while read -r pid; do
+        [[ -n "$pid" ]] || continue
+        [[ "$pid" != "$$" && "$pid" != "$current_bash_pid" ]] || continue
+        kill "$pid" 2>/dev/null || true
+    done < <(pgrep -f "$pattern" 2>/dev/null || true)
+}
+
+stop_watchdog_port_forwards_on_port() {
+    # A re-run may resolve a different service name for the same local API port
+    # (for example osmo-service before osmo-gateway appears). Replace by local
+    # port, not just watchdog tag, so stale watchdogs cannot race for :9000.
+    kill_processes_matching "$PGREP_WATCHDOG_PORT_FORWARD"
+    sleep 1
+    kill_processes_matching "$PGREP_WATCHDOG_PORT_FORWARD"
+}
 
 ###############################################################################
 # Watchdog mode — spawn a detached respawn loop and exit
 ###############################################################################
 if [[ "$WATCHDOG" == "1" ]]; then
-    # Replace any existing watchdog for this svc so re-runs are idempotent.
+    # Replace any existing watchdog on this local port so re-runs are idempotent.
     # Kill the bash loop AND any kubectl child it may have spawned — the
     # WATCHDOG_TAG only appears in the bash loop's argv, so the child kubectl
     # port-forward survives a naive `pkill -f WATCHDOG_TAG` and keeps the
     # local port bound, leaving the next watchdog pointed at a stale tunnel.
-    if pgrep -f "$WATCHDOG_TAG" >/dev/null; then
-        pkill -f "$WATCHDOG_TAG" || true
-        pkill -f "${KUBECTL} port-forward svc/${SVC} ${PORT}:.* -n ${NS}" || true
-        sleep 1
-    fi
+    stop_watchdog_port_forwards_on_port
 
     # The watchdog tag is embedded as a literal env-var assignment so it shows
     # up in `ps -eo args` / `pgrep -fl`. A leading `#` comment inside `bash -c`
@@ -98,17 +116,19 @@ if [[ "$WATCHDOG" == "1" ]]; then
     disown "$WATCHDOG_PID" 2>/dev/null || true
 
     # Wait for the PF to become healthy before returning so callers can rely on
-    # it. Generous deadline because kube-proxy can take 10-30s to program a new
-    # Service's endpoints right after a fresh install — the kubectl spawned by
-    # the watchdog will exit and respawn until the endpoint is reachable.
-    for _ in $(seq 1 90); do
+    # it. Keep the deadline generous for AKS cold-starts, where newly installed
+    # Service endpoints and load-balancer plumbing can lag well past 90s. The
+    # kubectl spawned by the watchdog exits and respawns until the endpoint is
+    # reachable.
+    for _ in $(seq 1 "$WATCHDOG_HEALTH_TIMEOUT_SECONDS"); do
         if curl -so /dev/null --max-time 1 "$URL/"; then
             echo "Watchdog $WATCHDOG_TAG started; PF healthy on localhost:$PORT"
             exit 0
         fi
         sleep 1
     done
-    echo "ERROR: watchdog started but PF on $PORT did not become healthy in 90s" >&2
+    echo "ERROR: watchdog started but PF on $PORT did not become healthy in ${WATCHDOG_HEALTH_TIMEOUT_SECONDS}s" >&2
+    stop_watchdog_port_forwards_on_port
     exit 1
 fi
 

--- a/deployments/scripts/port-forward.sh
+++ b/deployments/scripts/port-forward.sh
@@ -120,12 +120,32 @@ if [[ "$WATCHDOG" == "1" ]]; then
     # Service endpoints and load-balancer plumbing can lag well past 90s. The
     # kubectl spawned by the watchdog exits and respawns until the endpoint is
     # reachable.
-    for _ in $(seq 1 "$WATCHDOG_HEALTH_TIMEOUT_SECONDS"); do
-        if curl -so /dev/null --max-time 1 "$URL/"; then
+    watchdog_health_start_time=$(date +%s)
+    watchdog_health_end_time=$((watchdog_health_start_time + WATCHDOG_HEALTH_TIMEOUT_SECONDS))
+    while true; do
+        watchdog_health_now=$(date +%s)
+        watchdog_health_remaining_seconds=$((watchdog_health_end_time - watchdog_health_now))
+        if (( watchdog_health_remaining_seconds <= 0 )); then
+            break
+        fi
+        curl_max_time="$watchdog_health_remaining_seconds"
+        if (( curl_max_time > 1 )); then
+            curl_max_time=1
+        fi
+        if curl -so /dev/null --max-time "$curl_max_time" "$URL/"; then
             echo "Watchdog $WATCHDOG_TAG started; PF healthy on localhost:$PORT"
             exit 0
         fi
-        sleep 1
+        watchdog_health_now=$(date +%s)
+        watchdog_health_remaining_seconds=$((watchdog_health_end_time - watchdog_health_now))
+        if (( watchdog_health_remaining_seconds <= 0 )); then
+            break
+        fi
+        sleep_seconds="$watchdog_health_remaining_seconds"
+        if (( sleep_seconds > 1 )); then
+            sleep_seconds=1
+        fi
+        sleep "$sleep_seconds"
     done
     echo "ERROR: watchdog started but PF on $PORT did not become healthy in ${WATCHDOG_HEALTH_TIMEOUT_SECONDS}s" >&2
     stop_watchdog_port_forwards_on_port

--- a/deployments/scripts/verify.sh
+++ b/deployments/scripts/verify.sh
@@ -41,6 +41,8 @@ POOL="${POOL:-default}"
 OSMO_USERNAME="${OSMO_USERNAME:-admin}"
 OSMO_LOGIN_METHOD="${OSMO_LOGIN_METHOD:-dev}"
 WORKFLOWS_DIR="${WORKFLOWS_DIR:-$SCRIPT_DIR/../workflows}"
+OSMO_REACHABILITY_PATH="${OSMO_REACHABILITY_PATH:-/api/version}"
+OSMO_REACHABILITY_TIMEOUT_SECONDS="${OSMO_REACHABILITY_TIMEOUT_SECONDS:-5}"
 
 # Per-workflow poll timeouts (seconds). Should comfortably exceed each spec's
 # queue_timeout + exec_timeout. Override via env if your cluster needs longer.
@@ -52,9 +54,17 @@ check_command osmo
 check_command jq
 check_command curl
 
-# Probe URL — fail fast if no PF / ingress is reachable
-if ! curl -so /dev/null --max-time 2 "$OSMO_URL/"; then
+reachability_url_path="$OSMO_REACHABILITY_PATH"
+if [[ "$reachability_url_path" != /* ]]; then
+    reachability_url_path="/$reachability_url_path"
+fi
+reachability_url="${OSMO_URL%/}${reachability_url_path}"
+
+# Probe a lightweight unauthenticated API endpoint. The UI root serves the full
+# React app and can brush tight curl timeouts on a freshly spawned port-forward.
+if ! curl -fsS -o /dev/null --max-time "$OSMO_REACHABILITY_TIMEOUT_SECONDS" "$reachability_url"; then
     log_error "OSMO not reachable at $OSMO_URL"
+    log_error "Reachability probe failed: $reachability_url"
     log_error "Ensure port-forward is running (./port-forward.sh --watchdog osmo-service 9000)"
     log_error "or set OSMO_URL to a reachable endpoint."
     exit 1


### PR DESCRIPTION
## Description
  - Increase `port-forward.sh --watchdog` readiness gate from a hard-coded 90s to `OSMO_PF_HEALTH_TIMEOUT_SECONDS`, defaulting to 300s for AKS cold-starts.
  - Replace existing watchdog port-forwards by local port/namespace instead of service name only, preventing stale rerun watchdogs from racing for `:9000`.
  - Clean up watchdog port-forwards when readiness still times out, and document the new timeout knob.
  - Change `verify.sh` reachability preflight from `$OSMO_URL/` to a lightweight unauthenticated API probe, defaulting to `/api/version`.
  - Add `OSMO_REACHABILITY_PATH` and `OSMO_REACHABILITY_TIMEOUT_SECONDS` knobs for deployments that need a different probe path or timeout.
  - Document the new verify reachability settings.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified deployment scripts' watchdog behavior and how to restart/replace watchdogs.

* **New Features**
  * Added configurable environment variables to customize the reachability probe path and timeout used during verification.

* **Bug Fixes**
  * Improved watchdog start/stop and health-check behavior with deadline-based timeouts and more robust process handling to avoid stale tunnels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->