### PR TITLE
Fix ctrl upload stream failures

### DIFF
--- a/deployments/charts/service/quick-start-values.yaml
+++ b/deployments/charts/service/quick-start-values.yaml
@@ -71,6 +71,7 @@ services:
         credential:
           endpoint: s3://osmo/workflows
           override_url: http://localstack-s3.osmo:4566
+          addressing_style: path
           access_key_id: test
           access_key: test
           region: us-east-1
@@ -78,6 +79,7 @@ services:
         credential:
           endpoint: s3://osmo/workflows
           override_url: http://localstack-s3.osmo:4566
+          addressing_style: path
           access_key_id: test
           access_key: test
           region: us-east-1
@@ -85,6 +87,7 @@ services:
         credential:
           endpoint: s3://osmo/apps
           override_url: http://localstack-s3.osmo:4566
+          addressing_style: path
           access_key_id: test
           access_key: test
           region: us-east-1

--- a/src/runtime/pkg/common/common.go
+++ b/src/runtime/pkg/common/common.go
@@ -251,7 +251,9 @@ func RunCommand(cmd *exec.Cmd,
 	stdoutScanner.Split(splitFunc)
 	stderrScanner.Split(splitFunc)
 
-	cmd.Start()
+	if err := cmd.Start(); err != nil {
+		return fmt.Sprintf("Command failed to start with error: %v\n", err), err
+	}
 	waitStreamLogs.Add(2)
 	go streamOutCommand(cmd, stdoutScanner, &waitStreamLogs, timeoutChan)
 	go streamErrCommand(stderrScanner, &waitStreamLogs)

--- a/src/runtime/pkg/common/common_test.go
+++ b/src/runtime/pkg/common/common_test.go
@@ -19,9 +19,13 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
+	"bufio"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -51,6 +55,24 @@ func TestArrayFlags_Set_AppendsValue(t *testing.T) {
 	}
 	if !reflect.DeepEqual([]string(flags), []string{"first", "second"}) {
 		t.Errorf("expected [first second], got %v", flags)
+	}
+}
+
+func TestRunCommand_ReturnsStartError(t *testing.T) {
+	cmd := exec.Command(filepath.Join(t.TempDir(), "missing-command"))
+	streamOut := func(*exec.Cmd, *bufio.Scanner, *sync.WaitGroup, chan bool) {
+		t.Fatal("stdout stream callback should not run when cmd.Start fails")
+	}
+	streamErr := func(*bufio.Scanner, *sync.WaitGroup) {
+		t.Fatal("stderr stream callback should not run when cmd.Start fails")
+	}
+
+	msg, err := RunCommand(cmd, streamOut, streamErr)
+	if err == nil {
+		t.Fatalf("expected start error")
+	}
+	if !strings.Contains(msg, "Command failed to start") {
+		t.Fatalf("message = %q, want start failure", msg)
 	}
 }
 

--- a/src/runtime/pkg/data/data.go
+++ b/src/runtime/pkg/data/data.go
@@ -47,9 +47,9 @@ var DataTimeout time.Duration = 10 * time.Minute
 var CpuCount string = "1"
 
 const (
-	Download         string = "download"
-	NotApplicable    string = "N/A"
-	BenchmarkSuffix  string = "_benchmark.json"
+	Download        string = "download"
+	NotApplicable   string = "N/A"
+	BenchmarkSuffix string = "_benchmark.json"
 )
 
 // BenchmarkPath is the directory under which the OSMO data CLI writes its
@@ -58,7 +58,7 @@ const (
 var BenchmarkPath = "/osmo/data/benchmarks/"
 
 const (
-	URLOperation     string = "Url"
+	URLOperation string = "Url"
 )
 
 type WebsocketConnectionInfo struct {
@@ -124,40 +124,46 @@ func createOutCommandStream(osmoChan chan string) func(*exec.Cmd,
 		defer waitStreamLogs.Done()
 
 		lastMessageTime := time.Now()
-		quit := make(chan bool)
+		done := make(chan struct{})
+		var reportTimeout sync.Once
+		sendTimeout := func(timedOut bool) {
+			reportTimeout.Do(func() {
+				timeoutChan <- timedOut
+			})
+		}
 
 		go func() {
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
 			for {
 				select {
-				case <-quit:
+				case <-done:
 					return
-				default:
+				case <-ticker.C:
 					if time.Since(lastMessageTime) >= DataTimeout {
 						if err := cmd.Process.Kill(); err != nil {
 							osmo_errors.SetExitCode(osmo_errors.CMD_FAILED_CODE)
 							panic(fmt.Sprintf("Failed to kill process: %s", err))
 						}
-						timeoutChan <- true
+						sendTimeout(true)
 						return
 					}
-					// Wait a second between checks
-					time.Sleep(time.Second)
 				}
 			}
 		}()
 
+		defer close(done)
 		for scanner.Scan() {
 			log.Println(scanner.Text())
 			osmoChan <- scanner.Text()
 			lastMessageTime = time.Now()
 		}
 		if err := scanner.Err(); err != nil {
-			osmo_errors.SetExitCode(osmo_errors.CMD_FAILED_CODE)
-			panic(err)
+			log.Printf("Error: %s", err)
+			osmoChan <- fmt.Sprintf("Error: %s", err)
 		}
 
-		quit <- true
-		timeoutChan <- false
+		sendTimeout(false)
 	}
 	return streamOutCommand
 }

--- a/src/runtime/pkg/data/data_runtime_test.go
+++ b/src/runtime/pkg/data/data_runtime_test.go
@@ -492,13 +492,57 @@ func TestCreateErrCommandStream_StreamsScannerLinesToChannel(t *testing.T) {
 	wg.Wait()
 }
 
+func TestCreateOutCommandStream_ReportsScannerErrorWithoutPanic(t *testing.T) {
+	osmoChan := make(chan string, 16)
+	streamFn := createOutCommandStream(osmoChan)
+
+	scanner := bufio.NewScanner(&errReader{
+		data:  []byte("partial\n"),
+		limit: 1,
+		err:   fmt.Errorf("synthetic stdout read error"),
+	})
+
+	cmd := exec.Command("/usr/bin/true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start /usr/bin/true: %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait /usr/bin/true: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	timeoutChan := make(chan bool, 2)
+
+	streamFn(cmd, scanner, &wg, timeoutChan)
+	wg.Wait()
+
+	close(osmoChan)
+	var collected []string
+	for msg := range osmoChan {
+		collected = append(collected, msg)
+	}
+	if len(collected) < 2 {
+		t.Fatalf("expected at least 2 messages (data + error), got %v", collected)
+	}
+	if collected[0] != "partial" {
+		t.Errorf("first message = %q, want partial", collected[0])
+	}
+	if !strings.Contains(collected[len(collected)-1], "Error:") {
+		t.Errorf("last message = %q, want one containing 'Error:'", collected[len(collected)-1])
+	}
+	if timedOut := <-timeoutChan; timedOut {
+		t.Errorf("timeoutChan = true, want false on scanner error without timeout")
+	}
+}
+
 // errReader returns the given error after `okReads` successful reads.
 type errReader struct {
-	data    []byte
-	idx     int
-	limit   int
-	err     error
-	reads   int
+	data  []byte
+	idx   int
+	limit int
+	err   error
+	reads int
 }
 
 func (r *errReader) Read(p []byte) (int, error) {


### PR DESCRIPTION
## Description
Fix ctrl upload handling so stdout scanner errors from child upload commands are reported without panicking, and return `cmd.Start()` failures directly instead of continuing into `exec: not started`.

Also set quickstart LocalStack credentials to path-style S3 addressing, which keeps workflow uploads pointed at `localstack-s3.osmo` instead of virtual-host URLs such as `osmo.localstack-s3.osmo`.

Validation:
- `bazel test //src/runtime/pkg/common:common_test //src/runtime/pkg/data:data_test --cache_test_results=no`
- `helm lint deployments/charts/service -f deployments/charts/service/quick-start-values.yaml`
- `helm template test deployments/charts/service -f deployments/charts/service/quick-start-values.yaml`
- OETF `test_serial_workflow` completed successfully as `serial-workflow-7`

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution reliability by handling startup failures cleanly instead of continuing silently.
  * Updated streaming behavior so command output errors are reported gracefully without crashing, while preserving any partial output already received.
  * Refined timeout handling for long-running output streams to reduce duplicate timeout signals.
  * Adjusted S3 quick-start settings to use path-style addressing for workflow storage connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->