### PR TITLE
feat(helm): support authenticated gateway rate limiting

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -405,6 +405,15 @@ When enabled, the gateway exposes `/signout` and redirects it to `/oauth2/sign_o
 | `gateway.authz.imageTag` | Override image tag (defaults to `global.osmoImageTag`) | `""` |
 | `gateway.authz.grpcPort` | gRPC port | `50052` |
 
+#### Gateway Rate Limiting
+
+The chart does not create Redis credentials. Secret controllers such as External Secrets may provision a Kubernetes Secret, which can then be referenced through `gateway.rateLimit.extraEnv`.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `gateway.rateLimit.enabled` | Enable the Envoy rate-limit filter and standalone rate-limit service | `false` |
+| `gateway.rateLimit.extraEnv` | Additional rate-limit container environment variables, including Secret references such as `REDIS_AUTH` | `[]` |
+
 #### Network Policies
 
 | Parameter | Description | Default |

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -610,7 +610,7 @@ data:
             - name: envoy.filters.http.ratelimit
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
-                domain: ratelimit
+                domain: {{ $gw.rateLimit.config.domain | default "ratelimit" }}
                 enable_x_ratelimit_headers: DRAFT_VERSION_03
                 rate_limit_service:
                   transport_api_version: V3

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -617,6 +617,7 @@ spec:
         {{- include "osmo.gateway-component-labels" (dict "component" "ratelimit" "context" .) | nindent 8 }}
       annotations:
         checksum/ratelimit-config: {{ $gw.rateLimit.config | toYaml | sha256sum }}
+        {{- include "osmo.extra-annotations" $gw.rateLimit | nindent 8 }}
     spec:
       {{- with $gw.rateLimit.nodeSelector }}
       nodeSelector:
@@ -630,18 +631,29 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.global.imagePullSecret }}
       {{- end }}
+      serviceAccountName: {{ include "osmo.service-account-name" (dict "serviceAccountName" $gw.rateLimit.serviceAccountName "Values" .Values) }}
       containers:
       - name: ratelimit
         image: "{{ $gw.rateLimit.image }}"
         imagePullPolicy: "{{ $gw.rateLimit.imagePullPolicy }}"
         securityContext:
           {{- toYaml $gw.rateLimit.securityContext | nindent 10 }}
-        command: ["/bin/ratelimit"]
+        {{- /* The default 875d418c image does not define an ENTRYPOINT. */}}
+        command:
+          {{- toYaml ($gw.rateLimit.command | default (list "/bin/ratelimit")) | nindent 10 }}
+        {{- with $gw.rateLimit.args }}
+        args:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml $gw.rateLimit.resources | nindent 10 }}
         env:
         - name: LOG_LEVEL
           value: info
+        - name: PORT
+          value: {{ $gw.rateLimit.httpPort | quote }}
+        - name: GRPC_PORT
+          value: {{ $gw.rateLimit.grpcPort | quote }}
         - name: REDIS_SOCKET_TYPE
           value: tcp
         - name: REDIS_URL
@@ -662,6 +674,7 @@ spec:
           value: "::"
         - name: GRPC_HOST
           value: "::"
+        {{- include "osmo.extra-env" $gw.rateLimit | nindent 8 }}
         ports:
         - name: grpc
           containerPort: {{ $gw.rateLimit.grpcPort }}
@@ -670,6 +683,9 @@ spec:
         volumeMounts:
         - name: ratelimit-config
           mountPath: /data/ratelimit/config
+        {{- with $gw.rateLimit.extraVolumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         livenessProbe:
           tcpSocket:
             port: {{ $gw.rateLimit.grpcPort }}
@@ -683,6 +699,9 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+      {{- with $gw.rateLimit.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
 
 ---
 

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -2197,7 +2197,7 @@ gateway:
   rateLimit:
     enabled: false
     replicas: 1
-    image: envoyproxy/ratelimit:9d8d70a8
+    image: envoyproxy/ratelimit:875d418c
     imagePullPolicy: IfNotPresent
     grpcPort: 8091
     httpPort: 8090
@@ -2225,6 +2225,14 @@ gateway:
         memory: "200Mi"
     nodeSelector: {}
     tolerations: []
+    ## Additional environment variables for the ratelimit container. This can
+    ## reference credentials from a Kubernetes Secret managed outside the chart.
+    ##
+    extraEnv: []
+    extraPodAnnotations: {}
+    extraVolumeMounts: []
+    extraVolumes: []
+    serviceAccountName: ""
 
   ## Restrict upstream pod ingress to the gateway Envoy. Requires a CNI
   ## that enforces NetworkPolicy (Calico, Cilium, AWS VPC CNI with


### PR DESCRIPTION
## Description
We have a optional [ratelimit](https://github.com/envoyproxy/ratelimit) container, however no way to configure the redis authentication.

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable gateway rate limiting options, including enabling the filter/service and setting a custom rate-limit domain.
  * Support added for extra environment variables, annotations, command/args, volume mounts, volumes, and service account selection.
* **Documentation**
  * Expanded the chart README with gateway rate limiting setup details, including external Secret references for Redis credentials.
* **Bug Fixes**
  * Preserved existing behavior when new rate-limit settings are not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->