### PR TITLE
Use nim-env for distroless update workflow

### DIFF
--- a/.github/workflows/update-distroless-images.yaml
+++ b/.github/workflows/update-distroless-images.yaml
@@ -41,6 +41,7 @@ concurrency:
 
 jobs:
   update-distroless:
+    environment: nim-env
     runs-on: ubuntu-latest
     steps:
       - name: Schedule gate


### PR DESCRIPTION
## Description
Configure the `update-distroless` GitHub Actions job to run in the `nim-env` environment. The Slack token and channel for this automation are configured as `nim-env` environment secret/variable values (`TESTBOT_SLACK_BOT_TOKEN` and `TESTBOT_SLACK_CHANNEL`), so the job must attach to that environment before the Slack review request step can resolve them.

Validation:
- `python3 -m unittest scripts/distroless/tests/test_update_distroless.py`
- Parsed `.github/workflows/update-distroless-images.yaml` with Ruby YAML loader

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to enhance deployment environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->