### PR TITLE
oetf/aggregate: include external bzlmod targets in Allure report

### DIFF
--- a/test/oetf/aggregate.py
+++ b/test/oetf/aggregate.py
@@ -82,6 +82,38 @@ def _result_uuids(filenames: List[str]) -> List[str]:
     return [n[:-len(suffix)] for n in filenames if n.endswith(suffix)]
 
 
+def _target_testlogs_root(testlogs_dir: str, label: str) -> Optional[str]:
+    """Map a Bazel target label to its bazel-testlogs subdirectory.
+
+    Main-module label `//pkg:tgt`           → <testlogs>/pkg/tgt
+    External-module label `@@repo//pkg:tgt` → <testlogs>/external/repo/pkg/tgt
+
+    Returns None for labels that don't carry an explicit target name (bare
+    package labels like `//pkg`) or for non-Bazel strings — we can't derive
+    a testlogs path from those without a Bazel query. The `@<apparent>//`
+    short form doesn't appear in BEP output (which emits canonical names),
+    so it's intentionally not handled.
+    """
+    if ':' not in label:
+        return None
+    if label.startswith('@@'):
+        # Canonical bzlmod form. The portion before '//' is the canonical
+        # repo name (e.g. 'osmo_workspace+'); after '//' is the package +
+        # ':' + target. Bazel writes external-module testlogs to
+        # <testlogs>/external/<canonical_repo>/<pkg>/<tgt>/ (note: the '+'
+        # suffix on canonical names is part of the directory name on disk).
+        body = label[2:]
+        if '//' not in body:
+            return None
+        repo, rest = body.split('//', 1)
+        package, target_name = rest.split(':', 1)
+        return os.path.join(testlogs_dir, 'external', repo, package, target_name)
+    if label.startswith('//'):
+        package, target_name = label[2:].split(':', 1)
+        return os.path.join(testlogs_dir, package, target_name)
+    return None
+
+
 def collect_allure_results(
     testlogs_dir: str, targets: List[str], staging_dir: str
 ) -> int:
@@ -93,7 +125,9 @@ def collect_allure_results(
     - Per-attempt (--runs_per_test=N): test.outputs/test_attempts/attempt_*/allure-results/
 
     A label like //test/smoke:api-checks maps to
-    bazel-testlogs/test/smoke/api-checks/test.outputs/
+    bazel-testlogs/test/smoke/api-checks/test.outputs/; external bzlmod
+    targets like @@osmo_workspace+//test/scenarios:foo map to
+    bazel-testlogs/external/osmo_workspace+/test/scenarios/foo/test.outputs/.
 
     Also copies each target's test.log into staging_dir as an attachment
     and links it from every result.json the target produced — so the
@@ -106,14 +140,9 @@ def collect_allure_results(
     os.makedirs(staging_dir, exist_ok=True)
     count = 0
     for label in targets:
-        if not label.startswith('//') or ':' not in label:
-            # Skip non-Bazel labels and bare-package labels (`//pkg`
-            # without an explicit target name); we can't derive a
-            # testlogs path from the latter without a Bazel query.
+        target_root = _target_testlogs_root(testlogs_dir, label)
+        if target_root is None:
             continue
-        body = label[2:]
-        package, target_name = body.split(':', 1)
-        target_root = os.path.join(testlogs_dir, package, target_name)
         outputs_dir = os.path.join(target_root, 'test.outputs')
 
         target_files: List[str] = []

--- a/test/oetf/tests/test_aggregate.py
+++ b/test/oetf/tests/test_aggregate.py
@@ -112,6 +112,43 @@ class CollectAllureResultsTest(unittest.TestCase):
             )
             self.assertEqual(count, 0)
 
+    def test_collect_from_external_module_target(self):
+        # External bzlmod targets (e.g. @@osmo_workspace+//test/scenarios:foo)
+        # land in <testlogs>/external/<canonical_repo>/<pkg>/<tgt>/. Without
+        # explicit handling these labels are silently skipped and their
+        # scenarios never reach the Allure report.
+        with tempfile.TemporaryDirectory() as tmp:
+            results_dir = os.path.join(
+                tmp, "external", "osmo_workspace+",
+                "test", "scenarios", "exec-portforward",
+                "test.outputs", "allure-results",
+            )
+            os.makedirs(results_dir)
+            with open(os.path.join(results_dir, "ext-result.json"),
+                      "w", encoding="utf-8") as fh:
+                fh.write('{"uuid":"ext","status":"passed"}')
+            staging = os.path.join(tmp, "staging")
+            count = aggregate.collect_allure_results(
+                testlogs_dir=tmp,
+                targets=["@@osmo_workspace+//test/scenarios:exec-portforward"],
+                staging_dir=staging,
+            )
+            self.assertEqual(count, 1)
+            self.assertTrue(os.path.exists(
+                os.path.join(staging, "ext-result.json")))
+
+    def test_skips_unrecognized_label_forms(self):
+        # Bare-package labels (`//pkg`) and non-Bazel strings can't be mapped
+        # to a testlogs path without a query — skip them silently.
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = os.path.join(tmp, "staging")
+            count = aggregate.collect_allure_results(
+                testlogs_dir=tmp,
+                targets=["//pkg-no-target", "not-a-label", "@@repo-no-slashes"],
+                staging_dir=staging,
+            )
+            self.assertEqual(count, 0)
+
     def test_attaches_bazel_test_log_to_each_result(self):
         """Each Bazel target's test.log is added as a top-level
         attachment named 'test.log' on every linked result.json.


### PR DESCRIPTION
## Description

Issue - None

`collect_allure_results` silently skipped any target label not starting with `//`, so canonical bzlmod targets (`@@osmo_workspace+//pkg:tgt` in BEP output) never reached the Allure staging dir.

**Effect:** When an OETF runner consumes both an internal overlay (main module) AND the public framework as a bzlmod dep, only the main-module half of the test set appears in Allure — the BEP-derived OETF Run text summary correctly counts all targets. The internal staging Jenkins run showed Total: 44 tests in the log but **only 19** in Allure.

## Fix

Extract the label → testlogs-path mapping into `_target_testlogs_root()`. In addition to `//pkg:tgt` → `<testlogs>/pkg/tgt/`, now also map `@@<repo>//pkg:tgt` → `<testlogs>/external/<repo>/<pkg>/<tgt>/`, matching Bazel's on-disk layout for external-module test outputs. The `@<apparent>//` short form intentionally isn't handled — BEP emits canonical names so that's what `parse_bep_test_results` receives.

## End-to-end verification — reproduced exact Jenkins bug shape

Ran the same OETF flow Jenkins runs, against the same staging endpoint, with the patched aggregator:

```bash
OSMO_STAGING_TOKEN=<refresh-token> bazel run //test/oetf:run -- \
  --env staging --tags smoke,scenario --jobs 5
```

44 bazel targets executed — exactly matching `Total: 44` from the Jenkins log. BEP shows 12 main-module + 32 external bzlmod labels.

A/B on the SAME `.oetf-bep.json`:

| | Pre-fix | Post-fix |
|---|---|---|
| BEP targets | 44 | 44 |
| Result files staged | 28 | 86 |
| **Allure-rendered entries** | **19** | **71** |

Pre-fix produced exactly 19 — bit-identical to the broken Jenkins Allure count. Post-fix rendered 71 entries across 25 classes including all the previously-missing public-framework scenarios: `ApiChecks` (10), `CliChecks` (4), `CommandValidation` (2), `ExitActionsWorkflows` (5), `MountValidation` (2), `ParallelWorkflows` (5), `ResourceValidation` (4), `RouterConnectivity`, `SerialWorkflows` (4), `TemplateValidation` (3), `TaskRuntimeEnvironment`, `LoggerConnectivity`, `WebsocketChecks`, etc. All 19 tests from the original Jenkins report still appear; the fix adds the 52 external-module entries that were silently dropped.

Pipeline used: `aggregate.collect_allure_results` → `aggregate.run_allure_generate` → `aggregate.write_failure_summary` (Allure 3.7.0, same version `oetfTests.groovy` installs in Jenkins). Both `index.html` (5.4KB) and `summary.html` (16KB) generated successfully.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)