### PR TITLE
[storage] Add configurable S3 read timeout (OSMO_S3_READ_TIMEOUT)

### DIFF
--- a/src/lib/data/storage/backends/s3.py
+++ b/src/lib/data/storage/backends/s3.py
@@ -52,6 +52,10 @@ logger = logging.getLogger(__name__)
 # Timeout for S3 API calls.
 OSMO_S3_TIMEOUT = 'OSMO_S3_TIMEOUT'
 
+# Read timeout for the underlying S3 client (time to wait for a server response
+# after a request has been sent).
+OSMO_S3_READ_TIMEOUT = 'OSMO_S3_READ_TIMEOUT'
+
 # Max retry count for retryable S3 API calls.
 OSMO_S3_MAX_RETRY_COUNT = 'OSMO_S3_MAX_RETRY_COUNT'
 
@@ -92,6 +96,20 @@ def _get_s3_timeout() -> datetime.timedelta:
     Returns the timeout for S3 API calls.
     """
     return utils_common.to_timedelta(os.getenv(OSMO_S3_TIMEOUT, '24h'))
+
+
+def _get_s3_read_timeout() -> float:
+    """
+    Returns the read timeout (in seconds) for the underlying S3 client.
+
+    This bounds how long the client waits for a server response after a request
+    has been fully sent. botocore defaults to 60s, which is too short to
+    finalize large single-PUT objects on some backends (e.g. Swift), where the
+    server replicates and checksums the whole object before responding. That
+    produces spurious read timeouts and full-object retries, so we default to a
+    more generous 5m.
+    """
+    return utils_common.to_timedelta(os.getenv(OSMO_S3_READ_TIMEOUT, '5m')).total_seconds()
 
 
 _VALID_S3_ADDRESSING_STYLES = ('virtual', 'path', 'auto')
@@ -184,6 +202,7 @@ def _get_boto_config(
             'mode': 'standard',
         },
         'max_pool_connections': max_pool_connections,
+        'read_timeout': _get_s3_read_timeout(),
         'request_checksum_calculation': 'when_required',
         'response_checksum_validation': 'when_required',
     }

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -707,6 +707,19 @@ class GetBotoConfigTest(unittest.TestCase):
             config = s3._get_boto_config('s3', endpoint_url='https://cwobject.com')
         self.assertEqual(self._s3_options(config).get('addressing_style'), 'path')
 
+    def test_default_read_timeout(self):
+        """Default read_timeout is 5m (300s), overriding botocore's 60s default."""
+        with mock.patch.dict('os.environ', {}, clear=True):
+            config = s3._get_boto_config('swift', endpoint_url='https://swift.example.com')
+        # read_timeout is not in botocore's type stubs — read defensively.
+        self.assertEqual(getattr(config, 'read_timeout'), 300)
+
+    def test_env_override_read_timeout(self):
+        """OSMO_S3_READ_TIMEOUT overrides the default read_timeout."""
+        with mock.patch.dict('os.environ', {s3.OSMO_S3_READ_TIMEOUT: '10m'}):
+            config = s3._get_boto_config('s3', endpoint_url='https://cwobject.com')
+        self.assertEqual(getattr(config, 'read_timeout'), 600)
+
 
 class CredentialAddressingStyleTest(unittest.TestCase):
     """Tests for carrying S3 addressing style through data credentials."""


### PR DESCRIPTION
## Problem

The S3 client — also used for **Swift** via its S3-compatible API — never sets a `read_timeout`, so botocore's **60s default** applies (`_get_boto_config` in `src/lib/data/storage/backends/s3.py`).

For a large object uploaded as a **single PUT** (i.e. below `multipart_threshold`, default 512 MiB), the bytes transfer quickly but the server (e.g. Swift) replicates and checksums the whole object before responding. On a busy/slow backend that finalization exceeds 60s, so botocore raises `ReadTimeoutError` and the upload is retried in full — looping indefinitely even though the data transferred fine.

Observed symptom (480 MB upload to `swift://`):
```
100%|██████████| 480M/480M [00:20<00:00, 130MB/s]  Unknown error: Read timeout on endpoint URL: ".../gear_upload_test_large.bin". Retrying 3 more times.
... (repeats) ...
```

## Fix

Add a configurable `read_timeout` to the botocore `Config`, controlled by a new `OSMO_S3_READ_TIMEOUT` env var (default **5m**), mirroring the existing `_get_s3_timeout()` / `OSMO_S3_TIMEOUT` pattern. This applies to all S3-family backends (S3, Swift, GS, TOS).

## Changes
- `s3.py`: new `OSMO_S3_READ_TIMEOUT` constant, `_get_s3_read_timeout()` helper, and `read_timeout` added to the boto `Config`.
- `test_backends.py`: tests for the default (300s) and env override.

## Testing
```
bazel test //src/lib/data/storage/backends/tests:test_backends
```
Passes, including mypy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced configurable S3 read timeout via environment variable, enabling custom timeout settings for S3 storage connections (defaults to 5 minutes).

* **Tests**
  * Added unit tests verifying default and custom S3 read timeout configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->