### PR TITLE
testbot: tell LLM not to ls/find $RUNNER_TEMP, just call python on it

### DIFF
--- a/src/scripts/testbot/TESTBOT_PROMPT.md
+++ b/src/scripts/testbot/TESTBOT_PROMPT.md
@@ -108,8 +108,22 @@ shame you for.
       --json-output "$RUNNER_TEMP/coverage_self_check.json" \
       --markdown-output "$RUNNER_TEMP/coverage_self_check.md"
     ```
-    Then `Read "$RUNNER_TEMP/coverage_self_check.json"`. Each target has
-    a `hit_fraction` (0.0–1.0) and a `still_uncovered_ranges` list.
+    Run this command **directly** — do not `ls`/`find` against
+    `$RUNNER_TEMP` to verify the meta file first. The path is outside
+    Claude Code's `ls` sandbox and the workflow already staged the file
+    before this prompt ran. (runs/26791499822 lost 4 turns groping in
+    `/tmp`, got blocked, and dropped the verifier as a result.) Your
+    `Bash(python *)` permission passes the path straight through to the
+    Python subprocess, which can read `$RUNNER_TEMP` just fine.
+
+    To inspect the resulting JSON, first resolve the env var (the
+    `Read` tool doesn't shell-expand):
+    ```bash
+    echo $RUNNER_TEMP
+    ```
+    then `Read <resolved>/coverage_self_check.json` with the absolute
+    path. Each target has a `hit_fraction` (0.0–1.0) and a
+    `still_uncovered_ranges` list.
 
 11. **Iterate until the gap closes.** A target passes when
     `hit_fraction >= 0.70`. If you're below, return to step 5 and add
@@ -163,5 +177,5 @@ shame you for.
   creation, committing, pushing, and PR creation.
 - **No gaming the verifier**: don't change the picker's
   `uncovered_ranges` list to shrink the gap, and don't paste a fake
-  `/tmp/targets_meta.json`. The harness re-runs the verifier against the
-  unmodified meta and posts the truth to the PR.
+  `$RUNNER_TEMP/targets_meta.json`. The harness re-runs the verifier
+  against the unmodified meta and posts the truth to the PR.


### PR DESCRIPTION
## Description

[runs/26791499822](https://github.com/NVIDIA/OSMO/actions/runs/26791499822/job/78979266585) — the scheduled testbot on `main` after PR #1045 merged — sat in the Generate step for ~15 min without producing tests. Root cause from the stream log: the LLM tried to `ls`/`find` for `$RUNNER_TEMP/targets_meta.json` before calling `verify_coverage.py`, hit Claude Code's `ls` sandbox, and silently dropped the verifier instead of just running the command.

```
01:06:35  find /home/runner/work/OSMO/OSMO -name "targets_meta.json"  → (empty)
01:06:46  ls /tmp
          → "Claude Code may only list files in the allowed working
             directories: '/home/runner/work/OSMO/OSMO'"
```

The LLM never actually tried `Bash(python ... $RUNNER_TEMP/...)` or `Read` against `/tmp` — both of which **work** (Python subprocess inherits env and has full FS access; Read tool isn't path-restricted, verified locally). Only the `ls` verb is sandboxed to the workspace.

Two prompt clarifications, no path moves:

- "Run the verify command directly. Do **not** `ls`/`find` `$RUNNER_TEMP` first — the workflow already staged the file before this prompt ran."
- "`Read` doesn't shell-expand env vars. Resolve `$RUNNER_TEMP` via `echo` first, then `Read` the absolute path."

Keeps `$RUNNER_TEMP` everywhere — consistent with how the rest of the workflow (shortlist.json, targets.txt, bazelisk install, …) already uses it. (An earlier draft of this PR moved everything to a `.testbot/` workspace dir; that was over-broad — only the `ls`/`find` habit was broken, the paths themselves are fine.)

Cause 2 from runs/26791499822 (Claude's 200K context auto-compacting twice mid-run on huge targets like `jobs.py`) is the structural issue I'd flagged as a follow-up in #1045 — still not addressed here.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal testing instructions to clarify verification procedures and environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->