### PR TITLE
Update distroless images to v4.0.8

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -356,8 +356,8 @@ apt.install(
 
 oci.pull(
     name = "distroless_python3_14",
-    digest = "sha256:49751a52c1b4f59e0b68d6caf6728f305afc9e47c507008f8a9e8e1253929676",
-    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.7",
+    digest = "sha256:adda656ae3a8243d49df02228b4fba742084d88f4057847fc1c4a5c7c6ad1add",
+    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.8",
     platforms = [
         "linux/arm64/v8",
         "linux/amd64",
@@ -367,8 +367,8 @@ oci.pull(
 # Used for local debugging
 # oci.pull(
 #     name = "distroless_python3_14_dev",
-#     digest = "sha256:beb7d19b0434ef14752b2ba1bafe57c738e69ef45e4fb5b4a8333fa13378af43",
-#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.7-dev",
+#     digest = "sha256:84aef61c2e737ac04e38e0945d423af8e9121774f223f1650b71be8a6968abba",
+#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.8-dev",
 #     platforms = [
 #          "linux/amd64",
 #          "linux/arm64/v8"

--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -56,7 +56,7 @@
 # Stage 1: Dependencies (cached unless package.json/pnpm-lock.yaml change)
 # =============================================================================
 ARG NODE_BUILD_IMAGE=node:24-slim
-ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/node:24-v4.0.7
+ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/node:24-v4.0.8
 
 FROM ${NODE_BUILD_IMAGE} AS deps
 


### PR DESCRIPTION
## Description
Update NVIDIA distroless base images used by OSMO:
- Python 3.14 runtime: `3.14-v4.0.7` -> `3.14-v4.0.8`, pinned to OCI index digest `sha256:adda656ae3a8243d49df02228b4fba742084d88f4057847fc1c4a5c7c6ad1add`
- Python 3.14 debug image reference: `3.14-v4.0.7-dev` -> `3.14-v4.0.8-dev`, with OCI index digest `sha256:84aef61c2e737ac04e38e0945d423af8e9121774f223f1650b71be8a6968abba`
- UI Node 24 runtime: `24-v4.0.7` -> `24-v4.0.8`

Issue - None

## Validation
- Verified NGC lists Python 3.14 and Node 24 `v4.0.8` as the latest matching distroless tags, updated Jun 06, 2026.
- Verified NGC reports the Python and Node `v4.0.8` images as signed with malware scan status `CLEAN`.
- Ran `git diff --check`.

Not run:
- `bazel query '//src:osmo_docker_distroless_image_amd64 + //src:osmo_docker_distroless_image_arm64'` because local Bazel is 8.2.0 while the repo requires 8.5.1.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
