### PR TITLE
fix(azure deploy): honor TF_GPU_COUNT, add gpu_driver=None, fix gpu-pool layering (6263568)

### DIFF
--- a/deployments/scripts/azure/terraform.sh
+++ b/deployments/scripts/azure/terraform.sh
@@ -493,8 +493,8 @@ log_analytics_retention_days = 30
 # to the GPU prompt in azure_configure_interactively.
 gpu_node_pool_enabled = ${TF_GPU_NODE_POOL_ENABLED:-false}
 gpu_vm_size           = "${TF_GPU_VM_SIZE:-Standard_NC40ads_H100_v5}"
-gpu_min               = ${TF_GPU_COUNT:-0}
-gpu_max               = ${TF_GPU_COUNT:-0}
+gpu_node_pool_min_size = ${TF_GPU_COUNT:-0}
+gpu_node_pool_max_size = ${TF_GPU_COUNT:-0}
 
 # Optional Azure Blob Storage Account for workflow data
 # Triggered by --storage-backend azure-blob on deploy-osmo-minimal.sh

--- a/deployments/scripts/azure/terraform.sh
+++ b/deployments/scripts/azure/terraform.sh
@@ -495,6 +495,7 @@ gpu_node_pool_enabled = ${TF_GPU_NODE_POOL_ENABLED:-false}
 gpu_vm_size           = "${TF_GPU_VM_SIZE:-Standard_NC40ads_H100_v5}"
 gpu_node_pool_min_size = ${TF_GPU_COUNT:-0}
 gpu_node_pool_max_size = ${TF_GPU_COUNT:-0}
+gpu_driver             = "${TF_GPU_DRIVER:-None}"
 
 # Optional Azure Blob Storage Account for workflow data
 # Triggered by --storage-backend azure-blob on deploy-osmo-minimal.sh

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -871,9 +871,10 @@ extra_values_flags() {
     echo "$flags"
 }
 
-# Layer values/gpu-pool.yaml when GPU nodes are detected (or when --gpu-node-pool
-# was passed via NO_GPU=0 + force). Replaces the 6.2-era `osmo config update`
-# CLI dance — in 6.3 ConfigMap mode the pool definition lives in Helm values.
+# Layer values/gpu-pool.yaml when OSMO_GPU_POOL_ENABLED=true (set automatically
+# by --gpu-node-pool) or when a GPU node is already present. Replaces the
+# 6.2-era `osmo config update` CLI dance — in 6.3 ConfigMap mode the pool
+# definition lives in Helm values.
 #
 # To force-enable on a cluster without the gpu.present label, set
 # OSMO_GPU_POOL_ENABLED=true. To force-disable, set NO_GPU=1.

--- a/deployments/scripts/deploy-osmo-minimal.sh
+++ b/deployments/scripts/deploy-osmo-minimal.sh
@@ -493,6 +493,12 @@ setup_provider_env() {
     # TF variables.
     if [[ "$GPU_NODE_POOL" == true ]]; then
         export TF_GPU_NODE_POOL_ENABLED=true
+        # The pool is provisioned scale-from-zero (min=0 by default), so no GPU
+        # node may exist when deploy-k8s.sh decides whether to layer the OSMO
+        # `gpu` platform. Force-enable it off the requested-pool intent rather
+        # than current node presence, so `--gpu-node-pool` reliably configures
+        # the gpu platform even before the autoscaler brings a node up.
+        export OSMO_GPU_POOL_ENABLED=true
     fi
     # --with-nfs-storage: azure-only. Flips var.nfs_storage_account_enabled so
     # TF provisions the Premium FileStorage SA + 4 role assignments needed by

--- a/deployments/terraform/azure/example/example.tf
+++ b/deployments/terraform/azure/example/example.tf
@@ -275,6 +275,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "gpu" {
   vnet_subnet_id        = azurerm_subnet.private[0].id
   zones                 = var.availability_zones
   os_disk_size_gb       = 100
+  gpu_driver            = var.gpu_driver
   priority              = var.gpu_node_pool_priority
   eviction_policy       = var.gpu_node_pool_priority == "Spot" ? "Delete" : null
   spot_max_price        = var.gpu_node_pool_priority == "Spot" ? -1 : null

--- a/deployments/terraform/azure/example/variables.tf
+++ b/deployments/terraform/azure/example/variables.tf
@@ -296,6 +296,17 @@ variable "gpu_node_pool_priority" {
   }
 }
 
+variable "gpu_driver" {
+  description = "AKS-managed GPU driver install for the GPU node pool: 'None' (OSMO uses the GPU Operator) or 'Install'."
+  type        = string
+  default     = "None"
+
+  validation {
+    condition     = contains(["Install", "None"], var.gpu_driver)
+    error_message = "gpu_driver must be 'Install' or 'None'."
+  }
+}
+
 # Optional Storage Account for OSMO workflow data — disabled by default.
 # When false, BYO an existing Storage Account by setting STORAGE_ACCOUNT and
 # STORAGE_KEY env vars before running configure-storage.sh --backend azure-blob.


### PR DESCRIPTION
## Description

Three related fixes to the Azure minimal-deploy GPU node pool. Tracked in NVBug 6263568

**1. Honor `TF_GPU_COUNT` (tfvars ↔ module variable-name mismatch).** The tfvars generator wrote `gpu_min` / `gpu_max`, but the Terraform module reads `gpu_node_pool_min_size` / `gpu_node_pool_max_size`. The names never met, so Terraform treated `gpu_min` / `gpu_max` as undeclared variables (warning only) and the GPU pool was always created with the module defaults (`min=0` / `max=4`), ignoring the requested count. Fixed by emitting the declared variable names.

**2. Layer the OSMO `gpu` platform off requested intent.** `--gpu-node-pool` now also exports `OSMO_GPU_POOL_ENABLED=true`, so `values/gpu-pool.yaml` is layered based on the requested pool rather than only *current* GPU-node presence — a scale-from-zero pool no longer deploys without a `gpu` platform. The stale `render_gpu_pool_values` comment was corrected to match.

**3. Disable AKS-managed GPU driver (`gpu_driver = "None"`).** OSMO installs/manages the NVIDIA driver via the GPU Operator, so AKS's built-in driver install conflicts with it. Added a `gpu_driver` variable (default `"None"`, validated `Install|None`), wired it onto the GPU node pool, and emit it from the tfvars generator (`TF_GPU_DRIVER`, default `None`).

**Validation (dry runs):**
- `bash -n` clean on all touched scripts.
- tfvars generator now emits `gpu_node_pool_min_size` / `gpu_node_pool_max_size` and `gpu_driver = "None"`.
- Every emitted tfvars key is a declared module variable → **0 "undeclared variable" warnings**.
- The real `render_gpu_pool_values()` flips `skipped` → `LAYERS gpu-pool.yaml` with 0 GPU nodes once the flag is wired.
- `terraform fmt -check` clean on the changed lines.
- User-facing contract (`TF_GPU_COUNT` per `skills/osmo-deploy/SKILL.md`) unchanged.

Issue #None <!-- tracked in NVBug 6263568 / Jira OSMO-6432 -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes. <!-- deploy/terraform tooling has no automated test harness; validated via the dry runs above -->
- [x] The documentation is up to date with these changes. <!-- user-facing contract unchanged; gpu_driver documented via its variable description -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable GPU driver option for optional GPU node pools (Install or None).

* **Chores**
  * Renamed GPU sizing variables to gpu_node_pool_min_size and gpu_node_pool_max_size for consistency.
  * Clarified documentation about when GPU pool values are applied.
  * Ensured GPU enablement is exported deterministically before autoscaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->