### PR TITLE
Stablize the nightly Azure deployment test (AKS version pin, Redis capacity, apply retry, teardown + Slack invariants)

### DIFF
--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -546,7 +546,7 @@ jobs:
             echo ""
             echo "- AKS: \`${AZURE_CLUSTER_NAME}\` in \`${AZURE_RESOURCE_GROUP}\` (${AZURE_REGION})"
             echo "- Postgres flex: \`${AZURE_CLUSTER_NAME}-postgres\`"
-            echo "- Redis: \`$(terraform output -raw redis_cache_name 2>/dev/null || echo 'n/a')\`"
+            echo "- Redis: \`${AZURE_CLUSTER_NAME}-redis\`"
             echo "- finished at: $(date -u +%H:%M:%SZ)"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -1038,11 +1038,10 @@ jobs:
           tar -xzf /tmp/helm.tgz -C /tmp linux-amd64/helm
           sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
 
-      # tf-apply's stash step is if:always() and writes a marker file, so
-      # the artifact exists whenever tf-apply ran — a download failure here
-      # is genuinely transient and correctly fails the teardown loudly.
-      # A state-less artifact (marker only) falls through to a no-op
-      # destroy + leftover-count report.
+      # The stash step's marker file makes this artifact exist whenever
+      # tf-apply ran, so a download failure here is a genuine transient and
+      # correctly fails teardown loudly. A marker-only artifact falls
+      # through to a no-op destroy plus a leftover-count report.
       - name: download tf-state artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -335,7 +335,10 @@ jobs:
       ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
+      AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
     permissions:
       id-token: write
       contents: read
@@ -364,10 +367,6 @@ jobs:
           sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
 
       - name: environment snapshot
-        env:
-          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
-          AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
         run: |
           echo "::group::az identity"; az account show -o table || true; echo "::endgroup::"
           echo "::group::tool versions"; terraform version; az version 2>&1 | head -5; echo "::endgroup::"
@@ -395,20 +394,14 @@ jobs:
       #                                        Azure daemons + OSMO sidecars.
       #   - node_group_min_size=3              headroom for scenario tests.
       #   - redis_high_availability_enabled=false
-      #                                        HA doubles the allocation; an
-      #                                        ephemeral stack doesn't need it.
+      #                                        ephemeral stack; see variables.tf.
       #   - redis_sku_name=MemoryOptimized_M10
       #     redis_location=westus3             westus2 stopped allocating
-      #                                        Managed Redis (2026-07). Redis
-      #                                        is reached over a public
-      #                                        endpoint, so it can sit in
-      #                                        another region; the apply step
-      #                                        retries with X3/eastus2.
+      #                                        Managed Redis (2026-07); the
+      #                                        apply step retries with
+      #                                        X3/eastus2.
       - name: build TF var file
         env:
-          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
-          AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
           PG_PASS: ${{ steps.gen_pg.outputs.value }}
         run: |
           cat > "$RUNNER_TEMP/azure.tfvars" <<TFVARS
@@ -432,8 +425,6 @@ jobs:
       # level), so workflow-side `az group create` doesn't work; moving
       # to a different region is a manual op.
       - name: TEMP — verify resource group is in $AZURE_REGION
-        env:
-          AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
         run: |
           set -euo pipefail
           existing=$(az group show --name "$AZURE_RESOURCE_GROUP" --query location -o tsv 2>/dev/null || true)
@@ -500,9 +491,6 @@ jobs:
 
       - name: TEMP — terraform apply (provision AKS + Postgres + Redis)
         working-directory: deployments/terraform/azure/example
-        env:
-          AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
-          AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
         run: |
           set -euo pipefail
           echo "::notice::terraform apply starting — expected ~10–15 min (AKS dominates)"
@@ -517,7 +505,7 @@ jobs:
           terraform apply -input=false -auto-approve -no-color -var-file="$RUNNER_TEMP/azure.tfvars" || apply_failed=1
           echo "::endgroup::"
           if [ -n "$apply_failed" ]; then
-            fallback_args=()
+            echo "::warning::terraform apply attempt 1 failed — retrying once"
             if ! terraform state list 2>/dev/null | grep -qx 'azurerm_managed_redis.main'; then
               # A failed Managed Redis create leaves the cluster in Azure but
               # NOT in TF state (the provider only records finished creates),
@@ -530,12 +518,16 @@ jobs:
                 echo "::warning::deleting orphaned Managed Redis left by the failed create: ${id##*/}"
                 az resource delete --ids "$id" || true
               done
-              fallback_args=(-var "redis_sku_name=ComputeOptimized_X3" -var "redis_location=eastus2")
+              # Rewrite the tfvars rather than passing -var, so the artifact
+              # tf-destroy and deploy-osmo replay still describes the stack
+              # that was actually built.
+              sed -i -e 's|^redis_sku_name .*|redis_sku_name               = "ComputeOptimized_X3"|' \
+                     -e 's|^redis_location .*|redis_location               = "eastus2"|' \
+                     "$RUNNER_TEMP/azure.tfvars"
               echo "::warning::Redis did not create — retrying with fallback combo X3/eastus2"
             fi
-            echo "::warning::terraform apply attempt 1 failed — retrying once"
             echo "::group::terraform apply (retry)"
-            terraform apply -input=false -auto-approve -no-color -var-file="$RUNNER_TEMP/azure.tfvars" "${fallback_args[@]}"
+            terraform apply -input=false -auto-approve -no-color -var-file="$RUNNER_TEMP/azure.tfvars"
             echo "::endgroup::"
           fi
           echo "::group::resources provisioned (terraform state list)"
@@ -1003,6 +995,8 @@ jobs:
       ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
       RUN_DIR: ${{ github.workspace }}/runs/deployment-test-azure
     permissions:
       id-token: write
@@ -1038,10 +1032,8 @@ jobs:
           tar -xzf /tmp/helm.tgz -C /tmp linux-amd64/helm
           sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
 
-      # The stash step's marker file makes this artifact exist whenever
-      # tf-apply ran, so a download failure here is a genuine transient and
-      # correctly fails teardown loudly. A marker-only artifact falls
-      # through to a no-op destroy plus a leftover-count report.
+      # The STASH_RAN marker guarantees this artifact exists, so a download
+      # failure here is transient and should fail teardown loudly.
       - name: download tf-state artifact
         uses: actions/download-artifact@v4
         with:
@@ -1062,9 +1054,6 @@ jobs:
       - name: dump cluster + OSMO diagnostics (always)
         if: always()
         timeout-minutes: 5
-        env:
-          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
-          AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
         run: |
           set +e
           DIAG="$RUN_DIR/diagnostics"
@@ -1154,8 +1143,6 @@ jobs:
       - name: TEMP — terraform destroy
         if: always()
         working-directory: deployments/terraform/azure/example
-        env:
-          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
         run: |
           set -euo pipefail
           echo "::notice::terraform destroy starting — expected ~10–15 min"

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -326,13 +326,16 @@ jobs:
     needs: build-images
     if: ${{ needs.build-images.result == 'success' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # ~15 min clean apply + one retry (a failed attempt can poll 20+ min
+    # before Azure errors) + pre-apply cleanup of a dirty RG.
+    timeout-minutes: 75
     environment: internal-ci
     env:
       ARM_USE_OIDC: true
       ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
     permissions:
       id-token: write
       contents: read
@@ -363,7 +366,6 @@ jobs:
       - name: environment snapshot
         env:
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
           AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
         run: |
@@ -392,10 +394,19 @@ jobs:
       #   - node_instance_type=Standard_D8s_v3 D4s_v3 left K8_CPU=0 after
       #                                        Azure daemons + OSMO sidecars.
       #   - node_group_min_size=3              headroom for scenario tests.
+      #   - redis_high_availability_enabled=false
+      #                                        HA doubles the allocation; an
+      #                                        ephemeral stack doesn't need it.
+      #   - redis_sku_name=MemoryOptimized_M10
+      #     redis_location=westus3             westus2 stopped allocating
+      #                                        Managed Redis (2026-07). Redis
+      #                                        is reached over a public
+      #                                        endpoint, so it can sit in
+      #                                        another region; the apply step
+      #                                        retries with X3/eastus2.
       - name: build TF var file
         env:
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
           AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
           PG_PASS: ${{ steps.gen_pg.outputs.value }}
@@ -409,6 +420,9 @@ jobs:
           aks_private_cluster_enabled  = false
           node_instance_type           = "Standard_D8s_v3"
           node_group_min_size          = 3
+          redis_high_availability_enabled = false
+          redis_sku_name               = "MemoryOptimized_M10"
+          redis_location               = "westus3"
           TFVARS
           grep -v postgres_password "$RUNNER_TEMP/azure.tfvars"
 
@@ -419,7 +433,6 @@ jobs:
       # to a different region is a manual op.
       - name: TEMP — verify resource group is in $AZURE_REGION
         env:
-          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
         run: |
           set -euo pipefail
@@ -437,8 +450,6 @@ jobs:
       # RG without matching TF state — `terraform apply` would then fail
       # with "Resource already exists, import into state". Wipe leftovers.
       - name: TEMP — pre-apply cleanup (delete leftover resources in RG)
-        env:
-          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
         run: |
           set -euo pipefail
           echo "▶ $(date -u +%H:%M:%S) checking for leftover resources in $AZURE_RESOURCE_GROUP"
@@ -490,7 +501,6 @@ jobs:
       - name: TEMP — terraform apply (provision AKS + Postgres + Redis)
         working-directory: deployments/terraform/azure/example
         env:
-          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
           AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
         run: |
@@ -499,25 +509,61 @@ jobs:
           echo "::group::terraform init"
           terraform init -input=false -no-color
           echo "::endgroup::"
-          echo "::group::terraform apply (streaming)"
-          terraform apply -input=false -auto-approve -no-color -var-file="$RUNNER_TEMP/azure.tfvars"
+          # Retry once to absorb one-off ARM 5xx blips. The second apply is
+          # incremental against persisted state; persistent errors (quota,
+          # capacity) still fail the job.
+          echo "::group::terraform apply"
+          apply_failed=""
+          terraform apply -input=false -auto-approve -no-color -var-file="$RUNNER_TEMP/azure.tfvars" || apply_failed=1
           echo "::endgroup::"
+          if [ -n "$apply_failed" ]; then
+            fallback_args=()
+            if ! terraform state list 2>/dev/null | grep -qx 'azurerm_managed_redis.main'; then
+              # A failed Managed Redis create leaves the cluster in Azure but
+              # NOT in TF state (the provider only records finished creates),
+              # so the retry would fail with "already exists — needs import".
+              # Delete the orphan, waiting for the name to be released since
+              # the retry reuses it, then retry in another region+SKU — the
+              # likely cause is regional Redis Enterprise capacity.
+              for id in $(az resource list --resource-group "$AZURE_RESOURCE_GROUP" \
+                            --resource-type Microsoft.Cache/redisEnterprise --query '[].id' -o tsv || true); do
+                echo "::warning::deleting orphaned Managed Redis left by the failed create: ${id##*/}"
+                az resource delete --ids "$id" || true
+              done
+              fallback_args=(-var "redis_sku_name=ComputeOptimized_X3" -var "redis_location=eastus2")
+              echo "::warning::Redis did not create — retrying with fallback combo X3/eastus2"
+            fi
+            echo "::warning::terraform apply attempt 1 failed — retrying once"
+            echo "::group::terraform apply (retry)"
+            terraform apply -input=false -auto-approve -no-color -var-file="$RUNNER_TEMP/azure.tfvars" "${fallback_args[@]}"
+            echo "::endgroup::"
+          fi
           echo "::group::resources provisioned (terraform state list)"
           terraform state list || true
           echo "::endgroup::"
-          # Stash state file inside the workspace so upload-artifact can find it.
-          mkdir -p "$GITHUB_WORKSPACE/tf-state"
-          cp terraform.tfstate "$GITHUB_WORKSPACE/tf-state/" 2>/dev/null || true
-          cp .terraform.lock.hcl "$GITHUB_WORKSPACE/tf-state/" 2>/dev/null || true
-          cp "$RUNNER_TEMP/azure.tfvars" "$GITHUB_WORKSPACE/tf-state/" 2>/dev/null || true
           {
             echo "### TEMP terraform apply ✅"
             echo ""
             echo "- AKS: \`${AZURE_CLUSTER_NAME}\` in \`${AZURE_RESOURCE_GROUP}\` (${AZURE_REGION})"
             echo "- Postgres flex: \`${AZURE_CLUSTER_NAME}-postgres\`"
-            echo "- Redis: \`${AZURE_CLUSTER_NAME}-redis\`"
+            echo "- Redis: \`$(terraform output -raw redis_cache_name 2>/dev/null || echo 'n/a')\`"
             echo "- finished at: $(date -u +%H:%M:%SZ)"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Own always() step — stashing inside the apply step would be skipped
+      # when it fails or the job times out mid-apply. The STASH_RAN marker
+      # makes the artifact exist even with no state file, so tf-destroy can
+      # download unconditionally and treat a download failure as transient.
+      - name: stash tfstate + tfvars for upload
+        if: always()
+        run: |
+          tf_dir=deployments/terraform/azure/example
+          mkdir -p tf-state
+          cp "$tf_dir/terraform.tfstate" tf-state/ 2>/dev/null || true
+          cp "$tf_dir/.terraform.lock.hcl" tf-state/ 2>/dev/null || true
+          cp "$RUNNER_TEMP/azure.tfvars" tf-state/ 2>/dev/null || true
+          touch tf-state/STASH_RAN
+          ls -la tf-state/
 
       # Upload terraform state (and the tfvars file) so the tf-destroy job
       # can download and replay the same plan. `if: always()` so a partial
@@ -941,13 +987,14 @@ jobs:
           if-no-files-found: warn
 
   # ── Stage 4: terraform destroy + cluster diagnostics ─────────────────────
-  # Always runs as long as tf-apply succeeded — we don't want to leak AKS
-  # + Postgres + Redis after a verification run. Downloads the tfstate
-  # artifact tf-apply uploaded, captures a final cluster snapshot before
-  # destroy, then tears everything down.
+  # Downloads the tfstate artifact tf-apply uploaded, captures a final
+  # cluster snapshot before destroy, then tears everything down.
   tf-destroy:
     needs: [build-images, tf-apply, deploy-osmo, oetf]
-    if: ${{ always() && needs.tf-apply.result == 'success' }}
+    # Run whenever tf-apply ran (any result) — a failed apply usually
+    # leaves partial resources to tear down. Skip only if tf-apply never
+    # ran.
+    if: ${{ always() && needs.tf-apply.result != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: internal-ci
@@ -991,6 +1038,11 @@ jobs:
           tar -xzf /tmp/helm.tgz -C /tmp linux-amd64/helm
           sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
 
+      # tf-apply's stash step is if:always() and writes a marker file, so
+      # the artifact exists whenever tf-apply ran — a download failure here
+      # is genuinely transient and correctly fails the teardown loudly.
+      # A state-less artifact (marker only) falls through to a no-op
+      # destroy + leftover-count report.
       - name: download tf-state artifact
         uses: actions/download-artifact@v4
         with:
@@ -1169,8 +1221,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Best-effort decoration (author/subject/links) — must never block
+      # the notification; the post step has fallbacks for every output.
       - name: Gather context (commit metadata + commits since previous green run)
         id: ctx
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -1189,7 +1244,10 @@ jobs:
                               -H 'Accept: application/vnd.github+json' \
                               "https://api.github.com/repos/${REPO}/commits/${SHA}")
           author=$(jq -r '.commit.author.name // "unknown"' <<<"$commit_resp")
-          subject=$(jq -r '.commit.message // ""' <<<"$commit_resp" | head -1)
+          # First line extracted inside jq — piping jq to `head -1` can
+          # SIGPIPE jq on large squash-merge messages and kill the step
+          # under pipefail.
+          subject=$(jq -r '.commit.message // "" | split("\n")[0]' <<<"$commit_resp")
           # Trim subject to ≤ 120 chars so the Slack block doesn't sprawl.
           if [[ ${#subject} -gt 120 ]]; then subject="${subject:0:117}..."; fi
 
@@ -1204,7 +1262,7 @@ jobs:
                           -H 'Accept: application/vnd.github+json' \
                           "https://api.github.com/repos/${REPO}/actions/workflows/deployment-test.yaml/runs?event=schedule&status=success&per_page=2")
           prev_sha=$(jq -r --arg this "$RUN_ID" \
-            '[.workflow_runs[] | select((.id | tostring) != $this)] | .[0].head_sha // empty' \
+            '[(.workflow_runs // [])[] | select((.id | tostring) != $this)] | .[0].head_sha // empty' \
             <<<"$wf_runs")
           if [[ -n "$prev_sha" && "$prev_sha" != "$SHA" ]]; then
             compare_url="${SERVER_URL}/${REPO}/compare/${prev_sha}...${SHA}"
@@ -1233,8 +1291,10 @@ jobs:
           artifacts_resp=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
                                  -H 'Accept: application/vnd.github+json' \
                                  "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=10")
-          artifact_id=$(jq -r '[.artifacts[] | select(.expired==false)] | .[0].id // empty' <<<"$artifacts_resp")
-          artifact_name=$(jq -r '[.artifacts[] | select(.expired==false)] | .[0].name // empty' <<<"$artifacts_resp")
+          # `.artifacts // []` — an API error response has no .artifacts, and
+          # iterating null aborts jq (and the step) with exit 5.
+          artifact_id=$(jq -r '[(.artifacts // [])[] | select(.expired==false)] | .[0].id // empty' <<<"$artifacts_resp")
+          artifact_name=$(jq -r '[(.artifacts // [])[] | select(.expired==false)] | .[0].name // empty' <<<"$artifacts_resp")
           if [[ -n "$artifact_id" ]]; then
             artifact_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}/artifacts/${artifact_id}"
             artifact_label="Download ${artifact_name}"
@@ -1298,11 +1358,15 @@ jobs:
           fi
           commit_url="${SERVER_URL}/${REPO}/commit/${FULL_SHA}"
           workflow_url="${SERVER_URL}/${REPO}/blob/${REF_NAME}/.github/workflows/deployment-test.yaml"
-          # artifact_url comes from the "Gather context" step which already
-          # resolved the per-run artifact ID via the GH API. Falls back to
-          # the run page when no artifact exists (job died before upload).
-          artifact_url="${ARTIFACT_URL}"
-          artifact_label="${ARTIFACT_LABEL}"
+          # Gather-context is continue-on-error, so any of its outputs may
+          # be empty here.
+          AUTHOR="${AUTHOR:-unknown}"
+          SUBJECT="${SUBJECT:-(commit metadata unavailable)}"
+          SHORT_SHA="${SHORT_SHA:-${FULL_SHA:0:7}}"
+          COMPARE_URL="${COMPARE_URL:-${SERVER_URL}/${REPO}/commits/${REF_NAME}}"
+          COMPARE_LABEL="${COMPARE_LABEL:-Recent commits}"
+          artifact_url="${ARTIFACT_URL:-$run_url}"
+          artifact_label="${ARTIFACT_LABEL:-Open run page}"
           header_text=":x: OSMO Azure deployment-test FAILED"
           trigger_label="Daily schedule (00:00 UTC = 5pm PDT)"
 
@@ -1376,7 +1440,8 @@ jobs:
             }')
 
           echo "::group::Slack payload (preview)"
-          echo "$payload" | jq -C . | head -80
+          # head may close the pipe early — don't let SIGPIPE fail the step.
+          { echo "$payload" | jq -C . | head -80; } || true
           echo "::endgroup::"
 
           # Same `chat.postMessage` call pattern that

--- a/deployments/scripts/azure/terraform.sh
+++ b/deployments/scripts/azure/terraform.sh
@@ -487,6 +487,10 @@ postgres_extensions                    = ["hstore", "uuid-ossp", "pg_stat_statem
 # Override TF_REDIS_SKU_NAME for different tiers.
 redis_sku_name  = "${TF_REDIS_SKU_NAME:-ComputeOptimized_X3}"
 redis_version   = "7"
+# Escape hatches for regions with no Redis Enterprise capacity: drop HA
+# (halves the allocation) and/or place Redis in a nearby region.
+redis_high_availability_enabled = ${TF_REDIS_HIGH_AVAILABILITY_ENABLED:-true}
+redis_location                  = "${TF_REDIS_LOCATION:-}"
 
 # Log Analytics Configuration
 log_analytics_sku            = "PerGB2018"

--- a/deployments/scripts/storage/minio.sh
+++ b/deployments/scripts/storage/minio.sh
@@ -101,18 +101,35 @@ fi
 #    silently take from inside an automation. `--rm` reaps the new pod after
 #    `mc` exits. `timeout` guards against stuck image pull / Pending-forever
 #    scheduling.
+#    Retried because `-i` races the container: `mc` can exit before kubectl
+#    finishes attaching, kubectl then falls back to streaming logs, and that
+#    fallback fails too once `--rm` has reaped the pod. Both surface as a
+#    non-zero exit even though the bucket was created, so a retry with a
+#    fresh pod name settles it — `--ignore-existing` makes the repeat a
+#    no-op.
 BUCKET_SETUP_TIMEOUT="${BUCKET_SETUP_TIMEOUT:-300}"
-BUCKET_SETUP_POD="minio-bucket-setup-$RANDOM-$RANDOM"
-echo "[INFO] Ensuring MinIO bucket $MINIO_BUCKET exists (helper pod: $BUCKET_SETUP_POD)"
-timeout "$BUCKET_SETUP_TIMEOUT" \
-  $KUBECTL run "$BUCKET_SETUP_POD" --rm -i --restart=Never \
-    --namespace="$MINIO_NAMESPACE" \
-    --image=minio/mc:latest --command -- \
-    /bin/sh -c "
-        mc alias set local $MINIO_ENDPOINT_URL '$MINIO_USER' '$MINIO_PASS' >/dev/null && \
-        mc mb --ignore-existing local/$MINIO_BUCKET && \
-        echo 'Bucket ready: $MINIO_BUCKET'
-    " || { echo "[ERROR] mc bucket setup failed"; exit 1; }
+BUCKET_SETUP_ATTEMPTS="${BUCKET_SETUP_ATTEMPTS:-3}"
+for attempt in $(seq 1 "$BUCKET_SETUP_ATTEMPTS"); do
+    BUCKET_SETUP_POD="minio-bucket-setup-$RANDOM-$RANDOM"
+    echo "[INFO] Ensuring MinIO bucket $MINIO_BUCKET exists (helper pod: $BUCKET_SETUP_POD, attempt $attempt/$BUCKET_SETUP_ATTEMPTS)"
+    if timeout "$BUCKET_SETUP_TIMEOUT" \
+      $KUBECTL run "$BUCKET_SETUP_POD" --rm -i --restart=Never \
+        --namespace="$MINIO_NAMESPACE" \
+        --image=minio/mc:latest --command -- \
+        /bin/sh -c "
+            mc alias set local $MINIO_ENDPOINT_URL '$MINIO_USER' '$MINIO_PASS' >/dev/null && \
+            mc mb --ignore-existing local/$MINIO_BUCKET && \
+            echo 'Bucket ready: $MINIO_BUCKET'
+        "; then
+        break
+    fi
+    if [ "$attempt" -ge "$BUCKET_SETUP_ATTEMPTS" ]; then
+        echo "[ERROR] mc bucket setup failed after $BUCKET_SETUP_ATTEMPTS attempts"
+        exit 1
+    fi
+    echo "[WARN] mc bucket setup attempt $attempt failed — retrying with a fresh pod"
+    sleep 5
+done
 
 # 3. Create 3 K8s Secrets, one per workflow_* credential reference.
 create_workflow_cred_secrets \

--- a/deployments/scripts/storage/minio.sh
+++ b/deployments/scripts/storage/minio.sh
@@ -98,38 +98,42 @@ fi
 #    where a prior run left a pod stuck Terminating (e.g. CNI plugin errors
 #    blocking sandbox teardown) — the fixed name approach + delete-first
 #    still hangs there because force-delete-on-stuck isn't a path we can
-#    silently take from inside an automation. `--rm` reaps the new pod after
-#    `mc` exits. `timeout` guards against stuck image pull / Pending-forever
-#    scheduling.
-#    Retried because `-i` races the container: `mc` can exit before kubectl
-#    finishes attaching, kubectl then falls back to streaming logs, and that
-#    fallback fails too once `--rm` has reaped the pod. Both surface as a
-#    non-zero exit even though the bucket was created, so a retry with a
-#    fresh pod name settles it — `--ignore-existing` makes the repeat a
-#    no-op.
+#    silently take from inside an automation.
+#    Deliberately NOT `kubectl run -i`: attaching races a container that exits
+#    in well under a second, and kubectl's log fallback then races pod
+#    teardown — both lose intermittently and report failure even though the
+#    bucket was created. Run detached, poll for a terminal phase, then read
+#    the logs. (`--rm` isn't available without `-i`, hence the explicit
+#    delete.)
 BUCKET_SETUP_TIMEOUT="${BUCKET_SETUP_TIMEOUT:-300}"
-BUCKET_SETUP_ATTEMPTS="${BUCKET_SETUP_ATTEMPTS:-3}"
-for attempt in $(seq 1 "$BUCKET_SETUP_ATTEMPTS"); do
-    BUCKET_SETUP_POD="minio-bucket-setup-$RANDOM-$RANDOM"
-    echo "[INFO] Ensuring MinIO bucket $MINIO_BUCKET exists (helper pod: $BUCKET_SETUP_POD, attempt $attempt/$BUCKET_SETUP_ATTEMPTS)"
-    if timeout "$BUCKET_SETUP_TIMEOUT" \
-      $KUBECTL run "$BUCKET_SETUP_POD" --rm -i --restart=Never \
-        --namespace="$MINIO_NAMESPACE" \
-        --image=minio/mc:latest --command -- \
-        /bin/sh -c "
-            mc alias set local $MINIO_ENDPOINT_URL '$MINIO_USER' '$MINIO_PASS' >/dev/null && \
-            mc mb --ignore-existing local/$MINIO_BUCKET && \
-            echo 'Bucket ready: $MINIO_BUCKET'
-        "; then
-        break
-    fi
-    if [ "$attempt" -ge "$BUCKET_SETUP_ATTEMPTS" ]; then
-        echo "[ERROR] mc bucket setup failed after $BUCKET_SETUP_ATTEMPTS attempts"
-        exit 1
-    fi
-    echo "[WARN] mc bucket setup attempt $attempt failed — retrying with a fresh pod"
-    sleep 5
+BUCKET_SETUP_POD="minio-bucket-setup-$RANDOM-$RANDOM"
+echo "[INFO] Ensuring MinIO bucket $MINIO_BUCKET exists (helper pod: $BUCKET_SETUP_POD)"
+$KUBECTL run "$BUCKET_SETUP_POD" --restart=Never --attach=false \
+    --namespace="$MINIO_NAMESPACE" \
+    --image=minio/mc:latest --command -- \
+    /bin/sh -c "
+        mc alias set local $MINIO_ENDPOINT_URL '$MINIO_USER' '$MINIO_PASS' >/dev/null && \
+        mc mb --ignore-existing local/$MINIO_BUCKET && \
+        echo 'Bucket ready: $MINIO_BUCKET'
+    " >/dev/null
+
+bucket_setup_phase=""
+bucket_setup_deadline=$(( $(date +%s) + BUCKET_SETUP_TIMEOUT ))
+while [ "$(date +%s)" -lt "$bucket_setup_deadline" ]; do
+    bucket_setup_phase=$($KUBECTL get pod "$BUCKET_SETUP_POD" --namespace="$MINIO_NAMESPACE" \
+        -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    case "$bucket_setup_phase" in Succeeded|Failed) break ;; esac
+    sleep 2
 done
+
+$KUBECTL logs "$BUCKET_SETUP_POD" --namespace="$MINIO_NAMESPACE" 2>/dev/null || true
+$KUBECTL delete pod "$BUCKET_SETUP_POD" --namespace="$MINIO_NAMESPACE" \
+    --ignore-not-found --wait=false >/dev/null 2>&1 || true
+
+if [ "$bucket_setup_phase" != "Succeeded" ]; then
+    echo "[ERROR] mc bucket setup failed (pod phase: ${bucket_setup_phase:-timed out after ${BUCKET_SETUP_TIMEOUT}s})"
+    exit 1
+fi
 
 # 3. Create 3 K8s Secrets, one per workflow_* credential reference.
 create_workflow_cred_secrets \

--- a/deployments/scripts/verify.sh
+++ b/deployments/scripts/verify.sh
@@ -49,6 +49,8 @@ OSMO_REACHABILITY_TIMEOUT_SECONDS="${OSMO_REACHABILITY_TIMEOUT_SECONDS:-5}"
 HELLO_POLL_TIMEOUT="${HELLO_POLL_TIMEOUT:-600}"
 GPU_POLL_TIMEOUT="${GPU_POLL_TIMEOUT:-1500}"
 POLL_INTERVAL="${POLL_INTERVAL:-10}"
+# How long to wait for the backend to report its nodes into $POOL.
+POOL_RESOURCE_TIMEOUT="${POOL_RESOURCE_TIMEOUT:-300}"
 
 check_command osmo
 check_command jq
@@ -71,6 +73,23 @@ if ! curl -fsS -o /dev/null --max-time "$OSMO_REACHABILITY_TIMEOUT_SECONDS" "$re
 fi
 
 osmo login "$OSMO_URL" --method="$OSMO_LOGIN_METHOD" --username="$OSMO_USERNAME"
+
+# Pods being Ready doesn't mean the backend has finished reporting its nodes to
+# the control plane, and a submit before then fails outright with "There are no
+# resources in platform ... and pool ..." rather than queueing. This enforces
+# the "pool is registered and ONLINE" precondition in the header above.
+log_info "Waiting for pool $POOL to report resources (timeout ${POOL_RESOURCE_TIMEOUT}s)"
+pool_resource_deadline=$(( $(date +%s) + POOL_RESOURCE_TIMEOUT ))
+until osmo resource list --pool "$POOL" -t json 2>/dev/null \
+        | sed -n '/^{/,/^}/p' | jq -e '(.resources // []) | length > 0' >/dev/null 2>&1; do
+    if [[ "$(date +%s)" -ge "$pool_resource_deadline" ]]; then
+        log_error "Pool $POOL still reports no resources after ${POOL_RESOURCE_TIMEOUT}s"
+        osmo resource list --pool "$POOL" >&2 || true
+        exit 1
+    fi
+    sleep "$POLL_INTERVAL"
+done
+log_success "Pool $POOL has resources"
 
 # Submit a workflow, poll until terminal state, dump logs on failure.
 # Polls every $POLL_INTERVAL seconds up to $timeout seconds. Terminal states

--- a/deployments/terraform/azure/example/README.md
+++ b/deployments/terraform/azure/example/README.md
@@ -80,6 +80,8 @@ All resources are deployed in the same VNet and properly networked together.
 | `aks_dns_service_ip` | Kubernetes DNS service IP | `192.168.0.10` | Must be within service CIDR |
 | `node_instance_type` | AKS node VM size | `Standard_D2s_v3` | `Standard_D4s_v3+` |
 | `postgres_sku_name` | PostgreSQL SKU | `GP_Standard_D2s_v3` | `GP_Standard_D4s_v3+` |
+| `redis_high_availability_enabled` | Redis replica + zone-redundant placement | `true` | `true`; disable only for ephemeral stacks or where HA creates hit capacity limits |
+| `redis_location` | Region override for Redis | `""` (co-located with the RG) | Leave empty — a split stack pays cross-region latency on every Redis call |
 | `redis_sku_name` | Azure Managed Redis SKU | `ComputeOptimized_X3` | `Balanced_B*` / `ComputeOptimized_X*` / `MemoryOptimized_M*` / `FlashOptimized_A*` (X3 is the validated default; `Balanced_B0/B1/B3` have hit AllocationFailed in busy regions) |
 
 ### Security Considerations

--- a/deployments/terraform/azure/example/example.tf
+++ b/deployments/terraform/azure/example/example.tf
@@ -405,12 +405,10 @@ resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
 
 resource "azurerm_managed_redis" "main" {
   name                = "${local.name}-redis"
-  location            = var.redis_location != "" ? var.redis_location : data.azurerm_resource_group.main.location
+  location            = coalesce(var.redis_location, data.azurerm_resource_group.main.location)
   resource_group_name = data.azurerm_resource_group.main.name
   sku_name            = var.redis_sku_name
-  # HA doubles the allocation, and capacity-tight regions fail HA creates
-  # with a bare OperationFailed while non-HA creates of the same SKU
-  # succeed. Changing this forces replacement.
+  # Changing this forces replacement.
   high_availability_enabled = var.redis_high_availability_enabled
 
   default_database {

--- a/deployments/terraform/azure/example/example.tf
+++ b/deployments/terraform/azure/example/example.tf
@@ -405,9 +405,13 @@ resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
 
 resource "azurerm_managed_redis" "main" {
   name                = "${local.name}-redis"
-  location            = data.azurerm_resource_group.main.location
+  location            = var.redis_location != "" ? var.redis_location : data.azurerm_resource_group.main.location
   resource_group_name = data.azurerm_resource_group.main.name
   sku_name            = var.redis_sku_name
+  # HA doubles the allocation, and capacity-tight regions fail HA creates
+  # with a bare OperationFailed while non-HA creates of the same SKU
+  # succeed. Changing this forces replacement.
+  high_availability_enabled = var.redis_high_availability_enabled
 
   default_database {
     client_protocol = "Encrypted"

--- a/deployments/terraform/azure/example/terraform.tfvars.example
+++ b/deployments/terraform/azure/example/terraform.tfvars.example
@@ -18,10 +18,11 @@ database_subnets = ["10.0.201.0/24", "10.0.202.0/24"]
 availability_zones = ["1", "2"]
 
 # AKS Configuration
-# Azure rolls AKS-supported Kubernetes versions forward and prunes older
-# ones — if `terraform apply` errors with "version not found", check
-# `az aks get-versions -l <region> -o table` for the current GA list.
-kubernetes_version              = "1.33.11"
+# Pin `<major>.<minor>` only — AKS then selects the latest supported patch.
+# Azure prunes patches continuously and eventually moves a whole minor to
+# Long-Term Support, at which point apply fails with K8sVersionNotSupported;
+# `az aks get-versions -l <region> -o table` lists the minors still GA.
+kubernetes_version              = "1.35"
 node_instance_type             = "Standard_D2s_v3"  # Use Standard_D4s_v3 or higher for production
 node_group_min_size            = 1
 node_group_max_size            = 5
@@ -53,6 +54,14 @@ postgres_extensions                   = ["hstore", "uuid-ossp", "pg_stat_stateme
 # variables.tf for the empirical-allocation rationale; Balanced_B0/B1/B3
 # have hit AllocationFailed in capacity-constrained regions.
 redis_sku_name = "ComputeOptimized_X3"
+
+# Keep true for production; set false for ephemeral/test stacks (halves
+# the capacity ask — see variables.tf).
+redis_high_availability_enabled = true
+
+# Empty co-locates Redis with the resource group. Set a region only to work
+# around Redis Enterprise capacity gaps — see variables.tf.
+# redis_location = ""
 
 # Log Analytics Configuration
 log_analytics_sku            = "PerGB2018"  # Standard pricing tier

--- a/deployments/terraform/azure/example/terraform.tfvars.example
+++ b/deployments/terraform/azure/example/terraform.tfvars.example
@@ -18,10 +18,8 @@ database_subnets = ["10.0.201.0/24", "10.0.202.0/24"]
 availability_zones = ["1", "2"]
 
 # AKS Configuration
-# Pin `<major>.<minor>` only — AKS then selects the latest supported patch.
-# Azure prunes patches continuously and eventually moves a whole minor to
-# Long-Term Support, at which point apply fails with K8sVersionNotSupported;
-# `az aks get-versions -l <region> -o table` lists the minors still GA.
+# Pin `<major>.<minor>` only; AKS picks the latest supported patch — a patch
+# pin eventually fails with K8sVersionNotSupported. See variables.tf.
 kubernetes_version              = "1.35"
 node_instance_type             = "Standard_D2s_v3"  # Use Standard_D4s_v3 or higher for production
 node_group_min_size            = 1
@@ -59,9 +57,10 @@ redis_sku_name = "ComputeOptimized_X3"
 # the capacity ask — see variables.tf).
 redis_high_availability_enabled = true
 
-# Empty co-locates Redis with the resource group. Set a region only to work
-# around Redis Enterprise capacity gaps — see variables.tf.
-# redis_location = ""
+# Stopgap, not a supported topology: co-locate Redis with the resource group
+# (the default) unless that region has no Redis Enterprise capacity. A split
+# stack pays cross-region latency and egress on every Redis call.
+redis_location = ""
 
 # Log Analytics Configuration
 log_analytics_sku            = "PerGB2018"  # Standard pricing tier

--- a/deployments/terraform/azure/example/variables.tf
+++ b/deployments/terraform/azure/example/variables.tf
@@ -83,9 +83,9 @@ variable "availability_zones" {
 
 # AKS Variables
 variable "kubernetes_version" {
-  description = "Kubernetes version. Azure rolls AKS-supported versions forward and prunes older ones; if apply fails with 'version not found' check `az aks get-versions -l <region>` for the current GA list."
+  description = "Kubernetes version, as `<major>.<minor>` so AKS picks the latest supported patch. Azure prunes patch releases continuously and drops whole minors to Long-Term Support (which a cluster must opt into), so pinning a patch guarantees eventual `K8sVersionNotSupported`. Check `az aks get-versions -l <region> -o table` for minors still marked KubernetesOfficial."
   type        = string
-  default     = "1.33.11"
+  default     = "1.35"
 }
 
 variable "node_instance_type" {
@@ -234,6 +234,18 @@ variable "redis_sku_name" {
     condition     = can(regex("^(Balanced_B|ComputeOptimized_X|MemoryOptimized_M|FlashOptimized_A)[0-9]+$", var.redis_sku_name))
     error_message = "redis_sku_name must be a Managed Redis SKU (Balanced_B*, ComputeOptimized_X*, MemoryOptimized_M*, or FlashOptimized_A*)."
   }
+}
+
+variable "redis_location" {
+  description = "Azure region for the Managed Redis instance; empty uses the resource group's region. Managed Redis is reachable cross-region (public endpoint), so it can live in a nearby region when the RG's region lacks Redis Enterprise capacity. Keep empty for production latency."
+  type        = string
+  default     = ""
+}
+
+variable "redis_high_availability_enabled" {
+  description = "Enable high availability (replica + zone-redundant placement) for Azure Managed Redis. HA doubles the node allocation, so in capacity-constrained regions HA creates can fail with a generic OperationFailed while non-HA creates succeed. Disable for ephemeral/test deployments."
+  type        = bool
+  default     = true
 }
 
 variable "redis_version" {


### PR DESCRIPTION
Issue - None

## Problem and fixes

The nightly Azure deployment test was blocked by Azure provisioning failures and several CI races.

| Problem | Fix |
| --- | --- |
| The Azure example pinned AKS `1.33.11`, which moved to LTS-only support. | Pin minor version `1.35` so AKS selects a supported patch. |
| Managed Redis repeatedly failed to allocate in `westus2`. | Add configurable location and high availability settings. CI uses `MemoryOptimized_M10` in `westus3` with high availability disabled; production defaults remain co-located and enabled. |
| Transient ARM 5xx errors could fail a long apply. A failed Redis create could also leave an orphan outside Terraform state. | Retry `terraform apply` once. Delete the orphan before a fallback retry with `ComputeOptimized_X3` in `eastus2`, and raise the job timeout from 30 to 75 minutes. |
| Failed or timed-out applies could miss state upload and skip teardown, leaving infrastructure behind. | Stash Terraform state in an `if: always()` step and run destroy whenever apply started. |
| Slack context parsing could fail before the notification was posted. | Remove the `jq | head` SIGPIPE, tolerate missing artifact data, let enrichment fail safely, and use fallback values when posting. |
| `kubectl run -i` raced the fast MinIO helper container and could report failure after the bucket was created. | Run the helper detached, poll its terminal phase, read its logs, and delete it explicitly. |
| Kubernetes pods could be ready before the OSMO pool reported resources, causing the smoke-test submission to fail. | Wait for pool resources before submitting, bounded by `POOL_RESOURCE_TIMEOUT` (300 seconds by default). |

The MinIO and pool-resource fixes are in shared scripts and also cover KIND and minimal deployments.

## Verification

- [Final Azure deployment run 30503708646](https://github.com/NVIDIA/OSMO/actions/runs/30503708646) passed image build, Terraform apply, OSMO deployment, OETF, and Terraform destroy. Apply succeeded on the first attempt, and destroy removed all 28 managed resources.
- The same head passed the KIND `oetf:deploy_and_run` check. The run logs show both new waits completing successfully.
- A separate timed-out apply confirmed that state upload and destroy still run after apply is interrupted.
- `terraform validate`, shell syntax checks, wait-loop tests, the Redis fallback test, and provider-schema checks pass.

## Known follow-up

`deployments/scripts/azure/terraform.sh` still pins `TF_K8S_VERSION=1.33.11`. Updating it requires validating the GPU Operator against the containerd 2.x nodes used by AKS 1.34 and later. This deployment test does not use that provisioning path or create a GPU pool.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
