### PR TITLE
fix: envoy affinity and circuit breakers

### DIFF
--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -232,7 +232,7 @@ data:
                     hash_policy:
                     - cookie:
                         name: {{ $envoy.routerRoute.cookie.name | default "_osmo_router_affinity" }}
-                        ttl: {{ $envoy.routerRoute.cookie.ttl | default "60s" }}
+                        ttl: {{ $envoy.routerRoute.cookie.ttl | default "0s" }}
                   # osmo-router still expects x-forwarded-host, but it should
                   # only receive the sanitized gateway authority.
                   request_headers_to_add:

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -666,10 +666,10 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $gw.upstreams.service.host }}
           common_tls_context:
-            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
-                 SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
-                 the openssl version supports it). Allow up to 1.3 so
-                 negotiation can pick the most compatible option. */}}
+            # Envoy upstream TLS defaults can be narrower than uvicorn's
+            # SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if the
+            # openssl version supports it). Allow up to 1.3 so negotiation
+            # can pick the most compatible option.
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
@@ -709,10 +709,10 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $gw.upstreams.router.host }}
           common_tls_context:
-            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
-                 SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
-                 the openssl version supports it). Allow up to 1.3 so
-                 negotiation can pick the most compatible option. */}}
+            # Envoy upstream TLS defaults can be narrower than uvicorn's
+            # SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if the
+            # openssl version supports it). Allow up to 1.3 so negotiation
+            # can pick the most compatible option.
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
@@ -744,12 +744,10 @@ data:
                 socket_address:
                   address: {{ $gw.upstreams.ui.host }}
                   port_value: {{ $gw.upstreams.ui.port }}
-      {{/*
-        UI traffic stays HTTP — Next.js does not natively serve HTTPS and
-        the UI sits behind NetworkPolicy. Confidentiality of the UI HTML
-        relies on browser → gateway TLS (gateway.envoy.ssl.enabled), not on
-        Envoy → upstream TLS.
-      */}}
+      # UI traffic stays HTTP. Next.js does not natively serve HTTPS and the
+      # UI sits behind NetworkPolicy. Confidentiality of the UI HTML relies on
+      # browser to gateway TLS (gateway.envoy.ssl.enabled), not on Envoy to
+      # upstream TLS.
     {{- end }}
 
     {{- if $gw.upstreams.agent.enabled }}
@@ -775,10 +773,10 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $gw.upstreams.agent.host }}
           common_tls_context:
-            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
-                 SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
-                 the openssl version supports it). Allow up to 1.3 so
-                 negotiation can pick the most compatible option. */}}
+            # Envoy upstream TLS defaults can be narrower than uvicorn's
+            # SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if the
+            # openssl version supports it). Allow up to 1.3 so negotiation
+            # can pick the most compatible option.
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
@@ -817,10 +815,10 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $gw.upstreams.logger.host }}
           common_tls_context:
-            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
-                 SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
-                 the openssl version supports it). Allow up to 1.3 so
-                 negotiation can pick the most compatible option. */}}
+            # Envoy upstream TLS defaults can be narrower than uvicorn's
+            # SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if the
+            # openssl version supports it). Allow up to 1.3 so negotiation
+            # can pick the most compatible option.
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
@@ -946,10 +944,10 @@ data:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
           sni: {{ $jwksHost }}
           common_tls_context:
-            {{/* Envoy upstream TLS defaults can be narrower than uvicorn's
-                 SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if
-                 the openssl version supports it). Allow up to 1.3 so
-                 negotiation can pick the most compatible option. */}}
+            # Envoy upstream TLS defaults can be narrower than uvicorn's
+            # SSLContext uses Python defaults (TLS 1.2 floor, 1.3 if the
+            # openssl version supports it). Allow up to 1.3 so negotiation
+            # can pick the most compatible option.
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -185,6 +185,7 @@ metadata:
     alb.ingress.kubernetes.io/group.name: {{ $gw.envoy.ingress.albAnnotations.groupName | default "osmo" }}
     alb.ingress.kubernetes.io/group.order: {{ $gw.envoy.ingress.albAnnotations.groupOrder | default "10" | quote }}
     alb.ingress.kubernetes.io/certificate-arn: {{ $gw.envoy.ingress.albAnnotations.sslCertArn }}
+    alb.ingress.kubernetes.io/healthcheck-path: /api/version
     {{- end }}
     {{- range $k, $v := $gw.envoy.ingress.annotations }}
     {{ $k }}: {{ $v | quote }}

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -233,6 +233,24 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.services.logger.serviceName }}-headless
+  labels:
+    app: {{ .Values.services.logger.serviceName }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Values.services.logger.serviceName }}
+
+---
+
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -1983,7 +1983,7 @@ gateway:
       timeout: 0s
       cookie:
         name: _osmo_router_affinity
-        ttl: 60s
+        ttl: 0s
 
     ## Advanced service routes for the osmo-service upstream.
     ## Each entry is a standard Envoy route YAML block (match + route).
@@ -2032,8 +2032,10 @@ gateway:
       port: 80
     logger:
       enabled: true
-      host: osmo-logger
-      port: 80
+      host: osmo-logger-headless
+      ## Port 8000 (not 80) because the headless service resolves to pod IPs
+      ## directly, and Envoy connects to the pod port, not the Service port.
+      port: 8000
 
   ## -----------------------------------------------------------------------
   ## Gateway OAuth2 Proxy — handles OIDC authentication flows.


### PR DESCRIPTION
## Description
router affinity cookie was set to TTL 60 seconds, which was causing
reconnections after 60 sec of idle activity when using the CLI.

logger was trigging the default circuit breaker of 1024 connections,
because it did not use a headless service

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated session affinity cookie configuration in gateway routing.
  * Added explicit health check endpoint configuration for load balancer integration.
  * Enhanced infrastructure service architecture for improved pod addressing and communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->