### PR TITLE
Read legacy dataset config history

### DIFF
--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -27,6 +27,7 @@ from src.cli.formatters import RstStrippingHelpFormatter
 from src.lib.utils import client, common, config_history, osmo_errors, role, validation
 
 CONFIG_TYPES_STRING = ', '.join(config_history.CONFIG_TYPES)
+OPERABLE_CONFIG_TYPES_STRING = ', '.join(config_history.OPERABLE_CONFIG_TYPES)
 
 
 class ConfigApiMapping(TypedDict):
@@ -77,6 +78,7 @@ UPDATE_CONFIG_API_MAPPING: Dict[
         'named': {'method': client.RequestMethod.PUT, 'payload_key': 'configs'},
     },
 }
+update_choices = sorted([key.value for key in UPDATE_CONFIG_API_MAPPING])
 
 
 DELETE_CONFIG_SUPPORTED_TYPES: Set[config_history.ConfigHistoryType] = {
@@ -222,7 +224,7 @@ def _run_rollback_command(service_client: client.ServiceClient, args: argparse.N
         service_client: The service client instance
         args: Parsed command line arguments
     """
-    revision = config_history.ConfigHistoryRevision(args.revision)
+    revision = config_history.OperableConfigHistoryRevision(args.revision)
     payload = {
         'revision': revision.revision,
         'config_type': revision.config_type.value,
@@ -256,6 +258,7 @@ def _run_list_command(service_client: client.ServiceClient, args: argparse.Names
     """
     # Build query parameters
     params: Dict[str, Any] = {
+        'config_types': config_history.OPERABLE_CONFIG_TYPES,
         'omit_data': True,
         'at_timestamp': common.current_time()
     }
@@ -326,10 +329,10 @@ def _get_current_config(
         config_type: The string config type from parsed arguments
         params: Optional query parameters to include in the request
     """
-    if config_type not in [t.value for t in config_history.ConfigHistoryType]:
+    if config_type not in config_history.OPERABLE_CONFIG_TYPES:
         raise osmo_errors.OSMOUserError(
             f'Invalid config type "{config_type}". '
-            f'Available types: {CONFIG_TYPES_STRING}'
+            f'Available types: {OPERABLE_CONFIG_TYPES_STRING}'
         )
     return service_client.request(
         client.RequestMethod.GET, f'api/configs/{config_type.lower()}', params=params
@@ -556,7 +559,7 @@ def _run_delete_command(service_client: client.ServiceClient, args: argparse.Nam
     """
     # Check if config_type contains a revision number (format: CONFIG_TYPE:revision)
     if ':' in args.config:
-        revision = config_history.ConfigHistoryRevision(args.config)
+        revision = config_history.OperableConfigHistoryRevision(args.config)
 
         try:
             service_client.request(
@@ -568,10 +571,10 @@ def _run_delete_command(service_client: client.ServiceClient, args: argparse.Nam
         except Exception as e:
             raise osmo_errors.OSMOUserError(f'Error deleting config revision: {e}')
     else:
-        if args.config not in [t.value for t in config_history.ConfigHistoryType]:
+        if args.config not in config_history.OPERABLE_CONFIG_TYPES:
             raise osmo_errors.OSMOUserError(
                 f'Invalid config type "{args.config}". '
-                f'Available types: {CONFIG_TYPES_STRING}')
+                f'Available types: {OPERABLE_CONFIG_TYPES_STRING}')
 
         # Delete a named config
         if not args.name:
@@ -701,15 +704,15 @@ def _run_tag_command(service_client: client.ServiceClient, args: argparse.Namesp
     # Parse the config identifier
     if ':' in args.config:
         # Format is <CONFIG_TYPE>:<revision>
-        revision = config_history.ConfigHistoryRevision(args.config)
+        revision = config_history.OperableConfigHistoryRevision(args.config)
         config_type = revision.config_type.value.lower()
         revision_num = revision.revision
     else:
         # Format is <CONFIG_TYPE> - use current revision
-        if args.config not in [t.value for t in config_history.ConfigHistoryType]:
+        if args.config not in config_history.OPERABLE_CONFIG_TYPES:
             raise osmo_errors.OSMOUserError(
                 f'Invalid config type "{args.config}". '
-                f'Available types: {CONFIG_TYPES_STRING}')
+                f'Available types: {OPERABLE_CONFIG_TYPES_STRING}')
         config_type = args.config.lower()
         # Get the latest revision
         params = {
@@ -938,7 +941,7 @@ Show a pool configuration with parsed pod templates, group templates, and resour
         usage='osmo config update [-h] config_type [name] [--file FILE] [--description DESCRIPTION]'
               ' [--tags TAGS [TAGS ...]]',
         epilog=f'''
-Available config types (CONFIG_TYPE): {CONFIG_TYPES_STRING}
+Available config types (CONFIG_TYPE): {OPERABLE_CONFIG_TYPES_STRING}
 
 Examples
 ========
@@ -958,7 +961,7 @@ Update with description and tags::
     )
     update_parser.add_argument(
         'config',
-        choices=config_history.CONFIG_TYPES,
+        choices=update_choices,
         metavar='config_type',
         help='Config type to update (CONFIG_TYPE)',
     )
@@ -1146,7 +1149,7 @@ View history for a specific time range::
         usage='osmo config rollback [-h] revision [--description DESCRIPTION] '
               '[--tags TAGS [TAGS ...]]',
         epilog=f'''
-Available config types (CONFIG_TYPE): {CONFIG_TYPES_STRING}
+Available config types (CONFIG_TYPE): {OPERABLE_CONFIG_TYPES_STRING}
 
 Examples
 ========
@@ -1239,7 +1242,7 @@ Creating a new backend role::
         usage='osmo config tag [-h] config_type [--set SET [SET ...]] '
               '[--delete DELETE [DELETE ...]]',
         epilog=f'''
-Available config types (CONFIG_TYPE): {CONFIG_TYPES_STRING}
+Available config types (CONFIG_TYPE): {OPERABLE_CONFIG_TYPES_STRING}
 
 Examples
 ========

--- a/src/lib/utils/config_history.py
+++ b/src/lib/utils/config_history.py
@@ -24,6 +24,7 @@ from . import osmo_errors
 
 class ConfigHistoryType(enum.Enum):
     """ Type of configs supported by config history """
+    DATASET = 'DATASET'
     SERVICE = 'SERVICE'
     WORKFLOW = 'WORKFLOW'
     BACKEND = 'BACKEND'
@@ -37,6 +38,11 @@ class ConfigHistoryType(enum.Enum):
 
 CONFIG_TYPES = sorted([t.value for t in ConfigHistoryType])
 CONFIG_TYPES_REGEX = rf'^({'|'.join(CONFIG_TYPES)}):([1-9][0-9]*)$'
+
+OPERABLE_CONFIG_TYPES = sorted([
+    t.value for t in ConfigHistoryType if t != ConfigHistoryType.DATASET
+])
+OPERABLE_CONFIG_TYPES_REGEX = rf'^({'|'.join(OPERABLE_CONFIG_TYPES)}):([1-9][0-9]*)$'
 
 
 class ConfigHistoryRevision:
@@ -52,6 +58,24 @@ class ConfigHistoryRevision:
             raise osmo_errors.OSMOUserError(
                 f'Invalid revision "{revision}": expected <CONFIG_TYPE>:<revision> where ' +
                 f'<CONFIG_TYPE> is one of {', '.join(CONFIG_TYPES)}')
+
+        self.config_type = ConfigHistoryType(parsed_revision.group(1).upper())
+        self.revision = int(parsed_revision.group(2))
+
+
+class OperableConfigHistoryRevision:
+    """Splits operable config type and revision number."""
+
+    config_type: ConfigHistoryType
+    revision: int
+
+    def __init__(self, revision: str):
+        parsed_revision = re.fullmatch(OPERABLE_CONFIG_TYPES_REGEX, revision)
+
+        if not parsed_revision:
+            raise osmo_errors.OSMOUserError(
+                f'Invalid revision "{revision}": expected <CONFIG_TYPE>:<revision> where ' +
+                f'<CONFIG_TYPE> is one of {', '.join(OPERABLE_CONFIG_TYPES)}')
 
         self.config_type = ConfigHistoryType(parsed_revision.group(1).upper())
         self.revision = int(parsed_revision.group(2))

--- a/src/service/core/config/config_service.py
+++ b/src/service/core/config/config_service.py
@@ -1087,7 +1087,8 @@ def rollback_config(
         if request.description else description_base
     )
 
-    if request.config_type == connectors.OperableConfigHistoryType.SERVICE:
+    config_type_value = request.config_type.value
+    if config_type_value == connectors.ConfigHistoryType.SERVICE.value:
         helpers.put_configs(
             objects.PutConfigsRequest(
                 configs=connectors.ServiceConfig.from_db(history_entry['data']),
@@ -1099,7 +1100,7 @@ def rollback_config(
             # The config from history is already serialized, so we don't need to serialize it again
             should_serialize=False
         )
-    elif request.config_type == connectors.OperableConfigHistoryType.WORKFLOW:
+    elif config_type_value == connectors.ConfigHistoryType.WORKFLOW.value:
         helpers.put_configs(
             objects.PutConfigsRequest(
                 configs=connectors.WorkflowConfig.from_db(history_entry['data']),
@@ -1111,7 +1112,7 @@ def rollback_config(
             # The config from history is already serialized, so we don't need to serialize it again
             should_serialize=False
         )
-    elif request.config_type == connectors.OperableConfigHistoryType.BACKEND:
+    elif config_type_value == connectors.ConfigHistoryType.BACKEND.value:
         # Delete all existing backends
         existing_backends = connectors.Backend.list_from_db(postgres)
         next_backends = [backend['name'] for backend in history_entry['data']]
@@ -1132,7 +1133,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.OperableConfigHistoryType.POOL:
+    elif config_type_value == connectors.ConfigHistoryType.POOL.value:
         # Delete all existing pools
         existing_pools = connectors.fetch_editable_pool_config(postgres)
         pools_to_remove = [
@@ -1149,7 +1150,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.OperableConfigHistoryType.POD_TEMPLATE:
+    elif config_type_value == connectors.ConfigHistoryType.POD_TEMPLATE.value:
         # Delete all existing pod templates
         existing_pod_templates = connectors.PodTemplate.list_from_db(postgres)
         pod_templates_to_remove = [
@@ -1168,7 +1169,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.OperableConfigHistoryType.GROUP_TEMPLATE:
+    elif config_type_value == connectors.ConfigHistoryType.GROUP_TEMPLATE.value:
         # Delete all existing group templates
         existing_group_templates = connectors.GroupTemplate.list_from_db(postgres)
         group_templates_to_remove = [
@@ -1187,7 +1188,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.OperableConfigHistoryType.RESOURCE_VALIDATION:
+    elif config_type_value == connectors.ConfigHistoryType.RESOURCE_VALIDATION.value:
         # Delete all existing resource validations
         existing_resource_validations = connectors.ResourceValidation.list_from_db(postgres)
         resource_validations_to_remove = [
@@ -1206,7 +1207,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.OperableConfigHistoryType.BACKEND_TEST:
+    elif config_type_value == connectors.ConfigHistoryType.BACKEND_TEST.value:
         # Delete all existing backend tests
         existing_backend_tests = connectors.BackendTests.list_from_db(postgres)
         backend_tests_to_remove = [
@@ -1225,7 +1226,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.OperableConfigHistoryType.ROLE:
+    elif config_type_value == connectors.ConfigHistoryType.ROLE.value:
         # Delete all existing roles
         existing_roles = connectors.Role.list_from_db(postgres)
         next_roles = [role['name'] for role in history_entry['data']]

--- a/src/service/core/config/config_service.py
+++ b/src/service/core/config/config_service.py
@@ -1087,7 +1087,7 @@ def rollback_config(
         if request.description else description_base
     )
 
-    if request.config_type == connectors.ConfigHistoryType.SERVICE:
+    if request.config_type == connectors.OperableConfigHistoryType.SERVICE:
         helpers.put_configs(
             objects.PutConfigsRequest(
                 configs=connectors.ServiceConfig.from_db(history_entry['data']),
@@ -1099,7 +1099,7 @@ def rollback_config(
             # The config from history is already serialized, so we don't need to serialize it again
             should_serialize=False
         )
-    elif request.config_type == connectors.ConfigHistoryType.WORKFLOW:
+    elif request.config_type == connectors.OperableConfigHistoryType.WORKFLOW:
         helpers.put_configs(
             objects.PutConfigsRequest(
                 configs=connectors.WorkflowConfig.from_db(history_entry['data']),
@@ -1111,7 +1111,7 @@ def rollback_config(
             # The config from history is already serialized, so we don't need to serialize it again
             should_serialize=False
         )
-    elif request.config_type == connectors.ConfigHistoryType.BACKEND:
+    elif request.config_type == connectors.OperableConfigHistoryType.BACKEND:
         # Delete all existing backends
         existing_backends = connectors.Backend.list_from_db(postgres)
         next_backends = [backend['name'] for backend in history_entry['data']]
@@ -1132,7 +1132,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.ConfigHistoryType.POOL:
+    elif request.config_type == connectors.OperableConfigHistoryType.POOL:
         # Delete all existing pools
         existing_pools = connectors.fetch_editable_pool_config(postgres)
         pools_to_remove = [
@@ -1149,7 +1149,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.ConfigHistoryType.POD_TEMPLATE:
+    elif request.config_type == connectors.OperableConfigHistoryType.POD_TEMPLATE:
         # Delete all existing pod templates
         existing_pod_templates = connectors.PodTemplate.list_from_db(postgres)
         pod_templates_to_remove = [
@@ -1168,7 +1168,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.ConfigHistoryType.GROUP_TEMPLATE:
+    elif request.config_type == connectors.OperableConfigHistoryType.GROUP_TEMPLATE:
         # Delete all existing group templates
         existing_group_templates = connectors.GroupTemplate.list_from_db(postgres)
         group_templates_to_remove = [
@@ -1187,7 +1187,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.ConfigHistoryType.RESOURCE_VALIDATION:
+    elif request.config_type == connectors.OperableConfigHistoryType.RESOURCE_VALIDATION:
         # Delete all existing resource validations
         existing_resource_validations = connectors.ResourceValidation.list_from_db(postgres)
         resource_validations_to_remove = [
@@ -1206,7 +1206,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.ConfigHistoryType.BACKEND_TEST:
+    elif request.config_type == connectors.OperableConfigHistoryType.BACKEND_TEST:
         # Delete all existing backend tests
         existing_backend_tests = connectors.BackendTests.list_from_db(postgres)
         backend_tests_to_remove = [
@@ -1225,7 +1225,7 @@ def rollback_config(
             ),
             username
         )
-    elif request.config_type == connectors.ConfigHistoryType.ROLE:
+    elif request.config_type == connectors.OperableConfigHistoryType.ROLE:
         # Delete all existing roles
         existing_roles = connectors.Role.list_from_db(postgres)
         next_roles = [role['name'] for role in history_entry['data']]
@@ -1265,7 +1265,7 @@ def delete_config_history_revision(
         OSMOUserError: If the revision doesn't exist or is the current revision
     """
     try:
-        config_type_enum = connectors.ConfigHistoryType[config_type.upper()]
+        config_type_enum = connectors.OperableConfigHistoryType[config_type.upper()]
     except KeyError as e:
         raise osmo_errors.OSMOUserError(f'Invalid config type "{config_type}"') from e
     postgres = connectors.PostgresConnector.get_instance()
@@ -1327,7 +1327,7 @@ def update_config_history_tags(
         OSMOUserError: If the revision doesn't exist or is invalid
     """
     try:
-        config_type_enum = connectors.ConfigHistoryType[config_type.upper()]
+        config_type_enum = connectors.OperableConfigHistoryType[config_type.upper()]
     except KeyError as e:
         raise osmo_errors.OSMOUserError(f'Invalid config type "{config_type}"') from e
     postgres = connectors.PostgresConnector.get_instance()

--- a/src/service/core/config/objects.py
+++ b/src/service/core/config/objects.py
@@ -397,7 +397,7 @@ class GetConfigsHistoryResponse(pydantic.BaseModel):
 class RollbackConfigRequest(ConfigsRequest):
     """Request body for config rollback endpoint."""
 
-    config_type: connectors.ConfigHistoryType
+    config_type: connectors.OperableConfigHistoryType
     revision: int = pydantic.Field(gt=0, description='Revision to roll back to')
 
 

--- a/src/service/core/config/tests/test_config_history.py
+++ b/src/service/core/config/tests/test_config_history.py
@@ -178,7 +178,8 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'service-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.OperableConfigHistoryType.SERVICE,
+                config_type=connectors.OperableConfigHistoryType(
+                    connectors.ConfigHistoryType.SERVICE.value),
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back service config',
                 tags=rollback_tags,
@@ -256,7 +257,8 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'workflow-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.OperableConfigHistoryType.WORKFLOW,
+                config_type=connectors.OperableConfigHistoryType(
+                    connectors.ConfigHistoryType.WORKFLOW.value),
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back workflow config',
                 tags=rollback_tags,
@@ -345,7 +347,8 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'backend-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.OperableConfigHistoryType.BACKEND,
+                config_type=connectors.OperableConfigHistoryType(
+                    connectors.ConfigHistoryType.BACKEND.value),
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back backend config',
                 tags=rollback_tags,
@@ -429,7 +432,8 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'pool-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.OperableConfigHistoryType.POOL,
+                config_type=connectors.OperableConfigHistoryType(
+                    connectors.ConfigHistoryType.POOL.value),
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back pool config',
                 tags=rollback_tags,
@@ -508,7 +512,8 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'pod-template-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.OperableConfigHistoryType.POD_TEMPLATE,
+                config_type=connectors.OperableConfigHistoryType(
+                    connectors.ConfigHistoryType.POD_TEMPLATE.value),
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back pod template config',
                 tags=rollback_tags,
@@ -616,7 +621,8 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'resource-validation-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.OperableConfigHistoryType.RESOURCE_VALIDATION,
+                config_type=connectors.OperableConfigHistoryType(
+                    connectors.ConfigHistoryType.RESOURCE_VALIDATION.value),
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back resource validation config',
                 tags=rollback_tags,
@@ -709,7 +715,8 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'backend-test-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.OperableConfigHistoryType.BACKEND_TEST,
+                config_type=connectors.OperableConfigHistoryType(
+                    connectors.ConfigHistoryType.BACKEND_TEST.value),
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back backend test config',
                 tags=rollback_tags,
@@ -925,7 +932,8 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         with self.assertRaises(osmo_errors.OSMOUserError) as context:
             config_service.rollback_config(
                 request=objects.RollbackConfigRequest(
-                    config_type=connectors.OperableConfigHistoryType.SERVICE,
+                    config_type=connectors.OperableConfigHistoryType(
+                        connectors.ConfigHistoryType.SERVICE.value),
                     revision=middle_revision,
                     description='Attempting to roll back to deleted revision',
                 ),

--- a/src/service/core/config/tests/test_config_history.py
+++ b/src/service/core/config/tests/test_config_history.py
@@ -72,6 +72,45 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
             expected_tags=['initial-config'],
         )
 
+    def test_dataset_config_history_is_readable(self):
+        """Legacy dataset config history rows are readable as archived raw data."""
+        postgres = connectors.PostgresConnector.get_instance()
+        postgres.execute_commit_command(
+            """
+            INSERT INTO config_history
+                (config_type, revision, name, username, created_at, tags, description, data)
+            VALUES
+                (
+                    'dataset',
+                    1,
+                    '',
+                    'system',
+                    NOW(),
+                    ARRAY['legacy'],
+                    'Legacy dataset config',
+                    '{"buckets":{"legacy":{"dataset_path":"s3://legacy-bucket/datasets"}}}'
+                );
+            """,
+            (),
+        )
+
+        history = self._get_config_history(config_types=['DATASET'])
+
+        self.assertEqual(len(history['configs']), 1)
+        entry = history['configs'][0]
+        self.assertEqual(entry['config_type'], 'DATASET')
+        self.assertEqual(entry['data']['buckets']['legacy']['dataset_path'],
+                         's3://legacy-bucket/datasets')
+
+    def test_dataset_config_history_cannot_be_rolled_back(self):
+        """Dataset config history is readable but not a supported rollback target."""
+        response = self.client.post(
+            '/api/configs/history/rollback',
+            json={'config_type': 'DATASET', 'revision': 1},
+        )
+
+        self.assertEqual(response.status_code, 422)
+
     def test_service_config_history(self):
         """Test history entries for service config operations."""
         self._verify_initial_config_entry('SERVICE')
@@ -139,7 +178,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'service-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.ConfigHistoryType.SERVICE,
+                config_type=connectors.OperableConfigHistoryType.SERVICE,
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back service config',
                 tags=rollback_tags,
@@ -217,7 +256,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'workflow-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.ConfigHistoryType.WORKFLOW,
+                config_type=connectors.OperableConfigHistoryType.WORKFLOW,
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back workflow config',
                 tags=rollback_tags,
@@ -306,7 +345,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'backend-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.ConfigHistoryType.BACKEND,
+                config_type=connectors.OperableConfigHistoryType.BACKEND,
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back backend config',
                 tags=rollback_tags,
@@ -390,7 +429,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'pool-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.ConfigHistoryType.POOL,
+                config_type=connectors.OperableConfigHistoryType.POOL,
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back pool config',
                 tags=rollback_tags,
@@ -469,7 +508,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'pod-template-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.ConfigHistoryType.POD_TEMPLATE,
+                config_type=connectors.OperableConfigHistoryType.POD_TEMPLATE,
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back pod template config',
                 tags=rollback_tags,
@@ -577,7 +616,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'resource-validation-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.ConfigHistoryType.RESOURCE_VALIDATION,
+                config_type=connectors.OperableConfigHistoryType.RESOURCE_VALIDATION,
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back resource validation config',
                 tags=rollback_tags,
@@ -670,7 +709,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         rollback_tags = ['rollback-test', 'backend-test-rollback']
         config_service.rollback_config(
             request=objects.RollbackConfigRequest(
-                config_type=connectors.ConfigHistoryType.BACKEND_TEST,
+                config_type=connectors.OperableConfigHistoryType.BACKEND_TEST,
                 revision=history['configs'][-2]['revision'],
                 description='Rolling back backend test config',
                 tags=rollback_tags,
@@ -886,7 +925,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
         with self.assertRaises(osmo_errors.OSMOUserError) as context:
             config_service.rollback_config(
                 request=objects.RollbackConfigRequest(
-                    config_type=connectors.ConfigHistoryType.SERVICE,
+                    config_type=connectors.OperableConfigHistoryType.SERVICE,
                     revision=middle_revision,
                     description='Attempting to roll back to deleted revision',
                 ),

--- a/src/service/core/config/tests/test_config_history_helpers.py
+++ b/src/service/core/config/tests/test_config_history_helpers.py
@@ -21,6 +21,7 @@ import unittest
 
 from src.lib.utils import config_history, osmo_errors
 from src.service.core.config import config_history_helpers, objects
+from src.utils import connectors
 from src.utils.connectors.postgres import ListOrder
 
 
@@ -260,6 +261,23 @@ class TestConfigHistoryQueryParams(unittest.TestCase):
         with self.assertRaises(osmo_errors.OSMOUserError) as context:
             config_history.OperableConfigHistoryRevision('DATASET:1')
         self.assertIn('DATASET:1', str(context.exception))
+
+    def test_operable_config_history_type_excludes_history_only_types(self):
+        """Operable config history types are derived from history-readable types."""
+        expected_operable_values = {
+            config_type.value
+            for config_type in connectors.ConfigHistoryType
+            if config_type not in connectors.HISTORY_ONLY_CONFIG_HISTORY_TYPES
+        }
+
+        self.assertEqual(
+            {config_type.value for config_type in connectors.OperableConfigHistoryType},
+            expected_operable_values,
+        )
+        self.assertNotIn(
+            connectors.ConfigHistoryType.DATASET.value,
+            {config_type.value for config_type in connectors.OperableConfigHistoryType},
+        )
 
     def test_invalid_config_types(self):
         """Test validation of invalid config types."""

--- a/src/service/core/config/tests/test_config_history_helpers.py
+++ b/src/service/core/config/tests/test_config_history_helpers.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import datetime
 import unittest
 
-from src.lib.utils import config_history
+from src.lib.utils import config_history, osmo_errors
 from src.service.core.config import config_history_helpers, objects
 from src.utils.connectors.postgres import ListOrder
 
@@ -250,6 +250,16 @@ class TestConfigHistoryQueryParams(unittest.TestCase):
         self.assertEqual(
             params.config_types, config_types
         )
+
+    def test_dataset_history_revision_is_read_only(self):
+        """DATASET revisions are valid history ids but not operable ids."""
+        revision = config_history.ConfigHistoryRevision('DATASET:1')
+        self.assertEqual(revision.config_type, config_history.ConfigHistoryType.DATASET)
+        self.assertEqual(revision.revision, 1)
+
+        with self.assertRaises(osmo_errors.OSMOUserError) as context:
+            config_history.OperableConfigHistoryRevision('DATASET:1')
+        self.assertIn('DATASET:1', str(context.exception))
 
     def test_invalid_config_types(self):
         """Test validation of invalid config types."""

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -69,6 +69,20 @@ class ConfigType(enum.Enum):
 
 class ConfigHistoryType(enum.Enum):
     """ Type of configs supported by config history """
+    DATASET = 'DATASET'
+    SERVICE = 'SERVICE'
+    WORKFLOW = 'WORKFLOW'
+    BACKEND = 'BACKEND'
+    POOL = 'POOL'
+    POD_TEMPLATE = 'POD_TEMPLATE'
+    GROUP_TEMPLATE = 'GROUP_TEMPLATE'
+    RESOURCE_VALIDATION = 'RESOURCE_VALIDATION'
+    BACKEND_TEST = 'BACKEND_TEST'
+    ROLE = 'ROLE'
+
+
+class OperableConfigHistoryType(enum.Enum):
+    """Type of configs supported by config history mutations."""
     SERVICE = 'SERVICE'
     WORKFLOW = 'WORKFLOW'
     BACKEND = 'BACKEND'

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -81,17 +81,21 @@ class ConfigHistoryType(enum.Enum):
     ROLE = 'ROLE'
 
 
+HISTORY_ONLY_CONFIG_HISTORY_TYPES = frozenset({
+    ConfigHistoryType.DATASET,
+})
+
 class OperableConfigHistoryType(enum.Enum):
     """Type of configs supported by config history mutations."""
-    SERVICE = 'SERVICE'
-    WORKFLOW = 'WORKFLOW'
-    BACKEND = 'BACKEND'
-    POOL = 'POOL'
-    POD_TEMPLATE = 'POD_TEMPLATE'
-    GROUP_TEMPLATE = 'GROUP_TEMPLATE'
-    RESOURCE_VALIDATION = 'RESOURCE_VALIDATION'
-    BACKEND_TEST = 'BACKEND_TEST'
-    ROLE = 'ROLE'
+    SERVICE = ConfigHistoryType.SERVICE.value
+    WORKFLOW = ConfigHistoryType.WORKFLOW.value
+    BACKEND = ConfigHistoryType.BACKEND.value
+    POOL = ConfigHistoryType.POOL.value
+    POD_TEMPLATE = ConfigHistoryType.POD_TEMPLATE.value
+    GROUP_TEMPLATE = ConfigHistoryType.GROUP_TEMPLATE.value
+    RESOURCE_VALIDATION = ConfigHistoryType.RESOURCE_VALIDATION.value
+    BACKEND_TEST = ConfigHistoryType.BACKEND_TEST.value
+    ROLE = ConfigHistoryType.ROLE.value
 
 
 class DownloadType(str, enum.Enum):

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -85,17 +85,17 @@ HISTORY_ONLY_CONFIG_HISTORY_TYPES = frozenset({
     ConfigHistoryType.DATASET,
 })
 
-class OperableConfigHistoryType(enum.Enum):
-    """Type of configs supported by config history mutations."""
-    SERVICE = ConfigHistoryType.SERVICE.value
-    WORKFLOW = ConfigHistoryType.WORKFLOW.value
-    BACKEND = ConfigHistoryType.BACKEND.value
-    POOL = ConfigHistoryType.POOL.value
-    POD_TEMPLATE = ConfigHistoryType.POD_TEMPLATE.value
-    GROUP_TEMPLATE = ConfigHistoryType.GROUP_TEMPLATE.value
-    RESOURCE_VALIDATION = ConfigHistoryType.RESOURCE_VALIDATION.value
-    BACKEND_TEST = ConfigHistoryType.BACKEND_TEST.value
-    ROLE = ConfigHistoryType.ROLE.value
+# Mypy requires literal enum members, but deriving this enum keeps ConfigHistoryType
+# as the single source of truth for config history type values.
+OperableConfigHistoryType = enum.Enum(  # type: ignore[misc]
+    'OperableConfigHistoryType',
+    {
+        config_type.name: config_type.value for config_type in ConfigHistoryType
+        if config_type not in HISTORY_ONLY_CONFIG_HISTORY_TYPES
+    },
+    module=__name__,
+)
+OperableConfigHistoryType.__doc__ = 'Type of configs supported by config history mutations.'
 
 
 class DownloadType(str, enum.Enum):


### PR DESCRIPTION
## Description
Allow legacy `DATASET` config history rows to remain readable without restoring live dataset config support.

This adds `DATASET` back as a history-readable config type, keeps dataset history data raw, and introduces operable config-history types/revision parsing for mutation paths. Rollback, delete-revision, tag, update, set, and current-config listing remain limited to supported live config types, so `DATASET` behaves like an invalid target for mutating operations.

Concrete occasions where this matters: `osmo config list`, direct `GET /api/configs/history` calls, and any UI/CLI flow that renders config-history revision lists from that endpoint. In practice this is only needed when legacy `config_history` dataset rows are intentionally preserved in the database instead of being deleted during upgrade.

The deployment migration/hook changes that preserve `config_history` belong in #1125 and are intentionally not included here.



Issue #911

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for viewing dataset entries in the config history list.
* **Bug Fixes**
  * Rollback, delete, and tag now validate and interpret config types more consistently using “operable” config types; rollback of dataset history revisions is blocked.
* **Documentation**
  * CLI help and subcommand option choices now consistently display only config types that can be operated on (including update, rollback, and tag).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->