### PR TITLE
Fix Python 3.14.6 toolchain resolution on arm64 

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -154,6 +154,15 @@ python.single_version_platform_override(
         "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.14.6+20260610-aarch64-unknown-linux-gnu-install_only.tar.gz",
     ],
 )
+python.single_version_platform_override(
+    platform = "aarch64-apple-darwin",
+    python_version = PYTHON_VERSION,
+    sha256 = "953db72ff2dea68b5112231b1ba77163ec9114f87c7ece530b3ea742a3b492c5",
+    strip_prefix = "python",
+    urls = [
+        "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.14.6+20260610-aarch64-apple-darwin-install_only.tar.gz",
+    ],
+)
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -145,6 +145,15 @@ python.single_version_platform_override(
         "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.14.6+20260610-x86_64-unknown-linux-gnu-install_only.tar.gz",
     ],
 )
+python.single_version_platform_override(
+    platform = "aarch64-unknown-linux-gnu",
+    python_version = PYTHON_VERSION,
+    sha256 = "9bc4a8b40e849c927158403552ffea25627f17776e5200156b131ac78b049384",
+    strip_prefix = "python",
+    urls = [
+        "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.14.6+20260610-aarch64-unknown-linux-gnu-install_only.tar.gz",
+    ],
+)
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
 Fix Python 3.14.6 toolchain resolution on arm64 hosts by adding explicit `python.single_version_platform_override` entries for:

  - `aarch64-unknown-linux-gnu`
  - `aarch64-apple-darwin`

  This keeps the repo on Python 3.14.6 while allowing Bazel/rules_python pip hubs such as `client_ci_deps` to find a compatible host interpreter on Linux arm64 and macOS arm64 runners.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional Python standalone toolchain downloads on `aarch64` Linux and macOS.
  * Users on Apple Silicon and ARM Linux platforms can now use the updated Python toolchain override configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->