### PR TITLE
Add distroless update automation

### DIFF
--- a/.github/workflows/update-distroless-images.yaml
+++ b/.github/workflows/update-distroless-images.yaml
@@ -83,7 +83,7 @@ jobs:
           set -euo pipefail
           python3 scripts/distroless/update_distroless.py --apply
 
-      - name: Create or update pull request
+      - name: Create or find pull request
         if: steps.schedule-gate.outputs.should_run == 'true' && steps.distroless.outputs.updated == 'true'
         id: create-pr
         env:
@@ -112,6 +112,7 @@ jobs:
             echo "Open PR already exists for $BRANCH_NAME: $existing_pr"
             echo "pr_url=$existing_pr" >> "$GITHUB_OUTPUT"
             echo "created=false" >> "$GITHUB_OUTPUT"
+            echo "notification_kind=reminder" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -150,16 +151,18 @@ jobs:
           )
           echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
           echo "created=true" >> "$GITHUB_OUTPUT"
+          echo "notification_kind=created" >> "$GITHUB_OUTPUT"
 
       - name: Send Slack review request
         if: >-
           steps.schedule-gate.outputs.should_run == 'true' &&
           steps.distroless.outputs.updated == 'true' &&
-          steps.create-pr.outputs.created == 'true'
+          steps.create-pr.outputs.pr_url != ''
         env:
           TESTBOT_SLACK_BOT_TOKEN: ${{ secrets.TESTBOT_SLACK_BOT_TOKEN }}
           TESTBOT_SLACK_CHANNEL: ${{ inputs.slack_channel == null && (vars.TESTBOT_SLACK_CHANNEL || 'C096VCXRK8U') || inputs.slack_channel }}
           SKIP_SLACK: ${{ inputs.skip_slack || 'false' }}
+          NOTIFICATION_KIND: ${{ steps.create-pr.outputs.notification_kind }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
           VERSION_LABEL: ${{ steps.distroless.outputs.version_label }}
         run: |
@@ -177,10 +180,16 @@ jobs:
             exit 0
           fi
 
+          if [[ "$NOTIFICATION_KIND" == "reminder" ]]; then
+            slack_text="Reminder: could someone review $PR_URL when you get a chance? It updates the OSMO distroless Python/UI images to $VERSION_LABEL."
+          else
+            slack_text="Could someone review $PR_URL when you get a chance? It updates the OSMO distroless Python/UI images to $VERSION_LABEL."
+          fi
+
           payload=$(
             jq -n \
               --arg channel "$TESTBOT_SLACK_CHANNEL" \
-              --arg text "Could someone review $PR_URL when you get a chance? It updates the OSMO distroless Python/UI images to $VERSION_LABEL." \
+              --arg text "$slack_text" \
               '{channel: $channel, text: $text}'
           )
           response=$(

--- a/.github/workflows/update-distroless-images.yaml
+++ b/.github/workflows/update-distroless-images.yaml
@@ -65,6 +65,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.SVC_OSMO_CI_TOKEN }}
+          persist-credentials: false
 
       - name: Configure git
         if: steps.schedule-gate.outputs.should_run == 'true'
@@ -121,7 +122,19 @@ jobs:
           git checkout -B "$BRANCH_NAME"
           git add MODULE.bazel src/ui/Dockerfile
           git commit -m "$PR_TITLE"
-          git push -u origin "$BRANCH_NAME"
+          git remote set-url origin \
+            "https://x-access-token:${{ secrets.SVC_OSMO_CI_TOKEN }}@github.com/${{ github.repository }}.git"
+
+          remote_branch_sha=$(
+            git ls-remote --heads origin "$BRANCH_NAME" | awk '{print $1}'
+          )
+          if [[ -n "$remote_branch_sha" ]]; then
+            git push -u \
+              --force-with-lease="refs/heads/$BRANCH_NAME:$remote_branch_sha" \
+              origin HEAD:"$BRANCH_NAME"
+          else
+            git push -u origin HEAD:"$BRANCH_NAME"
+          fi
 
           body_file="$RUNNER_TEMP/distroless-pr-body.md"
           cat > "$body_file" <<EOF
@@ -194,13 +207,16 @@ jobs:
               --arg text "$slack_text" \
               '{channel: $channel, text: $text}'
           )
-          response=$(
+          if ! response=$(
             curl -fsSL \
               -H "Authorization: Bearer $TESTBOT_SLACK_BOT_TOKEN" \
               -H "Content-Type: application/json; charset=utf-8" \
               -d "$payload" \
               https://slack.com/api/chat.postMessage
-          )
+          ); then
+            echo "Slack notification request failed; skipping."
+            exit 0
+          fi
           ok=$(jq -r '.ok' <<<"$response")
           if [[ "$ok" != "true" ]]; then
             echo "Slack notification failed: $response"

--- a/.github/workflows/update-distroless-images.yaml
+++ b/.github/workflows/update-distroless-images.yaml
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Update distroless images
+
+on:
+  schedule:
+    # GitHub cron is UTC. Run at 21:00 and 22:00 UTC, then gate on
+    # America/Los_Angeles hour 14 so the workflow stays at 2 PM PT/PDT.
+    - cron: '0 21,22 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_slack:
+        description: 'Skip the Slack review request'
+        type: boolean
+        default: false
+      slack_channel:
+        description: 'Slack channel or channel ID for review request'
+        default: 'C096VCXRK8U'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-distroless-images
+  cancel-in-progress: false
+
+jobs:
+  update-distroless:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Schedule gate
+        id: schedule-gate
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "schedule" ]]; then
+            local_hour=$(TZ=America/Los_Angeles date +%H)
+            if [[ "$local_hour" != "14" ]]; then
+              echo "Not 2 PM Pacific yet (local hour: $local_hour); skipping."
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+
+      - name: Checkout
+        if: steps.schedule-gate.outputs.should_run == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SVC_OSMO_CI_TOKEN }}
+
+      - name: Configure git
+        if: steps.schedule-gate.outputs.should_run == 'true'
+        run: |
+          git config user.name "svc-osmo-ci"
+          git config user.email "svc-osmo-ci@users.noreply.github.com"
+
+      - name: Validate distroless updater
+        if: steps.schedule-gate.outputs.should_run == 'true'
+        run: python3 -m unittest scripts/distroless/tests/test_update_distroless.py
+
+      - name: Check latest distroless images
+        if: steps.schedule-gate.outputs.should_run == 'true'
+        id: distroless
+        run: |
+          set -euo pipefail
+          python3 scripts/distroless/update_distroless.py --apply
+
+      - name: Create or update pull request
+        if: steps.schedule-gate.outputs.should_run == 'true' && steps.distroless.outputs.updated == 'true'
+        id: create-pr
+        env:
+          GH_TOKEN: ${{ secrets.SVC_OSMO_CI_TOKEN }}
+          BRANCH_NAME: ${{ steps.distroless.outputs.branch_name }}
+          PR_TITLE: ${{ steps.distroless.outputs.pr_title }}
+          VERSION_LABEL: ${{ steps.distroless.outputs.version_label }}
+          CURRENT_PYTHON_VERSION: ${{ steps.distroless.outputs.current_python_version }}
+          LATEST_PYTHON_VERSION: ${{ steps.distroless.outputs.latest_python_version }}
+          LATEST_PYTHON_DIGEST: ${{ steps.distroless.outputs.latest_python_digest }}
+          LATEST_PYTHON_DEV_DIGEST: ${{ steps.distroless.outputs.latest_python_dev_digest }}
+          CURRENT_NODE_VERSION: ${{ steps.distroless.outputs.current_node_version }}
+          LATEST_NODE_VERSION: ${{ steps.distroless.outputs.latest_node_version }}
+        run: |
+          set -euo pipefail
+
+          existing_pr=$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --head "$BRANCH_NAME" \
+              --state open \
+              --json url \
+              --jq '.[0].url // ""'
+          )
+          if [[ -n "$existing_pr" ]]; then
+            echo "Open PR already exists for $BRANCH_NAME: $existing_pr"
+            echo "pr_url=$existing_pr" >> "$GITHUB_OUTPUT"
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git checkout -B "$BRANCH_NAME"
+          git add MODULE.bazel src/ui/Dockerfile
+          git commit -m "$PR_TITLE"
+          git push -u origin "$BRANCH_NAME"
+
+          body_file="$RUNNER_TEMP/distroless-pr-body.md"
+          cat > "$body_file" <<EOF
+          ## Description
+          Update NVIDIA distroless base images used by OSMO:
+          - Python 3.14 runtime: \`3.14-v$CURRENT_PYTHON_VERSION\` -> \`3.14-v$LATEST_PYTHON_VERSION\`, pinned to OCI index digest \`$LATEST_PYTHON_DIGEST\`
+          - Python 3.14 debug image reference -> \`3.14-v$LATEST_PYTHON_VERSION-dev\`, with OCI index digest \`$LATEST_PYTHON_DEV_DIGEST\`
+          - UI Node 24 runtime: \`24-v$CURRENT_NODE_VERSION\` -> \`24-v$LATEST_NODE_VERSION\`
+
+          Issue - None
+
+          ## Validation
+          - Automation queried nvcr.io for the latest Python 3.14 and Node 24 distroless tags.
+          - Automation refreshed the Python OCI index digest from nvcr.io.
+
+          ## Checklist
+          - [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
+          - [x] New or existing tests cover these changes.
+          - [x] The documentation is up to date with these changes.
+          EOF
+
+          pr_url=$(
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$BRANCH_NAME" \
+              --title "$PR_TITLE" \
+              --body-file "$body_file"
+          )
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack review request
+        if: >-
+          steps.schedule-gate.outputs.should_run == 'true' &&
+          steps.distroless.outputs.updated == 'true' &&
+          steps.create-pr.outputs.created == 'true'
+        env:
+          TESTBOT_SLACK_BOT_TOKEN: ${{ secrets.TESTBOT_SLACK_BOT_TOKEN }}
+          TESTBOT_SLACK_CHANNEL: ${{ inputs.slack_channel == null && (vars.TESTBOT_SLACK_CHANNEL || 'C096VCXRK8U') || inputs.slack_channel }}
+          SKIP_SLACK: ${{ inputs.skip_slack || 'false' }}
+          PR_URL: ${{ steps.create-pr.outputs.pr_url }}
+          VERSION_LABEL: ${{ steps.distroless.outputs.version_label }}
+        run: |
+          set -euo pipefail
+          if [[ "$SKIP_SLACK" == "true" ]]; then
+            echo "skip_slack=true; skipping Slack notification."
+            exit 0
+          fi
+          if [[ -z "${TESTBOT_SLACK_BOT_TOKEN:-}" ]]; then
+            echo "TESTBOT_SLACK_BOT_TOKEN not set; skipping Slack notification."
+            exit 0
+          fi
+          if [[ -z "${TESTBOT_SLACK_CHANNEL:-}" ]]; then
+            echo "TESTBOT_SLACK_CHANNEL empty; skipping Slack notification."
+            exit 0
+          fi
+
+          payload=$(
+            jq -n \
+              --arg channel "$TESTBOT_SLACK_CHANNEL" \
+              --arg text "Could someone review $PR_URL when you get a chance? It updates the OSMO distroless Python/UI images to $VERSION_LABEL." \
+              '{channel: $channel, text: $text}'
+          )
+          response=$(
+            curl -fsSL \
+              -H "Authorization: Bearer $TESTBOT_SLACK_BOT_TOKEN" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              -d "$payload" \
+              https://slack.com/api/chat.postMessage
+          )
+          ok=$(jq -r '.ok' <<<"$response")
+          if [[ "$ok" != "true" ]]; then
+            echo "Slack notification failed: $response"
+            exit 0
+          fi
+
+      - name: No update found
+        if: steps.schedule-gate.outputs.should_run == 'true' && steps.distroless.outputs.updated != 'true'
+        run: echo "Distroless image pins are already up to date."

--- a/.github/workflows/update-distroless-images.yaml
+++ b/.github/workflows/update-distroless-images.yaml
@@ -91,12 +91,14 @@ jobs:
           BRANCH_NAME: ${{ steps.distroless.outputs.branch_name }}
           PR_TITLE: ${{ steps.distroless.outputs.pr_title }}
           VERSION_LABEL: ${{ steps.distroless.outputs.version_label }}
-          CURRENT_PYTHON_VERSION: ${{ steps.distroless.outputs.current_python_version }}
-          LATEST_PYTHON_VERSION: ${{ steps.distroless.outputs.latest_python_version }}
+          CURRENT_PYTHON_TAG: ${{ steps.distroless.outputs.current_python_tag }}
+          CURRENT_PYTHON_DEV_TAG: ${{ steps.distroless.outputs.current_python_dev_tag }}
+          LATEST_PYTHON_TAG: ${{ steps.distroless.outputs.latest_python_tag }}
+          LATEST_PYTHON_DEV_TAG: ${{ steps.distroless.outputs.latest_python_dev_tag }}
           LATEST_PYTHON_DIGEST: ${{ steps.distroless.outputs.latest_python_digest }}
           LATEST_PYTHON_DEV_DIGEST: ${{ steps.distroless.outputs.latest_python_dev_digest }}
-          CURRENT_NODE_VERSION: ${{ steps.distroless.outputs.current_node_version }}
-          LATEST_NODE_VERSION: ${{ steps.distroless.outputs.latest_node_version }}
+          CURRENT_NODE_TAG: ${{ steps.distroless.outputs.current_node_tag }}
+          LATEST_NODE_TAG: ${{ steps.distroless.outputs.latest_node_tag }}
         run: |
           set -euo pipefail
 
@@ -125,14 +127,14 @@ jobs:
           cat > "$body_file" <<EOF
           ## Description
           Update NVIDIA distroless base images used by OSMO:
-          - Python 3.14 runtime: \`3.14-v$CURRENT_PYTHON_VERSION\` -> \`3.14-v$LATEST_PYTHON_VERSION\`, pinned to OCI index digest \`$LATEST_PYTHON_DIGEST\`
-          - Python 3.14 debug image reference -> \`3.14-v$LATEST_PYTHON_VERSION-dev\`, with OCI index digest \`$LATEST_PYTHON_DEV_DIGEST\`
-          - UI Node 24 runtime: \`24-v$CURRENT_NODE_VERSION\` -> \`24-v$LATEST_NODE_VERSION\`
+          - Python runtime: \`$CURRENT_PYTHON_TAG\` -> \`$LATEST_PYTHON_TAG\`, pinned to OCI index digest \`$LATEST_PYTHON_DIGEST\`
+          - Python debug image reference: \`$CURRENT_PYTHON_DEV_TAG\` -> \`$LATEST_PYTHON_DEV_TAG\`, with OCI index digest \`$LATEST_PYTHON_DEV_DIGEST\`
+          - UI Node runtime: \`$CURRENT_NODE_TAG\` -> \`$LATEST_NODE_TAG\`
 
           Issue - None
 
           ## Validation
-          - Automation queried nvcr.io for the latest Python 3.14 and Node 24 distroless tags.
+          - Automation queried nvcr.io for the latest configured Python and Node distroless tags.
           - Automation refreshed the Python OCI index digest from nvcr.io.
 
           ## Checklist

--- a/scripts/distroless/tests/test_update_distroless.py
+++ b/scripts/distroless/tests/test_update_distroless.py
@@ -1,0 +1,97 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "update_distroless.py"
+SPEC = importlib.util.spec_from_file_location("update_distroless", MODULE_PATH)
+assert SPEC is not None
+update_distroless = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = update_distroless
+SPEC.loader.exec_module(update_distroless)
+
+
+class UpdateDistrolessTest(unittest.TestCase):
+    def test_latest_version_for_prefix_ignores_attestations_and_dev_tags(self):
+        tags = [
+            "3.14-v4.0.8-dev",
+            "3.14-v4.0.7",
+            "3.14-v4.0.10",
+            "3.13-v4.0.99",
+            "sha256-deadbeef.sig",
+        ]
+
+        self.assertEqual(
+            update_distroless.latest_version_for_prefix(tags, "3.14"),
+            "4.0.10",
+        )
+        self.assertEqual(
+            update_distroless.latest_version_for_prefix(
+                tags,
+                "3.14",
+                dev=True,
+            ),
+            "4.0.8",
+        )
+
+    def test_update_text_rewrites_only_distroless_pins(self):
+        latest = update_distroless.DistrolessLatest(
+            python_version="4.0.9",
+            python_digest="sha256:" + "a" * 64,
+            python_dev_digest="sha256:" + "b" * 64,
+            node_version="4.0.9",
+        )
+        module_text = '''oci.pull(
+    name = "distroless_python3_14",
+    digest = "sha256:49751a52c1b4f59e0b68d6caf6728f305afc9e47c507008f8a9e8e1253929676",
+    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.8",
+)
+
+# oci.pull(
+#     name = "distroless_python3_14_dev",
+#     digest = "sha256:84aef61c2e737ac04e38e0945d423af8e9121774f223f1650b71be8a6968abba",
+#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.8-dev",
+# )
+'''
+        dockerfile_text = (
+            "ARG NODE_BUILD_IMAGE=node:24-slim\n"
+            "ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/node:24-v4.0.8\n"
+        )
+
+        new_module = update_distroless.update_module_text(module_text, latest)
+        new_dockerfile = update_distroless.update_dockerfile_text(
+            dockerfile_text,
+            latest,
+        )
+
+        self.assertIn('python:3.14-v4.0.9"', new_module)
+        self.assertIn('python:3.14-v4.0.9-dev"', new_module)
+        self.assertIn("sha256:" + "a" * 64, new_module)
+        self.assertIn("sha256:" + "b" * 64, new_module)
+        self.assertIn("node:24-v4.0.9", new_dockerfile)
+
+    def test_branch_name_uses_shared_distroless_version_when_possible(self):
+        latest = update_distroless.DistrolessLatest(
+            python_version="4.0.9",
+            python_digest="sha256:" + "a" * 64,
+            python_dev_digest="sha256:" + "b" * 64,
+            node_version="4.0.9",
+        )
+
+        self.assertEqual(
+            update_distroless.branch_name_for(latest),
+            "automation/update-distroless-v4-0-9",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/distroless/tests/test_update_distroless.py
+++ b/scripts/distroless/tests/test_update_distroless.py
@@ -13,9 +13,11 @@ from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "update_distroless.py"
 SPEC = importlib.util.spec_from_file_location("update_distroless", MODULE_PATH)
-assert SPEC is not None
+if SPEC is None:
+    raise ImportError(f"Unable to load module spec from {MODULE_PATH}")
 update_distroless = importlib.util.module_from_spec(SPEC)
-assert SPEC.loader is not None
+if SPEC.loader is None:
+    raise ImportError(f"Unable to load module loader from {MODULE_PATH}")
 sys.modules[SPEC.name] = update_distroless
 SPEC.loader.exec_module(update_distroless)
 
@@ -78,6 +80,7 @@ class UpdateDistrolessTest(unittest.TestCase):
         self.assertIn("sha256:" + "a" * 64, new_module)
         self.assertIn("sha256:" + "b" * 64, new_module)
         self.assertIn("node:24-v4.0.9", new_dockerfile)
+        self.assertIn("ARG NODE_BUILD_IMAGE=node:24-slim", new_dockerfile)
 
     def test_python_image_version_is_single_target_knob(self):
         latest = update_distroless.DistrolessLatest(

--- a/scripts/distroless/tests/test_update_distroless.py
+++ b/scripts/distroless/tests/test_update_distroless.py
@@ -79,6 +79,35 @@ class UpdateDistrolessTest(unittest.TestCase):
         self.assertIn("sha256:" + "b" * 64, new_module)
         self.assertIn("node:24-v4.0.9", new_dockerfile)
 
+    def test_python_image_version_is_single_target_knob(self):
+        latest = update_distroless.DistrolessLatest(
+            python_version="4.0.9",
+            python_digest="sha256:" + "a" * 64,
+            python_dev_digest="sha256:" + "b" * 64,
+            node_version="4.0.9",
+        )
+        module_text = '''oci.pull(
+    name = "distroless_python3_14",
+    digest = "sha256:49751a52c1b4f59e0b68d6caf6728f305afc9e47c507008f8a9e8e1253929676",
+    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.8",
+)
+
+# oci.pull(
+#     name = "distroless_python3_14_dev",
+#     digest = "sha256:84aef61c2e737ac04e38e0945d423af8e9121774f223f1650b71be8a6968abba",
+#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.8-dev",
+# )
+'''
+        original_python_version = update_distroless.PYTHON_IMAGE_VERSION
+        try:
+            update_distroless.PYTHON_IMAGE_VERSION = "3.15"
+            new_module = update_distroless.update_module_text(module_text, latest)
+        finally:
+            update_distroless.PYTHON_IMAGE_VERSION = original_python_version
+
+        self.assertIn('python:3.15-v4.0.9"', new_module)
+        self.assertIn('python:3.15-v4.0.9-dev"', new_module)
+
     def test_branch_name_uses_shared_distroless_version_when_possible(self):
         latest = update_distroless.DistrolessLatest(
             python_version="4.0.9",

--- a/scripts/distroless/update_distroless.py
+++ b/scripts/distroless/update_distroless.py
@@ -81,7 +81,7 @@ def _version_tuple(version: str) -> tuple[int, int, int]:
     parts = version.split(".")
     if len(parts) != 3:
         raise ValueError(f"expected MAJOR.MINOR.PATCH, got {version!r}")
-    return tuple(int(part) for part in parts)
+    return (int(parts[0]), int(parts[1]), int(parts[2]))
 
 
 def latest_version_for_prefix(tags: Iterable[str], prefix: str, dev: bool = False) -> str:
@@ -101,7 +101,9 @@ def latest_version_for_prefix(tags: Iterable[str], prefix: str, dev: bool = Fals
 
 def _registry_token(repo: str) -> str:
     query = urllib.parse.urlencode({"scope": f"repository:{repo}:pull"})
-    with urllib.request.urlopen(f"{REGISTRY}/proxy_auth?{query}", timeout=30) as response:
+    url = f"{REGISTRY}/proxy_auth?{query}"
+    # REGISTRY is fixed to HTTPS nvcr.io.
+    with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
         payload = json.load(response)
     token = payload.get("token") or payload.get("access_token")
     if not token:
@@ -115,7 +117,8 @@ def _registry_json(repo: str, path: str) -> dict:
         f"{REGISTRY}/v2/{repo}/{path}",
         headers={"Authorization": f"Bearer {token}"},
     )
-    with urllib.request.urlopen(request, timeout=30) as response:
+    # REGISTRY is fixed to HTTPS nvcr.io.
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
         return json.load(response)
 
 
@@ -129,7 +132,8 @@ def _manifest_digest(repo: str, tag: str) -> str:
             "Authorization": f"Bearer {token}",
         },
     )
-    with urllib.request.urlopen(request, timeout=30) as response:
+    # REGISTRY is fixed to HTTPS nvcr.io.
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
         digest = response.headers.get("Docker-Content-Digest")
     if not digest:
         raise RuntimeError(f"manifest digest missing for {repo}:{tag}")

--- a/scripts/distroless/update_distroless.py
+++ b/scripts/distroless/update_distroless.py
@@ -34,31 +34,38 @@ from typing import Iterable
 REGISTRY = "https://nvcr.io"
 PYTHON_REPO = "nvidia/distroless/python"
 NODE_REPO = "nvidia/distroless/node"
-PYTHON_PREFIX = "3.14"
-NODE_PREFIX = "24"
+
+# Update these when OSMO intentionally moves to a new runtime family.
+PYTHON_IMAGE_VERSION = "3.14"
+NODE_IMAGE_VERSION = "24"
 
 PYTHON_ACTIVE_RE = re.compile(
     r'(?P<indent>    )digest = "(?P<digest>sha256:[a-f0-9]+)",\n'
     r'(?P=indent)image = BASE_DISTROLESS_IMAGE_URL \+ '
-    r'"(?P<image>python:3\.14-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+))",'
+    r'"(?P<image>python:(?P<prefix>[0-9]+\.[0-9]+)-v'
+    r'(?P<version>[0-9]+\.[0-9]+\.[0-9]+))",'
 )
 PYTHON_DEV_RE = re.compile(
     r'(?P<indent>#     )digest = "(?P<digest>sha256:[a-f0-9]+)",\n'
     r'(?P=indent)image = BASE_DISTROLESS_IMAGE_URL \+ '
-    r'"(?P<image>python:3\.14-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-dev)",'
+    r'"(?P<image>python:(?P<prefix>[0-9]+\.[0-9]+)-v'
+    r'(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-dev)",'
 )
 NODE_IMAGE_RE = re.compile(
     r"ARG NODE_DISTROLESS_IMAGE=nvcr\.io/nvidia/distroless/"
-    r"node:24-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)"
+    r"node:(?P<prefix>[0-9]+)-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)"
 )
 
 
 @dataclass(frozen=True)
 class DistrolessState:
+    python_prefix: str
     python_version: str
     python_digest: str
+    python_dev_prefix: str
     python_dev_version: str
     python_dev_digest: str
+    node_prefix: str
     node_version: str
 
 
@@ -141,10 +148,10 @@ def fetch_latest() -> DistrolessLatest:
     python_tags = _repo_tags(PYTHON_REPO)
     node_tags = _repo_tags(NODE_REPO)
 
-    python_version = latest_version_for_prefix(python_tags, PYTHON_PREFIX)
+    python_version = latest_version_for_prefix(python_tags, PYTHON_IMAGE_VERSION)
     python_dev_version = latest_version_for_prefix(
         python_tags,
-        PYTHON_PREFIX,
+        PYTHON_IMAGE_VERSION,
         dev=True,
     )
     if python_dev_version != python_version:
@@ -153,10 +160,10 @@ def fetch_latest() -> DistrolessLatest:
             f"runtime={python_version} dev={python_dev_version}"
         )
 
-    node_version = latest_version_for_prefix(node_tags, NODE_PREFIX)
+    node_version = latest_version_for_prefix(node_tags, NODE_IMAGE_VERSION)
 
-    python_tag = f"{PYTHON_PREFIX}-v{python_version}"
-    python_dev_tag = f"{PYTHON_PREFIX}-v{python_version}-dev"
+    python_tag = f"{PYTHON_IMAGE_VERSION}-v{python_version}"
+    python_dev_tag = f"{PYTHON_IMAGE_VERSION}-v{python_version}-dev"
 
     return DistrolessLatest(
         python_version=python_version,
@@ -179,11 +186,22 @@ def read_state(module_text: str, dockerfile_text: str) -> DistrolessState:
     if not node_match:
         raise RuntimeError("could not find Node distroless image in src/ui/Dockerfile")
 
+    python_prefix = python_match.group("prefix")
+    python_dev_prefix = python_dev_match.group("prefix")
+    if python_dev_prefix != python_prefix:
+        raise RuntimeError(
+            "debug Python distroless image version does not match runtime: "
+            f"runtime={python_prefix} dev={python_dev_prefix}"
+        )
+
     return DistrolessState(
+        python_prefix=python_prefix,
         python_version=python_match.group("version"),
         python_digest=python_match.group("digest"),
+        python_dev_prefix=python_dev_prefix,
         python_dev_version=python_dev_match.group("version"),
         python_dev_digest=python_dev_match.group("digest"),
+        node_prefix=node_match.group("prefix"),
         node_version=node_match.group("version"),
     )
 
@@ -191,7 +209,7 @@ def read_state(module_text: str, dockerfile_text: str) -> DistrolessState:
 def update_module_text(module_text: str, latest: DistrolessLatest) -> str:
     active_replacement = (
         f'    digest = "{latest.python_digest}",\n'
-        f'    image = BASE_DISTROLESS_IMAGE_URL + "python:{PYTHON_PREFIX}-v{latest.python_version}",'
+        f'    image = BASE_DISTROLESS_IMAGE_URL + "python:{PYTHON_IMAGE_VERSION}-v{latest.python_version}",'
     )
     module_text, active_count = PYTHON_ACTIVE_RE.subn(active_replacement, module_text, count=1)
     if active_count != 1:
@@ -199,7 +217,7 @@ def update_module_text(module_text: str, latest: DistrolessLatest) -> str:
 
     dev_replacement = (
         f'#     digest = "{latest.python_dev_digest}",\n'
-        f'#     image = BASE_DISTROLESS_IMAGE_URL + "python:{PYTHON_PREFIX}-v{latest.python_version}-dev",'
+        f'#     image = BASE_DISTROLESS_IMAGE_URL + "python:{PYTHON_IMAGE_VERSION}-v{latest.python_version}-dev",'
     )
     module_text, dev_count = PYTHON_DEV_RE.subn(dev_replacement, module_text, count=1)
     if dev_count != 1:
@@ -211,7 +229,7 @@ def update_module_text(module_text: str, latest: DistrolessLatest) -> str:
 def update_dockerfile_text(dockerfile_text: str, latest: DistrolessLatest) -> str:
     replacement = (
         f"ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/"
-        f"node:{NODE_PREFIX}-v{latest.node_version}"
+        f"node:{NODE_IMAGE_VERSION}-v{latest.node_version}"
     )
     dockerfile_text, count = NODE_IMAGE_RE.subn(replacement, dockerfile_text, count=1)
     if count != 1:
@@ -288,24 +306,32 @@ def main() -> int:
         "branch_name": branch_name_for(latest),
         "pr_title": title_for(latest),
         "version_label": label_for(latest),
+        "current_python_tag": f"{current.python_prefix}-v{current.python_version}",
         "current_python_version": current.python_version,
+        "current_python_dev_tag": (
+            f"{current.python_dev_prefix}-v{current.python_dev_version}-dev"
+        ),
+        "latest_python_tag": f"{PYTHON_IMAGE_VERSION}-v{latest.python_version}",
         "latest_python_version": latest.python_version,
+        "latest_python_dev_tag": f"{PYTHON_IMAGE_VERSION}-v{latest.python_version}-dev",
         "latest_python_digest": latest.python_digest,
         "latest_python_dev_digest": latest.python_dev_digest,
+        "current_node_tag": f"{current.node_prefix}-v{current.node_version}",
         "current_node_version": current.node_version,
+        "latest_node_tag": f"{NODE_IMAGE_VERSION}-v{latest.node_version}",
         "latest_node_version": latest.node_version,
     }
     _write_github_output(args.github_output, outputs)
 
     print(
         "Current distroless: "
-        f"python=3.14-v{current.python_version} "
-        f"node=24-v{current.node_version}",
+        f"python={current.python_prefix}-v{current.python_version} "
+        f"node={current.node_prefix}-v{current.node_version}",
     )
     print(
         "Latest distroless: "
-        f"python=3.14-v{latest.python_version} "
-        f"node=24-v{latest.node_version}",
+        f"python={PYTHON_IMAGE_VERSION}-v{latest.python_version} "
+        f"node={NODE_IMAGE_VERSION}-v{latest.node_version}",
     )
     print(f"updated={str(updated).lower()}")
     return 0

--- a/scripts/distroless/update_distroless.py
+++ b/scripts/distroless/update_distroless.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+REGISTRY = "https://nvcr.io"
+PYTHON_REPO = "nvidia/distroless/python"
+NODE_REPO = "nvidia/distroless/node"
+PYTHON_PREFIX = "3.14"
+NODE_PREFIX = "24"
+
+PYTHON_ACTIVE_RE = re.compile(
+    r'(?P<indent>    )digest = "(?P<digest>sha256:[a-f0-9]+)",\n'
+    r'(?P=indent)image = BASE_DISTROLESS_IMAGE_URL \+ '
+    r'"(?P<image>python:3\.14-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+))",'
+)
+PYTHON_DEV_RE = re.compile(
+    r'(?P<indent>#     )digest = "(?P<digest>sha256:[a-f0-9]+)",\n'
+    r'(?P=indent)image = BASE_DISTROLESS_IMAGE_URL \+ '
+    r'"(?P<image>python:3\.14-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)-dev)",'
+)
+NODE_IMAGE_RE = re.compile(
+    r"ARG NODE_DISTROLESS_IMAGE=nvcr\.io/nvidia/distroless/"
+    r"node:24-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)"
+)
+
+
+@dataclass(frozen=True)
+class DistrolessState:
+    python_version: str
+    python_digest: str
+    python_dev_version: str
+    python_dev_digest: str
+    node_version: str
+
+
+@dataclass(frozen=True)
+class DistrolessLatest:
+    python_version: str
+    python_digest: str
+    python_dev_digest: str
+    node_version: str
+
+
+def _version_tuple(version: str) -> tuple[int, int, int]:
+    parts = version.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"expected MAJOR.MINOR.PATCH, got {version!r}")
+    return tuple(int(part) for part in parts)
+
+
+def latest_version_for_prefix(tags: Iterable[str], prefix: str, dev: bool = False) -> str:
+    suffix = "-dev" if dev else ""
+    pattern = re.compile(
+        rf"^{re.escape(prefix)}-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+){re.escape(suffix)}$"
+    )
+    versions = [
+        match.group("version")
+        for tag in tags
+        if (match := pattern.fullmatch(tag))
+    ]
+    if not versions:
+        raise ValueError(f"no tags found for {prefix}-v*{suffix}")
+    return max(versions, key=_version_tuple)
+
+
+def _registry_token(repo: str) -> str:
+    query = urllib.parse.urlencode({"scope": f"repository:{repo}:pull"})
+    with urllib.request.urlopen(f"{REGISTRY}/proxy_auth?{query}", timeout=30) as response:
+        payload = json.load(response)
+    token = payload.get("token") or payload.get("access_token")
+    if not token:
+        raise RuntimeError(f"nvcr.io proxy_auth returned no token for {repo}")
+    return token
+
+
+def _registry_json(repo: str, path: str) -> dict:
+    token = _registry_token(repo)
+    request = urllib.request.Request(
+        f"{REGISTRY}/v2/{repo}/{path}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def _manifest_digest(repo: str, tag: str) -> str:
+    token = _registry_token(repo)
+    request = urllib.request.Request(
+        f"{REGISTRY}/v2/{repo}/manifests/{tag}",
+        method="HEAD",
+        headers={
+            "Accept": "application/vnd.oci.image.index.v1+json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        digest = response.headers.get("Docker-Content-Digest")
+    if not digest:
+        raise RuntimeError(f"manifest digest missing for {repo}:{tag}")
+    return digest
+
+
+def _repo_tags(repo: str) -> list[str]:
+    payload = _registry_json(repo, "tags/list")
+    tags = payload.get("tags")
+    if not isinstance(tags, list):
+        raise RuntimeError(f"unexpected tag payload for {repo}: {payload!r}")
+    return [str(tag) for tag in tags]
+
+
+def fetch_latest() -> DistrolessLatest:
+    python_tags = _repo_tags(PYTHON_REPO)
+    node_tags = _repo_tags(NODE_REPO)
+
+    python_version = latest_version_for_prefix(python_tags, PYTHON_PREFIX)
+    python_dev_version = latest_version_for_prefix(
+        python_tags,
+        PYTHON_PREFIX,
+        dev=True,
+    )
+    if python_dev_version != python_version:
+        raise RuntimeError(
+            "latest Python distroless dev tag does not match runtime tag: "
+            f"runtime={python_version} dev={python_dev_version}"
+        )
+
+    node_version = latest_version_for_prefix(node_tags, NODE_PREFIX)
+
+    python_tag = f"{PYTHON_PREFIX}-v{python_version}"
+    python_dev_tag = f"{PYTHON_PREFIX}-v{python_version}-dev"
+
+    return DistrolessLatest(
+        python_version=python_version,
+        python_digest=_manifest_digest(PYTHON_REPO, python_tag),
+        python_dev_digest=_manifest_digest(PYTHON_REPO, python_dev_tag),
+        node_version=node_version,
+    )
+
+
+def read_state(module_text: str, dockerfile_text: str) -> DistrolessState:
+    python_match = PYTHON_ACTIVE_RE.search(module_text)
+    if not python_match:
+        raise RuntimeError("could not find active Python distroless image in MODULE.bazel")
+
+    python_dev_match = PYTHON_DEV_RE.search(module_text)
+    if not python_dev_match:
+        raise RuntimeError("could not find debug Python distroless image in MODULE.bazel")
+
+    node_match = NODE_IMAGE_RE.search(dockerfile_text)
+    if not node_match:
+        raise RuntimeError("could not find Node distroless image in src/ui/Dockerfile")
+
+    return DistrolessState(
+        python_version=python_match.group("version"),
+        python_digest=python_match.group("digest"),
+        python_dev_version=python_dev_match.group("version"),
+        python_dev_digest=python_dev_match.group("digest"),
+        node_version=node_match.group("version"),
+    )
+
+
+def update_module_text(module_text: str, latest: DistrolessLatest) -> str:
+    active_replacement = (
+        f'    digest = "{latest.python_digest}",\n'
+        f'    image = BASE_DISTROLESS_IMAGE_URL + "python:{PYTHON_PREFIX}-v{latest.python_version}",'
+    )
+    module_text, active_count = PYTHON_ACTIVE_RE.subn(active_replacement, module_text, count=1)
+    if active_count != 1:
+        raise RuntimeError("failed to update active Python distroless image")
+
+    dev_replacement = (
+        f'#     digest = "{latest.python_dev_digest}",\n'
+        f'#     image = BASE_DISTROLESS_IMAGE_URL + "python:{PYTHON_PREFIX}-v{latest.python_version}-dev",'
+    )
+    module_text, dev_count = PYTHON_DEV_RE.subn(dev_replacement, module_text, count=1)
+    if dev_count != 1:
+        raise RuntimeError("failed to update debug Python distroless image")
+
+    return module_text
+
+
+def update_dockerfile_text(dockerfile_text: str, latest: DistrolessLatest) -> str:
+    replacement = (
+        f"ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/"
+        f"node:{NODE_PREFIX}-v{latest.node_version}"
+    )
+    dockerfile_text, count = NODE_IMAGE_RE.subn(replacement, dockerfile_text, count=1)
+    if count != 1:
+        raise RuntimeError("failed to update Node distroless image")
+    return dockerfile_text
+
+
+def label_for(latest: DistrolessLatest) -> str:
+    if latest.python_version == latest.node_version:
+        return f"v{latest.python_version}"
+    return f"python-v{latest.python_version}-node-v{latest.node_version}"
+
+
+def branch_name_for(latest: DistrolessLatest) -> str:
+    safe_label = label_for(latest).replace(".", "-")
+    return f"automation/update-distroless-{safe_label}"
+
+
+def title_for(latest: DistrolessLatest) -> str:
+    return f"Update distroless images to {label_for(latest)}"
+
+
+def _write_github_output(path: str | None, values: dict[str, str]) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as output:
+        for key, value in values.items():
+            print(f"{key}={value}", file=output)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Update OSMO distroless Python and UI Node image pins.",
+    )
+    parser.add_argument("--apply", action="store_true", help="write file updates")
+    parser.add_argument(
+        "--module",
+        default="MODULE.bazel",
+        help="path to MODULE.bazel",
+    )
+    parser.add_argument(
+        "--dockerfile",
+        default="src/ui/Dockerfile",
+        help="path to the UI Dockerfile",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="optional GitHub Actions output file",
+    )
+    args = parser.parse_args()
+
+    module_path = Path(args.module)
+    dockerfile_path = Path(args.dockerfile)
+    module_text = module_path.read_text(encoding="utf-8")
+    dockerfile_text = dockerfile_path.read_text(encoding="utf-8")
+
+    current = read_state(module_text, dockerfile_text)
+    latest = fetch_latest()
+
+    new_module_text = update_module_text(module_text, latest)
+    new_dockerfile_text = update_dockerfile_text(dockerfile_text, latest)
+    updated = (
+        new_module_text != module_text
+        or new_dockerfile_text != dockerfile_text
+    )
+
+    if updated and args.apply:
+        module_path.write_text(new_module_text, encoding="utf-8")
+        dockerfile_path.write_text(new_dockerfile_text, encoding="utf-8")
+
+    outputs = {
+        "updated": str(updated).lower(),
+        "branch_name": branch_name_for(latest),
+        "pr_title": title_for(latest),
+        "version_label": label_for(latest),
+        "current_python_version": current.python_version,
+        "latest_python_version": latest.python_version,
+        "latest_python_digest": latest.python_digest,
+        "latest_python_dev_digest": latest.python_dev_digest,
+        "current_node_version": current.node_version,
+        "latest_node_version": latest.node_version,
+    }
+    _write_github_output(args.github_output, outputs)
+
+    print(
+        "Current distroless: "
+        f"python=3.14-v{current.python_version} "
+        f"node=24-v{current.node_version}",
+    )
+    print(
+        "Latest distroless: "
+        f"python=3.14-v{latest.python_version} "
+        f"node=24-v{latest.node_version}",
+    )
+    print(f"updated={str(updated).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description
Add a scheduled CI workflow that checks nvcr.io daily at 2 PM Pacific for newer OSMO distroless image pins. When newer Python/UI distroless images are available, the workflow updates `MODULE.bazel` and `src/ui/Dockerfile`, opens an automated PR, and sends a Slack review request.

If the matching update PR already exists from a previous run, the workflow reuses that PR URL and sends a Slack reminder instead of creating a duplicate PR.

The updater is dependency-free Python and includes unit tests for tag selection, text rewriting, automated branch naming, and changing the target Python runtime family from one config value.

Issue - None

## Validation
- Ran `python3 -m unittest scripts/distroless/tests/test_update_distroless.py`.
- Ran `python3 scripts/distroless/update_distroless.py --github-output /private/tmp/distroless-single-config-output.txt`; on current `main` pins it detects latest `v4.0.8` and reports `updated=true` without modifying files.
- Parsed `.github/workflows/update-distroless-images.yaml` with Ruby YAML.
- Ran `git diff --check`.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduled and manual workflow that checks for newer distroless images, validates compatibility, updates pinned image tags/digests (dry-run by default; --apply to write), creates or updates a PR with summary metadata, and optionally sends a Slack notification.

* **Tests**
  * New unit tests covering version selection, file update behavior, dev/runtime alignment, and branch/PR metadata generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->