### PR TITLE
Fix osmo-admin internal endpoint denial

### DIFF
--- a/src/service/authz_sidecar/server/authz_server_integration_test.go
+++ b/src/service/authz_sidecar/server/authz_server_integration_test.go
@@ -129,6 +129,24 @@ func TestIntegration(t *testing.T) {
 				method:   "GET",
 				wantCode: codes.OK,
 			},
+			{
+				name:     "admin cannot access operator endpoints",
+				path:     "/api/agent/listener/status",
+				method:   "GET",
+				wantCode: codes.PermissionDenied,
+			},
+			{
+				name:     "admin cannot access logger endpoints",
+				path:     "/api/logger/workflow/test-workflow/osmo_ctrl/logs",
+				method:   "GET",
+				wantCode: codes.PermissionDenied,
+			},
+			{
+				name:     "admin cannot access router backend endpoints",
+				path:     "/api/router/exec/test-workflow/backend/connect",
+				method:   "WEBSOCKET",
+				wantCode: codes.PermissionDenied,
+			},
 		}
 
 		for _, tt := range tests {

--- a/src/service/authz_sidecar/server/authz_server_test.go
+++ b/src/service/authz_sidecar/server/authz_server_test.go
@@ -516,23 +516,21 @@ func TestDefaultRoleAccess(t *testing.T) {
 }
 
 func TestAdminRoleAccess(t *testing.T) {
-	// Legacy admin role format - will be converted to semantic
-	// Note: deny patterns are ignored during conversion, so admin gets full access
 	adminRole := &roles.Role{
 		Name: "osmo-admin",
 		Policies: []roles.RolePolicy{
 			{
-				Actions: []roles.RoleAction{
-					{Base: "http", Path: "*", Method: "*"},
-					// These deny patterns are ignored during conversion
-					{Base: "http", Path: "!/api/agent/*", Method: "*"},
-					{Base: "http", Path: "!/api/logger/*", Method: "*"},
-				},
+				Effect:    roles.EffectAllow,
+				Actions:   roles.RoleActions{{Action: "*:*"}},
+				Resources: []string{"*"},
+			},
+			{
+				Effect:    roles.EffectDeny,
+				Actions:   roles.RoleActions{{Action: "internal:*"}},
+				Resources: []string{"*"},
 			},
 		},
 	}
-	// Convert to semantic - deny patterns are ignored
-	adminRole = roles.ConvertRoleToSemantic(adminRole)
 
 	tests := []struct {
 		name       string
@@ -548,26 +546,32 @@ func TestAdminRoleAccess(t *testing.T) {
 		},
 		{
 			name:       "workflow POST accessible",
-			path:       "/api/workflow",
+			path:       "/api/pool/default/workflow",
 			method:     "POST",
 			wantAccess: true,
 		},
 		{
-			name:       "agent endpoint accessible (deny ignored in conversion)",
+			name:       "agent endpoint denied",
 			path:       "/api/agent/listener/status",
 			method:     "GET",
-			wantAccess: true, // Deny patterns are ignored during conversion
+			wantAccess: false,
 		},
 		{
-			name:       "logger endpoint accessible (deny ignored in conversion)",
-			path:       "/api/logger/workflow/logs",
+			name:       "logger endpoint denied",
+			path:       "/api/logger/workflow/test-workflow/osmo_ctrl/logs",
 			method:     "GET",
-			wantAccess: true, // Deny patterns are ignored during conversion
+			wantAccess: false,
+		},
+		{
+			name:       "router backend endpoint denied",
+			path:       "/api/router/exec/test-workflow/backend/connect",
+			method:     "WEBSOCKET",
+			wantAccess: false,
 		},
 		{
 			name:       "router client endpoint accessible",
 			path:       "/api/router/exec/abc/client/connect",
-			method:     "GET",
+			method:     "WEBSOCKET",
 			wantAccess: true,
 		},
 	}

--- a/src/service/authz_sidecar/server/testdata/seed.sql
+++ b/src/service/authz_sidecar/server/testdata/seed.sql
@@ -10,12 +10,13 @@ INSERT INTO roles (name, description, policies, immutable) VALUES (
     TRUE
 );
 
--- Admin role: full access
+-- Admin role: full access except internal endpoints
 INSERT INTO roles (name, description, policies, immutable) VALUES (
     'osmo-admin',
-    'Full admin access',
+    'Full admin access except internal endpoints',
     ARRAY[
-        '{"actions": ["*:*"], "resources": ["*"]}'::jsonb
+        '{"actions": ["*:*"], "resources": ["*"]}'::jsonb,
+        '{"effect": "Deny", "actions": ["internal:*"], "resources": ["*"]}'::jsonb
     ],
     TRUE
 );

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -4848,11 +4848,9 @@ DEFAULT_ROLES: Dict[str, Role] = {
                 resources=['*']
             ),
             role.RolePolicy(
-                actions=[
-                    # Deny internal actions (handled via authz_sidecar deny logic)
-                    # Note: Deny is implicit - admin doesn't get internal:* actions
-                ],
-                resources=[]
+                effect=role.PolicyEffect.DENY,
+                actions=['internal:*'],
+                resources=['*']
             )
         ],
         immutable=True

--- a/src/utils/connectors/tests/test_default_roles.py
+++ b/src/utils/connectors/tests/test_default_roles.py
@@ -317,6 +317,36 @@ class TestDefaultRoleMerge(unittest.TestCase):
         self.assertFalse(did_update)
         self.assertEqual(existing_role.policies, [])
 
+    def test_osmo_admin_default_role_denies_internal_actions(self):
+        osmo_admin = connectors.DEFAULT_ROLES['osmo-admin']
+
+        self.assertEqual(osmo_admin.policies[0].effect, role.PolicyEffect.ALLOW)
+        self.assertEqual(osmo_admin.policies[0].actions, ['*:*'])
+        self.assertEqual(osmo_admin.policies[0].resources, ['*'])
+
+        self.assertEqual(osmo_admin.policies[1].effect, role.PolicyEffect.DENY)
+        self.assertEqual(osmo_admin.policies[1].actions, ['internal:*'])
+        self.assertEqual(osmo_admin.policies[1].resources, ['*'])
+
+    def test_default_role_merge_appends_admin_internal_deny(self):
+        existing_role = connectors.Role(
+            name='osmo-admin',
+            description='Administrator with full access except internal endpoints',
+            policies=[
+                role.RolePolicy(actions=['*:*'], resources=['*']),
+                role.RolePolicy(actions=[], resources=[]),
+            ],
+        )
+        default_role = connectors.DEFAULT_ROLES['osmo-admin']
+
+        did_update = connectors.merge_default_role_policies(existing_role, default_role)
+
+        self.assertTrue(did_update)
+        self.assertEqual(len(existing_role.policies), 3)
+        self.assertEqual(existing_role.policies[2].effect, role.PolicyEffect.DENY)
+        self.assertEqual(existing_role.policies[2].actions, ['internal:*'])
+        self.assertEqual(existing_role.policies[2].resources, ['*'])
+
     def test_osmo_user_default_role_allows_only_workflow_read_list_on_all_pools(self):
         osmo_user = connectors.DEFAULT_ROLES['osmo-user']
 


### PR DESCRIPTION
## Summary

This restores the intended osmo-admin boundary for internal OSMO endpoints. The admin role still gets broad `*:*` access, but now has an explicit `Deny internal:*` policy so operator, logger, and router backend endpoints remain reserved for the service roles that own them.

## Root Cause

The semantic default role kept the admin allow-all policy but replaced the old path-based internal deny rules with an empty policy. Because the authz sidecar only denies when a matching Deny policy exists, the empty policy did not block anything.

## Validation

- `go test ./service/authz_sidecar/server`
- `bazelisk test //src/utils/connectors/tests:test_default_roles //src/service/authz_sidecar/server:server_test //src/service/authz_sidecar/server:server_integration_test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated admin role authorization to explicitly deny access to internal system endpoints
  
* **Tests**
  * Expanded test coverage for admin role access restrictions
  * Added validation tests for admin role policy structure and internal endpoint denial

<!-- end of auto-generated comment: release notes by coderabbit.ai -->