### PR TITLE
fix: correct NGC release link

### DIFF
--- a/.github/release-notes-prompt.md
+++ b/.github/release-notes-prompt.md
@@ -124,7 +124,7 @@ read as "added entries for new commits" — not as a wholesale rewrite.
 
 ### Helm Charts and Containers
 
-Helm charts and container images are available on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/containers/osmo).
+Helm charts and container images are available on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/collections/osmo/artifacts).
 
 ### CLI Client
 

--- a/releases/6.3.0.md
+++ b/releases/6.3.0.md
@@ -118,7 +118,7 @@
 
 ### Helm Charts and Containers
 
-Helm charts and container images are available on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/containers/osmo).
+Helm charts and container images are available on [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/osmo/collections/osmo/artifacts).
 
 ### CLI Client
 


### PR DESCRIPTION
## Description

Correct the NGC link used in generated release notes and the 6.3.0 release notes file so GitHub release descriptions point to the OSMO collection artifacts page instead of the single container page.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NGC links for Helm charts and container images to point to the new artifacts collection page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->