### PR TITLE
Add Local KIND Deployment CI workflow

### DIFF
--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -98,7 +98,22 @@ jobs:
             exit 3
           fi
 
+      - name: Detect OETF framework presence
+        id: oetf
+        run: |
+          # The OETF framework lands in a separate PR (#1062). Until that
+          # merges, //test/oetf:deploy_and_run doesn't exist on main, and
+          # this workflow has nothing to verify against the PR-merged tree.
+          # Skip cleanly rather than failing red.
+          if [ -f test/oetf/BUILD ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::OETF framework not present in tree; skipping deploy_and_run."
+          fi
+
       - name: Build osmo CLI
+        if: steps.oetf.outputs.present == 'true'
         run: |
           # CLI-mode scenarios (e.g. router-connectivity, smoke:cli-checks)
           # need an `osmo` binary to invoke. Build from //src/cli and expose
@@ -109,6 +124,7 @@ jobs:
           /usr/local/bin/osmo --help >/dev/null
 
       - name: Run OETF deploy_and_run on KIND
+        if: steps.oetf.outputs.present == 'true'
         run: |
           # --jobs=1 serializes the test suite. The KIND-deployed
           # quick-start chart runs a single ingress-nginx replica with

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -1,0 +1,143 @@
+name: Local KIND Deployment
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'deployments/charts/**'
+      - 'deployments/scripts/**'
+      - 'deployments/values/**'
+      - 'test/oetf/**'
+      - 'test/workflow/**'
+      - 'bzl/**'
+      - 'MODULE.bazel'
+      - 'src/**'
+      - '.github/workflows/oetf-kind.yaml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: oetf-kind-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  oetf-kind:
+    name: oetf:deploy_and_run --env kind --tags kind
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install kind
+        run: |
+          set -euo pipefail
+          KIND_VERSION=v0.24.0
+          KIND_SHA256=b89aada5a39d620da3fcd16435b7f28d858927dd53f92cbac77686b0588b600d
+          curl -fsSLo /usr/local/bin/kind \
+            "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          echo "${KIND_SHA256}  /usr/local/bin/kind" | sha256sum -c -
+          sudo chmod +x /usr/local/bin/kind
+
+      - name: Install kubectl
+        run: |
+          set -euo pipefail
+          KUBECTL_VERSION=v1.31.0
+          curl -fsSLo /usr/local/bin/kubectl \
+            "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
+            | awk '{print $1"  /usr/local/bin/kubectl"}' | sha256sum -c -
+          sudo chmod +x /usr/local/bin/kubectl
+
+      - name: Install helm
+        run: |
+          set -euo pipefail
+          HELM_VERSION=v3.16.2
+          HELM_SHA256=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb
+          curl -fsSLo /tmp/helm.tgz \
+            "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          echo "${HELM_SHA256}  /tmp/helm.tgz" | sha256sum -c -
+          tar -xzf /tmp/helm.tgz -C /tmp linux-amd64/helm
+          sudo mv /tmp/linux-amd64/helm /usr/local/bin/helm
+          rm -rf /tmp/helm.tgz /tmp/linux-amd64
+
+      - name: Tool versions
+        run: |
+          docker --version
+          kind version
+          kubectl version --client --output=yaml | head -2 | tail -1
+          helm version --short
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8
+        with:
+          bazelisk-cache: true
+          bazelisk-version: 1.27.0
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Add quick-start.osmo to /etc/hosts
+        run: |
+          # The KIND adapter's check_kind_prereqs requires this name to
+          # resolve so tests can reach the chart's ingress at
+          # http://quick-start.osmo via the host port mapping published by
+          # `kind create cluster --config`.
+          echo "127.0.0.1 quick-start.osmo" | sudo tee -a /etc/hosts
+
+      - name: Preflight (OETF KIND adapter check_kind_prereqs)
+        run: |
+          set -euo pipefail
+          missing=()
+          for bin in docker kind kubectl helm; do
+            command -v "$bin" >/dev/null 2>&1 || missing+=("$bin")
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "ERROR: missing on runner: ${missing[*]}"
+            exit 3
+          fi
+
+      - name: Build osmo CLI
+        run: |
+          # CLI-mode scenarios (e.g. router-connectivity, smoke:cli-checks)
+          # need an `osmo` binary to invoke. Build from //src/cli and expose
+          # at /usr/local/bin/osmo (the default --local-osmo path) via
+          # symlink.
+          bazel build //src/cli:cli
+          sudo ln -sf "$(pwd)/bazel-bin/src/cli/cli" /usr/local/bin/osmo
+          /usr/local/bin/osmo --help >/dev/null
+
+      - name: Run OETF deploy_and_run on KIND
+        run: |
+          # --jobs=1 serializes the test suite. The KIND-deployed
+          # quick-start chart runs a single ingress-nginx replica with
+          # default resources; parallel scenario submits saturate it and
+          # intermittently 504. Trade-off: longer wall clock; in exchange
+          # we get deterministic green. Lift back to default jobs once the
+          # chart's kind profile bumps ingress replicas.
+          bazel run //test/oetf:deploy_and_run -- \
+            --env kind --tags kind \
+            --jobs 1 \
+            --output-json kind-smoke-result.json
+
+      - name: Cleanup KIND cluster
+        if: always()
+        run: |
+          kind delete clusters --all || true
+
+      - name: Upload OETF result JSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-smoke-result
+          path: kind-smoke-result.json
+          if-no-files-found: warn
+
+      - name: Upload bazel test logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bazel-testlogs
+          path: bazel-testlogs/
+          if-no-files-found: warn

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -100,6 +100,25 @@ jobs:
             exit 3
           fi
 
+      - name: Free runner disk for --build-local
+        # The 9 OSMO service OCI tarballs + 6 KIND nodes each loading them
+        # into their own containerd content store consumed 76 GB on prior
+        # measurement runs, against an 87-GB free baseline — ran out at
+        # `kind load backend-worker`. Reclaim ~25-30 GB of pre-installed
+        # tooling we don't use (dotnet, Android SDK, GHC, PyPy cache,
+        # CodeQL) so the build has headroom on the standard ubuntu-latest
+        # 145-GB volume.
+        run: |
+          set -euo pipefail
+          for d in /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                   /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/CodeQL; do
+            if [ -d "$d" ]; then
+              sudo rm -rf "$d" &
+            fi
+          done
+          wait
+          sudo docker image prune -af >/dev/null 2>&1 || true
+
       - name: Disk space (pre-deploy)
         run: df -h /
 
@@ -116,12 +135,27 @@ jobs:
       - name: Run OETF deploy_and_run on KIND
         id: deploy_and_run
         run: |
-          # --jobs=1 serializes the test suite. The KIND-deployed
-          # quick-start chart runs a single ingress-nginx replica with
-          # default resources; parallel scenario submits saturate it and
-          # intermittently 504. Trade-off: longer wall clock; in exchange
-          # we get deterministic green. Lift back to default jobs once the
-          # chart's kind profile bumps ingress replicas.
+          # --build-local: build the 9 OSMO service images + the web-ui
+          # locally from PR source and kind-load them, instead of helm
+          # pulling nvcr.io/nvidia/osmo:6.2 from NGC. Without this the
+          # gate would still pass when PR src/ changes regress service
+          # code — the chart would ignore the tree and use the released
+          # images. The "Free runner disk for --build-local" step above
+          # is paired with this: the 9 OCI tarballs + 6-node KIND content-
+          # store duplication consumed 76 GB on a prior unsuccessful run,
+          # so we reclaim 25-30 GB of pre-installed tooling for headroom.
+          #
+          # Scenario set is curated for PR-gate cost: smoke (api-checks +
+          # websocket-checks, ~5s) covers the service+router+logger HTTP/
+          # WS surfaces; templates + mount-validation (~6s) submit
+          # workflows so backend-listener / backend-worker / osmo_ctrl
+          # runtime get touched too. Slow scenarios (router-connectivity
+          # 140s, serial-workflow-mounting 60s, logger-connectivity 30s)
+          # stay out of the gate — they belong in a nightly/manual run.
+          #
+          # --jobs=1 serializes: the chart's single-replica ingress-nginx
+          # 504s under parallel scenario submits. With 4 tests at ~3s
+          # each, parallelism would save <10s anyway.
           #
           # `time` writes total wall clock to the step log so regressions
           # past the ~15-min PR-gate budget show up in the run timeline,
@@ -133,23 +167,6 @@ jobs:
           # deploy or test failure so the "Diagnose KIND state on failure"
           # step below can capture pod state. The explicit "Cleanup KIND
           # cluster" step (if: always()) tears it down afterward.
-          #
-          # NOTE on --build-local: not enabled here. Measured cost on
-          # hosted ubuntu-latest in run #26 (sha bdeb6b9): bazel-built 9
-          # OCI images in 7m9s (cold cache), then `kind load` filled the
-          # runner disk and the build aborted at 15m15s with `no space
-          # left on device` while loading backend-worker into the 6-node
-          # cluster. Two upstream blockers also surface: test/oetf/
-          # local_images.py hardcodes the UI source path to
-          # `external/src/ui` (internal-repo layout — fails immediately
-          # on the public checkout), and the chart's default KIND profile
-          # spawns 6 node containers that duplicate every image's
-          # containerd storage 6x — quickly exhausts the ~145 GB runner
-          # disk. Enabling --build-local will need either a larger
-          # runner, a single-node KIND profile, or a runner-disk
-          # reclamation step (delete /opt/ghc, /usr/share/dotnet, etc.)
-          # — and the local_images.py path fix. Tracking as a follow-up
-          # so this gate ships now against released NGC images.
           trap '
             echo "::group::deploy_and_run wall clock"
             cat /tmp/oetf.time 2>/dev/null || echo "(no timing file written)"
@@ -162,7 +179,10 @@ jobs:
           /usr/bin/time -p -o /tmp/oetf.time \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
+              --target-pattern //test/smoke/... \
+              --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
+              --build-local \
               --keep --keep-on-failure \
               --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -298,3 +298,5 @@ jobs:
           name: bazel-testlogs
           path: bazel-testlogs/
           if-no-files-found: warn
+
+# Warm-run trigger (no behavior change).

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -100,25 +100,6 @@ jobs:
             exit 3
           fi
 
-      - name: Free runner disk for --build-local
-        # The 9 OSMO service OCI tarballs + 6 KIND nodes each loading them
-        # into their own containerd content store consumed 76 GB on prior
-        # measurement runs, against an 87-GB free baseline — ran out at
-        # `kind load backend-worker`. Reclaim ~25-30 GB of pre-installed
-        # tooling we don't use (dotnet, Android SDK, GHC, PyPy cache,
-        # CodeQL) so the build has headroom on the standard ubuntu-latest
-        # 145-GB volume.
-        run: |
-          set -euo pipefail
-          for d in /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                   /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/CodeQL; do
-            if [ -d "$d" ]; then
-              sudo rm -rf "$d" &
-            fi
-          done
-          wait
-          sudo docker image prune -af >/dev/null 2>&1 || true
-
       - name: Disk space (pre-deploy)
         run: df -h /
 
@@ -135,27 +116,12 @@ jobs:
       - name: Run OETF deploy_and_run on KIND
         id: deploy_and_run
         run: |
-          # --build-local: build the 9 OSMO service images + the web-ui
-          # locally from PR source and kind-load them, instead of helm
-          # pulling nvcr.io/nvidia/osmo:6.2 from NGC. Without this the
-          # gate would still pass when PR src/ changes regress service
-          # code — the chart would ignore the tree and use the released
-          # images. The "Free runner disk for --build-local" step above
-          # is paired with this: the 9 OCI tarballs + 6-node KIND content-
-          # store duplication consumed 76 GB on a prior unsuccessful run,
-          # so we reclaim 25-30 GB of pre-installed tooling for headroom.
-          #
-          # Scenario set is curated for PR-gate cost: smoke (api-checks +
-          # websocket-checks, ~5s) covers the service+router+logger HTTP/
-          # WS surfaces; templates + mount-validation (~6s) submit
-          # workflows so backend-listener / backend-worker / osmo_ctrl
-          # runtime get touched too. Slow scenarios (router-connectivity
-          # 140s, serial-workflow-mounting 60s, logger-connectivity 30s)
-          # stay out of the gate — they belong in a nightly/manual run.
-          #
-          # --jobs=1 serializes: the chart's single-replica ingress-nginx
-          # 504s under parallel scenario submits. With 4 tests at ~3s
-          # each, parallelism would save <10s anyway.
+          # --jobs=1 serializes the test suite. The KIND-deployed
+          # quick-start chart runs a single ingress-nginx replica with
+          # default resources; parallel scenario submits saturate it and
+          # intermittently 504. Trade-off: longer wall clock; in exchange
+          # we get deterministic green. Lift back to default jobs once the
+          # chart's kind profile bumps ingress replicas.
           #
           # `time` writes total wall clock to the step log so regressions
           # past the ~15-min PR-gate budget show up in the run timeline,
@@ -167,6 +133,23 @@ jobs:
           # deploy or test failure so the "Diagnose KIND state on failure"
           # step below can capture pod state. The explicit "Cleanup KIND
           # cluster" step (if: always()) tears it down afterward.
+          #
+          # NOTE on --build-local: not enabled here. Measured on hosted
+          # ubuntu-latest across runs #26/#28/#29 — every attempt fails
+          # mid kind-load with the runner host disk exhausting. The 6-node
+          # KIND profile (one per chart node_group) duplicates each loaded
+          # image into 6 separate containerd content stores; 9 service
+          # images + web-ui together overrun the runner's 145 GB volume
+          # even after reclaiming 25-30 GB of pre-installed tooling. Run
+          # #29 died so hard the runner process itself crashed with `No
+          # space left on device` writing its diagnostic log, before
+          # cleanup steps could run. Two real local_images.py bugs that
+          # block --build-local on the public checkout (UI source path
+          # hardcoded for the internal overlay, disk-cache materialization
+          # missing) are fixed in this PR's accompanying commits, but the
+          # 6-node disk-pressure problem requires either a single-node
+          # KIND profile in the chart or a larger runner. Tracked as
+          # follow-up; ship the NGC-image gate today.
           trap '
             echo "::group::deploy_and_run wall clock"
             cat /tmp/oetf.time 2>/dev/null || echo "(no timing file written)"
@@ -179,10 +162,7 @@ jobs:
           /usr/bin/time -p -o /tmp/oetf.time \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
-              --target-pattern //test/smoke/... \
-              --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
-              --build-local \
               --keep --keep-on-failure \
               --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -8,6 +8,8 @@ on:
       - 'deployments/scripts/**'
       - 'deployments/values/**'
       - 'test/oetf/**'
+      - 'test/smoke/**'
+      - 'test/scenarios/**'
       - 'test/workflow/**'
       - 'bzl/**'
       - 'MODULE.bazel'

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -100,22 +100,10 @@ jobs:
             exit 3
           fi
 
-      - name: Detect OETF framework presence
-        id: oetf
-        run: |
-          # The OETF framework lands in a separate PR (#1062). Until that
-          # merges, //test/oetf:deploy_and_run doesn't exist on main, and
-          # this workflow has nothing to verify against the PR-merged tree.
-          # Skip cleanly rather than failing red.
-          if [ -f test/oetf/BUILD ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::OETF framework not present in tree; skipping deploy_and_run."
-          fi
+      - name: Disk space (pre-deploy)
+        run: df -h /
 
       - name: Build osmo CLI
-        if: steps.oetf.outputs.present == 'true'
         run: |
           # CLI-mode scenarios (e.g. router-connectivity, smoke:cli-checks)
           # need an `osmo` binary to invoke. Build from //src/cli and expose
@@ -126,7 +114,7 @@ jobs:
           /usr/local/bin/osmo --help >/dev/null
 
       - name: Run OETF deploy_and_run on KIND
-        if: steps.oetf.outputs.present == 'true'
+        id: deploy_and_run
         run: |
           # --jobs=1 serializes the test suite. The KIND-deployed
           # quick-start chart runs a single ingress-nginx replica with
@@ -134,15 +122,120 @@ jobs:
           # intermittently 504. Trade-off: longer wall clock; in exchange
           # we get deterministic green. Lift back to default jobs once the
           # chart's kind profile bumps ingress replicas.
-          bazel run //test/oetf:deploy_and_run -- \
-            --env kind --tags kind \
-            --jobs 1 \
-            --output-json kind-smoke-result.json
+          #
+          # `time` writes total wall clock to the step log so regressions
+          # past the ~15-min PR-gate budget show up in the run timeline,
+          # not just per-step in the Actions UI. EXIT trap so the timing
+          # block lands on the failure path too (default `set -e` would
+          # otherwise skip the cat after a bazel non-zero exit).
+          #
+          # --keep + --keep-on-failure: leave the cluster intact on either
+          # deploy or test failure so the "Diagnose KIND state on failure"
+          # step below can capture pod state. The explicit "Cleanup KIND
+          # cluster" step (if: always()) tears it down afterward.
+          trap '
+            echo "::group::deploy_and_run wall clock"
+            cat /tmp/oetf.time 2>/dev/null || echo "(no timing file written)"
+            echo "::endgroup::"
+          ' EXIT
+          /usr/bin/time -p -o /tmp/oetf.time \
+            bazel run //test/oetf:deploy_and_run -- \
+              --env kind --tags kind \
+              --jobs 1 \
+              --keep --keep-on-failure \
+              --output-json kind-smoke-result.json
+
+      - name: Diagnose KIND state on failure
+        if: failure() && steps.deploy_and_run.outcome == 'failure'
+        # Triggered only on deploy_and_run failure — preserves the cluster's
+        # post-mortem state for inspection BEFORE the cleanup step deletes
+        # it. Each subsection is wrapped in ::group:: so reviewers can fold
+        # what they don't need. `|| true` everywhere — diagnostic must
+        # never mask the real failure.
+        run: |
+          echo "::group::All pods (kubectl get pods -A -o wide)"
+          kubectl get pods -A -o wide || true
+          echo "::endgroup::"
+
+          echo "::group::Recent events (last 100, sorted by lastTimestamp)"
+          kubectl get events -A --sort-by=.lastTimestamp 2>/dev/null | tail -100 || true
+          echo "::endgroup::"
+
+          echo "::group::Non-Ready pod descriptions (osmo + kai-scheduler + ingress-nginx + kube-system)"
+          for ns in osmo kai-scheduler ingress-nginx kube-system; do
+            # `kubectl get pods` field-selector can't filter on .status.conditions; do it in jsonpath.
+            not_ready=$(kubectl get pods -n "$ns" -o jsonpath='{range .items[?(@.status.phase!="Running")]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+            also_unready=$(kubectl get pods -n "$ns" -o jsonpath='{range .items[?(@.status.containerStatuses[*].ready==false)]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+            for pod in $(printf '%s\n%s\n' "$not_ready" "$also_unready" | sort -u); do
+              [ -z "$pod" ] && continue
+              echo "--- $ns/$pod ---"
+              kubectl describe pod -n "$ns" "$pod" 2>/dev/null || true
+            done
+          done
+          echo "::endgroup::"
+
+          echo "::group::Non-Ready pod logs (last 200 lines, with --previous on crash)"
+          for ns in osmo kai-scheduler ingress-nginx; do
+            not_ready=$(kubectl get pods -n "$ns" -o jsonpath='{range .items[?(@.status.phase!="Running")]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+            also_unready=$(kubectl get pods -n "$ns" -o jsonpath='{range .items[?(@.status.containerStatuses[*].ready==false)]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+            for pod in $(printf '%s\n%s\n' "$not_ready" "$also_unready" | sort -u); do
+              [ -z "$pod" ] && continue
+              echo "--- $ns/$pod (current) ---"
+              kubectl logs -n "$ns" "$pod" --all-containers --tail=200 2>/dev/null || true
+              echo "--- $ns/$pod (previous, if crash-looped) ---"
+              kubectl logs -n "$ns" "$pod" --all-containers --previous --tail=200 2>/dev/null || true
+            done
+          done
+          echo "::endgroup::"
+
+          echo "::group::Helm releases (helm list -A)"
+          helm list -A || true
+          echo "::endgroup::"
+
+          echo "::group::Disk space"
+          df -h /
+          echo "::endgroup::"
 
       - name: Cleanup KIND cluster
         if: always()
         run: |
           kind delete clusters --all || true
+
+      - name: Write run summary to GitHub step summary
+        if: always()
+        # Surfaces the [PASS]/[FAIL] table on the PR check UI so reviewers
+        # see results without scrolling the 10-min step log. Reads from
+        # kind-smoke-result.json (always written by oetf:run, even on test
+        # failure) and falls back to a deploy-failure note if missing.
+        run: |
+          set -euo pipefail
+          {
+            echo "## OETF KIND results"
+            echo
+            if [ -s kind-smoke-result.json ]; then
+              # jq is preinstalled on ubuntu-latest runners.
+              total=$(jq -r '.total' kind-smoke-result.json)
+              passed=$(jq -r '.passed' kind-smoke-result.json)
+              failed=$(jq -r '.failed' kind-smoke-result.json)
+              errored=$(jq -r '.errored' kind-smoke-result.json)
+              skipped=$(jq -r '.skipped' kind-smoke-result.json)
+              echo "**Total ${total}  Passed ${passed}  Failed ${failed}  Errors ${errored}  Skipped ${skipped}**"
+              echo
+              echo "| Result | Test | Duration |"
+              echo "| --- | --- | --- |"
+              # `.target` is the bazel label (e.g. //test/smoke:api-checks); fall back to `.name` for ad-hoc tests.
+              jq -r '.results[] | "| \(.status|ascii_upcase) | \(if .target != "" then .target else .name end) | \(.time | tonumber | (. * 100 | round / 100))s |"' kind-smoke-result.json
+            else
+              echo "_No kind-smoke-result.json — deploy likely failed before tests ran. See \"Diagnose KIND state\" step above._"
+            fi
+            echo
+            if [ -s /tmp/oetf.time ]; then
+              echo "### Wall clock"
+              echo '```'
+              cat /tmp/oetf.time
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload OETF result JSON
         if: always()

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -212,6 +212,11 @@ jobs:
           # a relative `--output-json` path lands somewhere inside bazel-out
           # where actions/upload-artifact + the summary step can't find it.
           # Pass an absolute path under $GITHUB_WORKSPACE instead.
+          # --build-images excludes web-ui: a Next.js multi-stage docker
+          # buildx adds ~5 GB intermediate + ~500 MB tarball + ~300 MB
+          # image × 6 KIND nodes (~8 GB total). Smoke tests hit no UI
+          # endpoint, so scale the web-ui Deployment to 0 via --extra-set
+          # — kubectl wait then treats Available as trivially true.
           /usr/bin/time -p -o /tmp/oetf.time \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
@@ -219,6 +224,8 @@ jobs:
               --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
               --build-local \
+              --build-images service,agent,logger,worker,delayed-job-monitor,router,authz-sidecar,backend-listener,backend-worker \
+              --extra-set web-ui.services.ui.replicas=0 \
               --keep --keep-on-failure \
               --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -116,12 +116,25 @@ jobs:
       - name: Run OETF deploy_and_run on KIND
         id: deploy_and_run
         run: |
-          # --jobs=1 serializes the test suite. The KIND-deployed
-          # quick-start chart runs a single ingress-nginx replica with
-          # default resources; parallel scenario submits saturate it and
-          # intermittently 504. Trade-off: longer wall clock; in exchange
-          # we get deterministic green. Lift back to default jobs once the
-          # chart's kind profile bumps ingress replicas.
+          # --build-local: build the 9 OSMO service images + the web-ui
+          # locally from PR source (via bazel oci_load + docker buildx) and
+          # kind-load them, instead of helm pulling nvcr.io/nvidia/osmo:6.2
+          # from NGC. Without this, the gate would still pass even when
+          # PR src/ changes regress service code — the chart would just
+          # pull released images and ignore the tree.
+          #
+          # Scenario set is curated for PR-gate cost: smoke (api-checks +
+          # websocket-checks, ~5s) covers the service+router+logger HTTP
+          # surfaces; templates + mount-validation (~6s) exercise workflow
+          # submission so backend-listener / backend-worker / osmo_ctrl
+          # get touched too. Slow scenarios (router-connectivity 140s,
+          # serial-workflow-mounting 60s, logger-connectivity 30s) and
+          # negative-path scenarios stay out of the gate — they belong in
+          # a nightly/manual full run.
+          #
+          # --jobs=1 still serializes: the chart's single-replica
+          # ingress-nginx 504s under parallel scenario submits. With only
+          # 4 tests at ~3s each, parallelism would save <10s anyway.
           #
           # `time` writes total wall clock to the step log so regressions
           # past the ~15-min PR-gate budget show up in the run timeline,
@@ -145,7 +158,10 @@ jobs:
           /usr/bin/time -p -o /tmp/oetf.time \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
+              --target-pattern //test/smoke/... \
+              --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
+              --build-local \
               --keep --keep-on-failure \
               --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -140,19 +140,20 @@ jobs:
         id: deploy_and_run
         run: |
           # --build-local + --use-local-registry: build 9 OSMO service images
-          # from PR source, push to a host-side `registry:2` container, KIND
-          # nodes pull from it on-demand. Replaces `kind load docker-image`
-          # which duplicates each image into every node's containerd content
-          # store (6 nodes × 9 images = 54 image-copies — overruns hosted
-          # ubuntu-latest's 145 GB disk). With registry mode each KIND node
-          # only pulls images its pods actually schedule (1-2 nodes per
-          # image under the chart's node_group selectors), dropping the
-          # multiplier from 6x to 1-2x.
+          # + web-ui from PR source, push to a host-side `registry:2`
+          # container, KIND nodes pull from it on-demand. Replaces `kind
+          # load docker-image` which duplicates each image into every node's
+          # containerd content store (6 nodes × 10 images = 60 image-copies
+          # — overruns hosted ubuntu-latest's 145 GB disk). With registry
+          # mode each KIND node only pulls images its pods actually
+          # schedule (1-2 nodes per image under the chart's node_group
+          # selectors), dropping the multiplier from 6x to 1-2x.
           #
-          # --build-images skips web-ui (saves ~8 GB Next.js intermediates
-          # + 6-node duplication; UI still uses the kind-load path).
-          # --extra-set web-ui.services.ui.replicas=0 scales the chart's
-          # web-ui Deployment to zero so kubectl wait still succeeds.
+          # web-ui IS built and pushed: ingress-nginx has a hard
+          # `wait-for-web-ui` init container that polls osmo-ui:80, so
+          # scaling web-ui to 0 deadlocks the chart (verified empirically
+          # in run #35). Registry-push UI keeps the chart whole at ~1 GB
+          # host disk vs the prior ~5 GB kind-load duplication.
           #
           # "Free runner disk" step above reclaims 22-25 GB pre-deploy.
           #
@@ -187,8 +188,6 @@ jobs:
               --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
               --build-local --use-local-registry \
-              --build-images service,agent,logger,worker,delayed-job-monitor,router,authz-sidecar,backend-listener,backend-worker \
-              --extra-set web-ui.services.ui.replicas=0 \
               --keep --keep-on-failure \
               --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -28,7 +28,9 @@ jobs:
   oetf-kind:
     name: oetf:deploy_and_run --env kind --tags kind
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Bumped to 90m while measuring cold --build-local cost. Will be
+    # tightened back once warm-cache timing is known.
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -28,9 +28,7 @@ jobs:
   oetf-kind:
     name: oetf:deploy_and_run --env kind --tags kind
     runs-on: ubuntu-latest
-    # Bumped to 90m while measuring cold --build-local cost. Will be
-    # tightened back once warm-cache timing is known.
-    timeout-minutes: 90
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -118,25 +116,12 @@ jobs:
       - name: Run OETF deploy_and_run on KIND
         id: deploy_and_run
         run: |
-          # --build-local: build the 9 OSMO service images + the web-ui
-          # locally from PR source (via bazel oci_load + docker buildx) and
-          # kind-load them, instead of helm pulling nvcr.io/nvidia/osmo:6.2
-          # from NGC. Without this, the gate would still pass even when
-          # PR src/ changes regress service code — the chart would just
-          # pull released images and ignore the tree.
-          #
-          # Scenario set is curated for PR-gate cost: smoke (api-checks +
-          # websocket-checks, ~5s) covers the service+router+logger HTTP
-          # surfaces; templates + mount-validation (~6s) exercise workflow
-          # submission so backend-listener / backend-worker / osmo_ctrl
-          # get touched too. Slow scenarios (router-connectivity 140s,
-          # serial-workflow-mounting 60s, logger-connectivity 30s) and
-          # negative-path scenarios stay out of the gate — they belong in
-          # a nightly/manual full run.
-          #
-          # --jobs=1 still serializes: the chart's single-replica
-          # ingress-nginx 504s under parallel scenario submits. With only
-          # 4 tests at ~3s each, parallelism would save <10s anyway.
+          # --jobs=1 serializes the test suite. The KIND-deployed
+          # quick-start chart runs a single ingress-nginx replica with
+          # default resources; parallel scenario submits saturate it and
+          # intermittently 504. Trade-off: longer wall clock; in exchange
+          # we get deterministic green. Lift back to default jobs once the
+          # chart's kind profile bumps ingress replicas.
           #
           # `time` writes total wall clock to the step log so regressions
           # past the ~15-min PR-gate budget show up in the run timeline,
@@ -148,6 +133,23 @@ jobs:
           # deploy or test failure so the "Diagnose KIND state on failure"
           # step below can capture pod state. The explicit "Cleanup KIND
           # cluster" step (if: always()) tears it down afterward.
+          #
+          # NOTE on --build-local: not enabled here. Measured cost on
+          # hosted ubuntu-latest in run #26 (sha bdeb6b9): bazel-built 9
+          # OCI images in 7m9s (cold cache), then `kind load` filled the
+          # runner disk and the build aborted at 15m15s with `no space
+          # left on device` while loading backend-worker into the 6-node
+          # cluster. Two upstream blockers also surface: test/oetf/
+          # local_images.py hardcodes the UI source path to
+          # `external/src/ui` (internal-repo layout — fails immediately
+          # on the public checkout), and the chart's default KIND profile
+          # spawns 6 node containers that duplicate every image's
+          # containerd storage 6x — quickly exhausts the ~145 GB runner
+          # disk. Enabling --build-local will need either a larger
+          # runner, a single-node KIND profile, or a runner-disk
+          # reclamation step (delete /opt/ghc, /usr/share/dotnet, etc.)
+          # — and the local_images.py path fix. Tracking as a follow-up
+          # so this gate ships now against released NGC images.
           trap '
             echo "::group::deploy_and_run wall clock"
             cat /tmp/oetf.time 2>/dev/null || echo "(no timing file written)"
@@ -160,10 +162,7 @@ jobs:
           /usr/bin/time -p -o /tmp/oetf.time \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
-              --target-pattern //test/smoke/... \
-              --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
-              --build-local \
               --keep --keep-on-failure \
               --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -32,6 +32,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # No git push from this job — drop the auto-injected token from
+          # the workspace so artifact uploads (kind-smoke-result,
+          # bazel-testlogs) can't accidentally include or leak it.
+          persist-credentials: false
 
       - name: Install kind
         run: |
@@ -285,7 +290,7 @@ jobs:
 
       - name: Upload OETF result JSON
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: kind-smoke-result
           path: kind-smoke-result.json
@@ -293,7 +298,7 @@ jobs:
 
       - name: Upload bazel test logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: bazel-testlogs
           path: bazel-testlogs/

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -138,12 +138,16 @@ jobs:
             cat /tmp/oetf.time 2>/dev/null || echo "(no timing file written)"
             echo "::endgroup::"
           ' EXIT
+          # `bazel run` cwd is the runfiles sandbox, NOT the workspace root —
+          # a relative `--output-json` path lands somewhere inside bazel-out
+          # where actions/upload-artifact + the summary step can't find it.
+          # Pass an absolute path under $GITHUB_WORKSPACE instead.
           /usr/bin/time -p -o /tmp/oetf.time \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
               --jobs 1 \
               --keep --keep-on-failure \
-              --output-json kind-smoke-result.json
+              --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 
       - name: Diagnose KIND state on failure
         if: failure() && steps.deploy_and_run.outcome == 'failure'

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -100,8 +100,67 @@ jobs:
             exit 3
           fi
 
+      - name: Free runner disk + relocate docker to /mnt
+        # Two-pronged disk headroom for --build-local:
+        #
+        # 1. Reclaim ~30 GB on / by removing pre-installed tooling the OETF
+        #    gate doesn't use (dotnet, Android SDK, GHC, PyPy cache,
+        #    CodeQL, boost, swift, az, microsoft tools).
+        #
+        # 2. Move /var/lib/docker to /mnt (the runner's separate ~80 GB
+        #    ephemeral SSD), then restart docker. KIND nodes are docker
+        #    containers and their containerd content stores grow on the
+        #    docker storage root — without this move, even after step 1
+        #    the 6-node × 9-image duplication exhausts / and the runner
+        #    process itself crashes mid-job (measured: runs #26, #29).
+        run: |
+          set -euo pipefail
+          echo "::group::Before reclaim"
+          df -h / /mnt 2>/dev/null || df -h /
+          echo "::endgroup::"
+
+          echo "::group::Reclaim ~30 GB on /"
+          for d in /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                   /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/CodeQL \
+                   /opt/google/chrome /opt/microsoft /opt/az /opt/pipx \
+                   /opt/swift /usr/local/share/boost \
+                   /usr/local/share/powershell; do
+            if [ -d "$d" ]; then
+              sudo rm -rf "$d" &
+            fi
+          done
+          wait
+          sudo docker image prune -af >/dev/null 2>&1 || true
+          echo "::endgroup::"
+
+          echo "::group::Relocate /var/lib/docker → /mnt/docker"
+          if [ -d /mnt ] && [ "$(stat -c '%a' /mnt 2>/dev/null || echo 0)" != "0" ]; then
+            sudo systemctl stop docker docker.socket containerd 2>/dev/null || true
+            sudo mkdir -p /mnt/docker
+            # Rsync (not mv) so we preserve the live /var/lib/docker tree
+            # while validating it copied cleanly; remove only after success.
+            sudo rsync -aHAX --delete /var/lib/docker/ /mnt/docker/
+            sudo rm -rf /var/lib/docker
+            sudo ln -s /mnt/docker /var/lib/docker
+            sudo systemctl start docker
+            # docker.socket comes up via docker.service activation.
+            for _ in $(seq 1 30); do
+              docker info >/dev/null 2>&1 && break
+              sleep 1
+            done
+            echo "docker now backed by:"
+            docker info 2>/dev/null | grep -E '^ (Docker Root Dir|Storage Driver):'
+          else
+            echo "WARN: /mnt not available; staying on / (build-local may fail on disk)"
+          fi
+          echo "::endgroup::"
+
+          echo "::group::After reclaim + relocate"
+          df -h / /mnt 2>/dev/null || df -h /
+          echo "::endgroup::"
+
       - name: Disk space (pre-deploy)
-        run: df -h /
+        run: df -h / /mnt 2>/dev/null || df -h /
 
       - name: Build osmo CLI
         run: |
@@ -116,40 +175,34 @@ jobs:
       - name: Run OETF deploy_and_run on KIND
         id: deploy_and_run
         run: |
-          # --jobs=1 serializes the test suite. The KIND-deployed
-          # quick-start chart runs a single ingress-nginx replica with
-          # default resources; parallel scenario submits saturate it and
-          # intermittently 504. Trade-off: longer wall clock; in exchange
-          # we get deterministic green. Lift back to default jobs once the
-          # chart's kind profile bumps ingress replicas.
+          # --build-local: build the 9 OSMO service images + web-ui from
+          # the PR's source and kind-load them, instead of helm pulling
+          # nvcr.io/nvidia/osmo:6.2 from NGC. Disk pressure is real on
+          # hosted ubuntu-latest — see the "Free runner disk + relocate
+          # docker to /mnt" step above for the two-pronged mitigation
+          # (reclaim ~30 GB + move docker storage off / to the runner's
+          # /mnt ephemeral volume).
+          #
+          # Scenario set is curated for PR-gate cost: smoke (api-checks +
+          # websocket-checks, ~5s) covers service+router+logger HTTP/WS
+          # surfaces; templates + mount-validation (~6s) submit workflows
+          # so backend-listener / backend-worker / osmo_ctrl runtime get
+          # touched too. Slow scenarios (router-connectivity 140s,
+          # serial-workflow-mounting 60s, logger-connectivity 30s) stay
+          # out of the gate.
+          #
+          # --jobs=1 serializes: the chart's single-replica ingress-nginx
+          # 504s under parallel scenario submits. With 4 short tests,
+          # parallelism saves <10s anyway.
           #
           # `time` writes total wall clock to the step log so regressions
-          # past the ~15-min PR-gate budget show up in the run timeline,
-          # not just per-step in the Actions UI. EXIT trap so the timing
-          # block lands on the failure path too (default `set -e` would
-          # otherwise skip the cat after a bazel non-zero exit).
+          # past the ~15-min PR-gate budget show up in the run timeline.
+          # EXIT trap so the timing block lands on the failure path too.
           #
           # --keep + --keep-on-failure: leave the cluster intact on either
           # deploy or test failure so the "Diagnose KIND state on failure"
           # step below can capture pod state. The explicit "Cleanup KIND
           # cluster" step (if: always()) tears it down afterward.
-          #
-          # NOTE on --build-local: not enabled here. Measured on hosted
-          # ubuntu-latest across runs #26/#28/#29 — every attempt fails
-          # mid kind-load with the runner host disk exhausting. The 6-node
-          # KIND profile (one per chart node_group) duplicates each loaded
-          # image into 6 separate containerd content stores; 9 service
-          # images + web-ui together overrun the runner's 145 GB volume
-          # even after reclaiming 25-30 GB of pre-installed tooling. Run
-          # #29 died so hard the runner process itself crashed with `No
-          # space left on device` writing its diagnostic log, before
-          # cleanup steps could run. Two real local_images.py bugs that
-          # block --build-local on the public checkout (UI source path
-          # hardcoded for the internal overlay, disk-cache materialization
-          # missing) are fixed in this PR's accompanying commits, but the
-          # 6-node disk-pressure problem requires either a single-node
-          # KIND profile in the chart or a larger runner. Tracked as
-          # follow-up; ship the NGC-image gate today.
           trap '
             echo "::group::deploy_and_run wall clock"
             cat /tmp/oetf.time 2>/dev/null || echo "(no timing file written)"
@@ -162,7 +215,10 @@ jobs:
           /usr/bin/time -p -o /tmp/oetf.time \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
+              --target-pattern //test/smoke/... \
+              --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
+              --build-local \
               --keep --keep-on-failure \
               --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -139,17 +139,22 @@ jobs:
       - name: Run OETF deploy_and_run on KIND
         id: deploy_and_run
         run: |
-          # --build-local: build the 9 OSMO service images from PR source
-          # and kind-load them, instead of pulling nvcr.io/nvidia/osmo:6.2
-          # from NGC. Disk strategy on hosted ubuntu-latest:
-          #   - "Free runner disk" step above: reclaim 22-25 GB on /
-          #   - --build-images skips web-ui (saves ~8 GB Next.js intermediates
-          #     + 6-node image duplication)
-          #   - --extra-set web-ui.services.ui.replicas=0 scales the chart's
-          #     web-ui Deployment to zero so kubectl wait still succeeds
-          #   - local_images.build_and_load now docker-rmi's the host's copy
-          #     and deletes the bazel-out tarball after each per-image
-          #     kind-load completes (saves ~10-15 GB intra-step)
+          # --build-local + --use-local-registry: build 9 OSMO service images
+          # from PR source, push to a host-side `registry:2` container, KIND
+          # nodes pull from it on-demand. Replaces `kind load docker-image`
+          # which duplicates each image into every node's containerd content
+          # store (6 nodes × 9 images = 54 image-copies — overruns hosted
+          # ubuntu-latest's 145 GB disk). With registry mode each KIND node
+          # only pulls images its pods actually schedule (1-2 nodes per
+          # image under the chart's node_group selectors), dropping the
+          # multiplier from 6x to 1-2x.
+          #
+          # --build-images skips web-ui (saves ~8 GB Next.js intermediates
+          # + 6-node duplication; UI still uses the kind-load path).
+          # --extra-set web-ui.services.ui.replicas=0 scales the chart's
+          # web-ui Deployment to zero so kubectl wait still succeeds.
+          #
+          # "Free runner disk" step above reclaims 22-25 GB pre-deploy.
           #
           # Scenario set narrowed for PR-gate cost: smoke (api-checks +
           # websocket-checks, ~5s) covers service+router+logger HTTP/WS;
@@ -181,7 +186,7 @@ jobs:
               --target-pattern //test/smoke/... \
               --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
-              --build-local \
+              --build-local --use-local-registry \
               --build-images service,agent,logger,worker,delayed-job-monitor,router,authz-sidecar,backend-listener,backend-worker \
               --extra-set web-ui.services.ui.replicas=0 \
               --keep --keep-on-failure \

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -100,67 +100,8 @@ jobs:
             exit 3
           fi
 
-      - name: Free runner disk + relocate docker to /mnt
-        # Two-pronged disk headroom for --build-local:
-        #
-        # 1. Reclaim ~30 GB on / by removing pre-installed tooling the OETF
-        #    gate doesn't use (dotnet, Android SDK, GHC, PyPy cache,
-        #    CodeQL, boost, swift, az, microsoft tools).
-        #
-        # 2. Move /var/lib/docker to /mnt (the runner's separate ~80 GB
-        #    ephemeral SSD), then restart docker. KIND nodes are docker
-        #    containers and their containerd content stores grow on the
-        #    docker storage root — without this move, even after step 1
-        #    the 6-node × 9-image duplication exhausts / and the runner
-        #    process itself crashes mid-job (measured: runs #26, #29).
-        run: |
-          set -euo pipefail
-          echo "::group::Before reclaim"
-          df -h / /mnt 2>/dev/null || df -h /
-          echo "::endgroup::"
-
-          echo "::group::Reclaim ~30 GB on /"
-          for d in /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                   /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/CodeQL \
-                   /opt/google/chrome /opt/microsoft /opt/az /opt/pipx \
-                   /opt/swift /usr/local/share/boost \
-                   /usr/local/share/powershell; do
-            if [ -d "$d" ]; then
-              sudo rm -rf "$d" &
-            fi
-          done
-          wait
-          sudo docker image prune -af >/dev/null 2>&1 || true
-          echo "::endgroup::"
-
-          echo "::group::Relocate /var/lib/docker → /mnt/docker"
-          if [ -d /mnt ] && [ "$(stat -c '%a' /mnt 2>/dev/null || echo 0)" != "0" ]; then
-            sudo systemctl stop docker docker.socket containerd 2>/dev/null || true
-            sudo mkdir -p /mnt/docker
-            # Rsync (not mv) so we preserve the live /var/lib/docker tree
-            # while validating it copied cleanly; remove only after success.
-            sudo rsync -aHAX --delete /var/lib/docker/ /mnt/docker/
-            sudo rm -rf /var/lib/docker
-            sudo ln -s /mnt/docker /var/lib/docker
-            sudo systemctl start docker
-            # docker.socket comes up via docker.service activation.
-            for _ in $(seq 1 30); do
-              docker info >/dev/null 2>&1 && break
-              sleep 1
-            done
-            echo "docker now backed by:"
-            docker info 2>/dev/null | grep -E '^ (Docker Root Dir|Storage Driver):'
-          else
-            echo "WARN: /mnt not available; staying on / (build-local may fail on disk)"
-          fi
-          echo "::endgroup::"
-
-          echo "::group::After reclaim + relocate"
-          df -h / /mnt 2>/dev/null || df -h /
-          echo "::endgroup::"
-
       - name: Disk space (pre-deploy)
-        run: df -h / /mnt 2>/dev/null || df -h /
+        run: df -h /
 
       - name: Build osmo CLI
         run: |
@@ -175,34 +116,40 @@ jobs:
       - name: Run OETF deploy_and_run on KIND
         id: deploy_and_run
         run: |
-          # --build-local: build the 9 OSMO service images + web-ui from
-          # the PR's source and kind-load them, instead of helm pulling
-          # nvcr.io/nvidia/osmo:6.2 from NGC. Disk pressure is real on
-          # hosted ubuntu-latest — see the "Free runner disk + relocate
-          # docker to /mnt" step above for the two-pronged mitigation
-          # (reclaim ~30 GB + move docker storage off / to the runner's
-          # /mnt ephemeral volume).
-          #
-          # Scenario set is curated for PR-gate cost: smoke (api-checks +
-          # websocket-checks, ~5s) covers service+router+logger HTTP/WS
-          # surfaces; templates + mount-validation (~6s) submit workflows
-          # so backend-listener / backend-worker / osmo_ctrl runtime get
-          # touched too. Slow scenarios (router-connectivity 140s,
-          # serial-workflow-mounting 60s, logger-connectivity 30s) stay
-          # out of the gate.
-          #
-          # --jobs=1 serializes: the chart's single-replica ingress-nginx
-          # 504s under parallel scenario submits. With 4 short tests,
-          # parallelism saves <10s anyway.
+          # --jobs=1 serializes the test suite. The KIND-deployed
+          # quick-start chart runs a single ingress-nginx replica with
+          # default resources; parallel scenario submits saturate it and
+          # intermittently 504. Trade-off: longer wall clock; in exchange
+          # we get deterministic green. Lift back to default jobs once the
+          # chart's kind profile bumps ingress replicas.
           #
           # `time` writes total wall clock to the step log so regressions
-          # past the ~15-min PR-gate budget show up in the run timeline.
-          # EXIT trap so the timing block lands on the failure path too.
+          # past the ~15-min PR-gate budget show up in the run timeline,
+          # not just per-step in the Actions UI. EXIT trap so the timing
+          # block lands on the failure path too (default `set -e` would
+          # otherwise skip the cat after a bazel non-zero exit).
           #
           # --keep + --keep-on-failure: leave the cluster intact on either
           # deploy or test failure so the "Diagnose KIND state on failure"
           # step below can capture pod state. The explicit "Cleanup KIND
           # cluster" step (if: always()) tears it down afterward.
+          #
+          # NOTE on --build-local: not enabled. Measured five times on
+          # hosted ubuntu-latest with progressively more aggressive disk
+          # mitigations (runs #26, #28, #29, #31, #32); each ended with
+          # the Actions runner process crashing on `No space left on
+          # device` mid-job, before cleanup/diagnostic steps could run.
+          # Chart's 6-node KIND profile duplicates every loaded image
+          # into 6 separate containerd content stores; 9 service images
+          # (each ~500 MB) plus web-ui (~300 MB) overrun the runner's
+          # 145-GB volume even after reclaiming ~22 GB of pre-installed
+          # tooling AND skipping the web-ui build AND scaling its chart
+          # Deployment to 0. ubuntu-latest's /mnt is on the same physical
+          # device as / (confirmed via df -h showing /dev/root for both),
+          # so docker storage relocation didn't add headroom either.
+          # Enabling --build-local needs single-node KIND profile +
+          # chart-side scheduling override, OR a larger / self-hosted
+          # runner. Tracked as follow-up.
           trap '
             echo "::group::deploy_and_run wall clock"
             cat /tmp/oetf.time 2>/dev/null || echo "(no timing file written)"
@@ -212,20 +159,10 @@ jobs:
           # a relative `--output-json` path lands somewhere inside bazel-out
           # where actions/upload-artifact + the summary step can't find it.
           # Pass an absolute path under $GITHUB_WORKSPACE instead.
-          # --build-images excludes web-ui: a Next.js multi-stage docker
-          # buildx adds ~5 GB intermediate + ~500 MB tarball + ~300 MB
-          # image × 6 KIND nodes (~8 GB total). Smoke tests hit no UI
-          # endpoint, so scale the web-ui Deployment to 0 via --extra-set
-          # — kubectl wait then treats Available as trivially true.
           /usr/bin/time -p -o /tmp/oetf.time \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
-              --target-pattern //test/smoke/... \
-              --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
-              --build-local \
-              --build-images service,agent,logger,worker,delayed-job-monitor,router,authz-sidecar,backend-listener,backend-worker \
-              --extra-set web-ui.services.ui.replicas=0 \
               --keep --keep-on-failure \
               --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -100,6 +100,29 @@ jobs:
             exit 3
           fi
 
+      - name: Free runner disk for --build-local
+        # Reclaim ~22-25 GB by removing pre-installed tooling the OETF
+        # gate doesn't use. Pairs with the intra-step host-docker cleanup
+        # in local_images.build_and_load (docker rmi + tarball delete per
+        # image after kind-load), needed because the chart's 6-node KIND
+        # profile duplicates every loaded image into 6 separate
+        # containerd content stores. Without both mitigations the runner
+        # crashes mid-job with "No space left on device" (measured #29,
+        # #31, #32).
+        run: |
+          set -euo pipefail
+          for d in /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                   /opt/hostedtoolcache/PyPy /opt/hostedtoolcache/CodeQL \
+                   /opt/google/chrome /opt/microsoft /opt/az /opt/pipx \
+                   /opt/swift /usr/local/share/boost \
+                   /usr/local/share/powershell; do
+            if [ -d "$d" ]; then
+              sudo rm -rf "$d" &
+            fi
+          done
+          wait
+          sudo docker image prune -af >/dev/null 2>&1 || true
+
       - name: Disk space (pre-deploy)
         run: df -h /
 
@@ -116,53 +139,51 @@ jobs:
       - name: Run OETF deploy_and_run on KIND
         id: deploy_and_run
         run: |
-          # --jobs=1 serializes the test suite. The KIND-deployed
-          # quick-start chart runs a single ingress-nginx replica with
-          # default resources; parallel scenario submits saturate it and
-          # intermittently 504. Trade-off: longer wall clock; in exchange
-          # we get deterministic green. Lift back to default jobs once the
-          # chart's kind profile bumps ingress replicas.
+          # --build-local: build the 9 OSMO service images from PR source
+          # and kind-load them, instead of pulling nvcr.io/nvidia/osmo:6.2
+          # from NGC. Disk strategy on hosted ubuntu-latest:
+          #   - "Free runner disk" step above: reclaim 22-25 GB on /
+          #   - --build-images skips web-ui (saves ~8 GB Next.js intermediates
+          #     + 6-node image duplication)
+          #   - --extra-set web-ui.services.ui.replicas=0 scales the chart's
+          #     web-ui Deployment to zero so kubectl wait still succeeds
+          #   - local_images.build_and_load now docker-rmi's the host's copy
+          #     and deletes the bazel-out tarball after each per-image
+          #     kind-load completes (saves ~10-15 GB intra-step)
+          #
+          # Scenario set narrowed for PR-gate cost: smoke (api-checks +
+          # websocket-checks, ~5s) covers service+router+logger HTTP/WS;
+          # templates + mount-validation (~6s) submit workflows so
+          # backend-listener / backend-worker / osmo_ctrl runtime get
+          # touched.
+          #
+          # --jobs=1 serializes: chart's single-replica ingress-nginx 504s
+          # under parallel scenario submits.
           #
           # `time` writes total wall clock to the step log so regressions
-          # past the ~15-min PR-gate budget show up in the run timeline,
-          # not just per-step in the Actions UI. EXIT trap so the timing
-          # block lands on the failure path too (default `set -e` would
-          # otherwise skip the cat after a bazel non-zero exit).
+          # past the ~15-min PR-gate budget show up in the run timeline.
+          # EXIT trap so the timing block lands on the failure path too.
           #
           # --keep + --keep-on-failure: leave the cluster intact on either
           # deploy or test failure so the "Diagnose KIND state on failure"
-          # step below can capture pod state. The explicit "Cleanup KIND
-          # cluster" step (if: always()) tears it down afterward.
-          #
-          # NOTE on --build-local: not enabled. Measured five times on
-          # hosted ubuntu-latest with progressively more aggressive disk
-          # mitigations (runs #26, #28, #29, #31, #32); each ended with
-          # the Actions runner process crashing on `No space left on
-          # device` mid-job, before cleanup/diagnostic steps could run.
-          # Chart's 6-node KIND profile duplicates every loaded image
-          # into 6 separate containerd content stores; 9 service images
-          # (each ~500 MB) plus web-ui (~300 MB) overrun the runner's
-          # 145-GB volume even after reclaiming ~22 GB of pre-installed
-          # tooling AND skipping the web-ui build AND scaling its chart
-          # Deployment to 0. ubuntu-latest's /mnt is on the same physical
-          # device as / (confirmed via df -h showing /dev/root for both),
-          # so docker storage relocation didn't add headroom either.
-          # Enabling --build-local needs single-node KIND profile +
-          # chart-side scheduling override, OR a larger / self-hosted
-          # runner. Tracked as follow-up.
+          # step below can capture pod state.
           trap '
             echo "::group::deploy_and_run wall clock"
             cat /tmp/oetf.time 2>/dev/null || echo "(no timing file written)"
             echo "::endgroup::"
+            echo "::group::Disk space (post-run)"
+            df -h /
+            echo "::endgroup::"
           ' EXIT
-          # `bazel run` cwd is the runfiles sandbox, NOT the workspace root —
-          # a relative `--output-json` path lands somewhere inside bazel-out
-          # where actions/upload-artifact + the summary step can't find it.
-          # Pass an absolute path under $GITHUB_WORKSPACE instead.
           /usr/bin/time -p -o /tmp/oetf.time \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
+              --target-pattern //test/smoke/... \
+              --target-pattern //test/scenarios:templates,//test/scenarios:mount-validation \
               --jobs 1 \
+              --build-local \
+              --build-images service,agent,logger,worker,delayed-job-monitor,router,authz-sidecar,backend-listener,backend-worker \
+              --extra-set web-ui.services.ui.replicas=0 \
               --keep --keep-on-failure \
               --output-json "${GITHUB_WORKSPACE}/kind-smoke-result.json"
 

--- a/test/oetf/cli_args.py
+++ b/test/oetf/cli_args.py
@@ -100,6 +100,15 @@ def add_deploy_args(parser: argparse.ArgumentParser) -> None:
              "(default: all).",
     )
     parser.add_argument(
+        "--use-local-registry", action="store_true",
+        help="KIND --build-local: push built images to a local docker "
+             "registry that all KIND nodes pull from, instead of "
+             "`kind load docker-image` which duplicates each image into "
+             "every node's containerd. Required for environments where "
+             "the 6-node × 9-image kind-load footprint exceeds available "
+             "disk (e.g. hosted GitHub Actions ubuntu-latest runners).",
+    )
+    parser.add_argument(
         "--with-metrics-server", action="store_true",
         help="KIND only: install metrics-server (opt-in; adds ~1min to deploy).",
     )

--- a/test/oetf/deploy_adapters/factory.py
+++ b/test/oetf/deploy_adapters/factory.py
@@ -222,10 +222,21 @@ def _build_kind_adapter(args: argparse.Namespace, env: EnvironmentConfig) -> Kin
     image_tag = getattr(args, "image_tag", "")
     pre_install_hook = None
     build_local = getattr(args, "build_local", False)
+    use_local_registry = getattr(args, "use_local_registry", False) and build_local
     if build_local:
-        image_location = local_images.image_location()
+        # Registry mode publishes images to localhost:5001/osmo and the
+        # chart pulls from there; legacy --build-local stays on osmo.local
+        # (pseudo-prefix never actually contacted thanks to IfNotPresent).
+        image_location = (
+            local_images.registry_image_location()
+            if use_local_registry
+            else local_images.image_location()
+        )
         image_tag = local_images.image_tag()
-        pre_install_hook = _make_build_local_hook(getattr(args, "build_images", "all"))
+        pre_install_hook = _make_build_local_hook(
+            getattr(args, "build_images", "all"),
+            use_local_registry=use_local_registry,
+        )
     return KindAdapter(
         mode=getattr(args, "mode", None) or env.mode,
         image_location=image_location,
@@ -235,6 +246,7 @@ def _build_kind_adapter(args: argparse.Namespace, env: EnvironmentConfig) -> Kin
         install_metrics_server=getattr(args, "with_metrics_server", False),
         pre_install_hook=pre_install_hook,
         build_local=build_local,
+        use_local_registry=use_local_registry,
     )
 
 
@@ -257,12 +269,19 @@ def _build_custom_teardown_adapter(env: EnvironmentConfig) -> NoopAdapter:
     return NoopAdapter()
 
 
-def _make_build_local_hook(image_selector: str):
-    """Return a pre_install_hook callable that builds + kind-loads local images.
+def _make_build_local_hook(image_selector: str, use_local_registry: bool = False):
+    """Return a pre_install_hook callable that builds + ships local images.
 
     The 9 Python services build via bazel + oci_load + tarball; the web-ui
     builds via docker buildx (multi-stage Next.js Dockerfile). Independent
     pipelines, run concurrently for ~halved wall-clock vs. sequential.
+
+    Two delivery paths:
+      - default: ``kind load docker-image`` into every KIND node.
+      - ``use_local_registry=True``: docker push to a host-side ``registry:2``
+        container that the KIND nodes pull from on-demand. The 6x node-side
+        containerd duplication is replaced with single-copy registry
+        storage; required on disk-constrained CI runners.
     """
     def _hook(cluster_name: str) -> None:
         arch = local_images.detect_arch()
@@ -272,10 +291,19 @@ def _make_build_local_hook(image_selector: str):
 
         tasks = []
         if selected_services:
-            tasks.append(("services", lambda: local_images.build_and_load(
-                selected_services, cluster_name, arch=arch,
-            )))
+            if use_local_registry:
+                tasks.append(("services", lambda: local_images.build_and_push_to_registry(
+                    selected_services, arch=arch,
+                )))
+            else:
+                tasks.append(("services", lambda: local_images.build_and_load(
+                    selected_services, cluster_name, arch=arch,
+                )))
         if build_ui:
+            # web-ui still uses build_and_load_ui (docker buildx + kind
+            # load). Registry-push path for UI is a follow-up — the Next.js
+            # build is the biggest single space hit, but only one image
+            # so the multiplier is much smaller than for the services.
             tasks.append(("web-ui", lambda: local_images.build_and_load_ui(
                 cluster_name, arch=arch,
             )))

--- a/test/oetf/deploy_adapters/factory.py
+++ b/test/oetf/deploy_adapters/factory.py
@@ -300,13 +300,14 @@ def _make_build_local_hook(image_selector: str, use_local_registry: bool = False
                     selected_services, cluster_name, arch=arch,
                 )))
         if build_ui:
-            # web-ui still uses build_and_load_ui (docker buildx + kind
-            # load). Registry-push path for UI is a follow-up — the Next.js
-            # build is the biggest single space hit, but only one image
-            # so the multiplier is much smaller than for the services.
-            tasks.append(("web-ui", lambda: local_images.build_and_load_ui(
-                cluster_name, arch=arch,
-            )))
+            if use_local_registry:
+                tasks.append(("web-ui", lambda: local_images.build_and_push_ui_to_registry(
+                    arch=arch,
+                )))
+            else:
+                tasks.append(("web-ui", lambda: local_images.build_and_load_ui(
+                    cluster_name, arch=arch,
+                )))
 
         if not tasks:
             return

--- a/test/oetf/deploy_adapters/kind_adapter.py
+++ b/test/oetf/deploy_adapters/kind_adapter.py
@@ -185,6 +185,13 @@ class KindAdapter:
     # ``osmo.local`` isn't actually contacted) and skips the web-ui Deployment
     # (we don't build the UI image locally — only the 9 Python services).
     build_local: bool = False
+    # When True (paired with build_local), publish locally-built images to a
+    # host-side ``registry:2`` container that KIND nodes pull from on-demand
+    # via containerdConfigPatches. Replaces `kind load docker-image` (which
+    # duplicates each image into every node's containerd content store) and
+    # is required on disk-constrained CI runners — see local_images for the
+    # full rationale.
+    use_local_registry: bool = False
     # Injected for tests — callables matching subprocess.run / urllib.request.urlopen.
     subprocess_runner: Optional[Callable[..., Any]] = None
     url_opener: Optional[Callable[..., Any]] = None
@@ -412,8 +419,22 @@ class KindAdapter:
         )
         if cluster_name in existing.splitlines():
             logger.info("▶ KIND cluster '%s' already exists — reusing", cluster_name)
+            if self.use_local_registry and self.build_local:
+                # Make sure the per-node hosts.toml is in place even when
+                # we're reusing an existing cluster (defensive: a previous
+                # run may have failed before wiring).
+                local_images.ensure_local_registry()
+                local_images.connect_registry_to_kind(cluster_name)
             return True
         config_path = self.kind_config_path or _default_kind_config_path()
+        if self.use_local_registry and self.build_local:
+            # Start the registry container BEFORE the cluster comes up so
+            # the post-create wiring can connect it to the kind network.
+            local_images.ensure_local_registry()
+            # Inject containerdConfigPatches so each node's containerd looks
+            # under /etc/containerd/certs.d/ — the per-node hosts.toml we
+            # write next must be backed by this config-path mode.
+            config_path = local_images.patched_kind_config_with_registry(config_path)
         # Don't pre-check ``os.path.isfile(config_path)``: kind's own error
         # message ("could not find a config file…") is already actionable,
         # and a TOCTOU pre-check duplicates the failure mode without adding
@@ -422,6 +443,8 @@ class KindAdapter:
             ["kind", "create", "cluster", "--name", cluster_name, "--config", config_path],
             "Creating KIND cluster",
         )
+        if self.use_local_registry and self.build_local:
+            local_images.connect_registry_to_kind(cluster_name)
         return False
 
     def _helm_repo_add(self) -> None:

--- a/test/oetf/local_images.py
+++ b/test/oetf/local_images.py
@@ -280,17 +280,27 @@ def _tarballs_by_target_name(cquery_files_output: str) -> Dict[str, str]:
 
 
 WEB_UI_DOCKER_TAG_TEMPLATE = "osmo.local/web-ui:latest-{arch}"
-_UI_SOURCE_RELPATH = "external/src/ui"
+# Two layouts are valid: the internal overlay mounts the public OSMO repo at
+# external/ (UI lives at external/src/ui), while a standalone public checkout
+# has UI directly at src/ui. Tried in order — first existing path wins.
+_UI_SOURCE_RELPATH_CANDIDATES = ("external/src/ui", "src/ui")
 
 
 def _ui_dir(workspace: str) -> str:
-    """Resolve the UI source directory.
+    """Resolve the UI source directory for the current workspace layout.
 
-    The Bazel workspace is laid out with the OSMO submodule at
-    ``external/`` — UI source is ``external/src/ui``. This helper centralizes
-    the path so tests and callers don't string-build it.
+    Internal overlay: ``<workspace>/external/src/ui``.
+    Public standalone checkout: ``<workspace>/src/ui``.
+
+    Falls back to the first candidate if neither exists so the downstream
+    ``docker buildx build`` produces the same actionable "path not found"
+    error a hardcoded path would have produced.
     """
-    return os.path.join(workspace, _UI_SOURCE_RELPATH)
+    for candidate in _UI_SOURCE_RELPATH_CANDIDATES:
+        path = os.path.join(workspace, candidate)
+        if os.path.isdir(path):
+            return path
+    return os.path.join(workspace, _UI_SOURCE_RELPATH_CANDIDATES[0])
 
 
 def _buildx_platform(arch: HostArch) -> str:

--- a/test/oetf/local_images.py
+++ b/test/oetf/local_images.py
@@ -32,6 +32,7 @@ import logging
 import os
 import platform
 import subprocess
+import tempfile
 from typing import Dict, List, Literal
 
 HostArch = Literal["arm64", "x86_64"]
@@ -237,7 +238,9 @@ def build_and_load(
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
         )
         try:
-            tarball_abs = os.path.join(workspace, tarball) if not os.path.isabs(tarball) else tarball
+            tarball_abs = (
+                tarball if os.path.isabs(tarball) else os.path.join(workspace, tarball)
+            )
             if os.path.isfile(tarball_abs):
                 os.remove(tarball_abs)
         except OSError:
@@ -439,7 +442,6 @@ def patched_kind_config_with_registry(source_path: str) -> str:
     per-node ``hosts.toml`` written by :func:`connect_registry_to_kind`
     takes effect.
     """
-    import tempfile
     with open(source_path, "r", encoding="utf-8") as src:
         content = src.read()
     patch = (

--- a/test/oetf/local_images.py
+++ b/test/oetf/local_images.py
@@ -592,6 +592,50 @@ def build_and_load_ui(
     )
 
 
+def build_and_push_ui_to_registry(arch: HostArch) -> None:
+    """Build the web-ui image and push to the local registry.
+
+    Mirrors :func:`build_and_load_ui` but skips ``kind load`` in favor of
+    a ``docker push`` to ``localhost:5001/osmo/web-ui:latest-<arch>``. The
+    chart's ingress-nginx has a hard ``wait-for-web-ui`` init container
+    dependency, so the web-ui Deployment must actually come up — scaling
+    it to ``replicas=0`` deadlocks the entire stack. Pushing to the
+    registry keeps disk impact to a single host-side copy (no 6x KIND-
+    node duplication).
+
+    Cleans up host docker storage after push: the registry has the layers
+    now, and the built image alone is ~3 GB.
+    """
+    workspace = os.environ.get("BUILD_WORKSPACE_DIRECTORY", os.getcwd())
+    ui_dir = _ui_dir(workspace)
+    buildx_platform = _buildx_platform(arch)
+    registry_tag = (
+        f"{LOCAL_REGISTRY_IMAGE_LOCATION}/web-ui:latest-{arch}"
+    )
+
+    logger.info("▶ Building web-ui (%s, docker buildx --load) for registry push",
+                buildx_platform)
+    subprocess.run(
+        ["docker", "buildx", "build",
+         "--platform", buildx_platform,
+         "-t", registry_tag,
+         "--load",
+         ui_dir],
+        check=True, cwd=workspace,
+    )
+    logger.info("▶ docker push %s", registry_tag)
+    subprocess.run(
+        ["docker", "push", registry_tag],
+        check=True, cwd=workspace,
+    )
+    # Reclaim host docker storage — registry has the layers now.
+    subprocess.run(
+        ["docker", "rmi", "-f", registry_tag],
+        check=False, cwd=workspace,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
 def image_tag(arch: HostArch | None = None) -> str:
     """Return the tag to use for ``global.osmoImageTag`` when deploying local."""
     return f"latest-{arch or detect_arch()}"

--- a/test/oetf/local_images.py
+++ b/test/oetf/local_images.py
@@ -249,6 +249,215 @@ def build_and_load(
         list(pool.map(_load_one, images, tarball_paths))
 
 
+# --- Local-registry push path (used when --build-local --use-local-registry) ---
+#
+# The default build_and_load path uses `kind load docker-image` which copies
+# each image into every KIND node's separate containerd content store. With
+# the chart's 6-node profile and 9 service images that is 54 image-copies
+# of duplicated storage, which exhausts the disk on small CI runners
+# (e.g. GitHub Actions ubuntu-latest 145 GB).
+#
+# The registry path replaces `kind load` with a `docker push` to a host-
+# local `registry:2` container. KIND nodes are configured (via
+# `containerdConfigPatches` + a per-node `hosts.toml`) to resolve
+# `localhost:5001` to that registry. Each node then pulls *only* the images
+# its pods schedule — for our chart that's 1-2 nodes per image, dropping
+# the on-disk multiplier from 6x to 1-2x.
+
+LOCAL_REGISTRY_NAME = "kind-registry"
+LOCAL_REGISTRY_PORT_HOST = 5001
+LOCAL_REGISTRY_PORT_CONTAINER = 5000
+LOCAL_REGISTRY_HOSTNAME = LOCAL_REGISTRY_NAME  # how KIND nodes reach it via docker network
+LOCAL_REGISTRY_IMAGE_LOCATION = f"localhost:{LOCAL_REGISTRY_PORT_HOST}/osmo"
+
+
+def registry_image_location() -> str:
+    """Return the ``global.osmoImageLocation`` value when using the local registry."""
+    return LOCAL_REGISTRY_IMAGE_LOCATION
+
+
+def build_and_push_to_registry(
+    images: List[ImageSpec],
+    arch: HostArch,
+) -> None:
+    """Build each image via bazel, retag for the local registry, and docker push.
+
+    Single bazel build (same as :func:`build_and_load`) materializes
+    tarballs, docker-loads each, retags from ``osmo.local/<svc>:tag`` to
+    ``localhost:5001/osmo/<svc>:tag``, and docker-pushes. The local
+    ``registry:2`` container deduplicates layers across images, so the
+    on-host registry storage is much smaller than the union of individual
+    OCI tarballs would be.
+
+    The host's docker daemon copies + bazel-out tarballs are deleted
+    immediately after each successful push — they aren't needed once the
+    layer is in the registry, and CI runners with tight disk budgets
+    benefit from the intra-step reclaim.
+    """
+    if not images:
+        return
+    workspace = os.environ.get("BUILD_WORKSPACE_DIRECTORY", os.getcwd())
+    platforms = _platforms_flag(arch)
+    targets = [image.bazel_target for image in images]
+
+    logger.info("▶ Building %d image(s) for registry push: %s",
+                len(images), ", ".join(i.short_name for i in images))
+    subprocess.run(
+        ["bazel", "build", platforms,
+         "--remote_download_outputs=all",
+         "--output_groups=+tarball", *targets],
+        check=True, cwd=workspace,
+    )
+    tarball_paths = _tarball_paths(targets, platforms, workspace)
+
+    def _push_one(image: ImageSpec, tarball: str) -> None:
+        # docker_tag is the bazel oci_load tag (osmo.local/<svc>:<arch-tag>).
+        registry_tag = image.docker_tag.replace(
+            image_location(), LOCAL_REGISTRY_IMAGE_LOCATION,
+        )
+        logger.info("▶ docker load -i %s", tarball)
+        subprocess.run(["docker", "load", "-i", tarball], check=True, cwd=workspace)
+        logger.info("▶ docker tag %s %s", image.docker_tag, registry_tag)
+        subprocess.run(
+            ["docker", "tag", image.docker_tag, registry_tag],
+            check=True, cwd=workspace,
+        )
+        logger.info("▶ docker push %s", registry_tag)
+        subprocess.run(
+            ["docker", "push", registry_tag],
+            check=True, cwd=workspace,
+        )
+        # Reclaim host docker storage + bazel-out tarball — registry has
+        # the layers now. `|| true`-style: cleanup must not break the run.
+        for tag in (image.docker_tag, registry_tag):
+            subprocess.run(
+                ["docker", "rmi", "-f", tag],
+                check=False, cwd=workspace,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+        try:
+            tarball_abs = (
+                os.path.join(workspace, tarball)
+                if not os.path.isabs(tarball) else tarball
+            )
+            if os.path.isfile(tarball_abs):
+                os.remove(tarball_abs)
+        except OSError:
+            pass
+
+    # Concurrency cap matches build_and_load: registry pushes are
+    # I/O-bound on the same host docker daemon + bazel-out filesystem.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(len(images), 8)) as pool:
+        list(pool.map(_push_one, images, tarball_paths))
+
+
+def ensure_local_registry() -> None:
+    """Start the ``kind-registry`` container if it isn't already running.
+
+    Idempotent: a no-op when the container already exists. Listens on
+    ``127.0.0.1:5001`` so the host can `docker push` to it; KIND nodes
+    reach it as ``http://kind-registry:5000`` after the kind docker
+    network is connected (see :func:`connect_registry_to_kind`).
+    """
+    inspect = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Running}}", LOCAL_REGISTRY_NAME],
+        check=False, capture_output=True, text=True,
+    )
+    running = inspect.returncode == 0 and inspect.stdout.strip() == "true"
+    if running:
+        logger.info("▶ kind-registry already running — reusing")
+        return
+    if inspect.returncode == 0:
+        # Exists but stopped — remove so we get a clean port binding.
+        subprocess.run(
+            ["docker", "rm", "-f", LOCAL_REGISTRY_NAME],
+            check=False, capture_output=True,
+        )
+    logger.info("▶ Starting kind-registry container (registry:2)")
+    subprocess.run(
+        ["docker", "run", "-d", "--restart=always",
+         "-p", f"127.0.0.1:{LOCAL_REGISTRY_PORT_HOST}:{LOCAL_REGISTRY_PORT_CONTAINER}",
+         "--network", "bridge",
+         "--name", LOCAL_REGISTRY_NAME,
+         "registry:2"],
+        check=True, capture_output=True,
+    )
+
+
+def connect_registry_to_kind(cluster_name: str) -> None:
+    """Connect the registry container to the kind docker network + write per-node
+    containerd ``hosts.toml`` so `localhost:5001` resolves to the registry.
+
+    Must run AFTER the KIND cluster is created (the ``kind`` docker network
+    only exists once `kind create cluster` has run) and BEFORE helm install
+    (kubelet needs the registry mapping in place when it pulls pod images).
+
+    The KIND config must already include a ``containerdConfigPatches:``
+    entry enabling ``config_path = "/etc/containerd/certs.d"`` — see
+    :func:`patched_kind_config_with_registry`.
+    """
+    # Connect the registry to the kind network if not already connected. The
+    # docker network connect command errors with "already exists in network"
+    # if re-run; suppress that idempotently.
+    subprocess.run(
+        ["docker", "network", "connect", "kind", LOCAL_REGISTRY_NAME],
+        check=False, capture_output=True,
+    )
+
+    # Per-node containerd hosts.toml: map localhost:5001 -> kind-registry:5000.
+    hosts_toml = (
+        f'[host."http://{LOCAL_REGISTRY_HOSTNAME}:{LOCAL_REGISTRY_PORT_CONTAINER}"]\n'
+    )
+    nodes_out = subprocess.run(
+        ["kind", "get", "nodes", "--name", cluster_name],
+        check=True, capture_output=True, text=True,
+    )
+    nodes = [n.strip() for n in nodes_out.stdout.splitlines() if n.strip()]
+    cert_dir = f"/etc/containerd/certs.d/localhost:{LOCAL_REGISTRY_PORT_HOST}"
+    for node in nodes:
+        logger.info("▶ Wiring containerd hosts.toml on %s", node)
+        subprocess.run(
+            ["docker", "exec", node, "mkdir", "-p", cert_dir],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["docker", "exec", "-i", node,
+             "sh", "-c", f'cat > {cert_dir}/hosts.toml'],
+            check=True, input=hosts_toml, text=True, capture_output=True,
+        )
+
+
+def patched_kind_config_with_registry(source_path: str) -> str:
+    """Return a path to a KIND config that adds ``containerdConfigPatches``.
+
+    Reads ``source_path`` (the bundled kind-osmo-cluster-config.yaml), and
+    writes a copy to ``$TMPDIR`` with an injected ``containerdConfigPatches``
+    block. The original config stays untouched — internal callers that
+    don't use the registry are unaffected.
+
+    Uses the standard KIND local-registry patch (config_path mode) so the
+    per-node ``hosts.toml`` written by :func:`connect_registry_to_kind`
+    takes effect.
+    """
+    import tempfile
+    with open(source_path, "r", encoding="utf-8") as src:
+        content = src.read()
+    patch = (
+        "\ncontainerdConfigPatches:\n"
+        "  - |-\n"
+        '    [plugins."io.containerd.grpc.v1.cri".registry]\n'
+        '      config_path = "/etc/containerd/certs.d"\n'
+    )
+    # Append at end; YAML parses top-level keys in any order.
+    out_fd, out_path = tempfile.mkstemp(prefix="kind-osmo-registry-", suffix=".yaml")
+    os.close(out_fd)
+    with open(out_path, "w", encoding="utf-8") as dst:
+        dst.write(content)
+        if "containerdConfigPatches" not in content:
+            dst.write(patch)
+    return out_path
+
+
 def _tarball_paths(
     bazel_targets: List[str], platforms: str, workspace: str,
 ) -> List[str]:

--- a/test/oetf/local_images.py
+++ b/test/oetf/local_images.py
@@ -225,6 +225,23 @@ def build_and_load(
             ["kind", "load", "docker-image", image.docker_tag, "--name", cluster_name],
             check=True,
         )
+        # Each KIND node now owns its own containerd copy; the host's docker
+        # daemon copy and the on-disk tarball are redundant. Reclaim them.
+        # On hosted CI (e.g. GHA ubuntu-latest 145 GB / volume) the
+        # 9 × 6-node duplication crowds out the runner mid-run without
+        # this intra-step cleanup. `|| true` is intentional — cleanup
+        # failure must not break the build flow.
+        subprocess.run(
+            ["docker", "rmi", "-f", image.docker_tag],
+            check=False, cwd=workspace,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        try:
+            tarball_abs = os.path.join(workspace, tarball) if not os.path.isabs(tarball) else tarball
+            if os.path.isfile(tarball_abs):
+                os.remove(tarball_abs)
+        except OSError:
+            pass
 
     # Cap concurrency at 8: docker load is I/O-bound and `kind load`
     # serializes inside containerd anyway; more workers buy nothing.

--- a/test/oetf/local_images.py
+++ b/test/oetf/local_images.py
@@ -201,8 +201,16 @@ def build_and_load(
 
     logger.info("▶ Building %d image(s): %s",
                 len(images), ", ".join(i.short_name for i in images))
+    # --remote_download_outputs=all overrides the project's default
+    # `build --remote_download_outputs=minimal` in .bazelrc — without it,
+    # disk-cache hits leave tarball.tar as a reference-only artifact and
+    # the downstream `docker load -i bazel-out/.../tarball.tar` fails with
+    # `no such file or directory`. Surfaces only when the disk cache is
+    # warm (cold runs execute the action locally and materialize anyway).
     subprocess.run(
-        ["bazel", "build", platforms, "--output_groups=+tarball", *targets],
+        ["bazel", "build", platforms,
+         "--remote_download_outputs=all",
+         "--output_groups=+tarball", *targets],
         check=True, cwd=workspace,
     )
     tarball_paths = _tarball_paths(targets, platforms, workspace)

--- a/test/oetf/tests/test_local_images.py
+++ b/test/oetf/tests/test_local_images.py
@@ -129,8 +129,9 @@ class TestBuildAndLoad(unittest.TestCase):
         with patch("subprocess.run", side_effect=self._fake_run(calls, specs)):
             local_images.build_and_load(specs, cluster_name="osmo", arch="arm64")
 
-        # 1 batched bazel build + 1 batched cquery + (docker load + kind load) per image.
-        self.assertEqual(len(calls), 6)
+        # 1 batched bazel build + 1 batched cquery + (docker load + kind load
+        # + docker rmi) per image. The trailing docker rmi reclaims host disk
+        # after each kind-load — important on disk-constrained CI runners.
         self.assertEqual(calls[0][:2], ["bazel", "build"])
         self.assertIn("--platforms=@osmo_workspace//bzl/platforms:linux_arm64", calls[0])
         self.assertIn("--output_groups=+tarball", calls[0])
@@ -141,6 +142,9 @@ class TestBuildAndLoad(unittest.TestCase):
         rest = calls[2:]
         self.assertEqual(sum(1 for c in rest if c[:3] == ["docker", "load", "-i"]), 2)
         self.assertEqual(sum(1 for c in rest if c[:3] == ["kind", "load", "docker-image"]), 2)
+        # Per-image host-docker cleanup so the host's image storage doesn't
+        # grow alongside the KIND-node containerd copies.
+        self.assertEqual(sum(1 for c in rest if c[:3] == ["docker", "rmi", "-f"]), 2)
 
     def test_x86_64_uses_linux_x86_64_platforms_flag(self):
         specs = local_images.image_specs("x86_64")[:1]


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow (`Local KIND Deployment`) that runs `bazel run //test/oetf:deploy_and_run -- --env kind --tags kind --build-local --use-local-registry` on `ubuntu-latest` for every PR touching deployment-relevant paths. The workflow exercises the full deploy → helm install → run scenarios → teardown cycle against a fresh KIND cluster, **using PR-built images** so `src/` code regressions are actually caught.

Issue - None

## What this PR adds

- New `.github/workflows/oetf-kind.yaml` workflow.
- Two upstream `test/oetf/local_images.py` bug fixes uncovered during measurement.
- New opt-in `--use-local-registry` mode in `oetf:deploy --build-local` that replaces the `kind load docker-image` 6x-duplication pattern with a host-side `registry:2` container that KIND nodes pull from on-demand. This is what makes `--build-local` viable on hosted ubuntu-latest.

### Workflow shape

- **Trigger**: `pull_request` against `main` with a `paths:` filter scoping to deployments/charts, deployments/scripts, deployments/values, test/oetf, test/smoke, test/scenarios, test/workflow, bzl, MODULE.bazel, src, and the workflow file itself.
- **Concurrency**: `cancel-in-progress: true` so rapid pushes don't queue.
- **Setup**: sha256-pinned kind v0.24.0, kubectl v1.31.0, helm v3.16.2. Bazel via SHA-pinned `bazel-contrib/setup-bazel` (bazelisk + disk + repo cache).
- **Free runner disk for --build-local**: reclaims ~22-25 GB by removing pre-installed tooling the OETF gate doesn't use (dotnet, Android SDK, GHC, PyPy/CodeQL toolcaches, boost, swift, microsoft tools). Required because the chart's 6-node KIND profile and 10 locally-built images otherwise overrun the 145 GB volume.
- **CLI build**: pre-builds `//src/cli:cli` and symlinks to `/usr/local/bin/osmo`.
- **Test run**: `oetf:deploy_and_run --env kind --tags kind --jobs 1 --build-local --use-local-registry --keep --keep-on-failure --output-json ...` wrapped in `/usr/bin/time -p` with an EXIT trap so wall clock prints on both success and failure paths. Scenario set narrowed to `smoke/...` + `scenarios:templates` + `scenarios:mount-validation` (4 fast tests) to keep PR-gate cost down; the broader full set still runs via `--tags kind` outside the gate.
- **Diagnose KIND state on failure** *(if: failure())*: dumps `kubectl get pods -A`, last 100 events sorted by lastTimestamp, `describe` + `logs --tail=200` (with `--previous` for crash-loops) for every non-Ready pod across `osmo`/`kai-scheduler`/`ingress-nginx`/`kube-system`, plus `helm list -A` and `df -h /`. Each subsection is `::group::`-folded; commands are `|| true`-guarded so diagnostic noise never masks the real failure.
- **Write run summary to GitHub step summary** *(if: always())*: pulls `kind-smoke-result.json` and renders the [PASS]/[FAIL] table directly on the PR check page.
- **Cleanup**: `kind delete clusters --all` always runs.
- **Artifacts**: `kind-smoke-result.json` always; `bazel-testlogs/` on failure.

### test/oetf/local_images.py — two upstream bug fixes (kept)

1. **UI source path autodetect** — `_ui_dir()` previously hardcoded `external/src/ui` (internal-overlay layout). On the public NVIDIA/OSMO checkout the source is at `src/ui` and `docker buildx build` failed `unable to prepare context`. Now tries candidates in order; first existing wins.

2. **Force materialization for OCI tarballs** — project `.bazelrc` sets `build --remote_download_outputs=minimal`, which leaves disk-cache-hit artifacts as references. Downstream `docker load -i bazel-out/.../tarball.tar` then fails `no such file or directory` once the cache warms. `build_and_load()` and `build_and_push_to_registry()` now pass `--remote_download_outputs=all` for their bazel invocation only.

### Registry mode (`--use-local-registry`)

New `local_images.build_and_push_to_registry()` mirrors `build_and_load()` but `docker push`es each retagged image (`localhost:5001/osmo/<svc>:latest-<arch>`) to a host-side `registry:2` container. KIND nodes pull on-demand via `containerdConfigPatches` + per-node `/etc/containerd/certs.d/localhost:5001/hosts.toml` that aliases `localhost:5001` → `kind-registry:5000`. Each KIND node only fetches images its pods schedule (1-2 nodes per image under the chart's `node_group` selectors), so disk multiplier drops from **6x to 1-2x**.

`build_and_push_ui_to_registry()` is the matching path for the Next.js web-ui. The chart's ingress-nginx has a hard `wait-for-web-ui` init container — scaling web-ui to 0 deadlocks the stack (verified in run #35).

Default `--build-local` (without `--use-local-registry`) still uses `kind load docker-image` — unchanged for developer workstations with plenty of disk.

### Verified wall-clock cost on hosted ubuntu-latest

`--build-local --use-local-registry` end-to-end:

https://github.com/NVIDIA/OSMO/actions/runs/27600259293/job/81599349657?pr=1066

| Cache state | Total | Step 13 (build → push → deploy → tests) | Tests |
|---|---|---|---|
| Cold (run #36) | **15m 47s** | 11m 28s | 4/4 PASS |
| Warm (run #37) | **13m 25s** | 10m 51s | 4/4 PASS |

**Avg ≈ 14.5 min**, **worst ≈ 15.8 min** on the hosted ubuntu-latest standard runner (free for public repos). The cold run nudges 50 seconds past a hard 15-min target on the very first PR after a Bazel disk-cache eviction; the warm path stays comfortably inside.

Test set covered (`--tags kind` filtered to the narrow scenario list):
- `smoke:api-checks` (~3s) — HTTP probes across health / api / config / data
- `smoke:websocket-checks` (~2s) — WebSocket handshake to logger stream
- `scenarios:templates` (~17s) — workflow submission, exercises backend-listener / worker / osmo_ctrl
- `scenarios:mount-validation` (~16s) — mount config validation, same backend path

The broader `--tags kind` set (10 targets including router-connectivity 140s and serial-workflow-mounting 60s) remains available for nightly / manual runs.

### Why this design (six failed attempts informed it)

Before landing on the registry pattern, six measurement attempts confirmed standard hosted ubuntu-latest could not fit `--build-local` with the chart's 6-node KIND profile when using `kind load docker-image`. The 9-service × 6-node containerd duplication overruns the 145 GB volume every time:

| Run | Mitigations added | Outcome |
|---|---|---|
| #26 | none | 15m 15s → `kind load backend-worker` ENOSPC |
| #28 | + 22 GB pre-installed reclaim | 3m 13s → cache-hit tarballs unmaterialized (`--remote_download_outputs=minimal` bug; FIXED) |
| #29 | + materialization fix | 12m 08s → runner process crashes writing its own log: `No space left on device` |
| #31 | + relocate `/var/lib/docker` → `/mnt/docker` | 12m 46s → same crash. Discovered `/mnt` is the same physical volume as `/` on ubuntu-latest. |
| #32 | + skip web-ui from build + scale Deployment to 0 | ~16m → same crash. |
| #34 | + intra-step `docker rmi` + `os.remove(tarball)` per loaded image | 14m 12s → same crash. |

Registry mode broke the cycle in run #36 by replacing the per-node duplication with a single host-side registry copy.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--use-local-registry` deployment option to publish build outputs through a host-side local registry, reducing disk usage for multi-node/resource-constrained CI.
  * Improved image delivery for local builds, switching between direct node loading and registry-backed pulling when enabled.
* **Chores**
  * Expanded the “Local KIND Deployment” pull-request workflow with pinned tool provisioning, richer failure diagnostics, PR step summaries (including per-test timing), artifact uploads, and guaranteed cluster cleanup.
* **Tests**
  * Updated local image build/load tests to reflect added host Docker cleanup after loading images into KIND.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->