### PR TITLE
docs: build multiversion CLI pages from each version's own source (OSMO-6482)

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -55,6 +55,14 @@ jobs:
           git fetch
           pip install -U -r docs/locked_requirements.txt
           pip install -U -r src/locked_requirements.txt
+          # The multiversion build renders each version's CLI from its own
+          # checked-out src (see docs/conf.py). Install the modern release
+          # branches' src requirements so their parser imports (e.g. diskcache).
+          # Do NOT install legacy pydantic-v1 branches (6.1/6.2): those are
+          # frozen to static rST and would downgrade pydantic; the conf.py
+          # fallback routes them to main's src.
+          git show origin/release/6.3:src/locked_requirements.txt > /tmp/req-release-6.3.txt
+          pip install -U -r /tmp/req-release-6.3.txt
 
       - name: Build Sphinx documentation
         run: |

--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -55,12 +55,8 @@ jobs:
           git fetch
           pip install -U -r docs/locked_requirements.txt
           pip install -U -r src/locked_requirements.txt
-          # The multiversion build renders each version's CLI from its own
-          # checked-out src (see docs/conf.py). Install the modern release
-          # branches' src requirements so their parser imports (e.g. diskcache).
-          # Do NOT install legacy pydantic-v1 branches (6.1/6.2): those are
-          # frozen to static rST and would downgrade pydantic; the conf.py
-          # fallback routes them to main's src.
+          # Install release/6.3's src requirements so its CLI parser imports
+          # when the multiversion build renders 6.3 from its own checkout.
           git show origin/release/6.3:src/locked_requirements.txt > /tmp/req-release-6.3.txt
           pip install -U -r /tmp/req-release-6.3.txt
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -47,7 +47,7 @@ build:
 	rm -rf $(OUT_DIR)/_sources
 
 build-multiversion:
-	export OSMO_DOMAIN=public && $(SPHINXBUILD) . $(OUT_DIR)
+	export OSMO_DOMAIN=public && $(SPHINXBUILD) . $(OUT_DIR) --run-markdown-build
 	rm -rf $(OUT_DIR)/_sources
 	@cp _redirect/redirect_user_guide.html $(OUT_DIR)/index.html
 

--- a/docs/_extensions/module_aliasing.py
+++ b/docs/_extensions/module_aliasing.py
@@ -86,7 +86,11 @@ def _import_and_alias(modname: str):
         osmo_name = _get_osmo_name(src_name)
         sys.modules[osmo_name] = module
         return module
-    except ImportError:
+    except Exception:
+        # Skip aliasing when the module cannot be imported. Beyond a plain
+        # ImportError, a version's source built for older dependency pins may
+        # raise other errors under this build venv; skip rather than abort the
+        # whole multiversion build.
         return None
 
 

--- a/docs/_extensions/module_aliasing.py
+++ b/docs/_extensions/module_aliasing.py
@@ -87,10 +87,8 @@ def _import_and_alias(modname: str):
         sys.modules[osmo_name] = module
         return module
     except Exception:
-        # Skip aliasing when the module cannot be imported. Beyond a plain
-        # ImportError, a version's source built for older dependency pins may
-        # raise other errors under this build venv; skip rather than abort the
-        # whole multiversion build.
+        # Skip aliasing if the module can't import (e.g. a legacy version's
+        # source under newer deps) rather than aborting the whole build.
         return None
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,7 @@
 
 # -- Path setup --------------------------------------------------------------
 
-import importlib
-import json
+import os
 import sys
 from pathlib import Path
 
@@ -27,49 +26,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.resolve()))
 
 
-def _multiversion_repo_root():
-    """Return the repo root of the version sphinx-multiversion is building.
-
-    sphinx-multiversion passes ``-D smv_metadata_path`` and
-    ``-D smv_current_version`` to both its html and markdown passes; the metadata
-    file records each version's checked-out tree (``basedir``). This is used
-    instead of an env var or the cwd (which are not set consistently across both
-    passes). Returns None for a normal single-version build.
-    """
-    metadata_path = current_version = None
-    arguments = sys.argv
-    for index in range(len(arguments) - 1):
-        if arguments[index] != "-D":
-            continue
-        override = arguments[index + 1]
-        if override.startswith("smv_metadata_path="):
-            metadata_path = override.split("=", 1)[1]
-        elif override.startswith("smv_current_version="):
-            current_version = override.split("=", 1)[1]
-    if not metadata_path or not current_version:
-        return None
-    try:
-        with open(metadata_path, encoding="utf-8") as metadata_file:
-            metadata = json.load(metadata_file)
-        return metadata[current_version]["basedir"]
-    except (OSError, ValueError, KeyError):
-        return None
-
-
-# Under sphinx-multiversion, import `src` from the version being built (its own
-# checked-out tree) so each release's CLI autodoc/argparse pages reflect the
-# parser it shipped. If the version's source cannot be imported in this build
-# venv (e.g. legacy pydantic-v1 release branches, which are frozen), fall back to
-# the working-tree src already on PYTHONPATH so the build still succeeds.
-_version_root = _multiversion_repo_root()
-if _version_root and _version_root not in sys.path:
-    sys.path.insert(0, _version_root)
-    try:
-        importlib.import_module("src.cli.main_parser")
-    except Exception:
-        sys.path.remove(_version_root)
-        for _name in [n for n in sys.modules if n == "src" or n.startswith("src.")]:
-            del sys.modules[_name]
+# When sphinx-multiversion builds a release branch, the source files come from a
+# temporary checkout while this config still comes from the current checkout.
+# Prefer that versioned checkout for src.* imports so generated CLI docs match
+# the release docs being rendered.
+source_dir = Path(os.environ.get("SPHINX_MULTIVERSION_SOURCEDIR", Path.cwd())).resolve()
+sys.path.insert(1, str(source_dir.parent))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,10 +26,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.resolve()))
 
 
-# When sphinx-multiversion builds a release branch, the source files come from a
-# temporary checkout while this config still comes from the current checkout.
-# Prefer that versioned checkout for src.* imports so generated CLI docs match
-# the release docs being rendered.
+# Import `src.*` from the version being built (its own checkout under
+# sphinx-multiversion) so CLI docs match that release.
 source_dir = Path(os.environ.get("SPHINX_MULTIVERSION_SOURCEDIR", Path.cwd())).resolve()
 sys.path.insert(1, str(source_dir.parent))
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,8 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import importlib
+import json
 import sys
 from pathlib import Path
 
@@ -23,6 +25,51 @@ from pathlib import Path
 # Add the directory containing conf.py to the path so custom extensions can be found
 # This is important for sphinx-multiversion which runs from temporary directories
 sys.path.insert(0, str(Path(__file__).parent.resolve()))
+
+
+def _multiversion_repo_root():
+    """Return the repo root of the version sphinx-multiversion is building.
+
+    sphinx-multiversion passes ``-D smv_metadata_path`` and
+    ``-D smv_current_version`` to both its html and markdown passes; the metadata
+    file records each version's checked-out tree (``basedir``). This is used
+    instead of an env var or the cwd (which are not set consistently across both
+    passes). Returns None for a normal single-version build.
+    """
+    metadata_path = current_version = None
+    arguments = sys.argv
+    for index in range(len(arguments) - 1):
+        if arguments[index] != "-D":
+            continue
+        override = arguments[index + 1]
+        if override.startswith("smv_metadata_path="):
+            metadata_path = override.split("=", 1)[1]
+        elif override.startswith("smv_current_version="):
+            current_version = override.split("=", 1)[1]
+    if not metadata_path or not current_version:
+        return None
+    try:
+        with open(metadata_path, encoding="utf-8") as metadata_file:
+            metadata = json.load(metadata_file)
+        return metadata[current_version]["basedir"]
+    except (OSError, ValueError, KeyError):
+        return None
+
+
+# Under sphinx-multiversion, import `src` from the version being built (its own
+# checked-out tree) so each release's CLI autodoc/argparse pages reflect the
+# parser it shipped. If the version's source cannot be imported in this build
+# venv (e.g. legacy pydantic-v1 release branches, which are frozen), fall back to
+# the working-tree src already on PYTHONPATH so the build still succeeds.
+_version_root = _multiversion_repo_root()
+if _version_root and _version_root not in sys.path:
+    sys.path.insert(0, _version_root)
+    try:
+        importlib.import_module("src.cli.main_parser")
+    except Exception:
+        sys.path.remove(_version_root)
+        for _name in [n for n in sys.modules if n == "src" or n.startswith("src.")]:
+            del sys.modules[_name]
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/locked_requirements.txt
+++ b/docs/locked_requirements.txt
@@ -876,8 +876,8 @@ sphinx-markdown-builder==0.6.8 \
     # via
     #   -r docs_requirements.txt
     #   sphinx-multiversion
-sphinx-multiversion @ https://github.com/RyaliNvidia/sphinx-multiversion/archive/refs/tags/v0.2.5.zip \
-    --hash=sha256:2616bde204930ed6995d9acd86f35770c1d8b02b37383e0653a706b1306f2406
+sphinx-multiversion @ https://github.com/RyaliNvidia/sphinx-multiversion/archive/refs/tags/v0.2.7.zip \
+    --hash=sha256:f8d597ad5e2cd012f08808fe58d712701eacc2eae96e233b73d52956edf48c38
     # via -r docs_requirements.txt
 sphinx-new-tab-link==0.8.0 \
     --hash=sha256:6c757d99f559224a04142c3971c8baa6ac90aca905f15b129d57eeca0ece9582 \


### PR DESCRIPTION
## Description

The multiversion docs build rendered every version's CLI pages against `main`'s
parser, so release branches that still ship commands removed on `main` (e.g.
`release/6.3`'s `osmo bucket` / `osmo dataset`) failed with `NavigationException`.
Now each version's CLI is rendered from its own checked-out `src`, so releases
build without per-release freezing.

Changes:
- `docs/conf.py`: prepend the version being built (`SPHINX_MULTIVERSION_SOURCEDIR`,
  cwd fallback) to `sys.path` so `src.*` resolves to that release's source.
- `docs/locked_requirements.txt`: bump `sphinx-multiversion` to v0.2.7 (passes the
  env to the markdown pass too).
- `docs/Makefile`: add `--run-markdown-build` (markdown is opt-in in 0.2.7).
- `docs/_extensions/module_aliasing.py`: skip an `osmo.*` alias that can't import
  instead of failing the build.
- `.github/workflows/docs-deploy.yaml`: install `release/6.3`'s `src` reqs so its
  parser imports.

Validated: `make build-multiversion` builds `main` and `release/6.0`-`6.3`
(HTML + Markdown) with no `NavigationException`.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.