### PR TITLE
Remove dataset references from skills

### DIFF
--- a/skills/osmo-deploy/SKILL.md
+++ b/skills/osmo-deploy/SKILL.md
@@ -198,7 +198,7 @@ aws eks describe-cluster --name <cluster> --query "cluster.identity.oidc.issuer"
 
 ## NFS storage account (`--with-nfs-storage`, azure only)
 
-Pass `--with-nfs-storage` on Azure when a downstream skill on the cluster needs an Azure Files Premium NFS-backed `ReadWriteMany` StorageClass. The canonical consumer is NIM Operator multi-node inference (its NIMCache + shared-model volumes are RWX-only per https://docs.nvidia.com/nim-operator/latest/multi-node.html); other RWX users (shared dataset caches, KServe RWX models) need it too.
+Pass `--with-nfs-storage` on Azure when a downstream skill on the cluster needs an Azure Files Premium NFS-backed `ReadWriteMany` StorageClass. The canonical consumer is NIM Operator multi-node inference (its NIMCache + shared-model volumes are RWX-only per https://docs.nvidia.com/nim-operator/latest/multi-node.html); other RWX users (shared data caches, KServe RWX models) need it too.
 
 What osmo provisions: a Premium FileStorage Azure Storage Account (VNet-restricted, output as `nfs_storage_account`) and the four AKS role assignments `file.csi.azure.com` needs to dynamically provision NFS file shares against it — Network Contributor on the VNet, on the AKS NSG, and on the database NSG, plus Storage Account Contributor scoped to the NFS SA. Without all four, dynamic PVC provisioning fails with `LinkedAuthorizationFailed`.
 

--- a/skills/osmo-user/SKILL.md
+++ b/skills/osmo-user/SKILL.md
@@ -46,7 +46,7 @@ Before the first OSMO command in a conversation:
 - Do not edit cluster config, node taints, quota policies, or non-OSMO
   Kubernetes resources. Those are admin-side operations.
 - Do not edit server-side OSMO configuration (`osmo config`): pod or group
-  templates, resource validations, pool/backend config, roles, or dataset
+  templates, resource validations, pool/backend config, roles, or storage
   buckets. That is the OSMO admin surface — say it is out of scope and do not
   attempt it here.
 

--- a/skills/osmo-user/evals/environment/workflows/jinja_workflow.yaml
+++ b/skills/osmo-user/evals/environment/workflows/jinja_workflow.yaml
@@ -14,7 +14,7 @@ workflow:
         set -e
         echo "Starting GR00T fine-tuning with {{num_gpu}} GPUs"
         python -m gr00t.train \
-          --dataset /workflow/inputs/dataset \
+          --input-dir {{input:0}} \
           --output {{output}}/model \
           --num-gpus {{num_gpu}} \
           --epochs ${EPOCHS} \
@@ -22,11 +22,9 @@ workflow:
         echo "Training complete"
       path: /tmp/entry.sh
     inputs:
-    - dataset:
-        name: gr00t-pick-and-place
+    - url: s3://my-bucket/gr00t-pick-and-place/
     outputs:
-    - dataset:
-        name: gr00t-train-output
+    - url: s3://my-bucket/gr00t-train-output/
   resources:
     default:
       cpu: 32

--- a/skills/osmo-user/evals/environment/workflows/oversized.yaml
+++ b/skills/osmo-user/evals/environment/workflows/oversized.yaml
@@ -13,8 +13,7 @@ workflow:
         python -m isaac.sdg --num-images 1000 --out {{output}}/images
       path: /tmp/entry.sh
     outputs:
-    - dataset:
-        name: oversized-output
+    - url: s3://my-bucket/oversized-output/
   resources:
     default:
       cpu: 300

--- a/skills/osmo-user/evals/environment/workflows/simple_workflow.yaml
+++ b/skills/osmo-user/evals/environment/workflows/simple_workflow.yaml
@@ -16,8 +16,7 @@ workflow:
         echo "Hello World" > {{output}}/hello.txt
       path: /tmp/entry.sh
     outputs:
-    - dataset:
-        name: hello-world-output
+    - url: s3://my-bucket/hello-world-output/
   resources:
     default:
       cpu: 2

--- a/skills/osmo-user/evals/files/fixtures/default/workflow_logs_single_task.txt
+++ b/skills/osmo-user/evals/files/fixtures/default/workflow_logs_single_task.txt
@@ -1,6 +1,6 @@
 [2026-05-05 18:01:30] Starting GR00T training run
-[2026-05-05 18:01:31] Loading dataset from input mount: /workflow/inputs/dataset
-[2026-05-05 18:01:34] Dataset loaded: 12,800 trajectories
+[2026-05-05 18:01:31] Loading input data from mount: /osmo/input/0
+[2026-05-05 18:01:34] Input data loaded: 12,800 trajectories
 [2026-05-05 18:01:35] Initializing model: GR00T-N1.5-3B
 [2026-05-05 18:01:48] Model loaded onto 4x H100 GPUs
 [2026-05-05 18:01:48] Beginning training: 10000 steps total

--- a/skills/osmo-user/evals/files/fixtures/default/workflow_logs_tool.txt
+++ b/skills/osmo-user/evals/files/fixtures/default/workflow_logs_tool.txt
@@ -1,4 +1,4 @@
-[2026-05-09 09:01:30] Starting dataset conversion
-[2026-05-09 09:01:31] Reading manifest from /workflow/inputs/dataset/manifest.json
+[2026-05-09 09:01:30] Starting data conversion
+[2026-05-09 09:01:31] Reading manifest from /osmo/input/0/manifest.json
 [2026-05-09 09:01:33] Found 4,200 records to convert
 [2026-05-09 09:02:05] /tmp/entry.sh: line 6: jq: command not found

--- a/skills/osmo-user/evals/files/fixtures/default/workflow_spec_pending.yaml
+++ b/skills/osmo-user/evals/files/fixtures/default/workflow_spec_pending.yaml
@@ -6,7 +6,7 @@ workflow:
     command: ["bash"]
     args: ["/tmp/entry.sh"]
     environment:
-      DATASET_NAME: gr00t-pick-and-place
+      INPUT_NAME: gr00t-pick-and-place
       EPOCHS: "20"
       BATCH_SIZE: "64"
     files:
@@ -15,17 +15,15 @@ workflow:
         set -e
         echo "Starting GR00T fine-tuning"
         python -m gr00t.train \
-          --dataset /workflow/inputs/dataset \
+          --input-dir {{input:0}} \
           --output {{output}}/model \
           --num-gpus 32
         echo "Training complete"
       path: /tmp/entry.sh
     inputs:
-    - dataset:
-        name: gr00t-pick-and-place
+    - url: s3://my-bucket/gr00t-pick-and-place/
     outputs:
-    - dataset:
-        name: stuck-train-1-output
+    - url: s3://my-bucket/stuck-train-1-output/
   resources:
     default:
       cpu: 64

--- a/skills/osmo-user/evals/files/fixtures/default/workflow_spec_sdg.yaml
+++ b/skills/osmo-user/evals/files/fixtures/default/workflow_spec_sdg.yaml
@@ -14,7 +14,7 @@ workflow:
         echo "Starting Isaac Sim SDG"
         python -m isaac.sdg \
           --num-images 1000 \
-          --out {{outputs}}/images
+          --out {{output}}/images
         echo "Generation complete"
       path: /tmp/entry.sh
     outputs:

--- a/skills/osmo-user/evals/files/fixtures/default/workflow_spec_sdg.yaml
+++ b/skills/osmo-user/evals/files/fixtures/default/workflow_spec_sdg.yaml
@@ -18,8 +18,7 @@ workflow:
         echo "Generation complete"
       path: /tmp/entry.sh
     outputs:
-    - dataset:
-        name: sdg-train-1-output
+    - url: s3://my-bucket/sdg-train-1-output/
   resources:
     default:
       cpu: 16

--- a/skills/osmo-user/evals/files/fixtures/default/workflow_spec_template.yaml
+++ b/skills/osmo-user/evals/files/fixtures/default/workflow_spec_template.yaml
@@ -6,7 +6,7 @@ workflow:
     command: ["bash"]
     args: ["/tmp/entry.sh"]
     environment:
-      DATASET_NAME: gr00t-pick-and-place
+      INPUT_NAME: gr00t-pick-and-place
       EPOCHS: "10"
       BATCH_SIZE: "32"
     files:
@@ -15,17 +15,15 @@ workflow:
         set -e
         echo "Starting GR00T fine-tuning"
         python -m gr00t.train \
-          --dataset /workflow/inputs/dataset \
+          --input-dir {{input:0}} \
           --output {{output}}/model \
           --num-gpus {{num_gpu}}
         echo "Training complete"
       path: /tmp/entry.sh
     inputs:
-    - dataset:
-        name: gr00t-pick-and-place
+    - url: s3://my-bucket/gr00t-pick-and-place/
     outputs:
-    - dataset:
-        name: gr00t-train-1-output
+    - url: s3://my-bucket/gr00t-train-1-output/
   resources:
     default:
       cpu: 32

--- a/skills/osmo-user/references/cookbook-fetching.md
+++ b/skills/osmo-user/references/cookbook-fetching.md
@@ -84,8 +84,7 @@ workflow:
         <shell script to run>
       path: /tmp/entry.sh
     outputs:
-    - dataset:
-        name: <output-dataset-name>
+    - url: <output-storage-url>
   resources:
     default:
       cpu: <N>
@@ -95,5 +94,5 @@ workflow:
 ```
 
 Use `{{output}}` as a placeholder in the entry script wherever the task should
-write its output data — OSMO replaces this at runtime with the output dataset
+write its output data — OSMO replaces this at runtime with the task's output
 path. Do not use `{{outputs}}` (plural); only `{{output}}` is substituted.

--- a/skills/osmo-user/references/logs-reader.md
+++ b/skills/osmo-user/references/logs-reader.md
@@ -84,7 +84,7 @@ Return your response in this format:
 ## Workflow: <workflow_id>
 
 ### Task: <task_name>  (or "Overall" if un-split)
-- **Stage / progress**: What stage is this task at? (e.g. "downloading dataset",
+- **Stage / progress**: What stage is this task at? (e.g. "downloading input data",
   "training step 840/1000 — 84% complete", "completed successfully")
 - **Key events**: Any notable milestones, warnings, or errors seen in the logs
   (1–3 bullet points, skip if nothing notable)
@@ -102,7 +102,7 @@ Return your response in this format:
   so in one line (e.g. "Container starting, no application output yet").
 - If training is in progress, include the latest step/epoch count and loss if
   visible.
-- If the task completed, say so and note any output dataset paths mentioned.
+- If the task completed, say so and note any output storage paths mentioned.
 - Never dump raw log lines except for error output (up to 50 lines).
 - Keep the entire response under ~300 words so the main agent can use it
   efficiently without hitting context limits.

--- a/skills/osmo-user/references/troubleshooting.md
+++ b/skills/osmo-user/references/troubleshooting.md
@@ -204,8 +204,8 @@ prepare mounts). If init fails, the user task never runs.
 
 ### Fix
 - Common init failures:
-  - **Input dataset missing or wrong name** — verify the dataset name in
-    `inputs.dataset.name` matches an existing dataset (`osmo dataset list`).
+  - **Input storage path missing or wrong** — verify the task's `inputs` block
+    points to a valid upstream task output or object storage URL.
   - **Storage backend auth** — credentials for the pool's storage backend may be
     misconfigured; this is an admin issue, ask the user to file a ticket.
   - **Network/permission issue** — events usually carry the underlying error.
@@ -241,11 +241,11 @@ Inter-GPU communication is broken or too slow. Possible causes:
 
 ---
 
-## Output dataset empty or missing after COMPLETED
+## Output data missing after COMPLETED
 
 ### Signature
 - Workflow status `COMPLETED`, exit code `0`.
-- The output dataset listed in the workflow spec exists but is empty, or the
+- The output location listed in the workflow spec exists but is empty, or the
   expected files aren't there.
 - Common: the entry script created a directory like `{{outputs}}` or `output` as a
   literal name on the local filesystem instead of writing to the OSMO-mounted
@@ -253,7 +253,7 @@ Inter-GPU communication is broken or too slow. Possible causes:
 
 ### Diagnosis
 The script didn't write to the OSMO output mount. The workflow's `outputs` are
-declared via `outputs.dataset.name`, and the script is expected to write into the
+declared via the task's `outputs` block, and the script is expected to write into the
 path indicated by the placeholder `{{output}}` (singular).
 
 ### Fix

--- a/skills/osmo-user/references/workflow-expert.md
+++ b/skills/osmo-user/references/workflow-expert.md
@@ -38,7 +38,7 @@ Execute these steps using the osmo skill procedures:
 4. **Return** — After successful submission, return a structured response:
    - **Workflow ID** and **pool name**
    - **OSMO Web link**: <workflow overview link>
-   - **Output datasets** the workflow will produce (names from the YAML)
+   - **Output locations** the workflow will produce (task outputs or storage URLs from the YAML)
 
    Do NOT poll or monitor the workflow. Return immediately after submission.
 

--- a/skills/osmo-user/references/workflow-patterns.md
+++ b/skills/osmo-user/references/workflow-patterns.md
@@ -184,15 +184,15 @@ workflow:
   # Group 1: runs first
   - name: prepare-data
     tasks:
-    - name: generate-dataset
+    - name: generate-data
       lead: true
       image: ubuntu:24.04
       command: ["bash", "-c"]
       args:
       - |
         mkdir -p {{output}}/data
-        echo "sample_1,value_1" >> {{output}}/data/dataset.csv
-        echo "sample_2,value_2" >> {{output}}/data/dataset.csv
+        echo "sample_1,value_1" >> {{output}}/data/training_data.csv
+        echo "sample_2,value_2" >> {{output}}/data/training_data.csv
 
     - name: validate-data
       image: ubuntu:24.04
@@ -208,20 +208,20 @@ workflow:
       command: ["bash", "-c"]
       args:
       - |
-        cat {{input:0}}/data/dataset.csv
+        cat {{input:0}}/data/training_data.csv
         echo "Model A trained"
       inputs:
-      - task: generate-dataset   # establishes group dependency
+      - task: generate-data   # establishes group dependency
 
     - name: train-model-b
       image: ubuntu:24.04
       command: ["bash", "-c"]
       args:
       - |
-        wc -l {{input:0}}/data/dataset.csv
+        wc -l {{input:0}}/data/training_data.csv
         echo "Model B trained"
       inputs:
-      - task: generate-dataset
+      - task: generate-data
 ```
 
 **Execution flow:** `prepare-data` group completes → `train-models` group starts with
@@ -255,17 +255,17 @@ workflow:
     image: {{training_image}}
     command: ["python", "train.py"]
     args:
-    - "--dataset={{dataset_name}}"
+    - "--input={{input_url}}"
     - "--fold={{i}}"
     resource: training
     outputs:
-    - dataset:
-        name: "{{model_type}}_fold_{{i}}"
+    - url: "{{output_prefix}}/{{model_type}}/fold-{{i}}/"
   {% endfor %}
 
 default-values:
   workflow_name: ml-training
-  dataset_name: imagenet
+  input_url: s3://my-bucket/imagenet/
+  output_prefix: s3://my-bucket/training-runs
   model_type: resnet50
   num_tasks: 3
   gpu_count: 1

--- a/skills/osmo-user/references/workflow-status.md
+++ b/skills/osmo-user/references/workflow-status.md
@@ -109,10 +109,11 @@ whether this is quota exhaustion or physical capacity exhaustion. See
 
 After a workflow reaches `COMPLETED`:
 
-1. Offer the output dataset download. Ask: `Would you like me to download the
-   output dataset now?` Default the destination to `~/`. Run:
+1. If the workflow writes to an object storage URL, offer to download the
+   output data. Ask: `Would you like me to download the output data now?`
+   Default the destination to `~/`. Run:
    ```bash
-   osmo dataset download <dataset_name> <path>
+   osmo data download <storage_url> <path>
    ```
 2. Offer to create an OSMO app. Suggest a name derived from the workflow and a
    one-sentence description. If the user agrees, follow "Create an App" in
@@ -129,7 +130,7 @@ terminal state, handle failures, and report the result.
    Ask it to write workflow YAML if needed, check resources, and submit. Do not
    ask it to monitor, poll, or report final results.
 2. The subagent returns the workflow ID, pool name, OSMO Web link, and output
-   datasets.
+   locations.
 3. Monitor inline in the main conversation using "Check Workflow Status". If
    the user gives a cadence, honor it. Otherwise poll every 10-15 seconds for
    smoke tests, simple commands, and jobs expected to finish in minutes; poll
@@ -137,7 +138,7 @@ terminal state, handle failures, and report the result.
    seconds after several unchanged RUNNING or PENDING polls. Report state
    transitions to the user.
 4. If the workflow completes, report the workflow ID, OSMO Web link, output
-   datasets, and completed follow-ups.
+   locations, and completed follow-ups.
 5. If the workflow fails:
    - Fetch logs using the log-fetching rule from "Check Workflow Status".
    - Resume the same `workflow-expert` subagent and pass the logs summary:
@@ -157,7 +158,7 @@ workflow.
 2. Summarize the spec in plain language:
    - What it does
    - How it runs: image, command, entrypoint, and notable environment variables
-   - What it produces: datasets or artifacts
+   - What it produces: data outputs or artifacts
 
 Keep the summary concise. Do not provide a line-by-line YAML walkthrough unless
 the user asks.

--- a/skills/osmo-user/tests/orchestrator-runtime-failure.md
+++ b/skills/osmo-user/tests/orchestrator-runtime-failure.md
@@ -28,7 +28,7 @@ server-side validation:
 | #   | Bug                                                       | Why it passes validation                                          | Runtime symptom                                                                 | Expected fix                                                                      |
 | --- | --------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | 1   | `jq` used but not installed in `ubuntu:22.04`             | OSMO does not inspect script contents                             | `jq: command not found`, exit code 127                                          | Replace `jq` with pure bash, or prepend `apt-get update && apt-get install -y jq` |
-| 2   | `{{outputs}}` (plural) instead of `{{output}}` (singular) | OSMO does not validate template variables inside `files.contents` | `mkdir` creates a literal `{{outputs}}` directory; output dataset path is wrong | Change all `{{outputs}}` to `{{output}}`                                          |
+| 2   | `{{outputs}}` (plural) instead of `{{output}}` (singular) | OSMO does not validate template variables inside `files.contents` | `mkdir` creates a literal `{{outputs}}` directory; output path is wrong | Change all `{{outputs}}` to `{{output}}`                                          |
 
 **Bug ordering is deliberate.** Bug 1 triggers first because `set -e` aborts
 on the `jq` failure before reaching the `{{outputs}}` lines. This tests
@@ -68,7 +68,7 @@ workflow:
           '{message: "Hello World", host: $host, timestamp: $ts}' \
           > /tmp/report.json
 
-        # Write outputs to the dataset mount
+        # Write outputs to the output mount
         mkdir -p {{outputs}}
         cp /tmp/report.json {{outputs}}/report.json
         echo "Hello World from OSMO!" > {{outputs}}/hello.txt
@@ -76,8 +76,7 @@ workflow:
         echo "Done!"
       path: /tmp/entry.sh
     outputs:
-    - dataset:
-        name: hello-world-test-output
+    - url: s3://my-bucket/hello-world-test-output/
   resources:
     default:
       cpu: 2
@@ -113,7 +112,7 @@ status updates.
 - It checks pool availability, picks a pool with free GPUs, and submits.
 - Submission **succeeds** — no YAML structure or resource validation errors.
 - The workflow expert returns: workflow ID, pool name, monitoring commands,
-  and its agent ID for later resume.
+  output location, and its agent ID for later resume.
 
 **What to verify:**
 - The prompt sent to the workflow expert does NOT include monitoring instructions
@@ -169,7 +168,7 @@ status updates.
   - Workflow ID and COMPLETED status
   - OSMO Web link
   - What the workflow produced
-  - Offers to download the `hello-world-test-output` dataset
+  - Offers to download the output data from `s3://my-bucket/hello-world-test-output/`
 
 ## Success Criteria
 
@@ -206,7 +205,5 @@ status updates.
 
 ## Cleanup
 
-After the test, delete the test workflow and output dataset:
-```bash
-echo "y" | osmo dataset delete hello-world-test-output
-```
+After the test, delete the test workflow and remove the output files from
+`s3://my-bucket/hello-world-test-output/` if needed.


### PR DESCRIPTION
## Description
Remove stale OSMO dataset terminology from the skill docs and eval fixtures.

- update `skills/osmo-user` and `skills/osmo-deploy` guidance to use storage URLs and output locations instead of `dataset:` blocks and `osmo dataset`
- convert workflow snippets and eval fixtures from dataset-based inputs/outputs to storage URL or task-output examples
- refresh workflow follow-up and troubleshooting guidance to use output paths and `osmo data download`

Validation:
- `rg -n 'dataset|datasets|dataset:|osmo dataset|Dataset|Datasets' skills -g '*.md' -g '*.yaml' -g '*.yml' -g '*.txt'`
- `git diff --check -- skills`

Issue #911

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow and troubleshooting guidance to refer to output locations and storage paths instead of datasets.
  * Updated examples and templates to show S3 URL-based inputs and outputs.
  * Refined operating rules and workflow status wording for clearer scope and completion guidance.

* **Bug Fixes**
  * Improved workflow examples and logs to match the newer input/output path format, reducing confusion when following setup and runtime instructions.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->