### PR TITLE
Proper media type to prevent auto-download

### DIFF
--- a/src/service/core/workflow/workflow_service.py
+++ b/src/service/core/workflow/workflow_service.py
@@ -926,7 +926,7 @@ def get_workflow_spec(name: str, use_template: bool = False) -> Any:
     cred_allowlist = frozenset(row.name for row in rows)
     return fastapi.responses.StreamingResponse(
         redact_secrets(download_workflow_spec(name, use_template), cred_allowlist),
-        media_type='application/yaml'
+        media_type='text/plain; charset=utf-8',
     )
 
 @router.post('/api/workflow/{name}/tag')


### PR DESCRIPTION
## Description
`application/yaml` + Envoy's `X-Content-Type-Options: nosniff` prevents browser from displaying workflow spec in a new tab and instead triggers file download

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the format of workflow specification responses from the API endpoint to ensure proper compatibility with client applications and data processing systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/OSMO/pull/1051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->