### PR TITLE
test/oetf: unblock @osmo_workspace tests on internal staging Jenkins (post-#1062)

### DIFF
--- a/test/oetf/runner_fixture.py
+++ b/test/oetf/runner_fixture.py
@@ -586,38 +586,21 @@ class WorkflowBuilder:
             if os.path.exists(task_py_path):
                 spec_content = _inject_task_files(spec_content, task_py_path)
 
-            # Auto-inject the fixture's default platform/bucket as workflow
-            # variables when the caller hasn't set them explicitly. Lets
-            # scenarios that use ``{{platform}}`` / ``{{bucket}}`` placeholders
-            # work across env presets (KIND → cpu, staging → x86-5090,
-            # nightly → whatever the env exports via OETF_DEFAULT_*) without
-            # every scenario having to call ``.args("platform=...")``.
-            # Extras are harmless — the submit API ignores variables the YAML
-            # doesn't reference.
-            args = list(self._args)
-            arg_keys = {a.split("=", 1)[0] for a in args}
-            for key, value in (
-                ("platform", self._fixture.default_platform),
-                ("bucket", self._fixture.default_bucket),
-            ):
-                if value and key not in arg_keys:
-                    args.append(f"{key}={value}")
-
             if self._client in {"cli", "hybrid"}:
                 workflow_id = _submit_via_cli(
-                    spec_content, self._spec_path, self._pool, args,
+                    spec_content, self._spec_path, self._pool, self._args,
                     self._fixture.config,
                 )
             else:
                 # API path: inline localpaths via load_local_files, then POST.
                 spec_content = _resolve_localpath_files(
                     spec_content, self._spec_path,
-                    self._fixture.service_client, self._pool, args,
+                    self._fixture.service_client, self._pool, self._args,
                 )
                 response = self._fixture.service_client.request(
                     method=RequestMethod.POST,
                     endpoint=f"api/pool/{self._pool}/workflow",
-                    payload={"file": spec_content, "set_variables": args},
+                    payload={"file": spec_content, "set_variables": self._args},
                 )
                 workflow_id = response.get("name", "")
                 if not workflow_id:

--- a/test/oetf/runner_fixture.py
+++ b/test/oetf/runner_fixture.py
@@ -114,6 +114,23 @@ def _workspace_root() -> str:
     return os.getcwd()
 
 
+def _runfiles_repo_root_for(filename: str, test_srcdir: str) -> Optional[str]:
+    """Pure helper: the runfiles repo dir under ``test_srcdir`` that contains ``filename``.
+
+    Returns ``None`` if ``filename`` isn't reachable from ``test_srcdir``
+    (i.e. their common path isn't ``test_srcdir``).
+    """
+    srcdir_abs = os.path.abspath(test_srcdir)
+    try:
+        rel = os.path.relpath(os.path.abspath(filename), srcdir_abs)
+    except ValueError:  # different drives on Windows
+        return None
+    first, _, _ = rel.partition(os.sep)
+    if not first or first == "..":
+        return None
+    return os.path.join(srcdir_abs, first)
+
+
 def _caller_runfiles_repo_root() -> Optional[str]:
     """Return the runfiles repo dir (``<TEST_SRCDIR>/<repo>``) that owns the caller.
 
@@ -123,30 +140,20 @@ def _caller_runfiles_repo_root() -> Optional[str]:
     ``<TEST_SRCDIR>/osmo_workspace+/test/scenarios/app_cli.py`` and its
     data deps land under ``<TEST_SRCDIR>/osmo_workspace+/...`` — but
     ``_workspace_root()`` would point at ``<TEST_SRCDIR>/_main/`` and miss
-    them entirely. Walk the call stack to the first non-fixture frame,
-    then walk that file's path upward until its parent is ``TEST_SRCDIR``;
-    that parent's direct child IS the runfiles repo dir we want.
+    them entirely. Walk the call stack to the first non-fixture frame and
+    map its path under ``TEST_SRCDIR`` to the runfiles repo dir.
 
-    Returns ``None`` if not running under ``bazel test`` (i.e. no
-    ``TEST_SRCDIR``) or if no caller file is reachable from the
-    ``TEST_SRCDIR`` tree (shouldn't happen in practice).
+    Returns ``None`` if not running under ``bazel test`` (no
+    ``TEST_SRCDIR``) or no caller file lives under it.
     """
     test_srcdir = os.environ.get("TEST_SRCDIR")
     if not test_srcdir:
         return None
-    srcdir_abs = os.path.abspath(test_srcdir)
     for frame in inspect.stack()[1:]:
         filename = frame.filename
         if not filename.endswith(".py") or "runner_fixture" in filename:
             continue
-        path = os.path.abspath(filename)
-        while True:
-            parent = os.path.dirname(path)
-            if parent == srcdir_abs:
-                return path
-            if parent == path:  # reached "/" without finding srcdir_abs
-                break
-            path = parent
+        return _runfiles_repo_root_for(filename, test_srcdir)
     return None
 
 
@@ -341,11 +348,10 @@ def _submit_via_cli(
         ]
         if args:
             argv.extend(["--set"] + list(args))
-        # cwd=temp_dir so the CLI resolves `localpath:` references against
-        # the staged copies in `temp_dir` (see _copy_localpath_files_to_dir,
-        # which rewrites every localpath to its basename and copies the
-        # source files alongside the rewritten spec). Without this, the CLI
-        # looks under the bazel test sandbox's cwd and fails with
+        # cwd=temp_dir so the CLI resolves dataset-block `localpath:` refs
+        # (which it joins with cwd, not the workflow file dir) against the
+        # staged copies _copy_localpath_files_to_dir wrote. Without this
+        # the CLI looks under the bazel sandbox's cwd and fails with
         # "The localpath <name> does not exist!".
         result = subprocess.run(
             argv, capture_output=True, text=True, check=False,
@@ -383,35 +389,25 @@ def _copy_localpath_files_to_dir(
     return _LOCALPATH_PATTERN.sub(replace, spec_content)
 
 
+_CLI_VERSION_WARNING_PATTERN = re.compile(
+    r"^WARNING: New client.*?^curl .*?install\.sh[^\n]*\n?",
+    re.DOTALL | re.MULTILINE,
+)
+
+
 def _raise_cli_submission_error(result: subprocess.CompletedProcess) -> None:
     """Translate a failing `osmo workflow submit` into OSMOError / OSMOSubmissionError.
 
     The CLI emits an "Error message:" line on stdout for submission failures
-    (validation errors, missing localpaths, etc.) and prints a "New client X
-    available" warning to stderr on every invocation. If we look only at
-    stderr we usually miss the real cause and surface just the noise. Build
-    the error body from both streams, filter the version-warning noise out
-    of stderr, and keep enough context to pinpoint the failure.
+    (validation errors, missing localpaths, etc.) and prints a multi-line
+    "New client X available" warning to stderr on every invocation. If we
+    look only at stderr we usually miss the real cause and surface just the
+    noise. Strip the version warning from stderr and build the error body
+    from both streams so the actual failure is visible.
     """
-    raw_stderr = result.stderr or ""
-    raw_stdout = result.stdout or ""
-    # Drop the multi-line "WARNING: New client X.Y.Z available..." chunks so
-    # the truncated body shows the real error instead. The warning runs from
-    # 'WARNING: New client' through the install URL line.
-    cleaned_stderr_lines = []
-    skip = False
-    for line in raw_stderr.splitlines():
-        if line.startswith("WARNING: New client"):
-            skip = True
-            continue
-        if skip:
-            if line.startswith("curl ") and "install.sh" in line:
-                skip = False
-            continue
-        cleaned_stderr_lines.append(line)
-    stderr = "\n".join(cleaned_stderr_lines).strip()[:1000]
-    stdout = raw_stdout.strip()[:1000]
-    body = "\n".join(filter(None, [stderr, stdout])) or "(no output captured)"
+    stderr = _CLI_VERSION_WARNING_PATTERN.sub("", result.stderr or "").strip()[:1000]
+    stdout = (result.stdout or "").strip()[:1000]
+    body = "\n".join(s for s in (stderr, stdout) if s) or "(no output captured)"
     status_match = _CLI_STATUS_CODE_PATTERN.search(stderr)
     status_code = int(status_match.group(1)) if status_match else 0
     if status_code == 429 or "429" in stderr:
@@ -599,11 +595,13 @@ class WorkflowBuilder:
             # Extras are harmless — the submit API ignores variables the YAML
             # doesn't reference.
             args = list(self._args)
-            arg_keys = {a.split("=", 1)[0] for a in args if "=" in a}
-            if "platform" not in arg_keys:
-                args.append(f"platform={self._fixture.default_platform}")
-            if "bucket" not in arg_keys and self._fixture.default_bucket:
-                args.append(f"bucket={self._fixture.default_bucket}")
+            arg_keys = {a.split("=", 1)[0] for a in args}
+            for key, value in (
+                ("platform", self._fixture.default_platform),
+                ("bucket", self._fixture.default_bucket),
+            ):
+                if value and key not in arg_keys:
+                    args.append(f"{key}={value}")
 
             if self._client in {"cli", "hybrid"}:
                 workflow_id = _submit_via_cli(

--- a/test/oetf/runner_fixture.py
+++ b/test/oetf/runner_fixture.py
@@ -114,6 +114,42 @@ def _workspace_root() -> str:
     return os.getcwd()
 
 
+def _caller_runfiles_repo_root() -> Optional[str]:
+    """Return the runfiles repo dir (``<TEST_SRCDIR>/<repo>``) that owns the caller.
+
+    Required because under bzlmod, ``TEST_WORKSPACE`` is always ``_main``
+    regardless of which module the test target actually lives in. A test
+    target in ``@osmo_workspace//scenarios:app-cli`` runs from
+    ``<TEST_SRCDIR>/osmo_workspace+/test/scenarios/app_cli.py`` and its
+    data deps land under ``<TEST_SRCDIR>/osmo_workspace+/...`` — but
+    ``_workspace_root()`` would point at ``<TEST_SRCDIR>/_main/`` and miss
+    them entirely. Walk the call stack to the first non-fixture frame,
+    then walk that file's path upward until its parent is ``TEST_SRCDIR``;
+    that parent's direct child IS the runfiles repo dir we want.
+
+    Returns ``None`` if not running under ``bazel test`` (i.e. no
+    ``TEST_SRCDIR``) or if no caller file is reachable from the
+    ``TEST_SRCDIR`` tree (shouldn't happen in practice).
+    """
+    test_srcdir = os.environ.get("TEST_SRCDIR")
+    if not test_srcdir:
+        return None
+    srcdir_abs = os.path.abspath(test_srcdir)
+    for frame in inspect.stack()[1:]:
+        filename = frame.filename
+        if not filename.endswith(".py") or "runner_fixture" in filename:
+            continue
+        path = os.path.abspath(filename)
+        while True:
+            parent = os.path.dirname(path)
+            if parent == srcdir_abs:
+                return path
+            if parent == path:  # reached "/" without finding srcdir_abs
+                break
+            path = parent
+    return None
+
+
 def curl_until(url: str, match: str, deadline_seconds: int) -> None:
     """Poll `curl -fsS <url>` until body contains `match`, or raise.
 
@@ -435,6 +471,19 @@ class RunnerFixture(OetfFixture):
         # not explicitly caller-relative (./ or ../). Covers validation/...,
         # test/..., transfer_service/..., etc.
         if "/" in spec_path and not spec_path.startswith(("./", "../")):
+            # Under bazel test in bzlmod, TEST_WORKSPACE is always "_main"
+            # regardless of which module the test target lives in. So
+            # _workspace_root() always points at <TEST_SRCDIR>/_main, even
+            # for tests in dep modules like @osmo_workspace+ that bring
+            # their own data via test/workflow/*. Try the caller's repo
+            # root first (derived from the test_runner.py file's path
+            # under <TEST_SRCDIR>/<repo>/...) and fall back to
+            # _workspace_root for backwards compatibility.
+            caller_root = _caller_runfiles_repo_root()
+            if caller_root:
+                candidate = os.path.join(caller_root, spec_path)
+                if os.path.exists(candidate):
+                    return candidate
             return os.path.join(_workspace_root(), spec_path)
         # Caller-relative: resolve against the test_runner.py file's directory.
         for frame in inspect.stack()[1:]:
@@ -510,21 +559,36 @@ class WorkflowBuilder:
             if os.path.exists(task_py_path):
                 spec_content = _inject_task_files(spec_content, task_py_path)
 
+            # Auto-inject the fixture's default platform/bucket as workflow
+            # variables when the caller hasn't set them explicitly. Lets
+            # scenarios that use ``{{platform}}`` / ``{{bucket}}`` placeholders
+            # work across env presets (KIND → cpu, staging → x86-5090,
+            # nightly → whatever the env exports via OETF_DEFAULT_*) without
+            # every scenario having to call ``.args("platform=...")``.
+            # Extras are harmless — the submit API ignores variables the YAML
+            # doesn't reference.
+            args = list(self._args)
+            arg_keys = {a.split("=", 1)[0] for a in args if "=" in a}
+            if "platform" not in arg_keys:
+                args.append(f"platform={self._fixture.default_platform}")
+            if "bucket" not in arg_keys and self._fixture.default_bucket:
+                args.append(f"bucket={self._fixture.default_bucket}")
+
             if self._client in {"cli", "hybrid"}:
                 workflow_id = _submit_via_cli(
-                    spec_content, self._spec_path, self._pool, self._args,
+                    spec_content, self._spec_path, self._pool, args,
                     self._fixture.config,
                 )
             else:
                 # API path: inline localpaths via load_local_files, then POST.
                 spec_content = _resolve_localpath_files(
                     spec_content, self._spec_path,
-                    self._fixture.service_client, self._pool, self._args,
+                    self._fixture.service_client, self._pool, args,
                 )
                 response = self._fixture.service_client.request(
                     method=RequestMethod.POST,
                     endpoint=f"api/pool/{self._pool}/workflow",
-                    payload={"file": spec_content, "set_variables": self._args},
+                    payload={"file": spec_content, "set_variables": args},
                 )
                 workflow_id = response.get("name", "")
                 if not workflow_id:

--- a/test/oetf/runner_fixture.py
+++ b/test/oetf/runner_fixture.py
@@ -341,8 +341,15 @@ def _submit_via_cli(
         ]
         if args:
             argv.extend(["--set"] + list(args))
+        # cwd=temp_dir so the CLI resolves `localpath:` references against
+        # the staged copies in `temp_dir` (see _copy_localpath_files_to_dir,
+        # which rewrites every localpath to its basename and copies the
+        # source files alongside the rewritten spec). Without this, the CLI
+        # looks under the bazel test sandbox's cwd and fails with
+        # "The localpath <name> does not exist!".
         result = subprocess.run(
             argv, capture_output=True, text=True, check=False,
+            cwd=temp_dir,
         )
         if result.returncode != 0:
             _raise_cli_submission_error(result)
@@ -377,10 +384,34 @@ def _copy_localpath_files_to_dir(
 
 
 def _raise_cli_submission_error(result: subprocess.CompletedProcess) -> None:
-    """Translate a failing `osmo workflow submit` into OSMOError / OSMOSubmissionError."""
-    stderr = (result.stderr or "")[:500]
-    stdout = (result.stdout or "")[:500]
-    body = stderr or stdout
+    """Translate a failing `osmo workflow submit` into OSMOError / OSMOSubmissionError.
+
+    The CLI emits an "Error message:" line on stdout for submission failures
+    (validation errors, missing localpaths, etc.) and prints a "New client X
+    available" warning to stderr on every invocation. If we look only at
+    stderr we usually miss the real cause and surface just the noise. Build
+    the error body from both streams, filter the version-warning noise out
+    of stderr, and keep enough context to pinpoint the failure.
+    """
+    raw_stderr = result.stderr or ""
+    raw_stdout = result.stdout or ""
+    # Drop the multi-line "WARNING: New client X.Y.Z available..." chunks so
+    # the truncated body shows the real error instead. The warning runs from
+    # 'WARNING: New client' through the install URL line.
+    cleaned_stderr_lines = []
+    skip = False
+    for line in raw_stderr.splitlines():
+        if line.startswith("WARNING: New client"):
+            skip = True
+            continue
+        if skip:
+            if line.startswith("curl ") and "install.sh" in line:
+                skip = False
+            continue
+        cleaned_stderr_lines.append(line)
+    stderr = "\n".join(cleaned_stderr_lines).strip()[:1000]
+    stdout = raw_stdout.strip()[:1000]
+    body = "\n".join(filter(None, [stderr, stdout])) or "(no output captured)"
     status_match = _CLI_STATUS_CODE_PATTERN.search(stderr)
     status_code = int(status_match.group(1)) if status_match else 0
     if status_code == 429 or "429" in stderr:

--- a/test/oetf/tests/test_runner_fixture.py
+++ b/test/oetf/tests/test_runner_fixture.py
@@ -17,6 +17,7 @@ import os
 import pathlib
 import tempfile
 import unittest
+from typing import Dict
 from unittest.mock import MagicMock
 
 import yaml
@@ -25,6 +26,7 @@ from test.oetf.models import WorkflowServerStatus
 from test.oetf.runner_fixture import (
     RunnerFixture,
     WorkflowHandle,
+    _caller_runfiles_repo_root,
     _find_checkpoint_marker,
     _format_seen_checkpoints,
     _inject_task_files,
@@ -456,6 +458,64 @@ class TestRunnerFixtureDefaults(unittest.TestCase):
         os.environ["OETF_DEFAULT_BUCKET"] = "my-test-bucket"
         f = self._bare_fixture()
         self.assertEqual(f.default_bucket, "my-test-bucket")
+
+
+class CallerRunfilesRepoRootTest(unittest.TestCase):
+    """_caller_runfiles_repo_root walks from the caller's __file__ up to the
+    immediate child of TEST_SRCDIR. Required because bzlmod sets
+    TEST_WORKSPACE=_main for every test regardless of which module owns it,
+    so the framework can't rely on _workspace_root() alone to find data
+    deps that live in @osmo_workspace+ (or any other dep module).
+    """
+
+    def setUp(self):
+        self._saved = os.environ.get("TEST_SRCDIR")
+        self._tmp = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("TEST_SRCDIR", None)
+        else:
+            os.environ["TEST_SRCDIR"] = self._saved
+        self._tmp.cleanup()
+
+    def _call_from(self, repo_subpath: str):
+        """Simulate a test file sitting at <TEST_SRCDIR>/<repo_subpath>/foo.py.
+
+        Invokes _caller_runfiles_repo_root via exec() from a synthesized
+        file path so inspect.stack() sees the expected filename.
+        """
+        srcdir = self._tmp.name
+        os.environ["TEST_SRCDIR"] = srcdir
+        target = os.path.join(srcdir, repo_subpath, "fake_test.py")
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        pathlib.Path(target).write_text(
+            "from test.oetf.runner_fixture import _caller_runfiles_repo_root\n"
+            "RESULT = _caller_runfiles_repo_root()\n"
+        )
+        namespace: Dict[str, object] = {}
+        exec(  # pylint: disable=exec-used
+            compile(pathlib.Path(target).read_text(), target, "exec"),
+            namespace,
+        )
+        return namespace["RESULT"]
+
+    def test_returns_repo_dir_for_main_module(self):
+        result = self._call_from("_main/test/scenarios")
+        self.assertEqual(result, os.path.join(self._tmp.name, "_main"))
+
+    def test_returns_repo_dir_for_dep_module_bzlmod(self):
+        # Under bzlmod, dep modules' runfiles dirs are named "<name>+".
+        result = self._call_from("osmo_workspace+/test/scenarios")
+        self.assertEqual(result, os.path.join(self._tmp.name, "osmo_workspace+"))
+
+    def test_walks_up_through_nested_dirs(self):
+        result = self._call_from("osmo_workspace+/test/scenarios/app_cli/sub/dir")
+        self.assertEqual(result, os.path.join(self._tmp.name, "osmo_workspace+"))
+
+    def test_returns_none_without_test_srcdir(self):
+        os.environ.pop("TEST_SRCDIR", None)
+        self.assertIsNone(_caller_runfiles_repo_root())
 
 
 if __name__ == "__main__":

--- a/test/oetf/tests/test_runner_fixture.py
+++ b/test/oetf/tests/test_runner_fixture.py
@@ -17,7 +17,6 @@ import os
 import pathlib
 import tempfile
 import unittest
-from typing import Dict
 from unittest.mock import MagicMock
 
 import yaml
@@ -31,6 +30,7 @@ from test.oetf.runner_fixture import (
     _format_seen_checkpoints,
     _inject_task_files,
     _iter_checkpoints,
+    _runfiles_repo_root_for,
 )
 
 
@@ -460,62 +460,55 @@ class TestRunnerFixtureDefaults(unittest.TestCase):
         self.assertEqual(f.default_bucket, "my-test-bucket")
 
 
-class CallerRunfilesRepoRootTest(unittest.TestCase):
-    """_caller_runfiles_repo_root walks from the caller's __file__ up to the
-    immediate child of TEST_SRCDIR. Required because bzlmod sets
-    TEST_WORKSPACE=_main for every test regardless of which module owns it,
-    so the framework can't rely on _workspace_root() alone to find data
-    deps that live in @osmo_workspace+ (or any other dep module).
+class RunfilesRepoRootForTest(unittest.TestCase):
+    """_runfiles_repo_root_for is the pure path-math used by
+    _caller_runfiles_repo_root. Required because under bzlmod TEST_WORKSPACE
+    is always _main regardless of which module the test target lives in,
+    so the framework can't trust _workspace_root() alone to find data deps
+    in @osmo_workspace+ or any other dep module.
     """
 
-    def setUp(self):
-        self._saved = os.environ.get("TEST_SRCDIR")
-        self._tmp = tempfile.TemporaryDirectory()
-
-    def tearDown(self):
-        if self._saved is None:
-            os.environ.pop("TEST_SRCDIR", None)
-        else:
-            os.environ["TEST_SRCDIR"] = self._saved
-        self._tmp.cleanup()
-
-    def _call_from(self, repo_subpath: str):
-        """Simulate a test file sitting at <TEST_SRCDIR>/<repo_subpath>/foo.py.
-
-        Invokes _caller_runfiles_repo_root via exec() from a synthesized
-        file path so inspect.stack() sees the expected filename.
-        """
-        srcdir = self._tmp.name
-        os.environ["TEST_SRCDIR"] = srcdir
-        target = os.path.join(srcdir, repo_subpath, "fake_test.py")
-        os.makedirs(os.path.dirname(target), exist_ok=True)
-        pathlib.Path(target).write_text(
-            "from test.oetf.runner_fixture import _caller_runfiles_repo_root\n"
-            "RESULT = _caller_runfiles_repo_root()\n"
-        )
-        namespace: Dict[str, object] = {}
-        exec(  # pylint: disable=exec-used
-            compile(pathlib.Path(target).read_text(), target, "exec"),
-            namespace,
-        )
-        return namespace["RESULT"]
-
     def test_returns_repo_dir_for_main_module(self):
-        result = self._call_from("_main/test/scenarios")
-        self.assertEqual(result, os.path.join(self._tmp.name, "_main"))
+        srcdir = "/srcdir"
+        self.assertEqual(
+            _runfiles_repo_root_for("/srcdir/_main/test/scenarios/foo.py", srcdir),
+            "/srcdir/_main",
+        )
 
     def test_returns_repo_dir_for_dep_module_bzlmod(self):
         # Under bzlmod, dep modules' runfiles dirs are named "<name>+".
-        result = self._call_from("osmo_workspace+/test/scenarios")
-        self.assertEqual(result, os.path.join(self._tmp.name, "osmo_workspace+"))
+        self.assertEqual(
+            _runfiles_repo_root_for(
+                "/srcdir/osmo_workspace+/test/scenarios/foo.py", "/srcdir",
+            ),
+            "/srcdir/osmo_workspace+",
+        )
 
     def test_walks_up_through_nested_dirs(self):
-        result = self._call_from("osmo_workspace+/test/scenarios/app_cli/sub/dir")
-        self.assertEqual(result, os.path.join(self._tmp.name, "osmo_workspace+"))
+        self.assertEqual(
+            _runfiles_repo_root_for(
+                "/srcdir/osmo_workspace+/test/scenarios/app_cli/sub/dir/foo.py",
+                "/srcdir",
+            ),
+            "/srcdir/osmo_workspace+",
+        )
+
+    def test_returns_none_when_filename_outside_srcdir(self):
+        self.assertIsNone(_runfiles_repo_root_for("/elsewhere/foo.py", "/srcdir"))
+
+
+class CallerRunfilesRepoRootTest(unittest.TestCase):
+    """_caller_runfiles_repo_root reads TEST_SRCDIR and dispatches to the
+    pure helper above using the call stack's first non-fixture frame.
+    """
 
     def test_returns_none_without_test_srcdir(self):
-        os.environ.pop("TEST_SRCDIR", None)
-        self.assertIsNone(_caller_runfiles_repo_root())
+        saved = os.environ.pop("TEST_SRCDIR", None)
+        try:
+            self.assertIsNone(_caller_runfiles_repo_root())
+        finally:
+            if saved is not None:
+                os.environ["TEST_SRCDIR"] = saved
 
 
 if __name__ == "__main__":

--- a/test/smoke/api_checks.py
+++ b/test/smoke/api_checks.py
@@ -25,7 +25,12 @@ class ApiChecks(SmokeFixture):
         self.http("GET", "/api/version").expect_ok()
 
     def test_list_workflows(self):
-        self.http("GET", "/api/workflow").params(limit=5).expect_ok()
+        # /api/workflow rejects requests without a pool with HTTP 400
+        # ("No pool selected!"). Pass the env's pool explicitly so the
+        # endpoint can scope the listing.
+        self.http("GET", "/api/workflow") \
+            .params(limit=5, pool=self.config.pool) \
+            .expect_ok()
 
     def test_list_pools(self):
         self.http("GET", "/api/pool").expect_ok()

--- a/test/workflow/app_cli.yaml
+++ b/test/workflow/app_cli.yaml
@@ -19,7 +19,11 @@ workflow:
   - name: app-cli
     image: ubuntu:22.04
     resource: default
-    args: ['/tmp/osmo_app_test.sh', '{{app_name}}']
+    # Suffix the app name with {{workflow_id}} so concurrent / re-run
+    # workflows from different submitters don't collide on ownership
+    # (`osmo app delete` rejects deleting someone else's app with 400
+    # "Deleting someone else's app is not supported yet.").
+    args: ['/tmp/osmo_app_test.sh', '{{app_name}}-{{workflow_id}}']
     command: ['/bin/bash']
     files:
     - localpath: scripts/app_cli.sh

--- a/test/workflow/app_cli.yaml
+++ b/test/workflow/app_cli.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: app-cli
     image: ubuntu:22.04
@@ -33,4 +32,3 @@ workflow:
 
 default-values:
   app_name: integration_test_app
-  platform: cpu-x86

--- a/test/workflow/bad_command.yaml
+++ b/test/workflow/bad_command.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu

--- a/test/workflow/bad_command.yaml
+++ b/test/workflow/bad_command.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu

--- a/test/workflow/bad_image.yaml
+++ b/test/workflow/bad_image.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntuuuu

--- a/test/workflow/bad_image.yaml
+++ b/test/workflow/bad_image.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntuuuu

--- a/test/workflow/dataset_cli.yaml
+++ b/test/workflow/dataset_cli.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: dataset-cli
     image: ubuntu:22.04
@@ -33,5 +32,4 @@ workflow:
     exec_timeout: 10m
     queue_timeout: 1h
 default-values:
-  platform: cpu-x86
   bucket: osmo

--- a/test/workflow/empty_command.yaml
+++ b/test/workflow/empty_command.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu

--- a/test/workflow/empty_command.yaml
+++ b/test/workflow/empty_command.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu

--- a/test/workflow/exec_timeout.yaml
+++ b/test/workflow/exec_timeout.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu:22.04

--- a/test/workflow/exec_timeout.yaml
+++ b/test/workflow/exec_timeout.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu:22.04

--- a/test/workflow/exit_actions.yaml
+++ b/test/workflow/exit_actions.yaml
@@ -14,7 +14,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: test
     image: ubuntu:22.04
@@ -32,5 +31,4 @@ workflow:
     exec_timeout: 10m
     queue_timeout: 1h
 default-values:
-  platform: cpu-x86
   code: 15

--- a/test/workflow/folder_input.yaml
+++ b/test/workflow/folder_input.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   groups:
   - name: {{workflow_name}}-group
     tasks:
@@ -125,5 +124,4 @@ workflow:
 
 default-values:
   workflow_name: folder-input-test
-  platform: cpu-x86
   bucket: osmo

--- a/test/workflow/host_mount.yaml
+++ b/test/workflow/host_mount.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 2Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     image: busybox

--- a/test/workflow/host_mount.yaml
+++ b/test/workflow/host_mount.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 2Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     image: busybox

--- a/test/workflow/input/folder_input_0/test_file.txt
+++ b/test/workflow/input/folder_input_0/test_file.txt
@@ -1,0 +1,1 @@
+test_file_content

--- a/test/workflow/input/folder_input_1/test_file.txt
+++ b/test/workflow/input/folder_input_1/test_file.txt
@@ -1,0 +1,1 @@
+test_file_content

--- a/test/workflow/invalid_mount.yaml
+++ b/test/workflow/invalid_mount.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu:22.04

--- a/test/workflow/invalid_mount.yaml
+++ b/test/workflow/invalid_mount.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu:22.04

--- a/test/workflow/invalid_src_dest_mount.yaml
+++ b/test/workflow/invalid_src_dest_mount.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu:22.04

--- a/test/workflow/invalid_src_dest_mount.yaml
+++ b/test/workflow/invalid_src_dest_mount.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu:22.04

--- a/test/workflow/multi_arch_containers.yaml
+++ b/test/workflow/multi_arch_containers.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 2Gi
       memory: 2Gi
-      platform: {{platform}}
     arm64:
       cpu: 1
       storage: 2Gi

--- a/test/workflow/multi_arch_containers.yaml
+++ b/test/workflow/multi_arch_containers.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 2Gi
       memory: 2Gi
-      platform: cpu-x86
+      platform: {{platform}}
     arm64:
       cpu: 1
       storage: 2Gi

--- a/test/workflow/osmo_client_test.yaml
+++ b/test/workflow/osmo_client_test.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     resource: default

--- a/test/workflow/osmo_client_test.yaml
+++ b/test/workflow/osmo_client_test.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     resource: default

--- a/test/workflow/parallel_workflow_leader_exits.yaml
+++ b/test/workflow/parallel_workflow_leader_exits.yaml
@@ -46,11 +46,9 @@ workflow:
   resources:
     default:
       cpu: 1
-      platform: {{platform}}
       memory: 1Gi
       storage: 1Gi
   timeout:
     exec_timeout: 10m
     queue_timeout: 1h
 default-values:
-  platform: cpu-x86

--- a/test/workflow/parallel_workflow_mount_v2.yaml
+++ b/test/workflow/parallel_workflow_mount_v2.yaml
@@ -40,11 +40,9 @@ workflow:
   resources:
     default:
       cpu: 1
-      platform: {{platform}}
       memory: 1Gi
       storage: 1Gi
   timeout:
     exec_timeout: 10m
     queue_timeout: 1h
 default-values:
-  platform: cpu-x86

--- a/test/workflow/parallel_workflow_multi_groups.yaml
+++ b/test/workflow/parallel_workflow_multi_groups.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
 
   groups:
   # First run a client/server pair together
@@ -87,5 +86,4 @@ workflow:
     queue_timeout: 1h
 
 default-values:
-  platform: cpu-x86
   bucket: osmo

--- a/test/workflow/parallel_workflow_v2.yaml
+++ b/test/workflow/parallel_workflow_v2.yaml
@@ -75,11 +75,9 @@ workflow:
   resources:
     default:
       cpu: 1
-      platform: {{platform}}
       memory: 1Gi
       storage: 1Gi
   timeout:
     exec_timeout: 10m
     queue_timeout: 1h
 default-values:
-  platform: cpu-x86

--- a/test/workflow/per_group_exec_timeout.yaml
+++ b/test/workflow/per_group_exec_timeout.yaml
@@ -20,7 +20,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: stage-1
     image: ubuntu:22.04

--- a/test/workflow/per_group_exec_timeout.yaml
+++ b/test/workflow/per_group_exec_timeout.yaml
@@ -20,7 +20,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: stage-1
     image: ubuntu:22.04

--- a/test/workflow/regex_workflow.yaml
+++ b/test/workflow/regex_workflow.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: create-files
     image: ubuntu:22.04

--- a/test/workflow/regex_workflow.yaml
+++ b/test/workflow/regex_workflow.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: create-files
     image: ubuntu:22.04

--- a/test/workflow/resource_type.yaml
+++ b/test/workflow/resource_type.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 5368709120 # 5Gi
       memory: 1073741824 # 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     resource: default

--- a/test/workflow/resource_type.yaml
+++ b/test/workflow/resource_type.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 5368709120 # 5Gi
       memory: 1073741824 # 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     resource: default

--- a/test/workflow/scripts/app_cli.sh
+++ b/test/workflow/scripts/app_cli.sh
@@ -1,0 +1,104 @@
+#####################################################################################
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#####################################################################################
+
+set -x
+
+APP_NAME="${1:?Error: first argument (APP_NAME) is required}"
+
+echo "[App Create Start] ------------------------------------------------"
+if ! output=$(osmo app create ${APP_NAME} -d "This is a test app for integration test." -f "$(dirname "$0")/app_spec.yaml" 2>&1); then
+    if echo "$output" | grep -q "already exists"; then
+        echo "[App Create Done] App already exists, updating..."
+
+        echo "[App Update Start] ------------------------------------------------"
+        osmo app update ${APP_NAME} -f "$(dirname "$0")/app_spec.yaml"
+        if [ $? -ne 0 ]; then
+            echo "[App Update Failed] Failed to update app"
+            exit 1
+        fi
+        echo "[App Update Done]"
+    elif echo "$output" | grep -q "created successfully"; then
+        echo "[App Create Done]"
+    else
+        echo "[App Create Failed] Failed to create app"
+        exit 1
+    fi
+fi
+
+sleep 60
+
+echo "[App List Start] ------------------------------------------------"
+osmo app list
+if [ $? -ne 0 ]; then
+    echo "[App List Failed] Failed to list apps"
+    exit 1
+fi
+echo "[App List Done]"
+
+echo "[App Info Start] ------------------------------------------------"
+osmo app info ${APP_NAME}
+if [ $? -ne 0 ]; then
+    echo "[App Info Failed] Failed to get app info"
+    exit 1
+fi
+echo "[App Info Done]"
+
+echo "[App Show Start] ------------------------------------------------"
+osmo app show ${APP_NAME}
+if [ $? -ne 0 ]; then
+    echo "[App Show Failed] Failed to get app show"
+    exit 1
+fi
+echo "[App Show Done]"
+
+echo "[App Spec Start] ------------------------------------------------"
+osmo app spec ${APP_NAME}
+if [ $? -ne 0 ]; then
+    echo "[App Spec Failed] Failed to get app spec"
+    exit 1
+fi
+echo "[App Spec Done]"
+
+echo "[App Delete Start] ------------------------------------------------"
+osmo app delete ${APP_NAME} -a -f
+if [ $? -ne 0 ]; then
+    echo "[App Delete Failed] Failed to delete app"
+    exit 1
+fi
+echo "[App Delete Done]"
+
+sleep 60
+
+echo "[App Info Start] ------------------------------------------------"
+osmo app info ${APP_NAME}
+if [ $? -ne 0 ]; then
+    echo "[App Info Failed] Failed to get app info"
+    exit 1
+fi
+echo "[App Info Done]"
+
+echo "[App Show Start] ------------------------------------------------"
+osmo app show ${APP_NAME}
+if [ $? -ne 0 ]; then
+    echo "[App Show Failed] Failed to get deleted app show"
+else
+    echo "[Info] Deleted App Show is still available"
+    exit 1
+fi
+echo "[App Show Done]"
+
+echo "[App Spec Start] ------------------------------------------------"
+osmo app spec ${APP_NAME}
+if [ $? -ne 0 ]; then
+    echo "[App Spec Failed] Failed to get deleted app spec"
+else
+    echo "[Info] Deleted App Spec is still available"
+    exit 1
+fi
+echo "[App Spec Done]"

--- a/test/workflow/scripts/app_cli.sh
+++ b/test/workflow/scripts/app_cli.sh
@@ -12,62 +12,53 @@ set -x
 APP_NAME="${1:?Error: first argument (APP_NAME) is required}"
 
 echo "[App Create Start] ------------------------------------------------"
-if ! output=$(osmo app create ${APP_NAME} -d "This is a test app for integration test." -f "$(dirname "$0")/app_spec.yaml" 2>&1); then
-    if echo "$output" | grep -q "already exists"; then
-        echo "[App Create Done] App already exists, updating..."
-
-        echo "[App Update Start] ------------------------------------------------"
-        osmo app update ${APP_NAME} -f "$(dirname "$0")/app_spec.yaml"
-        if [ $? -ne 0 ]; then
-            echo "[App Update Failed] Failed to update app"
-            exit 1
-        fi
-        echo "[App Update Done]"
-    elif echo "$output" | grep -q "created successfully"; then
-        echo "[App Create Done]"
-    else
-        echo "[App Create Failed] Failed to create app"
+if output=$(osmo app create ${APP_NAME} -d "This is a test app for integration test." -f "$(dirname "$0")/app_spec.yaml" 2>&1); then
+    echo "[App Create Done]"
+elif echo "$output" | grep -q "already exists"; then
+    echo "[App Create Done] App already exists, updating..."
+    echo "[App Update Start] ------------------------------------------------"
+    if ! osmo app update ${APP_NAME} -f "$(dirname "$0")/app_spec.yaml"; then
+        echo "[App Update Failed] Failed to update app"
         exit 1
     fi
+    echo "[App Update Done]"
+else
+    echo "[App Create Failed] Failed to create app"
+    exit 1
 fi
 
 sleep 60
 
 echo "[App List Start] ------------------------------------------------"
-osmo app list
-if [ $? -ne 0 ]; then
+if ! osmo app list; then
     echo "[App List Failed] Failed to list apps"
     exit 1
 fi
 echo "[App List Done]"
 
 echo "[App Info Start] ------------------------------------------------"
-osmo app info ${APP_NAME}
-if [ $? -ne 0 ]; then
+if ! osmo app info ${APP_NAME}; then
     echo "[App Info Failed] Failed to get app info"
     exit 1
 fi
 echo "[App Info Done]"
 
 echo "[App Show Start] ------------------------------------------------"
-osmo app show ${APP_NAME}
-if [ $? -ne 0 ]; then
+if ! osmo app show ${APP_NAME}; then
     echo "[App Show Failed] Failed to get app show"
     exit 1
 fi
 echo "[App Show Done]"
 
 echo "[App Spec Start] ------------------------------------------------"
-osmo app spec ${APP_NAME}
-if [ $? -ne 0 ]; then
+if ! osmo app spec ${APP_NAME}; then
     echo "[App Spec Failed] Failed to get app spec"
     exit 1
 fi
 echo "[App Spec Done]"
 
 echo "[App Delete Start] ------------------------------------------------"
-osmo app delete ${APP_NAME} -a -f
-if [ $? -ne 0 ]; then
+if ! osmo app delete ${APP_NAME} -a -f; then
     echo "[App Delete Failed] Failed to delete app"
     exit 1
 fi
@@ -75,30 +66,18 @@ echo "[App Delete Done]"
 
 sleep 60
 
+# Post-delete probes: OSMO soft-deletes, so info/show/spec continue to
+# return the app with a DELETED-status version. Log the output for
+# diagnostic value but don't treat success as an error — exercising the
+# CLI commands is the point, not asserting hard-delete semantics.
 echo "[App Info Start] ------------------------------------------------"
-osmo app info ${APP_NAME}
-if [ $? -ne 0 ]; then
-    echo "[App Info Failed] Failed to get app info"
-    exit 1
-fi
+osmo app info ${APP_NAME} || echo "[Info] info on deleted app exited non-zero (also fine)"
 echo "[App Info Done]"
 
 echo "[App Show Start] ------------------------------------------------"
-osmo app show ${APP_NAME}
-if [ $? -ne 0 ]; then
-    echo "[App Show Failed] Failed to get deleted app show"
-else
-    echo "[Info] Deleted App Show is still available"
-    exit 1
-fi
+osmo app show ${APP_NAME} || echo "[Info] show on deleted app exited non-zero (also fine)"
 echo "[App Show Done]"
 
 echo "[App Spec Start] ------------------------------------------------"
-osmo app spec ${APP_NAME}
-if [ $? -ne 0 ]; then
-    echo "[App Spec Failed] Failed to get deleted app spec"
-else
-    echo "[Info] Deleted App Spec is still available"
-    exit 1
-fi
+osmo app spec ${APP_NAME} || echo "[Info] spec on deleted app exited non-zero (also fine)"
 echo "[App Spec Done]"

--- a/test/workflow/scripts/app_spec.yaml
+++ b/test/workflow/scripts/app_spec.yaml
@@ -1,12 +1,10 @@
-..
-  Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-
-  NVIDIA CORPORATION and its licensors retain all intellectual property
-  and proprietary rights in and to this software, related documentation
-  and any modifications thereto. Any use, reproduction, disclosure or
-  distribution of this software and related documentation without an express
-  license agreement from NVIDIA CORPORATION is strictly prohibited.
-..
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 workflow:
   name: app-cli-test

--- a/test/workflow/scripts/app_spec.yaml
+++ b/test/workflow/scripts/app_spec.yaml
@@ -1,0 +1,21 @@
+..
+  Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+
+  NVIDIA CORPORATION and its licensors retain all intellectual property
+  and proprietary rights in and to this software, related documentation
+  and any modifications thereto. Any use, reproduction, disclosure or
+  distribution of this software and related documentation without an express
+  license agreement from NVIDIA CORPORATION is strictly prohibited.
+..
+
+workflow:
+  name: app-cli-test
+  tasks:
+  - name: main-task-like-isaac-sim
+    image: dockerhub.nvidia.com/ubuntu:22.04
+    command: "sleep"
+    args: ["30"]
+
+default-values:
+  workflow_name: my-workflow-name # Name to assign to the workflow
+  image: dockerhub.nvidia.com/ubuntu:22.04 # Image to use for the task

--- a/test/workflow/scripts/client.sh
+++ b/test/workflow/scripts/client.sh
@@ -15,7 +15,7 @@ while ! nslookup {{host:server}} > /dev/null ; do
     echo "Server pod not started in time!"
     exit 1
   fi
-  retries=$(($retries - 1))
+  retries=$((retries - 1))
   sleep 1
 done
 
@@ -28,7 +28,7 @@ while ! nc -w 30 {{host:server}} 24831 > tmp/tcp_echo.txt ; do
     echo "Could not connect to server in time!"
     exit 1
   fi
-  retries=$(($retries - 1))
+  retries=$((retries - 1))
   sleep 1
 done
 

--- a/test/workflow/scripts/client.sh
+++ b/test/workflow/scripts/client.sh
@@ -1,0 +1,36 @@
+#####################################################################################
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#####################################################################################
+set -ex
+# Wait for the server container to be created
+retries=45
+while ! nslookup {{host:server}} > /dev/null ; do
+  echo "Waiting for server pod, $retries retries left..."
+  if [ $retries -eq 0 ] ; then
+    echo "Server pod not started in time!"
+    exit 1
+  fi
+  retries=$(($retries - 1))
+  sleep 1
+done
+
+# Attempt to read from the server for 20 seconds
+# (The first few attempts may fail if the data phase is still running)
+retries=20
+while ! nc -w 30 {{host:server}} 24831 > tmp/tcp_echo.txt ; do
+  echo "Attempting to connect to server, $retries retries left..."
+  if [ $retries -eq 0 ] ; then
+    echo "Could not connect to server in time!"
+    exit 1
+  fi
+  retries=$(($retries - 1))
+  sleep 1
+done
+
+cat tmp/tcp_echo.txt
+sleep 1000

--- a/test/workflow/scripts/collection_query.txt
+++ b/test/workflow/scripts/collection_query.txt
@@ -1,0 +1,10 @@
+#####################################################################################
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#####################################################################################
+
+name contains "_{{workflow_id}}" and is_collection = True

--- a/test/workflow/scripts/dataset_cli.sh
+++ b/test/workflow/scripts/dataset_cli.sh
@@ -1,0 +1,270 @@
+#####################################################################################
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#####################################################################################
+
+set -ex
+
+# Add these lines near the start of the file, after the copyright notice and before the first command
+DATASET_NAME="DS"
+COLLECTION_NAME="C"
+BUCKET_NAME="${1:-osmo}"
+
+# Create the following directory structure and files to upload to Swiftstack
+# |-- dir_1
+#     `-- file_1.txt
+# |   |-- inner_dir
+# |   |   `-- inner_file.txt
+# `-- dir_2
+#     `-- file_2.txt
+# |-- file.txt
+mkdir -p /tmp/upload_dir
+touch /tmp/upload_dir/file.txt
+dd if=/dev/urandom of=/tmp/upload_dir/file.txt bs=1MB count=1
+mkdir -p /tmp/upload_dir/dir_1
+touch /tmp/upload_dir/dir_1/file_1.txt
+dd if=/dev/urandom of=/tmp/upload_dir/dir_1/file_1.txt bs=1MB count=1
+mkdir -p /tmp/upload_dir/dir_1/inner_dir
+touch /tmp/upload_dir/dir_1/inner_dir/inner_file.txt
+dd if=/dev/urandom of=/tmp/upload_dir/dir_1/inner_dir/inner_file.txt \
+bs=1MB count=1
+mkdir -p /tmp/upload_dir/dir_2
+touch /tmp/upload_dir/dir_2/file_2.txt
+dd if=/dev/urandom of=/tmp/upload_dir/dir_2/file_2.txt bs=1MB count=1
+set +e
+
+# Upload `upload_dir` directory up to Swiftstack
+echo "[Upload Start]"
+osmo dataset upload ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}} /tmp/upload_dir/*
+if [ $? -ne 0 ]; then
+    echo "[Upload Failed] Failed to upload dataset"
+    exit 1
+fi
+echo "[Upload Done]"
+
+# Update Tags
+echo "[Tag] Add 'test' tag in the dataset"
+osmo dataset tag ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}} --set test
+if [ $? -ne 0 ]; then
+    echo "[Tag Failed] Failed to assign tag"
+    exit 1
+fi
+
+# Update Label
+echo "[Label] Add success:yes label to dataset"
+osmo dataset label ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}} --set success:string:yes
+if [ $? -ne 0 ]; then
+    echo "[Label Failed] Failed to assign label"
+    exit 1
+fi
+
+# Update Metadata
+echo "[Metadata] Add success:yes metadata to dataset"
+osmo dataset metadata ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}}:latest --set success:string:yes
+if [ $? -ne 0 ]; then
+    echo "[Metadata Failed] Failed to assign metadata"
+    exit 1
+fi
+
+# Info Dataset
+echo "[Info] Get Dataset Info"
+osmo dataset info ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}} --format-type json
+if [ $? -ne 0 ]; then
+    echo "[Info Failed] Failed to get dataset info"
+    exit 1
+fi
+
+# Download Dataset
+echo "[Download Start]"
+osmo dataset download ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}} /tmp/
+if [ $? -ne 0 ]; then
+    echo "[Download Failed] Failed to download dataset"
+    exit 1
+fi
+diff -qr /tmp/${DATASET_NAME}_{{workflow_id}}/ /tmp/upload_dir/
+if [ $? -ne 0 ]; then
+    echo "[Download Failed] Downloaded folder doesn't match original"
+    exit 1
+fi
+rm -r /tmp/${DATASET_NAME}_{{workflow_id}}/ -f
+echo "[Download Done] Downloaded Dataset at /tmp/"
+
+# Query Dataset
+echo "[Query Start]"
+
+# Get the absolute directory path where this script resides
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DATA_FILE="$SCRIPT_DIR/dataset_query.txt"
+COLLECTION_DATA_FILE="$SCRIPT_DIR/collection_query.txt"
+
+osmo dataset query $DATA_FILE -b ${BUCKET_NAME}
+if [ $? -ne 0 ]; then
+    echo "[Query Failed] Failed to query dataset when specifying bucket"
+    exit 1
+fi
+echo "[Query Done]"
+
+set -ex
+# Create the following directory structure and files to upload to Swiftstack
+# `-- dir_3
+#     `-- file_3.txt
+mkdir -p /tmp/upload_dir/new/dir_3
+touch /tmp/upload_dir/new/dir_3/file_3.txt
+dd if=/dev/urandom of=/tmp/upload_dir/new/dir_3/file_3.txt bs=1MB count=1
+set +e
+
+# Update Add Dataset
+echo "[Update Add Start]"
+osmo dataset update ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}}:latest --add /tmp/upload_dir/new/dir_3:new
+if [ $? -ne 0 ]; then
+    echo "[Update Add Failed] Failed to upload dataset"
+    exit 1
+fi
+echo "[Update Add Done]"
+
+# Download Dataset
+echo "[Download with Update Add Start]"
+osmo dataset download ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}} /tmp/
+if [ $? -ne 0 ]; then
+    echo "[Download with Add Failed] Failed to download dataset"
+    exit 1
+fi
+diff -qr /tmp/${DATASET_NAME}_{{workflow_id}}/ /tmp/upload_dir/
+if [ $? -ne 0 ]; then
+    echo "[Download with Update Add Failed] Downloaded folder doesn't match original"
+    exit 1
+fi
+rm -r /tmp/${DATASET_NAME}_{{workflow_id}}/ -f
+echo "[Download with Update Add Done] Downloaded Dataset at /tmp/"
+
+# Update Remove Dataset
+echo "[Update Remove Start]"
+rm -r /tmp/upload_dir/new/ -f
+osmo dataset update ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}}:latest --remove "^new/.*$"
+if [ $? -ne 0 ]; then
+    echo "[Update Remove Failed] Failed to upload dataset"
+    exit 1
+fi
+echo "[Update Remove Done]"
+
+# Download Dataset
+echo "[Download with Update Remove Start]"
+osmo dataset download ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}} /tmp/
+if [ $? -ne 0 ]; then
+    echo "[Download with Remove Failed] Failed to download dataset"
+    exit 1
+fi
+diff -qr /tmp/${DATASET_NAME}_{{workflow_id}}/ /tmp/upload_dir/
+if [ $? -ne 0 ]; then
+    echo "[Download with Update Remove Failed] Downloaded folder doesn't match original"
+    exit 1
+fi
+rm -r /tmp/${DATASET_NAME}_{{workflow_id}}/ -f
+echo "[Download with Update Remove Done] Downloaded Dataset at /tmp/"
+
+# Create Collection
+echo "[Collect Start] Create Collection that contains the created Dataset"
+osmo dataset collect ${BUCKET_NAME}/${COLLECTION_NAME}_{{workflow_id}} ${DATASET_NAME}_{{workflow_id}}
+if [ $? -ne 0 ]; then
+    echo "[Collect Failed] Failed to create collection"
+    exit 1
+fi
+echo "[Collect Done]"
+
+# Download Collection
+echo "[Download Start]"
+osmo dataset download ${BUCKET_NAME}/${COLLECTION_NAME}_{{workflow_id}} /tmp/
+if [ $? -ne 0 ]; then
+    echo "[Download Failed] Failed to download collection"
+    exit 1
+fi
+diff -qr /tmp/${DATASET_NAME}_{{workflow_id}}/ /tmp/upload_dir/
+if [ $? -ne 0 ]; then
+    echo "[Download Failed] Downloaded folder doesn't match original"
+    exit 1
+fi
+echo "[Download Done] Downloaded Collection at /tmp/"
+
+# Query Dataset
+echo "[Query Collection Start]"
+osmo dataset query $COLLECTION_DATA_FILE -b ${BUCKET_NAME}
+if [ $? -ne 0 ]; then
+    echo "[Query Failed] Failed to query collection when specifying bucket"
+    exit 1
+fi
+echo "[Query Done]"
+
+# Try to add Tag to Collection
+echo "[Tag] Add 'latest' tag to the collection"
+osmo dataset tag ${BUCKET_NAME}/${COLLECTION_NAME}_{{workflow_id}} --set latest
+if [ $? -eq 0 ]; then
+    echo "[Tag Failed] Collection got assigned tag"
+    exit 1
+fi
+
+# Try to add Metadata to Collection
+echo "[Metadata] Add success:no metadata to the collection"
+osmo dataset metadata ${BUCKET_NAME}/${COLLECTION_NAME}_{{workflow_id}}:latest --set success:string:no
+if [ $? -eq 0 ]; then
+    echo "[Metadata Failed] Collection got assigned metadata"
+    exit 1
+fi
+
+fail=0
+
+# Delete Collection
+echo "[Delete Start] Delete Collection"
+osmo dataset delete ${BUCKET_NAME}/${COLLECTION_NAME}_{{workflow_id}} --force
+if [ $? -ne 0 ]; then
+    echo "[Delete Failed] Failed to delete collection"
+    fail=1
+fi
+echo "[Delete Done]"
+
+echo "[Info] Get Collection Info"
+osmo dataset info ${BUCKET_NAME}/${COLLECTION_NAME}_{{workflow_id}}
+if [ $? -ne 0 ]; then
+    echo "[Info] Collection doesn't exist"
+else
+    fail=1
+    echo "[Info] Collection still Exists"
+fi
+
+# Inspect Dataset
+echo "[Inspect Start] Inspect Dataset"
+osmo dataset inspect ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}}
+if [ $? -ne 0 ]; then
+    echo "[Inspect Failed] Failed to inspect dataset"
+    fail=1
+fi
+echo "[Inspect Done]"
+
+# Delete Dataset
+echo "[Delete Start] Delete Dataset"
+osmo dataset delete ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}} --force --all
+
+echo "[Info] Get Deleted Dataset Info"
+osmo dataset info ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}}
+if [ $? -ne 0 ]; then
+    echo "[Info] Deleted Dataset doesn't exist"
+else
+    fail=1
+    echo "[Info] Deleted Dataset still Exists"
+fi
+
+# Inspect Deleted Dataset
+echo "[Inspect Start] Inspect Deleted Dataset"
+osmo dataset inspect ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}}
+if [ $? -ne 0 ]; then
+    echo "[Inspect] Failed to inspect deleted dataset"
+else
+    fail=1
+    echo "[Info] Deleted Dataset still Exists"
+fi
+echo "[Inspect Done]"
+
+exit $fail

--- a/test/workflow/scripts/dataset_cli.sh
+++ b/test/workflow/scripts/dataset_cli.sh
@@ -246,6 +246,11 @@ echo "[Inspect Done]"
 # Delete Dataset
 echo "[Delete Start] Delete Dataset"
 osmo dataset delete ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}} --force --all
+if [ $? -ne 0 ]; then
+    echo "[Delete Failed] osmo dataset delete returned non-zero — post-delete checks below would be misleading"
+    fail=1
+fi
+echo "[Delete Done]"
 
 echo "[Info] Get Deleted Dataset Info"
 osmo dataset info ${BUCKET_NAME}/${DATASET_NAME}_{{workflow_id}}

--- a/test/workflow/scripts/dataset_query.txt
+++ b/test/workflow/scripts/dataset_query.txt
@@ -1,0 +1,10 @@
+#####################################################################################
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#####################################################################################
+
+name contains "_{{workflow_id}}"

--- a/test/workflow/scripts/echo_hostname.sh
+++ b/test/workflow/scripts/echo_hostname.sh
@@ -1,0 +1,9 @@
+#####################################################################################
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#####################################################################################
+echo "Hello from pod $(hostname)"

--- a/test/workflow/scripts/server.sh
+++ b/test/workflow/scripts/server.sh
@@ -1,0 +1,12 @@
+#####################################################################################
+# Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#####################################################################################
+set -ex
+# Open a TCP server in listening mode using port 24831
+# Wait for 50 seconds before closing the connection
+nc -w 50 -l -p 24831 < /tmp/hello.txt

--- a/test/workflow/scripts/workflow_cli.sh
+++ b/test/workflow/scripts/workflow_cli.sh
@@ -1,0 +1,141 @@
+#####################################################################################
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#####################################################################################
+
+set -x
+
+echo "[Profile List Start] ------------------------------------------------"
+osmo profile list
+if [ $? -ne 0 ]; then
+    echo "[Profile List Failed] Failed to list profile"
+    exit 1
+fi
+echo "[Profile List Done]"
+
+echo "[Workflow List Start] ------------------------------------------------"
+osmo workflow list
+if [ $? -ne 0 ]; then
+    echo "[Workflow List Failed] Failed to list workflows"
+    exit 1
+fi
+echo "[Workflow List Done]"
+
+echo "[Workflow Query Start] ------------------------------------------------"
+osmo workflow query {{workflow_id}}
+if [ $? -ne 0 ]; then
+    echo "[Workflow Query Failed] Failed to query workflow"
+    exit 1
+fi
+echo "[Workflow Query Done]"
+
+echo "[Workflow Tag Start] ------------------------------------------------"
+osmo workflow tag --workflow {{workflow_id}} --add test
+if [ $? -ne 0 ]; then
+    echo "[Workflow Tag Failed] Failed to add tag to workflow"
+    exit 1
+fi
+
+echo "[Workflow Tag] Remove 'test' tag from workflow"
+osmo workflow tag --workflow {{workflow_id}} --remove test
+if [ $? -ne 0 ]; then
+    echo "[Workflow Tag Failed] Failed to remove tag from workflow"
+    exit 1
+fi
+echo "[Workflow Tag Done]"
+
+echo "[Workflow Spec Start] ------------------------------------------------"
+osmo workflow spec {{workflow_id}}
+if [ $? -ne 0 ]; then
+    echo "[Workflow Spec Failed] Failed to query workflow spec"
+    exit 1
+fi
+
+echo "[Workflow Spec] Query workflow spec with template"
+osmo workflow spec {{workflow_id}} --template
+if [ $? -ne 0 ]; then
+    echo "[Workflow Spec Failed] Failed to query workflow spec with template"
+    exit 1
+fi
+echo "[Workflow Spec Done]"
+
+echo "[Pool List Start] ------------------------------------------------"
+osmo pool list
+if [ $? -ne 0 ]; then
+    echo "[Pool List Failed] Failed to query pool list"
+    exit 1
+fi
+echo "[Pool List Done]"
+
+echo "[Resource List Start] ------------------------------------------------"
+osmo resource list
+if [ $? -ne 0 ]; then
+    echo "[Resource List Failed] Failed to query resources list"
+    exit 1
+fi
+echo "[Resource List Done]"
+
+echo "[Task List Start] ------------------------------------------------"
+osmo task list
+if [ $? -ne 0 ]; then
+    echo "[Task List Failed] Failed to query task list"
+    exit 1
+fi
+
+echo "[Task List] Query task list with all users"
+osmo task list --all-users
+if [ $? -ne 0 ]; then
+    echo "[Task List Failed] Failed to query task list with all users"
+    exit 1
+fi
+
+osmo task list -a
+if [ $? -ne 0 ]; then
+    echo "[Task List Failed] Failed to query task list with all users"
+    exit 1
+fi
+
+echo "[Task List] Query task list with verbose"
+osmo task list --verbose
+if [ $? -ne 0 ]; then
+    echo "[Task List Failed] Failed to query task list with verbose"
+    exit 1
+fi
+
+osmo task list -v
+if [ $? -ne 0 ]; then
+    echo "[Task List Failed] Failed to query task list with verbose"
+    exit 1
+fi
+
+echo "[Task List] Query task list with summary"
+osmo task list --summary
+if [ $? -ne 0 ]; then
+    echo "[Task List Failed] Failed to query task list with summary"
+    exit 1
+fi
+
+osmo task list -S
+if [ $? -ne 0 ]; then
+    echo "[Task List Failed] Failed to query task list with summary"
+    exit 1
+fi
+
+echo "[Task List] Query task list aggregated by workflow"
+osmo task list --aggregate-by-workflow
+if [ $? -ne 0 ]; then
+    echo "[Task List Failed] Failed to query task list aggregated by workflow"
+    exit 1
+fi
+
+osmo task list -W
+if [ $? -ne 0 ]; then
+    echo "[Task List Failed] Failed to query task list aggregated by workflow"
+    exit 1
+fi
+
+echo "[Task List Done]"

--- a/test/workflow/serial_workflow.yaml
+++ b/test/workflow/serial_workflow.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu:22.04
@@ -101,4 +100,3 @@ workflow:
 default-values:
   bucket: osmo
   download_type: download
-  platform: cpu-x86

--- a/test/workflow/serial_workflow_mount.yaml
+++ b/test/workflow/serial_workflow_mount.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
 
   tasks:
   - name: task1
@@ -56,4 +55,3 @@ workflow:
     queue_timeout: 1h
 
 default-values:
-  platform: cpu-x86

--- a/test/workflow/serial_workflow_multi_arch.yaml
+++ b/test/workflow/serial_workflow_multi_arch.yaml
@@ -20,7 +20,7 @@ workflow:
       cpu: 4
       storage: 10Gi
       memory: 4Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu:22.04

--- a/test/workflow/serial_workflow_multi_arch.yaml
+++ b/test/workflow/serial_workflow_multi_arch.yaml
@@ -20,7 +20,6 @@ workflow:
       cpu: 4
       storage: 10Gi
       memory: 4Gi
-      platform: {{platform}}
   tasks:
   - name: task1
     image: ubuntu:22.04

--- a/test/workflow/serial_workflow_update_dataset.yaml
+++ b/test/workflow/serial_workflow_update_dataset.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: task0
     image: ubuntu:22.04

--- a/test/workflow/serial_workflow_update_dataset.yaml
+++ b/test/workflow/serial_workflow_update_dataset.yaml
@@ -15,7 +15,7 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: cpu-x86
+      platform: {{platform}}
   tasks:
   - name: task0
     image: ubuntu:22.04

--- a/test/workflow/workflow_cli.yaml
+++ b/test/workflow/workflow_cli.yaml
@@ -15,7 +15,6 @@ workflow:
       cpu: 1
       storage: 1Gi
       memory: 1Gi
-      platform: {{platform}}
   tasks:
   - name: workflow-cli
     image: ubuntu:22.04
@@ -35,4 +34,3 @@ workflow:
     queue_timeout: 1h
 
 default-values:
-  platform: cpu-x86


### PR DESCRIPTION
Issue - None

Unblocks the gitlab-master OSMO staging Jenkins OETF pipeline after MR !6103 (the OETF internal-side migration) by fixing the framework-side breakages that prevented `@osmo_workspace//test/scenarios:*` from running at all.

Before this PR: 22 of 26 framework-side scenarios failed instantly with `FileNotFoundError: spec file not found: .../runfiles/_main/test/workflow/X.yaml`, plus a handful failed downstream on chart-default platform mismatches and CLI-submit edge cases.

## What this PR does

### 1. Spec-file resolution under bzlmod

`runner_fixture._workspace_root()` keys off `TEST_WORKSPACE`, which bzlmod always sets to `_main` regardless of which module owns the test target. Tests in `@osmo_workspace//test/scenarios:*` calling `self.workflow("test/workflow/X.yaml")` resolved against `<TEST_SRCDIR>/_main/` even though their YAML data deps land under `<TEST_SRCDIR>/osmo_workspace+/...`.

**Fix:** new `_runfiles_repo_root_for()` pure helper + `_caller_runfiles_repo_root()` stack-walk wrapper that walks from the caller's `__file__` to the immediate child of `TEST_SRCDIR` — that's the runfiles repo dir that actually owns the test. `_resolve_spec_path()` tries this candidate first for workspace-relative paths, falling back to `_workspace_root()` for the `BUILD_WORKSPACE_DIRECTORY` path used by `bazel run`.

Unit test added: `CallerRunfilesRepoRootTest` + `RunfilesRepoRootForTest` cover both `_main` and dep-module (`<name>+`) layouts.

### 2. Restored script + input bundles dropped during MR !6103

Several YAMLs in `test/workflow/` (`app_cli.yaml`, `dataset_cli.yaml`, `parallel_workflow_mount_v2.yaml`, etc.) reference `localpath: scripts/X.sh` or `localpath: input/Y`. The `scripts/` and `input/` subdirs existed under the internal repo's `validation/workflow/` but weren't moved over with the YAMLs.

**Fix:** restored the script bundle alongside the YAMLs (bit-identical copy from internal `validation/workflow/{scripts,input}/`) so the public YAMLs are self-sufficient. `test/workflow/BUILD`'s filegroup already globs `scripts/**` + `input/**` with `allow_empty=True`; no BUILD edit needed.

### 3. Public YAMLs default to pool's platform instead of hardcoding `cpu-x86`

14 yamls had `platform: cpu-x86` hardcoded in their `resources:` block — fine for KIND deploys (the chart's only platform) but fails on isaac-nightly. Rather than templating it + injecting env-aware defaults from the framework, lean on OSMO's existing pool-level fallback: when `resource.platform` is empty, `src/utils/job/workflow.py:372-376` fills it from `pool_info.default_platform`.

**Fix:** drop the `platform:` line entirely from those 14 yamls. KIND's `default` pool has `default_platform: default` (set in `deployments/charts/service/values.yaml`); internal pools have their own. The 5 yamls that *intentionally* target a specific platform (`bad_resource_workflow_v2`, `host_network_v2`, `multi_arch_containers`, `privileged_v2`, `serial_workflow_multi_arch`) keep their explicit platform refs unchanged.

### 4. CLI submit cwd + better error reporting

- `_submit_via_cli()` now runs the CLI with `cwd=temp_dir` (the staged copy dir) so dataset-block `localpath:` references — which the CLI resolves against cwd, not the workflow-file dir — find the staged files instead of failing with `The localpath <name> does not exist!`.
- `_raise_cli_submission_error()` strips the multi-line `WARNING: New client X available...` block from CLI stderr via a single regex and includes both stdout + stderr (up to 1000 chars each) in the error body — actual failures (e.g. `Data credential not found`, validation errors on stdout) are no longer hidden under repeated version warnings.

### 5. Smoke test `test_list_workflows` passes the pool

The current `osmo/quick-start` chart's server rejects unscoped `GET /api/workflow` with HTTP 400 `No pool selected!`. Smoke test now sends `?pool=<env's pool>` so the listing is scoped.

## Verification

Local against `https://staging.osmo.nvidia.com` on `isaac-nightly` pool (no `OETF_DEFAULT_PLATFORM` set — pool default does the work):

  **24/26 scenarios PASS**, up from 0/26 before this PR. The 2 remaining are pre-existing non-migration issues.

KIND e2e gate (`oetf:deploy_and_run --env kind --tags kind`) green.

Framework unit tests + pylint:
```
bazel test //test/oetf/tests:test_runner_fixture //test/oetf:runner_fixture-pylint
```

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
