### PR TITLE
Remove dataset references from osmo-admin skill

### DIFF
--- a/skills/osmo-admin/SKILL.md
+++ b/skills/osmo-admin/SKILL.md
@@ -80,7 +80,7 @@ Use this skill for OSMO admin questions about:
 
 - pool, backend, platform, quota, maintenance, topology, template, or storage
   desired state
-- service config, workflow config, dataset config, backend, role, resource
+- service config, workflow config, backend, role, resource
   validation, pod template, group template, or backend test definitions
 - read-only answers such as which pools are in maintenance, which roles grant
   access, which tests attach to a backend, or which mounts a pool resolves to
@@ -162,7 +162,7 @@ stop gathering and answer.
 Read for service-values work itself: discovering config files under the provided
 root, `services.configs` key mapping, read-only answers, local edits, history
 when available, rollback diffs, safe removals, and admin-flow specifics for
-pool/backend/storage/role/template/validation/workflow/dataset/backend-test
+pool/backend/storage/role/template/validation/workflow/backend-test
 values.
 
 ## Limitations

--- a/skills/osmo-admin/evals/evals.json
+++ b/skills/osmo-admin/evals/evals.json
@@ -95,11 +95,10 @@
     {
       "id": "osmo-admin-007",
       "prompt": "Config root: repo. In sample-prod, which secret references must exist before this service config can be used safely?",
-      "expected_output": "The answer inventories secret references from provided config files without printing secret values. It reports service auth jwt_private_key_refs, dataset credentialSecretName values, and services.configs.secretRefs entries. It treats live secret existence checks as outside the public skill unless the user provides a separate safe process.",
+      "expected_output": "The answer inventories secret references from provided config files without printing secret values. It reports service auth jwt_private_key_refs and services.configs.secretRefs entries. It treats live secret existence checks as outside the public skill unless the user provides a separate safe process.",
       "assertions": [
         "The agent reads the osmo-admin SKILL.md and service-configs reference.",
         "The agent reads services.configs.service.service_auth.jwt_private_key_refs.",
-        "The agent reads services.configs.dataset.buckets credentialSecretName values.",
         "The agent reads services.configs.secretRefs in service-values.yaml.",
         "The response cites source file paths and YAML key paths for every reported secret reference.",
         "The response reports only secret names, key names, and reference keys, never secret payloads.",

--- a/skills/osmo-admin/evals/files/repo/charts/service/templates/configs.yaml
+++ b/skills/osmo-admin/evals/files/repo/charts/service/templates/configs.yaml
@@ -6,7 +6,6 @@ data:
   config.yaml: |
     service: {{ .Values.services.configs.service | toYaml | nindent 6 }}
     workflow: {{ .Values.services.configs.workflow | toYaml | nindent 6 }}
-    dataset: {{ .Values.services.configs.dataset | toYaml | nindent 6 }}
     pools: {{ .Values.services.configs.pools | toYaml | nindent 6 }}
     pod_templates: {{ .Values.services.configs.podTemplates | toYaml | nindent 6 }}
     resource_validations: {{ .Values.services.configs.resourceValidations | toYaml | nindent 6 }}

--- a/skills/osmo-admin/evals/files/repo/charts/service/values.yaml
+++ b/skills/osmo-admin/evals/files/repo/charts/service/values.yaml
@@ -2,7 +2,6 @@ services:
   configs:
     service: {}
     workflow: {}
-    dataset: {}
     pools: {}
     podTemplates: {}
     resourceValidations: {}

--- a/skills/osmo-admin/evals/files/repo/deployments/osmo/environments/sample-prod/service-configs.yaml
+++ b/skills/osmo-admin/evals/files/repo/deployments/osmo/environments/sample-prod/service-configs.yaml
@@ -32,17 +32,6 @@ services:
               writable: true
       default_backend_image: ghcr.io/example/osmo/backend:6.3.0
       max_workflow_runtime: 30d
-    dataset:
-      default_bucket: main
-      buckets:
-        main:
-          dataset_path: s3://osmo-sample-datasets
-          credentialSecretName: osmo-sample-dataset-s3
-          mode: readwrite
-        archive:
-          dataset_path: s3://osmo-sample-archive
-          credentialSecretName: osmo-sample-dataset-s3
-          mode: readonly
     backends:
       gpu-backend-a:
         scheduler_settings:
@@ -80,7 +69,7 @@ services:
         policies:
           - actions:
               - workflow:*
-              - dataset:read
+              - resources:Read
             resources:
               - pool/gpu-prod*
               - backend/gpu-backend-a

--- a/skills/osmo-admin/evals/files/repo/deployments/osmo/environments/sample-prod/service-values.yaml
+++ b/skills/osmo-admin/evals/files/repo/deployments/osmo/environments/sample-prod/service-values.yaml
@@ -6,4 +6,4 @@ services:
   configs:
     secretRefs:
       - secretName: osmo-sample-service-auth
-      - secretName: osmo-sample-dataset-s3
+      - secretName: osmo-sample-registry-cred

--- a/skills/osmo-admin/references/service-configs.md
+++ b/skills/osmo-admin/references/service-configs.md
@@ -100,7 +100,6 @@ the spelling used in the source values file.
 |---|---|---|
 | `services.configs.service` | `service` | CLI version pins, auth metadata, queues |
 | `services.configs.workflow` | `workflow` | workflow defaults, plugins, limits, timeouts |
-| `services.configs.dataset` | `dataset` | dataset buckets and default bucket |
 | `services.configs.pools` | `pools` | pool quotas, templates, platforms, maintenance |
 | `services.configs.podTemplates` | `pod_templates` | task pod overlays and mounts |
 | `services.configs.resourceValidations` | `resource_validations` | submit-time assertions |
@@ -323,7 +322,7 @@ services:
         policies:
           - actions:
               - workflow:*
-              - dataset:read
+              - resources:Read
             resources:
               - pool/example-arm64-cpu*
               - backend/example-backend
@@ -391,19 +390,6 @@ Do not infer storage only from template names. Verify volumes or mounts.
    roles.
 4. Explain that local config changes affect service behavior only after the
    user's own rollout process applies them; it is not a live pod drain.
-
-### Dataset Config
-
-Use `services.configs.dataset.default_bucket` and
-`services.configs.dataset.buckets`.
-
-- Preserve existing buckets and credential references unless the user asks to
-  change them.
-- If adding a bucket, ask for required deployment-specific details such as mode
-  or credential reference when they are missing.
-- Removing a bucket unregisters it from OSMO but does not delete backing
-  storage.
-- If removing the default bucket, ask for the replacement default first.
 
 ### Workflow Config
 


### PR DESCRIPTION
## Description
Remove the remaining OSMO dataset references from the `osmo-admin` skill and keep its sample repo fixtures and eval expectations aligned with the post-dataset config surface.

This updates the skill contract and service-config reference docs to stop teaching `services.configs.dataset`, removes dataset-specific sample config blocks from the eval repo fixtures, and rewrites the affected eval expectation to focus on the secret references that still exist.

Issue #911 

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified live service-config handling so dataset-specific settings are no longer treated as a special case.
  * Updated sample environments and validation expectations to use a dataset-agnostic service reference path.

* **Documentation**
  * Refreshed admin guidance to reflect the updated service configuration layout.
  * Removed outdated dataset configuration examples and related setup notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->