### PR TITLE
Fix default role policy merge scopes

### DIFF
--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -567,18 +567,12 @@ services:
           - "profile:Update"
           - "resources:Read"
           - "user:List"
-          - "workflow:Cancel"
-          - "workflow:Delete"
-          - "workflow:Exec"
           - "workflow:List"
-          - "workflow:PortForward"
           - "workflow:Read"
-          - "workflow:Rsync"
-          - "workflow:Update"
           resources: ["*"]
         - effect: Allow
           actions:
-          - "workflow:Create"
+          - "workflow:*"
           resources: ["pool/default"]
         external_roles: [osmo-user]
       osmo-default:

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -567,10 +567,18 @@ services:
           - "profile:Update"
           - "resources:Read"
           - "user:List"
+          - "workflow:Cancel"
+          - "workflow:Delete"
+          - "workflow:Exec"
+          - "workflow:List"
+          - "workflow:PortForward"
+          - "workflow:Read"
+          - "workflow:Rsync"
+          - "workflow:Update"
           resources: ["*"]
         - effect: Allow
           actions:
-          - "workflow:*"
+          - "workflow:Create"
           resources: ["pool/default"]
         external_roles: [osmo-user]
       osmo-default:

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -567,16 +567,11 @@ services:
           - "profile:Update"
           - "resources:Read"
           - "user:List"
-          - "workflow:Cancel"
-          - "workflow:Create"
-          - "workflow:Delete"
-          - "workflow:Exec"
-          - "workflow:List"
-          - "workflow:PortForward"
-          - "workflow:Read"
-          - "workflow:Rsync"
-          - "workflow:Update"
           resources: ["*"]
+        - effect: Allow
+          actions:
+          - "workflow:*"
+          resources: ["pool/default"]
         external_roles: [osmo-user]
       osmo-default:
         description: "Default role — login, profile, health check"

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -4783,13 +4783,18 @@ def _role_policy_scope_key(policy: role.RolePolicy) -> Tuple[role.PolicyEffect, 
     return policy.effect, tuple(sorted(set(resources)))
 
 
+def _semantic_action_resource_type(action_str: str) -> str:
+    return action_str.split(':', 1)[0]
+
+
 def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool:
     """
     Merge default role policies into an existing role without broadening scopes.
 
     Default-role updates should add newly introduced actions only to a policy with
-    the same effect and resource scope. If that policy scope does not exist, copy
-    the default policy as a new scoped policy.
+    the same effect and resource scope. Existing default scopes are also
+    normalized when an action resource type moves to a different default scope.
+    Policies in scopes that are not managed by the default role are preserved.
     """
     if not existing_role.policies:
         if not default_role.policies:
@@ -4797,15 +4802,46 @@ def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool
         existing_role.policies = copy.deepcopy(default_role.policies)
         return True
 
+    default_actions_by_scope: Dict[
+        Tuple[role.PolicyEffect, Tuple[str, ...]], set[str]
+    ] = {}
+    default_scopes_by_action_resource: Dict[
+        str, set[Tuple[role.PolicyEffect, Tuple[str, ...]]]
+    ] = {}
+    for default_policy in default_role.policies:
+        policy_scope_key = _role_policy_scope_key(default_policy)
+        default_actions = default_actions_by_scope.setdefault(policy_scope_key, set())
+        for action_str in default_policy.actions:
+            role.validate_semantic_action(action_str)
+            default_actions.add(action_str)
+            action_resource_type = _semantic_action_resource_type(action_str)
+            default_scopes_by_action_resource.setdefault(
+                action_resource_type,
+                set()).add(policy_scope_key)
+
     existing_policies_by_scope: Dict[
         Tuple[role.PolicyEffect, Tuple[str, ...]], role.RolePolicy
     ] = {}
-    for existing_policy in existing_role.policies:
-        existing_policies_by_scope.setdefault(
-            _role_policy_scope_key(existing_policy),
-            existing_policy)
-
     did_update = False
+    for existing_policy in existing_role.policies:
+        policy_scope_key = _role_policy_scope_key(existing_policy)
+        existing_policies_by_scope.setdefault(policy_scope_key, existing_policy)
+
+        if policy_scope_key not in default_actions_by_scope:
+            continue
+
+        normalized_actions = []
+        for action_str in existing_policy.actions:
+            role.validate_semantic_action(action_str)
+            action_resource_type = _semantic_action_resource_type(action_str)
+            default_scopes = default_scopes_by_action_resource.get(action_resource_type)
+            if default_scopes and policy_scope_key not in default_scopes:
+                did_update = True
+                continue
+            normalized_actions.append(action_str)
+
+        existing_policy.actions = normalized_actions
+
     for default_policy in default_role.policies:
         policy_scope_key = _role_policy_scope_key(default_policy)
         matching_policy = existing_policies_by_scope.get(policy_scope_key)

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -4787,6 +4787,36 @@ def _semantic_action_resource_type(action_str: str) -> str:
     return action_str.split(':', 1)[0]
 
 
+def _semantic_action_is_wildcard(action_str: str) -> bool:
+    _, action_name = action_str.split(':', 1)
+    return action_name == '*'
+
+
+def _default_action_covers_existing_action(
+    default_action: str,
+    existing_action: str,
+) -> bool:
+    default_resource, default_name = default_action.split(':', 1)
+    existing_resource, existing_name = existing_action.split(':', 1)
+    if default_resource not in ('*', existing_resource):
+        return False
+    return default_name in ('*', existing_name)
+
+
+def _default_scopes_for_action(
+    action_str: str,
+    default_scopes_by_action: Dict[
+        str, set[Tuple[role.PolicyEffect, Tuple[str, ...]]]
+    ],
+) -> set[Tuple[role.PolicyEffect, Tuple[str, ...]]]:
+    return {
+        scope
+        for default_action, scopes in default_scopes_by_action.items()
+        if _default_action_covers_existing_action(default_action, action_str)
+        for scope in scopes
+    }
+
+
 def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool:
     """
     Merge default role policies into an existing role without broadening scopes.
@@ -4805,18 +4835,22 @@ def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool
     default_actions_by_scope: Dict[
         Tuple[role.PolicyEffect, Tuple[str, ...]], set[str]
     ] = {}
-    default_scopes_by_action_resource: Dict[
+    default_scopes_by_action: Dict[
         str, set[Tuple[role.PolicyEffect, Tuple[str, ...]]]
     ] = {}
+    default_action_resource_types: set[str] = set()
+    default_policy_scopes: set[Tuple[role.PolicyEffect, Tuple[str, ...]]] = set()
     for default_policy in default_role.policies:
         policy_scope_key = _role_policy_scope_key(default_policy)
+        default_policy_scopes.add(policy_scope_key)
         default_actions = default_actions_by_scope.setdefault(policy_scope_key, set())
         for action_str in default_policy.actions:
             role.validate_semantic_action(action_str)
             default_actions.add(action_str)
             action_resource_type = _semantic_action_resource_type(action_str)
-            default_scopes_by_action_resource.setdefault(
-                action_resource_type,
+            default_action_resource_types.add(action_resource_type)
+            default_scopes_by_action.setdefault(
+                action_str,
                 set()).add(policy_scope_key)
 
     existing_policies_by_scope: Dict[
@@ -4833,9 +4867,16 @@ def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool
         normalized_actions = []
         for action_str in existing_policy.actions:
             role.validate_semantic_action(action_str)
-            action_resource_type = _semantic_action_resource_type(action_str)
-            default_scopes = default_scopes_by_action_resource.get(action_resource_type)
+            default_scopes = _default_scopes_for_action(
+                action_str, default_scopes_by_action)
             if default_scopes and policy_scope_key not in default_scopes:
+                did_update = True
+                continue
+            action_resource_type = _semantic_action_resource_type(action_str)
+            if (_semantic_action_is_wildcard(action_str)
+                    and action_resource_type in default_action_resource_types
+                    and policy_scope_key in default_policy_scopes
+                    and action_str not in default_actions_by_scope[policy_scope_key]):
                 did_update = True
                 continue
             normalized_actions.append(action_str)
@@ -4888,6 +4929,14 @@ DEFAULT_ROLES: Dict[str, Role] = {
         policies=[
             role.RolePolicy(
                 actions=[
+                    'workflow:List',
+                    'workflow:Read',
+                    'workflow:Update',
+                    'workflow:Delete',
+                    'workflow:Cancel',
+                    'workflow:Exec',
+                    'workflow:PortForward',
+                    'workflow:Rsync',
                     'dataset:*',
                     'credentials:*',
                     'pool:List',
@@ -4898,7 +4947,7 @@ DEFAULT_ROLES: Dict[str, Role] = {
             ),
             role.RolePolicy(
                 actions=[
-                    'workflow:*',
+                    'workflow:Create',
                 ],
                 resources=['pool/default']
             )

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -4931,12 +4931,6 @@ DEFAULT_ROLES: Dict[str, Role] = {
                 actions=[
                     'workflow:List',
                     'workflow:Read',
-                    'workflow:Update',
-                    'workflow:Delete',
-                    'workflow:Cancel',
-                    'workflow:Exec',
-                    'workflow:PortForward',
-                    'workflow:Rsync',
                     'dataset:*',
                     'credentials:*',
                     'pool:List',
@@ -4947,7 +4941,7 @@ DEFAULT_ROLES: Dict[str, Role] = {
             ),
             role.RolePolicy(
                 actions=[
-                    'workflow:Create',
+                    'workflow:*',
                 ],
                 resources=['pool/default']
             )

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -4783,48 +4783,13 @@ def _role_policy_scope_key(policy: role.RolePolicy) -> Tuple[role.PolicyEffect, 
     return policy.effect, tuple(sorted(set(resources)))
 
 
-def _semantic_action_resource_type(action_str: str) -> str:
-    return action_str.split(':', 1)[0]
-
-
-def _semantic_action_is_wildcard(action_str: str) -> bool:
-    _, action_name = action_str.split(':', 1)
-    return action_name == '*'
-
-
-def _default_action_covers_existing_action(
-    default_action: str,
-    existing_action: str,
-) -> bool:
-    default_resource, default_name = default_action.split(':', 1)
-    existing_resource, existing_name = existing_action.split(':', 1)
-    if default_resource not in ('*', existing_resource):
-        return False
-    return default_name in ('*', existing_name)
-
-
-def _default_scopes_for_action(
-    action_str: str,
-    default_scopes_by_action: Dict[
-        str, set[Tuple[role.PolicyEffect, Tuple[str, ...]]]
-    ],
-) -> set[Tuple[role.PolicyEffect, Tuple[str, ...]]]:
-    return {
-        scope
-        for default_action, scopes in default_scopes_by_action.items()
-        if _default_action_covers_existing_action(default_action, action_str)
-        for scope in scopes
-    }
-
-
 def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool:
     """
-    Merge default role policies into an existing role without broadening scopes.
+    Append missing default role policies/actions into an existing role.
 
     Default-role updates should add newly introduced actions only to a policy with
-    the same effect and resource scope. Existing default scopes are also
-    normalized when an action resource type moves to a different default scope.
-    Policies in scopes that are not managed by the default role are preserved.
+    the same effect and resource scope. Existing policies and actions are
+    preserved exactly, including operator-added grants.
     """
     if not existing_role.policies:
         if not default_role.policies:
@@ -4835,23 +4800,12 @@ def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool
     default_actions_by_scope: Dict[
         Tuple[role.PolicyEffect, Tuple[str, ...]], set[str]
     ] = {}
-    default_scopes_by_action: Dict[
-        str, set[Tuple[role.PolicyEffect, Tuple[str, ...]]]
-    ] = {}
-    default_action_resource_types: set[str] = set()
-    default_policy_scopes: set[Tuple[role.PolicyEffect, Tuple[str, ...]]] = set()
     for default_policy in default_role.policies:
         policy_scope_key = _role_policy_scope_key(default_policy)
-        default_policy_scopes.add(policy_scope_key)
         default_actions = default_actions_by_scope.setdefault(policy_scope_key, set())
         for action_str in default_policy.actions:
             role.validate_semantic_action(action_str)
             default_actions.add(action_str)
-            action_resource_type = _semantic_action_resource_type(action_str)
-            default_action_resource_types.add(action_resource_type)
-            default_scopes_by_action.setdefault(
-                action_str,
-                set()).add(policy_scope_key)
 
     existing_policies_by_scope: Dict[
         Tuple[role.PolicyEffect, Tuple[str, ...]], role.RolePolicy
@@ -4860,28 +4814,8 @@ def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool
     for existing_policy in existing_role.policies:
         policy_scope_key = _role_policy_scope_key(existing_policy)
         existing_policies_by_scope.setdefault(policy_scope_key, existing_policy)
-
-        if policy_scope_key not in default_actions_by_scope:
-            continue
-
-        normalized_actions = []
         for action_str in existing_policy.actions:
             role.validate_semantic_action(action_str)
-            default_scopes = _default_scopes_for_action(
-                action_str, default_scopes_by_action)
-            if default_scopes and policy_scope_key not in default_scopes:
-                did_update = True
-                continue
-            action_resource_type = _semantic_action_resource_type(action_str)
-            if (_semantic_action_is_wildcard(action_str)
-                    and action_resource_type in default_action_resource_types
-                    and policy_scope_key in default_policy_scopes
-                    and action_str not in default_actions_by_scope[policy_scope_key]):
-                did_update = True
-                continue
-            normalized_actions.append(action_str)
-
-        existing_policy.actions = normalized_actions
 
     for default_policy in default_role.policies:
         policy_scope_key = _role_policy_scope_key(default_policy)
@@ -4929,13 +4863,17 @@ DEFAULT_ROLES: Dict[str, Role] = {
         policies=[
             role.RolePolicy(
                 actions=[
+                    'app:*',
+                    'auth:Token',
+                    'credentials:*',
+                    'dataset:*',
+                    'pool:List',
+                    'profile:Read',
+                    'profile:Update',
+                    'resources:Read',
+                    'user:List',
                     'workflow:List',
                     'workflow:Read',
-                    'dataset:*',
-                    'credentials:*',
-                    'pool:List',
-                    'app:*',
-                    'resources:Read',
                 ],
                 resources=['*']
             ),

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1439,30 +1439,8 @@ class PostgresConnector:
             if default_role_name not in role_objects:
                 default_role_object.insert_into_db(self, force=True)
             else:
-                # Add any action in default_role_object that isn't in existing role
                 existing_role = role_objects[default_role_name]
-
-                # Flatten actions for comparison
-                def flatten_actions(policies):
-                    return set(
-                        action
-                        for policy in policies
-                        for action in getattr(policy, 'actions', [])
-                    )
-
-                existing_actions = flatten_actions(existing_role.policies)
-                default_actions = flatten_actions(default_role_object.policies)
-
-                # Find actions in default_role_object not in existing_role
-                missing_actions = default_actions - existing_actions
-                if missing_actions:
-                    # Add missing actions to the first policy of the existing role
-                    if not existing_role.policies:
-                        existing_role.policies = default_role_object.policies
-                    else:
-                        for action_str in missing_actions:
-                            role.validate_semantic_action(action_str)
-                            existing_role.policies[0].actions.append(action_str)
+                if merge_default_role_policies(existing_role, default_role_object):
                     existing_role.insert_into_db(self, force=True)
                     updated_roles = True
 
@@ -4800,6 +4778,52 @@ class Role(role.Role):
             raise osmo_errors.OSMOUserError(f'Role {self.name} is immutable.')
 
 
+def _role_policy_scope_key(policy: role.RolePolicy) -> Tuple[role.PolicyEffect, Tuple[str, ...]]:
+    resources = policy.resources or ['*']
+    return policy.effect, tuple(sorted(set(resources)))
+
+
+def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool:
+    """
+    Merge default role policies into an existing role without broadening scopes.
+
+    Default-role updates should add newly introduced actions only to a policy with
+    the same effect and resource scope. If that policy scope does not exist, copy
+    the default policy as a new scoped policy.
+    """
+    if not existing_role.policies:
+        if not default_role.policies:
+            return False
+        existing_role.policies = copy.deepcopy(default_role.policies)
+        return True
+
+    existing_policies_by_scope: Dict[
+        Tuple[role.PolicyEffect, Tuple[str, ...]], role.RolePolicy
+    ] = {}
+    for existing_policy in existing_role.policies:
+        existing_policies_by_scope.setdefault(
+            _role_policy_scope_key(existing_policy),
+            existing_policy)
+
+    did_update = False
+    for default_policy in default_role.policies:
+        policy_scope_key = _role_policy_scope_key(default_policy)
+        matching_policy = existing_policies_by_scope.get(policy_scope_key)
+        if matching_policy is None:
+            existing_role.policies.append(copy.deepcopy(default_policy))
+            existing_policies_by_scope[policy_scope_key] = existing_role.policies[-1]
+            did_update = True
+            continue
+
+        for action_str in default_policy.actions:
+            role.validate_semantic_action(action_str)
+            if action_str not in matching_policy.actions:
+                matching_policy.actions.append(action_str)
+                did_update = True
+
+    return did_update
+
+
 # Default roles using semantic action format.
 # Authorization is now handled by the authz_sidecar (Go service).
 # These roles are seeded into the database on startup.
@@ -4828,14 +4852,6 @@ DEFAULT_ROLES: Dict[str, Role] = {
         policies=[
             role.RolePolicy(
                 actions=[
-                    'workflow:List',
-                    'workflow:Read',
-                    'workflow:Update',
-                    'workflow:Delete',
-                    'workflow:Cancel',
-                    'workflow:Exec',
-                    'workflow:PortForward',
-                    'workflow:Rsync',
                     'dataset:*',
                     'credentials:*',
                     'pool:List',
@@ -4846,7 +4862,7 @@ DEFAULT_ROLES: Dict[str, Role] = {
             ),
             role.RolePolicy(
                 actions=[
-                    'workflow:Create',
+                    'workflow:*',
                 ],
                 resources=['pool/default']
             )

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -44,3 +44,17 @@ py_test(
     ],
     size = "small"
 )
+
+py_test(
+    name = "test_default_roles",
+    srcs = [
+        "test_default_roles.py"
+        ],
+    deps = [
+        "//src/utils/connectors:connectors",
+    ],
+    tags = [
+        "exclusive"
+    ],
+    size = "small"
+)

--- a/src/utils/connectors/tests/test_default_roles.py
+++ b/src/utils/connectors/tests/test_default_roles.py
@@ -64,7 +64,11 @@ class TestDefaultRoleMerge(unittest.TestCase):
                     resources=['*'],
                 ),
                 role.RolePolicy(
-                    actions=['workflow:Create'],
+                    actions=['workflow:List', 'workflow:Read'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(
+                    actions=['workflow:*'],
                     resources=['pool/default'],
                 ),
             ],
@@ -75,8 +79,9 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertTrue(did_update)
         self.assertNotIn('workflow:Create', existing_role.policies[0].actions)
         self.assertIn('workflow:List', existing_role.policies[0].actions)
+        self.assertIn('workflow:Read', existing_role.policies[0].actions)
         self.assertEqual(existing_role.policies[0].resources, ['*'])
-        self.assertEqual(existing_role.policies[1].actions, ['workflow:Create'])
+        self.assertEqual(existing_role.policies[1].actions, ['workflow:*'])
         self.assertEqual(existing_role.policies[1].resources, ['pool/default'])
 
     def test_preserves_existing_extra_policy_and_external_roles(self):
@@ -104,7 +109,11 @@ class TestDefaultRoleMerge(unittest.TestCase):
                     resources=['*'],
                 ),
                 role.RolePolicy(
-                    actions=['workflow:Create'],
+                    actions=['workflow:List', 'workflow:Read'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(
+                    actions=['workflow:*'],
                     resources=['pool/default'],
                 ),
             ],
@@ -116,7 +125,7 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertEqual(existing_role.external_roles, ['osmo-user'])
         self.assertEqual(existing_role.policies[1].actions, ['workflow:*'])
         self.assertEqual(existing_role.policies[1].resources, ['pool/orion-gb200-02'])
-        self.assertEqual(existing_role.policies[2].actions, ['workflow:Create'])
+        self.assertEqual(existing_role.policies[2].actions, ['workflow:*'])
         self.assertEqual(existing_role.policies[2].resources, ['pool/default'])
 
     def test_normalizes_broadened_default_actions_back_to_default_scope(self):
@@ -144,6 +153,10 @@ class TestDefaultRoleMerge(unittest.TestCase):
                     resources=['*'],
                 ),
                 role.RolePolicy(
+                    actions=['workflow:List', 'workflow:Read'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(
                     actions=['workflow:*'],
                     resources=['pool/default'],
                 ),
@@ -154,20 +167,29 @@ class TestDefaultRoleMerge(unittest.TestCase):
 
         self.assertTrue(did_update)
         self.assertEqual(existing_role.external_roles, ['osmo-user'])
-        self.assertEqual(existing_role.policies[0].actions, ['app:*'])
+        self.assertEqual(existing_role.policies[0].actions, [
+            'app:*',
+            'workflow:List',
+            'workflow:Read',
+        ])
         self.assertEqual(existing_role.policies[0].resources, ['*'])
         self.assertEqual(existing_role.policies[1].actions, ['workflow:*'])
         self.assertEqual(existing_role.policies[1].resources, ['pool/orion-gb200-02'])
         self.assertEqual(existing_role.policies[2].actions, ['workflow:*'])
         self.assertEqual(existing_role.policies[2].resources, ['pool/default'])
 
-    def test_keeps_default_wildcard_workflow_actions_but_moves_create(self):
+    def test_keeps_read_list_wildcard_but_moves_other_workflow_actions(self):
         existing_role = connectors.Role(
             name='osmo-user',
             description='User role',
             policies=[
                 role.RolePolicy(
-                    actions=['workflow:Create', 'workflow:List', 'workflow:Read'],
+                    actions=[
+                        'workflow:Create',
+                        'workflow:List',
+                        'workflow:Read',
+                        'workflow:Update',
+                    ],
                     resources=['*'],
                 ),
             ],
@@ -181,7 +203,7 @@ class TestDefaultRoleMerge(unittest.TestCase):
                     resources=['*'],
                 ),
                 role.RolePolicy(
-                    actions=['workflow:Create'],
+                    actions=['workflow:*'],
                     resources=['pool/default'],
                 ),
             ],
@@ -195,7 +217,7 @@ class TestDefaultRoleMerge(unittest.TestCase):
             ['workflow:List', 'workflow:Read'],
         )
         self.assertEqual(existing_role.policies[0].resources, ['*'])
-        self.assertEqual(existing_role.policies[1].actions, ['workflow:Create'])
+        self.assertEqual(existing_role.policies[1].actions, ['workflow:*'])
         self.assertEqual(existing_role.policies[1].resources, ['pool/default'])
 
     def test_returns_false_when_existing_role_already_contains_defaults(self):
@@ -203,16 +225,22 @@ class TestDefaultRoleMerge(unittest.TestCase):
             name='osmo-user',
             description='User role',
             policies=[
-                role.RolePolicy(actions=['app:*'], resources=['*']),
-                role.RolePolicy(actions=['workflow:Create'], resources=['pool/default']),
+                role.RolePolicy(
+                    actions=['app:*', 'workflow:List', 'workflow:Read'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(actions=['workflow:*'], resources=['pool/default']),
             ],
         )
         default_role = connectors.Role(
             name='osmo-user',
             description='Standard user role',
             policies=[
-                role.RolePolicy(actions=['app:*'], resources=['*']),
-                role.RolePolicy(actions=['workflow:Create'], resources=['pool/default']),
+                role.RolePolicy(
+                    actions=['app:*', 'workflow:List', 'workflow:Read'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(actions=['workflow:*'], resources=['pool/default']),
             ],
         )
 
@@ -282,7 +310,7 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertFalse(did_update)
         self.assertEqual(existing_role.policies, [])
 
-    def test_osmo_user_default_role_scopes_workflow_create_to_default_pool(self):
+    def test_osmo_user_default_role_allows_only_workflow_read_list_on_all_pools(self):
         osmo_user = connectors.DEFAULT_ROLES['osmo-user']
 
         wildcard_workflow_actions = [
@@ -303,16 +331,10 @@ class TestDefaultRoleMerge(unittest.TestCase):
             [
                 'workflow:List',
                 'workflow:Read',
-                'workflow:Update',
-                'workflow:Delete',
-                'workflow:Cancel',
-                'workflow:Exec',
-                'workflow:PortForward',
-                'workflow:Rsync',
             ],
         )
         self.assertEqual(len(scoped_workflow_policies), 1)
-        self.assertEqual(scoped_workflow_policies[0].actions, ['workflow:Create'])
+        self.assertEqual(scoped_workflow_policies[0].actions, ['workflow:*'])
 
 
 if __name__ == '__main__':

--- a/src/utils/connectors/tests/test_default_roles.py
+++ b/src/utils/connectors/tests/test_default_roles.py
@@ -128,7 +128,7 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertEqual(existing_role.policies[2].actions, ['workflow:*'])
         self.assertEqual(existing_role.policies[2].resources, ['pool/default'])
 
-    def test_normalizes_broadened_default_actions_back_to_default_scope(self):
+    def test_preserves_existing_actions_when_appending_default_scopes(self):
         existing_role = connectors.Role(
             name='osmo-user',
             description='User role',
@@ -169,7 +169,9 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertEqual(existing_role.external_roles, ['osmo-user'])
         self.assertEqual(existing_role.policies[0].actions, [
             'app:*',
+            'workflow:Create',
             'workflow:List',
+            'workflow:*',
             'workflow:Read',
         ])
         self.assertEqual(existing_role.policies[0].resources, ['*'])
@@ -178,7 +180,7 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertEqual(existing_role.policies[2].actions, ['workflow:*'])
         self.assertEqual(existing_role.policies[2].resources, ['pool/default'])
 
-    def test_keeps_read_list_wildcard_but_moves_other_workflow_actions(self):
+    def test_append_only_does_not_move_existing_workflow_actions(self):
         existing_role = connectors.Role(
             name='osmo-user',
             description='User role',
@@ -214,7 +216,12 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertTrue(did_update)
         self.assertEqual(
             existing_role.policies[0].actions,
-            ['workflow:List', 'workflow:Read'],
+            [
+                'workflow:Create',
+                'workflow:List',
+                'workflow:Read',
+                'workflow:Update',
+            ],
         )
         self.assertEqual(existing_role.policies[0].resources, ['*'])
         self.assertEqual(existing_role.policies[1].actions, ['workflow:*'])
@@ -313,6 +320,12 @@ class TestDefaultRoleMerge(unittest.TestCase):
     def test_osmo_user_default_role_allows_only_workflow_read_list_on_all_pools(self):
         osmo_user = connectors.DEFAULT_ROLES['osmo-user']
 
+        wildcard_policy_actions = [
+            action
+            for policy in osmo_user.policies
+            if policy.resources == ['*']
+            for action in policy.actions
+        ]
         wildcard_workflow_actions = [
             action
             for policy in osmo_user.policies
@@ -326,6 +339,22 @@ class TestDefaultRoleMerge(unittest.TestCase):
             if policy.resources == ['pool/default']
         ]
 
+        self.assertEqual(
+            wildcard_policy_actions,
+            [
+                'app:*',
+                'auth:Token',
+                'credentials:*',
+                'dataset:*',
+                'pool:List',
+                'profile:Read',
+                'profile:Update',
+                'resources:Read',
+                'user:List',
+                'workflow:List',
+                'workflow:Read',
+            ],
+        )
         self.assertEqual(
             wildcard_workflow_actions,
             [

--- a/src/utils/connectors/tests/test_default_roles.py
+++ b/src/utils/connectors/tests/test_default_roles.py
@@ -117,6 +117,48 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertEqual(existing_role.policies[2].actions, ['workflow:Create'])
         self.assertEqual(existing_role.policies[2].resources, ['pool/default'])
 
+    def test_normalizes_broadened_default_actions_back_to_default_scope(self):
+        existing_role = connectors.Role(
+            name='osmo-user',
+            description='User role',
+            external_roles=['osmo-user'],
+            policies=[
+                role.RolePolicy(
+                    actions=['app:*', 'workflow:Create', 'workflow:List', 'workflow:*'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(
+                    actions=['workflow:*'],
+                    resources=['pool/orion-gb200-02'],
+                ),
+            ],
+        )
+        default_role = connectors.Role(
+            name='osmo-user',
+            description='Standard user role',
+            policies=[
+                role.RolePolicy(
+                    actions=['app:*'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(
+                    actions=['workflow:*'],
+                    resources=['pool/default'],
+                ),
+            ],
+        )
+
+        did_update = connectors.merge_default_role_policies(existing_role, default_role)
+
+        self.assertTrue(did_update)
+        self.assertEqual(existing_role.external_roles, ['osmo-user'])
+        self.assertEqual(existing_role.policies[0].actions, ['app:*'])
+        self.assertEqual(existing_role.policies[0].resources, ['*'])
+        self.assertEqual(existing_role.policies[1].actions, ['workflow:*'])
+        self.assertEqual(existing_role.policies[1].resources, ['pool/orion-gb200-02'])
+        self.assertEqual(existing_role.policies[2].actions, ['workflow:*'])
+        self.assertEqual(existing_role.policies[2].resources, ['pool/default'])
+
     def test_returns_false_when_existing_role_already_contains_defaults(self):
         existing_role = connectors.Role(
             name='osmo-user',

--- a/src/utils/connectors/tests/test_default_roles.py
+++ b/src/utils/connectors/tests/test_default_roles.py
@@ -162,6 +162,45 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertEqual(existing_role.policies[0].actions, ['app:*', 'dataset:*'])
         self.assertEqual(existing_role.policies[0].resources, ['*'])
 
+    def test_copies_default_policies_when_existing_role_has_none(self):
+        existing_role = connectors.Role(
+            name='osmo-user',
+            description='User role',
+            policies=[],
+        )
+        default_role = connectors.Role(
+            name='osmo-user',
+            description='Standard user role',
+            policies=[
+                role.RolePolicy(actions=['app:*'], resources=['*']),
+            ],
+        )
+
+        did_update = connectors.merge_default_role_policies(existing_role, default_role)
+
+        self.assertTrue(did_update)
+        self.assertEqual(existing_role.policies[0].actions, ['app:*'])
+        self.assertEqual(existing_role.policies[0].resources, ['*'])
+        existing_role.policies[0].actions.append('dataset:*')
+        self.assertEqual(default_role.policies[0].actions, ['app:*'])
+
+    def test_returns_false_when_both_existing_and_default_have_no_policies(self):
+        existing_role = connectors.Role(
+            name='empty-role',
+            description='Empty role',
+            policies=[],
+        )
+        default_role = connectors.Role(
+            name='empty-role',
+            description='Empty default role',
+            policies=[],
+        )
+
+        did_update = connectors.merge_default_role_policies(existing_role, default_role)
+
+        self.assertFalse(did_update)
+        self.assertEqual(existing_role.policies, [])
+
     def test_osmo_user_default_role_scopes_workflow_actions_to_default_pool(self):
         osmo_user = connectors.DEFAULT_ROLES['osmo-user']
 

--- a/src/utils/connectors/tests/test_default_roles.py
+++ b/src/utils/connectors/tests/test_default_roles.py
@@ -59,6 +59,7 @@ class TestDefaultRoleMerge(unittest.TestCase):
                         'profile:Update',
                         'resources:Read',
                         'user:List',
+                        'workflow:List',
                     ],
                     resources=['*'],
                 ),
@@ -73,6 +74,7 @@ class TestDefaultRoleMerge(unittest.TestCase):
 
         self.assertTrue(did_update)
         self.assertNotIn('workflow:Create', existing_role.policies[0].actions)
+        self.assertIn('workflow:List', existing_role.policies[0].actions)
         self.assertEqual(existing_role.policies[0].resources, ['*'])
         self.assertEqual(existing_role.policies[1].actions, ['workflow:Create'])
         self.assertEqual(existing_role.policies[1].resources, ['pool/default'])
@@ -159,6 +161,43 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertEqual(existing_role.policies[2].actions, ['workflow:*'])
         self.assertEqual(existing_role.policies[2].resources, ['pool/default'])
 
+    def test_keeps_default_wildcard_workflow_actions_but_moves_create(self):
+        existing_role = connectors.Role(
+            name='osmo-user',
+            description='User role',
+            policies=[
+                role.RolePolicy(
+                    actions=['workflow:Create', 'workflow:List', 'workflow:Read'],
+                    resources=['*'],
+                ),
+            ],
+        )
+        default_role = connectors.Role(
+            name='osmo-user',
+            description='Standard user role',
+            policies=[
+                role.RolePolicy(
+                    actions=['workflow:List', 'workflow:Read'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(
+                    actions=['workflow:Create'],
+                    resources=['pool/default'],
+                ),
+            ],
+        )
+
+        did_update = connectors.merge_default_role_policies(existing_role, default_role)
+
+        self.assertTrue(did_update)
+        self.assertEqual(
+            existing_role.policies[0].actions,
+            ['workflow:List', 'workflow:Read'],
+        )
+        self.assertEqual(existing_role.policies[0].resources, ['*'])
+        self.assertEqual(existing_role.policies[1].actions, ['workflow:Create'])
+        self.assertEqual(existing_role.policies[1].resources, ['pool/default'])
+
     def test_returns_false_when_existing_role_already_contains_defaults(self):
         existing_role = connectors.Role(
             name='osmo-user',
@@ -243,7 +282,7 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertFalse(did_update)
         self.assertEqual(existing_role.policies, [])
 
-    def test_osmo_user_default_role_scopes_workflow_actions_to_default_pool(self):
+    def test_osmo_user_default_role_scopes_workflow_create_to_default_pool(self):
         osmo_user = connectors.DEFAULT_ROLES['osmo-user']
 
         wildcard_workflow_actions = [
@@ -259,9 +298,21 @@ class TestDefaultRoleMerge(unittest.TestCase):
             if policy.resources == ['pool/default']
         ]
 
-        self.assertEqual(wildcard_workflow_actions, [])
+        self.assertEqual(
+            wildcard_workflow_actions,
+            [
+                'workflow:List',
+                'workflow:Read',
+                'workflow:Update',
+                'workflow:Delete',
+                'workflow:Cancel',
+                'workflow:Exec',
+                'workflow:PortForward',
+                'workflow:Rsync',
+            ],
+        )
         self.assertEqual(len(scoped_workflow_policies), 1)
-        self.assertEqual(scoped_workflow_policies[0].actions, ['workflow:*'])
+        self.assertEqual(scoped_workflow_policies[0].actions, ['workflow:Create'])
 
 
 if __name__ == '__main__':

--- a/src/utils/connectors/tests/test_default_roles.py
+++ b/src/utils/connectors/tests/test_default_roles.py
@@ -1,0 +1,187 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+
+from src.lib.utils import role
+from src.utils import connectors
+
+
+class TestDefaultRoleMerge(unittest.TestCase):
+    """Tests for merging updated DEFAULT_ROLES into existing roles."""
+
+    def test_preserves_default_policy_resource_scope_for_missing_actions(self):
+        existing_role = connectors.Role(
+            name='osmo-user',
+            description='User role',
+            policies=[
+                role.RolePolicy(
+                    actions=[
+                        'app:*',
+                        'credentials:*',
+                        'dataset:*',
+                        'pool:List',
+                        'profile:Read',
+                        'profile:Update',
+                        'resources:Read',
+                        'user:List',
+                    ],
+                    resources=['*'],
+                )
+            ],
+        )
+        default_role = connectors.Role(
+            name='osmo-user',
+            description='Standard user role',
+            policies=[
+                role.RolePolicy(
+                    actions=[
+                        'app:*',
+                        'credentials:*',
+                        'dataset:*',
+                        'pool:List',
+                        'profile:Read',
+                        'profile:Update',
+                        'resources:Read',
+                        'user:List',
+                    ],
+                    resources=['*'],
+                ),
+                role.RolePolicy(
+                    actions=['workflow:Create'],
+                    resources=['pool/default'],
+                ),
+            ],
+        )
+
+        did_update = connectors.merge_default_role_policies(existing_role, default_role)
+
+        self.assertTrue(did_update)
+        self.assertNotIn('workflow:Create', existing_role.policies[0].actions)
+        self.assertEqual(existing_role.policies[0].resources, ['*'])
+        self.assertEqual(existing_role.policies[1].actions, ['workflow:Create'])
+        self.assertEqual(existing_role.policies[1].resources, ['pool/default'])
+
+    def test_preserves_existing_extra_policy_and_external_roles(self):
+        existing_role = connectors.Role(
+            name='osmo-user',
+            description='User role',
+            external_roles=['osmo-user'],
+            policies=[
+                role.RolePolicy(
+                    actions=['app:*'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(
+                    actions=['workflow:*'],
+                    resources=['pool/orion-gb200-02'],
+                ),
+            ],
+        )
+        default_role = connectors.Role(
+            name='osmo-user',
+            description='Standard user role',
+            policies=[
+                role.RolePolicy(
+                    actions=['app:*'],
+                    resources=['*'],
+                ),
+                role.RolePolicy(
+                    actions=['workflow:Create'],
+                    resources=['pool/default'],
+                ),
+            ],
+        )
+
+        did_update = connectors.merge_default_role_policies(existing_role, default_role)
+
+        self.assertTrue(did_update)
+        self.assertEqual(existing_role.external_roles, ['osmo-user'])
+        self.assertEqual(existing_role.policies[1].actions, ['workflow:*'])
+        self.assertEqual(existing_role.policies[1].resources, ['pool/orion-gb200-02'])
+        self.assertEqual(existing_role.policies[2].actions, ['workflow:Create'])
+        self.assertEqual(existing_role.policies[2].resources, ['pool/default'])
+
+    def test_returns_false_when_existing_role_already_contains_defaults(self):
+        existing_role = connectors.Role(
+            name='osmo-user',
+            description='User role',
+            policies=[
+                role.RolePolicy(actions=['app:*'], resources=['*']),
+                role.RolePolicy(actions=['workflow:Create'], resources=['pool/default']),
+            ],
+        )
+        default_role = connectors.Role(
+            name='osmo-user',
+            description='Standard user role',
+            policies=[
+                role.RolePolicy(actions=['app:*'], resources=['*']),
+                role.RolePolicy(actions=['workflow:Create'], resources=['pool/default']),
+            ],
+        )
+
+        did_update = connectors.merge_default_role_policies(existing_role, default_role)
+
+        self.assertFalse(did_update)
+
+    def test_adds_missing_actions_to_matching_policy_scope(self):
+        existing_role = connectors.Role(
+            name='osmo-user',
+            description='User role',
+            policies=[
+                role.RolePolicy(actions=['app:*'], resources=['*']),
+            ],
+        )
+        default_role = connectors.Role(
+            name='osmo-user',
+            description='Standard user role',
+            policies=[
+                role.RolePolicy(actions=['app:*', 'dataset:*'], resources=['*']),
+            ],
+        )
+
+        did_update = connectors.merge_default_role_policies(existing_role, default_role)
+
+        self.assertTrue(did_update)
+        self.assertEqual(len(existing_role.policies), 1)
+        self.assertEqual(existing_role.policies[0].actions, ['app:*', 'dataset:*'])
+        self.assertEqual(existing_role.policies[0].resources, ['*'])
+
+    def test_osmo_user_default_role_scopes_workflow_actions_to_default_pool(self):
+        osmo_user = connectors.DEFAULT_ROLES['osmo-user']
+
+        wildcard_workflow_actions = [
+            action
+            for policy in osmo_user.policies
+            if policy.resources == ['*']
+            for action in policy.actions
+            if action.startswith('workflow:')
+        ]
+        scoped_workflow_policies = [
+            policy
+            for policy in osmo_user.policies
+            if policy.resources == ['pool/default']
+        ]
+
+        self.assertEqual(wildcard_workflow_actions, [])
+        self.assertEqual(len(scoped_workflow_policies), 1)
+        self.assertEqual(scoped_workflow_policies[0].actions, ['workflow:*'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description
Fix default-role updates so they preserve policy resource scopes instead of flattening actions across policies. This prevents a newly introduced default action scoped to `pool/default` from being appended to an existing wildcard `resources: ["*"]` policy.

This PR also aligns the shipped `osmo-user` defaults in both Python seeding and Helm chart values: non-workflow user actions remain wildcard-scoped, while workflow operations are scoped to `pool/default` via `workflow:*`.

Issue - None

## Summary
- Merge default role updates by policy effect/resource scope instead of action-only flattening.
- Keep `osmo-user` workflow permissions scoped to `pool/default` in Python defaults and Helm values.
- Add regression tests covering scoped default-role merges and the default `osmo-user` role shape.

## Tests
- `bazel test //src/utils/connectors/tests:test_default_roles`
- `bazel test //src/utils/connectors/tests:all`
- `bazel test //src/utils/roles:roles_test //src/utils/roles:roles_integration_test`
- `bazel test //src/service/authz_sidecar/server:server_test //src/service/authz_sidecar/server:server_integration_test`
- `helm lint deployments/charts/service`
- `git diff --cached --check`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scoped workflow permissions: global rights limited to read/list; full workflow actions (including Create) are confined to the default pool.
  * Safer default-role updates: default policies are merged into matching scopes and preserve unrelated permissions.

* **Tests**
  * Added tests covering default-role merge behavior, scope normalization, preservation of extra policies, copying defaults, and osmo-user workflow scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->