### PR TITLE
Add gateway PodMonitors

### DIFF
--- a/deployments/charts/service/templates/api-monitor.yaml
+++ b/deployments/charts/service/templates/api-monitor.yaml
@@ -34,3 +34,37 @@ spec:
                  {{ .Values.services.delayedJobMonitor.serviceName }}]
       }
 {{- end }}
+{{- if and .Values.podMonitor.enabled .Values.gateway.envoy.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: gateway-envoy-monitor
+spec:
+  podMetricsEndpoints:
+  - interval: 15s
+    port: envoy-admin
+    path: /stats/prometheus
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "osmo.gateway-name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: envoy
+{{- end }}
+{{- if and .Values.podMonitor.enabled .Values.gateway.oauth2Proxy.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: gateway-oauth2-proxy-monitor
+spec:
+  podMetricsEndpoints:
+  - interval: 15s
+    port: oauth2-metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "osmo.gateway-name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: oauth2-proxy
+{{- end }}


### PR DESCRIPTION
## Description
Add PodMonitor resources for gateway Envoy and oauth2-proxy pods when the gateway components are enabled. This lets Prometheus scrape gateway metrics using the existing `podMonitor.enabled` chart switch, alongside the existing service PodMonitor.

Issue #None

## Validation
- `helm template osmo deployments/charts/service --set podMonitor.enabled=true --set gateway.envoy.enabled=true --set gateway.oauth2Proxy.enabled=true --show-only templates/api-monitor.yaml`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced gateway monitoring: Added optional Prometheus monitoring support for gateway components. Envoy proxy metrics are now available via admin port, and OAuth2-proxy metrics via dedicated endpoint. Each component's monitoring can be independently enabled through configuration, providing improved visibility into gateway operations and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->