### PR TITLE
docs: freeze versioned CLI reference to static rST (OSMO-6482)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,6 +41,13 @@ help:
 clean:
 	rm -rf _build
 
+# Freeze the CLI reference pages into static reStructuredText. Run this in the
+# environment of the branch being frozen (so the parser imports), then commit the
+# modified cli_*.rst files so the multiversion build renders them without
+# importing src.
+cli-rst:
+	python generate_cli_rst.py
+
 build:
 	export OSMO_DOMAIN=public && sphinx-build -b html . -w $(ERR_DIR)/build.log $(OUT_DIR)
 	export OSMO_DOMAIN=public && sphinx-build -b markdown . -w $(ERR_DIR)/markdown.log $(OUT_DIR)

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,3 +48,22 @@ Check if there are any misspelled words with:
 ```bash
 make spelling
 ```
+
+## Versioned builds and the CLI reference
+
+The deployed site is built with `sphinx-multiversion` (`make build-multiversion`),
+which renders `main` and each `release/*` branch. The CLI reference pages
+introspect the live `src.cli` parser, which only imports cleanly for `main`.
+Older release branches may not import under the current dependencies, so their
+CLI pages are **frozen** to static reStructuredText instead.
+
+When you cut a new release branch (or need to refresh a frozen one), run this in
+that branch's environment (where its dependencies are installed) and commit the
+modified `cli_*.rst` files:
+
+```bash
+make -C docs cli-rst
+```
+
+This rewrites each CLI page from the live parser into static rST (see
+`generate_cli_rst.py`). `main` intentionally stays "live" and is not frozen.

--- a/docs/_extensions/argparse_postprocess.py
+++ b/docs/_extensions/argparse_postprocess.py
@@ -313,58 +313,78 @@ class ArgParseWithPostprocessDirective(ArgParseDirective):
         'argument-anchor': directives.flag,
     })
 
-    def run(self) -> List[nodes.Node]:
-        """Run the directive and postprocess the results."""
+    def _run_live(self) -> List[nodes.Node]:
+        """Render by introspecting the live CLI parser (original behavior)."""
         import importlib
         from sphinxarg.ext import mock
-
-        # Get our custom options before running parent
-        ref_prefix = self.options.get('ref-prefix', '').strip()
-        add_argument_anchors = 'argument-anchor' in self.options
-
-        # Remove our custom options so parent directive doesn't see them
-        options_to_remove = ['ref-prefix', 'argument-anchor']
-        for opt in options_to_remove:
-            self.options.pop(opt, None)
 
         # Temporarily patch the parser factory to preprocess epilogs
         # This converts RST section headers to rubrics before parsing,
         # avoiding "Unexpected section title" warnings.
         original_func = None
         mod = None
+        attr_name = None
 
         if 'module' in self.options and 'func' in self.options:
             module_name = self.options['module']
             attr_name = self.options['func']
 
-            try:
-                with mock(self.config.autodoc_mock_imports):
-                    mod = importlib.import_module(module_name)
-                    if hasattr(mod, attr_name):
-                        original_func = getattr(mod, attr_name)
+            with mock(self.config.autodoc_mock_imports):
+                mod = importlib.import_module(module_name)
+                if hasattr(mod, attr_name):
+                    original_func = getattr(mod, attr_name)
 
-                        def wrapper_func():
-                            if isinstance(original_func, argparse.ArgumentParser):
-                                parser = original_func
-                            else:
-                                parser = original_func()
-                            preprocess_parser_epilogs(parser)
-                            return parser
+                    def wrapper_func():
+                        if isinstance(original_func, argparse.ArgumentParser):
+                            parser = original_func
+                        else:
+                            parser = original_func()
+                        preprocess_parser_epilogs(parser)
+                        return parser
 
-                        setattr(mod, attr_name, wrapper_func)
-            except Exception as e:
-                LOGGER.warning(f"Failed to preprocess epilogs: {e}")
-                original_func = None
+                    setattr(mod, attr_name, wrapper_func)
 
         try:
-            result = super().run()
+            return super().run()
         finally:
             if mod is not None and original_func is not None:
                 setattr(mod, attr_name, original_func)
 
-        # Get environment info
+    def run(self) -> List[nodes.Node]:
+        """Run the directive and postprocess the results."""
+        # Get our custom options before running parent
+        ref_prefix = self.options.get('ref-prefix', '').strip()
+        add_argument_anchors = 'argument-anchor' in self.options
+
+        # Remove our custom options so parent directive doesn't see them
+        for opt in ('ref-prefix', 'argument-anchor'):
+            self.options.pop(opt, None)
+
         env = self.state.document.settings.env
         docname = env.docname
+
+        # Introspect the live CLI. If that fails (e.g. the documented branch's
+        # code is not importable in this build environment) degrade to a warning
+        # so a single page cannot break the entire multiversion build. Frozen
+        # release branches avoid this path entirely by shipping pre-rendered
+        # static rST (see docs/generate_cli_rst.py).
+        try:
+            result = self._run_live()
+        except Exception as exc:  # noqa: BLE001 - directive must not crash build
+            LOGGER.warning(
+                f"Could not generate CLI reference for {docname}: {exc}. "
+                f"Freeze this version's CLI to static rST "
+                f"(see docs/generate_cli_rst.py).",
+                location=docname,
+            )
+            return [
+                nodes.warning(
+                    '',
+                    nodes.paragraph(
+                        text='CLI reference is unavailable for this version.'
+                    ),
+                )
+            ]
 
         # Convert rubrics to proper sections in the result
         for node in result:

--- a/docs/generate_cli_rst.py
+++ b/docs/generate_cli_rst.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Freeze the CLI reference pages into static reStructuredText.
+
+The CLI reference pages normally use the ``argparse-with-postprocess`` directive,
+which imports ``src.cli.main_parser`` and introspects the live parser at build
+time. For ``sphinx-multiversion`` builds that is a problem on older release
+branches whose code is not importable under the current dependencies. This
+script renders each page's CLI section to static rST (mimicking the directive's
+output, including the ``cli_reference_*`` cross-reference anchors) and rewrites
+the page in place, so the documentation build no longer needs to import any code
+for those pages.
+
+Run this in the environment of the branch you are freezing (so the parser
+reflects that branch's CLI), then commit the modified ``*.rst`` files:
+
+    make -C docs cli-rst
+
+The rewrite is idempotent: a provenance comment records the original directive
+options so the page can be regenerated. It detects either a live
+``argparse-with-postprocess`` directive or a previously generated block.
+
+Note: subcommand-level and subsection-level anchors (the ones referenced from
+other pages, e.g. ``cli_reference_workflow_submit``) are reproduced. Per-argument
+deep-link anchors produced by ``:argument-anchor:`` are intentionally omitted on
+the static pages, as nothing cross-references them.
+"""
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = DOCS_DIR.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sphinxarg.parser import parse_parser, parser_navigate  # noqa: E402
+
+DIRECTIVE_PREFIX = '.. argparse-with-postprocess::'
+SENTINEL = '.. CLI-REFERENCE-GENERATED'
+SOURCE_PREFIX = '.. cli-source:'
+
+# Heading underline characters for levels below the page title (which uses '=').
+HEADING_CHARS = ['-', '~', '^', '"', '+']
+
+# RST section header inside an epilog, e.g. "Examples\n--------".
+_RST_SECTION_PATTERN = re.compile(r'^([^\n]+)\n([=\-~`\'"^_*+#]+)$', re.MULTILINE)
+
+
+def convert_epilog_sections_to_rubric(epilog: str) -> str:
+    """Convert RST section headers in an epilog to ``.. rubric::`` directives.
+
+    Mirrors the directive's epilog handling so section titles inside epilogs do
+    not break the page's heading hierarchy.
+    """
+    if not epilog:
+        return epilog
+
+    def replace_section(match: re.Match) -> str:
+        title = match.group(1).strip()
+        underline = match.group(2)
+        if len(underline) >= len(title):
+            return f'.. rubric:: {title}'
+        return match.group(0)
+
+    return _RST_SECTION_PATTERN.sub(replace_section, epilog)
+
+
+def slugify(text: str) -> str:
+    """Match the slug scheme used by the argparse postprocess extension."""
+    text = re.sub(r'^-+', '', text)
+    text = re.sub(r'[^a-zA-Z0-9]+', '_', text)
+    return text.strip('_').lower()
+
+
+def _is_suppressed(value) -> bool:
+    if value is None:
+        return True
+    return str(value).replace('"', '').replace("'", '') == '==SUPPRESS=='
+
+
+def _heading(text: str, level: int) -> list[str]:
+    char = HEADING_CHARS[min(level, len(HEADING_CHARS) - 1)]
+    return [text, char * max(len(text), 3), '']
+
+
+def _anchor(label: str) -> list[str]:
+    return [f'.. _{label}:', '']
+
+
+def _usage_block(usage: str) -> list[str]:
+    out = ['.. code-block:: text', '']
+    for line in (usage.splitlines() or ['']):
+        out.append(f'   {line}' if line else '')
+    out.append('')
+    return out
+
+
+def _indent(text: str, spaces: int = 4) -> list[str]:
+    pad = ' ' * spaces
+    return [(pad + line if line else '') for line in text.splitlines()]
+
+
+def _render_option(option: dict) -> list[str]:
+    """Render one argument as a definition-list entry."""
+    term = ', '.join(option['name'])
+    parts: list[str] = []
+    if 'choices' in option:
+        parts.append('Possible choices: ' + ', '.join(str(c) for c in option['choices']))
+    if option.get('help'):
+        parts.append(option['help'])
+    if not _is_suppressed(option.get('default')):
+        default_str = str(option['default']).replace('`', r'\`')
+        parts.append(f'Default: ``{default_str}``')
+    if not parts:
+        parts.append('Undocumented')
+
+    lines = [f'``{term}``']
+    for index, part in enumerate(parts):
+        if index:
+            lines.append('')
+        lines.extend(_indent(part))
+    lines.append('')
+    return lines
+
+
+def _render_action_groups(data: dict, level: int, anchor_prefix: str) -> list[str]:
+    lines: list[str] = []
+    for group in data.get('action_groups', []):
+        options = group.get('options', [])
+        if not options:
+            continue
+        title = group['title']
+        lines.extend(_anchor(f'{anchor_prefix}_{slugify(title)}'))
+        lines.extend(_heading(title, level))
+        if group.get('description'):
+            lines.extend([group['description'], ''])
+        for option in options:
+            lines.extend(_render_option(option))
+    return lines
+
+
+def _render_epilog(epilog: str) -> list[str]:
+    return ['', convert_epilog_sections_to_rubric(epilog), '']
+
+
+def _render_subcommand(child: dict, ref_prefix: str, level: int) -> list[str]:
+    name = child['name']
+    ref = f'{ref_prefix}_{slugify(name)}'
+    lines: list[str] = []
+    lines.extend(_anchor(ref))
+    lines.extend(_heading(name, level))
+
+    description = child.get('description') or child.get('help') or 'Undocumented'
+    lines.extend([description, ''])
+    if child.get('bare_usage'):
+        lines.extend(_usage_block(child['bare_usage']))
+
+    lines.extend(_render_action_groups(child, level + 1, ref))
+
+    for grandchild in child.get('children', []):
+        lines.extend(_render_subcommand(grandchild, ref, level + 1))
+
+    if child.get('epilog'):
+        lines.extend(_render_epilog(child['epilog']))
+    return lines
+
+
+def render_page(result: dict, ref_prefix: str) -> str:
+    """Render the static rST body for one CLI page's ``:path:`` target."""
+    lines: list[str] = []
+
+    if result.get('description'):
+        lines.extend([result['description'], ''])
+    if result.get('usage'):
+        lines.extend(_usage_block(result['usage']))
+
+    # The command's own options (present on leaf commands).
+    lines.extend(_render_action_groups(result, level=0, anchor_prefix=ref_prefix))
+
+    children = result.get('children', [])
+    if children:
+        lines.extend(_heading('Sub-commands', 0))
+        for child in children:
+            lines.extend(_render_subcommand(child, ref_prefix, level=1))
+
+    if result.get('epilog'):
+        lines.extend(_render_epilog(result['epilog']))
+
+    # Collapse trailing blank lines to a single newline at EOF.
+    while lines and lines[-1] == '':
+        lines.pop()
+    return '\n'.join(lines) + '\n'
+
+
+def _parse_directive_options(block_lines: list[str]) -> dict:
+    options: dict = {}
+    for line in block_lines:
+        stripped = line.strip()
+        match = re.match(r':([a-zA-Z0-9_-]+):\s*(.*)$', stripped)
+        if match:
+            options[match.group(1)] = match.group(2).strip()
+    return options
+
+
+def _parse_source_comment(line: str) -> dict:
+    payload = line.split(SOURCE_PREFIX, 1)[1].strip()
+    options: dict = {}
+    for field in payload.split('|'):
+        field = field.strip()
+        if not field:
+            continue
+        if field.startswith('flags='):
+            for flag in field[len('flags='):].split(','):
+                flag = flag.strip()
+                if flag:
+                    options[flag] = ''
+        elif '=' in field:
+            key, value = field.split('=', 1)
+            options[key.strip()] = value.strip()
+    return options
+
+
+def _find_region_start(lines: list[str]) -> int | None:
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith(DIRECTIVE_PREFIX) or stripped.startswith(SENTINEL):
+            return index
+    return None
+
+
+def _extract_options(lines: list[str], start: int) -> dict:
+    region = lines[start:]
+    # Live directive block.
+    if region[0].strip().startswith(DIRECTIVE_PREFIX):
+        return _parse_directive_options(region[1:])
+    # Previously generated: read the provenance comment.
+    for line in region:
+        if line.strip().startswith(SOURCE_PREFIX):
+            return _parse_source_comment(line.strip())
+    return {}
+
+
+def _provenance(options: dict) -> list[str]:
+    flags = [k for k in ('argument-anchor', 'markdown', 'nosubcommands', 'nodescription')
+             if k in options]
+    fields = [
+        f"module={options.get('module', 'src.cli.main_parser')}",
+        f"func={options.get('func', 'create_cli_parser')}",
+        f"prog={options.get('prog', 'osmo')}",
+        f"path={options.get('path', '')}",
+        f"ref-prefix={options.get('ref-prefix', '')}",
+        f"flags={','.join(flags)}",
+    ]
+    return [
+        f'{SENTINEL} -- do not edit by hand; regenerate with: make -C docs cli-rst',
+        f'{SOURCE_PREFIX} ' + ' | '.join(fields),
+        '',
+    ]
+
+
+def process_page(path: Path, parser_cache: dict) -> bool:
+    """Rewrite one CLI page in place. Returns True if the page was changed."""
+    original = path.read_text(encoding='utf-8')
+    lines = original.splitlines()
+
+    start = _find_region_start(lines)
+    if start is None:
+        return False
+
+    options = _extract_options(lines, start)
+    cli_path = options.get('path', '')
+    ref_prefix = options.get('ref-prefix', '')
+    if not ref_prefix:
+        raise ValueError(f'{path}: could not determine :ref-prefix:')
+
+    module_name = options.get('module', 'src.cli.main_parser')
+    func_name = options.get('func', 'create_cli_parser')
+    prog = options.get('prog', 'osmo')
+
+    cache_key = (module_name, func_name, prog)
+    if cache_key not in parser_cache:
+        module = importlib.import_module(module_name)
+        parser = getattr(module, func_name)()
+        parser.prog = prog
+        parser_cache[cache_key] = parse_parser(parser)
+    data = parser_cache[cache_key]
+
+    result = parser_navigate(data, cli_path)
+    body = render_page(result, ref_prefix)
+
+    preamble = lines[:start]
+    while preamble and preamble[-1].strip() == '':
+        preamble.pop()
+
+    new_lines = preamble + [''] + _provenance(options) + body.splitlines()
+    new_text = '\n'.join(new_lines).rstrip('\n') + '\n'
+
+    if new_text != original:
+        path.write_text(new_text, encoding='utf-8')
+        return True
+    return False
+
+
+def discover_pages() -> list[Path]:
+    pages: list[Path] = []
+    for rst in DOCS_DIR.rglob('*.rst'):
+        text = rst.read_text(encoding='utf-8')
+        if DIRECTIVE_PREFIX in text or SENTINEL in text:
+            pages.append(rst)
+    return sorted(pages)
+
+
+def main() -> None:
+    parser_cache: dict = {}
+    changed = 0
+    pages = discover_pages()
+    for page in pages:
+        if process_page(page, parser_cache):
+            changed += 1
+            print(f'updated {page.relative_to(REPO_ROOT)}')
+    print(f'Processed {len(pages)} page(s); {changed} updated.')
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -27,7 +27,6 @@ header."Accept-Language" = "en-US,en;q=0.5"
 
 # Throttling to avoid rate limiting and bot detection
 max_concurrency = 16           # Limit parallel requests (default is 128)
-max_requests_per_second = 8    # Rate limit requests per second
 
 # Timeout and retries
 timeout = 60


### PR DESCRIPTION
## Description

The CLI reference pages use the `argparse-with-postprocess` directive, which
imports `src.cli.main_parser` and introspects the live parser at build time.
`sphinx-multiversion` builds every ref (`main`, `release/6.x`) in a single
Python environment, so older branches either fail to import (incompatible
dependencies) or reference commands that no longer exist (`bucket`/`dataset` →
`NavigationException`). A single failing page aborts the whole build and blocks
the Pages deploy.

Fix: render the CLI reference to static reStructuredText per version instead of
introspecting code at build time. A generator (`docs/generate_cli_rst.py`, run
via `make -C docs cli-rst`) mimics the directive's output -- usage, options,
sub-commands, examples, and the `cli_reference_*` cross-reference anchors -- and
pastes it directly into each CLI page. Frozen pages need no code import, so the
build is accurate per version and cannot crash.

- `main` stays live (keeps the directive, auto-updates from current code).
- Release branches are frozen to static rST (run the generator in that branch's
  environment and commit the pages).
- The directive keeps a graceful fallback: if a live import fails, it emits a
  warning and a placeholder instead of aborting the build.

Jira: OSMO-6482

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned documentation builds with frozen CLI reference pages for release branches.
  * Introduced a build workflow to generate and commit static CLI reference pages.
* **Bug Fixes**
  * Improved CLI reference rendering to continue builds by falling back to a warning when the live command parser can’t be imported.
* **Documentation**
  * Documented the versioned build and CLI-freezing workflow for main vs release branches.
* **Chores**
  * Added a docs build target and script to freeze CLI references into static reStructuredText.
  * Adjusted request throttling to use parallel concurrency instead of requests-per-second.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->