### PR TITLE
Refactor Envoy Configuration

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -327,14 +327,15 @@ Benefits of the separate gateway model:
 
 Envoy uses filesystem-based dynamic configuration (LDS/CDS). When the ConfigMap is updated, Envoy automatically reloads listeners and clusters without a pod restart.
 
-**Identity header trust by mode.** The gateway either trusts or strips client-supplied `x-osmo-{user,roles,allowed-pools}` headers based on whether `gateway.oauth2Proxy.enabled` or `gateway.authz.enabled` is `true`:
+**Identity header trust by mode.** The gateway either trusts or strips client-supplied `x-osmo-*` identity/context headers based on whether any gateway auth source is configured:
 
-| `oauth2Proxy.enabled` | `authz.enabled` | Identity headers from clients |
-|---|---|---|
-| `true` (default) | `true` (default) | Stripped by Envoy's native header sanitization. ext_authz (the authz sidecar) is the only source. Production posture. |
-| `true` | `false` | Same — native header sanitization still runs. |
-| `false` | `true` | Same — native header sanitization still runs. |
-| `false` | `false` (minimal mode) | **Trusted.** Identity-header sanitization is skipped so dev-mode CLI's `x-osmo-user: <name>` flows through. `defaultIdentity` is only injected via `ADD_IF_ABSENT` when the client did not set its own. **Any caller with network access to the gateway can claim any user, role, or pool — only safe on clusters whose gateway is not exposed to untrusted networks.** |
+| `oauth2Proxy.enabled` | `authz.enabled` | `jwt.providers` | Identity headers from clients |
+|---|---|---|---|
+| `true` (default) | `true` (default) | any | Stripped by Envoy's native header sanitization. ext_authz (the authz sidecar) is the canonical identity source. Production posture. |
+| `true` | `false` | any | Stripped by Envoy's native header sanitization. |
+| `false` | `true` | any | Stripped by Envoy's native header sanitization. |
+| `false` | `false` | non-empty | Stripped by Envoy's native header sanitization so JWT claims are the identity source. |
+| `false` | `false` | empty (minimal mode) | **Trusted.** Identity-header sanitization is skipped so dev-mode CLI's `x-osmo-user: <name>` flows through. `defaultIdentity` is only injected via `ADD_IF_ABSENT` when the client did not set its own. **Any caller with network access to the gateway can claim any user, role, or pool — only safe on clusters whose gateway is not exposed to untrusted networks.** |
 
 #### Gateway Upstreams
 

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -51,6 +51,8 @@ This Helm chart deploys the OSMO platform with its core services and an optional
 |-----------|-------------|---------|
 | `services.configFile.enabled` | Enable external configuration file loading | `false` |
 | `services.configFile.path` | Path to the configuration file | `/opt/osmo/config.yaml` |
+| `services.configs.enabled` | Enable ConfigMap-backed dynamic configuration | `false` |
+| `services.configs.extraAnnotations` | Annotations on the generated configs ConfigMap (e.g., ArgoCD sync options) | `{}` |
 
 ### Database Migration Settings (pgroll)
 
@@ -301,7 +303,7 @@ Benefits of the separate gateway model:
 | `gateway.envoy.scaling.hpaCpuTarget` | Target CPU utilization percentage for HPA | `80` |
 | `gateway.envoy.scaling.hpaMemoryTarget` | Target memory utilization percentage for HPA | `80` |
 | `gateway.envoy.scaling.customMetrics` | Additional custom metrics for HPA scaling (list of autoscaling/v2 metric specs) | `[]` |
-| `gateway.envoy.image` | Envoy image | `envoyproxy/envoy:v1.29.0` |
+| `gateway.envoy.image` | Envoy image | `envoyproxy/envoy:v1.38.1` |
 | `gateway.envoy.logLevel` | Envoy log level | `info` |
 | `gateway.envoy.listenerPort` | Listener port | `8080` |
 | `gateway.envoy.maxHeadersSizeKb` | Max header size in KB | `128` |
@@ -329,10 +331,10 @@ Envoy uses filesystem-based dynamic configuration (LDS/CDS). When the ConfigMap 
 
 | `oauth2Proxy.enabled` | `authz.enabled` | Identity headers from clients |
 |---|---|---|
-| `true` (default) | `true` (default) | Stripped at the HCM `internal_only_headers` layer **and** by the Lua filter. ext_authz (the authz sidecar) is the only source. Production posture. |
-| `true` | `false` | Same — both strip mechanisms still run. |
-| `false` | `true` | Same — both strip mechanisms still run. |
-| `false` | `false` (minimal mode) | **Trusted.** Both strip mechanisms are skipped so dev-mode CLI's `x-osmo-user: <name>` flows through. `defaultIdentity` is only injected via `ADD_IF_ABSENT` when the client did not set its own. **Any caller with network access to the gateway can claim any user, role, or pool — only safe on clusters whose gateway is not exposed to untrusted networks.** |
+| `true` (default) | `true` (default) | Stripped by Envoy's native header sanitization. ext_authz (the authz sidecar) is the only source. Production posture. |
+| `true` | `false` | Same — native header sanitization still runs. |
+| `false` | `true` | Same — native header sanitization still runs. |
+| `false` | `false` (minimal mode) | **Trusted.** Identity-header sanitization is skipped so dev-mode CLI's `x-osmo-user: <name>` flows through. `defaultIdentity` is only injected via `ADD_IF_ABSENT` when the client did not set its own. **Any caller with network access to the gateway can claim any user, role, or pool — only safe on clusters whose gateway is not exposed to untrusted networks.** |
 
 #### Gateway Upstreams
 

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -141,21 +141,28 @@ data:
               name: gateway_routes
 
               # Headers Envoy auto-strips from external requests at the HCM
-              # layer (before any HTTP filter runs). The identity headers
-              # (x-osmo-user, x-osmo-roles, x-osmo-allowed-pools) are only
-              # listed when an upstream auth component owns them. In
-              # minimal mode (oauth2Proxy and authz both off) the CLI and
-              # gateway-injected defaults are the only sources, so we
-              # leave them off and let client values flow.
+              # layer (before any HTTP filter runs). When authz is enabled,
+              # the authz sidecar owns all x-osmo-* identity/context headers
+              # below. In OAuth2-only mode, keep stripping the identity headers
+              # covered by defaultIdentity. In minimal mode, leave them off so
+              # gateway-injected defaults or trusted dev-mode client values
+              # can flow.
               internal_only_headers:
-              - x-osmo-auth-skip
-              {{- if or $gw.oauth2Proxy.enabled $gw.authz.enabled }}
+              {{- if $gw.authz.enabled }}
+              - x-osmo-user
+              - x-osmo-roles
+              - x-osmo-token-name
+              - x-osmo-workflow-id
+              - x-osmo-allowed-pools
+              {{- else if $gw.oauth2Proxy.enabled }}
               - x-osmo-user
               - x-osmo-roles
               - x-osmo-allowed-pools
               {{- end }}
-              - x-osmo-token-name
-              - x-osmo-workflow-id
+              # Client-supplied x-forwarded-host is not trusted. The
+              # osmo-router route re-adds it from :authority after this
+              # sanitization step.
+              - x-forwarded-host
 
               virtual_hosts:
               - name: gateway
@@ -213,6 +220,13 @@ data:
                     - cookie:
                         name: {{ $envoy.routerRoute.cookie.name | default "_osmo_router_affinity" }}
                         ttl: {{ $envoy.routerRoute.cookie.ttl | default "60s" }}
+                  # osmo-router still expects x-forwarded-host, but it should
+                  # only receive the sanitized gateway authority.
+                  request_headers_to_add:
+                  - header:
+                      key: x-forwarded-host
+                      value: "%REQ(:AUTHORITY)%"
+                    append_action: OVERWRITE_IF_EXISTS_OR_ADD
                 {{- end }}
 
                 {{- /* Agent routes — WebSocket to osmo-agent */}}
@@ -255,6 +269,15 @@ data:
                     prefix: /
                   route:
                     cluster: osmo-ui
+                  {{- if $gw.authz.enabled }}
+                  # The UI cluster never needs the authz sidecar. Let this
+                  # route run the metadata setter so the authz matcher consumes
+                  # the same osmo.authz.skip signal as other authz bypasses.
+                  typed_per_filter_config:
+                    set-authz-skip-metadata:
+                      "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcherPerRoute
+                      xds_matcher: {}
+                  {{- end }}
                 {{- end }}
 
             upgrade_configs:
@@ -303,82 +326,104 @@ data:
                         return
                       end
                     end
-            - name: strip-unauthorized-headers
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                default_source_code:
-                  inline_string: |
-                    function envoy_on_request(request_handle)
-                      request_handle:headers():remove("x-osmo-auth-skip")
-                      {{- /* In minimal mode (no oauth2Proxy, no authz),
-                             trust the client-supplied identity headers so
-                             dev-mode CLI multi-user works (workflows get
-                             attributed to the right user). When either auth
-                             component is on, ext_authz is the canonical
-                             source and any client claim must be stripped to
-                             prevent impersonation.
-                          */ -}}
-                      {{- if or $gw.oauth2Proxy.enabled $gw.authz.enabled }}
-                      request_handle:headers():remove("x-osmo-user")
-                      request_handle:headers():remove("x-osmo-roles")
-                      request_handle:headers():remove("x-osmo-allowed-pools")
-                      {{- end }}
-                      request_handle:headers():remove("x-osmo-token-name")
-                      request_handle:headers():remove("x-osmo-workflow-id")
-                      request_handle:headers():remove("x-envoy-internal")
-                      request_handle:headers():remove("x-forwarded-host")
-                    end
-            - name: add-auth-skip
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                default_source_code:
-                  inline_string: |
-                    function starts_with(str, start)
-                       return str:sub(1, #start) == start
-                    end
-
-                    function envoy_on_request(request_handle)
-                      skip = false
-                      {{- range $skipAuthPaths }}
-                      if (starts_with(request_handle:headers():get(':path'), '{{.}}')) then
-                        skip = true
-                      end
-                      {{- end}}
-                      if (skip) then
-                        request_handle:headers():add("x-osmo-auth-skip", "true")
-                      end
-                    end
-
-            - name: add-forwarded-host
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                default_source_code:
-                  inline_string: |
-                    function envoy_on_request(request_handle)
-                      local authority = request_handle:headers():get(":authority")
-                      if authority ~= nil then
-                        request_handle:headers():replace("x-forwarded-host", authority)
-                      end
-                    end
-
-            {{- if $gw.oauth2Proxy.enabled }}
-            - name: ext-authz-oauth2-proxy
+            {{- if $skipAuthPaths }}
+            {{- /* Authn skip paths bypass both authn and authz. Authz-only
+                   bypasses use route-specific set_metadata config. */}}
+            # set_metadata has no path matcher of its own, so wrap it and
+            # skip the metadata filter on non-skip paths. Matching skip paths
+            # set both authn and authz metadata because bypassing authn also
+            # bypasses downstream authz.
+            - name: set-authn-skip-metadata
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
                 xds_matcher:
                   matcher_list:
                     matchers:
                     - predicate:
+                        not_matcher:
+                          {{- /* Envoy validates or_matcher as requiring at
+                                 least two predicates. A single skipAuthPath
+                                 must be emitted as a bare single_predicate. */}}
+                          {{- if gt (len $skipAuthPaths) 1 }}
+                          or_matcher:
+                            predicate:
+                            {{- range $skipAuthPaths }}
+                            - single_predicate:
+                                input:
+                                  name: request-headers
+                                  typed_config:
+                                    "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                    header_name: ":path"
+                                value_match:
+                                  prefix: {{ . | quote }}
+                            {{- end }}
+                          {{- else }}
+                          single_predicate:
+                            input:
+                              name: request-headers
+                              typed_config:
+                                "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                header_name: ":path"
+                            value_match:
+                              prefix: {{ (index $skipAuthPaths 0) | quote }}
+                          {{- end }}
+                      on_match:
+                        action:
+                          name: skip
+                          typed_config:
+                            "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
+                extension_config:
+                  name: envoy.filters.http.set_metadata
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
+                    metadata:
+                    - metadata_namespace: osmo.authn
+                      allow_overwrite: true
+                      value:
+                        skip: "true"
+                    - metadata_namespace: osmo.authz
+                      allow_overwrite: true
+                      value:
+                        skip: "true"
+            {{- end }}
+
+            {{- if $gw.authz.enabled }}
+            # Skipped by default; routes such as the UI can override the
+            # wrapper matcher and run this filter to set osmo.authz.skip
+            # before the authz matcher runs.
+            - name: set-authz-skip-metadata
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+                xds_matcher:
+                  on_no_match:
+                    action:
+                      name: skip
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
+                extension_config:
+                  name: envoy.filters.http.set_metadata
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
+                    metadata:
+                    - metadata_namespace: osmo.authz
+                      allow_overwrite: true
+                      value:
+                        skip: "true"
+            {{- end }}
+
+            {{- if $gw.oauth2Proxy.enabled }}
+            - name: ext-authz-oauth2-proxy
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+                # Skip the OAuth2 proxy when another authn mechanism is in
+                # play (JWT bearer/x-osmo-auth) or a skipAuthPath marked
+                # osmo.authn.skip earlier in the chain.
+                xds_matcher:
+                  matcher_list:
+                    matchers:
+                    - predicate:
                         or_matcher:
                           predicate:
-                          - single_predicate:
-                              input:
-                                name: request-headers
-                                typed_config:
-                                  "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
-                                  header_name: x-osmo-auth-skip
-                              value_match:
-                                exact: "true"
                           - single_predicate:
                               input:
                                 name: request-headers
@@ -397,6 +442,23 @@ data:
                                   header_name: authorization
                               value_match:
                                 prefix: "Bearer "
+                          {{- if $skipAuthPaths }}
+                          - single_predicate:
+                              input:
+                                name: envoy.matching.inputs.dynamic_metadata
+                                typed_config:
+                                  "@type": type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.DynamicMetadataInput
+                                  filter: osmo.authn
+                                  path:
+                                  - key: skip
+                              custom_match:
+                                name: envoy.matching.matchers.metadata_matcher
+                                typed_config:
+                                  "@type": type.googleapis.com/envoy.extensions.matching.input_matchers.metadata.v3.Metadata
+                                  value:
+                                    string_match:
+                                      exact: "true"
+                          {{- end }}
                       on_match:
                         action:
                           name: skip
@@ -429,69 +491,56 @@ data:
             {{- end }}
 
             {{- if $envoy.jwt.providers }}
-            - name: jwt-authn-with-matcher
+            - name: envoy.filters.http.jwt_authn
               typed_config:
-                "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
-                xds_matcher:
-                  matcher_list:
-                    matchers:
-                    - predicate:
-                        single_predicate:
-                          input:
-                            name: request-headers
-                            typed_config:
-                              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
-                              header_name: x-osmo-auth-skip
-                          value_match:
-                            exact: "true"
-                      on_match:
-                        action:
-                          name: skip
-                          typed_config:
-                            "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
-                extension_config:
-                  name: envoy.filters.http.jwt_authn
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
-                    providers:
-                      {{- range $i, $provider := $envoy.jwt.providers }}
-                      provider_{{$i}}:
-                        issuer: {{ $provider.issuer }}
-                        audiences:
-                        - {{ $provider.audience }}
-                        forward: true
-                        payload_in_metadata: verified_jwt
-                        from_headers:
-                        - name: authorization
-                          value_prefix: "Bearer "
-                        - name: x-osmo-auth
-                        remote_jwks:
-                          http_uri:
-                            uri: {{ $provider.jwks_uri }}
-                            cluster: {{ $provider.cluster }}
-                            timeout: 5s
-                          cache_duration:
-                            seconds: 600
-                          async_fetch:
-                            failed_refetch_duration: 1s
-                          retry_policy:
-                            num_retries: 3
-                            retry_back_off:
-                              base_interval: 0.01s
-                              max_interval: 3s
-                        claim_to_headers:
-                        - claim_name: {{$provider.user_claim}}
-                          header_name: {{$envoy.jwt.user_header}}
-                      {{- end }}
-                    rules:
-                    - match:
-                        prefix: /
-                      requires:
-                        requires_any:
-                          requirements:
-                          {{- range $i, $provider := $envoy.jwt.providers }}
-                          - provider_name: provider_{{$i}}
-                          {{- end}}
+                "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+                providers:
+                  {{- range $i, $provider := $envoy.jwt.providers }}
+                  provider_{{$i}}:
+                    issuer: {{ $provider.issuer }}
+                    audiences:
+                    - {{ $provider.audience }}
+                    forward: true
+                    payload_in_metadata: verified_jwt
+                    from_headers:
+                    - name: authorization
+                      value_prefix: "Bearer "
+                    - name: x-osmo-auth
+                    remote_jwks:
+                      http_uri:
+                        uri: {{ $provider.jwks_uri }}
+                        cluster: {{ $provider.cluster }}
+                        timeout: 5s
+                      cache_duration:
+                        seconds: 600
+                      async_fetch:
+                        failed_refetch_duration: 1s
+                      retry_policy:
+                        num_retries: 3
+                        retry_back_off:
+                          base_interval: 0.01s
+                          max_interval: 3s
+                    claim_to_headers:
+                    - claim_name: {{$provider.user_claim}}
+                      header_name: {{$envoy.jwt.user_header}}
+                  {{- end }}
+                rules:
+                  {{- if $skipAuthPaths }}
+                  # A jwt_authn rule with no "requires" allows the matching
+                  # path through without JWT validation.
+                  {{- range $skipAuthPaths }}
+                  - match:
+                      prefix: {{ . | quote }}
+                  {{- end }}
+                  {{- end }}
+                  - match:
+                      prefix: /
+                    requires:
+                      requires_any:
+                        requirements:
+                        {{- range $i, $provider := $envoy.jwt.providers }}
+                        - provider_name: provider_{{$i}}
+                        {{- end}}
             {{- end }}
 
             - name: envoy.filters.http.lua.roles
@@ -517,21 +566,31 @@ data:
                     end
 
             {{- if $gw.authz.enabled }}
-            - name: authz-with-matcher
+            - name: envoy.filters.http.ext_authz
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
+                # Dynamic metadata set by an earlier filter must be evaluated
+                # by ExtensionWithMatcher before ext_authz instantiation; the
+                # ext_authz metadata gate would run too late for this use.
                 xds_matcher:
                   matcher_list:
                     matchers:
                     - predicate:
                         single_predicate:
                           input:
-                            name: request-headers
+                            name: envoy.matching.inputs.dynamic_metadata
                             typed_config:
-                              "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
-                              header_name: x-osmo-auth-skip
-                          value_match:
-                            exact: "true"
+                              "@type": type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.DynamicMetadataInput
+                              filter: osmo.authz
+                              path:
+                              - key: skip
+                          custom_match:
+                            name: envoy.matching.matchers.metadata_matcher
+                            typed_config:
+                              "@type": type.googleapis.com/envoy.extensions.matching.input_matchers.metadata.v3.Metadata
+                              value:
+                                string_match:
+                                  exact: "true"
                       on_match:
                         action:
                           name: skip
@@ -614,7 +673,7 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $gw.upstreams.service.host }}
           common_tls_context:
-            {{/* Envoy 1.29 upstream defaults to TLS 1.2 max. uvicorn's
+            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
                  SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
                  the openssl version supports it). Allow up to 1.3 so
                  negotiation can pick the most compatible option. */}}
@@ -657,7 +716,7 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $gw.upstreams.router.host }}
           common_tls_context:
-            {{/* Envoy 1.29 upstream defaults to TLS 1.2 max. uvicorn's
+            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
                  SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
                  the openssl version supports it). Allow up to 1.3 so
                  negotiation can pick the most compatible option. */}}
@@ -723,7 +782,7 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $gw.upstreams.agent.host }}
           common_tls_context:
-            {{/* Envoy 1.29 upstream defaults to TLS 1.2 max. uvicorn's
+            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
                  SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
                  the openssl version supports it). Allow up to 1.3 so
                  negotiation can pick the most compatible option. */}}
@@ -765,7 +824,7 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $gw.upstreams.logger.host }}
           common_tls_context:
-            {{/* Envoy 1.29 upstream defaults to TLS 1.2 max. uvicorn's
+            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
                  SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
                  the openssl version supports it). Allow up to 1.3 so
                  negotiation can pick the most compatible option. */}}
@@ -894,7 +953,7 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $jwksHost }}
           common_tls_context:
-            {{/* Envoy 1.29 upstream defaults to TLS 1.2 max. uvicorn's
+            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
                  SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
                  the openssl version supports it). Allow up to 1.3 so
                  negotiation can pick the most compatible option. */}}

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -270,13 +270,14 @@ data:
                   route:
                     cluster: osmo-ui
                   {{- if $gw.authz.enabled }}
-                  # The UI cluster never needs the authz sidecar. Let this
-                  # route run the metadata setter so the authz matcher consumes
-                  # the same osmo.authz.skip signal as other authz bypasses.
+                  # UI traffic does not need the authz sidecar. Disable
+                  # ext_authz with its native per-route config; this only works
+                  # because the filter below is configured directly, not
+                  # wrapped in ExtensionWithMatcher.
                   typed_per_filter_config:
-                    set-authz-skip-metadata:
-                      "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcherPerRoute
-                      xds_matcher: {}
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
                   {{- end }}
                 {{- end }}
 
@@ -327,8 +328,7 @@ data:
                       end
                     end
             {{- if $skipAuthPaths }}
-            {{- /* Authn skip paths bypass both authn and authz. Authz-only
-                   bypasses use route-specific set_metadata config. */}}
+            {{- /* Authn skip paths bypass both authn and authz. */}}
             # set_metadata has no path matcher of its own, so wrap it and
             # skip the metadata filter on non-skip paths. Matching skip paths
             # set both authn and authz metadata because bypassing authn also
@@ -381,30 +381,6 @@ data:
                       allow_overwrite: true
                       value:
                         skip: "true"
-                    - metadata_namespace: osmo.authz
-                      allow_overwrite: true
-                      value:
-                        skip: "true"
-            {{- end }}
-
-            {{- if $gw.authz.enabled }}
-            # Skipped by default; routes such as the UI can override the
-            # wrapper matcher and run this filter to set osmo.authz.skip
-            # before the authz matcher runs.
-            - name: set-authz-skip-metadata
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
-                xds_matcher:
-                  on_no_match:
-                    action:
-                      name: skip
-                      typed_config:
-                        "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
-                extension_config:
-                  name: envoy.filters.http.set_metadata
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.filters.http.set_metadata.v3.Config
-                    metadata:
                     - metadata_namespace: osmo.authz
                       allow_overwrite: true
                       value:
@@ -568,49 +544,29 @@ data:
             {{- if $gw.authz.enabled }}
             - name: envoy.filters.http.ext_authz
               typed_config:
-                "@type": type.googleapis.com/envoy.extensions.common.matching.v3.ExtensionWithMatcher
-                # Dynamic metadata set by an earlier filter must be evaluated
-                # by ExtensionWithMatcher before ext_authz instantiation; the
-                # ext_authz metadata gate would run too late for this use.
-                xds_matcher:
-                  matcher_list:
-                    matchers:
-                    - predicate:
-                        single_predicate:
-                          input:
-                            name: envoy.matching.inputs.dynamic_metadata
-                            typed_config:
-                              "@type": type.googleapis.com/envoy.extensions.matching.common_inputs.network.v3.DynamicMetadataInput
-                              filter: osmo.authz
-                              path:
-                              - key: skip
-                          custom_match:
-                            name: envoy.matching.matchers.metadata_matcher
-                            typed_config:
-                              "@type": type.googleapis.com/envoy.extensions.matching.input_matchers.metadata.v3.Metadata
-                              value:
-                                string_match:
-                                  exact: "true"
-                      on_match:
-                        action:
-                          name: skip
-                          typed_config:
-                            "@type": type.googleapis.com/envoy.extensions.filters.common.matcher.action.v3.SkipFilter
-                extension_config:
-                  name: envoy.filters.http.ext_authz
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
-                    transport_api_version: V3
-                    with_request_body:
-                      max_request_bytes: 8192
-                      allow_partial_message: true
-                    failure_mode_allow: false
-                    grpc_service:
-                      envoy_grpc:
-                        cluster_name: authz
-                      timeout: 1s
-                    metadata_context_namespaces:
-                      - envoy.filters.http.jwt_authn
+                "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                transport_api_version: V3
+                with_request_body:
+                  max_request_bytes: 8192
+                  allow_partial_message: true
+                failure_mode_allow: false
+                # set-authn-skip-metadata writes osmo.authz.skip before this
+                # filter. Invert the metadata match so ext_authz runs for
+                # ordinary requests and stays disabled for authn skip paths.
+                filter_enabled_metadata:
+                  filter: osmo.authz
+                  path:
+                  - key: skip
+                  value:
+                    string_match:
+                      exact: "true"
+                  invert: true
+                grpc_service:
+                  envoy_grpc:
+                    cluster_name: authz
+                  timeout: 1s
+                metadata_context_namespaces:
+                  - envoy.filters.http.jwt_authn
             {{- end }}
 
             {{- if $gw.rateLimit.enabled }}

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -141,22 +141,16 @@ data:
               name: gateway_routes
 
               # Headers Envoy auto-strips from external requests at the HCM
-              # layer (before any HTTP filter runs). When authz is enabled,
-              # the authz sidecar owns all x-osmo-* identity/context headers
-              # below. In OAuth2-only mode, keep stripping the identity headers
-              # covered by defaultIdentity. In minimal mode, leave them off so
-              # gateway-injected defaults or trusted dev-mode client values
-              # can flow.
+              # layer, before HTTP filters run. When any gateway auth source
+              # is configured, clients must not be able to spoof x-osmo-*
+              # identity/context headers. Minimal/demo deployments with no
+              # auth source keep their legacy client-header behavior.
               internal_only_headers:
-              {{- if $gw.authz.enabled }}
+              {{- if or $gw.authz.enabled $gw.oauth2Proxy.enabled $envoy.jwt.providers }}
               - x-osmo-user
               - x-osmo-roles
               - x-osmo-token-name
               - x-osmo-workflow-id
-              - x-osmo-allowed-pools
-              {{- else if $gw.oauth2Proxy.enabled }}
-              - x-osmo-user
-              - x-osmo-roles
               - x-osmo-allowed-pools
               {{- end }}
               # Client-supplied x-forwarded-host is not trusted. The
@@ -508,6 +502,14 @@ data:
                   - match:
                       prefix: {{ . | quote }}
                   {{- end }}
+                  {{- end }}
+                  {{- if $gw.oauth2Proxy.enabled }}
+                  # OAuth2 proxy endpoints must be reachable before a user has
+                  # a JWT, so these rules intentionally have no "requires".
+                  - match:
+                      prefix: /oauth2/
+                  - match:
+                      prefix: /signout
                   {{- end }}
                   - match:
                       prefix: /

--- a/deployments/charts/service/templates/configs.yaml
+++ b/deployments/charts/service/templates/configs.yaml
@@ -20,6 +20,10 @@ metadata:
   name: {{ .Values.services.service.serviceName }}-configs
   labels:
     app: {{ .Values.services.service.serviceName }}
+  {{- with .Values.services.configs.extraAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   config.yaml: |
     {{- $cfg := .Values.services.configs }}

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -35,7 +35,6 @@ kind: Deployment
 metadata:
   name: {{ $gwName }}-envoy
 spec:
-  replicas: {{ $gw.envoy.scaling.minReplicas }}
   selector:
     matchLabels:
       {{- include "osmo.gateway-component-labels" (dict "component" "envoy" "context" .) | nindent 6 }}
@@ -256,7 +255,6 @@ kind: Deployment
 metadata:
   name: {{ $gwName }}-oauth2-proxy
 spec:
-  replicas: {{ $gw.oauth2Proxy.scaling.minReplicas }}
   selector:
     matchLabels:
       {{- include "osmo.gateway-component-labels" (dict "component" "oauth2-proxy" "context" .) | nindent 6 }}
@@ -432,7 +430,6 @@ kind: Deployment
 metadata:
   name: {{ $gwName }}-authz
 spec:
-  replicas: {{ $gw.authz.scaling.minReplicas }}
   selector:
     matchLabels:
       {{- include "osmo.gateway-component-labels" (dict "component" "authz" "context" .) | nindent 6 }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1787,22 +1787,20 @@ gateway:
     ## empty role/pool lists, so the UI shows blank pages.
     ##
     ## Setting these renders Envoy `request_headers_to_add` rules at the
-    ## gateway virtual host with `append_action: ADD_IF_ABSENT`. The chart
-    ## also conditionally drops these headers from the gateway's native
-    ## header sanitization rules when oauth2Proxy and authz are both
-    ## disabled, so client-supplied identity (e.g. dev-mode CLI's
-    ## `x-osmo-user: <name>`) flows through; the default is only injected
-    ## when the client didn't set its own.
+    ## gateway virtual host with `append_action: ADD_IF_ABSENT`. When
+    ## oauth2Proxy, authz, or JWT providers are configured, Envoy strips
+    ## client-supplied x-osmo-* identity headers before filters run. In
+    ## minimal/demo mode, where all three auth sources are disabled,
+    ## sanitization is skipped so trusted dev-mode client identity headers
+    ## can still flow through.
     ##
-    ## SECURITY: in this mode the gateway TRUSTS the client's identity
-    ## headers. Any caller with network access can claim any user, any
-    ## role, and any pool. Only enable on clusters whose gateway is not
+    ## SECURITY: in minimal/demo mode the gateway TRUSTS the client's
+    ## identity headers. Any caller with network access can claim any user,
+    ## role, and pool. Only use that mode on clusters whose gateway is not
     ## reachable from untrusted networks.
     ##
-    ## In production (oauth2Proxy or authz enabled), client identity
-    ## headers are stripped by Envoy's native header sanitization, so
-    ## defaultIdentity is irrelevant — authz/JWT is the canonical source.
-    ## Leave all three empty in that mode.
+    ## In production, leave all three empty; authz/JWT is the canonical
+    ## source of identity.
     ##
     defaultIdentity:
       user: ""           # e.g. "admin"

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -451,6 +451,14 @@ services:
     ##
     enabled: false
 
+    ## Annotations on the generated configs ConfigMap.
+    ## Useful for large config payloads that need Argo CD server-side apply.
+    ## Example:
+    ##   extraAnnotations:
+    ##     argocd.argoproj.io/sync-options: ServerSideApply=true
+    ##
+    extraAnnotations: {}
+
     ## Service config. service_base_url is auto-derived from
     ## services.service.hostname if not set here.
     ##
@@ -1740,7 +1748,7 @@ gateway:
 
     ## Envoy container image
     ##
-    image: "envoyproxy/envoy:v1.29.0"
+    image: "envoyproxy/envoy:v1.38.1"
 
     ## Image pull policy for Envoy containers
     ##
@@ -1780,11 +1788,11 @@ gateway:
     ##
     ## Setting these renders Envoy `request_headers_to_add` rules at the
     ## gateway virtual host with `append_action: ADD_IF_ABSENT`. The chart
-    ## also conditionally drops these headers from the gateway's
-    ## `internal_only_headers` and Lua strip filter when oauth2Proxy and
-    ## authz are both disabled, so client-supplied identity (e.g. dev-mode
-    ## CLI's `x-osmo-user: <name>`) flows through; the default is only
-    ## injected when the client didn't set its own.
+    ## also conditionally drops these headers from the gateway's native
+    ## header sanitization rules when oauth2Proxy and authz are both
+    ## disabled, so client-supplied identity (e.g. dev-mode CLI's
+    ## `x-osmo-user: <name>`) flows through; the default is only injected
+    ## when the client didn't set its own.
     ##
     ## SECURITY: in this mode the gateway TRUSTS the client's identity
     ## headers. Any caller with network access can claim any user, any
@@ -1792,7 +1800,7 @@ gateway:
     ## reachable from untrusted networks.
     ##
     ## In production (oauth2Proxy or authz enabled), client identity
-    ## headers are stripped at both the HCM and Lua-filter layers, so
+    ## headers are stripped by Envoy's native header sanitization, so
     ## defaultIdentity is irrelevant — authz/JWT is the canonical source.
     ## Leave all three empty in that mode.
     ##


### PR DESCRIPTION
## Description
Fixes a bug where osmo-user could not access the UI, due to failing ext-authz calls. osmo-admin persona was unaffected.

Rather than just patch that behavior, this PR goes further and refactors our Envoy configuration, with an overall goal to reduce LUA code where native Envoy configuration already covers it.

Splitting x-osmo-auth-skip header into skip authn and authz metadata

A couple of minor piggybacks
- Add support for extra annotations so large configs can be server-side applied in ArgoCD
- Fix HPA conflict with replicas

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom annotations on ConfigMap-backed dynamic configuration.

* **Documentation**
  * Clarified identity-header sanitization and trust behavior across authentication modes.
  * Updated gateway configuration guidance and image documentation.

* **Chores**
  * Upgraded gateway Envoy container image to v1.38.1.
  * Removed explicit replica counts from several deployment manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->