### PR TITLE
Clean up cookbook dataset naming

### DIFF
--- a/cookbook/cosmos/predict/README.md
+++ b/cookbook/cosmos/predict/README.md
@@ -41,7 +41,7 @@ conditions for pulling the model. The terms and conditions submission can be fou
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/cosmos/cosmos_video2world.yaml
-osmo workflow submit cosmos_video2world.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit cosmos_video2world.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 The workflow will take this input image below, and create a video from this image.
@@ -54,7 +54,7 @@ The workflow will take this input image below, and create a video from this imag
 After the workflow completes successfully, you can download the generated video from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-osmo data download s3://my-bucket/datasets/cosmos_video2world/<workflow-id>/ ./
+osmo data download s3://my-bucket/osmo-data/cosmos_video2world/<workflow-id>/ ./
 ```
 
 ## More Information

--- a/cookbook/cosmos/predict/cosmos_video2world.yaml
+++ b/cookbook/cosmos/predict/cosmos_video2world.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit cosmos_video2world.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit cosmos_video2world.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: cosmos_video2world

--- a/cookbook/cosmos/reason/README.md
+++ b/cookbook/cosmos/reason/README.md
@@ -47,7 +47,7 @@ In order for your workflow to pull the Cosmos model from HuggingFace, you will *
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/cosmos/reason/cosmos_reason.yaml
-osmo workflow submit cosmos_reason.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit cosmos_reason.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 ## Output
@@ -101,7 +101,7 @@ The workflow will also answer the question asked in the workflow:
 After the workflow completes successfully, you can download the generated temporal caption results and extracted frames from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-osmo data download s3://my-bucket/datasets/cosmos-reason-sample/<workflow-id>/ ~/
+osmo data download s3://my-bucket/osmo-data/cosmos-reason-sample/<workflow-id>/ ~/
 ```
 
 

--- a/cookbook/cosmos/reason/cosmos_reason.yaml
+++ b/cookbook/cosmos/reason/cosmos_reason.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit cosmos_reason.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit cosmos_reason.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: cosmos-reason

--- a/cookbook/cosmos/transfer/README.md
+++ b/cookbook/cosmos/transfer/README.md
@@ -50,7 +50,7 @@ You must agree to the terms and conditions for the Cosmos model on Hugging Face:
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/cosmos/transfer/cosmos_transfer.yaml
-osmo workflow submit cosmos_transfer.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit cosmos_transfer.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 ## What the workflow does
@@ -83,12 +83,12 @@ After successful completion, you can download the results from the URLs the work
 
 ### Isaac Sim Synthetic Data
 ```bash
-osmo data download s3://my-bucket/datasets/isaac-sim-cosmos-warehouse-sample/<workflow-id>/ ./
+osmo data download s3://my-bucket/osmo-data/isaac-sim-cosmos-warehouse-sample/<workflow-id>/ ./
 ```
 
 ### Cosmos Transfer Augmented Data
 ```bash
-osmo data download s3://my-bucket/datasets/cosmos-transfer-sample/<workflow-id>/ ./
+osmo data download s3://my-bucket/osmo-data/cosmos-transfer-sample/<workflow-id>/ ./
 ```
 
 The final output includes:

--- a/cookbook/cosmos/transfer/cosmos_transfer.yaml
+++ b/cookbook/cosmos/transfer/cosmos_transfer.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit cosmos_transfer.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit cosmos_transfer.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: isaac-sim-cosmos-transfer

--- a/cookbook/dnn_training/deepspeed_multinode/README.md
+++ b/cookbook/dnn_training/deepspeed_multinode/README.md
@@ -30,7 +30,7 @@ The workflow creates `n_nodes` tasks (configurable), each with `n_gpus_per_node`
 - A **master task** that coordinates the distributed training and saves model outputs
 - Multiple **worker tasks** that communicate with the master
 - Each task runs DeepSpeed for efficient distributed training
-- Model snapshots are saved to the output dataset
+- Model snapshots are saved to the configured output location
 
 ## Files
 
@@ -48,7 +48,7 @@ The workflow creates `n_nodes` tasks (configurable), each with `n_gpus_per_node`
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/deepspeed_multinode/train.py
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/deepspeed_multinode/train.yaml
-osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets n_nodes=2 n_gpus_per_node=4 n_epochs=10
+osmo workflow submit train.yaml --set storage_url=s3://my-bucket/osmo-data n_nodes=2 n_gpus_per_node=4 n_epochs=10
 ```
 
 > **Note:** The DeepSpeed configuration file (`/tmp/ds_config.json`) in the workflow specifies

--- a/cookbook/dnn_training/deepspeed_multinode/train.yaml
+++ b/cookbook/dnn_training/deepspeed_multinode/train.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets n_nodes=2 n_gpus_per_node=4 n_epochs=10
+# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/osmo-data n_nodes=2 n_gpus_per_node=4 n_epochs=10
 
 workflow:
   name: deepspeed-sample
@@ -34,7 +34,7 @@ workflow:
     - name: master
       lead: true
       outputs:
-      - url: {{ storage_url }}/{{ dataset }}/{{workflow_id}}/
+      - url: {{ storage_url }}/{{ output_prefix }}/{{workflow_id}}/
     {% else %}
     - name: worker_{{item}}
     {% endif %}
@@ -89,4 +89,4 @@ default-values:
   master_port: 29400
   n_epochs: 10
   batch_size: 32
-  dataset: model-sample  # Name of the output dataset under storage_url.
+  output_prefix: model-sample  # Output prefix under storage_url.

--- a/cookbook/dnn_training/single_node/README.md
+++ b/cookbook/dnn_training/single_node/README.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # TorchRun: Training on a Single Node
 
-This example demonstrates how to run a PyTorch training job on a single node using OSMO. It trains a simple CNN on the MNIST dataset and showcases key OSMO features including resource management, dataset handling, checkpointing, and TensorBoard integration.
+This example demonstrates how to run a PyTorch training job on a single node using OSMO. It trains a simple CNN on the MNIST dataset and showcases key OSMO features including resource management, data handling, checkpointing, and TensorBoard integration.
 
 This workflow example contains:
 - `train.py`: A PyTorch training script that trains a CNN on the MNIST dataset
@@ -34,7 +34,7 @@ This workflow example contains:
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/single_node/train.yaml
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/single_node/train.py
-osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit train.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 ## Open Tensorboard

--- a/cookbook/dnn_training/single_node/train.yaml
+++ b/cookbook/dnn_training/single_node/train.yaml
@@ -38,7 +38,7 @@ workflow:
           set -ex
 
           # Directory of training inputs
-          {% if input_dataset %}
+          {% if input_prefix %}
           INPUT_DIR="{{input:0}}"
           {% else %}
           INPUT_DIR="./data"
@@ -64,12 +64,12 @@ workflow:
 
       - path: /tmp/train.py
         localpath: train.py
-    {% if input_dataset %}
+    {% if input_prefix %}
     inputs:
-      - url: {{ storage_url }}/{{ input_dataset }}/
+      - url: {{ storage_url }}/{{ input_prefix }}/
     {% endif %}
     outputs:
-      - url: {{ storage_url }}/{{ output_dataset }}/{{workflow_id}}/
+      - url: {{ storage_url }}/{{ output_prefix }}/{{workflow_id}}/
     {% if checkpoint_url %}
     checkpoint:
     - path: experiments/checkpoints  # The local path of the checkpoints
@@ -79,6 +79,6 @@ workflow:
     {% endif %}
 
 default-values:
-  input_dataset: ""  # Optional. Name of the input dataset under storage_url.
-  output_dataset: my-trained-model  # Name of the output dataset under storage_url.
+  input_prefix: ""  # Optional. Input prefix under storage_url.
+  output_prefix: my-trained-model  # Output prefix under storage_url.
   checkpoint_url: ""  # The remote path in the data store to checkpoint to

--- a/cookbook/dnn_training/torchrun_elastic/README.md
+++ b/cookbook/dnn_training/torchrun_elastic/README.md
@@ -35,5 +35,5 @@ This workflow example contains:
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_elastic/train.py
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_elastic/train.yaml
-osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets min_nodes=2 max_nodes=4 n_epochs=10
+osmo workflow submit train.yaml --set storage_url=s3://my-bucket/osmo-data min_nodes=2 max_nodes=4 n_epochs=10
 ```

--- a/cookbook/dnn_training/torchrun_elastic/train.yaml
+++ b/cookbook/dnn_training/torchrun_elastic/train.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets min_nodes=2 max_nodes=4 n_epochs=10
+# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/osmo-data min_nodes=2 max_nodes=4 n_epochs=10
 
 workflow:
   name: elastic-sample
@@ -34,7 +34,7 @@ workflow:
     - name: master  # Master task for torchrun
       lead: true
       outputs:
-      - url: {{ storage_url }}/{{ dataset }}/{{workflow_id}}/
+      - url: {{ storage_url }}/{{ output_prefix }}/{{workflow_id}}/
     {% else %}
     - name: worker_{{item}}  # Worker task that will communicate with the master task
     {% endif %}
@@ -67,4 +67,4 @@ default-values:
   master_port: 29400
   n_epochs: 10
   batch_size: 32
-  dataset: model-sample  # Name of the output dataset under storage_url.
+  output_prefix: model-sample  # Output prefix under storage_url.

--- a/cookbook/dnn_training/torchrun_multinode/README.md
+++ b/cookbook/dnn_training/torchrun_multinode/README.md
@@ -36,5 +36,5 @@ This workflow example contains:
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_multinode/train_template.yaml
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_multinode/train.py
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/dnn_training/torchrun_multinode/osmo_barrier.py
-osmo workflow submit train_template.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit train_template.yaml --set storage_url=s3://my-bucket/osmo-data
 ```

--- a/cookbook/dnn_training/torchrun_multinode/train.yaml
+++ b/cookbook/dnn_training/torchrun_multinode/train.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: train-multi-gpu
@@ -48,7 +48,7 @@ workflow:
       - path: /tmp/train.py
         localpath: train.py
       outputs:
-        - url: {{ storage_url }}/{{ output_dataset }}/{{workflow_id}}/
+        - url: {{ storage_url }}/{{ output_prefix }}/{{workflow_id}}/
 
     - name: worker  # Worker task that will communicate with the master task
       image: nvcr.io/nvidia/pytorch:24.03-py3
@@ -69,4 +69,4 @@ workflow:
         localpath: train.py
 
 default-values:
-  output_dataset: my-trained-model  # Name of the output dataset under storage_url.
+  output_prefix: my-trained-model  # Output prefix under storage_url.

--- a/cookbook/dnn_training/torchrun_multinode/train_template.yaml
+++ b/cookbook/dnn_training/torchrun_multinode/train_template.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit train_template.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit train_template.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: train-torchrun
@@ -34,7 +34,7 @@ workflow:
     - name: master  # Master task for torchrun
       lead: true  # Set to the lead of the group
       outputs:  # Only save the trained model in lead task
-      - url: {{ storage_url }}/{{ output_dataset }}/{{workflow_id}}/
+      - url: {{ storage_url }}/{{ output_prefix }}/{{workflow_id}}/
     {% else %}
     - name: worker_{{item}}  # Worker task that will communicate with the master task
     {% endif %}
@@ -67,4 +67,4 @@ default-values:
   master_port: 29400
   n_epochs: 10
   batch_size: 32
-  output_dataset: my-trained-model  # Name of the output dataset under storage_url.
+  output_prefix: my-trained-model  # Output prefix under storage_url.

--- a/cookbook/groot/groot_finetune/README.md
+++ b/cookbook/groot/groot_finetune/README.md
@@ -25,11 +25,11 @@ This workflow how to perform fine-tuning using [Isaac Groot](https://github.com/
 ## Running the Workflow
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/groot/groot_finetune/groot_finetune.yaml
-osmo workflow submit groot_finetune.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit groot_finetune.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
-You can download the generated demonstrations from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
+You can download the fine-tuned model artifacts from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-osmo data download s3://my-bucket/datasets/groot-finetune-dataset/<workflow-id>/ ./
+osmo data download s3://my-bucket/osmo-data/groot-finetune/<workflow-id>/ ./
 ```

--- a/cookbook/groot/groot_finetune/groot_finetune.yaml
+++ b/cookbook/groot/groot_finetune/groot_finetune.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit groot_finetune.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit groot_finetune.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: groot-finetune
@@ -72,4 +72,4 @@ workflow:
 
       path: /tmp/entry.sh
     outputs:
-    - url: {{ storage_url }}/groot-finetune-dataset/{{workflow_id}}/
+    - url: {{ storage_url }}/groot-finetune/{{workflow_id}}/

--- a/cookbook/groot/groot_mimic/README.md
+++ b/cookbook/groot/groot_mimic/README.md
@@ -29,11 +29,11 @@ The full tutorial from Isaac Lab can be found [here](https://isaac-sim.github.io
 ## Running the Workflow
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/groot/groot_mimic/groot_mimic.yaml
-osmo workflow submit groot_mimic.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit groot_mimic.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 You can download the generated demonstrations and agent checkpoints from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-osmo data download s3://my-bucket/datasets/mimic-dataset/<workflow-id>/ ./
+osmo data download s3://my-bucket/osmo-data/groot-mimic/<workflow-id>/ ./
 ```

--- a/cookbook/groot/groot_mimic/groot_mimic.yaml
+++ b/cookbook/groot/groot_mimic/groot_mimic.yaml
@@ -15,10 +15,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit groot_mimic.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit groot_mimic.yaml --set storage_url=s3://my-bucket/osmo-data
 #
 # To use more demonstrations:
-# osmo workflow submit groot_mimic.yaml --set storage_url=s3://my-bucket/datasets num_envs=10 num_trials=1000
+# osmo workflow submit groot_mimic.yaml --set storage_url=s3://my-bucket/osmo-data num_envs=10 num_trials=1000
 
 workflow:
   groups:
@@ -62,7 +62,7 @@ workflow:
       image: nvcr.io/nvidia/isaac-lab:2.3.0
       name: mimic
       outputs:
-      - url: {{ storage_url }}/mimic-dataset/{{workflow_id}}/
+      - url: {{ storage_url }}/groot-mimic/{{workflow_id}}/
   name: groot-mimic
   resources:
     default:

--- a/cookbook/integration_and_tools/wandb/README.md
+++ b/cookbook/integration_and_tools/wandb/README.md
@@ -42,7 +42,7 @@ osmo credential set wandb --type GENERIC --payload wandb_api_key=<YOUR_API_KEY>
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/integration_and_tools/wandb/train.yaml
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/integration_and_tools/wandb/train.py
-osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit train.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 ## Monitoring Training

--- a/cookbook/integration_and_tools/wandb/train.yaml
+++ b/cookbook/integration_and_tools/wandb/train.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/datasets n_nodes=<number of nodes> n_gpus_per_node=<number of GPUs per node>
+# osmo workflow submit train.yaml --set storage_url=s3://my-bucket/osmo-data n_nodes=<number of nodes> n_gpus_per_node=<number of GPUs per node>
 
 workflow:
   name: wandb-sample
@@ -33,7 +33,7 @@ workflow:
     - name: master  # Master task for torchrun
       lead: true
       outputs:
-      - url: {{ storage_url }}/{{ dataset }}/{{workflow_id}}/
+      - url: {{ storage_url }}/{{ output_prefix }}/{{workflow_id}}/
     {% else %}
     - name: worker_{{item}}  # Worker task that will communicate with the master task
     {% endif %}
@@ -70,4 +70,4 @@ default-values:
   master_port: 29400
   n_epochs: 10
   batch_size: 32
-  dataset: model-sample  # Name of the output dataset under storage_url.
+  output_prefix: model-sample  # Output prefix under storage_url.

--- a/cookbook/mobility_gen/README.md
+++ b/cookbook/mobility_gen/README.md
@@ -81,7 +81,7 @@ Once raw trajectories are recorded, use Cosmos Transfer to apply diffusion-based
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/mobility_gen/cosmos_augmentation.yaml
-osmo workflow submit cosmos_augmentation.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit cosmos_augmentation.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 **Example Prompt:**

--- a/cookbook/mobility_gen/cosmos_augmentation.yaml
+++ b/cookbook/mobility_gen/cosmos_augmentation.yaml
@@ -2,7 +2,7 @@
 # Generates photorealistic videos from synthetic robot data using Cosmos Transfer
 #
 # To submit:
-#   osmo workflow submit cosmos_transfer_mobility.yaml --pool isaac-hil --set storage_url=s3://my-bucket/datasets
+#   osmo workflow submit cosmos_transfer_mobility.yaml --pool isaac-hil --set storage_url=s3://my-bucket/osmo-data
 #
 # To connect:
 #   osmo workflow exec <workflow-id> -t cosmos_transfer

--- a/cookbook/nut_pouring/01_mimic_generation.yaml
+++ b/cookbook/nut_pouring/01_mimic_generation.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 1: Generate MimicGen dataset from teleop data
-# Usage: osmo workflow submit 01_mimic_generation.yaml --pool default --set storage_url=s3://my-bucket/datasets
+# Usage: osmo workflow submit 01_mimic_generation.yaml --pool default --set storage_url=s3://my-bucket/osmo-data
 
 version: 2
 workflow:
@@ -84,9 +84,9 @@ workflow:
         path: /tmp/nutpour_gr1t2_base_env_cfg.py
       image: {{ image_name }}
       inputs:
-      - url: {{ storage_url }}/{{ input_dataset }}/
+      - url: {{ storage_url }}/{{ input_prefix }}/
       outputs:
-      - url: {{ storage_url }}/{{ output_dataset }}/
+      - url: {{ storage_url }}/{{ output_prefix }}/
       lead: true
       name: mimic_task
   name: isaac_mimic_25
@@ -102,5 +102,5 @@ workflow:
 
 default-values:
   image_name: nvcr.io/nvidia/isaac-lab:2.3.0
-  input_dataset: PhysAI-InputMimic  # Name of the input dataset under storage_url.
-  output_dataset: PhysAI-MimicGen  # Name of the output dataset under storage_url; consumed by stage 02.
+  input_prefix: PhysAI-InputMimic  # Input prefix under storage_url.
+  output_prefix: PhysAI-MimicGen  # Output prefix under storage_url; consumed by stage 02.

--- a/cookbook/nut_pouring/02_hdf5_to_mp4.yaml
+++ b/cookbook/nut_pouring/02_hdf5_to_mp4.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 2: Convert HDF5 camera observations to MP4 videos
-# Usage: osmo workflow submit 02_hdf5_to_mp4.yaml --pool default --set storage_url=s3://my-bucket/datasets
+# Usage: osmo workflow submit 02_hdf5_to_mp4.yaml --pool default --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: {{ workflow_name }}
@@ -41,9 +41,9 @@ workflow:
           HF_TOKEN: token
 
     inputs:
-    - url: {{ storage_url }}/{{ input_dataset }}/
+    - url: {{ storage_url }}/{{ input_prefix }}/
     outputs:
-    - url: {{ storage_url }}/{{ output_dataset }}/
+    - url: {{ storage_url }}/{{ output_prefix }}/
 
     args:
     - /tmp/entry.sh
@@ -131,5 +131,5 @@ default-values:
   storage: 256Gi
   num_gpu: 1
   num_cpu: 16
-  input_dataset: PhysAI-MimicGen  # Produced by stage 01.
-  output_dataset: PhysAI-MP4Videos  # Consumed by stage 03.
+  input_prefix: PhysAI-MimicGen  # Input prefix produced by stage 01.
+  output_prefix: PhysAI-MP4Videos  # Output prefix consumed by stage 03.

--- a/cookbook/nut_pouring/03_cosmos_augmentation.yaml
+++ b/cookbook/nut_pouring/03_cosmos_augmentation.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 3: Apply Cosmos Transfer 2.5 for visual augmentation
-# Usage: osmo workflow submit 03_cosmos_augmentation.yaml --pool default --set storage_url=s3://my-bucket/datasets
+# Usage: osmo workflow submit 03_cosmos_augmentation.yaml --pool default --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   groups:
@@ -143,11 +143,11 @@ workflow:
         path: /tmp/entry.sh
       image: nvcr.io/nvidia/cosmos/cosmos-predict2-container:1.2
       inputs:
-      - url: {{ storage_url }}/{{ input_dataset }}/
+      - url: {{ storage_url }}/{{ input_prefix }}/
       lead: true
       name: cosmos_transfer_augmentation
       outputs:
-      - url: {{ storage_url }}/{{ output_dataset }}/
+      - url: {{ storage_url }}/{{ output_prefix }}/
   name: cosmos_transfer_augmentation
   resources:
     default:
@@ -160,5 +160,5 @@ workflow:
     queue_timeout: 1d
 
 default-values:
-  input_dataset: PhysAI-MP4Videos  # Produced by stage 02.
-  output_dataset: PhysAI-CosmosAugmentedMP4  # Consumed by stage 04.
+  input_prefix: PhysAI-MP4Videos  # Input prefix produced by stage 02.
+  output_prefix: PhysAI-CosmosAugmentedMP4  # Output prefix consumed by stage 04.

--- a/cookbook/nut_pouring/04_mp4_to_hdf5.yaml
+++ b/cookbook/nut_pouring/04_mp4_to_hdf5.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 4: Merge augmented MP4 videos back into HDF5 format
-# Usage: osmo workflow submit 04_mp4_to_hdf5.yaml --pool default --set storage_url=s3://my-bucket/datasets
+# Usage: osmo workflow submit 04_mp4_to_hdf5.yaml --pool default --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: {{ workflow_name }}
@@ -41,10 +41,10 @@ workflow:
         HF_TOKEN: token
 
     inputs:
-    - url: {{ storage_url }}/{{ input_dataset_mimic_gen }}/
-    - url: {{ storage_url }}/{{ input_dataset_cosmos_augmented_mp4 }}/
+    - url: {{ storage_url }}/{{ input_prefix_mimic_gen }}/
+    - url: {{ storage_url }}/{{ input_prefix_cosmos_augmented_mp4 }}/
     outputs:
-    - url: {{ storage_url }}/{{ output_dataset }}/
+    - url: {{ storage_url }}/{{ output_prefix }}/
 
     args:
     - /tmp/entry.sh
@@ -105,6 +105,6 @@ default-values:
   storage: 256Gi
   num_gpu: 1
   num_cpu: 16
-  input_dataset_mimic_gen: PhysAI-MimicGen  # Produced by stage 01.
-  input_dataset_cosmos_augmented_mp4: PhysAI-CosmosAugmentedMP4  # Produced by stage 03.
-  output_dataset: PhysAI-CosmosAugmentedHDF5  # Consumed by stage 05.
+  input_prefix_mimic_gen: PhysAI-MimicGen  # Input prefix produced by stage 01.
+  input_prefix_cosmos_augmented_mp4: PhysAI-CosmosAugmentedMP4  # Input prefix produced by stage 03.
+  output_prefix: PhysAI-CosmosAugmentedHDF5  # Output prefix consumed by stage 05.

--- a/cookbook/nut_pouring/05_lerobot_conversion.yaml
+++ b/cookbook/nut_pouring/05_lerobot_conversion.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 5: Convert HDF5 to LeRobot dataset format for GROOT training
-# Usage: osmo workflow submit 05_lerobot_conversion.yaml --pool default --set storage_url=s3://my-bucket/datasets
+# Usage: osmo workflow submit 05_lerobot_conversion.yaml --pool default --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: {{workflow_name}}
@@ -38,10 +38,10 @@ workflow:
       OMNI_KIT_ALLOW_ROOT: 1
 
     inputs:
-    - url: {{ storage_url }}/{{ input_dataset }}/
+    - url: {{ storage_url }}/{{ input_prefix }}/
 
     outputs:
-    - url: {{ storage_url }}/{{ output_dataset }}/
+    - url: {{ storage_url }}/{{ output_prefix }}/
 
     command: ["bash"]
     args: ["/tmp/entry.sh"]
@@ -139,5 +139,5 @@ default-values:
   num_cpu: 32
   platform: ovx-a40
   image_name: nvcr.io/nvidia/isaac-lab:2.3.0
-  input_dataset: PhysAI-CosmosAugmentedHDF5  # Produced by stage 04.
-  output_dataset: PhysAI-LeRobotDataset  # Consumed by stage 06.
+  input_prefix: PhysAI-CosmosAugmentedHDF5  # Input prefix produced by stage 04.
+  output_prefix: PhysAI-LeRobotDataset  # Output prefix consumed by stage 06.

--- a/cookbook/nut_pouring/06_groot_finetune.yaml
+++ b/cookbook/nut_pouring/06_groot_finetune.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Step 6: Fine-tune GROOT-N1.5 VLA model on prepared dataset
-# Usage: osmo workflow submit 06_groot_finetune.yaml --pool default --set storage_url=s3://my-bucket/datasets
+# Usage: osmo workflow submit 06_groot_finetune.yaml --pool default --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   groups:
@@ -93,11 +93,11 @@ workflow:
         path: /tmp/entry.sh
       image: pytorch/pytorch:2.6.0-cuda12.4-cudnn9-devel
       inputs:
-      - url: {{ storage_url }}/{{ input_dataset }}/
+      - url: {{ storage_url }}/{{ input_prefix }}/
       lead: true
       name: master
       outputs:
-      - url: {{ storage_url }}/{{ output_dataset }}/{{workflow_id}}/
+      - url: {{ storage_url }}/{{ output_prefix }}/{{workflow_id}}/
   name: groot_finetune_nut_pouring
   resources:
     default:
@@ -110,5 +110,5 @@ workflow:
     queue_timeout: 2d
 
 default-values:
-  input_dataset: PhysAI-LeRobotDataset  # Produced by stage 05.
-  output_dataset: PhysAI-GR00T-Finetuned  # Per-run outputs are written to <output_dataset>/<workflow_id>/.
+  input_prefix: PhysAI-LeRobotDataset  # Input prefix produced by stage 05.
+  output_prefix: PhysAI-GR00T-Finetuned  # Per-run outputs are written to <output_prefix>/<workflow_id>/.

--- a/cookbook/nut_pouring/README.md
+++ b/cookbook/nut_pouring/README.md
@@ -76,7 +76,7 @@ Pick a base storage URL for the chain (every stage will read from / write to it)
 and upload the seed input HDF5 to `$STORAGE_URL/PhysAI-InputMimic/`:
 
 ```bash
-export STORAGE_URL=s3://my-bucket/datasets
+export STORAGE_URL=s3://my-bucket/osmo-data
 
 curl -O https://download.isaacsim.omniverse.nvidia.com/isaaclab/dataset/dataset_annotated_gr1_nut_pouring.hdf5
 osmo data upload $STORAGE_URL/PhysAI-InputMimic/ dataset_annotated_gr1_nut_pouring.hdf5
@@ -91,7 +91,7 @@ mkdir -p nut_pouring && cd nut_pouring
 curl https://codeload.github.com/NVIDIA/OSMO/tar.gz/main | tar -xz --strip=4 OSMO-main/cookbook/nut_pouring
 
 # Pick a base URL the entire chain will read from and write to.
-export STORAGE_URL=s3://my-bucket/datasets
+export STORAGE_URL=s3://my-bucket/osmo-data
 
 # Step 1: MimicGen data generation
 osmo workflow submit 01_mimic_generation.yaml --set storage_url=$STORAGE_URL

--- a/cookbook/reinforcement_learning/multi_gpu/README.md
+++ b/cookbook/reinforcement_learning/multi_gpu/README.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Isaac Lab: Multi-GPU Training Robot Policy with Reinforcement Learning
 
-This example demonstrates how to run a reinforcement learning training job using multiple GPUs on a single node with OSMO. It trains a robot policy based on [RSL-RL](https://github.com/leggedrobotics/rsl_rl) using PyTorch's distributed training capabilities and showcases key OSMO features including multi-GPU resource management, dataset handling, and TensorBoard integration.
+This example demonstrates how to run a reinforcement learning training job using multiple GPUs on a single node with OSMO. It trains a robot policy based on [RSL-RL](https://github.com/leggedrobotics/rsl_rl) using PyTorch's distributed training capabilities and showcases key OSMO features including multi-GPU resource management, data handling, and TensorBoard integration.
 
 This workflow example contains:
 - `train_policy.yaml`: An OSMO workflow configuration that orchestrates the multi-GPU training job
@@ -39,7 +39,7 @@ This workflow example contains:
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
-osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 ### Customizing GPU Count
@@ -47,5 +47,5 @@ osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
 To run with a different number of GPUs, override the default value:
 
 ```bash
-osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets num_gpu=4
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/osmo-data num_gpu=4
 ```

--- a/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
+++ b/cookbook/reinforcement_learning/multi_gpu/train_policy.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   tasks:
@@ -41,7 +41,7 @@ workflow:
 
       path: /tmp/entry.sh
     outputs:
-    - url: {{ storage_url }}/robot-policy-dataset/{{workflow_id}}/
+    - url: {{ storage_url }}/robot-policy/{{workflow_id}}/
   name: train-robot-multi-gpu
   resources:
     default:

--- a/cookbook/reinforcement_learning/multi_node/README.md
+++ b/cookbook/reinforcement_learning/multi_node/README.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Isaac Lab: Multi-Node Training Robot Policy with Reinforcement Learning
 
-This example demonstrates how to run a reinforcement learning training job using multiple GPUs across multiple nodes with OSMO. It trains a robot policy based on [RSL-RL](https://github.com/leggedrobotics/rsl_rl) using PyTorch's distributed training capabilities and showcases key OSMO features including multi-node resource management, distributed coordination, dataset handling, and TensorBoard integration.
+This example demonstrates how to run a reinforcement learning training job using multiple GPUs across multiple nodes with OSMO. It trains a robot policy based on [RSL-RL](https://github.com/leggedrobotics/rsl_rl) using PyTorch's distributed training capabilities and showcases key OSMO features including multi-node resource management, distributed coordination, data handling, and TensorBoard integration.
 
 This workflow example contains:
 - `train_policy.yaml`: An OSMO workflow configuration that orchestrates the multi-node training job
@@ -40,7 +40,7 @@ This workflow example contains:
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/reinforcement_learning/multi_node/train_policy.yaml
-osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 ### Customizing GPU Count
@@ -48,7 +48,7 @@ osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
 To run with a different number of GPUs per node, override the default value:
 
 ```bash
-osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets num_gpu=4
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/osmo-data num_gpu=4
 ```
 
 ## Architecture

--- a/cookbook/reinforcement_learning/multi_node/train_policy.yaml
+++ b/cookbook/reinforcement_learning/multi_node/train_policy.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   groups:
@@ -44,7 +44,7 @@ workflow:
 
         path: /tmp/entry.sh
       outputs:
-      - url: {{ storage_url }}/robot-policy-dataset/{{workflow_id}}/
+      - url: {{ storage_url }}/robot-policy/{{workflow_id}}/
     {% for i in range(1, num_nodes) %}
     - name: worker-{{i}}
       command: ["bash"]

--- a/cookbook/reinforcement_learning/single_gpu/README.md
+++ b/cookbook/reinforcement_learning/single_gpu/README.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Isaac Lab: Training Robot Policy with Reinforcement Learning
 
-This example demonstrates how to run a reinforcement learning training job on a single node using OSMO. It trains a robot policy based on [Stable Baselines 3](https://stable-baselines3.readthedocs.io/en/master/) and showcases key OSMO features including resource management, dataset handling, and TensorBoard integration.
+This example demonstrates how to run a reinforcement learning training job on a single node using OSMO. It trains a robot policy based on [Stable Baselines 3](https://stable-baselines3.readthedocs.io/en/master/) and showcases key OSMO features including resource management, data handling, and TensorBoard integration.
 
 This workflow example contains:
 - `train_policy.yaml`: An OSMO workflow configuration that orchestrates the training job
@@ -32,7 +32,7 @@ This workflow example contains:
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
-osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
 ## Open Tensorboard

--- a/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
+++ b/cookbook/reinforcement_learning/single_gpu/train_policy.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit train_policy.yaml --set storage_url=s3://my-bucket/osmo-data
 # To see TensorBoard dashboard:
 # osmo workflow port-forward <workflow ID> train --port 6006
 
@@ -51,7 +51,7 @@ workflow:
 
       path: /tmp/entry.sh
     outputs:
-    - url: {{ storage_url }}/robot-policy-dataset/{{workflow_id}}/
+    - url: {{ storage_url }}/robot-policy/{{workflow_id}}/
   name: train-robot-policy
   resources:
     default:

--- a/cookbook/synthetic_data_generation/gazebo/README.md
+++ b/cookbook/synthetic_data_generation/gazebo/README.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Gazebo: Generating Synthetic Data
 
-This workflow demonstrates synthetic data generation using the Gazebo simulator. It launches Gazebo with a segmentation world, randomly places objects (vehicles, trees, cones) in the scene, captures synthetic images with semantic labels, and saves them to a dataset.
+This workflow demonstrates synthetic data generation using the Gazebo simulator. It launches Gazebo with a segmentation world, randomly places objects (vehicles, trees, cones) in the scene, captures synthetic images with semantic labels, and writes them to object storage.
 
 ## Files
 
@@ -32,15 +32,15 @@ This workflow demonstrates synthetic data generation using the Gazebo simulator.
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/synthetic_data_generation/gazebo/sdg.py
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/synthetic_data_generation/gazebo/segmentation_world.sdf
-osmo workflow submit gazebo_sdg.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit gazebo_sdg.yaml --set storage_url=s3://my-bucket/osmo-data
 ```
 
-## Downloading Output Dataset
+## Downloading Output
 
 Once the workflow is completed, download the generated data from the URL the workflow wrote to (replace `<workflow-id>` with the value printed at submit time):
 
 ```bash
-osmo data download s3://my-bucket/datasets/gazebo-sdg-sample/<workflow-id>/ <local_folder>
+osmo data download s3://my-bucket/osmo-data/gazebo-sdg-sample/<workflow-id>/ <local_folder>
 ```
 
 ## Example Output

--- a/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
+++ b/cookbook/synthetic_data_generation/gazebo/gazebo_sdg.yaml
@@ -16,7 +16,7 @@
 
 # This workflow has multiple files. Please refer to README for more details.
 # To submit:
-# osmo workflow submit gazebo_sdg.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit gazebo_sdg.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: gazebo-sdg
@@ -27,7 +27,7 @@ workflow:
     command: ["bash"]
     args: ["/tmp/entry.sh"]
     outputs:
-    - url: {{ storage_url }}/{{ dataset }}/{{workflow_id}}/
+    - url: {{ storage_url }}/{{ output_prefix }}/{{workflow_id}}/
     files:
     - path: /tmp/entry.sh
       contents: |
@@ -60,4 +60,4 @@ workflow:
 
 default-values:
   platform: ovx-a40
-  dataset: gazebo-sdg-sample  # Name of the output dataset under storage_url.
+  output_prefix: gazebo-sdg-sample  # Output prefix under storage_url.

--- a/cookbook/synthetic_data_generation/isaac_sim/README.md
+++ b/cookbook/synthetic_data_generation/isaac_sim/README.md
@@ -31,5 +31,5 @@ networks. The workflow consists of one main task that launches Isaac Sim, and ge
 
 ```bash
 curl -O https://raw.githubusercontent.com/NVIDIA/OSMO/main/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
-osmo workflow submit isaac_sim_sdg.yaml --set storage_url=s3://my-bucket/datasets
+osmo workflow submit isaac_sim_sdg.yaml --set storage_url=s3://my-bucket/osmo-data
 ```

--- a/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
+++ b/cookbook/synthetic_data_generation/isaac_sim/isaac_sim_sdg.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # To submit:
-# osmo workflow submit isaac_sim_sdg.yaml --set storage_url=s3://my-bucket/datasets
+# osmo workflow submit isaac_sim_sdg.yaml --set storage_url=s3://my-bucket/osmo-data
 
 workflow:
   name: isaac-sim-sdg

--- a/cookbook/tutorials/data_filter.yaml
+++ b/cookbook/tutorials/data_filter.yaml
@@ -27,9 +27,9 @@ workflow:
     args: ["ls -la {{input:0}}/"]
 
     inputs:
-    - url: {{ storage_url }}/large_dataset/
+    - url: {{ storage_url }}/source-data/
       regex: .*\.txt$ # (1)
 
     outputs:
-    - url: {{ storage_url }}/output_dataset/{{workflow_id}}/
+    - url: {{ storage_url }}/filtered-output/{{workflow_id}}/
       regex: .*\.(json|yaml)$ # (2)


### PR DESCRIPTION
## Description
This PR removes stale OSMO dataset-era naming from cookbook examples and README commands.

- update sample storage URLs from `s3://my-bucket/datasets` to `s3://my-bucket/osmo-data`
- rename OSMO-facing YAML variables like `dataset`, `input_dataset`, and `output_dataset` to storage-prefix names such as `output_prefix` and `input_prefix`
- rename example output prefixes like `robot-policy-dataset`, `groot-finetune-dataset`, and `mimic-dataset`
- keep non-OSMO dataset references intact, such as `MNIST dataset`, `LeRobot dataset`, `--dataset-path`, and `torchvision.datasets`

Issue #911

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow examples across multiple cookbooks to use the new `osmo-data` storage path.
  * Aligned submission and download commands with the latest storage location conventions.
  * Reworded several examples from “dataset handling” to “data handling” for clearer guidance.
  * Standardized some workflow templates to use `input_prefix` and `output_prefix` naming in place of older dataset-based terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->