### PR TITLE
Add delegated token minting endpoint

### DIFF
--- a/src/lib/utils/common.py
+++ b/src/lib/utils/common.py
@@ -94,6 +94,27 @@ DOCKER_MANIFEST_LIST_ENCODING = 'application/vnd.docker.distribution.manifest.li
 CONFIG_NAME_REGEX = r'^[a-zA-Z]([a-zA-Z0-9_.-]*[a-zA-Z0-9])?$'
 TOKEN_NAME_REGEX = r'^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$'
 USERNAME_REGEX = r'^[a-zA-Z0-9]([a-zA-Z0-9_.@-]*[a-zA-Z0-9])?$'
+MAX_AUTHENTICATED_USER_ID_BYTES = 256
+REQUEST_ID_REGEX = r'[A-Za-z0-9][A-Za-z0-9._:-]{0,127}'
+
+
+def is_valid_authenticated_user_id(user_id: str) -> bool:
+    """Return whether a trusted IdP identity is safe for headers and cache keys."""
+    try:
+        encoded_length = len(user_id.encode('utf-8'))
+    except UnicodeEncodeError:
+        return False
+    return (
+        bool(user_id) and
+        user_id == user_id.strip() and
+        encoded_length <= MAX_AUTHENTICATED_USER_ID_BYTES and
+        all(character.isprintable() for character in user_id)
+    )
+
+
+def is_valid_request_id(request_id: str) -> bool:
+    """Return whether a request ID is safe to forward and include in logs."""
+    return re.fullmatch(REQUEST_ID_REGEX, request_id) is not None
 
 # The keys to look for in the docker auth response
 DOCKER_AUTH_TOKEN_KEYS = ['token', 'access_token']

--- a/src/lib/utils/tests/test_common.py
+++ b/src/lib/utils/tests/test_common.py
@@ -34,6 +34,55 @@ class TestCommon(unittest.TestCase):
     Unit tests for the common module.
     """
 
+    def test_authenticated_user_id_validation(self):
+        valid_user_ids = (
+            'alice@example.com',
+            'alice+tag@example.com',
+            'guest#EXT#@tenant.example',
+            'álîce@example.com',
+            'é' * 128,
+        )
+        for user_id in valid_user_ids:
+            with self.subTest(user_id=user_id):
+                self.assertTrue(common.is_valid_authenticated_user_id(user_id))
+
+        invalid_user_ids = (
+            '',
+            ' alice@example.com',
+            'alice@example.com ',
+            'alice\n@example.com',
+            'alice\x7f@example.com',
+            'a' * 257,
+            'é' * 129,
+            '\U0001f600' * 65,
+            '\u200balice@example.com',
+            '\ud800',
+        )
+        for user_id in invalid_user_ids:
+            with self.subTest(user_id=user_id):
+                self.assertFalse(common.is_valid_authenticated_user_id(user_id))
+
+    def test_request_id_validation(self):
+        valid_request_ids = (
+            'a',
+            'request-123.trace_456:span',
+            'r' * 128,
+        )
+        for request_id in valid_request_ids:
+            with self.subTest(request_id=request_id):
+                self.assertTrue(common.is_valid_request_id(request_id))
+
+        invalid_request_ids = (
+            '',
+            '-request',
+            'contains space',
+            'request\nnewline',
+            'r' * 129,
+        )
+        for request_id in invalid_request_ids:
+            with self.subTest(request_id=request_id):
+                self.assertFalse(common.is_valid_request_id(request_id))
+
     def test_convert_resource_value(self):
         self.assertEqual(common.convert_resource_value_str('10Gi', target='TiB'), 10.0 / 1024)
         self.assertEqual(common.convert_resource_value_str('1.5Ti', target='GiB'), 1.5 * 1024)

--- a/src/service/core/auth/BUILD
+++ b/src/service/core/auth/BUILD
@@ -27,6 +27,7 @@ osmo_py_library(
     ],
     deps = [
         requirement("fastapi"),
+        requirement("pyjwt"),
         requirement("pydantic"),
         "//src/lib/utils:common",
         "//src/lib/utils:login",

--- a/src/service/core/auth/auth_service.py
+++ b/src/service/core/auth/auth_service.py
@@ -16,22 +16,26 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import datetime
+import json
+import logging
 import re
 import secrets
 import time
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import fastapi
-
-from src.lib.utils import common, osmo_errors
-from src.utils.job import task as task_lib
+import jwt  # type: ignore
+from src.lib.utils import common, login, osmo_errors
 from src.service.core.auth import objects
 from src.utils import auth, connectors
-
+from src.utils.job import task as task_lib
 
 router = fastapi.APIRouter(
     tags = ['Auth API']
 )
+
+logger = logging.getLogger(__name__)
+REQUEST_ID_HEADER = 'x-request-id'
 
 
 # =============================================================================
@@ -50,6 +54,201 @@ def get_keys():
     postgres = connectors.PostgresConnector.get_instance()
     service_config = postgres.get_service_configs()
     return service_config.service_auth.get_keyset()
+
+
+def _authentication_error() -> fastapi.HTTPException:
+    return fastapi.HTTPException(
+        status_code=fastapi.status.HTTP_401_UNAUTHORIZED,
+        detail='A valid service bearer token is required',
+        headers={'WWW-Authenticate': 'Bearer'},
+    )
+
+
+def _extract_bearer_token(authorization: Optional[str]) -> str:
+    if authorization is None:
+        raise _authentication_error()
+    parts = authorization.split()
+    if len(parts) != 2 or parts[0].lower() != 'bearer' or not parts[1]:
+        raise _authentication_error()
+    return parts[1]
+
+
+def _decode_service_jwt(
+    encoded_token: str,
+    service_auth: auth.AuthenticationConfig,
+) -> Dict[str, Any]:
+    """Verify a JWT against every currently configured Core signing key."""
+    for key_pair in service_auth.keys.values():
+        try:
+            public_key = jwt.PyJWK.from_json(key_pair.public_key).key
+            return jwt.decode(
+                encoded_token,
+                key=public_key,
+                algorithms=['RS256'],
+                audience=service_auth.audience,
+                issuer=service_auth.issuer,
+                options={'require': ['aud', 'exp', 'iat', 'iss', 'nbf']},
+            )
+        except jwt.PyJWTError:
+            continue
+    raise _authentication_error()
+
+
+def _get_service_jwt_expiration(claims: Dict[str, Any]) -> int:
+    """Return the integer expiry required from OSMO-issued service JWTs."""
+    expires_at = claims.get('exp')
+    if not isinstance(expires_at, int) or isinstance(expires_at, bool):
+        raise _authentication_error()
+    return expires_at
+
+
+def _validate_delegator_claims(
+    claims: Dict[str, Any],
+    gateway_user: Optional[str],
+) -> str:
+    """Validate caller integrity after Gateway policy authorization."""
+    actor = claims.get('unique_name')
+    if not isinstance(actor, str) or not actor.strip():
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_403_FORBIDDEN,
+            detail='The authenticated principal is invalid',
+        )
+
+    if 'act' in claims:
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_403_FORBIDDEN,
+            detail='A delegated token cannot mint another delegated token',
+        )
+
+    if gateway_user != actor:
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_403_FORBIDDEN,
+            detail='Gateway and bearer token identities do not match',
+        )
+
+    return actor
+
+
+def _sanitize_request_id(request_id: Optional[str]) -> Optional[str]:
+    if request_id is None or not common.is_valid_request_id(request_id):
+        return None
+    return request_id
+
+
+def _log_delegation(
+    actor: str,
+    subject: str,
+    request_id: Optional[str],
+    expires_at: Optional[int],
+    outcome: str,
+) -> None:
+    audit_fields = {
+        'actor': actor,
+        'subject': subject,
+        'request_id': request_id,
+        'expires_at': expires_at,
+        'outcome': outcome,
+    }
+    logger.info(
+        'Delegated access token request %s',
+        json.dumps(audit_fields, separators=(',', ':')),
+        extra=audit_fields,
+    )
+
+
+@router.post(
+    '/api/auth/jwt/delegated_access_token',
+    response_model=objects.DelegatedTokenResponse,
+    include_in_schema=False,
+)
+def post_delegated_access_token(
+    delegation_request: objects.DelegatedTokenRequest,
+    authorization: Optional[str] = fastapi.Header(
+        default=None, alias=login.OSMO_AUTH_HEADER),
+    gateway_user: Optional[str] = fastapi.Header(
+        default=None, alias=login.OSMO_USER_HEADER),
+    request_id: Optional[str] = fastapi.Header(
+        default=None, alias=REQUEST_ID_HEADER),
+) -> objects.DelegatedTokenResponse:
+    """Mint a short-lived token that represents an OSMO user."""
+    postgres = connectors.PostgresConnector.get_instance()
+    service_auth = postgres.get_service_configs().service_auth
+    actor = 'unknown'
+    request_id = _sanitize_request_id(request_id)
+
+    try:
+        encoded_token = _extract_bearer_token(authorization)
+        claims = _decode_service_jwt(encoded_token, service_auth)
+        candidate_actor = claims.get('unique_name')
+        if isinstance(candidate_actor, str) and candidate_actor.strip():
+            actor = candidate_actor
+        parent_expires_at = _get_service_jwt_expiration(claims)
+        actor = _validate_delegator_claims(claims, gateway_user)
+    except fastapi.HTTPException as error:
+        outcome = 'unauthorized' if error.status_code == 401 else 'forbidden'
+        _log_delegation(
+            actor, delegation_request.subject_user, request_id, None, outcome)
+        raise
+
+    fetch_cmd = '''
+        SELECT
+            u.id,
+            COALESCE(
+                ARRAY_AGG(ur.role_name ORDER BY ur.role_name)
+                FILTER (WHERE ur.role_name IS NOT NULL),
+                ARRAY[]::text[]
+            ) AS roles
+        FROM users u
+        LEFT JOIN user_roles ur ON ur.user_id = u.id
+        WHERE u.id = %s
+        GROUP BY u.id;
+    '''
+    rows = postgres.execute_fetch_command(
+        fetch_cmd, (delegation_request.subject_user,), True)
+    if not rows:
+        _log_delegation(
+            actor, delegation_request.subject_user,
+            request_id, None, 'subject_not_found')
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_404_NOT_FOUND,
+            detail=f'User {delegation_request.subject_user} not found',
+        )
+
+    roles = rows[0]['roles']
+    if not roles:
+        _log_delegation(
+            actor, delegation_request.subject_user,
+            request_id, None, 'subject_has_no_roles')
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_403_FORBIDDEN,
+            detail=f'User {delegation_request.subject_user} has no roles to delegate',
+        )
+
+    issued_at = int(time.time())
+    if parent_expires_at <= issued_at:
+        _log_delegation(
+            actor, delegation_request.subject_user,
+            request_id, None, 'unauthorized')
+        raise _authentication_error()
+    expires_at = min(
+        issued_at + common.ACCESS_TOKEN_TIMEOUT,
+        parent_expires_at,
+    )
+    delegated_token = service_auth.create_idtoken_jwt(
+        expires_at,
+        delegation_request.subject_user,
+        roles=roles,
+        token_name=auth.DELEGATED_TOKEN_NAME,
+        actor=actor,
+        issued_at=issued_at,
+    )
+    _log_delegation(
+        actor, delegation_request.subject_user,
+        request_id, expires_at, 'success')
+    return objects.DelegatedTokenResponse(
+        token=delegated_token,
+        expires_at=expires_at,
+    )
 
 
 @router.get('/api/auth/jwt/refresh_token', response_model=objects.JwtTokenResponse,

--- a/src/service/core/auth/objects.py
+++ b/src/service/core/auth/objects.py
@@ -21,7 +21,6 @@ import re
 from typing import List, Optional
 
 import pydantic
-
 from src.lib.utils import common, osmo_errors
 from src.utils import auth, connectors
 
@@ -247,6 +246,28 @@ class UserWithRoles(User):
 class TokenRequest(pydantic.BaseModel):
     """Request body containing a token for JWT generation."""
     token: str
+
+
+class DelegatedTokenRequest(pydantic.BaseModel):
+    """Request body for minting a delegated access token."""
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    subject_user: str
+
+    @pydantic.field_validator('subject_user')
+    @classmethod
+    def validate_subject_user(cls, subject_user: str) -> str:
+        if not common.is_valid_authenticated_user_id(subject_user):
+            raise ValueError('subject_user is not a valid authenticated user ID')
+        return subject_user
+
+
+class DelegatedTokenResponse(pydantic.BaseModel):
+    """A delegated access token and its absolute expiration time."""
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    token: str
+    expires_at: int
 
 
 class CreateUserRequest(pydantic.BaseModel):

--- a/src/service/core/auth/tests/BUILD
+++ b/src/service/core/auth/tests/BUILD
@@ -17,14 +17,19 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 load("//bzl:py.bzl", "osmo_py_test")
+load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_test(
     name = "test_auth_service",
     srcs = ["test_auth_service.py"],
     deps = [
+        requirement("pyjwt"),
+        "//src/lib/utils:common",
+        "//src/lib/utils:login",
         "//src/service/core/auth:auth",
         "//src/service/core/tests:fixture",
         "//src/tests/common",
+        "//src/utils:auth",
         "//src/utils/connectors",
     ],
     size = "large",

--- a/src/service/core/auth/tests/test_auth_service.py
+++ b/src/service/core/auth/tests/test_auth_service.py
@@ -16,12 +16,18 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import time
 from typing import Any, Dict, List, Optional
+from unittest import mock
 
+import jwt  # type: ignore
+from src.lib.utils import common, login
 from src.service.core.auth import objects
 from src.service.core.tests import fixture
-from src.utils import connectors
 from src.tests.common import runner
+from src.utils import auth, connectors
+
+TEST_DELEGATOR = 'svc-mcp'
 
 
 class AuthServiceTestCase(fixture.ServiceTestFixture):
@@ -145,6 +151,495 @@ class AuthServiceTestCase(fixture.ServiceTestFixture):
         '''
         rows = postgres.execute_fetch_command(fetch_cmd, (user_name, token_name), True)
         return [row['role_name'] for row in rows]
+
+    def _create_service_jwt(
+        self,
+        username: str = TEST_DELEGATOR,
+        roles: Optional[List[str]] = None,
+        token_name: Optional[str] = 'mcp-test-token',
+        claim_overrides: Optional[Dict[str, Any]] = None,
+        claim_removals: Optional[List[str]] = None,
+        authentication_config: Optional[auth.AuthenticationConfig] = None,
+    ) -> str:
+        """Create a service JWT with optional malformed claims for denial tests."""
+        service_auth = authentication_config or (
+            connectors.PostgresConnector.get_instance()
+            .get_service_configs().service_auth
+        )
+        now = int(time.time())
+        claims: Dict[str, Any] = {
+            'iss': service_auth.issuer,
+            'aud': service_auth.audience,
+            'iat': now,
+            'nbf': now,
+            'exp': now + common.ACCESS_TOKEN_TIMEOUT,
+            'unique_name': username,
+            'roles': roles if roles is not None else [auth.MCP_DELEGATOR_ROLE],
+        }
+        if token_name is not None:
+            claims['osmo_token_name'] = token_name
+        if claim_overrides:
+            claims.update(claim_overrides)
+        for claim_name in claim_removals or []:
+            claims.pop(claim_name, None)
+        return service_auth.get_current_key().create_jwt(claims)
+
+    def _post_delegation(
+        self,
+        subject_user: str,
+        encoded_token: Optional[str],
+        gateway_user: Optional[str] = TEST_DELEGATOR,
+        payload_overrides: Optional[Dict[str, Any]] = None,
+        request_id: Optional[str] = 'delegation-test-request',
+    ):
+        payload: Dict[str, Any] = {'subject_user': subject_user}
+        if payload_overrides:
+            payload.update(payload_overrides)
+        headers = {}
+        if gateway_user is not None:
+            headers[login.OSMO_USER_HEADER] = gateway_user
+        if request_id is not None:
+            headers['x-request-id'] = request_id
+        if encoded_token is not None:
+            headers[login.OSMO_AUTH_HEADER] = f'Bearer {encoded_token}'
+        return self.client.post(
+            '/api/auth/jwt/delegated_access_token',
+            json=payload,
+            headers=headers,
+        )
+
+    def _decode_jwt(self, encoded_token: str) -> Dict[str, Any]:
+        service_auth = (
+            connectors.PostgresConnector.get_instance()
+            .get_service_configs().service_auth
+        )
+        public_key = jwt.PyJWK.from_json(
+            service_auth.get_current_key().public_key).key
+        return jwt.decode(
+            encoded_token,
+            key=public_key,
+            algorithms=['RS256'],
+            audience=service_auth.audience,
+            issuer=service_auth.issuer,
+        )
+
+    # =========================================================================
+    # Delegated Access Token Tests
+    # =========================================================================
+
+    def test_create_delegated_access_token(self):
+        """Delegated tokens contain current, sorted roles and bounded claims."""
+        subject = 'delegated@example.com'
+        self._create_user(subject, roles=['osmo-user', 'osmo-admin'])
+        issued_at = int(time.time())
+        parent_expires_at = issued_at + 2 * common.ACCESS_TOKEN_TIMEOUT
+        service_token = self._create_service_jwt(claim_overrides={
+            'iat': issued_at,
+            'nbf': issued_at,
+            'exp': parent_expires_at,
+        })
+
+        with mock.patch(
+            'src.service.core.auth.auth_service.time.time',
+            return_value=issued_at,
+        ):
+            response = self._post_delegation(subject, service_token)
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(sorted(result), ['expires_at', 'token'])
+        claims = self._decode_jwt(result['token'])
+        self.assertEqual(claims['unique_name'], subject)
+        self.assertEqual(claims['roles'], ['osmo-admin', 'osmo-user'])
+        self.assertEqual(claims['osmo_token_name'], auth.DELEGATED_TOKEN_NAME)
+        self.assertEqual(claims['act'], {'sub': TEST_DELEGATOR})
+        self.assertEqual(claims['exp'], result['expires_at'])
+        self.assertEqual(
+            claims['exp'] - claims['iat'], common.ACCESS_TOKEN_TIMEOUT)
+        self.assertLess(claims['exp'], parent_expires_at)
+
+    def test_delegated_access_token_is_capped_by_parent_expiration(self):
+        subject = 'short-parent@example.com'
+        self._create_user(subject, roles=['osmo-user'])
+        issued_at = int(time.time())
+        parent_expires_at = issued_at + 60
+        service_token = self._create_service_jwt(claim_overrides={
+            'iat': issued_at,
+            'nbf': issued_at,
+            'exp': parent_expires_at,
+        })
+
+        with mock.patch(
+            'src.service.core.auth.auth_service.time.time',
+            return_value=issued_at,
+        ):
+            response = self._post_delegation(subject, service_token)
+
+        self.assertEqual(response.status_code, 200)
+        claims = self._decode_jwt(response.json()['token'])
+        self.assertEqual(response.json()['expires_at'], parent_expires_at)
+        self.assertEqual(claims['exp'], parent_expires_at)
+        self.assertEqual(claims['iat'], issued_at)
+
+    def test_delegation_does_not_mint_after_parent_expires_during_request(self):
+        subject = 'expired-parent@example.com'
+        self._create_user(subject, roles=['osmo-user'])
+        parent_issued_at = int(time.time())
+        parent_expires_at = parent_issued_at + 120
+        service_token = self._create_service_jwt(claim_overrides={
+            'iat': parent_issued_at,
+            'nbf': parent_issued_at,
+            'exp': parent_expires_at,
+        })
+
+        with (
+            mock.patch(
+                'src.service.core.auth.auth_service.time.time',
+                return_value=parent_expires_at,
+            ),
+            self.assertLogs(
+                'src.service.core.auth.auth_service', level='INFO') as captured,
+        ):
+            response = self._post_delegation(subject, service_token)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.headers['www-authenticate'], 'Bearer')
+        audit_record = captured.records[-1]
+        self.assertEqual(getattr(audit_record, 'outcome'), 'unauthorized')
+        self.assertIsNone(getattr(audit_record, 'expires_at'))
+
+    def test_delegated_access_token_rejects_non_integer_parent_expiration(self):
+        service_token = self._create_service_jwt(claim_overrides={
+            'exp': str(int(time.time()) + common.ACCESS_TOKEN_TIMEOUT),
+        })
+
+        response = self._post_delegation(
+            'delegated@example.com', service_token)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.headers['www-authenticate'], 'Bearer')
+
+    def test_delegation_endpoint_is_not_in_public_openapi(self):
+        response = self.client.get('/api/openapi.json')
+        self.assertEqual(response.status_code, 200)
+        openapi_paths = response.json()['paths']
+
+        self.assertNotIn(
+            '/api/auth/jwt/delegated_access_token',
+            openapi_paths,
+        )
+
+    def test_delegated_access_token_request_is_strict(self):
+        """Unknown and missing body fields are rejected by the request model."""
+        service_token = self._create_service_jwt()
+        response = self._post_delegation(
+            'delegated@example.com', service_token,
+            payload_overrides={'unexpected': True})
+        self.assertEqual(response.status_code, 422)
+
+        response = self.client.post(
+            '/api/auth/jwt/delegated_access_token',
+            json={},
+            headers={login.OSMO_AUTH_HEADER: f'Bearer {service_token}'},
+        )
+        self.assertEqual(response.status_code, 422)
+
+        invalid_subjects = [' ', ' bad-user', 'bad-user ', 'bad\nname', 'a' * 257]
+        for invalid_subject in invalid_subjects:
+            with self.subTest(subject_user=invalid_subject):
+                response = self._post_delegation(
+                    invalid_subject, service_token)
+                self.assertEqual(response.status_code, 422)
+
+        # IdP-provisioned identities are not limited to CLI username syntax.
+        response = self._post_delegation(
+            'alice+tag#EXT#@example.com', service_token)
+        self.assertEqual(response.status_code, 404)
+
+    def test_delegated_access_token_requires_valid_bearer(self):
+        """Missing and malformed bearer credentials return 401."""
+        response = self._post_delegation('delegated@example.com', None)
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.headers['www-authenticate'], 'Bearer')
+
+        response = self.client.post(
+            '/api/auth/jwt/delegated_access_token',
+            json={'subject_user': 'delegated@example.com'},
+            headers={
+                login.OSMO_AUTH_HEADER: 'Basic credentials',
+                login.OSMO_USER_HEADER: TEST_DELEGATOR,
+            },
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_delegated_access_token_bearer_parser_is_strict(self):
+        subject = 'bearer-parser@example.com'
+        self._create_user(subject, roles=['osmo-user'])
+        service_token = self._create_service_jwt()
+        headers = {
+            login.OSMO_USER_HEADER: TEST_DELEGATOR,
+            login.OSMO_AUTH_HEADER: f'bEaReR {service_token}',
+        }
+
+        accepted = self.client.post(
+            '/api/auth/jwt/delegated_access_token',
+            json={'subject_user': subject},
+            headers=headers,
+        )
+        self.assertEqual(accepted.status_code, 200)
+
+        malformed_headers = (
+            '',
+            'Bearer',
+            'Bearer token extra',
+            f'Basic {service_token}',
+            'Bearer not-a-jwt',
+        )
+        for authorization in malformed_headers:
+            with self.subTest(authorization=authorization):
+                denied = self.client.post(
+                    '/api/auth/jwt/delegated_access_token',
+                    json={'subject_user': subject},
+                    headers={
+                        login.OSMO_USER_HEADER: TEST_DELEGATOR,
+                        login.OSMO_AUTH_HEADER: authorization,
+                    },
+                )
+                self.assertEqual(denied.status_code, 401)
+                self.assertEqual(denied.headers['www-authenticate'], 'Bearer')
+
+    def test_delegated_access_token_rejects_invalid_jwt(self):
+        """Signature, audience, issuer, and expiration are validated locally."""
+        now = int(time.time())
+        other_auth = auth.AuthenticationConfig.generate_default()
+        valid_claims = jwt.decode(
+            self._create_service_jwt(),
+            options={'verify_signature': False},
+        )
+        invalid_tokens = {
+            'signature': self._create_service_jwt(authentication_config=other_auth),
+            'hs256_algorithm': jwt.encode(
+                valid_claims, key='attacker-secret', algorithm='HS256'),
+            'none_algorithm': jwt.encode(
+                valid_claims, key='', algorithm='none'),
+            'audience': self._create_service_jwt(claim_overrides={'aud': 'other-audience'}),
+            'issuer': self._create_service_jwt(claim_overrides={'iss': 'other-issuer'}),
+            'expiration': self._create_service_jwt(claim_overrides={
+                'iat': now - 10,
+                'nbf': now - 10,
+                'exp': now - 1,
+            }),
+            'issued_at': self._create_service_jwt(
+                claim_overrides={'iat': now + 60}),
+            'not_before': self._create_service_jwt(
+                claim_overrides={'nbf': now + 60}),
+        }
+        for label, encoded_token in invalid_tokens.items():
+            with self.subTest(label=label):
+                response = self._post_delegation(
+                    'delegated@example.com', encoded_token)
+                self.assertEqual(response.status_code, 401)
+
+    def test_delegated_access_token_accepts_configured_previous_signing_key(self):
+        subject = 'key-rotation@example.com'
+        self._create_user(subject, roles=['osmo-user'])
+        postgres = connectors.PostgresConnector.get_instance()
+        service_config = postgres.get_service_configs().model_copy(deep=True)
+        previous_key = auth.AuthenticationConfig.generate_default().get_current_key()
+        service_config.service_auth.keys['previous'] = previous_key
+        now = int(time.time())
+        previous_key_token = previous_key.create_jwt({
+            'iss': service_config.service_auth.issuer,
+            'aud': service_config.service_auth.audience,
+            'iat': now,
+            'nbf': now,
+            'exp': now + common.ACCESS_TOKEN_TIMEOUT,
+            'unique_name': TEST_DELEGATOR,
+            'roles': [auth.MCP_DELEGATOR_ROLE],
+            'osmo_token_name': 'mcp-previous-key',
+        })
+
+        with mock.patch.object(
+            postgres,
+            'get_service_configs',
+            return_value=service_config,
+        ):
+            response = self._post_delegation(subject, previous_key_token)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self._decode_jwt(response.json()['token'])['unique_name'],
+            subject,
+        )
+
+    def test_delegated_access_token_requires_standard_jwt_claims(self):
+        for required_claim in ('aud', 'exp', 'iat', 'iss', 'nbf'):
+            with self.subTest(required_claim=required_claim):
+                encoded_token = self._create_service_jwt(
+                    claim_removals=[required_claim])
+                response = self._post_delegation(
+                    'delegated@example.com', encoded_token)
+                self.assertEqual(response.status_code, 401)
+                self.assertEqual(response.headers['www-authenticate'], 'Bearer')
+
+    def test_delegated_access_token_uses_gateway_authorized_actor(self):
+        """Core preserves the actor authorized by Gateway policy evaluation."""
+        subject = 'dynamic-actor@example.com'
+        actor = 'alternate-mcp-service'
+        self._create_user(subject, roles=['osmo-user'])
+        service_token = self._create_service_jwt(
+            username=actor,
+            roles=['custom-delegator', 'osmo-user'],
+            token_name=None,
+        )
+
+        with self.assertLogs(
+                'src.service.core.auth.auth_service', level='INFO') as captured:
+            response = self._post_delegation(
+                subject,
+                service_token,
+                gateway_user=actor,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        claims = self._decode_jwt(response.json()['token'])
+        self.assertEqual(claims['act'], {'sub': actor})
+        audit_record = next(
+            record for record in captured.records
+            if getattr(record, 'outcome', None) == 'success')
+        self.assertEqual(getattr(audit_record, 'actor'), actor)
+
+    def test_delegated_access_token_rejects_delegated_caller(self):
+        delegated_caller = self._create_service_jwt(
+            claim_overrides={'act': {'sub': TEST_DELEGATOR}})
+
+        response = self._post_delegation(
+            'delegated@example.com', delegated_caller)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_delegated_access_token_rejects_invalid_actor_claims(self):
+        malformed_claims: Dict[str, tuple[Dict[str, Any], List[str]]] = {
+            'missing_actor': ({}, ['unique_name']),
+            'numeric_actor': ({'unique_name': 123}, []),
+            'empty_actor': ({'unique_name': ''}, []),
+            'blank_actor': ({'unique_name': ' \t '}, []),
+        }
+
+        for label, (claim_overrides, claim_removals) in malformed_claims.items():
+            with self.subTest(label=label):
+                encoded_token = self._create_service_jwt(
+                    claim_overrides=claim_overrides,
+                    claim_removals=claim_removals,
+                )
+                response = self._post_delegation(
+                    'delegated@example.com', encoded_token)
+                self.assertEqual(response.status_code, 403)
+
+    def test_delegated_access_token_rejects_gateway_identity_mismatch(self):
+        service_token = self._create_service_jwt()
+        response = self._post_delegation(
+            'delegated@example.com', service_token, gateway_user=self.TEST_ADMIN)
+        self.assertEqual(response.status_code, 403)
+
+    def test_delegated_access_token_requires_gateway_identity(self):
+        service_token = self._create_service_jwt()
+        default_gateway_user = self.client.headers.pop(login.OSMO_USER_HEADER)
+        try:
+            response = self._post_delegation(
+                'delegated@example.com', service_token, gateway_user=None)
+        finally:
+            self.client.headers[login.OSMO_USER_HEADER] = default_gateway_user
+        self.assertEqual(response.status_code, 403)
+
+    def test_delegated_access_token_rejects_unknown_or_roleless_subject(self):
+        service_token = self._create_service_jwt()
+
+        response = self._post_delegation(
+            'unknown@example.com', service_token)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn('not found', response.json()['detail'])
+
+        self._create_user('roleless@example.com')
+        response = self._post_delegation(
+            'roleless@example.com', service_token)
+        self.assertEqual(response.status_code, 403)
+        self.assertIn('no roles', response.json()['detail'])
+
+    def test_delegation_resolves_current_roles_for_every_token(self):
+        subject = 'changing-roles@example.com'
+        self._create_user(subject, roles=['osmo-user'])
+        service_token = self._create_service_jwt()
+
+        first = self._post_delegation(subject, service_token)
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(self._decode_jwt(first.json()['token'])['roles'], ['osmo-user'])
+
+        self._assign_role(subject, 'osmo-admin')
+        second = self._post_delegation(subject, service_token)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(
+            self._decode_jwt(second.json()['token'])['roles'],
+            ['osmo-admin', 'osmo-user'],
+        )
+
+        postgres = connectors.PostgresConnector.get_instance()
+        postgres.execute_commit_command(
+            'DELETE FROM user_roles WHERE user_id = %s AND role_name = %s;',
+            (subject, 'osmo-user'),
+        )
+        third = self._post_delegation(subject, service_token)
+        self.assertEqual(third.status_code, 200)
+        self.assertEqual(self._decode_jwt(third.json()['token'])['roles'], ['osmo-admin'])
+
+    def test_delegation_logs_exclude_tokens(self):
+        """Audit logging records metadata without either credential."""
+        subject = 'logged-delegation@example.com'
+        self._create_user(subject, roles=['osmo-user'])
+        service_token = self._create_service_jwt()
+
+        with self.assertLogs(
+                'src.service.core.auth.auth_service', level='INFO') as captured:
+            response = self._post_delegation(subject, service_token)
+
+        self.assertEqual(response.status_code, 200)
+        delegated_token = response.json()['token']
+        serialized_records = '\n'.join(
+            str(record.__dict__) for record in captured.records)
+        self.assertNotIn(service_token, serialized_records)
+        self.assertNotIn(delegated_token, serialized_records)
+        audit_record = next(
+            record for record in captured.records
+            if record.getMessage().startswith('Delegated access token request '))
+        self.assertEqual(getattr(audit_record, 'actor'), TEST_DELEGATOR)
+        self.assertEqual(getattr(audit_record, 'subject'), subject)
+        self.assertEqual(
+            getattr(audit_record, 'request_id'), 'delegation-test-request')
+        self.assertEqual(getattr(audit_record, 'outcome'), 'success')
+        self.assertEqual(
+            getattr(audit_record, 'expires_at'), response.json()['expires_at'])
+
+    def test_delegation_drops_invalid_request_id_from_logs(self):
+        subject = 'sanitized-log@example.com'
+        self._create_user(subject, roles=['osmo-user'])
+        service_token = self._create_service_jwt()
+        invalid_request_ids = [
+            'request id must not reach logs',
+            'a' * 129,
+        ]
+
+        for invalid_request_id in invalid_request_ids:
+            with self.subTest(request_id=invalid_request_id):
+                with self.assertLogs(
+                        'src.service.core.auth.auth_service', level='INFO') as captured:
+                    response = self._post_delegation(
+                        subject, service_token, request_id=invalid_request_id)
+
+                self.assertEqual(response.status_code, 200)
+                serialized_records = '\n'.join(
+                    str(record.__dict__) for record in captured.records)
+                self.assertNotIn(invalid_request_id, serialized_records)
+        self.assertIsNone(getattr(captured.records[0], 'request_id'))
 
     # =========================================================================
     # User Management Tests

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -31,6 +31,7 @@ from src.lib.utils import common, osmo_errors
 DEFAULT_LENGTH = 20 * 24 * 60 * 60
 
 MCP_DELEGATOR_ROLE = 'osmo-mcp-delegator'
+DELEGATED_TOKEN_NAME = 'delegated-svc-mcp'
 
 
 class AsymmetricKeyPair(pydantic.BaseModel):


### PR DESCRIPTION
## Description

Stack PR 2 of 7 for MCP Phase B. This PR depends on [stack PR 1](https://github.com/NVIDIA/OSMO/pull/1171) and is the required base for [stack PR 3](https://github.com/NVIDIA/OSMO/pull/1173).

Merge the stack bottom-up with merge commits. After each merge, retarget the next PR to `feature/mcp` and rerun its checks.

Adds the Core endpoint that mints short-lived delegated JWTs for the authenticated MCP caller. The endpoint:

- verifies OSMO-issued service JWTs against configured signing keys;
- relies on Gateway role-policy authorization while independently validating a nonblank actor, matching Gateway identity, and the no-delegation-chain invariant;
- introduces the stable delegated-token name where it is first used, marking its roles as already resolved;
- records the verified service-account identity in audit logs and the delegated token's `act.sub` claim;
- resolves the subject's current roles from PostgreSQL for every mint;
- caps delegated-token expiration at both the normal access-token lifetime and parent-token expiration; and
- validates identities and request IDs while keeping audit logs free of credentials.

Commit: `3349a715` (`Add delegated token minting endpoint`).

## Validation

Validation completed locally on the rebuilt stack:

- `//src/lib/utils/tests:test_common`
- PostgreSQL-backed `//src/service/core/auth/tests:test_auth_service`
- `//src/utils/tests:test_auth`
- All 10 focused Phase B targets and both PostgreSQL-backed integration targets
- `git diff --check`

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.