### PR TITLE
Fix streaming api endpoints

### DIFF
--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -278,10 +278,12 @@ data:
                     prefix: /api/
                   route:
                     cluster: osmo-service
+                    timeout: 60s
                 - match:
                     prefix: /client/
                   route:
                     cluster: osmo-service
+                    timeout: 60s
                 {{- end }}
 
                 {{- if $gw.upstreams.ui.enabled }}

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -248,6 +248,17 @@ data:
                 {{- if $envoy.serviceRoutes }}
                 {{- toYaml $envoy.serviceRoutes | nindent 16 }}
                 {{- else }}
+                # Workflow log/event endpoints can stream while a workflow runs.
+                # Disable Envoy's per-route timeout and rely on idle timeout
+                # so quiet-but-open streams are not cut by the default
+                # /api/ route timeout.
+                - match:
+                    safe_regex:
+                      regex: "^/api/workflow/.+/(logs|events|error_logs)$"
+                  route:
+                    cluster: osmo-service
+                    timeout: 0s
+                    idle_timeout: 60s
                 - match:
                     prefix: /api/
                   route:

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -198,10 +198,25 @@ data:
                     {{- else }}
                     path_redirect: "/oauth2/sign_out"
                     {{- end }}
+                  {{- if $gw.authz.enabled }}
+                  # OAuth2 control routes are part of authentication itself.
+                  # They must not require authorization from the OSMO authz
+                  # sidecar before the browser can complete login/logout.
+                  typed_per_filter_config:
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+                  {{- end }}
                 - match:
                     prefix: /oauth2/
                   route:
                     cluster: oauth2-proxy
+                  {{- if $gw.authz.enabled }}
+                  typed_per_filter_config:
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+                  {{- end }}
                 {{- end }}
 
                 {{- if $gw.upstreams.router.enabled }}


### PR DESCRIPTION
## Description
Fix regression in API endpoints that stream data back while a workflow is running.

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Improvements**
  * Disabled external authorization on OAuth2 control and signout routes to change auth handling for those endpoints.
  * Added a dedicated streaming route for workflow logs, events, and error logs with no request timeout and a 60s idle timeout for improved streaming.
  * Set explicit 60s timeouts for general API and client routes to standardize request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->