### PR TITLE
release notes: 6.3.0 — add workload identity support

### DIFF
--- a/releases/6.3.0.md
+++ b/releases/6.3.0.md
@@ -29,7 +29,6 @@
   - **Azure (AKS / Arc)**: annotate the SA with `azure.workload.identity/client-id: <uami-client-id>` and label pods with `azure.workload.identity/use: "true"`. The Azure storage backend falls back to `DefaultAzureCredential` when no static connection string is supplied.
   - **AWS (EKS IRSA / Pod Identity)**: annotate the SA with `eks.amazonaws.com/role-arn: <iam-role-arn>`. The S3 backend picks up the federated token from boto3's default credential chain — no pod labels required.
 
-  Keyless auth for the GCS, Swift, and TOS storage backends is not yet wired up — those backends still require static credentials. (#508)
 - **Gateway consolidation**: A unified gateway now handles load balancing for all service types (API, router, UI), simplifying ingress configuration. (#817, #799)
 - **Gateway extension hooks**: Inject custom Envoy filters and additive auth-skip paths via `gateway.envoy.extensions` and `gateway.envoy.authSkipPaths`, useful for sidecar integrations and bypassing authz on specific endpoints. (#1009)
 - **Default identity headers**: Minimal deployments can now inject default `x-osmo-user`, `x-osmo-roles`, and `x-osmo-allowed-pools` headers for unauthenticated browser requests via `gateway.envoy.defaultIdentity` values. (#902)

--- a/releases/6.3.0.md
+++ b/releases/6.3.0.md
@@ -8,6 +8,7 @@
 - **Dataset CLI and API deprecated** — `osmo dataset` commands and the `/datasets` API endpoints are deprecated and will be removed in 6.4. Migrate to workflow-managed dataset outputs.
 - **Rsync download support** — Pull files from running workflow tasks to your local machine with `osmo workflow rsync download`, complementing the existing upload capability.
 - **Visual transfer progress** — File sync operations now display a progress bar showing bytes transferred, percentage, rate, and ETA.
+- **Workload identity for core services** — Run OSMO services under a cloud-issued federated identity (Azure Workload Identity on AKS/Arc, AWS IRSA / EKS Pod Identity) via new cloud-neutral `serviceAccount` annotations and per-component `extraPodLabels` hooks, removing the need to mount cloud storage keys as Kubernetes Secrets.
 - **Privilege escalation fix** — Policies with empty resources lists no longer grant access to resource-scoped endpoints.
 
 ## Breaking Changes
@@ -24,6 +25,11 @@
 - **ConfigMap configuration mode**: Set `services.configs.enabled: true` to manage all service configs via Helm values. CLI/API writes return HTTP 409 when active. The chart ships with default roles, pod templates, resource validations, backend, and pool. (#822)
 - **ConfigMap mode for worker, agent, and logger**: The ConfigMapWatcher now runs in the worker, agent, and logger services. Previously only the API service watched the ConfigMap, so workflow pods built by the worker could be constructed from stale config. (#926)
 - **TLS termination at the gateway**: Configure a serving cert/key, optional HTTP-to-HTTPS redirect, and SAN list via `gateway.tls`. The gateway template generates the matching Envoy listener config. (#953)
+- **Cloud workload identity**: New top-level `serviceAccount` block (`create`, `name`, `annotations`) and per-component `extraPodLabels` on `agent`, `api`, `worker`, `logger`, `router`, and `delayedJobMonitor`. The hooks are cloud-neutral — set the annotations and labels your CSP's identity webhook expects:
+  - **Azure (AKS / Arc)**: annotate the SA with `azure.workload.identity/client-id: <uami-client-id>` and label pods with `azure.workload.identity/use: "true"`. The Azure storage backend falls back to `DefaultAzureCredential` when no static connection string is supplied.
+  - **AWS (EKS IRSA / Pod Identity)**: annotate the SA with `eks.amazonaws.com/role-arn: <iam-role-arn>`. The S3 backend picks up the federated token from boto3's default credential chain — no pod labels required.
+
+  Keyless auth for the GCS, Swift, and TOS storage backends is not yet wired up — those backends still require static credentials. (#508)
 - **Gateway consolidation**: A unified gateway now handles load balancing for all service types (API, router, UI), simplifying ingress configuration. (#817, #799)
 - **Gateway extension hooks**: Inject custom Envoy filters and additive auth-skip paths via `gateway.envoy.extensions` and `gateway.envoy.authSkipPaths`, useful for sidecar integrations and bypassing authz on specific endpoints. (#1009)
 - **Default identity headers**: Minimal deployments can now inject default `x-osmo-user`, `x-osmo-roles`, and `x-osmo-allowed-pools` headers for unauthenticated browser requests via `gateway.envoy.defaultIdentity` values. (#902)


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description

PR #508 (merged Feb 24, 2026, before the 6.3.0 tag on Apr 27) added cloud-neutral workload-identity support to the service chart but never landed in the 6.3.0 release notes. This PR backfills two entries:

- **Highlights**: a one-line bullet calling out workload identity for core services on Azure (AKS WI / Arc) and AWS (EKS IRSA / Pod Identity).
- **Helm Charts**: a detailed entry naming the new top-level `serviceAccount` block (`create`, `name`, `annotations`) and per-component `extraPodLabels` on `agent`, `api`, `worker`, `logger`, `router`, and `delayedJobMonitor`. Includes the exact annotations/labels each CSP's webhook expects, and an explicit caveat that GCS/Swift/TOS backends still require static credentials (those backends `NotImplementedError` on `DefaultDataCredential` in [backends.py](https://github.com/NVIDIA/OSMO/blob/main/src/lib/data/storage/backends/backends.py)).

The chart hooks themselves are cloud-neutral — the per-CSP differences (Azure needs both an SA annotation and a pod label; AWS only needs the SA annotation; the storage-backend side needs `DefaultAzureCredential` for Azure but boto3's default credential chain handles IRSA on S3 without code changes) are documented as concrete examples rather than buried in prose.

Doc-only change — no code or tests touched.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload identity support enables services to run with cloud-issued federated identities
  * New service account configuration with annotation support for federated identities
  * Per-component extra pod label options for finer control
  * Guidance for Azure (AKS/Arc) and AWS (IRSA/Pod Identity) setups, including token usage for storage backends

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1042?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->