### PR TITLE
Clean up stale dataset leftovers

### DIFF
--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -564,7 +564,6 @@ services:
           - "app:*"
           - "auth:Token"
           - "credentials:*"
-          - "dataset:*"
           - "pool:List"
           - "profile:Read"
           - "profile:Update"

--- a/skills/osmo-user/evals/evals.json
+++ b/skills/osmo-user/evals/evals.json
@@ -212,7 +212,7 @@
   },
   {
     "id": "osmo-user-017",
-    "question": "sdg-train-1 finished successfully but its output dataset is empty. The job exited 0 — why are there no files?",
+    "question": "sdg-train-1 finished successfully but its output directory is empty. The job exited 0 — why are there no files?",
     "expected_skill": "osmo-user",
     "expected_script": null,
     "ground_truth": "The agent used osmo-user to diagnose an empty-output-after-COMPLETED case: queried sdg-train-1 (COMPLETED, exit 0, empty outputs), read the workflow spec, and spotted that the entry script wrote to the literal placeholder {{outputs}} (plural) instead of the OSMO-substituted {{output}} (singular) mount, so nothing was uploaded. It recommended fixing the placeholder to {{output}} and rerunning.",

--- a/src/ui/eslint.config.mjs
+++ b/src/ui/eslint.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 
-const FEATURE_NAMES = ["dashboard", "datasets", "log-viewer", "pools", "profile", "resources", "workflows"];
+const FEATURE_NAMES = ["dashboard", "log-viewer", "pools", "profile", "resources", "workflows"];
 const crossFeatureZones = FEATURE_NAMES.map((featureName) => ({
   target: `./src/features/${featureName}`,
   from: "./src/features",

--- a/src/ui/src/components/chrome/page-context.tsx
+++ b/src/ui/src/components/chrome/page-context.tsx
@@ -39,7 +39,7 @@ export interface PageConfig {
   /**
    * Inline breadcrumbs rendered after `breadcrumbs` in the nav flow (no extra margin).
    * Use for dynamic in-page navigation that can't be expressed as BreadcrumbSegment hrefs,
-   * e.g. callback-based path navigation in the dataset file browser.
+   * e.g. callback-based path navigation in a hierarchical file browser.
    */
   trailingBreadcrumbs?: React.ReactNode;
   /** Custom actions to render in the header after the title */

--- a/src/ui/src/lib/api/adapter/transforms.ts
+++ b/src/ui/src/lib/api/adapter/transforms.ts
@@ -32,7 +32,7 @@
  * When backend is fixed, these transforms can be simplified or removed.
  *
  * ✅ Resolved Issues (no longer workarounds here):
- * - Issue #1: Response types for Pool/Resource/Workflow/Dataset/Credential/Profile APIs
+ * - Issue #1: Response types for Pool/Resource/Workflow/Credential/Profile APIs
  *   now use proper $ref schemas via response_model= annotations on FastAPI endpoints.
  * - Issue #4: Version endpoint now has response_model=Version; no runtime type checks needed.
  *


### PR DESCRIPTION
## Description
Remove a few stale dataset leftovers that remained after the main deprecation work landed.

This PR:
- removes the stale `dataset:*` default permission from the Helm service chart values
- removes leftover dataset references from UI scaffolding comments and config
- updates the `osmo-user` eval wording to refer to an empty output directory instead of an output dataset

These are follow-up cleanup changes only. They do not restore or remove any additional dataset runtime behavior.

Issue #911

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] No new tests were needed for this scoped cleanup.
- [x] The documentation is up to date with these changes.
