### PR TITLE
deployment: adjust port-forward curl time to be more generous

### DIFF
--- a/deployments/scripts/port-forward.sh
+++ b/deployments/scripts/port-forward.sh
@@ -129,8 +129,8 @@ if [[ "$WATCHDOG" == "1" ]]; then
             break
         fi
         curl_max_time="$watchdog_health_remaining_seconds"
-        if (( curl_max_time > 1 )); then
-            curl_max_time=1
+        if (( curl_max_time > 10 )); then
+            curl_max_time=10
         fi
         if curl -so /dev/null --max-time "$curl_max_time" "$URL/"; then
             echo "Watchdog $WATCHDOG_TAG started; PF healthy on localhost:$PORT"


### PR DESCRIPTION
## Description
The watchdog is intended to ensure the deployment comes up healthy within `WATCHDOG_HEALTH_TIMEOUT_SECONDS` (default: 300s = 5 minutes). However inside that loop we set `--max-time` on `curl` which gives the command only that much time to return. Where network latencies are a bit longer 1 second may not be enough, but we also don't want to unset it as curl will let it hang indefinitely.

This change gives a much more liberal 10 seconds for the curl command to return before trying again.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment health-check reliability by adjusting timeout parameters to better accommodate slower network conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->