### PR TITLE
Remove stale dataset Postgres and testbot cleanup

### DIFF
--- a/src/scripts/testbot/coverage_targets.py
+++ b/src/scripts/testbot/coverage_targets.py
@@ -30,15 +30,6 @@ IGNORE_PATTERNS = [
     "bzl/**",
     "run/**",
     "deployments/**",
-
-    # --- Deprecation in flight (WIP) ---
-    # Group entries by feature so a contiguous chunk drops in one
-    # commit when the deprecation lands.
-    #
-    # Dataset / data-service (#1093, #1119):
-    "src/cli/dataset*.py",
-    "src/lib/data/dataset/**",
-    "src/service/core/data/**",
 ]
 
 SKIP_BASENAME_PATTERNS = [
@@ -88,8 +79,6 @@ def _is_ignored(file_path: str) -> bool:
     - Files inside any tests/ directory (fixtures, helpers, etc.)
     - Scripts, build config, and deployment files
     - Generated code, test files, __init__.py, BUILD
-    - Paths under active feature deprecation
-      (see the "Deprecation in flight" block in IGNORE_PATTERNS)
     """
     for pattern in IGNORE_PATTERNS:
         if fnmatch.fnmatch(file_path, pattern):

--- a/src/scripts/testbot/tests/test_coverage_targets.py
+++ b/src/scripts/testbot/tests/test_coverage_targets.py
@@ -71,44 +71,10 @@ class TestIsIgnored(unittest.TestCase):
     def test_allows_runtime_go(self):
         self.assertFalse(_is_ignored("src/runtime/cmd/ctrl/main.go"))
 
-    # === IGNORE_PATTERNS "Deprecation in flight" block ===
-    # See coverage_targets.py — paths under active feature deprecation
-    # are filtered from the picker's candidate list. Currently scoped
-    # to the dataset / data-service feature (#1093 removed the
-    # frontend, #1119 removed the backend); future deprecations
-    # append in the same block. These tests guard both the filtered
-    # patterns and a few false-positive risks (storage SDK, unrelated
-    # CLI entries).
-
-    def test_dataset_cli_entry_point_stays_testable(self):
-        # src/cli/data.py is staying — it's being repurposed during
-        # the transition rather than deleted. Guard against a future
-        # well-meaning glob that would re-filter it.
+    def test_data_cli_entry_point_stays_testable(self):
         self.assertFalse(_is_ignored("src/cli/data.py"))
 
-    def test_ignores_future_dataset_cli_files(self):
-        # Pattern is `src/cli/dataset*.py` — any future re-introduction
-        # of dataset-named CLI files during the WIP transition stays
-        # filtered.
-        self.assertTrue(_is_ignored("src/cli/dataset_helpers.py"))
-
-    def test_ignores_data_service_module_preemptively(self):
-        # src/service/core/data/ was removed in #1119 but the pattern
-        # stays so the deprecation doesn't silently flap back into
-        # the testbot's queue if any file lands there during WIP.
-        self.assertTrue(
-            _is_ignored("src/service/core/data/data_service.py"),
-        )
-
-    def test_ignores_dataset_lib_module_preemptively(self):
-        self.assertTrue(
-            _is_ignored("src/lib/data/dataset/manager.py"),
-        )
-
     def test_storage_sdk_is_not_filtered(self):
-        # `src/lib/data/storage/**` is the multi-cloud storage SDK,
-        # imported by workflow/app/logger services — it survives the
-        # dataset deprecation and must remain testable.
         self.assertFalse(
             _is_ignored("src/lib/data/storage/backends/s3.py"),
         )
@@ -117,8 +83,6 @@ class TestIsIgnored(unittest.TestCase):
         )
 
     def test_unrelated_cli_files_are_not_filtered(self):
-        # Don't over-match — `src/cli/workflow.py`, `src/cli/login.py`,
-        # etc. are not dataset-related and should still be considered.
         self.assertFalse(_is_ignored("src/cli/workflow.py"))
         self.assertFalse(_is_ignored("src/cli/login.py"))
 

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1068,74 +1068,6 @@ class PostgresConnector:
         '''
         self.execute_commit_command(create_cmd, ())
 
-        # Dataset/Collection Table
-        create_cmd = '''
-            CREATE TABLE IF NOT EXISTS dataset (
-                name TEXT,
-                id TEXT,
-                created_by TEXT,
-                created_date TIMESTAMP,
-                is_collection BOOLEAN,
-                labels JSONB,
-                hash_location TEXT,
-                hash_location_size BIGINT,
-                last_version INT,
-                bucket TEXT,
-                PRIMARY KEY (id),
-                CONSTRAINT dataset_name_bucket_key UNIQUE(name, bucket)
-            );
-        '''
-        self.execute_commit_command(create_cmd, ())
-
-        # Dataset Version
-        create_cmd = '''
-            CREATE TABLE IF NOT EXISTS dataset_version (
-                dataset_id TEXT REFERENCES dataset (id),
-                version_id TEXT,
-                location TEXT, -- stores location of manifest file
-                status TEXT,
-                created_by TEXT,
-                created_date TIMESTAMP,
-                last_used TIMESTAMP,
-                last_updated TIMESTAMP,
-                size BIGINT,
-                checksum TEXT,
-                metadata JSONB,
-                PRIMARY KEY (dataset_id, version_id)
-            );
-        '''
-        self.execute_commit_command(create_cmd, ())
-
-        # Dataset Tag
-        create_cmd = '''
-            CREATE TABLE IF NOT EXISTS dataset_tag (
-                dataset_id TEXT,
-                version_id TEXT,
-                tag TEXT,
-                PRIMARY KEY (dataset_id, tag),
-                FOREIGN KEY (dataset_id, version_id)
-                    REFERENCES dataset_version (dataset_id, version_id)
-                    ON UPDATE CASCADE
-                    ON DELETE CASCADE
-            );
-        '''
-        self.execute_commit_command(create_cmd, ())
-
-        # Collection
-        create_cmd = '''
-            CREATE TABLE IF NOT EXISTS collection (
-                id TEXT REFERENCES dataset (id) ON DELETE CASCADE,
-                dataset_id TEXT,
-                version_id TEXT,
-                PRIMARY KEY (id, dataset_id),
-                FOREIGN KEY (dataset_id, version_id)
-                    REFERENCES dataset_version (dataset_id, version_id)
-                    ON UPDATE CASCADE
-                    ON DELETE CASCADE
-            );
-        '''
-        self.execute_commit_command(create_cmd, ())
-
         create_cmd = '''
             do $$
             BEGIN
@@ -1583,10 +1515,6 @@ class PostgresConnector:
                 SELECT DISTINCT id FROM users
                 UNION
                 SELECT DISTINCT submitted_by FROM workflows
-                UNION
-                SELECT DISTINCT created_by FROM dataset
-                UNION
-                SELECT DISTINCT created_by FROM dataset_version
                 UNION
                 SELECT DISTINCT owner FROM apps
                 UNION


### PR DESCRIPTION
## Description
Remove the remaining non-UI, non-OETF dataset cleanup residue after the dataset deprecation work.

Issue #911

This PR stops fresh Postgres initialization from creating deprecated dataset persistence tables, and removes dataset/dataset_version from user lookup queries so fresh databases no longer depend on those tables. It also removes the temporary testbot coverage ignore block that hid deleted dataset module paths while the deprecation was in flight.

Existing osmo data storage paths are intentionally untouched.

Validation:
- bazel test //src/scripts/testbot/tests:test_coverage_targets //src/utils/connectors/tests:all //src/service/core/config/tests:all //src/service/core/tests:all
- bazel test ...

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy dataset and collection-related database tables from schema initialization
  * Updated test coverage configuration to reflect recent deprecations
  * Simplified user identification logic in database queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->