### PR TITLE
docs: freeze CLI reference to static rST (OSMO-6482)

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -41,6 +41,13 @@ help:
 clean:
 	rm -rf _build
 
+# Freeze the CLI reference pages into static reStructuredText. Run this in the
+# environment of the branch being frozen (so the parser imports), then commit the
+# modified cli_*.rst files so the multiversion build renders them without
+# importing src.
+cli-rst:
+	python generate_cli_rst.py
+
 build:
 	export OSMO_DOMAIN=public && sphinx-build -b html . -w $(ERR_DIR)/build.log $(OUT_DIR)
 	export OSMO_DOMAIN=public && sphinx-build -b markdown . -w $(ERR_DIR)/markdown.log $(OUT_DIR)

--- a/docs/deployment_guide/install_backend/validate_osmo.rst
+++ b/docs/deployment_guide/install_backend/validate_osmo.rst
@@ -27,7 +27,7 @@ Run sample workflows to validate the backend and pool configuration.
     :gutter: 3
 
     .. grid-item-card:: :octicon:`workflow` Simple Workflow
-        :link: https://github.com/NVIDIA/OSMO/blob/main/workflows/tutorials/hello_world.yaml
+        :link: https://github.com/NVIDIA/OSMO/blob/release/6.1/workflows/tutorials/hello_world.yaml
         :link-type: url
 
         **Validates:** Basic workflow execution, logging, data access and scheduling
@@ -35,7 +35,7 @@ Run sample workflows to validate the backend and pool configuration.
         Submit the ``Hello World`` workflow to verify core functionality.
 
     .. grid-item-card:: :octicon:`workflow` Parallel Workflow
-        :link: https://github.com/NVIDIA/OSMO/blob/main/workflows/tutorials/parallel_tasks.yaml
+        :link: https://github.com/NVIDIA/OSMO/blob/release/6.1/workflows/tutorials/parallel_tasks.yaml
         :link-type: url
 
         **Validates:** Co-scheduling and parallel task execution
@@ -43,7 +43,7 @@ Run sample workflows to validate the backend and pool configuration.
         Submit the ``Parallel Tasks`` workflow to test concurrent execution.
 
     .. grid-item-card:: :octicon:`workflow` GPU Workflow
-        :link: https://github.com/NVIDIA/OSMO/blob/main/workflows/dnn_training/single_node/README.md
+        :link: https://github.com/NVIDIA/OSMO/blob/release/6.1/workflows/dnn_training/single_node/README.md
         :link-type: url
 
         **Validates:** GPU resource allocation and usage
@@ -51,7 +51,7 @@ Run sample workflows to validate the backend and pool configuration.
         Submit the ``Single Node GPU`` workflow to verify GPU access.
 
     .. grid-item-card:: :octicon:`workflow` Router Workflow
-        :link: https://github.com/NVIDIA/OSMO/blob/main/workflows/integration_and_tools/jupyterlab/README.md
+        :link: https://github.com/NVIDIA/OSMO/blob/release/6.1/workflows/integration_and_tools/jupyterlab/README.md
         :link-type: url
 
         **Validates:** Router functionality

--- a/docs/deployment_guide/references/config_cli/config_delete.rst
+++ b/docs/deployment_guide/references/config_cli/config_delete.rst
@@ -21,10 +21,52 @@
 osmo config delete
 ==================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: config delete
-   :ref-prefix: cli_reference_config_delete
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=config delete | ref-prefix=cli_reference_config_delete | flags=argument-anchor
+
+Delete a named configuration or a specific config revision
+
+.. code-block:: text
+
+   usage: osmo config delete [-h] config_type [name] [--description DESCRIPTION] [--tags TAGS [TAGS ...]]
+
+.. _cli_reference_config_delete_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``config_type``
+    Type of config to delete (CONFIG_TYPE) or CONFIG_TYPE:revision_number to delete a specific revision
+
+``name``
+    Name of the config to delete (required when not deleting a revision)
+
+.. _cli_reference_config_delete_named_arguments:
+
+Named Arguments
+---------------
+
+``--description, -d``
+    Description of the deletion (only used when deleting a named config)
+
+``--tags, -t``
+    Tags for the deletion (only used when deleting a named config)
+
+
+
+Available config types (CONFIG_TYPE): BACKEND, BACKEND_TEST, DATASET, POD_TEMPLATE, POOL, RESOURCE_VALIDATION, ROLE
+
+.. rubric:: Examples
+
+Delete a named pool configuration::
+
+    osmo config delete POOL my-pool
+
+Delete a specific revision::
+
+    osmo config delete SERVICE:123
+
+Delete with description and tags::
+
+    osmo config delete BACKEND my-backend --description "Removing unused backend" --tags cleanup deprecated
+        

--- a/docs/deployment_guide/references/config_cli/config_diff.rst
+++ b/docs/deployment_guide/references/config_cli/config_diff.rst
@@ -21,10 +21,45 @@
 osmo config diff
 ================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: config diff
-   :ref-prefix: cli_reference_config_diff
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=config diff | ref-prefix=cli_reference_config_diff | flags=argument-anchor
+
+Show the difference between two config revisions
+
+Available config types (config_type): BACKEND, BACKEND_TEST, DATASET, POD_TEMPLATE, POOL, RESOURCE_VALIDATION, ROLE, SERVICE, WORKFLOW
+
+.. code-block:: text
+
+   usage: osmo config diff [-h] first [second]
+
+.. _cli_reference_config_diff_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``first``
+    First config to compare. Format: <config_type>[:<revision>] (e.g. BACKEND:3). If no revision is provided, uses the current revision.
+
+``second``
+    Second config to compare. Format: <config_type>[:<revision>] (e.g. BACKEND:6). If no revision is provided, uses the current revision.
+
+
+
+.. rubric:: Examples
+
+Show changes made to the workflow config since revision 15::
+
+  osmo config diff WORKFLOW:15
+
+.. image:: images/config_diff_workflow.png
+    :align: center
+    :class: mb-2
+
+Show changes made between two revisions of the service configuration::
+
+  osmo config diff SERVICE:14 SERVICE:15
+
+.. image:: images/config_diff_service.png
+    :align: center
+    :class: mb-2
+        

--- a/docs/deployment_guide/references/config_cli/config_history.rst
+++ b/docs/deployment_guide/references/config_cli/config_history.rst
@@ -21,10 +21,96 @@
 osmo config history
 ===================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: config history
-   :ref-prefix: cli_reference_config_history
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=config history | ref-prefix=cli_reference_config_history | flags=argument-anchor
+
+List history of configuration changes
+
+.. code-block:: text
+
+   usage: osmo config history [-h] [config_type] [--offset OFFSET] [--count COUNT] [--order {asc,desc}] [--name NAME] [--revision REVISION] [--tags TAGS [TAGS ...]] [--at-timestamp AT_TIMESTAMP] [--created-before CREATED_BEFORE] [--created-after CREATED_AFTER] [--format-type {json,text}] [--fit-width]
+
+.. _cli_reference_config_history_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``config_type``
+    Possible choices: BACKEND, BACKEND_TEST, DATASET, POD_TEMPLATE, POOL, RESOURCE_VALIDATION, ROLE, SERVICE, WORKFLOW
+
+    Config type to show history for (CONFIG_TYPE)
+
+.. _cli_reference_config_history_named_arguments:
+
+Named Arguments
+---------------
+
+``--offset, -o``
+    Number of records to skip for pagination (default 0)
+
+    Default: ``0``
+
+``--count, -c``
+    Maximum number of records to return (default 20, max 1000)
+
+    Default: ``20``
+
+``--order``
+    Possible choices: asc, desc
+
+    Sort order by creation time (default asc)
+
+    Default: ``'asc'``
+
+``--name, -n``
+    Filter by changes to a particular config, e.g. "isaac-hil" pool
+
+``--revision, -r``
+    Filter by revision number
+
+``--tags``
+    Filter by tags
+
+``--at-timestamp``
+    Get config state at specific timestamp (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS) in current timezone
+
+``--created-before``
+    Filter by creation time before (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS) in current timezone
+
+``--created-after``
+    Filter by creation time after (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS) in current timezone
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (default text)
+
+    Default: ``'text'``
+
+``--fit-width``
+    Fit the table width to the terminal width
+
+    Default: ``False``
+
+
+
+Available config types (CONFIG_TYPE): BACKEND, BACKEND_TEST, DATASET, POD_TEMPLATE, POOL, RESOURCE_VALIDATION, ROLE, SERVICE, WORKFLOW
+
+.. rubric:: Examples
+
+View history in text format (default)::
+
+    osmo config history
+
+View history in JSON format with pagination::
+
+    osmo config history --format-type json --offset 10 --count 2
+
+View history for a specific configuration type::
+
+    osmo config history SERVICE
+
+View history for a specific time range::
+
+    osmo config history --created-after "2025-05-18" --created-before "2025-05-25"
+        

--- a/docs/deployment_guide/references/config_cli/config_list.rst
+++ b/docs/deployment_guide/references/config_cli/config_list.rst
@@ -21,10 +21,42 @@
 osmo config list
 ================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: config list
-   :ref-prefix: cli_reference_config_list
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=config list | ref-prefix=cli_reference_config_list | flags=argument-anchor
+
+List current configuration revisions for each config type
+
+.. code-block:: text
+
+   usage: osmo config list [-h] [--format-type {json,text}]
+                           [--fit-width]
+
+.. _cli_reference_config_list_named_arguments:
+
+Named Arguments
+---------------
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (default text)
+
+    Default: ``'text'``
+
+``--fit-width``
+    Fit the table width to the terminal width
+
+    Default: ``False``
+
+
+
+.. rubric:: Examples
+
+List configurations in text format (default)::
+
+    osmo config list
+
+List configurations in JSON format::
+
+    osmo config list --format-type json
+        

--- a/docs/deployment_guide/references/config_cli/config_rollback.rst
+++ b/docs/deployment_guide/references/config_cli/config_rollback.rst
@@ -21,10 +21,47 @@
 osmo config rollback
 ====================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: config rollback
-   :ref-prefix: cli_reference_config_rollback
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=config rollback | ref-prefix=cli_reference_config_rollback | flags=argument-anchor
+
+Roll back a configuration to a previous revision
+
+When rolling back a configuration, the revision number is incremented by 1 and a new revision is created. The new revision will have the same data as the desired rollback revision.
+
+.. code-block:: text
+
+   usage: osmo config rollback [-h] revision [--description DESCRIPTION] [--tags TAGS [TAGS ...]]
+
+.. _cli_reference_config_rollback_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``revision``
+    Revision to roll back to in format <CONFIG_TYPE>:<revision>, e.g. SERVICE:12
+
+.. _cli_reference_config_rollback_named_arguments:
+
+Named Arguments
+---------------
+
+``--description``
+    Optional description for the rollback action
+
+``--tags``
+    Optional tags for the rollback action
+
+
+
+Available config types (CONFIG_TYPE): BACKEND, BACKEND_TEST, DATASET, POD_TEMPLATE, POOL, RESOURCE_VALIDATION, ROLE, SERVICE, WORKFLOW
+
+.. rubric:: Examples
+
+Roll back a service configuration::
+
+    osmo config rollback SERVICE:4
+
+Roll back with description and tags::
+
+    osmo config rollback BACKEND:7 --description "Rolling back to stable version" --tags rollback stable
+        

--- a/docs/deployment_guide/references/config_cli/config_set.rst
+++ b/docs/deployment_guide/references/config_cli/config_set.rst
@@ -21,10 +21,62 @@
 osmo config set
 ===============
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: config set
-   :ref-prefix: cli_reference_config_set
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=config set | ref-prefix=cli_reference_config_set | flags=argument-anchor
+
+Set a field into the config
+
+.. code-block:: text
+
+   usage: osmo config set [-h] config_type name type [--field FIELD] [--description DESCRIPTION] [--tags TAGS [TAGS ...]]
+
+.. _cli_reference_config_set_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``config_type``
+    Possible choices: ROLE
+
+    Config type to set (CONFIG_TYPE)
+
+``name``
+    Name of the role
+
+``type``
+    Type of field
+
+.. _cli_reference_config_set_named_arguments:
+
+Named Arguments
+---------------
+
+``--field``
+    Field name in context. For example, the backend to target.
+
+``--description``
+    Optional description for the set action
+
+``--tags``
+    Optional tags for the set action
+
+
+
+Available config types (CONFIG_TYPE): ROLE
+
+.. rubric:: Examples
+
+Creating a new pool role::
+
+    osmo config set ROLE osmo-pool-name pool
+
+.. note::
+
+    The pool name **MUST** start with ``osmo-`` to be correctly recognized so that users
+    can see the pool in the UI and profile settings. This will be changed to be more flexible
+    in the future.
+
+Creating a new backend role::
+
+    osmo config set ROLE my-backend-role backend --field name-of-backend
+        

--- a/docs/deployment_guide/references/config_cli/config_show.rst
+++ b/docs/deployment_guide/references/config_cli/config_show.rst
@@ -21,10 +21,40 @@
 osmo config show
 ================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: config show
-   :ref-prefix: cli_reference_config_show
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=config show | ref-prefix=cli_reference_config_show | flags=argument-anchor
+
+Show a configuration or previous revision of a configuration
+
+.. code-block:: text
+
+   usage: osmo config show [-h] config_type [names ...]
+
+.. _cli_reference_config_show_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``config_type``
+    Config to show in format <CONFIG_TYPE>[:<revision>]
+
+``names``
+    Optional names/indices to index into the config. Can be used to show a named config.
+
+
+
+Available config types (CONFIG_TYPE): BACKEND, BACKEND_TEST, DATASET, POD_TEMPLATE, POOL, RESOURCE_VALIDATION, ROLE, SERVICE, WORKFLOW
+
+.. rubric:: Examples
+
+Show a service configuration in JSON format::
+
+    osmo config show SERVICE
+
+Show the ``default_cpu`` resource validation rule::
+
+    osmo config show RESOURCE_VALIDATION default_cpu
+
+Show the ``user_workflow_limits`` workflow configuration in a previous revision::
+
+    osmo config show WORKFLOW:3 user_workflow_limits

--- a/docs/deployment_guide/references/config_cli/config_tag.rst
+++ b/docs/deployment_guide/references/config_cli/config_tag.rst
@@ -21,10 +21,53 @@
 osmo config tag
 ===============
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: config tag
-   :ref-prefix: cli_reference_config_tag
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=config tag | ref-prefix=cli_reference_config_tag | flags=argument-anchor
+
+Update tags for a config revision. Tags can be used for organizing configs by category and filtering output of ``osmo config history``. Tags do not affect the configuration itself.
+
+.. code-block:: text
+
+   usage: osmo config tag [-h] config_type [--set SET [SET ...]] [--delete DELETE [DELETE ...]]
+
+.. _cli_reference_config_tag_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``config_type``
+    Config to update tags for in format <CONFIG_TYPE>[:<revision>]
+
+.. _cli_reference_config_tag_named_arguments:
+
+Named Arguments
+---------------
+
+``--set, -s``
+    Tags to add to the config history entry
+
+``--delete, -d``
+    Tags to remove from the config history entry
+
+
+
+Available config types (CONFIG_TYPE): BACKEND, BACKEND_TEST, DATASET, POD_TEMPLATE, POOL, RESOURCE_VALIDATION, ROLE, SERVICE, WORKFLOW
+
+.. rubric:: Examples
+
+View current tags for a revision::
+
+    osmo config history BACKEND -r 5
+
+Update tags by adding and removing::
+
+    osmo config tag BACKEND:5 --set foo --delete test-4 test-3
+
+Verify the updated tags::
+
+    osmo config history BACKEND -r 5
+
+Update tags for current revision::
+
+    osmo config tag BACKEND --set current-tag
+        

--- a/docs/deployment_guide/references/config_cli/config_update.rst
+++ b/docs/deployment_guide/references/config_cli/config_update.rst
@@ -21,10 +21,57 @@
 osmo config update
 ==================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: config update
-   :ref-prefix: cli_reference_config_update
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=config update | ref-prefix=cli_reference_config_update | flags=argument-anchor
+
+Update a configuration
+
+.. code-block:: text
+
+   usage: osmo config update [-h] config_type [name] [--file FILE] [--description DESCRIPTION] [--tags TAGS [TAGS ...]]
+
+.. _cli_reference_config_update_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``config_type``
+    Possible choices: BACKEND, BACKEND_TEST, DATASET, POD_TEMPLATE, POOL, RESOURCE_VALIDATION, ROLE, SERVICE, WORKFLOW
+
+    Config type to update (CONFIG_TYPE)
+
+``name``
+    Optional name of the config to update
+
+.. _cli_reference_config_update_named_arguments:
+
+Named Arguments
+---------------
+
+``--file, -f``
+    Path to a JSON file containing the updated config
+
+``--description, -d``
+    Description of the config update
+
+``--tags, -t``
+    Tags for the config update
+
+
+
+Available config types (CONFIG_TYPE): BACKEND, BACKEND_TEST, DATASET, POD_TEMPLATE, POOL, RESOURCE_VALIDATION, ROLE, SERVICE, WORKFLOW
+
+.. rubric:: Examples
+
+Update a service configuration::
+
+    osmo config update SERVICE
+
+Update a backend configuration from a file::
+
+    osmo config update BACKEND my-backend --file config.json
+
+Update with description and tags::
+
+    osmo config update POOL my-pool --description "Updated pool settings" --tags production high-priority
+        

--- a/docs/generate_cli_rst.py
+++ b/docs/generate_cli_rst.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Freeze the CLI reference pages into static reStructuredText.
+
+The CLI reference pages normally use the ``argparse-with-postprocess`` directive,
+which imports ``src.cli.main_parser`` and introspects the live parser at build
+time. For ``sphinx-multiversion`` builds that is a problem on older release
+branches whose code is not importable under the current dependencies. This
+script renders each page's CLI section to static rST (mimicking the directive's
+output, including the ``cli_reference_*`` cross-reference anchors) and rewrites
+the page in place, so the documentation build no longer needs to import any code
+for those pages.
+
+Run this in the environment of the branch you are freezing (so the parser
+reflects that branch's CLI), then commit the modified ``*.rst`` files:
+
+    make -C docs cli-rst
+
+The rewrite is idempotent: a provenance comment records the original directive
+options so the page can be regenerated. It detects either a live
+``argparse-with-postprocess`` directive or a previously generated block.
+
+Note: subcommand-level and subsection-level anchors (the ones referenced from
+other pages, e.g. ``cli_reference_workflow_submit``) are reproduced. Per-argument
+deep-link anchors produced by ``:argument-anchor:`` are intentionally omitted on
+the static pages, as nothing cross-references them.
+"""
+
+import importlib
+import re
+import sys
+from pathlib import Path
+
+DOCS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = DOCS_DIR.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sphinxarg.parser import parse_parser, parser_navigate  # noqa: E402
+
+DIRECTIVE_PREFIX = '.. argparse-with-postprocess::'
+SENTINEL = '.. CLI-REFERENCE-GENERATED'
+SOURCE_PREFIX = '.. cli-source:'
+
+# Heading underline characters for levels below the page title (which uses '=').
+HEADING_CHARS = ['-', '~', '^', '"', '+']
+
+# RST section header inside an epilog, e.g. "Examples\n--------".
+_RST_SECTION_PATTERN = re.compile(r'^([^\n]+)\n([=\-~`\'"^_*+#]+)$', re.MULTILINE)
+
+
+def convert_epilog_sections_to_rubric(epilog: str) -> str:
+    """Convert RST section headers in an epilog to ``.. rubric::`` directives.
+
+    Mirrors the directive's epilog handling so section titles inside epilogs do
+    not break the page's heading hierarchy.
+    """
+    if not epilog:
+        return epilog
+
+    def replace_section(match: re.Match) -> str:
+        title = match.group(1).strip()
+        underline = match.group(2)
+        if len(underline) >= len(title):
+            return f'.. rubric:: {title}'
+        return match.group(0)
+
+    return _RST_SECTION_PATTERN.sub(replace_section, epilog)
+
+
+def slugify(text: str) -> str:
+    """Match the slug scheme used by the argparse postprocess extension."""
+    text = re.sub(r'^-+', '', text)
+    text = re.sub(r'[^a-zA-Z0-9]+', '_', text)
+    return text.strip('_').lower()
+
+
+def _is_suppressed(value) -> bool:
+    if value is None:
+        return True
+    return str(value).replace('"', '').replace("'", '') == '==SUPPRESS=='
+
+
+def _heading(text: str, level: int) -> list[str]:
+    char = HEADING_CHARS[min(level, len(HEADING_CHARS) - 1)]
+    return [text, char * max(len(text), 3), '']
+
+
+def _anchor(label: str) -> list[str]:
+    return [f'.. _{label}:', '']
+
+
+def _usage_block(usage: str) -> list[str]:
+    out = ['.. code-block:: text', '']
+    for line in (usage.splitlines() or ['']):
+        out.append(f'   {line}' if line else '')
+    out.append('')
+    return out
+
+
+def _indent(text: str, spaces: int = 4) -> list[str]:
+    pad = ' ' * spaces
+    return [(pad + line if line else '') for line in text.splitlines()]
+
+
+def _render_option(option: dict) -> list[str]:
+    """Render one argument as a definition-list entry."""
+    term = ', '.join(option['name'])
+    parts: list[str] = []
+    if 'choices' in option:
+        parts.append('Possible choices: ' + ', '.join(str(c) for c in option['choices']))
+    if option.get('help'):
+        parts.append(option['help'])
+    if not _is_suppressed(option.get('default')):
+        default_str = str(option['default']).replace('`', r'\`')
+        parts.append(f'Default: ``{default_str}``')
+    if not parts:
+        parts.append('Undocumented')
+
+    lines = [f'``{term}``']
+    for index, part in enumerate(parts):
+        if index:
+            lines.append('')
+        lines.extend(_indent(part))
+    lines.append('')
+    return lines
+
+
+def _render_action_groups(data: dict, level: int, anchor_prefix: str) -> list[str]:
+    lines: list[str] = []
+    for group in data.get('action_groups', []):
+        options = group.get('options', [])
+        if not options:
+            continue
+        title = group['title']
+        lines.extend(_anchor(f'{anchor_prefix}_{slugify(title)}'))
+        lines.extend(_heading(title, level))
+        if group.get('description'):
+            lines.extend([group['description'], ''])
+        for option in options:
+            lines.extend(_render_option(option))
+    return lines
+
+
+def _render_epilog(epilog: str) -> list[str]:
+    return ['', convert_epilog_sections_to_rubric(epilog), '']
+
+
+def _render_subcommand(child: dict, ref_prefix: str, level: int) -> list[str]:
+    name = child['name']
+    ref = f'{ref_prefix}_{slugify(name)}'
+    lines: list[str] = []
+    lines.extend(_anchor(ref))
+    lines.extend(_heading(name, level))
+
+    description = child.get('description') or child.get('help') or 'Undocumented'
+    lines.extend([description, ''])
+    if child.get('bare_usage'):
+        lines.extend(_usage_block(child['bare_usage']))
+
+    lines.extend(_render_action_groups(child, level + 1, ref))
+
+    for grandchild in child.get('children', []):
+        lines.extend(_render_subcommand(grandchild, ref, level + 1))
+
+    if child.get('epilog'):
+        lines.extend(_render_epilog(child['epilog']))
+    return lines
+
+
+def render_page(result: dict, ref_prefix: str) -> str:
+    """Render the static rST body for one CLI page's ``:path:`` target."""
+    lines: list[str] = []
+
+    if result.get('description'):
+        lines.extend([result['description'], ''])
+    if result.get('usage'):
+        lines.extend(_usage_block(result['usage']))
+
+    # The command's own options (present on leaf commands).
+    lines.extend(_render_action_groups(result, level=0, anchor_prefix=ref_prefix))
+
+    children = result.get('children', [])
+    if children:
+        lines.extend(_heading('Sub-commands', 0))
+        for child in children:
+            lines.extend(_render_subcommand(child, ref_prefix, level=1))
+
+    if result.get('epilog'):
+        lines.extend(_render_epilog(result['epilog']))
+
+    # Collapse trailing blank lines to a single newline at EOF.
+    while lines and lines[-1] == '':
+        lines.pop()
+    return '\n'.join(lines) + '\n'
+
+
+def _parse_directive_options(block_lines: list[str]) -> dict:
+    options: dict = {}
+    for line in block_lines:
+        stripped = line.strip()
+        match = re.match(r':([a-zA-Z0-9_-]+):\s*(.*)$', stripped)
+        if match:
+            options[match.group(1)] = match.group(2).strip()
+    return options
+
+
+def _parse_source_comment(line: str) -> dict:
+    payload = line.split(SOURCE_PREFIX, 1)[1].strip()
+    options: dict = {}
+    for field in payload.split('|'):
+        field = field.strip()
+        if not field:
+            continue
+        if field.startswith('flags='):
+            for flag in field[len('flags='):].split(','):
+                flag = flag.strip()
+                if flag:
+                    options[flag] = ''
+        elif '=' in field:
+            key, value = field.split('=', 1)
+            options[key.strip()] = value.strip()
+    return options
+
+
+def _find_region_start(lines: list[str]) -> int | None:
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith(DIRECTIVE_PREFIX) or stripped.startswith(SENTINEL):
+            return index
+    return None
+
+
+def _extract_options(lines: list[str], start: int) -> dict:
+    region = lines[start:]
+    # Live directive block.
+    if region[0].strip().startswith(DIRECTIVE_PREFIX):
+        return _parse_directive_options(region[1:])
+    # Previously generated: read the provenance comment.
+    for line in region:
+        if line.strip().startswith(SOURCE_PREFIX):
+            return _parse_source_comment(line.strip())
+    return {}
+
+
+def _provenance(options: dict) -> list[str]:
+    flags = [k for k in ('argument-anchor', 'markdown', 'nosubcommands', 'nodescription')
+             if k in options]
+    fields = [
+        f"module={options.get('module', 'src.cli.main_parser')}",
+        f"func={options.get('func', 'create_cli_parser')}",
+        f"prog={options.get('prog', 'osmo')}",
+        f"path={options.get('path', '')}",
+        f"ref-prefix={options.get('ref-prefix', '')}",
+        f"flags={','.join(flags)}",
+    ]
+    return [
+        f'{SENTINEL} -- do not edit by hand; regenerate with: make -C docs cli-rst',
+        f'{SOURCE_PREFIX} ' + ' | '.join(fields),
+        '',
+    ]
+
+
+def process_page(path: Path, parser_cache: dict) -> bool:
+    """Rewrite one CLI page in place. Returns True if the page was changed."""
+    original = path.read_text(encoding='utf-8')
+    lines = original.splitlines()
+
+    start = _find_region_start(lines)
+    if start is None:
+        return False
+
+    options = _extract_options(lines, start)
+    cli_path = options.get('path', '')
+    ref_prefix = options.get('ref-prefix', '')
+    if not ref_prefix:
+        raise ValueError(f'{path}: could not determine :ref-prefix:')
+
+    module_name = options.get('module', 'src.cli.main_parser')
+    func_name = options.get('func', 'create_cli_parser')
+    prog = options.get('prog', 'osmo')
+
+    cache_key = (module_name, func_name, prog)
+    if cache_key not in parser_cache:
+        module = importlib.import_module(module_name)
+        parser = getattr(module, func_name)()
+        parser.prog = prog
+        parser_cache[cache_key] = parse_parser(parser)
+    data = parser_cache[cache_key]
+
+    result = parser_navigate(data, cli_path)
+    body = render_page(result, ref_prefix)
+
+    preamble = lines[:start]
+    while preamble and preamble[-1].strip() == '':
+        preamble.pop()
+
+    new_lines = preamble + [''] + _provenance(options) + body.splitlines()
+    new_text = '\n'.join(new_lines).rstrip('\n') + '\n'
+
+    if new_text != original:
+        path.write_text(new_text, encoding='utf-8')
+        return True
+    return False
+
+
+def discover_pages() -> list[Path]:
+    pages: list[Path] = []
+    for rst in DOCS_DIR.rglob('*.rst'):
+        text = rst.read_text(encoding='utf-8')
+        if DIRECTIVE_PREFIX in text or SENTINEL in text:
+            pages.append(rst)
+    return sorted(pages)
+
+
+def main() -> None:
+    parser_cache: dict = {}
+    changed = 0
+    pages = discover_pages()
+    for page in pages:
+        if process_page(page, parser_cache):
+            changed += 1
+            print(f'updated {page.relative_to(REPO_ROOT)}')
+    print(f'Processed {len(pages)} page(s); {changed} updated.')
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -27,7 +27,6 @@ header."Accept-Language" = "en-US,en;q=0.5"
 
 # Throttling to avoid rate limiting and bot detection
 max_concurrency = 16           # Limit parallel requests (default is 128)
-max_requests_per_second = 8    # Rate limit requests per second
 
 # Timeout and retries
 timeout = 60

--- a/docs/user_guide/appendix/cli/cli_app.rst
+++ b/docs/user_guide/appendix/cli/cli_app.rst
@@ -23,10 +23,364 @@
 osmo app
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: app
-   :ref-prefix: cli_reference_app
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=app | ref-prefix=cli_reference_app | flags=argument-anchor
+
+Apps are reusable workflow files that can be shared with other users.
+
+.. code-block:: text
+
+   usage: osmo app [-h]
+                   {create,update,info,show,spec,list,delete,rename,submit}
+                   ...
+
+.. _cli_reference_app_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: create, update, info, show, spec, list, delete, rename, submit
+
+Sub-commands
+------------
+
+.. _cli_reference_app_create:
+
+create
+~~~~~~
+
+If file is not provided, the app will be created using the user's editor.
+
+.. code-block:: text
+
+   osmo app create [-h] --description DESCRIPTION [--file FILE] name
+
+.. _cli_reference_app_create_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the app.
+
+.. _cli_reference_app_create_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--description, -d``
+    Description of the app.
+
+``--file, -f``
+    Path to the app file.
+
+
+Ex. osmo app create my-app --description "My app description"
+
+.. _cli_reference_app_update:
+
+update
+~~~~~~
+
+Update a workflow app using the user's editor.
+
+.. code-block:: text
+
+   osmo app update [-h] [--file FILE] name
+
+.. _cli_reference_app_update_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the app. Can specify a version number to edit from a specific version by using <app>:<version> format.
+
+.. _cli_reference_app_update_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--file, -f``
+    Path to the app file.
+
+
+Ex. osmo app update my-app
+
+.. _cli_reference_app_info:
+
+info
+~~~~
+
+Show app and app version information.
+
+.. code-block:: text
+
+   osmo app info [-h] [--count COUNT] [--order {asc,desc}]
+                 [--format-type {json,text}]
+                 name
+
+.. _cli_reference_app_info_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the app. Specify version to get info from a specific version by using <app>:<version> format.
+
+.. _cli_reference_app_info_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--count, -c``
+    For Datasets. Display the given number of versions. Default 20.
+
+    Default: ``20``
+
+``--order, -o``
+    Possible choices: asc, desc
+
+    Display in the given order. asc means latest at the bottom. desc means latest at the top
+
+    Default: ``'asc'``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo app info my-app
+
+.. _cli_reference_app_show:
+
+show
+~~~~
+
+Show app parameters.
+
+.. code-block:: text
+
+   osmo app show [-h] name
+
+.. _cli_reference_app_show_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the app. Specify version to get info from a specific version by using <app>:<version> format.
+
+.. _cli_reference_app_spec:
+
+spec
+~~~~
+
+Show app spec.
+
+.. code-block:: text
+
+   osmo app spec [-h] name
+
+.. _cli_reference_app_spec_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the app. Specify version to get info from a specific version by using <app>:<version> format.
+
+.. _cli_reference_app_list:
+
+list
+~~~~
+
+Lists all apps you created, updated, or submitted by default. If --user is specified, it will list all apps owned by the user(s).
+
+.. code-block:: text
+
+   osmo app list [-h] [--name NAME] [--user USER [USER ...]]
+                 [--all-users] [--count COUNT] [--order {asc,desc}]
+                 [--format-type {json,text}]
+
+.. _cli_reference_app_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--name, -n``
+    Display apps that have the given substring in their name
+
+``--user, -u``
+    Display all app where the user has created.
+
+``--all-users, -a``
+    Display all apps with no filtering on users
+
+    Default: ``False``
+
+``--count, -c``
+    Display the given number of apps. Default 20.
+
+    Default: ``20``
+
+``--order, -o``
+    Possible choices: asc, desc
+
+    Display in the given order. asc means latest at the bottom. desc means latest at the top
+
+    Default: ``'asc'``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+.. _cli_reference_app_delete:
+
+delete
+~~~~~~
+
+Delete a workflow app version you created.
+
+.. code-block:: text
+
+   osmo app delete [-h] [--all] [--force] name
+
+.. _cli_reference_app_delete_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the app. Specify version to delete a specific version by using <app>:<version> format.
+
+.. _cli_reference_app_delete_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--all, -a``
+    Delete all versions of the app.
+
+    Default: ``False``
+
+``--force, -f``
+    Delete the app without user confirmation.
+
+    Default: ``False``
+
+
+Ex. osmo app delete my-app
+
+.. _cli_reference_app_rename:
+
+rename
+~~~~~~
+
+Rename a workflow app from the original name to a new name.
+
+.. code-block:: text
+
+   osmo app rename [-h] [--force] original_name new_name
+
+.. _cli_reference_app_rename_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``original_name``
+    Original name of the app.
+
+``new_name``
+    New name for the app.
+
+.. _cli_reference_app_rename_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--force, -f``
+    Rename the app without user confirmation.
+
+    Default: ``False``
+
+
+Ex. osmo app rename original-app-name new-app-name
+
+.. _cli_reference_app_submit:
+
+submit
+~~~~~~
+
+Submit a workflow app version you created.
+
+.. code-block:: text
+
+   osmo app submit [-h] [--format-type {json,text}]
+                   [--set SET [SET ...]]
+                   [--set-string SET_STRING [SET_STRING ...]]
+                   [--set-env SET_ENV [SET_ENV ...]] [--dry-run]
+                   [--pool POOL] [--local-path LOCAL_PATH]
+                   [--rsync RSYNC] [--priority {HIGH,NORMAL,LOW}]
+                   name
+
+.. _cli_reference_app_submit_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the app. Specify version to submit a specific version by using <app>:<version> format.
+
+.. _cli_reference_app_submit_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+``--set``
+    Assign fields in the workflow file with desired elements in the form "<field>=<value>". These values will override values set in the "default-values" section. Overridden fields in the yaml file should be in the form {{ field }}. Values will be cast as int or float if applicable
+
+    Default: ``[]``
+
+``--set-string``
+    Assign fields in the workflow file with desired elements in the form "<field>=<value>". These values will override values set in the "default-values" section. Overridden fields in the yaml file should be in the form {{ field }}. All values will be cast as string
+
+    Default: ``[]``
+
+``--set-env``
+    Assign environment variables to the workflow. The value should be in the format <key>=<value>. Multiple key-value pairs can be passed. If an environment variable passed here is already defined in the workflow, the value declared here will override the value in the workflow.
+
+    Default: ``[]``
+
+``--dry-run``
+    Does not submit the workflow and prints the workflow into the console.
+
+    Default: ``False``
+
+``--pool, -p``
+    The target pool to run the workflow with. If no pool is specified, the default pool assigned in the profile will be used.
+
+``--local-path, -l``
+    The absolute path to the location for where local files in the workflow file should be fetched from. If not specified, the current working directory will be used.
+
+``--rsync``
+    Start a background rsync daemon to continuously upload data from local machine to the lead task of the workflow. The value should be in the format <local_path>:<remote_path>. The daemon process will automatically exit when the workflow is terminated.
+
+``--priority``
+    Possible choices: HIGH, NORMAL, LOW
+
+    The priority to use when scheduling the workflow. If none is provided, NORMAL will be used. The scheduler will prioritize scheduling workflows in the order of HIGH, NORMAL, LOW. LOW workflows may be preempted to allow a higher priority workflow to run.

--- a/docs/user_guide/appendix/cli/cli_bucket.rst
+++ b/docs/user_guide/appendix/cli/cli_bucket.rst
@@ -23,10 +23,46 @@
 osmo bucket
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: bucket
-   :ref-prefix: cli_reference_bucket
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=bucket | ref-prefix=cli_reference_bucket | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo bucket [-h] {list} ...
+
+.. _cli_reference_bucket_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: list
+
+Sub-commands
+------------
+
+.. _cli_reference_bucket_list:
+
+list
+~~~~
+
+List available and default buckets
+
+.. code-block:: text
+
+   osmo bucket list [-h] [--format-type {json,text}]
+
+.. _cli_reference_bucket_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo bucket list

--- a/docs/user_guide/appendix/cli/cli_credential.rst
+++ b/docs/user_guide/appendix/cli/cli_credential.rst
@@ -23,10 +23,127 @@
 osmo credential
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: credential
-   :ref-prefix: cli_reference_credential
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=credential | ref-prefix=cli_reference_credential | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo credential [-h] [--format-type {json,text}]
+                          {set,list,delete} ...
+
+.. _cli_reference_credential_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: set, list, delete
+
+.. _cli_reference_credential_named_arguments:
+
+Named Arguments
+---------------
+
+``--format-type``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+Sub-commands
+------------
+
+.. _cli_reference_credential_set:
+
+set
+~~~
+
+Create or update a credential
+
+.. code-block:: text
+
+   osmo credential set [-h] [--type {REGISTRY,DATA,GENERIC}]
+                       (--payload PAYLOAD [PAYLOAD ...] | --payload-file PAYLOAD_FILE [PAYLOAD_FILE ...])
+                       name
+
+.. _cli_reference_credential_set_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the credential.
+
+.. _cli_reference_credential_set_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--type``
+    Possible choices: REGISTRY, DATA, GENERIC
+
+    Type of the credential.
+
+    Default: ``'GENERIC'``
+
+``--payload``
+    List of key-value pairs.
+    The tabulated information illustrates the mandatory and optional keys for the payload corresponding to each type of credential:
+
+    +-----------------+-------------------------------------+-----------------------------+
+    | Credential Type | Mandatory keys                      | Optional keys               |
+    +-----------------+-------------------------------------+-----------------------------+
+    | REGISTRY        | auth                                | registry, username          |
+    +-----------------+-------------------------------------+-----------------------------+
+    | DATA            | access_key_id, access_key, endpoint | region (default: us-east-1) |
+    +-----------------+-------------------------------------+-----------------------------+
+    | GENERIC         |                                     |                             |
+    +-----------------+-------------------------------------+-----------------------------+
+
+
+``--payload-file``
+    List of key-value pairs, but the value provided needs to be a path to a file.
+    Retrieves the value of the secret from a file.
+
+
+Ex. osmo credential set registry_cred_name --type REGISTRY --payload registry=your_registry username=your_username auth=xxxxxx 
+Ex. osmo credential set data_cred_name --type DATA --payload access_key_id=your_s3_username access_key=xxxxxx endpoint=s3://bucket 
+Ex. osmo credential set generic_cred_name --type GENERIC --payload omni_user=your_omni_username omni_pass=xxxxxx 
+Ex. osmo credential set generic_cred_name --type GENERIC --payload-file ssh_public_key=<path to file>
+
+.. _cli_reference_credential_list:
+
+list
+~~~~
+
+List all credentials
+
+.. code-block:: text
+
+   osmo credential list [-h]
+
+
+Ex. osmo credential list
+
+.. _cli_reference_credential_delete:
+
+delete
+~~~~~~
+
+Delete an existing credential
+
+.. code-block:: text
+
+   osmo credential delete [-h] name
+
+.. _cli_reference_credential_delete_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Delete credential with name.
+
+
+Ex. osmo credential delete omni_cred

--- a/docs/user_guide/appendix/cli/cli_data.rst
+++ b/docs/user_guide/appendix/cli/cli_data.rst
@@ -23,10 +23,237 @@
 osmo data
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: data
-   :ref-prefix: cli_reference_data
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=data | ref-prefix=cli_reference_data | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo data [-h] {upload,download,list,delete,check} ...
+
+.. _cli_reference_data_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: upload, download, list, delete, check
+
+Sub-commands
+------------
+
+.. _cli_reference_data_upload:
+
+upload
+~~~~~~
+
+Upload data to a backend URI
+
+.. code-block:: text
+
+   osmo data upload [-h] [--regex REGEX] [--processes PROCESSES]
+                    [--threads THREADS]
+                    [--benchmark-out BENCHMARK_OUT]
+                    remote_uri local_path [local_path ...]
+
+.. _cli_reference_data_upload_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``remote_uri``
+    Location where data will be uploaded to.
+
+``local_path``
+    Path(s) where the data lies.
+
+.. _cli_reference_data_upload_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--regex, -x``
+    Regex to filter which types of files to upload
+
+``--processes, -p``
+    Number of processes. Defaults to 10
+
+    Default: ``10``
+
+``--threads, -T``
+    Number of threads per process. Defaults to 20
+
+    Default: ``20``
+
+``--benchmark-out, -b``
+    Path to folder where benchmark data will be written to.
+
+
+Ex. osmo data upload s3://bucket/ /path/to/file
+
+.. _cli_reference_data_download:
+
+download
+~~~~~~~~
+
+Download a data from a backend URI
+
+.. code-block:: text
+
+   osmo data download [-h] [--regex REGEX] [--resume]
+                      [--processes PROCESSES] [--threads THREADS]
+                      [--benchmark-out BENCHMARK_OUT]
+                      remote_uri local_path
+
+.. _cli_reference_data_download_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``remote_uri``
+    URI where data will be downloaded from.
+
+``local_path``
+    Path where data will be downloaded to.
+
+.. _cli_reference_data_download_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--regex, -x``
+    Regex to filter which types of files to download
+
+``--resume, -r``
+    Resume a download.
+
+    Default: ``False``
+
+``--processes, -p``
+    Number of processes. Defaults to 10
+
+    Default: ``10``
+
+``--threads, -T``
+    Number of threads per process. Defaults to 20
+
+    Default: ``20``
+
+``--benchmark-out, -b``
+    Path to folder where benchmark data will be written to.
+
+
+Ex. osmo data download s3://bucket/ /path/to/folder
+
+.. _cli_reference_data_list:
+
+list
+~~~~
+
+List a data from a backend URI
+
+.. code-block:: text
+
+   osmo data list [-h] [--regex REGEX] [--prefix PREFIX]
+                  [--recursive] [--no-pager]
+                  remote_uri [local_path]
+
+.. _cli_reference_data_list_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``remote_uri``
+    URI where data will be listed for.
+
+``local_path``
+    Path where list data will be written to.
+
+.. _cli_reference_data_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--regex, -x``
+    Regex to filter which types of files to list
+
+``--prefix, -p``
+    Prefix/directory to list from the remote URI.
+
+    Default: ``''``
+
+``--recursive, -r``
+    List recursively.
+
+    Default: ``False``
+
+``--no-pager``
+    Do not use a pager to display the list results, print directly to stdout.
+
+    Default: ``False``
+
+
+Ex. osmo data list s3://bucket/ /path/with/file_name
+
+.. _cli_reference_data_delete:
+
+delete
+~~~~~~
+
+Delete a data from a backend URI
+
+.. code-block:: text
+
+   osmo data delete [-h] [--regex REGEX] remote_uri
+
+.. _cli_reference_data_delete_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``remote_uri``
+    URI where data will be delete from.
+
+.. _cli_reference_data_delete_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--regex, -x``
+    Regex to filter which types of files to delete
+
+
+Ex. osmo data delete s3://bucket/ 
+
+.. _cli_reference_data_check:
+
+check
+~~~~~
+
+Check the access to a backend URI
+
+.. code-block:: text
+
+   osmo data check [-h] [--access-type {READ,WRITE,DELETE}]
+                   [--config-file CONFIG_FILE]
+                   remote_uri
+
+.. _cli_reference_data_check_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``remote_uri``
+    URI where access will be checked to.
+
+.. _cli_reference_data_check_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--access-type, -a``
+    Possible choices: READ, WRITE, DELETE
+
+    Access type to check access to the backend URI.
+
+``--config-file, -c``
+    Path to the config file to use for the access check.

--- a/docs/user_guide/appendix/cli/cli_dataset.rst
+++ b/docs/user_guide/appendix/cli/cli_dataset.rst
@@ -23,10 +23,792 @@
 osmo dataset
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: dataset
-   :ref-prefix: cli_reference_dataset
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=dataset | ref-prefix=cli_reference_dataset | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo dataset [-h]
+                       {info,upload,delete,download,update,recollect,list,tag,label,metadata,rename,query,collect,inspect,checksum,migrate,check}
+                       ...
+
+.. _cli_reference_dataset_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: info, upload, delete, download, update, recollect, list, tag, label, metadata, rename, query, collect, inspect, checksum, migrate, check
+
+Sub-commands
+------------
+
+.. _cli_reference_dataset_info:
+
+info
+~~~~
+
+Provide details of the dataset/collection
+
+.. code-block:: text
+
+   osmo dataset info [-h] [--all] [--count COUNT]
+                     [--order {asc,desc}]
+                     [--format-type {json,text}]
+                     name
+
+.. _cli_reference_dataset_info_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name. Specify bucket with [bucket/]DS.
+
+.. _cli_reference_dataset_info_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--all, -a``
+    Display all versions in any state.
+
+    Default: ``False``
+
+``--count, -c``
+    For Datasets. Display the given number of versions. Default 100.
+
+    Default: ``100``
+
+``--order, -o``
+    Possible choices: asc, desc
+
+    For Datasets. Display in the given order based on date created
+
+    Default: ``'asc'``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo dataset info DS1 --format-type json
+
+.. _cli_reference_dataset_upload:
+
+upload
+~~~~~~
+
+Upload a new Dataset/Collection
+
+.. code-block:: text
+
+   osmo dataset upload [-h] [--desc DESCRIPTION]
+                       [--metadata METADATA [METADATA ...]]
+                       [--labels LABELS [LABELS ...]]
+                       [--regex REGEX] [--resume]
+                       [--processes PROCESSES] [--threads THREADS]
+                       [--benchmark-out BENCHMARK_OUT]
+                       name path [path ...]
+
+.. _cli_reference_dataset_upload_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name. Specify bucket and tag with [bucket/]DS[:tag].If you want to continue an upload, then the most recent PENDING version is chosen
+
+``path``
+    Path where the dataset lies.
+
+.. _cli_reference_dataset_upload_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--desc, -d``
+    Description of dataset.
+
+    Default: ``''``
+
+``--metadata, -m``
+    Yaml files of metadata to assign to dataset version
+
+    Default: ``[]``
+
+``--labels, -l``
+    Yaml files of labels to assign to dataset
+
+    Default: ``[]``
+
+``--regex, -x``
+    Regex to filter which types of files to upload
+
+``--resume, -r``
+    Resume a canceled/failed upload. To resume, there must be atag.
+
+    Default: ``False``
+
+``--processes, -p``
+    Number of processes. Defaults to 10
+
+    Default: ``10``
+
+``--threads, -T``
+    Number of threads per process. Defaults to 20
+
+    Default: ``20``
+
+``--benchmark-out, -b``
+    Path to folder where benchmark data will be written to.
+
+
+Ex. osmo dataset upload DS1:latest /path/to/file --desc "My description"
+
+.. _cli_reference_dataset_delete:
+
+delete
+~~~~~~
+
+Marks a Dataset version(s) as PENDING_DELETE. If all versions are marked, prompts the user to delete the dataset from storage. Collection are deleted
+
+.. code-block:: text
+
+   osmo dataset delete [-h] [--all] [--force]
+                       [--format-type {json,text}]
+                       name
+
+.. _cli_reference_dataset_delete_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name. Specify bucket and tag/version with [bucket/]DS[:tag/version].
+
+.. _cli_reference_dataset_delete_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--all, -a``
+    Deletes all versions.
+
+    Default: ``False``
+
+``--force, -f``
+    Deletes without confirmation.
+
+    Default: ``False``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo dataset delete DS1:latest --force --format-type json
+
+.. _cli_reference_dataset_download:
+
+download
+~~~~~~~~
+
+Download the dataset
+
+.. code-block:: text
+
+   osmo dataset download [-h] [--regex REGEX] [--resume]
+                         [--processes PROCESSES] [--threads THREADS]
+                         [--benchmark-out BENCHMARK_OUT]
+                         name path
+
+.. _cli_reference_dataset_download_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name. Specify bucket and tag/version with [bucket/]DS[:tag/version].
+
+``path``
+    Location where the dataset is downloaded to.
+
+.. _cli_reference_dataset_download_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--regex, -x``
+    Regex to filter which types of files to download
+
+``--resume, -r``
+    Resume a canceled/failed download.
+
+    Default: ``False``
+
+``--processes, -p``
+    Number of processes. Defaults to 10
+
+    Default: ``10``
+
+``--threads, -T``
+    Number of threads per process. Defaults to 20
+
+    Default: ``20``
+
+``--benchmark-out, -b``
+    Path to folder where benchmark data will be written to.
+
+
+Ex. osmo dataset download DS1:latest /path/to/folder
+
+.. _cli_reference_dataset_update:
+
+update
+~~~~~~
+
+Creates a new dataset version from an existing version by adding or removing files.
+
+.. code-block:: text
+
+   osmo dataset update [-h] [--add ADD [ADD ...]] [--remove REMOVE]
+                       [--metadata METADATA [METADATA ...]]
+                       [--labels LABELS [LABELS ...]]
+                       [--resume RESUME] [--processes PROCESSES]
+                       [--threads THREADS]
+                       [--benchmark-out BENCHMARK_OUT]
+                       name
+
+.. _cli_reference_dataset_update_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name. Specify bucket and tag/version with [bucket/]DS[:tag/version].
+
+.. _cli_reference_dataset_update_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--add, -a``
+    Local paths/Remote URIs to append to the dataset. To specify path in the dataset where the files should be stored, use ":" to delineate local/path:remote/path. Files in the local path will be stored with the prefix of the remote path. If the path contains ":", use "\:" in the path.
+
+    Default: ``[]``
+
+``--remove, -r``
+    Regex to filter which types of files to remove.
+
+``--metadata, -m``
+    Yaml files of metadata to assign to the newly created dataset version
+
+    Default: ``[]``
+
+``--labels, -l``
+    Yaml files of labels to assign to the dataset
+
+    Default: ``[]``
+
+``--resume``
+    Resume a canceled/failed update. To resume, specify the PENDING version to continue.
+
+``--processes, -p``
+    Number of processes. Defaults to 10
+
+    Default: ``10``
+
+``--threads, -T``
+    Number of threads per process. Defaults to 20
+
+    Default: ``20``
+
+``--benchmark-out, -b``
+    Path to folder where benchmark data will be written to.
+
+
+Ex. osmo dataset update DS1 --add relative/path:remote/path /other/local/path s3://path:remote/path
+Ex. osmo dataset update DS1 --remove ".*\.(yaml|json)$"
+
+
+.. _cli_reference_dataset_recollect:
+
+recollect
+~~~~~~~~~
+
+Add or remove datasets from a collection.
+
+.. code-block:: text
+
+   osmo dataset recollect [-h] [--add ADD [ADD ...]]
+                          [--remove REMOVE [REMOVE ...]]
+                          name
+
+.. _cli_reference_dataset_recollect_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Collection name. Specify bucket with [bucket/]Collection.
+
+.. _cli_reference_dataset_recollect_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--add, -a``
+    Datasets to add to collection.
+
+    Default: ``[]``
+
+``--remove, -r``
+    Datasets to remove from collection. The remove operation happens before the add.
+
+    Default: ``[]``
+
+
+Ex. osmo dataset recollect C1 --remove DS1 --add DS2:4
+
+.. _cli_reference_dataset_list:
+
+list
+~~~~
+
+List all Datasets/Collections uploaded by the user
+
+.. code-block:: text
+
+   osmo dataset list [-h] [--name NAME] [--user USER [USER ...]]
+                     [--bucket BUCKET [BUCKET ...]] [--all-users]
+                     [--count COUNT] [--order {asc,desc}]
+                     [--format-type {json,text}]
+
+.. _cli_reference_dataset_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--name, -n``
+    Display datasets that have the given substring in their name
+
+    Default: ``''``
+
+``--user, -u``
+    Display all datasets where the user has uploaded to.
+
+    Default: ``[]``
+
+``--bucket, -b``
+    Display all datasets from the given buckets.
+
+    Default: ``[]``
+
+``--all-users, -a``
+    Display all datasets with no filtering on users
+
+    Default: ``False``
+
+``--count, -c``
+    Display the given number of datasets. Default 20. Max 1000.
+
+    Default: ``20``
+
+``--order, -o``
+    Possible choices: asc, desc
+
+    Display in the given order. asc means latest at the bottom. desc means latest at the top
+
+    Default: ``'asc'``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo dataset list --all-users or osmo dataset list --user abc xyz
+
+.. _cli_reference_dataset_tag:
+
+tag
+~~~
+
+Update Dataset Version tags
+
+.. code-block:: text
+
+   osmo dataset tag [-h] [--set SET [SET ...]]
+                    [--delete DELETE [DELETE ...]]
+                    name
+
+.. _cli_reference_dataset_tag_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name to update. Specify bucket and tag/version with [bucket/]DS[:tag/version].
+
+.. _cli_reference_dataset_tag_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--set, -s``
+    Set tag to dataset version.
+
+    Default: ``[]``
+
+``--delete, -d``
+    Delete tag from dataset version.
+
+    Default: ``[]``
+
+
+Ex. osmo dataset tag DS1 --set tag1 --delete tag2
+
+.. _cli_reference_dataset_label:
+
+label
+~~~~~
+
+Update Dataset labels.
+
+.. code-block:: text
+
+   osmo dataset label [-h] [--file] [--set SET [SET ...]]
+                      [--delete DELETE [DELETE ...]]
+                      [--format-type {json,text}]
+                      name
+
+.. _cli_reference_dataset_label_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name to update. Specify bucket with [bucket/][DS].
+
+.. _cli_reference_dataset_label_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--file, -f``
+    If enabled, the inputs to set and delete must be files.
+
+    Default: ``False``
+
+``--set, -s``
+    Set label for dataset in the form "<key>:<type>:<value>" where type is string or numericor the file-path
+
+    Default: ``[]``
+
+``--delete, -d``
+    Delete labels from dataset in the form "<key>"or the file-path
+
+    Default: ``[]``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo dataset label DS1 --set key1:string:value1 --delete key2
+
+.. _cli_reference_dataset_metadata:
+
+metadata
+~~~~~~~~
+
+Update Dataset Version metadata. A tag/version is required.
+
+.. code-block:: text
+
+   osmo dataset metadata [-h] [--file] [--set SET [SET ...]]
+                         [--delete DELETE [DELETE ...]]
+                         [--format-type {json,text}]
+                         name
+
+.. _cli_reference_dataset_metadata_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name to update. Specify bucket and tag/version with [bucket/]DS[:tag/version].
+
+.. _cli_reference_dataset_metadata_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--file, -f``
+    If enabled, the inputs to set and delete must be files.
+
+    Default: ``False``
+
+``--set, -s``
+    Set metadata from dataset in the form "<key>:<type>:<value>" where type is string or numericor the file-path
+
+    Default: ``[]``
+
+``--delete, -d``
+    Delete metadata from dataset in the form "<key>"or the file-path
+
+    Default: ``[]``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo dataset metadata DS1:latest --set key1:string:value1 --delete key2
+
+.. _cli_reference_dataset_rename:
+
+rename
+~~~~~~
+
+Rename dataset/collection
+
+.. code-block:: text
+
+   osmo dataset rename [-h] original_name new_name
+
+.. _cli_reference_dataset_rename_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``original_name``
+    Old dataset/collection name. Specify bucket with [bucket/][DS].
+
+``new_name``
+    New dataset/collection name.
+
+
+Ex. osmo dataset rename original_name new_name
+
+.. _cli_reference_dataset_query:
+
+query
+~~~~~
+
+Query datasets based on metadata
+
+.. code-block:: text
+
+   osmo dataset query [-h] [--bucket BUCKET]
+                      [--format-type {json,text}]
+                      file
+
+.. _cli_reference_dataset_query_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``file``
+    The Query file to submit
+
+.. _cli_reference_dataset_query_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--bucket, -b``
+    bucket to query.
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo dataset query file.yaml
+
+.. _cli_reference_dataset_collect:
+
+collect
+~~~~~~~
+
+Create a Collection
+
+.. code-block:: text
+
+   osmo dataset collect [-h] name datasets [datasets ...]
+
+.. _cli_reference_dataset_collect_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Collection name. Specify bucket and with [bucket/][C]. All datasets and collections added to this collection are based off of this bucket
+
+``datasets``
+    Each Dataset to add to collection. To create a collection from another collection, add the collection name.
+
+
+Ex. osmo dataset collect CName C1 DS1 DS2 DS3:latest
+
+.. _cli_reference_dataset_inspect:
+
+inspect
+~~~~~~~
+
+Display Dataset Directory
+
+.. code-block:: text
+
+   osmo dataset inspect [-h] [--format-type {text,tree,json}]
+                        [--regex REGEX] [--count COUNT]
+                        name
+
+.. _cli_reference_dataset_inspect_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name. Specify bucket and tag/version with [bucket/]DS[:tag/version].
+
+.. _cli_reference_dataset_inspect_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--format-type, -t``
+    Possible choices: text, tree, json
+
+    Type text is that files are just printed out. Type tree displays a better representation of the directory structure. Type json prints out the list of json objects with both URI and URL links.
+
+    Default: ``'text'``
+
+``--regex, -x``
+    Regex to filter which types of files to inspect
+
+``--count, -c``
+    Number of files to print. Default 1,000.
+
+    Default: ``1000``
+
+
+Ex. osmo dataset inspect DS1:latest --format-type json
+
+.. _cli_reference_dataset_checksum:
+
+checksum
+~~~~~~~~
+
+Calculate Directory Checksum
+
+.. code-block:: text
+
+   osmo dataset checksum [-h] path [path ...]
+
+.. _cli_reference_dataset_checksum_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``path``
+    Paths where the folder lies.
+
+
+Ex. osmo dataset checksum /path/to/folder
+
+.. _cli_reference_dataset_migrate:
+
+migrate
+~~~~~~~
+
+Migrate a legacy (non-manifest based) dataset to a new manifest based dataset.
+
+.. code-block:: text
+
+   osmo dataset migrate [-h] [--processes PROCESSES]
+                        [--threads THREADS]
+                        [--benchmark-out BENCHMARK_OUT]
+                        name
+
+.. _cli_reference_dataset_migrate_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name. Specify bucket and tag/version with [bucket/]DS[:tag/version].
+
+.. _cli_reference_dataset_migrate_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--processes, -p``
+    Number of processes. Defaults to 10
+
+    Default: ``10``
+
+``--threads, -T``
+    Number of threads per process. Defaults to 20
+
+    Default: ``20``
+
+``--benchmark-out, -b``
+    Path to folder where benchmark data will be written to.
+
+
+Ex. osmo dataset migrate DS1:latest
+
+.. _cli_reference_dataset_check:
+
+check
+~~~~~
+
+Check access permissions for dataset operations
+
+.. code-block:: text
+
+   osmo dataset check [-h] [--access-type {READ,WRITE,DELETE}]
+                      [--config-file CONFIG_FILE]
+                      name
+
+.. _cli_reference_dataset_check_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Dataset name. Specify bucket and tag/version with [bucket/]DS[:tag/version].
+
+.. _cli_reference_dataset_check_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--access-type, -a``
+    Possible choices: READ, WRITE, DELETE
+
+    Access type to check access to the dataset.
+
+``--config-file, -c``
+    Path to the config file to use for the access check.

--- a/docs/user_guide/appendix/cli/cli_login.rst
+++ b/docs/user_guide/appendix/cli/cli_login.rst
@@ -23,10 +23,52 @@
 osmo login
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: login
-   :ref-prefix: cli_reference_login
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=login | ref-prefix=cli_reference_login | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo login [-h] [--device-endpoint DEVICE_ENDPOINT]
+                     [--method {code,password,token,dev}]
+                     [--username USERNAME]
+                     [--password PASSWORD | --password-file PASSWORD_FILE]
+                     [--token TOKEN | --token-file TOKEN_FILE]
+                     url
+
+.. _cli_reference_login_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``url``
+    The url of the osmo server to connect to
+
+.. _cli_reference_login_named_arguments:
+
+Named Arguments
+---------------
+
+``--device-endpoint``
+    The url to use to completed device flow authentication. If not provided, it will be fetched from the service.
+
+``--method``
+    Possible choices: code, password, token, dev
+
+    code: Get a device code and url to log in securely through browser. password: Provide username and password directly through CLI. token: Read an idToken directly from a file.
+
+    Default: ``'code'``
+
+``--username``
+    Username if logging in with credentials. This should only be used for service accounts that cannot authenticate via web browser.
+
+``--password``
+    Password if logging in with credentials.
+
+``--password-file``
+    File containing password if logging in with credentials.
+
+``--token``
+    Token if logging in with credentials.
+
+``--token-file``
+    File containing the refresh token URL, with all parameters appended.

--- a/docs/user_guide/appendix/cli/cli_logout.rst
+++ b/docs/user_guide/appendix/cli/cli_logout.rst
@@ -23,10 +23,9 @@
 osmo logout
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: logout
-   :ref-prefix: cli_reference_logout
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=logout | ref-prefix=cli_reference_logout | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo logout [-h]

--- a/docs/user_guide/appendix/cli/cli_pool.rst
+++ b/docs/user_guide/appendix/cli/cli_pool.rst
@@ -23,10 +23,73 @@
 osmo pool
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: pool
-   :ref-prefix: cli_reference_pool
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=pool | ref-prefix=cli_reference_pool | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo pool [-h] {list} ...
+
+.. _cli_reference_pool_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: list
+
+Sub-commands
+------------
+
+.. _cli_reference_pool_list:
+
+list
+~~~~
+
+Pool resource display formats::
+
+  Mode           | Description
+  ---------------|----------------------------------------------------
+  Used (default) | Shows the number of GPUs used and total GPUs
+  Free           | Shows the number of GPUs available for use
+
+Display table columns::
+
+  Column          | Description
+  ----------------|----------------------------------------------------
+  Quota Limit     | Max GPUs for HIGH/NORMAL priority workflows
+  Quota Used      | GPUs used by HIGH/NORMAL priority workflows
+  Quota Free      | Available GPUs for HIGH/NORMAL priority workflows
+  Total Capacity  | Total GPUs available on nodes in the pool
+  Total Usage     | Total GPUs used by all workflows in pool
+  Total Free      | Free GPUs on nodes in the pool
+
+
+.. code-block:: text
+
+   osmo pool list [-h] [--pool POOL [POOL ...]]
+                  [--format-type {json,text}] [--mode {free,used}]
+
+.. _cli_reference_pool_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--pool, -p``
+    Display resources for specified pool.
+
+    Default: ``[]``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+``--mode, -m``
+    Possible choices: free, used
+
+    Show free or used resources (Default used).
+
+    Default: ``'used'``

--- a/docs/user_guide/appendix/cli/cli_profile.rst
+++ b/docs/user_guide/appendix/cli/cli_profile.rst
@@ -23,10 +23,79 @@
 osmo profile
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: profile
-   :ref-prefix: cli_reference_profile
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=profile | ref-prefix=cli_reference_profile | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo profile [-h] {set,list} ...
+
+.. _cli_reference_profile_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: set, list
+
+Sub-commands
+------------
+
+.. _cli_reference_profile_set:
+
+set
+~~~
+
+Set profile settings.
+
+.. code-block:: text
+
+   osmo profile set [-h]
+                    {notifications,bucket,pool} value [{true,false}]
+
+.. _cli_reference_profile_set_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``setting``
+    Possible choices: notifications, bucket, pool
+
+    Field to set
+
+``value``
+    Type of notification, or name of bucket/pool
+
+``enabled``
+    Possible choices: true, false
+
+    Enable or disable, strictly for notifications.
+
+
+Ex. osmo profile set bucket my_bucket
+Ex. osmo profile set pool my_pool
+Ex. osmo profile set notifications email true # Enable only email notifications
+Ex. osmo profile set notifications slack false # Disable slack notifications
+
+.. _cli_reference_profile_list:
+
+list
+~~~~
+
+Fetch notification settings.
+
+.. code-block:: text
+
+   osmo profile list [-h] [--format-type {json,text}]
+
+.. _cli_reference_profile_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``

--- a/docs/user_guide/appendix/cli/cli_resource.rst
+++ b/docs/user_guide/appendix/cli/cli_resource.rst
@@ -23,10 +23,108 @@
 osmo resource
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: resource
-   :ref-prefix: cli_reference_resource
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=resource | ref-prefix=cli_reference_resource | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo resource [-h] {list,info} ...
+
+.. _cli_reference_resource_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: list, info
+
+Sub-commands
+------------
+
+.. _cli_reference_resource_list:
+
+list
+~~~~
+
+Resource display formats::
+
+  Mode           | Description
+  ---------------|----------------------------------------------------
+  Used (default) | Shows "used/total" (e.g., 40/100 means 40 Gi used
+                 | out of 100 Gi total memory)
+  Free           | Shows available resources as a single number
+                 | (e.g., 60 means 60 Gi of memory is available for use)
+
+This applies to all allocatable resources: CPU, memory, storage, and GPU.
+
+.. code-block:: text
+
+   osmo resource list [-h] [--pool POOL [POOL ...]]
+                      [--platform PLATFORM [PLATFORM ...]] [--all]
+                      [--format-type {json,text}]
+                      [--mode {free,used}]
+
+.. _cli_reference_resource_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--pool, -p``
+    Display resources for specified pool.
+
+    Default: ``[]``
+
+``--platform``
+    Display resources for specified platform.
+
+    Default: ``[]``
+
+``--all, -a``
+    Show all resources from all pools.
+
+    Default: ``False``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+``--mode, -m``
+    Possible choices: free, used
+
+    Show free or used resources (Default used).
+
+    Default: ``'used'``
+
+.. _cli_reference_resource_info:
+
+info
+~~~~
+
+Get resource allocatable and configurations of a node.
+
+.. code-block:: text
+
+   osmo resource info [-h] [--pool POOL] [--platform PLATFORM]
+                      node_name
+
+.. _cli_reference_resource_info_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``node_name``
+    Name of node.
+
+.. _cli_reference_resource_info_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--pool, -p``
+    Specify the pool to see specific allocatable and configurations.
+
+``--platform, -pl``
+    Specify the platform to see specific allocatable and configurations.

--- a/docs/user_guide/appendix/cli/cli_task.rst
+++ b/docs/user_guide/appendix/cli/cli_task.rst
@@ -23,10 +23,127 @@
 osmo task
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: task
-   :ref-prefix: cli_reference_task
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=task | ref-prefix=cli_reference_task | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo task [-h] {list} ...
+
+.. _cli_reference_task_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: list
+
+Sub-commands
+------------
+
+.. _cli_reference_task_list:
+
+list
+~~~~
+
+List tasks with different filters.
+
+.. code-block:: text
+
+   osmo task list [-h] [--status STATUS [STATUS ...]]
+                  [--workflow-id WORKFLOW_ID]
+                  [--user USER [USER ...] | --all-users]
+                  [--pool POOL [POOL ...] | --node NODE [NODE ...]]
+                  [--started-after STARTED_AFTER]
+                  [--started-before STARTED_BEFORE] [--count COUNT]
+                  [--offset OFFSET] [--order {asc,desc}]
+                  [--verbose | --summary] [--aggregate-by-workflow]
+                  [--priority {HIGH,NORMAL,LOW} [{HIGH,NORMAL,LOW} ...]]
+                  [--format-type {json,text}]
+
+.. _cli_reference_task_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--status, -s``
+    Possible choices: WAITING, PROCESSING, SCHEDULING, INITIALIZING, RUNNING, FAILED, COMPLETED, FAILED_EXEC_TIMEOUT, FAILED_START_ERROR, FAILED_START_TIMEOUT, FAILED_SERVER_ERROR, FAILED_BACKEND_ERROR, FAILED_QUEUE_TIMEOUT, FAILED_IMAGE_PULL, FAILED_UPSTREAM, FAILED_EVICTED, FAILED_PREEMPTED, FAILED_CANCELED
+
+    Display all tasks with the given status(es). Users can pass multiple values to this flag. Defaults to PROCESSING, SCHEDULING, INITIALIZING and RUNNING. Acceptable values: WAITING, PROCESSING, SCHEDULING, INITIALIZING, RUNNING, FAILED, COMPLETED, FAILED_EXEC_TIMEOUT, FAILED_START_ERROR, FAILED_START_TIMEOUT, FAILED_SERVER_ERROR, FAILED_BACKEND_ERROR, FAILED_QUEUE_TIMEOUT, FAILED_IMAGE_PULL, FAILED_UPSTREAM, FAILED_EVICTED, FAILED_PREEMPTED, FAILED_CANCELED.
+
+    Default: ``['PROCESSING', 'SCHEDULING', 'INITIALIZING', 'RUNNING']``
+
+``--workflow-id, -w``
+    Display workflows which contains the string.
+
+``--user, -u``
+    Display all tasks by this user. Users can pass multiple values to this flag.
+
+    Default: ``[]``
+
+``--all-users, -a``
+    Display all tasks with no filtering on users.
+
+    Default: ``False``
+
+``--pool, -p``
+    Display all tasks by this pool. Users can pass multiple values to this flag. If not specified, all pools will be selected.
+
+    Default: ``[]``
+
+``--node, -n``
+    Display all tasks which ran on this node. Users can pass multiple values to this flag. If not specified, all nodes will be selected.
+
+    Default: ``[]``
+
+``--started-after``
+    Filter for tasks that were started after AND including this date. Must be in format YYYY-MM-DD.
+    Example: --started-after 2023-05-03.
+
+``--started-before``
+    Filter for tasks that were started before (NOT including) this date. Must be in format YYYY-MM-DD.
+    Example: --started-after 2023-05-02 --started-before 2023-05-04 includes all tasks that were started any time on May 2nd and May 3rd only.
+
+``--count, -c``
+    Display the given count of tasks. Default value is 20. Max value of 1000.
+
+    Default: ``20``
+
+``--offset, -f``
+    Used for pagination. Returns starting tasks from the offset index.
+
+    Default: ``0``
+
+``--order, -o``
+    Possible choices: asc, desc
+
+    Display in the order in which tasks were started. asc means latest at the bottom. desc means latest at the top.
+
+    Default: ``'asc'``
+
+``--verbose, -v``
+    Display storage, cpu, memory, and gpu request.
+
+    Default: ``False``
+
+``--summary, -S``
+    Displays resource request grouped by user and pool.
+
+    Default: ``False``
+
+``--aggregate-by-workflow, -W``
+    Aggregate resource request by workflow.
+
+    Default: ``False``
+
+``--priority``
+    Possible choices: HIGH, NORMAL, LOW
+
+    Filter tasks by priority levels.
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``

--- a/docs/user_guide/appendix/cli/cli_token.rst
+++ b/docs/user_guide/appendix/cli/cli_token.rst
@@ -23,10 +23,137 @@
 osmo token
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: token
-   :ref-prefix: cli_reference_token
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=token | ref-prefix=cli_reference_token | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo token [-h] {set,delete,list} ...
+
+.. _cli_reference_token_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: set, delete, list
+
+Sub-commands
+------------
+
+.. _cli_reference_token_set:
+
+set
+~~~
+
+Set a token for the current user.
+
+.. code-block:: text
+
+   osmo token set [-h] [--expires-at EXPIRES_AT]
+                  [--description DESCRIPTION] [--service]
+                  [--roles ROLES [ROLES ...]]
+                  [--format-type {json,text}]
+                  name
+
+.. _cli_reference_token_set_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the token.
+
+.. _cli_reference_token_set_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--expires-at, -e``
+    Expiration date of the token. The date is based on UTC time. Format: YYYY-MM-DD
+
+    Default: ``2026-07-26``
+
+``--description, -d``
+    Description of the token.
+
+``--service, -s``
+    Create a service token.
+
+    Default: ``False``
+
+``--roles, -r``
+    Roles for the token. Only applicable for service tokens.
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo token set my-token --expires-at 2026-05-01 --description "My token description"
+
+.. _cli_reference_token_delete:
+
+delete
+~~~~~~
+
+Delete a token for the current user.
+
+.. code-block:: text
+
+   osmo token delete [-h] [--service] name
+
+.. _cli_reference_token_delete_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``name``
+    Name of the token.
+
+.. _cli_reference_token_delete_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--service, -s``
+    Delete a service token.
+
+    Default: ``False``
+
+
+Ex. osmo token delete my-token
+
+.. _cli_reference_token_list:
+
+list
+~~~~
+
+List all tokens for the current user.
+
+.. code-block:: text
+
+   osmo token list [-h] [--service] [--format-type {json,text}]
+
+.. _cli_reference_token_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--service, -s``
+    List all service tokens.
+
+    Default: ``False``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+
+Ex. osmo token list

--- a/docs/user_guide/appendix/cli/cli_version.rst
+++ b/docs/user_guide/appendix/cli/cli_version.rst
@@ -23,10 +23,21 @@
 osmo version
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: version
-   :ref-prefix: cli_reference_version
-   :argument-anchor:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=version | ref-prefix=cli_reference_version | flags=argument-anchor
+
+.. code-block:: text
+
+   usage: osmo version [-h] [--format-type {json,text}]
+
+.. _cli_reference_version_named_arguments:
+
+Named Arguments
+---------------
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``

--- a/docs/user_guide/appendix/cli/cli_workflow.rst
+++ b/docs/user_guide/appendix/cli/cli_workflow.rst
@@ -23,11 +23,645 @@
 osmo workflow
 ================================================
 
-.. argparse-with-postprocess::
-   :module: src.cli.main_parser
-   :func: create_cli_parser
-   :prog: osmo
-   :path: workflow
-   :ref-prefix: cli_reference_workflow
-   :argument-anchor:
-   :markdown:
+.. CLI-REFERENCE-GENERATED -- do not edit by hand; regenerate with: make -C docs cli-rst
+.. cli-source: module=src.cli.main_parser | func=create_cli_parser | prog=osmo | path=workflow | ref-prefix=cli_reference_workflow | flags=argument-anchor,markdown
+
+.. code-block:: text
+
+   usage: osmo workflow [-h]
+                        {submit,restart,validate,logs,cancel,query,list,tag,exec,spec,port-forward,rsync}
+                        ...
+
+.. _cli_reference_workflow_positional_arguments:
+
+Positional Arguments
+--------------------
+
+``command``
+    Possible choices: submit, restart, validate, logs, cancel, query, list, tag, exec, spec, port-forward, rsync
+
+Sub-commands
+------------
+
+.. _cli_reference_workflow_submit:
+
+submit
+~~~~~~
+
+Submit a workflow to the workflow service.
+
+.. code-block:: text
+
+   osmo workflow submit [-h] [--format-type {json,text}]
+                        [--set SET [SET ...]]
+                        [--set-string SET_STRING [SET_STRING ...]]
+                        [--set-env SET_ENV [SET_ENV ...]]
+                        [--dry-run] [--pool POOL] [--rsync RSYNC]
+                        [--priority {HIGH,NORMAL,LOW}]
+                        workflow_file
+
+.. _cli_reference_workflow_submit_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_file``
+    The workflow file to submit, or the spec of a workflow ID to submit. If using a workflow ID, --dry-run and --set are not supported.
+
+.. _cli_reference_workflow_submit_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+``--set``
+    Assign fields in the workflow file with desired elements in the form "<field>=<value>". These values will override values set in the "default-values" section. Overridden fields in the yaml file should be in the form {{ field }}. Values will be cast as int or float if applicable
+
+    Default: ``[]``
+
+``--set-string``
+    Assign fields in the workflow file with desired elements in the form "<field>=<value>". These values will override values set in the "default-values" section. Overridden fields in the yaml file should be in the form {{ field }}. All values will be cast as string
+
+    Default: ``[]``
+
+``--set-env``
+    Assign environment variables to the workflow. The value should be in the format <key>=<value>. Multiple key-value pairs can be passed. If an environment variable passed here is already defined in the workflow, the value declared here will override the value in the workflow.
+
+    Default: ``[]``
+
+``--dry-run``
+    Does not submit the workflow and prints the workflow into the console.
+
+    Default: ``False``
+
+``--pool, -p``
+    The target pool to run the workflow with. If no pool is specified, the default pool assigned in the profile will be used.
+
+``--rsync``
+    Start a background rsync daemon to continuously upload data from local machine to the lead task of the workflow. The value should be in the format <local_path>:<remote_path>. The daemon process will automatically exit when the workflow is terminated.
+
+``--priority``
+    Possible choices: HIGH, NORMAL, LOW
+
+    The priority to use when scheduling the workflow. If none is provided, NORMAL will be used. The scheduler will prioritize scheduling workflows in the order of HIGH, NORMAL, LOW. LOW workflows may be preempted to allow a higher priority workflow to run.
+
+.. _cli_reference_workflow_restart:
+
+restart
+~~~~~~~
+
+Restart a failed workflow.
+
+.. code-block:: text
+
+   osmo workflow restart [-h] [--format-type {json,text}]
+                         [--pool POOL]
+                         workflow_id
+
+.. _cli_reference_workflow_restart_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_id``
+    The workflow ID or UUID to restart.
+
+.. _cli_reference_workflow_restart_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+``--pool, -p``
+    The target pool to run the workflow with.
+
+.. _cli_reference_workflow_validate:
+
+validate
+~~~~~~~~
+
+validate a workflow to the workflow server.
+
+.. code-block:: text
+
+   osmo workflow validate [-h] [--set SET [SET ...]]
+                          [--set-string SET_STRING [SET_STRING ...]]
+                          [--pool POOL]
+                          workflow_file
+
+.. _cli_reference_workflow_validate_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_file``
+    The workflow file to submit.
+
+.. _cli_reference_workflow_validate_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--set``
+    Assign fields in the workflow file with desired elements in the form "<field>=<value>". These values will override values set in the "default-values" section. Overridden fields in the yaml file should be in the form {{ field }}. Values will be cast as int or float if applicable
+
+    Default: ``[]``
+
+``--set-string``
+    Assign fields in the workflow file with desired elements in the form "<field>=<value>". These values will override values set in the "default-values" section. Overridden fields in the yaml file should be in the form {{ field }}. All values will be cast as string
+
+    Default: ``[]``
+
+``--pool, -p``
+    The target pool to run the workflow with. If no pool is specified, the default pool assigned in the profile will be used.
+
+.. _cli_reference_workflow_logs:
+
+logs
+~~~~
+
+Get the logs from a workflow.
+
+.. code-block:: text
+
+   osmo workflow logs [-h] [--task TASK] [--retry-id RETRY_ID]
+                      [--error] [-n LAST_N_LINES]
+                      workflow_id
+
+.. _cli_reference_workflow_logs_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_id``
+    The workflow ID or UUID for which to fetch the logs.
+
+.. _cli_reference_workflow_logs_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--task, -t``
+    The task name for which to fetch the logs.
+
+``--retry-id, -r``
+    The retry ID for the task which to fetch the logs. If not provided, the latest retry ID will be used.
+
+``--error``
+    Show task error logs instead of regular logs
+
+    Default: ``False``
+
+``-n``
+    Show last n lines of logs
+
+.. _cli_reference_workflow_cancel:
+
+cancel
+~~~~~~
+
+Cancel a queued or running workflow.
+
+.. code-block:: text
+
+   osmo workflow cancel [-h] [--message MESSAGE] [--force]
+                        [--format-type {json,text}]
+                        workflow_ids [workflow_ids ...]
+
+.. _cli_reference_workflow_cancel_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_ids``
+    The workflow IDs or UUIDs to cancel. Multiple IDs or UUIDs can be passed.
+
+.. _cli_reference_workflow_cancel_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--message, -m``
+    Additional message describing reason for cancelation.
+
+``--force, -f``
+    Force cancel task group pods in the cluster.
+
+    Default: ``False``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+.. _cli_reference_workflow_query:
+
+query
+~~~~~
+
+Query the status of a running workflow.
+
+.. code-block:: text
+
+   osmo workflow query [-h] [--verbose] [--format-type {json,text}]
+                       workflow_id
+
+.. _cli_reference_workflow_query_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_id``
+    The workflow ID or UUID to query the status of.
+
+.. _cli_reference_workflow_query_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--verbose, -v``
+    Whether to show all retried tasks.
+
+    Default: ``False``
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+.. _cli_reference_workflow_list:
+
+list
+~~~~
+
+List workflows with different filters. Without the --pool flag, workflows from all pools will be listed.
+
+.. code-block:: text
+
+   osmo workflow list [-h] [--count COUNT] [--name NAME]
+                      [--order {asc,desc}]
+                      [--status STATUS [STATUS ...]]
+                      [--format-type {json,text}]
+                      [--submitted-after SUBMITTED_AFTER]
+                      [--submitted-before SUBMITTED_BEFORE]
+                      [--tags TAGS [TAGS ...]]
+                      [--priority {HIGH,NORMAL,LOW} [{HIGH,NORMAL,LOW} ...]]
+                      [--user USER [USER ...] | --all-users]
+                      [--pool POOL [POOL ...]] [--app APP]
+
+.. _cli_reference_workflow_list_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--count, -c``
+    Display the given count of workflows. Default value is 20.
+
+    Default: ``20``
+
+``--name, -n``
+    Display workflows which contains the string.
+
+``--order, -o``
+    Possible choices: asc, desc
+
+    Display in the order in which workflows were submitted. asc means latest at the bottom. desc means latest at the top. Default is asc.
+
+    Default: ``'asc'``
+
+``--status, -s``
+    Possible choices: RUNNING, FAILED, COMPLETED, PENDING, WAITING, FAILED_EXEC_TIMEOUT, FAILED_SERVER_ERROR, FAILED_QUEUE_TIMEOUT, FAILED_SUBMISSION, FAILED_CANCELED, FAILED_BACKEND_ERROR, FAILED_IMAGE_PULL, FAILED_EVICTED, FAILED_START_ERROR, FAILED_START_TIMEOUT, FAILED_PREEMPTED
+
+    Display all workflows with the given status(es). Users can pass multiple values to this flag. Acceptable values: RUNNING, FAILED, COMPLETED, PENDING, WAITING, FAILED_EXEC_TIMEOUT, FAILED_SERVER_ERROR, FAILED_QUEUE_TIMEOUT, FAILED_SUBMISSION, FAILED_CANCELED, FAILED_BACKEND_ERROR, FAILED_IMAGE_PULL, FAILED_EVICTED, FAILED_START_ERROR, FAILED_START_TIMEOUT, FAILED_PREEMPTED
+
+``--format-type, -t``
+    Possible choices: json, text
+
+    Specify the output format type (Default text).
+
+    Default: ``'text'``
+
+``--submitted-after``
+    Filter for workflows that were submitted after AND including this date. Must be in format YYYY-MM-DD.
+    Example: --submitted-after 2023-05-03
+
+``--submitted-before``
+    Filter for workflows that were submitted before (NOT including) this date. Must be in format YYYY-MM-DD.
+    Example: --submitted-after 2023-05-02 --submitted-before 2023-05-04 includes all workflows that were submitted any time on May 2nd and May 3rd only.
+
+``--tags``
+    Filter for workflows that contain the tag(s).
+
+``--priority``
+    Possible choices: HIGH, NORMAL, LOW
+
+    Filter workflows by priority levels.
+
+``--user, -u``
+    Display all workflows by this user. Users can pass multiple values to this flag.
+
+    Default: ``[]``
+
+``--all-users, -a``
+    Display all workflows with no filtering on users.
+
+    Default: ``False``
+
+``--pool, -p``
+    Display all workflows by this pool. Users can pass multiple values to this flag.
+
+    Default: ``[]``
+
+``--app, -P``
+    Display all workflows created by this app. For a specific app or app version, use the format <app>:<version>.
+
+.. _cli_reference_workflow_tag:
+
+tag
+~~~
+
+List or change tags from workflow(s) if no workflow is specified. Remove is applied before add
+
+.. code-block:: text
+
+   osmo workflow tag [-h] [--workflow WORKFLOW [WORKFLOW ...]]
+                     [--add ADD [ADD ...]]
+                     [--remove REMOVE [REMOVE ...]]
+
+.. _cli_reference_workflow_tag_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--workflow, -w``
+    List of workflows to update. If not set, the CLI will return the list of available tags to assign.
+
+``--add, -a``
+    List of tags to add.
+
+    Default: ``[]``
+
+``--remove, -r``
+    List of tags to remove.
+
+    Default: ``[]``
+
+.. _cli_reference_workflow_exec:
+
+exec
+~~~~
+
+Exec into a task of a workflow.
+
+.. code-block:: text
+
+   osmo workflow exec [-h] [--group GROUP]
+                      [--entry EXEC_ENTRY_COMMAND]
+                      [--connect-timeout CONNECT_TIMEOUT]
+                      [--keep-alive]
+                      workflow_id [task]
+
+.. _cli_reference_workflow_exec_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_id``
+    The workflow ID or UUID to exec in.
+
+``task``
+    The task name to exec into.
+
+.. _cli_reference_workflow_exec_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--group``
+    Send command to all tasks in the group.
+
+``--entry``
+    Specify the entry point for exec (Default /bin/bash).
+
+    Default: ``'/bin/bash'``
+
+``--connect-timeout``
+    The connection timeout period in seconds. Default is 60 seconds.
+
+    Default: ``60``
+
+``--keep-alive``
+    Restart the exec command if connection is lost.
+
+    Default: ``False``
+
+.. _cli_reference_workflow_spec:
+
+spec
+~~~~
+
+Get workflow spec.
+
+.. code-block:: text
+
+   osmo workflow spec [-h] [--template] workflow_id
+
+.. _cli_reference_workflow_spec_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_id``
+    The workflow ID or UUID to query the status of.
+
+.. _cli_reference_workflow_spec_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--template``
+    Show the original templated spec
+
+    Default: ``False``
+
+.. _cli_reference_workflow_port_forward:
+
+port-forward
+~~~~~~~~~~~~
+
+Port-forward data from workflow to local machine.
+
+.. code-block:: text
+
+   osmo workflow port-forward [-h] [--host HOST] --port PORT [--udp]
+                              [--connect-timeout CONNECT_TIMEOUT]
+                              workflow_id task
+
+.. _cli_reference_workflow_port_forward_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_id``
+    The ID or UUID of the workflow to port forward from
+
+``task``
+    Name of the task in the workflow to port forward from
+
+.. _cli_reference_workflow_port_forward_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--host``
+    The hostname used to bind the local port. Default value is localhost.
+
+    Default: ``'localhost'``
+
+``--port``
+    Port forward from task in the pool. Input value should be in format local_port[:task_port], or in range port1-port2,port3-port4 (right end inclusive). e.g. "8000:2000", "8000", "8000-8010:9000-9010,8015-8016". If using a single port value or range, the client will use that port value for both local port and task port.
+
+``--udp``
+    Use UDP port forward.
+
+    Default: ``False``
+
+``--connect-timeout``
+    The connection timeout period in seconds. Default is 60 seconds.
+
+    Default: ``60``
+
+
+
+.. rubric:: Examples
+
+Forward UDP traffic from a task to your local machine::
+
+  osmo workflow port-forward wf-1 sim-task --port 47995-48012,49000-49007 --udp
+        
+
+.. _cli_reference_workflow_rsync:
+
+rsync
+~~~~~
+
+Syncs data from local machine to a remote workflow task via a persistent background daemon. It will continuously monitors the source path and automatically upload any changes to the remote task.
+
+/osmo/run/workspace is always available as a remote path.
+
+.. code-block:: text
+
+   osmo workflow rsync [-h] [--status] [--stop] [--timeout TIMEOUT]
+                       [--upload-rate-limit UPLOAD_RATE_LIMIT]
+                       [--poll-interval POLL_INTERVAL]
+                       [--debounce-delay DEBOUNCE_DELAY]
+                       [--reconcile-interval RECONCILE_INTERVAL]
+                       [--max-log-size MAX_LOG_SIZE] [--verbose]
+                       [--once]
+                       [workflow_id] [task] [path]
+
+.. _cli_reference_workflow_rsync_positional_arguments:
+
+Positional Arguments
+^^^^^^^^^^^^^^^^^^^^
+
+``workflow_id``
+    The ID or UUID of the workflow to rsync to/from
+
+``task``
+    (Optional) The task to rsync upload to. If not provided, the upload will be to the lead task of the first group.
+
+``path``
+    The src:dst path to rsync between.
+
+.. _cli_reference_workflow_rsync_named_arguments:
+
+Named Arguments
+^^^^^^^^^^^^^^^
+
+``--status, -s``
+    Show the status of all rsync daemons
+
+    Default: ``False``
+
+``--stop``
+    Stop one or more rsync daemons
+
+    Default: ``False``
+
+``--timeout``
+    The connection timeout period in seconds. Default is 10 seconds.
+
+    Default: ``10``
+
+``--upload-rate-limit``
+    Rate limit the upload speed in bytes per second. The upload speed is also subjected to admin configured rate-limit.
+
+``--poll-interval``
+    The amount of time (seconds) between polling the task for changes in daemon mode. If not provided, the admin-configured default will be used.
+
+``--debounce-delay``
+    The amount of time (seconds) of inactivity after last file change before a sync is triggered in daemon mode. If not provided, the admin-configured default will be used.
+
+``--reconcile-interval``
+    The amount of time (seconds) between reconciling the upload in daemon mode. This is used to ensure that failed uploads during network interruptions will resume after connection is restored. If not provided, the admin-configured default will be used.
+
+``--max-log-size``
+    The maximum log size in bytes for the daemon before log rotation. Default is 2MB.
+
+    Default: ``2097152``
+
+``--verbose``
+    Enable verbose logging for the daemon.
+
+    Default: ``False``
+
+``--once``
+    Run a single rsync upload to the workflow. The upload will be done in the foreground and will automatically exit once the upload completes.
+
+    Default: ``False``
+
+
+
+.. rubric:: Examples
+
+Upload to a task::
+
+    osmo workflow rsync <workflow_id> <task_name> <local_path>:<remote_path>
+
+Upload to lead task::
+
+    osmo workflow rsync <workflow_id> <local_path>:<remote_path>
+
+Run a single upload::
+
+    osmo workflow rsync <workflow_id> <local_path>:<remote_path> --once
+
+Get the status of daemons::
+
+    osmo workflow rsync --status
+
+Stop all daemons::
+
+    osmo workflow rsync --stop
+
+Stop a specific daemon::
+
+    osmo workflow rsync <workflow_id> --stop
+        

--- a/docs/user_guide/faq/workflow.in.rst
+++ b/docs/user_guide/faq/workflow.in.rst
@@ -208,7 +208,7 @@ To manually rerun tasks in a workflow that have failed, see :ref:`cli_reference_
 
 To have your workflow automatically reschedule and retry failed tasks, see  :ref:`workflow_spec_exit_actions`
 
-For a practical example of rescheduling training workflows for backend errors, see `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/dnn_training/torchrun_reschedule>`__.
+For a practical example of rescheduling training workflows for backend errors, see `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/dnn_training/torchrun_reschedule>`__.
 
 How to save the intermediate data when the workflow is stuck or hangs?
 -----------------------------------------------------------------------
@@ -448,4 +448,4 @@ Running a NIM in an OSMO workflow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You can run NVIDIA Inference Microservices (NIMs) directly in your OSMO workflows. This allows you to either host a NIM server as part of your workflow or connect to an external NIM service.
 
-For a complete guide with examples, see the `NIM workflow example <https://github.com/NVIDIA/OSMO/tree/main/workflows/nims>`_.
+For a complete guide with examples, see the `NIM workflow example <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/nims>`_.

--- a/docs/user_guide/how_to/hil.rst
+++ b/docs/user_guide/how_to/hil.rst
@@ -285,12 +285,12 @@ And finally, we will add the locomotion-policy task:
   1. Running the install_dependencies.sh script to install the dependencies for the locomotion policy.
   2. Launch the locomotion policy, and the application will start publishing the movements while subscribing to the robot's state.
 
-The complete workflow file and required scripts can be found on `Github <https://github.com/NVIDIA/OSMO/tree/main/workflows/hil>`_.
+The complete workflow file and required scripts can be found on `Github <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/hil>`_.
 
 Interfacing with Simulation Window
 ----------------------------------
 
-For a refresher on connecting to the Isaac Sim Streaming Client, see the `Livestream tutorial <https://github.com/NVIDIA/OSMO/tree/main/workflows/integration_and_tools/isaacsim>`_.
+For a refresher on connecting to the Isaac Sim Streaming Client, see the `Livestream tutorial <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/integration_and_tools/isaacsim>`_.
 
 After you submit the workflow, you will need to look at the logs for the ``isaac-lab`` task.
 You can click on the link for ``Workflow Overview``, and click on the ``Logs`` tab of the ``isaac-lab`` task

--- a/docs/user_guide/how_to/isaac_groot_notebook.rst
+++ b/docs/user_guide/how_to/isaac_groot_notebook.rst
@@ -44,7 +44,7 @@ Fetch the workflow spec:
 
 .. note::
 
-    The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/groot/groot_notebook>`_.
+    The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/groot/groot_notebook>`_.
 
 Add any platform value if necessary to target a specific type of hardware.
 To read more about platforms, please refer to the :ref:`Platforms <concepts_platforms>`.

--- a/docs/user_guide/how_to/isaac_sim_sdg.rst
+++ b/docs/user_guide/how_to/isaac_sim_sdg.rst
@@ -25,7 +25,7 @@ In this tutorial, you will generate synthetic data using `Isaac Sim <https://dev
 NVIDIA's robotics simulator. By the end of the tutorial, you will have a dataset of synthetic images of warehouse scenes,
 that can be used to train neural network models.
 
-The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/synthetic_data_generation/isaac_sim>`_.
+The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/synthetic_data_generation/isaac_sim>`_.
 
 Prerequisites
 -------------

--- a/docs/user_guide/how_to/reinforcement_learning.rst
+++ b/docs/user_guide/how_to/reinforcement_learning.rst
@@ -174,11 +174,11 @@ Running Other Reinforcement Learning Examples
 ---------------------------------------------
 
 Isaac Lab supports other reinforcement learning libraries such as RL Games, RSL-RL, and SKRL too, and you can view
-all the examples in the `Isaac Lab documentation <https://isaac-sim.github.io/IsaacLab/release/2.2.0/source/overview/reinforcement-learning/rl_existing_scripts.html>`_.
+all the examples in the `Isaac Lab documentation <https://isaac-sim.github.io/IsaacLab/main/source/overview/reinforcement-learning/rl_existing_scripts.html>`_.
 
 In this tutorial we were using Stable Baselines 3 to train the policy, but you can modify the entry script to use other libraries as well.
 
-For example, you can pick the `RSL-RL training script <https://isaac-sim.github.io/IsaacLab/release/2.2.0/source/overview/reinforcement-learning/rl_existing_scripts.html#rsl-rl>`_,
+For example, you can pick the `RSL-RL training script <https://isaac-sim.github.io/IsaacLab/main/source/overview/reinforcement-learning/rl_existing_scripts.html#rsl-rl>`_,
 which will train a Franka arm robot to reach target locations. You can modify the entry script to call the new training script:
 
 .. code-block:: bash

--- a/docs/user_guide/how_to/reinforcement_learning.rst
+++ b/docs/user_guide/how_to/reinforcement_learning.rst
@@ -27,7 +27,7 @@ using `Isaac Lab <https://developer.nvidia.com/isaac/lab>`_, NVIDIA's framework 
 You will learn the basics of launching a training script, monitoring training progress using TensorBoard,
 and reviewing the checkpoints and videos of the trained policy.
 
-The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/reinforcement_learning>`_.
+The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/reinforcement_learning>`_.
 
 Prerequisites
 -------------
@@ -115,7 +115,7 @@ and kill it after the training is done.
 
     If you launch TensorBoard in the same task as the training script, you need to stop it at the end so that the workflow can finish.
 
-The complete workflow spec file is available as `train_policy.yaml <https://github.com/NVIDIA/OSMO/blob/main/workflows/reinforcement_learning/single_gpu/train_policy.yaml>`_.
+The complete workflow spec file is available as `train_policy.yaml <https://github.com/NVIDIA/OSMO/blob/release/6.1/workflows/reinforcement_learning/single_gpu/train_policy.yaml>`_.
 
 Running the Workflow
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/user_guide/how_to/ros2_comm.rst
+++ b/docs/user_guide/how_to/ros2_comm.rst
@@ -27,7 +27,7 @@ which is essential for building scalable robotics applications.
 
 This tutorial is based on the official `ROS 2 Discovery Server tutorial <https://docs.ros.org/en/foxy/Tutorials/Advanced/Discovery-Server/Discovery-Server.html#run-this-tutorial>`_.
 
-The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/ros/comm>`_.
+The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/ros/comm>`_.
 
 Architecture
 ------------

--- a/docs/user_guide/how_to/training/multi_node.rst
+++ b/docs/user_guide/how_to/training/multi_node.rst
@@ -24,8 +24,8 @@ Multi-Node Distributed Training
 
 You will learn how to train a model on multiple nodes in OSMO.
 
-The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/dnn_training/torchrun_multinode>`__.
-More examples with other distributed training frameworks can be found `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/dnn_training>`__.
+The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/dnn_training/torchrun_multinode>`__.
+More examples with other distributed training frameworks can be found `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/dnn_training>`__.
 
 .. important::
 
@@ -35,7 +35,7 @@ Making a TorchRun Multi-Node Training Script
 --------------------------------------------
 
 To train a model on multiple nodes in OSMO, you need to first make your training script compatible with distributed training,
-for example, using `train.py <https://github.com/NVIDIA/OSMO/blob/main/workflows/dnn_training/torchrun_multinode/train.py>`_.
+for example, using `train.py <https://github.com/NVIDIA/OSMO/blob/release/6.1/workflows/dnn_training/torchrun_multinode/train.py>`_.
 
 Training on Two Nodes
 ---------------------
@@ -186,7 +186,7 @@ This prevents different initialization timing that causes timeout issues.
 
 In some cases, you may want to synchronize the training starting time by yourself.
 For example, you need to install some heavy dependencies before the training starts and that can take varies of time.
-You can use the a barrier script like `osmo_barrier.py <https://github.com/NVIDIA/OSMO/blob/main/workflows/dnn_training/torchrun_multinode/osmo_barrier.py>`_ to synchronize before the training launches.
+You can use the a barrier script like `osmo_barrier.py <https://github.com/NVIDIA/OSMO/blob/release/6.1/workflows/dnn_training/torchrun_multinode/osmo_barrier.py>`_ to synchronize before the training launches.
 
 .. code-block:: jinja
 

--- a/docs/user_guide/how_to/training/reschedule_backend_errors.rst
+++ b/docs/user_guide/how_to/training/reschedule_backend_errors.rst
@@ -26,8 +26,8 @@ automatically reschedule tasks when backend errors occur. This is particularly
 useful for long-running training jobs that may encounter transient failures
 (e.g. NCCL errors).
 
-The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/dnn_training/torchrun_reschedule>`__.
-For other elastic training examples, please visit `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/dnn_training>`__.
+The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/dnn_training/torchrun_reschedule>`__.
+For other elastic training examples, please visit `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/dnn_training>`__.
 
 Resume Training When Tasks Rerun
 --------------------------------

--- a/docs/user_guide/how_to/training/single_node.rst
+++ b/docs/user_guide/how_to/training/single_node.rst
@@ -26,12 +26,12 @@ This tutorial walks you through running a neural network training job on a singl
 You will learn the basics of launching your training script, selecting resources, managing data
 and monitoring training progress using TensorBoard or Weights & Biases.
 
-The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/main/workflows/dnn_training/single_node>`_.
+The complete workflow example is available `here <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/dnn_training/single_node>`_.
 
 Launching a Training Script in a Workflow
 -----------------------------------------
 
-Suppose you have a training script `train.py <https://github.com/NVIDIA/OSMO/blob/main/workflows/dnn_training/single_node/train.py>`_ ready to use.
+Suppose you have a training script `train.py <https://github.com/NVIDIA/OSMO/blob/release/6.1/workflows/dnn_training/single_node/train.py>`_ ready to use.
 Use the ``files`` field in your task spec to include the script in your workflow as a local file.
 Then you can launch the training script in your entry script:
 

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -262,7 +262,7 @@ Connect any S3-compatible object storage or Azure Blob Storage. Store datasets a
 .. toctree::
   :hidden:
 
-  More Examples <https://github.com/NVIDIA/OSMO/tree/main/workflows>
+  More Examples <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows>
 
 .. toctree::
   :hidden:

--- a/docs/user_guide/tutorials/combination_workflows/index.rst
+++ b/docs/user_guide/tutorials/combination_workflows/index.rst
@@ -124,7 +124,7 @@ here: :download:`combination_workflow_complex.yaml <../../../../workflows/tutori
    the ``lead`` task **does not terminate** before non-lead tasks.
 
    This can be done by coordinating task completion through a barrier script
-   (`osmo_barrier.py <https://github.com/NVIDIA/OSMO/blob/main/workflows/dnn_training/torchrun_multinode/osmo_barrier.py>`_)
+   (`osmo_barrier.py <https://github.com/NVIDIA/OSMO/blob/release/6.1/workflows/dnn_training/torchrun_multinode/osmo_barrier.py>`_)
    or by ensuring that the ``lead`` task duration is longer than the non-lead tasks.
 
 .. important::

--- a/docs/user_guide/workflows/interactive/port_forward.rst
+++ b/docs/user_guide/workflows/interactive/port_forward.rst
@@ -51,9 +51,9 @@ Browser
 
 Forwarding a port through the browser is useful when your task has a web service running that
 listens on a single port and serves http traffic, such as a
-`Jupyter Notebook <https://github.com/NVIDIA/OSMO/tree/main/workflows/integration_and_tools/jupyterlab>`_,
-a `VSCode Server <https://github.com/NVIDIA/OSMO/tree/main/workflows/integration_and_tools/vscode>`_
-or a `Ray dashboard <https://github.com/NVIDIA/OSMO/tree/main/workflows/integration_and_tools/ray>`_ .
+`Jupyter Notebook <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/integration_and_tools/jupyterlab>`_,
+a `VSCode Server <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/integration_and_tools/vscode>`_
+or a `Ray dashboard <https://github.com/NVIDIA/OSMO/tree/release/6.1/workflows/integration_and_tools/ray>`_ .
 
 You can forward a port from **a running workflow task** in the browser using the ``Port Forward``
 option in the ``Task Details`` menu for that task. You may select the task, enter the port number


### PR DESCRIPTION
## Description

Freezes the 6.1 CLI reference pages to static reStructuredText so the multiversion docs
build renders this version's CLI without importing this branch's code. Generated with
`make -C docs cli-rst` in a 6.1 environment (Python 3.10): each page's
`argparse-with-postprocess` directive is replaced by pre-rendered rST (usage, options,
sub-commands, examples) plus the `cli_reference_*` anchors other pages link to.

The deployed multiversion build introspects `main`'s live CLI parser for every version.
6.1 documents `bucket`/`dataset` (removed on `main`) and its code is not importable under
current dependencies (Pydantic v1), so its CLI pages broke the build. Freezing renders them
from 6.1's own parser — accurate and import-free. Validated with a local multiversion build:
6.1's pages render with no placeholders and all cross-references resolve.

Issue #None

Jira: OSMO-6482

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.