### PR TITLE
testbot: skip dataset / data-service paths (deprecation WIP)

### DIFF
--- a/src/scripts/testbot/coverage_targets.py
+++ b/src/scripts/testbot/coverage_targets.py
@@ -31,6 +31,24 @@ IGNORE_PATTERNS = [
     "deployments/**",
 ]
 
+# Paths excluded because the dataset / data-service feature is being
+# deprecated (WIP). The bulk of the surface — the FastAPI module
+# `src/service/core/data/` (#1119) and the frontend (#1093) — is
+# already gone; the CLI entry point and any pre-emptive return of
+# `dataset` directories follow. New tests on this surface would be
+# churn against code that's moving out. Remove this list when the
+# deprecation lands and the remaining files are deleted.
+#
+# Notably NOT excluded: `src/lib/data/storage/**`. That's the
+# multi-cloud storage SDK and it survives the dataset deprecation —
+# workflow_service / app_service / ctrl_websocket all import it.
+DEPRECATED_DATASET_PATTERNS = [
+    "src/cli/data.py",
+    "src/cli/dataset*.py",
+    "src/lib/data/dataset/**",
+    "src/service/core/data/**",
+]
+
 SKIP_BASENAME_PATTERNS = [
     "*generated.ts",
     "*_pb2.py",
@@ -78,8 +96,13 @@ def _is_ignored(file_path: str) -> bool:
     - Files inside any tests/ directory (fixtures, helpers, etc.)
     - Scripts, build config, and deployment files
     - Generated code, test files, __init__.py, BUILD
+    - Dataset / data-service paths under active deprecation
+      (see DEPRECATED_DATASET_PATTERNS)
     """
     for pattern in IGNORE_PATTERNS:
+        if fnmatch.fnmatch(file_path, pattern):
+            return True
+    for pattern in DEPRECATED_DATASET_PATTERNS:
         if fnmatch.fnmatch(file_path, pattern):
             return True
     basename = file_path.rsplit("/", maxsplit=1)[-1]

--- a/src/scripts/testbot/coverage_targets.py
+++ b/src/scripts/testbot/coverage_targets.py
@@ -32,19 +32,10 @@ IGNORE_PATTERNS = [
     "deployments/**",
 
     # --- Deprecation in flight (WIP) ---
-    # Features moving out of the repo. Testing them is churn; the
-    # testbot's limited budget should go to code that's staying. Group
-    # entries by feature so a contiguous chunk drops in one commit
-    # when the deprecation lands.
+    # Group entries by feature so a contiguous chunk drops in one
+    # commit when the deprecation lands.
     #
-    # Dataset / data-service: #1093 removed the frontend; #1119
-    # removed the backend bucket API and the 1373-line
-    # src/service/core/data/data_service.py.
-    # NOT included:
-    #   - src/cli/data.py — staying, repurposed during the transition.
-    #   - src/lib/data/storage/** — the multi-cloud storage SDK
-    #     survives the deprecation (workflow_service / app_service /
-    #     ctrl_websocket all import it).
+    # Dataset / data-service (#1093, #1119):
     "src/cli/dataset*.py",
     "src/lib/data/dataset/**",
     "src/service/core/data/**",

--- a/src/scripts/testbot/coverage_targets.py
+++ b/src/scripts/testbot/coverage_targets.py
@@ -24,31 +24,25 @@ logger = logging.getLogger(__name__)
 CODECOV_API_BASE = "https://api.codecov.io/api/v2"
 
 IGNORE_PATTERNS = [
+    # --- Permanently uninteresting: tests, build/scripts/deploy infra ---
     "*/tests/*",
     "src/scripts/**",
     "bzl/**",
     "run/**",
     "deployments/**",
-]
 
-# Paths excluded because the underlying feature is being deprecated
-# (WIP). Tests on a moving-out surface would just be churn, and the
-# testbot's limited budget should go to code that's staying.
-#
-# Each block names what's being deprecated, why, and what to keep when
-# tearing the block out. The whole list is intended to shrink over
-# time as deprecations land — keep entries grouped by feature so it's
-# easy to drop a contiguous chunk in one commit.
-#
-# --- Dataset / data-service feature ---
-#   #1093 removed the dataset frontend; #1119 removed the backend
-#   bucket API and the 1373-line src/service/core/data/data_service.py.
-#   src/cli/data.py is next. Notably NOT in the list:
-#   src/lib/data/storage/** — the multi-cloud storage SDK survives the
-#   deprecation (workflow_service / app_service / ctrl_websocket all
-#   import it).
-DEPRECATED_PATTERNS = [
-    # Dataset / data-service
+    # --- Deprecation in flight (WIP) ---
+    # Features moving out of the repo. Testing them is churn; the
+    # testbot's limited budget should go to code that's staying. Group
+    # entries by feature so a contiguous chunk drops in one commit
+    # when the deprecation lands.
+    #
+    # Dataset / data-service: #1093 removed the frontend; #1119
+    # removed the backend bucket API and the 1373-line
+    # src/service/core/data/data_service.py. src/cli/data.py is next.
+    # NOT included: src/lib/data/storage/** — the multi-cloud storage
+    # SDK survives the deprecation (workflow_service / app_service /
+    # ctrl_websocket all import it).
     "src/cli/data.py",
     "src/cli/dataset*.py",
     "src/lib/data/dataset/**",
@@ -102,12 +96,10 @@ def _is_ignored(file_path: str) -> bool:
     - Files inside any tests/ directory (fixtures, helpers, etc.)
     - Scripts, build config, and deployment files
     - Generated code, test files, __init__.py, BUILD
-    - Paths under active deprecation (see DEPRECATED_PATTERNS)
+    - Paths under active feature deprecation
+      (see the "Deprecation in flight" block in IGNORE_PATTERNS)
     """
     for pattern in IGNORE_PATTERNS:
-        if fnmatch.fnmatch(file_path, pattern):
-            return True
-    for pattern in DEPRECATED_PATTERNS:
         if fnmatch.fnmatch(file_path, pattern):
             return True
     basename = file_path.rsplit("/", maxsplit=1)[-1]

--- a/src/scripts/testbot/coverage_targets.py
+++ b/src/scripts/testbot/coverage_targets.py
@@ -31,18 +31,24 @@ IGNORE_PATTERNS = [
     "deployments/**",
 ]
 
-# Paths excluded because the dataset / data-service feature is being
-# deprecated (WIP). The bulk of the surface — the FastAPI module
-# `src/service/core/data/` (#1119) and the frontend (#1093) — is
-# already gone; the CLI entry point and any pre-emptive return of
-# `dataset` directories follow. New tests on this surface would be
-# churn against code that's moving out. Remove this list when the
-# deprecation lands and the remaining files are deleted.
+# Paths excluded because the underlying feature is being deprecated
+# (WIP). Tests on a moving-out surface would just be churn, and the
+# testbot's limited budget should go to code that's staying.
 #
-# Notably NOT excluded: `src/lib/data/storage/**`. That's the
-# multi-cloud storage SDK and it survives the dataset deprecation —
-# workflow_service / app_service / ctrl_websocket all import it.
-DEPRECATED_DATASET_PATTERNS = [
+# Each block names what's being deprecated, why, and what to keep when
+# tearing the block out. The whole list is intended to shrink over
+# time as deprecations land — keep entries grouped by feature so it's
+# easy to drop a contiguous chunk in one commit.
+#
+# --- Dataset / data-service feature ---
+#   #1093 removed the dataset frontend; #1119 removed the backend
+#   bucket API and the 1373-line src/service/core/data/data_service.py.
+#   src/cli/data.py is next. Notably NOT in the list:
+#   src/lib/data/storage/** — the multi-cloud storage SDK survives the
+#   deprecation (workflow_service / app_service / ctrl_websocket all
+#   import it).
+DEPRECATED_PATTERNS = [
+    # Dataset / data-service
     "src/cli/data.py",
     "src/cli/dataset*.py",
     "src/lib/data/dataset/**",
@@ -96,13 +102,12 @@ def _is_ignored(file_path: str) -> bool:
     - Files inside any tests/ directory (fixtures, helpers, etc.)
     - Scripts, build config, and deployment files
     - Generated code, test files, __init__.py, BUILD
-    - Dataset / data-service paths under active deprecation
-      (see DEPRECATED_DATASET_PATTERNS)
+    - Paths under active deprecation (see DEPRECATED_PATTERNS)
     """
     for pattern in IGNORE_PATTERNS:
         if fnmatch.fnmatch(file_path, pattern):
             return True
-    for pattern in DEPRECATED_DATASET_PATTERNS:
+    for pattern in DEPRECATED_PATTERNS:
         if fnmatch.fnmatch(file_path, pattern):
             return True
     basename = file_path.rsplit("/", maxsplit=1)[-1]

--- a/src/scripts/testbot/coverage_targets.py
+++ b/src/scripts/testbot/coverage_targets.py
@@ -39,11 +39,12 @@ IGNORE_PATTERNS = [
     #
     # Dataset / data-service: #1093 removed the frontend; #1119
     # removed the backend bucket API and the 1373-line
-    # src/service/core/data/data_service.py. src/cli/data.py is next.
-    # NOT included: src/lib/data/storage/** — the multi-cloud storage
-    # SDK survives the deprecation (workflow_service / app_service /
-    # ctrl_websocket all import it).
-    "src/cli/data.py",
+    # src/service/core/data/data_service.py.
+    # NOT included:
+    #   - src/cli/data.py — staying, repurposed during the transition.
+    #   - src/lib/data/storage/** — the multi-cloud storage SDK
+    #     survives the deprecation (workflow_service / app_service /
+    #     ctrl_websocket all import it).
     "src/cli/dataset*.py",
     "src/lib/data/dataset/**",
     "src/service/core/data/**",

--- a/src/scripts/testbot/tests/test_coverage_targets.py
+++ b/src/scripts/testbot/tests/test_coverage_targets.py
@@ -71,12 +71,13 @@ class TestIsIgnored(unittest.TestCase):
     def test_allows_runtime_go(self):
         self.assertFalse(_is_ignored("src/runtime/cmd/ctrl/main.go"))
 
-    # === Dataset / data-service deprecation filter (DEPRECATED_DATASET_PATTERNS) ===
-    # See coverage_targets.py — the dataset feature is being deprecated;
-    # most of the surface (#1093 frontend, #1119 backend) is already gone.
-    # These tests guard against the testbot picking up new tests on the
-    # remaining slices, and guard the not-deprecated storage SDK from
-    # being filtered by accident.
+    # === DEPRECATED_PATTERNS filter ===
+    # See coverage_targets.py — paths under active deprecation are
+    # filtered from the picker's candidate list. Currently scoped to
+    # the dataset / data-service feature (#1093 removed the frontend,
+    # #1119 removed the backend); future deprecations append here.
+    # These tests guard both the filtered patterns and a few false-
+    # positive risks (storage SDK, unrelated CLI entries).
 
     def test_ignores_dataset_cli_entry_point(self):
         # src/cli/data.py is the CLI surface for the deprecated

--- a/src/scripts/testbot/tests/test_coverage_targets.py
+++ b/src/scripts/testbot/tests/test_coverage_targets.py
@@ -71,13 +71,14 @@ class TestIsIgnored(unittest.TestCase):
     def test_allows_runtime_go(self):
         self.assertFalse(_is_ignored("src/runtime/cmd/ctrl/main.go"))
 
-    # === DEPRECATED_PATTERNS filter ===
-    # See coverage_targets.py — paths under active deprecation are
-    # filtered from the picker's candidate list. Currently scoped to
-    # the dataset / data-service feature (#1093 removed the frontend,
-    # #1119 removed the backend); future deprecations append here.
-    # These tests guard both the filtered patterns and a few false-
-    # positive risks (storage SDK, unrelated CLI entries).
+    # === IGNORE_PATTERNS "Deprecation in flight" block ===
+    # See coverage_targets.py — paths under active feature deprecation
+    # are filtered from the picker's candidate list. Currently scoped
+    # to the dataset / data-service feature (#1093 removed the
+    # frontend, #1119 removed the backend); future deprecations
+    # append in the same block. These tests guard both the filtered
+    # patterns and a few false-positive risks (storage SDK, unrelated
+    # CLI entries).
 
     def test_ignores_dataset_cli_entry_point(self):
         # src/cli/data.py is the CLI surface for the deprecated

--- a/src/scripts/testbot/tests/test_coverage_targets.py
+++ b/src/scripts/testbot/tests/test_coverage_targets.py
@@ -71,6 +71,54 @@ class TestIsIgnored(unittest.TestCase):
     def test_allows_runtime_go(self):
         self.assertFalse(_is_ignored("src/runtime/cmd/ctrl/main.go"))
 
+    # === Dataset / data-service deprecation filter (DEPRECATED_DATASET_PATTERNS) ===
+    # See coverage_targets.py — the dataset feature is being deprecated;
+    # most of the surface (#1093 frontend, #1119 backend) is already gone.
+    # These tests guard against the testbot picking up new tests on the
+    # remaining slices, and guard the not-deprecated storage SDK from
+    # being filtered by accident.
+
+    def test_ignores_dataset_cli_entry_point(self):
+        # src/cli/data.py is the CLI surface for the deprecated
+        # dataset feature.
+        self.assertTrue(_is_ignored("src/cli/data.py"))
+
+    def test_ignores_future_dataset_cli_files(self):
+        # Pattern is `src/cli/dataset*.py` — any future re-introduction
+        # of dataset-named CLI files during the WIP transition stays
+        # filtered.
+        self.assertTrue(_is_ignored("src/cli/dataset_helpers.py"))
+
+    def test_ignores_data_service_module_preemptively(self):
+        # src/service/core/data/ was removed in #1119 but the pattern
+        # stays so the deprecation doesn't silently flap back into
+        # the testbot's queue if any file lands there during WIP.
+        self.assertTrue(
+            _is_ignored("src/service/core/data/data_service.py"),
+        )
+
+    def test_ignores_dataset_lib_module_preemptively(self):
+        self.assertTrue(
+            _is_ignored("src/lib/data/dataset/manager.py"),
+        )
+
+    def test_storage_sdk_is_not_filtered(self):
+        # `src/lib/data/storage/**` is the multi-cloud storage SDK,
+        # imported by workflow/app/logger services — it survives the
+        # dataset deprecation and must remain testable.
+        self.assertFalse(
+            _is_ignored("src/lib/data/storage/backends/s3.py"),
+        )
+        self.assertFalse(
+            _is_ignored("src/lib/data/storage/client.py"),
+        )
+
+    def test_unrelated_cli_files_are_not_filtered(self):
+        # Don't over-match — `src/cli/workflow.py`, `src/cli/login.py`,
+        # etc. are not dataset-related and should still be considered.
+        self.assertFalse(_is_ignored("src/cli/workflow.py"))
+        self.assertFalse(_is_ignored("src/cli/login.py"))
+
 
 class TestLinesToRanges(unittest.TestCase):
     """Tests for _lines_to_ranges conversion."""

--- a/src/scripts/testbot/tests/test_coverage_targets.py
+++ b/src/scripts/testbot/tests/test_coverage_targets.py
@@ -80,10 +80,11 @@ class TestIsIgnored(unittest.TestCase):
     # patterns and a few false-positive risks (storage SDK, unrelated
     # CLI entries).
 
-    def test_ignores_dataset_cli_entry_point(self):
-        # src/cli/data.py is the CLI surface for the deprecated
-        # dataset feature.
-        self.assertTrue(_is_ignored("src/cli/data.py"))
+    def test_dataset_cli_entry_point_stays_testable(self):
+        # src/cli/data.py is staying — it's being repurposed during
+        # the transition rather than deleted. Guard against a future
+        # well-meaning glob that would re-filter it.
+        self.assertFalse(_is_ignored("src/cli/data.py"))
 
     def test_ignores_future_dataset_cli_files(self):
         # Pattern is `src/cli/dataset*.py` — any future re-introduction


### PR DESCRIPTION
## Description

The dataset feature is being deprecated. The bulk of the surface is already gone — [#1093](https://github.com/NVIDIA/OSMO/pull/1093) removed the dataset frontend, [#1119](https://github.com/NVIDIA/OSMO/pull/1119) removed the dataset backend bucket API + the 1373-line `src/service/core/data/data_service.py`. Without this filter, if any dataset code briefly reappears during the WIP, the testbot would pick it up and burn inference on tests that are about to be deleted.

### What the filter is

Extend `IGNORE_PATTERNS` in `coverage_targets.py` with a second sub-block, `# --- Deprecation in flight (WIP) ---`. The block contains the pre-emptive dataset-feature paths:

- `src/cli/dataset*.py` — pre-emptive (none today)
- `src/lib/data/dataset/**` — already removed, pre-emptive
- `src/service/core/data/**` — already removed, pre-emptive

Each block is grouped by feature with a leading comment, so **future deprecations append here** (a legacy auth surface, a storage backend being retired, etc.) — one list, one removal mechanism, contiguous chunks per feature for easy delete-when-done.

### What is NOT filtered

- **`src/cli/data.py`** — the dataset CLI entry point is staying; it's being repurposed during the transition. The test suite asserts it remains testable so a future well-meaning glob doesn't re-filter it.
- **`src/lib/data/storage/**`** — the multi-cloud storage SDK. It survives the dataset deprecation because `workflow_service`, `app_service`, and `ctrl_websocket` all import it.
- **Other `src/cli/` entries** — `workflow.py`, `login.py`, etc. are unaffected.
- **Runtime data plumbing in `src/runtime/pkg/data/`** (Go) — used by `osmo_ctrl` for workflow data uploads/downloads, unrelated to the dataset feature.

### Where the filter lands

`parse_coverage_entries` calls `_is_ignored` on every Codecov entry — deprecated paths never enter the criticality-scorer shortlist, never reach the Stage 2 LLM picker, never make it into a generated PR. No prompt changes are needed; the filter is at the data layer.

### Tests

Six unit tests in `TestIsIgnored`:

- `test_dataset_cli_entry_point_stays_testable` — `src/cli/data.py` NOT filtered (file is staying) ✓
- `test_ignores_future_dataset_cli_files` — `src/cli/dataset_helpers.py` filtered ✓
- `test_ignores_data_service_module_preemptively` — `src/service/core/data/data_service.py` filtered ✓
- `test_ignores_dataset_lib_module_preemptively` — `src/lib/data/dataset/manager.py` filtered ✓
- `test_storage_sdk_is_not_filtered` — `src/lib/data/storage/{client.py,backends/s3.py}` kept testable ✓
- `test_unrelated_cli_files_are_not_filtered` — `src/cli/workflow.py`, `src/cli/login.py` kept testable ✓

Spot-checked against frequently-picked targets (`src/utils/job/jobs.py`, `src/utils/roles/user_role_sync.go`, `src/service/core/auth/auth_service.py`, etc.) — none are false-positives. All 19 testbot suite targets green.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended unit tests to verify coverage analysis correctly excludes “Deprecation in flight (WIP)” dataset and data-service paths.
  * Added checks that non-deprecated CLI entry points (e.g., dataset entry point) and multi-cloud storage areas are not excluded.

* **Chores**
  * Updated coverage target ignore rules to filter additional in-progress dataset/data-service deprecation areas, reducing low-coverage noise.
  * Clarified the intent of the ignore logic via updated in-code documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->