### PR TITLE
Testbot: increase workflow timeout from 30 to 60 minutes

### DIFF
--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -39,7 +39,7 @@ on:
         default: '200'
       timeout_minutes:
         description: 'Workflow timeout in minutes'
-        default: '30'
+        default: '60'
       model:
         description: 'LLM model name on NVIDIA gateway'
         default: 'aws/anthropic/bedrock-claude-opus-4-7'
@@ -98,7 +98,7 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.should_run == 'true'
     environment: nim-env
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes || '30') }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes || '60') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
Recent runs to cover 500 lines with tests reached timeout limit. Increase the limit to let testbot have more time to create the PR.

Issue #760 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased test generation workflow timeout from 30 to 60 minutes to accommodate longer-running test operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->