### PR TITLE
Remove diskcache dependency

### DIFF
--- a/bzl/mypy/mypy.ini
+++ b/bzl/mypy/mypy.ini
@@ -31,9 +31,6 @@ ignore_missing_imports = True
 [mypy-deprecated.*]
 ignore_missing_imports = True
 
-[mypy-diskcache.*]
-ignore_missing_imports = True
-
 [mypy-docker.*]
 ignore_missing_imports = True
 

--- a/src/locked_requirements.txt
+++ b/src/locked_requirements.txt
@@ -331,10 +331,6 @@ cryptography==46.0.7 \
     #   jwcrypto
     #   msal
     #   pyjwt
-diskcache==5.6.3 \
-    --hash=sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc \
-    --hash=sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19
-    # via -r requirements.txt
 durationpy==0.10 \
     --hash=sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba \
     --hash=sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -100,9 +100,6 @@ wrapt==1.15.0
 # MacOS build
 macholib==1.16.3
 
-# File system based cache
-diskcache==5.6.3
-
 # For tutorials
 amqp==5.3.1
 

--- a/src/service/core/BUILD
+++ b/src/service/core/BUILD
@@ -28,7 +28,6 @@ osmo_py_library(
         "service.py",
     ],
     deps = [
-        requirement("diskcache"),
         requirement("fastapi"),
         requirement("redis"),
         requirement("opentelemetry-instrumentation-fastapi"),


### PR DESCRIPTION
## Description

  Remove the unused `diskcache` dependency from OSMO service dependencies. This drops it from `requirements.txt`, `locked_requirements.txt`, the service core
  Bazel dependency list, and the mypy ignore list. No remaining `diskcache` references were found.

Issue #None

### Validation
  - `rg -n "diskcache|DiskCache|disk_cache" /home/tdewan/code/osmo/external` returned no matches.
  - `git diff --check`
  - `bazel test //src/service/core/tests:test_asyncio_startup`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed diskcache dependency from project requirements, build configuration, and type checking settings.
  * Updated type checking configuration to support deprecated module handling.
  * Updated locked dependency file to reflect dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->