### PR TITLE
#1102 - Update distroless images to v4.0.9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -362,8 +362,8 @@ apt.install(
 
 oci.pull(
     name = "distroless_python3_14",
-    digest = "sha256:adda656ae3a8243d49df02228b4fba742084d88f4057847fc1c4a5c7c6ad1add",
-    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.8",
+    digest = "sha256:e75772d395b9053b65f95009f0389a0216d42617adc01d3295bd7664f982a2dc",
+    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.9",
     platforms = [
         "linux/arm64/v8",
         "linux/amd64",
@@ -373,8 +373,8 @@ oci.pull(
 # Used for local debugging
 # oci.pull(
 #     name = "distroless_python3_14_dev",
-#     digest = "sha256:84aef61c2e737ac04e38e0945d423af8e9121774f223f1650b71be8a6968abba",
-#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.8-dev",
+#     digest = "sha256:23685736e38e60fba8db553bb2d6ddfaa3ea1a445eac51c4a99f25cdf7fdd1c4",
+#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.9-dev",
 #     platforms = [
 #          "linux/amd64",
 #          "linux/arm64/v8"

--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -56,7 +56,7 @@
 # Stage 1: Dependencies (cached unless package.json/pnpm-lock.yaml change)
 # =============================================================================
 ARG NODE_BUILD_IMAGE=node:24-slim
-ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/node:24-v4.0.8
+ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/node:24-v4.0.9
 
 FROM ${NODE_BUILD_IMAGE} AS deps
 


### PR DESCRIPTION
## Description
Cherry-pick #1102 to release/6.3.

Update NVIDIA distroless base images used by OSMO:
- Python runtime: 3.14-v4.0.8 -> 3.14-v4.0.9
- Python debug image reference: 3.14-v4.0.8-dev -> 3.14-v4.0.9-dev
- UI Node runtime: 24-v4.0.8 -> 24-v4.0.9

Issue #1102

## Validation
- bazel build //src:osmo_docker_distroless_image_arm64
- bazel build --platforms=//bzl/platforms:linux_x86_64 //src:osmo_docker_distroless_image_amd64

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.