### PR TITLE
Add MCP delegation authorization primitives

### DIFF
--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -654,10 +654,13 @@ services:
     ##
     roles:
       osmo-admin:
-        description: "Admin role — full access to all resources"
+        description: "Admin role — full access except restricted service actions"
         policies:
         - effect: Allow
           actions: ["*:*"]
+          resources: ["*"]
+        - effect: Deny
+          actions: ["auth:Delegate"]
           resources: ["*"]
         external_roles: [osmo-admin]
       osmo-user:

--- a/src/service/authz_sidecar/server/BUILD
+++ b/src/service/authz_sidecar/server/BUILD
@@ -56,6 +56,7 @@ go_test(
         "authz_server_integration_test.go",
     ],
     data = glob(["testdata/**"]),
+    gotags = ["integration"],
     tags = [
         "requires-network",
     ],

--- a/src/service/authz_sidecar/server/authz_server_integration_test.go
+++ b/src/service/authz_sidecar/server/authz_server_integration_test.go
@@ -337,6 +337,95 @@ func TestIntegration(t *testing.T) {
 		}
 	})
 
+	t.Run("MCPDelegationPolicy", func(t *testing.T) {
+		authzServer := fixture.resetAndSeed(t)
+
+		tests := []struct {
+			name      string
+			user      string
+			roles     string
+			tokenName string
+			wantCode  codes.Code
+		}{
+			{
+				name:      "conventional service account with delegator role is allowed",
+				user:      "svc-mcp",
+				roles:     "osmo-mcp-delegator",
+				tokenName: "mcp-service-token",
+				wantCode:  codes.OK,
+			},
+			{
+				name:      "different principal with delegator role is allowed",
+				user:      "another-service",
+				roles:     "osmo-mcp-delegator",
+				tokenName: "service-token",
+				wantCode:  codes.OK,
+			},
+			{
+				name:     "custom delegation role without token name is allowed",
+				user:     "user@example.com",
+				roles:    "custom-delegator",
+				wantCode: codes.OK,
+			},
+			{
+				name:      "admin explicit deny overrides wildcard allow",
+				user:      "admin@example.com",
+				roles:     "osmo-admin",
+				tokenName: "admin-token",
+				wantCode:  codes.PermissionDenied,
+			},
+			{
+				name:      "ordinary role without delegation policy is denied",
+				user:      "user@example.com",
+				roles:     "osmo-user",
+				tokenName: "user-token",
+				wantCode:  codes.PermissionDenied,
+			},
+			{
+				name:      "unrelated extra role does not remove delegation grant",
+				user:      "another-service",
+				roles:     "osmo-mcp-delegator,osmo-user",
+				tokenName: "service-token",
+				wantCode:  codes.OK,
+			},
+			{
+				name:      "duplicate delegator role remains allowed",
+				user:      "another-service",
+				roles:     "osmo-mcp-delegator,osmo-mcp-delegator",
+				tokenName: "service-token",
+				wantCode:  codes.OK,
+			},
+			{
+				name:      "explicit deny in another role overrides delegation grant",
+				user:      "another-service",
+				roles:     "osmo-mcp-delegator,osmo-admin",
+				tokenName: "service-token",
+				wantCode:  codes.PermissionDenied,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req := makeCheckRequestWithHeaders(
+					tt.user,
+					"/api/auth/jwt/delegated_access_token",
+					"POST",
+					tt.roles,
+					tt.tokenName,
+					"",
+				)
+				resp, err := authzServer.Check(context.Background(), req)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				gotCode := codes.Code(resp.Status.Code)
+				if gotCode != tt.wantCode {
+					t.Errorf("Check() status = %v, want %v", gotCode, tt.wantCode)
+				}
+			})
+		}
+	})
+
 	// Tests that x-osmo-workflow-id skips SyncUserRoles the same way tokens do.
 	t.Run("WorkflowIDBypassesRoleSync", func(t *testing.T) {
 		authzServer := fixture.resetAndSeed(t)

--- a/src/service/authz_sidecar/server/authz_server_test.go
+++ b/src/service/authz_sidecar/server/authz_server_test.go
@@ -707,9 +707,18 @@ func newFileBackedTestServer(t *testing.T, configPath string) *AuthzServer {
 }
 
 func makeFileBackedCheckRequest(user, path, method, roleNames string) *envoy_service_auth_v3.CheckRequest {
+	return makeFileBackedCheckRequestWithToken(user, path, method, roleNames, "")
+}
+
+func makeFileBackedCheckRequestWithToken(
+	user, path, method, roleNames, tokenName string,
+) *envoy_service_auth_v3.CheckRequest {
 	headers := map[string]string{
 		"x-osmo-user":  user,
 		"x-osmo-roles": roleNames,
+	}
+	if tokenName != "" {
+		headers["x-osmo-token-name"] = tokenName
 	}
 	return &envoy_service_auth_v3.CheckRequest{
 		Attributes: &envoy_service_auth_v3.AttributeContext{
@@ -729,11 +738,28 @@ func makeFileBackedCheckRequest(user, path, method, roleNames string) *envoy_ser
 
 const testConfigYAML = `
 roles:
+  osmo-mcp-delegator:
+    description: "MCP delegator"
+    policies:
+    - effect: Allow
+      actions: ["auth:Delegate"]
+      resources: ["*"]
+    external_roles: []
+  custom-delegator:
+    description: "Custom delegator"
+    policies:
+    - effect: Allow
+      actions: ["auth:Delegate"]
+      resources: ["*"]
+    external_roles: []
   osmo-admin:
     description: "Admin"
     policies:
     - effect: Allow
       actions: ["*:*"]
+      resources: ["*"]
+    - effect: Deny
+      actions: ["auth:Delegate"]
       resources: ["*"]
     external_roles: [admin-group]
   osmo-user:
@@ -774,6 +800,116 @@ func TestFileBackedCheck_AdminAccess(t *testing.T) {
 	}
 	if resp.GetDeniedResponse() != nil {
 		t.Errorf("expected allow, got deny")
+	}
+}
+
+func TestFileBackedCheck_DelegationPolicy(t *testing.T) {
+	path := writeTestConfigFile(t, testConfigYAML)
+	server := newFileBackedTestServer(t, path)
+
+	tests := []struct {
+		name      string
+		user      string
+		path      string
+		roleNames string
+		tokenName string
+		wantAllow bool
+	}{
+		{
+			name:      "conventional service account with delegator role",
+			user:      "svc-mcp",
+			path:      "/api/auth/jwt/delegated_access_token",
+			roleNames: "osmo-mcp-delegator",
+			tokenName: "mcp-service-token",
+			wantAllow: true,
+		},
+		{
+			name:      "different principal with delegator role",
+			user:      "another-service",
+			path:      "/api/auth/jwt/delegated_access_token",
+			roleNames: "osmo-mcp-delegator",
+			tokenName: "service-token",
+			wantAllow: true,
+		},
+		{
+			name:      "custom role granting delegation",
+			user:      "custom-service",
+			path:      "/api/auth/jwt/delegated_access_token",
+			roleNames: "custom-delegator",
+			wantAllow: true,
+		},
+		{
+			name:      "delegator role with query",
+			user:      "another-service",
+			path:      "/api/auth/jwt/delegated_access_token?request_id=123",
+			roleNames: "osmo-mcp-delegator",
+			wantAllow: true,
+		},
+		{
+			name:      "delegator role with trailing slash and query",
+			user:      "another-service",
+			path:      "/api/auth/jwt/delegated_access_token/?request_id=123",
+			roleNames: "  osmo-mcp-delegator  ",
+			wantAllow: true,
+		},
+		{
+			name:      "ordinary role without delegation policy",
+			user:      "user@test.com",
+			path:      "/api/auth/jwt/delegated_access_token",
+			roleNames: "osmo-user",
+			wantAllow: false,
+		},
+		{
+			name:      "unknown role",
+			user:      "user@test.com",
+			path:      "/api/auth/jwt/delegated_access_token",
+			roleNames: "unknown-role",
+			wantAllow: false,
+		},
+		{
+			name:      "admin explicit deny overrides wildcard allow",
+			user:      "admin@test.com",
+			path:      "/api/auth/jwt/delegated_access_token",
+			roleNames: "osmo-admin",
+			tokenName: "admin-token",
+			wantAllow: false,
+		},
+		{
+			name:      "delegator with unrelated extra role",
+			user:      "another-service",
+			path:      "/api/auth/jwt/delegated_access_token",
+			roleNames: "osmo-mcp-delegator,osmo-user",
+			wantAllow: true,
+		},
+		{
+			name:      "duplicate delegator role",
+			user:      "another-service",
+			path:      "/api/auth/jwt/delegated_access_token",
+			roleNames: "osmo-mcp-delegator,osmo-mcp-delegator",
+			wantAllow: true,
+		},
+		{
+			name:      "explicit deny in another role overrides delegation allow",
+			user:      "another-service",
+			path:      "/api/auth/jwt/delegated_access_token",
+			roleNames: "osmo-mcp-delegator,osmo-admin",
+			wantAllow: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := makeFileBackedCheckRequestWithToken(
+				tt.user, tt.path, "POST", tt.roleNames, tt.tokenName,
+			)
+			resp, err := server.Check(context.Background(), req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotAllow := resp.GetDeniedResponse() == nil; gotAllow != tt.wantAllow {
+				t.Errorf("Check() allow = %v, want %v", gotAllow, tt.wantAllow)
+			}
+		})
 	}
 }
 

--- a/src/service/authz_sidecar/server/testdata/seed.sql
+++ b/src/service/authz_sidecar/server/testdata/seed.sql
@@ -10,14 +10,37 @@ INSERT INTO roles (name, description, policies, immutable) VALUES (
     TRUE
 );
 
--- Admin role: full access
+-- Admin role: broad access with an explicit delegation denial.
 INSERT INTO roles (name, description, policies, immutable) VALUES (
     'osmo-admin',
-    'Full admin access',
+    'Full admin access except restricted service actions',
     ARRAY[
-        '{"actions": ["*:*"], "resources": ["*"]}'::jsonb
+        '{"actions": ["*:*"], "resources": ["*"]}'::jsonb,
+        '{"effect": "Deny", "actions": ["auth:Delegate"], "resources": ["*"]}'::jsonb
     ],
     TRUE
+);
+
+-- MCP delegation role: grants the policy evaluated by the authorization sidecar.
+INSERT INTO roles (name, description, policies, immutable, sync_mode) VALUES (
+    'osmo-mcp-delegator',
+    'Allows the MCP service to mint delegated access tokens',
+    ARRAY[
+        '{"actions": ["auth:Delegate"], "resources": ["*"]}'::jsonb
+    ],
+    TRUE,
+    'ignore'
+);
+
+-- Custom role with the same grant, proving delegation is policy-based.
+INSERT INTO roles (name, description, policies, immutable, sync_mode) VALUES (
+    'custom-delegator',
+    'Custom delegation role',
+    ARRAY[
+        '{"actions": ["auth:Delegate"], "resources": ["*"]}'::jsonb
+    ],
+    FALSE,
+    'ignore'
 );
 
 -- User role: workflow read/create, pool read, app CRUD

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -24,13 +24,13 @@ import uuid
 from jwcrypto import jwk  # type: ignore
 import jwt  # type: ignore
 import pydantic
+
 from src.lib.utils import common, osmo_errors
 
 # The default length of time a token should be valid for. Defaults to 20 days
 DEFAULT_LENGTH = 20 * 24 * 60 * 60
 
 MCP_DELEGATOR_ROLE = 'osmo-mcp-delegator'
-DELEGATED_TOKEN_NAME = 'delegated-svc-mcp'
 
 
 class AsymmetricKeyPair(pydantic.BaseModel):

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -17,19 +17,20 @@ SPDX-License-Identifier: Apache-2.0
 """
 import hashlib
 import json
+import time
 from typing import Any, Dict, List
 import uuid
-import time
 
-import pydantic
 from jwcrypto import jwk  # type: ignore
 import jwt  # type: ignore
-
+import pydantic
 from src.lib.utils import common, osmo_errors
-
 
 # The default length of time a token should be valid for. Defaults to 20 days
 DEFAULT_LENGTH = 20 * 24 * 60 * 60
+
+MCP_DELEGATOR_ROLE = 'osmo-mcp-delegator'
+DELEGATED_TOKEN_NAME = 'delegated-svc-mcp'
 
 
 class AsymmetricKeyPair(pydantic.BaseModel):
@@ -134,7 +135,9 @@ class AuthenticationConfig(pydantic.BaseModel):
     def create_idtoken_jwt(self, expire_timestamp: int, username: str,
                            roles: List[str],
                            token_name: str | None = None,
-                           workflow_id: str | None = None) -> str:
+                           workflow_id: str | None = None,
+                           actor: str | None = None,
+                           issued_at: int | None = None) -> str:
         '''
         aud: Audience
         iss: Issuer
@@ -142,7 +145,7 @@ class AuthenticationConfig(pydantic.BaseModel):
         nbf: Not before
         exp: Expires
         '''
-        current_time = int(time.time())
+        current_time = issued_at if issued_at is not None else int(time.time())
         payload = {
             'iss': self.issuer,
             'aud': self.audience,
@@ -151,7 +154,7 @@ class AuthenticationConfig(pydantic.BaseModel):
             'exp': expire_timestamp
         }
 
-        template_payload = {
+        template_payload: Dict[str, Any] = {
             'unique_name': username,
             'roles': roles
         }
@@ -159,6 +162,8 @@ class AuthenticationConfig(pydantic.BaseModel):
             template_payload['osmo_token_name'] = token_name
         if workflow_id:
             template_payload['osmo_workflow_id'] = workflow_id
+        if actor:
+            template_payload['act'] = {'sub': actor}
 
         # Substitute the template
         payload.update(template_payload)
@@ -169,4 +174,3 @@ class AuthenticationConfig(pydantic.BaseModel):
 def hash_access_token(access_token: str) -> bytes:
     """ Hash the access token """
     return hashlib.sha256(access_token.encode()).digest()
-

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1361,13 +1361,22 @@ class PostgresConnector:
         """
         roles = Role.list_from_db(self)
         updated_roles = False
+        has_existing_roles = bool(roles)
 
         role_objects = {r.name: r for r in roles}
         for default_role_name, default_role_object in DEFAULT_ROLES.items():
             if default_role_name not in role_objects:
                 default_role_object.insert_into_db(self, force=True)
+                updated_roles = updated_roles or has_existing_roles
             else:
                 existing_role = role_objects[default_role_name]
+                if (default_role_name == MCP_DELEGATOR_ROLE_NAME and
+                        existing_role != default_role_object):
+                    # This service-only role is a security boundary, so upgrades
+                    # restore its complete definition instead of merging grants.
+                    default_role_object.insert_into_db(self, force=True)
+                    updated_roles = True
+                    continue
                 if merge_default_role_policies(existing_role, default_role_object):
                     existing_role.insert_into_db(self, force=True)
                     updated_roles = True
@@ -4577,6 +4586,7 @@ class Role(role.Role):
                 DO UPDATE SET
                     description = EXCLUDED.description,
                     policies = EXCLUDED.policies,
+                    immutable = EXCLUDED.immutable,
                     sync_mode = EXCLUDED.sync_mode
                 {check_immutable}
                 RETURNING policies, immutable, (xmax = 0) AS is_new_role
@@ -4617,7 +4627,7 @@ class Role(role.Role):
                 self.name,
                 self.description,
                 [json.dumps(policy.to_dict()) for policy in self.policies],
-                False,
+                self.immutable,
                 self.sync_mode.value,
                 # sync_config params
                 external_roles_provided,  # first %s in sync_config (should_sync)
@@ -4698,21 +4708,34 @@ def merge_default_role_policies(existing_role: Role, default_role: Role) -> bool
 # Default roles using semantic action format.
 # Authorization is now handled by the authz_sidecar (Go service).
 # These roles are seeded into the database on startup.
+MCP_DELEGATOR_ROLE_NAME = auth.MCP_DELEGATOR_ROLE
+
 DEFAULT_ROLES: Dict[str, Role] = {
+    MCP_DELEGATOR_ROLE_NAME: Role(
+        name=MCP_DELEGATOR_ROLE_NAME,
+        description='Allows the MCP service to mint delegated access tokens',
+        policies=[
+            role.RolePolicy(
+                actions=['auth:Delegate'],
+                resources=['*']
+            )
+        ],
+        immutable=True,
+        sync_mode=role.SyncMode.IGNORE,
+        external_roles=[]
+    ),
     'osmo-admin': Role(
         name='osmo-admin',
-        description='Administrator with full access except internal endpoints',
+        description='Administrator with full access except restricted service actions',
         policies=[
             role.RolePolicy(
                 actions=['*:*'],
                 resources=['*']
             ),
             role.RolePolicy(
-                actions=[
-                    # Deny internal actions (handled via authz_sidecar deny logic)
-                    # Note: Deny is implicit - admin doesn't get internal:* actions
-                ],
-                resources=[]
+                effect=role.PolicyEffect.DENY,
+                actions=['auth:Delegate'],
+                resources=['*'],
             )
         ],
         immutable=True

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library")
+load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 py_test(
@@ -57,4 +57,15 @@ py_test(
         "exclusive"
     ],
     size = "small"
+)
+
+osmo_py_test(
+    name = "test_default_roles_integration",
+    srcs = ["test_default_roles_integration.py"],
+    deps = [
+        "//src/tests/common",
+        "//src/utils/connectors",
+    ],
+    size = "large",
+    tags = ["requires-network"],
 )

--- a/src/utils/connectors/tests/test_default_roles.py
+++ b/src/utils/connectors/tests/test_default_roles.py
@@ -16,7 +16,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import copy
 import unittest
+from unittest import mock
 
 from src.lib.utils import role
 from src.utils import connectors
@@ -362,6 +364,212 @@ class TestDefaultRoleMerge(unittest.TestCase):
         )
         self.assertEqual(len(scoped_workflow_policies), 1)
         self.assertEqual(scoped_workflow_policies[0].actions, ['workflow:*'])
+
+    def test_osmo_admin_explicitly_denies_delegation(self):
+        osmo_admin = connectors.DEFAULT_ROLES['osmo-admin']
+
+        deny_policies = [
+            policy
+            for policy in osmo_admin.policies
+            if policy.effect == role.PolicyEffect.DENY
+        ]
+
+        self.assertEqual(len(deny_policies), 1)
+        self.assertEqual(deny_policies[0].actions, ['auth:Delegate'])
+        self.assertEqual(deny_policies[0].resources, ['*'])
+
+    def test_osmo_admin_upgrade_adds_delegation_deny_policy(self):
+        existing_admin = connectors.Role(
+            name='osmo-admin',
+            description='Existing admin',
+            policies=[
+                role.RolePolicy(actions=['*:*'], resources=['*']),
+            ],
+        )
+
+        did_update = connectors.merge_default_role_policies(
+            existing_admin,
+            connectors.DEFAULT_ROLES['osmo-admin'],
+        )
+
+        self.assertTrue(did_update)
+        self.assertEqual(len(existing_admin.policies), 2)
+        self.assertEqual(existing_admin.policies[0].actions, ['*:*'])
+        self.assertEqual(existing_admin.policies[0].effect, role.PolicyEffect.ALLOW)
+        self.assertEqual(existing_admin.policies[1].actions, ['auth:Delegate'])
+        self.assertEqual(existing_admin.policies[1].effect, role.PolicyEffect.DENY)
+        self.assertEqual(existing_admin.policies[1].resources, ['*'])
+
+    def test_mcp_delegator_role_is_isolated_from_idp_sync(self):
+        self.assertEqual(connectors.MCP_DELEGATOR_ROLE_NAME, 'osmo-mcp-delegator')
+        delegator = connectors.DEFAULT_ROLES[connectors.MCP_DELEGATOR_ROLE_NAME]
+
+        self.assertTrue(delegator.immutable)
+        self.assertEqual(delegator.sync_mode, role.SyncMode.IGNORE)
+        self.assertEqual(delegator.external_roles, [])
+        self.assertEqual(len(delegator.policies), 1)
+        self.assertEqual(delegator.policies[0].actions, ['auth:Delegate'])
+        self.assertEqual(delegator.policies[0].resources, ['*'])
+
+    def test_mcp_delegator_insert_persists_security_attributes(self):
+        delegator = connectors.DEFAULT_ROLES[connectors.MCP_DELEGATOR_ROLE_NAME]
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = [{
+            'policies': [policy.to_dict() for policy in delegator.policies],
+            'immutable': True,
+            'is_new_role': True,
+        }]
+
+        delegator.insert_into_db(database, force=True)
+
+        command, parameters, return_dicts = database.execute_fetch_command.call_args.args
+        immutable = parameters[3]
+        sync_mode = parameters[4]
+        external_roles_provided = parameters[5]
+        external_roles = parameters[7]
+        self.assertIn('immutable = EXCLUDED.immutable', command)
+        self.assertTrue(immutable)
+        self.assertEqual(sync_mode, role.SyncMode.IGNORE.value)
+        self.assertTrue(external_roles_provided)
+        self.assertEqual(external_roles, [])
+        self.assertTrue(return_dicts)
+
+    def test_mcp_delegator_upgrade_restores_canonical_role(self):
+        existing_roles = [
+            copy.deepcopy(default_role)
+            for default_role in connectors.DEFAULT_ROLES.values()
+        ]
+        canonical_roles = [
+            copy.deepcopy(default_role)
+            for default_role in connectors.DEFAULT_ROLES.values()
+        ]
+        existing_delegator = next(
+            existing_role
+            for existing_role in existing_roles
+            if existing_role.name == connectors.MCP_DELEGATOR_ROLE_NAME
+        )
+        existing_delegator.description = 'Compromised role'
+        existing_delegator.policies = [
+            role.RolePolicy(actions=['*:*'], resources=['*'])
+        ]
+        existing_delegator.immutable = False
+        existing_delegator.sync_mode = role.SyncMode.IMPORT
+        existing_delegator.external_roles = ['idp-admin']
+        database = mock.Mock()
+
+        with (
+            mock.patch.object(
+                connectors.Role,
+                'list_from_db',
+                side_effect=[existing_roles, canonical_roles],
+            ),
+            mock.patch.object(
+                connectors.Role,
+                'insert_into_db',
+                autospec=True,
+            ) as insert_role,
+        ):
+            connectors.PostgresConnector.create_default_roles(database)
+
+        insert_role.assert_called_once_with(
+            connectors.DEFAULT_ROLES[connectors.MCP_DELEGATOR_ROLE_NAME],
+            database,
+            force=True,
+        )
+        database.create_config_history_entry.assert_called_once_with(
+            config_type=connectors.ConfigHistoryType.ROLE,
+            name='',
+            username='system',
+            data=canonical_roles,
+            description='Updated roles',
+        )
+
+    def test_canonical_mcp_delegator_does_not_write_or_create_history(self):
+        existing_roles = [
+            copy.deepcopy(default_role)
+            for default_role in connectors.DEFAULT_ROLES.values()
+        ]
+        database = mock.Mock()
+
+        with (
+            mock.patch.object(
+                connectors.Role,
+                'list_from_db',
+                return_value=existing_roles,
+            ),
+            mock.patch.object(
+                connectors.Role,
+                'insert_into_db',
+                autospec=True,
+            ) as insert_role,
+        ):
+            connectors.PostgresConnector.create_default_roles(database)
+
+        insert_role.assert_not_called()
+        database.create_config_history_entry.assert_not_called()
+
+    def test_missing_mcp_delegator_records_role_history(self):
+        existing_roles = [
+            copy.deepcopy(default_role)
+            for role_name, default_role in connectors.DEFAULT_ROLES.items()
+            if role_name != connectors.MCP_DELEGATOR_ROLE_NAME
+        ]
+        all_default_roles = [
+            copy.deepcopy(default_role)
+            for default_role in connectors.DEFAULT_ROLES.values()
+        ]
+        database = mock.Mock()
+
+        with (
+            mock.patch.object(
+                connectors.Role,
+                'list_from_db',
+                side_effect=[existing_roles, all_default_roles],
+            ),
+            mock.patch.object(
+                connectors.Role,
+                'insert_into_db',
+                autospec=True,
+            ) as insert_role,
+        ):
+            connectors.PostgresConnector.create_default_roles(database)
+
+        insert_role.assert_called_once_with(
+            connectors.DEFAULT_ROLES[connectors.MCP_DELEGATOR_ROLE_NAME],
+            database,
+            force=True,
+        )
+        database.create_config_history_entry.assert_called_once_with(
+            config_type=connectors.ConfigHistoryType.ROLE,
+            name='',
+            username='system',
+            data=all_default_roles,
+            description='Updated roles',
+        )
+
+    def test_fresh_install_leaves_initial_role_history_to_initializer(self):
+        database = mock.Mock()
+
+        with (
+            mock.patch.object(connectors.Role, 'list_from_db', return_value=[]),
+            mock.patch.object(
+                connectors.Role,
+                'insert_into_db',
+                autospec=True,
+            ) as insert_role,
+        ):
+            connectors.PostgresConnector.create_default_roles(database)
+
+        self.assertEqual(insert_role.call_count, len(connectors.DEFAULT_ROLES))
+        self.assertEqual(
+            [call.args[0].name for call in insert_role.call_args_list],
+            list(connectors.DEFAULT_ROLES),
+        )
+        self.assertTrue(all(
+            call.kwargs == {'force': True}
+            for call in insert_role.call_args_list
+        ))
+        database.create_config_history_entry.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/src/utils/connectors/tests/test_default_roles_integration.py
+++ b/src/utils/connectors/tests/test_default_roles_integration.py
@@ -1,0 +1,177 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import unittest
+from typing import Any, Dict, List, cast
+
+from src.tests.common import fixtures
+from src.utils import connectors
+from src.utils.connectors import postgres
+
+
+class TestDefaultRoleIntegration(
+    fixtures.PostgresFixture,
+    fixtures.OsmoTestFixture,
+):
+    """Exercise default-role repair against PostgreSQL, including its CTEs."""
+
+    database: postgres.PostgresConnector
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.database = postgres.PostgresConnector(
+            postgres.PostgresConfig(
+                postgres_host=cls.postgres_container.get_container_host_ip(),
+                postgres_port=cls.postgres_container.get_database_port(),
+                postgres_password=cls.postgres_container.password,
+                postgres_database_name=cls.postgres_container.dbname,
+                postgres_user=cls.postgres_container.username,
+                method='dev',
+            )
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        try:
+            if postgres.PostgresConnector._instance:  # pylint: disable=protected-access
+                cls.database.close()
+                # Avoid leaking the singleton if other tests share this process.
+                postgres.PostgresConnector._instance = None  # pylint: disable=protected-access
+        finally:
+            super().tearDownClass()
+
+    def _fetch_role_history(self) -> List[Dict[str, Any]]:
+        rows = self.database.execute_fetch_command(
+            '''
+                SELECT revision, name, username, tags, description, data
+                FROM config_history
+                WHERE config_type = %s
+                ORDER BY revision;
+            ''',
+            (connectors.ConfigHistoryType.ROLE.value.lower(),),
+            True,
+        )
+        return cast(List[Dict[str, Any]], rows)
+
+    def _fetch_delegator_row_version(self) -> str:
+        rows = self.database.execute_fetch_command(
+            'SELECT xmin::text AS row_version FROM roles WHERE name = %s;',
+            (connectors.MCP_DELEGATOR_ROLE_NAME,),
+            True,
+        )
+        self.assertEqual(len(rows), 1)
+        return cast(str, rows[0]['row_version'])
+
+    def test_compromised_delegator_is_restored_once(self) -> None:
+        role_name = connectors.MCP_DELEGATOR_ROLE_NAME
+        canonical_role = connectors.DEFAULT_ROLES[role_name]
+        compromised_policy = {
+            'effect': 'Allow',
+            'actions': ['*:*'],
+            'resources': ['*'],
+        }
+
+        initial_history = self._fetch_role_history()
+        self.assertEqual([entry['revision'] for entry in initial_history], [1])
+
+        # Seed every security-sensitive field with a non-canonical value. Direct
+        # SQL keeps this precondition independent from the CTE under test.
+        self.database.execute_commit_command(
+            '''
+                UPDATE roles
+                SET description = %s,
+                    policies = %s::jsonb[],
+                    immutable = FALSE,
+                    sync_mode = 'import'
+                WHERE name = %s;
+            ''',
+            ('Compromised role', [json.dumps(compromised_policy)], role_name),
+        )
+        self.database.execute_commit_command(
+            '''
+                INSERT INTO role_external_mappings (role_name, external_role)
+                VALUES (%s, %s);
+            ''',
+            (role_name, 'idp-admin'),
+        )
+
+        compromised_role = connectors.Role.fetch_from_db(self.database, role_name)
+        self.assertEqual(compromised_role.description, 'Compromised role')
+        self.assertEqual(
+            [policy.to_dict() for policy in compromised_role.policies],
+            [compromised_policy],
+        )
+        self.assertFalse(compromised_role.immutable)
+        self.assertEqual(compromised_role.sync_mode.value, 'import')
+        self.assertEqual(compromised_role.external_roles, ['idp-admin'])
+
+        self.database.create_default_roles()
+
+        restored_role = connectors.Role.fetch_from_db(self.database, role_name)
+        self.assertEqual(restored_role, canonical_role)
+        self.assertEqual(restored_role.external_roles, [])
+        mappings = self.database.execute_fetch_command(
+            '''
+                SELECT external_role
+                FROM role_external_mappings
+                WHERE role_name = %s;
+            ''',
+            (role_name,),
+            True,
+        )
+        self.assertEqual(mappings, [])
+
+        history_after_repair = self._fetch_role_history()
+        self.assertEqual(
+            [entry['revision'] for entry in history_after_repair],
+            [1, 2],
+        )
+        repair_history = history_after_repair[-1]
+        self.assertEqual(repair_history['name'], '')
+        self.assertEqual(repair_history['username'], 'system')
+        self.assertIsNone(repair_history['tags'])
+        self.assertEqual(repair_history['description'], 'Updated roles')
+        expected_payload = [
+            role.model_dump(mode='json')
+            for role in connectors.Role.list_from_db(self.database)
+        ]
+        self.assertEqual(repair_history['data'], expected_payload)
+        self.assertEqual(
+            next(role for role in repair_history['data'] if role['name'] == role_name),
+            canonical_role.model_dump(mode='json'),
+        )
+
+        row_version_after_repair = self._fetch_delegator_row_version()
+        self.database.create_default_roles()
+
+        self.assertEqual(
+            connectors.Role.fetch_from_db(self.database, role_name),
+            canonical_role,
+        )
+        self.assertEqual(
+            self._fetch_delegator_row_version(),
+            row_version_after_repair,
+        )
+        self.assertEqual(self._fetch_role_history(), history_after_repair)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/utils/roles/action_registry.go
+++ b/src/utils/roles/action_registry.go
@@ -107,9 +107,10 @@ const (
 	ActionConfigUpdate = resourceTypeConfig + ":Update"
 
 	// Auth actions
-	ActionAuthLogin   = resourceTypeAuth + ":Login"
-	ActionAuthRefresh = resourceTypeAuth + ":Refresh"
-	ActionAuthToken   = resourceTypeAuth + ":Token"
+	ActionAuthDelegate = resourceTypeAuth + ":Delegate"
+	ActionAuthLogin    = resourceTypeAuth + ":Login"
+	ActionAuthRefresh  = resourceTypeAuth + ":Refresh"
+	ActionAuthToken    = resourceTypeAuth + ":Token"
 
 	// MCP actions
 	ActionMCPAccess = resourceTypeMCP + ":Access"
@@ -273,6 +274,9 @@ var ActionRegistry = map[string][]EndpointPattern{
 	},
 
 	// ==================== AUTH ====================
+	ActionAuthDelegate: {
+		{Path: "/api/auth/jwt/delegated_access_token", Methods: []string{"POST"}},
+	},
 	ActionAuthLogin: {
 		{Path: "/api/auth/login", Methods: []string{"GET"}},
 		{Path: "/api/auth/keys", Methods: []string{"GET"}},
@@ -441,11 +445,12 @@ func getPatternIndex() *patternIndex {
 func ResolvePathToAction(
 	ctx context.Context, path, method string, pgClient *postgres.PostgresClient,
 ) (action string, resource string) {
-	// Normalize path - remove trailing slash and query string
-	normalizedPath := strings.TrimSuffix(path, "/")
+	// Normalize path - remove query string and trailing slash
+	normalizedPath := path
 	if idx := strings.Index(normalizedPath, "?"); idx != -1 {
 		normalizedPath = normalizedPath[:idx]
 	}
+	normalizedPath = strings.TrimSuffix(normalizedPath, "/")
 
 	method = strings.ToUpper(method)
 	pidx := getPatternIndex()

--- a/src/utils/roles/action_registry_test.go
+++ b/src/utils/roles/action_registry_test.go
@@ -126,6 +126,76 @@ func TestMCPActionAuthorization(t *testing.T) {
 	}
 }
 
+func TestAuthDelegateActionRegistry(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		method     string
+		wantAction string
+	}{
+		{
+			name:       "POST delegation endpoint",
+			path:       "/api/auth/jwt/delegated_access_token",
+			method:     "POST",
+			wantAction: ActionAuthDelegate,
+		},
+		{
+			name:       "POST delegation endpoint with query",
+			path:       "/api/auth/jwt/delegated_access_token?request_id=123",
+			method:     "POST",
+			wantAction: ActionAuthDelegate,
+		},
+		{
+			name:       "POST delegation endpoint with trailing slash",
+			path:       "/api/auth/jwt/delegated_access_token/",
+			method:     "POST",
+			wantAction: ActionAuthDelegate,
+		},
+		{
+			name:       "POST delegation endpoint with trailing slash and query",
+			path:       "/api/auth/jwt/delegated_access_token/?request_id=123",
+			method:     "POST",
+			wantAction: ActionAuthDelegate,
+		},
+		{
+			name:   "GET delegation endpoint",
+			path:   "/api/auth/jwt/delegated_access_token",
+			method: "GET",
+		},
+		{
+			name:   "PUT delegation endpoint",
+			path:   "/api/auth/jwt/delegated_access_token",
+			method: "PUT",
+		},
+		{
+			name:   "nested delegation path",
+			path:   "/api/auth/jwt/delegated_access_token/user",
+			method: "POST",
+		},
+		{
+			name:   "adjacent delegation path",
+			path:   "/api/auth/jwt/delegated_access_tokens",
+			method: "POST",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action, resource := ResolvePathToAction(
+				context.Background(), tt.path, tt.method, nil,
+			)
+			if action != tt.wantAction {
+				t.Errorf("ResolvePathToAction(%q, %q) action = %q, want %q",
+					tt.path, tt.method, action, tt.wantAction)
+			}
+			if resource != "" {
+				t.Errorf("ResolvePathToAction(%q, %q) resource = %q, want empty",
+					tt.path, tt.method, resource)
+			}
+		})
+	}
+}
+
 func TestMatchMethodRegistry(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/src/utils/tests/test_auth.py
+++ b/src/utils/tests/test_auth.py
@@ -18,10 +18,10 @@ SPDX-License-Identifier: Apache-2.0
 """
 import base64
 import json
+import time
 import unittest
 
 from jwcrypto import jwk, jws, jwt
-
 from src.utils import auth
 
 # Verify that the keys we use have a RSA modulus of at least 4096 bits
@@ -70,6 +70,26 @@ class TestAuth(unittest.TestCase):
             jwt1.validate(jwk.JWK.from_json(default_key_pair_2.get_current_key().public_key))
         with self.assertRaises(jws.InvalidJWSSignature):
             jwt2.validate(jwk.JWK.from_json(default_key_pair_1.get_current_key().public_key))
+
+    def test_create_idtoken_jwt_without_actor_is_unchanged(self):
+        """Existing callers do not gain delegation-only claims."""
+        authentication_config = auth.AuthenticationConfig.generate_default()
+        encoded_token = authentication_config.create_idtoken_jwt(
+            int(time.time()) + 60,
+            'test-user',
+            ['osmo-user'],
+        )
+        decoded_token = jwt.JWT(
+            jwt=encoded_token,
+            key=jwk.JWK.from_json(
+                authentication_config.get_current_key().public_key),
+        )
+        claims = json.loads(decoded_token.claims)
+
+        self.assertEqual(claims['unique_name'], 'test-user')
+        self.assertEqual(claims['roles'], ['osmo-user'])
+        self.assertNotIn('act', claims)
+        self.assertNotIn('osmo_token_name', claims)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Stack PR 1 of 7 for MCP Phase B. This PR targets `feature/mcp` and is the required base for [stack PR 2](https://github.com/NVIDIA/OSMO/pull/1172).

Merge the stack bottom-up with merge commits. After each merge, retarget the next PR to `feature/mcp` and rerun its checks.

Adds the authorization foundation for delegated MCP access:

- registers the `auth:Delegate` action and POST route;
- seeds and repairs the immutable `osmo-mcp-delegator` role without IdP mappings;
- authorizes delegation through standard role policies instead of a hard-coded username;
- explicitly denies `auth:Delegate` for the built-in `osmo-admin` role while supporting custom roles that grant it;
- preserves role immutability and records upgrade repairs in role history; and
- adds optional JWT actor and issued-at claims without changing existing callers.

A follow-up cleanup removes the delegated-token name constant from this layer because it is first used by stack PR 2.

Commits:

- `e4550f9c` (`Add MCP delegation authorization primitives`)
- `b8a8ec0d` (`Remove unused delegated token name constant`)

## Validation

Validation completed locally on the rebuilt stack:

- `//src/utils/roles:roles_test`
- `//src/utils/connectors/tests:test_default_roles`
- `//src/utils/tests:test_auth`
- `//src/service/authz_sidecar/server:server_test`
- PostgreSQL-backed `//src/utils/connectors/tests:test_default_roles_integration`
- PostgreSQL-backed `//src/service/authz_sidecar/server:server_integration_test`
- MCP Helm security checks, service-chart lint, and `git diff --check`

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.