### PR TITLE
fix Azure GPU quota SKU parsing

### DIFF
--- a/deployments/scripts/azure/terraform.sh
+++ b/deployments/scripts/azure/terraform.sh
@@ -259,9 +259,13 @@ azure_find_region_with_gpu_quota() {
     local sku="$1" count="$2" sub="$3"
     if ! [[ "$count" =~ ^[1-9][0-9]*$ ]]; then return 0; fi
     local family vcpus_per_node
-    read -r family vcpus_per_node <<<"$(azure_describe_vm_sku "$sku")"
+    IFS=$'\t' read -r family vcpus_per_node <<<"$(azure_describe_vm_sku "$sku")"
     if [[ -z "$family" || -z "$vcpus_per_node" ]]; then
         log_warning "  az vm list-skus returned no family/vCPU data for '$sku' — auto-search cannot continue."
+        return 0
+    fi
+    if ! [[ "$vcpus_per_node" =~ ^[0-9]+$ ]]; then
+        log_warning "  az vm list-skus returned invalid vCPU data for '$sku': '$vcpus_per_node' — auto-search cannot continue."
         return 0
     fi
     local need=$(( count * vcpus_per_node ))


### PR DESCRIPTION
## Summary
- Parse Azure VM SKU family/vCPU data using the tab delimiter emitted by `azure_describe_vm_sku`.
- Validate the parsed vCPU value before arithmetic so malformed Azure CLI output fails with a warning instead of a nounset crash.

## Root Cause
`azure_describe_vm_sku` emits `<family>\t<vcpus>`, but `azure_find_region_with_gpu_quota` used default shell splitting. Azure family display names such as `Standard NCASv3_T4 Family` contain spaces, so `vcpus_per_node` became non-numeric and Bash arithmetic under `set -u` crashed with `NCASv3_T4: unbound variable`.

## Validation
- `bash -n deployments/scripts/azure/terraform.sh`
- Stubbed `azure_describe_vm_sku` with `Standard NCASv3_T4 Family\t4` and confirmed quota search computed `8 vCPU` and returned `eastus2`.
- Stubbed malformed vCPU data and confirmed the helper logs a warning instead of entering arithmetic.

Issue - None 

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
