### PR TITLE
Remove stale dataset references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,8 @@ Entry point: `service/core/service.py`. Framework: FastAPI + Uvicorn + OpenTelem
 |-----------|---------|
 | `auth/` | JWT token lifecycle, access token CRUD, user management, role assignment |
 | `workflow/` | Workflow submit/list/cancel, resource quota, pool allocation, task coordination, credential management |
-| `config/` | Service/workflow configuration CRUD with versioning and history. Pod templates, resource validation rules, pool/backend config. Dataset config is deprecated; stale ConfigMap `dataset` blocks are ignored. |
-| `data/` | Dataset/collection management, versioning with tags, multi-backend storage, streaming downloads |
+| `config/` | Service/workflow configuration CRUD with versioning and history. Pod templates, resource validation rules, pool/backend config. |
+| `data/` | Workflow data and storage operations built on multi-backend storage. |
 | `app/` | Workflow app lifecycle (create, version, rename, delete), YAML spec validation |
 | `profile/` | User profile/preferences, token identity, role/pool visibility |
 
@@ -164,7 +164,7 @@ Features: Tab completion (shtab), response formatting (`formatters.py`), spec ed
 
 | Package | Purpose |
 |---------|---------|
-| `roles/` | Semantic RBAC. Actions like `workflow:Create`, `dataset:Read`. LRU cache with TTL. Role sync from IDP. Pool access evaluation. |
+| `roles/` | Semantic RBAC. Actions like `workflow:Create` and `pool:List`. LRU cache with TTL. Role sync from IDP. Pool access evaluation. |
 | `postgres/` | PostgreSQL client with pgx connection pool and pgroll schema version support. |
 | `redis/` | Redis client with optional TLS. |
 | `logging/` | Structured slog handler compatible with Fluent Bit parsers. |
@@ -182,7 +182,7 @@ Features: Tab completion (shtab), response formatting (`formatters.py`), spec ed
 - **State**: TanStack Query (data fetching), Zustand (UI state), nuqs (URL state)
 - **Testing**: Vitest (unit), Playwright (E2E), MSW (API mocking)
 - **API layer**: OpenAPI-generated types (`lib/api/generated.ts` — DO NOT EDIT) + adapter layer (`lib/api/adapter/`) that bridges backend quirks to UI expectations
-- **Key routes**: pools, resources, workflows, datasets, occupancy, profile, log-viewer (under `app/(dashboard)/`)
+- **Key routes**: pools, resources, workflows, occupancy, profile, log-viewer (under `app/(dashboard)/`)
 - **Import rules**: Absolute imports only (`@/...`), no barrel exports, API types from adapter (not generated)
 
 ### Operator (`operator/`)

--- a/skills/osmo-user/evals/files/fixtures/default/workflow_spec_private_image.yaml
+++ b/skills/osmo-user/evals/files/fixtures/default/workflow_spec_private_image.yaml
@@ -12,8 +12,8 @@ workflow:
         python -m gr00t.train --output {{output}}/model
       path: /tmp/entry.sh
     outputs:
-    - dataset:
-        name: private-image-output
+    - url:
+        path: s3://my-bucket/private-image-1-output/
   resources:
     default:
       cpu: 32

--- a/src/utils/job/task.py
+++ b/src/utils/job/task.py
@@ -2734,7 +2734,7 @@ class TaskGroup(pydantic.BaseModel):
                             '-serviceConfig', service_config_file.path]
 
         # Create default metadata file
-        dataset_metadata_info = {
+        default_metadata_info = {
             'default': {
                 'input_data': input_urls,
                 'wfid': self.workflow_id,
@@ -2742,7 +2742,7 @@ class TaskGroup(pydantic.BaseModel):
             }
         }
         metadata_file = File(path='/metadata',
-                                contents=yaml.dump(dataset_metadata_info))
+                                contents=yaml.dump(default_metadata_info))
         metadata_file.path = f'{kb_objects.DATA_LOCATION}/default_metadata.yaml'
 
         def _build_file_mount(file: File) -> kb_objects.FileMount:


### PR DESCRIPTION
## Description
Remove the last living-code references to the deprecated OSMO dataset surface that are not part of archived project docs or intentional compatibility coverage.

Changes:
- Update the remaining osmo-user skill fixture to use URL workflow output instead of dataset output.
- Rename stale task metadata variable naming now that default workflow metadata is not dataset-specific.
- Refresh AGENTS.md so future agent guidance no longer points at removed dataset surfaces.

Validation:
- `bazel test //src/utils/job/tests:test_task_pure`
- `git diff --check`

Notes:
- Leaves project archive docs untouched.
- Leaves ConfigMap compatibility tests intact.
- Leaves cookbook/domain uses of the word dataset intact.

Issue #911

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.