### PR TITLE
Fix retry pods failing to mount generated file secrets

### DIFF
--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -1184,7 +1184,7 @@ class UpdateGroup(WorkflowJob):
         # Get create job
         pod_list = {new_task.name: kb_objects.construct_pod_name(
             self.workflow_uuid, new_task.task_uuid)}
-        pod, _, _ = group.convert_to_pod_spec(
+        pod, files, _ = group.convert_to_pod_spec(
             new_task,
             spec,
             self.workflow_uuid,
@@ -1199,13 +1199,16 @@ class UpdateGroup(WorkflowJob):
             skip_refresh_token=True,
         )
         k8s_factory.update_pod_k8s_resource(pod, group.group_uuid, pool, workflow_obj.priority)
+        labels = pod.get('metadata', {}).get('labels', {})
+        k8s_resources = [file.secret(labels) for file in files.values()]
+        k8s_resources.append(pod)
 
         create_job = CreateGroup(
             backend=spec.backend,
             group_name=group.name,
             workflow_id=self.workflow_id,
             workflow_uuid=self.workflow_uuid,
-            k8s_resources=[pod],
+            k8s_resources=k8s_resources,
             user=self.user)
 
         reschedule_job = RescheduleTask(

--- a/src/utils/job/tests/test_task_pure.py
+++ b/src/utils/job/tests/test_task_pure.py
@@ -22,10 +22,10 @@ from unittest import mock
 
 import pydantic
 
-from src.lib.utils import credentials, osmo_errors
+from src.lib.utils import credentials, osmo_errors, priority as wf_priority
 from src.lib.utils.osmo_errors import OSMOResourceError
 from src.utils import connectors
-from src.utils.job import task, kb_objects
+from src.utils.job import jobs, task, kb_objects
 
 
 class ShortenNameToFitKbTest(unittest.TestCase):
@@ -92,6 +92,100 @@ class CreateLoginDictTest(unittest.TestCase):
         result = task.create_login_dict(user='bob', url='https://example.com')
         self.assertNotIn('token_login', result)
         self.assertNotIn('osmo_token', result)
+
+
+class RetryTaskK8sResourcesTest(unittest.TestCase):
+    """Tests for retry resource reconciliation."""
+
+    def test_retry_task_recreates_generated_file_secrets(self):
+        workflow_uuid = 'a' * 32
+        task_db_key = 'c' * 32
+        group_uuid = 'd' * 32
+        user = 'alice'
+        database = mock.Mock()
+        context = mock.Mock(postgres=database)
+        progress_writer = mock.Mock()
+        k8s_factory = kb_objects.K8sObjectFactory('default-scheduler')
+        file_mount = kb_objects.FileMount(
+            group_uid=group_uuid,
+            path='/workspace/run.sh',
+            content='ZWNobyBoZWxsbwo=',
+            k8s_factory=k8s_factory,
+        )
+        pod_labels = {
+            'osmo.workflow_uuid': workflow_uuid,
+            'osmo.group_uuid': group_uuid,
+            'osmo.group_name': 'group',
+            'osmo.submitted_by': user,
+            'osmo.task_name': 'worker',
+            'osmo.retry_id': '1',
+        }
+        pod = {
+            'apiVersion': 'v1',
+            'kind': 'Pod',
+            'metadata': {'name': 'retry-pod', 'labels': pod_labels},
+            'spec': {},
+        }
+
+        spec = task.TaskSpec(
+            name='worker',
+            image='ubuntu:22.04',
+            command=['/bin/sh'],
+            backend='default',
+        )
+        group = mock.Mock()
+        group.name = 'group'
+        group.group_uuid = group_uuid
+        group.spec.tasks = [spec]
+        group.convert_to_pod_spec.return_value = (pod, {'run.sh': file_mount}, None)
+
+        new_task = mock.Mock()
+        new_task.name = 'worker'
+        new_task.task_uuid = 'b' * 32
+        new_task.task_db_key = 'e' * 32
+        new_task.retry_id = 1
+        task_obj = mock.Mock()
+        task_obj.name = 'worker'
+        task_obj.task_db_key = task_db_key
+        task_obj.retry_id = 0
+        task_obj.create_new.return_value = new_task
+        workflow_obj = mock.Mock()
+        workflow_obj.plugins = mock.Mock()
+        workflow_obj.priority = wf_priority.WorkflowPriority.NORMAL
+        update_job = jobs.UpdateGroup(
+            workflow_id='workflow-1',
+            workflow_uuid=workflow_uuid,
+            group_name='group',
+            task_name='worker',
+            retry_id=0,
+            status=task.TaskGroupStatus.RESCHEDULED,
+            user=user,
+        )
+
+        with mock.patch.object(
+            task.TaskGroup, 'fetch_metadata_from_db', return_value=group
+        ), mock.patch.object(
+            jobs.RescheduleTask, 'send_job_to_queue', autospec=True
+        ) as send_job:
+            update_job._retry_task(  # pylint: disable=protected-access
+                task_obj,
+                group,
+                'default',
+                mock.Mock(max_error_log_lines=1000),
+                mock.Mock(),
+                context,
+                progress_writer,
+                workflow_obj,
+                k8s_factory,
+            )
+
+        reschedule_job = send_job.call_args.args[0]
+        resources = reschedule_job.create_job.k8s_resources
+        self.assertEqual(['Secret', 'Pod'], [resource['kind'] for resource in resources])
+        self.assertEqual(file_mount.name, resources[0]['metadata']['name'])
+        self.assertEqual(pod_labels, resources[0]['metadata']['labels'])
+        self.assertEqual(pod, resources[1])
+        self.assertEqual(2, progress_writer.report_progress.call_count)
 
 
 class CreateConfigDictTest(unittest.TestCase):


### PR DESCRIPTION
## Description
Retry now recreates generated file Secret resources when a task is rescheduled. Previously the retry path rebuilt the Kubernetes pod from `TaskGroup.convert_to_pod_spec(...)` but discarded the returned generated `FileMount` objects, so the retry `CreateGroup` payload only contained the pod. If the original generated Secret was already gone, the retry pod failed with `FailedMount: secret ... not found` and eventually `FAILED_START_TIMEOUT`.

This change includes the generated file Secret resources before the retry pod in the retry `CreateGroup` payload. If the Secret still exists, backend create already treats `AlreadyExists` as harmless.

Issue - None
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

Verification:
- `bazel test //src/utils/job/tests:test_task_pure`
- `bazel test //src/utils/job:job-pylint //src/utils/job/tests:test_task_pure-pylint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job retry behavior so rescheduled tasks now include all generated Kubernetes resources (secrets and pod configs) ensuring more reliable automatic recovery of failed work.

* **Tests**
  * Added test coverage validating that task retry/reschedule flows assemble and submit the full set of Kubernetes configuration resources in the correct order and report progress as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
