### PR TITLE
Add MCP defensive branch coverage

### DIFF
--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -85,6 +85,16 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ready_response.status_code, 200)
         self.assertEqual(ready_response.json(), {'status': 'ok'})
 
+    async def test_mcp_lifespan_requires_application_context(self) -> None:
+        application = server.create_application(self.config)
+        mcp_server = application.state.mcp_server
+
+        with self.assertRaisesRegex(
+            RuntimeError, 'MCP application lifespan is not running.',
+        ):
+            async with mcp_server.settings.lifespan(mcp_server):
+                self.fail('The MCP lifespan must fail without application context.')
+
     async def test_initialize_and_production_tool_catalog(self) -> None:
         application = server.create_application(self.config)
         mcp_server = application.state.mcp_server

--- a/src/service/mcp/tests/test_tokens.py
+++ b/src/service/mcp/tests/test_tokens.py
@@ -26,6 +26,7 @@ import shutil
 import tempfile
 import unittest
 from collections.abc import AsyncIterator, Callable, Coroutine
+from typing import cast
 from unittest import mock
 
 import httpx
@@ -179,6 +180,32 @@ class TokenProviderTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await surviving_waiter, 'service-jwt')
         self.assertEqual(await provider.get_token(), 'service-jwt')
         self.assertEqual(request_count, 1)
+
+    async def test_stale_service_refresh_preserves_replacement_task(self) -> None:
+        # White-box setup is required to exercise the stale-task cleanup guard.
+        # pylint: disable=protected-access
+        request_started = asyncio.Event()
+        release_request = asyncio.Event()
+
+        async def handler(unused_request: httpx.Request) -> httpx.Response:
+            del unused_request
+            request_started.set()
+            await release_request.wait()
+            return self._token_response('service-jwt', lifetime=300)
+
+        provider = self._service_provider(handler)
+        token_waiter = asyncio.create_task(provider.get_token())
+        await asyncio.wait_for(request_started.wait(), timeout=5)
+
+        replacement_task = cast(
+            asyncio.Task[tokens._CachedToken], asyncio.current_task())
+        self.assertIsNotNone(replacement_task)
+        async with provider._lock:
+            provider._refresh_task = replacement_task
+
+        release_request.set()
+        self.assertEqual(await token_waiter, 'service-jwt')
+        self.assertIs(provider._refresh_task, replacement_task)
 
     async def test_stale_service_token_invalidation_preserves_replacement(self) -> None:
         request_count = 0
@@ -498,6 +525,33 @@ class TokenProviderTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await surviving_waiter, 'delegated-alice')
         self.assertEqual(request_count, 1)
 
+    async def test_stale_delegated_mint_preserves_replacement_task(self) -> None:
+        # White-box setup is required to exercise the stale-task cleanup guard.
+        # pylint: disable=protected-access
+        delegation_started = asyncio.Event()
+        release_delegation = asyncio.Event()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            delegation_started.set()
+            await release_delegation.wait()
+            return self._token_response('delegated-alice', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        token_waiter = self._create_delegated_token_task(provider, 'alice')
+        await asyncio.wait_for(delegation_started.wait(), timeout=5)
+
+        replacement_task = cast(
+            asyncio.Task[tokens._CachedToken], asyncio.current_task())
+        self.assertIsNotNone(replacement_task)
+        async with provider._lock:
+            provider._mint_tasks['alice'] = replacement_task
+
+        release_delegation.set()
+        self.assertEqual(await token_waiter, 'delegated-alice')
+        self.assertIs(provider._mint_tasks['alice'], replacement_task)
+
     async def test_delegation_401_invalidates_service_token_and_retries_once(self) -> None:
         service_request_count = 0
         authorization_headers: list[str] = []
@@ -767,6 +821,20 @@ class TokenProviderTest(unittest.IsolatedAsyncioTestCase):
 
         with self.assertRaises(tokens.InvalidGatewayResponseError):
             await provider.get_token()
+
+    async def test_cancelled_refresh_callback_is_ignored(self) -> None:
+        # pylint: disable=protected-access
+        # The callback only inspects cancellation state, so its result type is
+        # intentionally adapted to match a completed token refresh task.
+        cancelled_task = cast(
+            asyncio.Task[tokens._CachedToken],
+            asyncio.create_task(asyncio.sleep(60)),
+        )
+        cancelled_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await cancelled_task
+
+        tokens._consume_task_exception(cancelled_task)
 
     async def test_app_context_configures_hardened_http_client(self) -> None:
         transport = mock.Mock(spec=httpx.AsyncBaseTransport)

--- a/src/service/mcp/tests/test_tools.py
+++ b/src/service/mcp/tests/test_tools.py
@@ -24,10 +24,11 @@ import pathlib
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 import httpx
 
-from src.service.mcp import server
+from src.service.mcp import server, tools as mcp_tools
 
 
 GatewayHandler = (
@@ -277,6 +278,43 @@ class MCPToolsTest(unittest.IsolatedAsyncioTestCase):
             requests, '/api/auth/jwt/delegated_access_token')[0]
         self.assertEqual(
             json.loads(delegated_request.content), {'subject_user': 'alice'})
+
+    async def test_invalid_lifespan_context_returns_sanitized_error(self) -> None:
+        def gateway_handler(unused_request: httpx.Request) -> httpx.Response:
+            del unused_request
+            self.fail('An invalid MCP context must fail before Gateway access.')
+
+        application = server.create_application(
+            self.config,
+            http_transport=httpx.MockTransport(gateway_handler),
+        )
+        request = {
+            'jsonrpc': '2.0',
+            'id': 1,
+            'method': 'tools/call',
+            'params': {'name': 'get_current_profile', 'arguments': {}},
+        }
+        headers = {
+            'Accept': 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'x-osmo-user': 'alice',
+        }
+
+        class UnexpectedAppContext:
+            """Type sentinel used to reject the real lifespan context."""
+
+        async with application.router.lifespan_context(application):
+            with mock.patch.object(
+                mcp_tools.tokens, 'AppContext', UnexpectedAppContext,
+            ):
+                async with httpx.AsyncClient(
+                    transport=httpx.ASGITransport(app=application),
+                    base_url='http://mcp.test',
+                ) as client:
+                    response = await client.post(
+                        '/mcp', headers=headers, json=request)
+
+        self._assert_sanitized_error(response)
 
     async def _call_tool(
         self,


### PR DESCRIPTION
## Description

Stack PR 7 of 7 for MCP Phase B. This PR depends on [stack PR 6](https://github.com/NVIDIA/OSMO/pull/1176) and is the top of the stack.

Merge the stack bottom-up with merge commits. After stack PR 6 merges, retarget this PR to `feature/mcp` and rerun its checks.

Adds defensive tests without changing production behavior. The cases cover stale service-token and delegated-token task cleanup, cancelled refresh callbacks, MCP lifespan use without application context, and sanitized handling of an invalid tool lifespan context.

Commit: `0b774ef5` (`Add MCP defensive branch coverage`).

## Validation

Validation completed locally on the rebuilt final stack:

- All 10 focused Bazel unit and component targets passed with test-result caching disabled
- Both PostgreSQL-backed integration targets passed with test-result caching disabled
- MCP Helm security checks and service-chart lint passed
- `git diff --check` passed

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.