### PR TITLE
 Remove dataset bootstrap config generation

### DIFF
--- a/deployments/charts/README.md
+++ b/deployments/charts/README.md
@@ -103,7 +103,7 @@ osmo credential set osmo --type DATA --payload \
 ```
 
 The quick-start values use the chart-managed LocalStack S3 service and already
-include OSMO's workflow, log, app, and dataset storage config. Do not run
+include OSMO's workflow, log, and app storage config. Do not run
 `deployments/scripts/configure-storage.sh` for this local flow. If you replace
 LocalStack with an external S3, Azure Blob, or BYO storage backend, run
 `deployments/scripts/configure-storage.sh` before the service Helm install and

--- a/deployments/charts/service/quick-start-values.yaml
+++ b/deployments/charts/service/quick-start-values.yaml
@@ -93,11 +93,6 @@ services:
         client: nvcr.io/nvidia/osmo/client:latest
       credential_config:
         disable_data_validation: ["s3"]
-    dataset:
-      buckets:
-        osmo:
-          dataset_path: s3://osmo/datasets
-      default_bucket: osmo
     podTemplates:
       default_compute:
         spec:

--- a/deployments/charts/service/templates/configs.yaml
+++ b/deployments/charts/service/templates/configs.yaml
@@ -39,10 +39,6 @@ data:
     workflow:
       {{- toYaml $cfg.workflow | nindent 6 }}
     {{- end }}
-    {{- if $cfg.dataset }}
-    dataset:
-      {{- toYaml $cfg.dataset | nindent 6 }}
-    {{- end }}
     {{- if $cfg.pools }}
     pools:
       {{- toYaml $cfg.pools | nindent 6 }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -473,11 +473,6 @@ services:
       max_exec_timeout: "30d"
       default_exec_timeout: "7d"
 
-    ## Dataset config (buckets, credentials).
-    ## Use credentialSecretName to reference K8s Secrets for bucket creds.
-    ##
-    dataset: {}
-
     ## Pod templates applied to workflow containers.
     ##
     podTemplates:

--- a/deployments/scripts/storage/common.sh
+++ b/deployments/scripts/storage/common.sh
@@ -77,13 +77,6 @@ EOF
       workflow_app:
         credential:
           secretName: osmo-workflow-app-cred
-    dataset:
-      buckets:
-        osmo-workflows:
-          dataset_path: $base_url
-          default_credential:
-            secretName: osmo-workflow-data-cred
-      default_bucket: osmo-workflows
 EOF
     } > "$OUTPUT_VALUES"
 }

--- a/deployments/upgrades/export_configs_to_helm.py
+++ b/deployments/upgrades/export_configs_to_helm.py
@@ -126,7 +126,7 @@ def strip_fields(data, fields):
 
 
 def export_singleton(base_url, headers, config_type, strip):
-    """Export a singleton config (service, workflow, dataset)."""
+    """Export a singleton config (service or workflow)."""
     data = fetch(base_url, f'/api/configs/{config_type}', headers)
     if data is None:
         return None
@@ -271,11 +271,6 @@ def main():
     workflow = export_singleton(base_url, headers, 'workflow', set())
     if workflow:
         configs['workflow'] = workflow
-
-    print('Exporting dataset config...', file=sys.stderr)
-    dataset = export_singleton(base_url, headers, 'dataset', set())
-    if dataset:
-        configs['dataset'] = dataset
 
     # Named configs
     print('Exporting backends...', file=sys.stderr)

--- a/run/update_configs.py
+++ b/run/update_configs.py
@@ -221,47 +221,6 @@ def _update_pod_template_config(detected_platform: str) -> None:
         raise RuntimeError(f'Unexpected error updating pod template configuration: {e}') from e
 
 
-def _update_dataset_config(dataset_path: str) -> None:
-    """Update dataset configuration."""
-    logger.info('📁 Updating dataset configuration...')
-
-    try:
-        dataset_config = {
-            'buckets': {
-                'osmo': {
-                    'dataset_path': dataset_path
-                }
-            },
-            'default_bucket': 'osmo'
-        }
-
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-            json.dump(dataset_config, f, indent=2)
-            dataset_file = f.name
-
-        process = run_command_with_logging([
-            'bazel', 'run', '@osmo_workspace//src/cli', '--', 'config', 'update', 'DATASET',
-            '--file', dataset_file,
-            '--description', 'Add dataset bucket'
-        ], 'Adding dataset configuration')
-
-        try:
-            os.unlink(dataset_file)
-        except OSError:
-            pass
-
-        if not process.has_failed():
-            logger.info('✅ Dataset configuration updated successfully in %.2fs',
-                        process.get_elapsed_time())
-        else:
-            logger.warning('⚠️  Warning: Failed to add dataset configuration')
-            logger.debug('   Check stderr: %s', process.stderr_file)
-
-    except OSError as e:
-        logger.error('❌ Unexpected error updating dataset configuration: %s', e)
-        raise RuntimeError(f'Unexpected error updating dataset configuration: {e}') from e
-
-
 def _update_service_config(mode: str) -> None:
     """Update service configuration."""
     logger.info('🔧 Updating service configuration...')
@@ -412,11 +371,6 @@ def main():
     parser.add_argument(
         '--object-storage-region', default='us-east-1',
         help='Object storage region (default: us-east-1)')
-    parser.add_argument(
-        '--dataset-path',
-        default='s3://osmo/datasets',
-        help='Dataset path (default: s3://osmo/datasets)')
-
     args = parser.parse_args()
 
     logger.setLevel(args.log_level)
@@ -451,9 +405,6 @@ def main():
                 args.image_tag)
 
             _update_pod_template_config(detected_platform)
-            dataset_path = args.dataset_path \
-                if args.dataset_path else posixpath.join(args.object_storage_endpoint, 'datasets')
-            _update_dataset_config(dataset_path)
             _update_service_config(args.mode)
             _update_backend_config(args.mode)
             _set_default_pool()


### PR DESCRIPTION
## Description
Remove the remaining run/deployments code paths that still generate dataset config during local/bootstrap setup. This stops `run/update_configs.py`, the merged service chart quick-start values, the storage values fragment, and the service chart config template from writing or accepting dataset config.

Validation for this PR:
- `PYTHONPYCACHEPREFIX=/private/tmp/pythoncache python3 -m py_compile run/update_configs.py`
- `helm lint deployments/charts/service`
- `helm lint deployments/charts/service -f deployments/charts/service/quick-start-values.yaml`
- `helm template test deployments/charts/service -f deployments/values/service.yaml >/tmp/osmo-service-template.yaml`
- `helm template test deployments/charts/service -f deployments/charts/service/quick-start-values.yaml >/tmp/osmo-quickstart-template.yaml`
- `rg -n "api/configs/dataset|dataset_path|default_bucket|Add dataset bucket|services\.configs\.dataset" run deployments`

Issue #911

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed dataset bucket configuration from the service’s default and generated Helm/static values.
  - Simplified local update tooling by removing dataset path support and related export logic.
  - Updated generated config output to proceed directly from workflow settings to pool settings.
- **Documentation**
  - Revised the Local KIND Example README wording to reflect that dataset storage config is no longer included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->