### PR TITLE
Fix UUID pattern anchoring

### DIFF
--- a/src/lib/utils/common.py
+++ b/src/lib/utils/common.py
@@ -97,7 +97,7 @@ OLD_UUID_REGEX = r'[a-z2-7]{26}'
 UuidPattern = Annotated[
     str,
     pydantic.Field(
-        pattern=f'^{UUID_REGEX}|{OLD_UUID_REGEX}|{GROUP_UUID_REGEX}$')]
+        pattern=f'^(?:{UUID_REGEX}|{OLD_UUID_REGEX}|{GROUP_UUID_REGEX})$')]
 
 WFID_REGEX = r'[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?-\d+$'
 RESOURCE_REGEX = r'(?P<size>(\d+(?:\.\d+)?))(?P<unit>([a-zA-Z]*))'

--- a/src/lib/utils/tests/test_common.py
+++ b/src/lib/utils/tests/test_common.py
@@ -783,6 +783,33 @@ class TestGenerateUniqueId(unittest.TestCase):
         self.assertEqual(len(uid), 8)
 
 
+class TestUuidPattern(unittest.TestCase):
+    """ Tests for UUID validation. """
+
+    def test_accepts_supported_uuid_formats(self):
+        adapter = pydantic.TypeAdapter(common.UuidPattern)
+
+        for uuid_value in [
+            'a' * 32,
+            'osmo-' + 'a' * 32,
+            'abcdefghijklmnopqrstuvwxyz',
+        ]:
+            with self.subTest(uuid_value=uuid_value):
+                self.assertEqual(adapter.validate_python(uuid_value), uuid_value)
+
+    def test_rejects_partial_or_uppercase_uuid_values(self):
+        adapter = pydantic.TypeAdapter(common.UuidPattern)
+
+        for uuid_value in [
+            'a' * 32 + '-junk',
+            'xxxabcdefghijklmnopqrstuvwxyzyyy',
+            'A' * 32,
+        ]:
+            with self.subTest(uuid_value=uuid_value):
+                with self.assertRaises(pydantic.ValidationError):
+                    adapter.validate_python(uuid_value)
+
+
 class TestConvertCpuUnit(unittest.TestCase):
     """ Tests for convert_cpu_unit. """
 


### PR DESCRIPTION
## Summary

Fix `UuidPattern` so all supported UUID formats are validated as complete strings.

## Details

The previous pattern anchored only the first and last alternatives because regex alternation has lower precedence than the anchors. That allowed partial strings to validate when they started with a 32-character UUID, contained an old-format UUID substring, or ended with a group UUID.

This wraps the alternatives in a non-capturing group under one start/end anchor pair. The existing lowercase-only UUID formats remain unchanged.

## Validation

- `/Users/hoangvu/go/bin/bazelisk test //src/lib/utils/tests:test_common`
- `/Users/hoangvu/go/bin/bazelisk test //src/lib/utils:common-pylint //src/lib/utils/tests:test_common-pylint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UUID validation to correctly enforce supported formats and prevent partial matches from being accepted

* **Tests**
  * Added comprehensive validation test coverage for UUID format acceptance and rejection rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->