### PR TITLE
docs: add 'integrations' to spelling wordlist

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -134,6 +134,7 @@ ini
 init
 inotify
 instantiation
+integrations
 io
 ip
 IPv


### PR DESCRIPTION
## Description

Adds `integrations` to `docs/spelling_wordlist.txt`. The word is used in
`docs/user_guide/architecture.rst` ("…workflow and storage integrations…")
but was missing from the wordlist, so `make -C docs spelling` reported a
misspelling and failed the docs spellcheck. Adding it to the wordlist
clears the check; no prose or other files change.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the project’s spelling word list to include “integrations,” reducing false spelling warnings for that term.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->