### PR TITLE
Add MCP delegated token client

### DIFF
--- a/src/lib/utils/login.py
+++ b/src/lib/utils/login.py
@@ -36,6 +36,7 @@ OSMO_USER_HEADER = 'x-osmo-user'
 OSMO_USER_ROLES = 'x-osmo-roles'
 OSMO_TOKEN_NAME_HEADER = 'x-osmo-token-name'
 OSMO_ALLOWED_POOLS = 'x-osmo-allowed-pools'
+REQUEST_ID_HEADER = 'x-request-id'
 # Don't use a token that will expire within the next N seconds
 EXPIRE_WINDOW = 3
 TIMEOUT = 60
@@ -293,5 +294,4 @@ def parse_allowed_pools(allowed_pools_header: str | None) -> List[str]:
     if not allowed_pools_header:
         return []
     return [pool.strip() for pool in allowed_pools_header.split(',') if pool.strip()]
-
 

--- a/src/service/core/auth/auth_service.py
+++ b/src/service/core/auth/auth_service.py
@@ -35,7 +35,6 @@ router = fastapi.APIRouter(
 )
 
 logger = logging.getLogger(__name__)
-REQUEST_ID_HEADER = 'x-request-id'
 
 
 # =============================================================================
@@ -168,7 +167,7 @@ def post_delegated_access_token(
     gateway_user: Optional[str] = fastapi.Header(
         default=None, alias=login.OSMO_USER_HEADER),
     request_id: Optional[str] = fastapi.Header(
-        default=None, alias=REQUEST_ID_HEADER),
+        default=None, alias=login.REQUEST_ID_HEADER),
 ) -> objects.DelegatedTokenResponse:
     """Mint a short-lived token that represents an OSMO user."""
     postgres = connectors.PostgresConnector.get_instance()

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -36,6 +36,7 @@ osmo_py_library(
         requirement("starlette"),
         requirement("uvicorn"),
         "//src/lib/utils:common",
+        "//src/lib/utils:login",
         "//src/utils:ssl_config",
         "//src/utils:static_config",
     ],

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -23,20 +23,37 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@osmo_constants//:constants.bzl", "BASE_IMAGE_URL", "IMAGE_TAG")
 
 osmo_py_library(
-    name = "mcp_service_lib",
-    srcs = [
-        "identity.py",
-        "server.py",
-        "tokens.py",
+    name = "identity",
+    srcs = ["identity.py"],
+    deps = [
+        requirement("starlette"),
+        "//src/lib/utils:common",
+        "//src/lib/utils:login",
     ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "tokens",
+    srcs = ["tokens.py"],
     deps = [
         requirement("httpx"),
+        requirement("pydantic"),
+        ":identity",
+        "//src/lib/utils:common",
+        "//src/lib/utils:login",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "server",
+    srcs = ["server.py"],
+    deps = [
         requirement("mcp"),
         requirement("pydantic"),
         requirement("starlette"),
         requirement("uvicorn"),
-        "//src/lib/utils:common",
-        "//src/lib/utils:login",
         "//src/utils:ssl_config",
         "//src/utils:static_config",
     ],
@@ -47,7 +64,7 @@ osmo_py_binary(
     name = "mcp_binary",
     main = "server.py",
     srcs = ["server.py"],
-    deps = [":mcp_service_lib"],
+    deps = [":server"],
 )
 
 py_image_layer(

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -24,12 +24,18 @@ load("@osmo_constants//:constants.bzl", "BASE_IMAGE_URL", "IMAGE_TAG")
 
 osmo_py_library(
     name = "mcp_service_lib",
-    srcs = ["server.py"],
+    srcs = [
+        "identity.py",
+        "server.py",
+        "tokens.py",
+    ],
     deps = [
+        requirement("httpx"),
         requirement("mcp"),
         requirement("pydantic"),
         requirement("starlette"),
         requirement("uvicorn"),
+        "//src/lib/utils:common",
         "//src/utils:ssl_config",
         "//src/utils:static_config",
     ],

--- a/src/service/mcp/identity.py
+++ b/src/service/mcp/identity.py
@@ -23,11 +23,11 @@ from typing import Iterable
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from src.lib.utils import common
+from src.lib.utils import common, login
 
 
-_USER_HEADER = b'x-osmo-user'
-_REQUEST_ID_HEADER = b'x-request-id'
+_USER_HEADER = login.OSMO_USER_HEADER.encode('ascii')
+_REQUEST_ID_HEADER = login.REQUEST_ID_HEADER.encode('ascii')
 _FORBIDDEN_HEADERS = frozenset((
     b'authorization',
     b'cookie',

--- a/src/service/mcp/identity.py
+++ b/src/service/mcp/identity.py
@@ -1,0 +1,127 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import contextvars
+import dataclasses
+from typing import Iterable
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from src.lib.utils import common
+
+
+_USER_HEADER = b'x-osmo-user'
+_REQUEST_ID_HEADER = b'x-request-id'
+_FORBIDDEN_HEADERS = frozenset((
+    b'authorization',
+    b'cookie',
+    b'proxy-authorization',
+    b'x-osmo-auth',
+))
+
+
+@dataclasses.dataclass(frozen=True)
+class RequestIdentity:
+    """Gateway-authenticated identity associated with one MCP request."""
+
+    user_name: str
+    request_id: str | None
+
+
+_request_identity: contextvars.ContextVar[RequestIdentity | None] = (
+    contextvars.ContextVar('mcp_request_identity', default=None))
+
+
+class TrustedIdentityMiddleware:
+    """Establish request-local identity from Gateway-owned headers."""
+
+    def __init__(self, application: ASGIApp, path: str = '/mcp') -> None:
+        self._application = application
+        self._path = path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope['type'] != 'http' or scope.get('path') != self._path:
+            await self._application(scope, receive, send)
+            return
+
+        headers = scope.get('headers', [])
+        identity = _parse_identity(headers)
+        if identity is None:
+            response = JSONResponse(
+                {'error': 'Invalid trusted identity headers.'}, status_code=400)
+            await response(scope, receive, send)
+            return
+
+        token = _request_identity.set(identity)
+        try:
+            await self._application(scope, receive, send)
+        finally:
+            _request_identity.reset(token)
+
+
+def get_request_identity() -> RequestIdentity:
+    """Return the current trusted identity, or fail outside an MCP request."""
+    identity = _request_identity.get()
+    if identity is None:
+        raise RuntimeError('Trusted MCP request identity is unavailable.')
+    return identity
+
+
+def get_request_id() -> str | None:
+    """Return the current request ID when one was supplied by the Gateway."""
+    identity = _request_identity.get()
+    return identity.request_id if identity is not None else None
+
+
+def _parse_identity(raw_headers: Iterable[tuple[bytes, bytes]]) -> RequestIdentity | None:
+    headers: dict[bytes, list[bytes]] = {}
+    for name, value in raw_headers:
+        normalized_name = name.lower()
+        if normalized_name in _FORBIDDEN_HEADERS:
+            return None
+        if normalized_name in (_USER_HEADER, _REQUEST_ID_HEADER):
+            headers.setdefault(normalized_name, []).append(value)
+
+    user_values = headers.get(_USER_HEADER, [])
+    if len(user_values) != 1:
+        return None
+    user_name = _decode_nonempty(user_values[0])
+    if user_name is None or not common.is_valid_authenticated_user_id(user_name):
+        return None
+
+    request_id_values = headers.get(_REQUEST_ID_HEADER, [])
+    if len(request_id_values) > 1:
+        return None
+    request_id: str | None = None
+    if request_id_values:
+        request_id = _decode_nonempty(request_id_values[0])
+        if request_id is None or not common.is_valid_request_id(request_id):
+            return None
+
+    return RequestIdentity(user_name=user_name, request_id=request_id)
+
+
+def _decode_nonempty(value: bytes) -> str | None:
+    try:
+        decoded = value.decode('utf-8')
+    except UnicodeDecodeError:
+        return None
+    if not decoded or decoded != decoded.strip():
+        return None
+    return decoded

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -26,7 +26,7 @@ osmo_py_test(
         requirement("httpx"),
         requirement("mcp"),
         requirement("pydantic"),
-        "//src/service/mcp:mcp_service_lib",
+        "//src/service/mcp:server",
     ],
 )
 
@@ -35,6 +35,7 @@ osmo_py_test(
     srcs = ["test_tokens.py"],
     deps = [
         requirement("httpx"),
-        "//src/service/mcp:mcp_service_lib",
+        "//src/service/mcp:identity",
+        "//src/service/mcp:tokens",
     ],
 )

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -25,6 +25,16 @@ osmo_py_test(
     deps = [
         requirement("httpx"),
         requirement("mcp"),
+        requirement("pydantic"),
+        "//src/service/mcp:mcp_service_lib",
+    ],
+)
+
+osmo_py_test(
+    name = "test_tokens",
+    srcs = ["test_tokens.py"],
+    deps = [
+        requirement("httpx"),
         "//src/service/mcp:mcp_service_lib",
     ],
 )

--- a/src/service/mcp/tests/test_tokens.py
+++ b/src/service/mcp/tests/test_tokens.py
@@ -1,0 +1,939 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import contextvars
+import dataclasses
+import inspect
+import json
+import pathlib
+import shutil
+import ssl
+import tempfile
+import unittest
+from collections.abc import AsyncIterator, Callable, Coroutine
+from unittest import mock
+
+import httpx
+
+from src.service.mcp import identity, tokens
+
+
+@dataclasses.dataclass
+class _FakeClock:
+    """Wall and monotonic clocks advanced together by tests."""
+
+    wall: float = 1000
+    monotonic: float = 5000
+
+    def wall_time(self) -> float:
+        return self.wall
+
+    def monotonic_time(self) -> float:
+        return self.monotonic
+
+    def advance(self, seconds: float) -> None:
+        self.wall += seconds
+        self.monotonic += seconds
+
+
+class _TrackingStream(httpx.AsyncByteStream):
+    """Async response stream that records how many chunks were consumed."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+        self.chunks_read = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            self.chunks_read += 1
+            yield chunk
+
+    async def aclose(self) -> None:
+        return None
+
+
+Handler = (
+    Callable[[httpx.Request], httpx.Response] |
+    Callable[[httpx.Request], Coroutine[None, None, httpx.Response]]
+)
+
+
+class TokenProviderTest(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self) -> None:
+        temporary_directory = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temporary_directory)
+        self.credential_path = temporary_directory / 'service-token'
+        self.credential_path.write_text('initial-pat\n', encoding='utf-8')
+        self.clock = _FakeClock()
+        self.clients: list[httpx.AsyncClient] = []
+        self.request_identity: contextvars.ContextVar[identity.RequestIdentity] = (
+            contextvars.ContextVar(
+                'test_mcp_request_identity',
+                default=identity.RequestIdentity('alice', None),
+            ))
+
+    async def asyncTearDown(self) -> None:
+        await asyncio.gather(*(client.aclose() for client in self.clients))
+
+    async def test_service_token_exact_request_cache_and_request_id(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return self._token_response('service-jwt', lifetime=300)
+
+        provider = self._service_provider(handler)
+        first = await provider.get_token('request-123')
+        second = await provider.get_token('request-456')
+
+        self.assertEqual(first, 'service-jwt')
+        self.assertEqual(second, 'service-jwt')
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].method, 'POST')
+        self.assertEqual(requests[0].url.path, '/api/auth/jwt/access_token')
+        self.assertEqual(json.loads(requests[0].content), {'token': 'initial-pat'})
+        self.assertEqual(requests[0].headers['x-request-id'], 'request-123')
+        self.assertNotIn('authorization', requests[0].headers)
+
+    async def test_service_token_refresh_rereads_rotated_credential(self) -> None:
+        request_bodies: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            request_body = json.loads(request.content)
+            request_bodies.append(request_body)
+            return self._token_response(
+                f'service-jwt-{len(request_bodies)}', lifetime=100)
+
+        provider = self._service_provider(handler, cache_skew_seconds=30)
+        self.assertEqual(await provider.get_token(), 'service-jwt-1')
+        self.clock.advance(69)
+        self.assertEqual(await provider.get_token(), 'service-jwt-1')
+
+        self.credential_path.write_text('rotated-pat\n', encoding='utf-8')
+        self.clock.advance(2)
+        self.assertEqual(await provider.get_token(), 'service-jwt-2')
+        self.assertEqual(
+            request_bodies,
+            [{'token': 'initial-pat'}, {'token': 'rotated-pat'}],
+        )
+
+    async def test_service_token_refresh_is_single_flight(self) -> None:
+        request_started = asyncio.Event()
+        release_request = asyncio.Event()
+        request_count = 0
+
+        async def handler(unused_request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            del unused_request
+            request_count += 1
+            request_started.set()
+            await release_request.wait()
+            return self._token_response('service-jwt', lifetime=300)
+
+        provider = self._service_provider(handler)
+        waiters = [asyncio.create_task(provider.get_token()) for _ in range(10)]
+        await asyncio.wait_for(request_started.wait(), timeout=5)
+        release_request.set()
+
+        self.assertEqual(await asyncio.gather(*waiters), ['service-jwt'] * 10)
+        self.assertEqual(request_count, 1)
+
+    async def test_cancelled_waiter_does_not_cancel_service_token_refresh(self) -> None:
+        request_started = asyncio.Event()
+        release_request = asyncio.Event()
+        request_count = 0
+
+        async def handler(unused_request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            del unused_request
+            request_count += 1
+            request_started.set()
+            await release_request.wait()
+            return self._token_response('service-jwt', lifetime=300)
+
+        provider = self._service_provider(handler)
+        cancelled_waiter = asyncio.create_task(provider.get_token())
+        await asyncio.wait_for(request_started.wait(), timeout=5)
+        cancelled_waiter.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await cancelled_waiter
+
+        surviving_waiter = asyncio.create_task(provider.get_token())
+        release_request.set()
+        self.assertEqual(await surviving_waiter, 'service-jwt')
+        self.assertEqual(await provider.get_token(), 'service-jwt')
+        self.assertEqual(request_count, 1)
+
+    async def test_stale_service_token_invalidation_preserves_replacement(self) -> None:
+        request_count = 0
+
+        def handler(unused_request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            del unused_request
+            request_count += 1
+            return self._token_response(
+                f'service-jwt-{request_count}', lifetime=300)
+
+        provider = self._service_provider(handler)
+        first_token = await provider.get_token()
+        self.assertTrue(await provider.invalidate(first_token))
+        replacement_token = await provider.get_token()
+
+        self.assertFalse(await provider.invalidate(first_token))
+        self.assertEqual(await provider.get_token(), replacement_token)
+        self.assertEqual(replacement_token, 'service-jwt-2')
+        self.assertEqual(request_count, 2)
+
+    async def test_service_token_failure_does_not_expose_secrets(self) -> None:
+        response_secret = 'upstream-secret'
+
+        def handler(unused_request: httpx.Request) -> httpx.Response:
+            del unused_request
+            return httpx.Response(500, text=f'{response_secret}: initial-pat')
+
+        provider = self._service_provider(handler)
+        with self.assertRaises(tokens.GatewayResponseError) as raised:
+            await provider.get_token()
+
+        message = str(raised.exception)
+        self.assertNotIn('initial-pat', message)
+        self.assertNotIn(response_secret, message)
+
+    async def test_service_token_failure_is_not_cached(self) -> None:
+        request_count = 0
+
+        def handler(unused_request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            del unused_request
+            request_count += 1
+            if request_count == 1:
+                return httpx.Response(503, text='try again')
+            return self._token_response('service-jwt', lifetime=300)
+
+        provider = self._service_provider(handler)
+        with self.assertRaises(tokens.GatewayResponseError):
+            await provider.get_token()
+        self.assertEqual(await provider.get_token(), 'service-jwt')
+        self.assertEqual(request_count, 2)
+
+    async def test_service_token_rejects_unbounded_or_malformed_secret(self) -> None:
+        request_count = 0
+
+        def handler(unused_request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            del unused_request
+            request_count += 1
+            return self._token_response('unused', lifetime=300)
+
+        invalid_credentials = (
+            b'',
+            b'\n',
+            b'two tokens',
+            b'two\ntokens',
+            b'token\x00suffix',
+            b'\xff',
+            b'x' * (16 * 1024 + 1),
+        )
+        for credential in invalid_credentials:
+            with self.subTest(credential_size=len(credential)):
+                self.credential_path.write_bytes(credential)
+                provider = self._service_provider(handler)
+                with self.assertRaises(tokens.CredentialError):
+                    await provider.get_token()
+
+        self.credential_path.unlink()
+        provider = self._service_provider(handler)
+        with self.assertRaises(tokens.CredentialError):
+            await provider.get_token()
+        self.assertEqual(request_count, 0)
+
+    async def test_service_credential_accepts_exact_size_limit(self) -> None:
+        credential = 'x' * (16 * 1024)
+        request_bodies: list[dict[str, str]] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            request_bodies.append(json.loads(request.content))
+            return self._token_response('service-jwt', lifetime=300)
+
+        self.credential_path.write_text(credential, encoding='utf-8')
+        provider = self._service_provider(handler)
+
+        self.assertEqual(await provider.get_token(), 'service-jwt')
+        self.assertEqual(request_bodies, [{'token': credential}])
+
+    async def test_delegated_tokens_are_isolated_and_cached_per_exact_user(self) -> None:
+        delegated_requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            delegated_requests.append(request)
+            subject_user = json.loads(request.content)['subject_user']
+            return self._token_response(f'delegated-{subject_user}', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        self.assertEqual(tuple(inspect.signature(provider.get_token).parameters), ())
+        self.assertEqual(
+            tuple(inspect.signature(provider.invalidate).parameters), ('token',))
+        self.assertEqual(
+            await self._get_delegated_token(
+                provider, 'Alice', 'request-alice'), 'delegated-Alice')
+        self.assertEqual(
+            await self._get_delegated_token(
+                provider, 'alice', 'request-lower'), 'delegated-alice')
+        self.assertEqual(
+            await self._get_delegated_token(
+                provider, 'Alice', 'request-cached'), 'delegated-Alice')
+
+        self.assertEqual(len(delegated_requests), 2)
+        self.assertEqual(
+            json.loads(delegated_requests[0].content), {'subject_user': 'Alice'})
+        self.assertEqual(
+            delegated_requests[0].headers['authorization'], 'Bearer service-jwt')
+        self.assertEqual(
+            delegated_requests[0].headers['x-request-id'], 'request-alice')
+
+    async def test_delegated_token_cache_uses_lru_eviction(self) -> None:
+        delegated_subjects: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            subject_user = json.loads(request.content)['subject_user']
+            delegated_subjects.append(subject_user)
+            return self._token_response(
+                f'{subject_user}-{delegated_subjects.count(subject_user)}', lifetime=300)
+
+        provider = self._delegated_provider(handler, cache_max_size=2)
+        self.assertEqual(await self._get_delegated_token(provider, 'alice'), 'alice-1')
+        self.assertEqual(await self._get_delegated_token(provider, 'bob'), 'bob-1')
+        self.assertEqual(await self._get_delegated_token(provider, 'alice'), 'alice-1')
+        self.assertEqual(await self._get_delegated_token(provider, 'carol'), 'carol-1')
+        self.assertEqual(await self._get_delegated_token(provider, 'bob'), 'bob-2')
+        self.assertEqual(delegated_subjects, ['alice', 'bob', 'carol', 'bob'])
+
+    async def test_delegated_invalidation_compares_user_and_token(self) -> None:
+        request_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            request_count += 1
+            return self._token_response(f'delegated-{request_count}', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        first_token = await self._get_delegated_token(provider, 'alice')
+
+        self.assertFalse(
+            await self._invalidate_delegated_token(provider, 'bob', first_token))
+        self.assertFalse(await self._invalidate_delegated_token(
+            provider, 'alice', 'different-token'))
+        self.assertEqual(
+            await self._get_delegated_token(provider, 'alice'), first_token)
+        self.assertTrue(
+            await self._invalidate_delegated_token(provider, 'alice', first_token))
+        self.assertEqual(
+            await self._get_delegated_token(provider, 'alice'), 'delegated-2')
+
+    async def test_delegated_token_cache_refreshes_at_skew(self) -> None:
+        request_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            request_count += 1
+            return self._token_response(f'delegated-{request_count}', lifetime=100)
+
+        provider = self._delegated_provider(handler, cache_skew_seconds=30)
+        self.assertEqual(
+            await self._get_delegated_token(provider, 'alice'), 'delegated-1')
+        self.clock.advance(69)
+        self.assertEqual(
+            await self._get_delegated_token(provider, 'alice'), 'delegated-1')
+        self.clock.advance(2)
+        self.assertEqual(
+            await self._get_delegated_token(provider, 'alice'), 'delegated-2')
+
+    async def test_token_with_lifetime_equal_to_skew_is_not_cached(self) -> None:
+        delegated_request_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal delegated_request_count
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            delegated_request_count += 1
+            return self._token_response(
+                f'delegated-{delegated_request_count}', lifetime=30)
+
+        provider = self._delegated_provider(handler, cache_skew_seconds=30)
+
+        self.assertEqual(
+            await self._get_delegated_token(provider, 'alice'), 'delegated-1')
+        self.assertEqual(
+            await self._get_delegated_token(provider, 'alice'), 'delegated-2')
+        self.assertEqual(delegated_request_count, 2)
+
+    async def test_invalid_delegated_subject_fails_before_gateway_requests(self) -> None:
+        request_count = 0
+
+        def handler(unused_request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            del unused_request
+            request_count += 1
+            return self._token_response('unused', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        with self.assertRaises(ValueError):
+            await self._get_delegated_token(provider, 'invalid\nsubject')
+        self.assertEqual(request_count, 0)
+
+    async def test_same_user_delegation_is_single_flight(self) -> None:
+        delegation_started = asyncio.Event()
+        release_delegation = asyncio.Event()
+        request_count = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            request_count += 1
+            delegation_started.set()
+            await release_delegation.wait()
+            return self._token_response('delegated-alice', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        waiters = [
+            self._create_delegated_token_task(provider, 'alice') for _ in range(10)]
+        await asyncio.wait_for(delegation_started.wait(), timeout=5)
+        release_delegation.set()
+
+        self.assertEqual(
+            await asyncio.gather(*waiters), ['delegated-alice'] * 10)
+        self.assertEqual(request_count, 1)
+
+    async def test_different_user_delegations_run_in_parallel(self) -> None:
+        subjects_started: list[str] = []
+        both_started = asyncio.Event()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            subject_user = json.loads(request.content)['subject_user']
+            subjects_started.append(subject_user)
+            if len(subjects_started) == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=5)
+            return self._token_response(f'delegated-{subject_user}', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        alice, bob = await asyncio.gather(
+            self._get_delegated_token(provider, 'alice'),
+            self._get_delegated_token(provider, 'bob'),
+        )
+
+        self.assertEqual(alice, 'delegated-alice')
+        self.assertEqual(bob, 'delegated-bob')
+        self.assertCountEqual(subjects_started, ['alice', 'bob'])
+
+    async def test_failed_delegation_is_removed_from_single_flight(self) -> None:
+        request_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            request_count += 1
+            if request_count == 1:
+                return httpx.Response(500, text='delegation failed')
+            return self._token_response('delegated-alice', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        with self.assertRaises(tokens.GatewayResponseError):
+            await self._get_delegated_token(provider, 'alice')
+        self.assertEqual(
+            await self._get_delegated_token(provider, 'alice'), 'delegated-alice')
+        self.assertEqual(request_count, 2)
+
+    async def test_cancelled_waiter_does_not_cancel_shared_delegation(self) -> None:
+        delegation_started = asyncio.Event()
+        release_delegation = asyncio.Event()
+        request_count = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            request_count += 1
+            delegation_started.set()
+            await release_delegation.wait()
+            return self._token_response('delegated-alice', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        cancelled_waiter = self._create_delegated_token_task(provider, 'alice')
+        await asyncio.wait_for(delegation_started.wait(), timeout=5)
+        cancelled_waiter.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await cancelled_waiter
+
+        surviving_waiter = self._create_delegated_token_task(provider, 'alice')
+        release_delegation.set()
+        self.assertEqual(await surviving_waiter, 'delegated-alice')
+        self.assertEqual(request_count, 1)
+
+    async def test_delegation_401_invalidates_service_token_and_retries_once(self) -> None:
+        service_request_count = 0
+        authorization_headers: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal service_request_count
+            if request.url.path == '/api/auth/jwt/access_token':
+                service_request_count += 1
+                return self._token_response(
+                    f'service-jwt-{service_request_count}', lifetime=600)
+            authorization = request.headers['authorization']
+            authorization_headers.append(authorization)
+            if authorization == 'Bearer service-jwt-1':
+                return httpx.Response(401, text='expired service token')
+            return self._token_response('delegated-alice', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        self.assertEqual(
+            await self._get_delegated_token(provider, 'alice'), 'delegated-alice')
+        self.assertEqual(service_request_count, 2)
+        self.assertEqual(
+            authorization_headers,
+            ['Bearer service-jwt-1', 'Bearer service-jwt-2'],
+        )
+
+    async def test_concurrent_delegation_401s_share_one_service_refresh(self) -> None:
+        service_request_count = 0
+        old_token_attempt_count = 0
+        all_old_token_attempts_started = asyncio.Event()
+        delegation_attempts: dict[str, list[str]] = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal old_token_attempt_count, service_request_count
+            if request.url.path == '/api/auth/jwt/access_token':
+                service_request_count += 1
+                return self._token_response(
+                    f'service-jwt-{service_request_count}', lifetime=600)
+
+            subject_user = json.loads(request.content)['subject_user']
+            authorization = request.headers['authorization']
+            delegation_attempts.setdefault(subject_user, []).append(authorization)
+            if authorization == 'Bearer service-jwt-1':
+                old_token_attempt_count += 1
+                if old_token_attempt_count == 3:
+                    all_old_token_attempts_started.set()
+                await asyncio.wait_for(
+                    all_old_token_attempts_started.wait(), timeout=5)
+                return httpx.Response(401)
+            return self._token_response(
+                f'delegated-{subject_user}', lifetime=300)
+
+        provider = self._delegated_provider(handler)
+        alice, bob, carol = await asyncio.gather(
+            self._get_delegated_token(provider, 'alice'),
+            self._get_delegated_token(provider, 'bob'),
+            self._get_delegated_token(provider, 'carol'),
+        )
+
+        self.assertEqual(
+            (alice, bob, carol),
+            ('delegated-alice', 'delegated-bob', 'delegated-carol'),
+        )
+        self.assertEqual(service_request_count, 2)
+        self.assertEqual(
+            delegation_attempts,
+            {
+                'alice': ['Bearer service-jwt-1', 'Bearer service-jwt-2'],
+                'bob': ['Bearer service-jwt-1', 'Bearer service-jwt-2'],
+                'carol': ['Bearer service-jwt-1', 'Bearer service-jwt-2'],
+            },
+        )
+
+    async def test_second_delegation_401_is_not_retried(self) -> None:
+        delegated_request_count = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal delegated_request_count
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt', lifetime=600)
+            delegated_request_count += 1
+            return httpx.Response(401, text='still unauthorized')
+
+        provider = self._delegated_provider(handler)
+        with self.assertRaises(tokens.GatewayResponseError) as raised:
+            await self._get_delegated_token(provider, 'alice')
+        self.assertEqual(raised.exception.status_code, 401)
+        self.assertEqual(delegated_request_count, 2)
+
+    async def test_other_delegation_failures_are_not_retried(self) -> None:
+        for status_code in (403, 404, 429, 500):
+            with self.subTest(status_code=status_code):
+                delegated_request_count = 0
+
+                def handler(
+                    request: httpx.Request,
+                    response_status: int = status_code,
+                ) -> httpx.Response:
+                    nonlocal delegated_request_count
+                    if request.url.path == '/api/auth/jwt/access_token':
+                        return self._token_response('service-jwt', lifetime=600)
+                    delegated_request_count += 1
+                    return httpx.Response(response_status, text='sensitive body')
+
+                provider = self._delegated_provider(handler)
+                with self.assertRaises(tokens.GatewayResponseError) as raised:
+                    await self._get_delegated_token(provider, 'alice')
+                self.assertEqual(raised.exception.status_code, status_code)
+                self.assertEqual(delegated_request_count, 1)
+
+    async def test_gateway_transport_errors_are_sanitized(self) -> None:
+        secret = 'sensitive.internal.example'
+        error_factories = (
+            lambda request: httpx.ConnectError(secret, request=request),
+            lambda request: httpx.ConnectTimeout(secret, request=request),
+            lambda request: httpx.ReadError(secret, request=request),
+        )
+
+        for error_factory in error_factories:
+            with self.subTest(error_type=error_factory):
+                def handler(
+                    request: httpx.Request,
+                    factory: Callable[[httpx.Request], httpx.RequestError] = error_factory,
+                ) -> httpx.Response:
+                    raise factory(request)
+
+                provider = self._service_provider(handler)
+                with self.assertRaises(tokens.GatewayUnavailableError) as raised:
+                    await provider.get_token()
+                self.assertNotIn(secret, str(raised.exception))
+
+    async def test_gateway_redirect_is_not_followed(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(
+                302,
+                headers={'location': 'https://attacker.test/collect'},
+            )
+
+        provider = self._service_provider(handler)
+        with self.assertRaises(tokens.GatewayResponseError) as raised:
+            await provider.get_token()
+
+        self.assertEqual(raised.exception.status_code, 302)
+        self.assertEqual(len(requests), 1)
+        self.assertEqual(requests[0].url.path, '/api/auth/jwt/access_token')
+
+    async def test_invalid_gateway_response_is_strict_and_redacted(self) -> None:
+        leaked_token = 'leaked-jwt'
+
+        def handler(unused_request: httpx.Request) -> httpx.Response:
+            del unused_request
+            return httpx.Response(200, json={
+                'token': leaked_token,
+                'expires_at': int(self.clock.wall + 300),
+                'unexpected': 'field',
+            })
+
+        provider = self._service_provider(handler)
+        with self.assertRaises(tokens.InvalidGatewayResponseError) as raised:
+            await provider.get_token()
+        self.assertNotIn(leaked_token, str(raised.exception))
+
+    async def test_gateway_response_rejects_expired_wrong_type_and_huge_expiry(self) -> None:
+        invalid_responses: tuple[object, ...] = (
+            {'token': 'jwt', 'expires_at': int(self.clock.wall)},
+            {'token': 'jwt', 'expires_at': '1300'},
+            {'token': 123, 'expires_at': 1300},
+            {'token': 'jwt'},
+            {'expires_at': 1300},
+            {'token': 'jwt', 'expires_at': 10**400},
+            ['jwt', 1300],
+        )
+
+        for response_body in invalid_responses:
+            with self.subTest(response_body=response_body):
+                provider = self._service_provider(
+                    lambda unused_request, body=response_body: httpx.Response(
+                        200, json=body))
+                with self.assertRaises(tokens.InvalidGatewayResponseError):
+                    await provider.get_token()
+
+    async def test_gateway_token_rejects_ascii_control_characters(self) -> None:
+        for token_value in ('prefix\x00suffix', 'prefix\x1fsuffix', 'prefix\x7fsuffix'):
+            with self.subTest(token_value=repr(token_value)):
+                provider = self._service_provider(
+                    lambda unused_request, value=token_value: self._token_response(
+                        value, lifetime=300))
+                with self.assertRaises(tokens.InvalidGatewayResponseError):
+                    await provider.get_token()
+
+    async def test_gateway_token_response_has_a_size_limit(self) -> None:
+        response_secret = 'response-secret'
+
+        def handler(unused_request: httpx.Request) -> httpx.Response:
+            del unused_request
+            return httpx.Response(
+                200,
+                content=(
+                    b'{"token":"' +
+                    response_secret.encode() +
+                    b'x' * (128 * 1024) +
+                    b'","expires_at":1300}'
+                ),
+            )
+
+        provider = self._service_provider(handler)
+        with self.assertRaises(tokens.InvalidGatewayResponseError) as raised:
+            await provider.get_token()
+
+        self.assertIn('size limit', str(raised.exception))
+        self.assertNotIn(response_secret, str(raised.exception))
+
+    async def test_gateway_response_size_limit_is_cumulative(self) -> None:
+        stream = _TrackingStream([
+            b'x' * (64 * 1024),
+            b'y' * (65 * 1024),
+            b'secret-third-chunk',
+        ])
+        provider = self._service_provider(
+            lambda unused_request: httpx.Response(200, stream=stream))
+
+        with self.assertRaises(tokens.InvalidGatewayResponseError):
+            await provider.get_token()
+
+        self.assertEqual(stream.chunks_read, 2)
+
+    async def test_gateway_error_response_body_is_not_read(self) -> None:
+        stream = _TrackingStream([b'sensitive-error-body'])
+        provider = self._service_provider(
+            lambda unused_request: httpx.Response(503, stream=stream))
+
+        with self.assertRaises(tokens.GatewayResponseError) as raised:
+            await provider.get_token()
+
+        self.assertEqual(raised.exception.status_code, 503)
+        self.assertEqual(stream.chunks_read, 0)
+
+    async def test_gateway_token_length_boundary(self) -> None:
+        accepted_token = 'x' * 65536
+        accepted_provider = self._service_provider(
+            lambda unused_request: self._token_response(
+                accepted_token, lifetime=300))
+        self.assertEqual(await accepted_provider.get_token(), accepted_token)
+
+        rejected_provider = self._service_provider(
+            lambda unused_request: self._token_response(
+                'x' * 65537, lifetime=300))
+        with self.assertRaises(tokens.InvalidGatewayResponseError):
+            await rejected_provider.get_token()
+
+    async def test_gateway_token_must_be_ascii(self) -> None:
+        provider = self._service_provider(
+            lambda unused_request: self._token_response('tökén', lifetime=300))
+
+        with self.assertRaises(tokens.InvalidGatewayResponseError):
+            await provider.get_token()
+
+    def test_gateway_ssl_context_loads_private_ca(self) -> None:
+        ssl_context = mock.Mock()
+        ca_file = pathlib.Path('/etc/osmo/gateway-ca.pem')
+
+        with mock.patch(
+            'src.service.mcp.tokens.ssl.create_default_context',
+            return_value=ssl_context,
+        ) as default_context:
+            result = tokens.build_gateway_ssl_context(ca_file)
+
+        self.assertIs(result, ssl_context)
+        default_context.assert_called_once_with()
+        ssl_context.load_verify_locations.assert_called_once_with(cafile=ca_file)
+
+    def test_default_gateway_ssl_context_verifies_hostnames(self) -> None:
+        ssl_context = tokens.build_gateway_ssl_context(None)
+
+        self.assertEqual(ssl_context.verify_mode, ssl.CERT_REQUIRED)
+        self.assertTrue(ssl_context.check_hostname)
+
+    async def test_app_context_configures_hardened_http_client(self) -> None:
+        ssl_context = mock.Mock(spec=ssl.SSLContext)
+        transport = mock.Mock(spec=httpx.AsyncBaseTransport)
+        client = mock.MagicMock(spec=httpx.AsyncClient)
+        client_context = mock.MagicMock()
+        client_context.__aenter__ = mock.AsyncMock(return_value=client)
+        client_context.__aexit__ = mock.AsyncMock(return_value=None)
+
+        with (
+            mock.patch(
+                'src.service.mcp.tokens.build_gateway_ssl_context',
+                return_value=ssl_context,
+            ),
+            mock.patch(
+                'src.service.mcp.tokens.httpx.AsyncClient',
+                return_value=client_context,
+            ) as async_client,
+        ):
+            async with tokens.create_app_context(
+                api_url='https://gateway.test',
+                service_token_file=self.credential_path,
+                request_timeout_seconds=12.5,
+                token_cache_max_size=512,
+                token_cache_skew_seconds=30,
+                transport=transport,
+            ) as app_context:
+                self.assertIs(app_context.http_client, client)
+
+        async_client.assert_called_once()
+        client_context.__aenter__.assert_awaited_once_with()
+        client_context.__aexit__.assert_awaited_once()
+        kwargs = async_client.call_args.kwargs
+        self.assertEqual(kwargs['base_url'], 'https://gateway.test')
+        timeout = kwargs['timeout']
+        self.assertEqual(
+            (timeout.connect, timeout.read, timeout.write, timeout.pool),
+            (12.5, 12.5, 12.5, 12.5),
+        )
+        self.assertFalse(kwargs['follow_redirects'])
+        self.assertFalse(kwargs['trust_env'])
+        self.assertIs(kwargs['verify'], ssl_context)
+        self.assertIs(kwargs['transport'], transport)
+
+    async def test_invalid_gateway_ca_error_is_sanitized(self) -> None:
+        ca_file = pathlib.Path(self.credential_path.parent) / 'sensitive-ca-name.pem'
+
+        with self.assertRaises(tokens.GatewayTLSConfigurationError) as raised:
+            async with tokens.create_app_context(
+                api_url='https://gateway.test',
+                service_token_file=self.credential_path,
+                request_timeout_seconds=10,
+                token_cache_max_size=512,
+                token_cache_skew_seconds=30,
+                gateway_ca_file=ca_file,
+                transport=httpx.MockTransport(
+                    lambda request: self._token_response('unused', lifetime=300)),
+            ):
+                self.fail('Invalid CA unexpectedly initialized the application context.')
+
+        self.assertNotIn(str(ca_file), str(raised.exception))
+        self.assertNotIn('sensitive-ca-name', str(raised.exception))
+
+    def _service_provider(
+        self,
+        handler: Handler,
+        *,
+        cache_skew_seconds: float = 30,
+    ) -> tokens.ServiceTokenProvider:
+        client = self._client(handler)
+        return tokens.ServiceTokenProvider(
+            client,
+            self.credential_path,
+            cache_skew_seconds,
+            wall_time=self.clock.wall_time,
+            monotonic_time=self.clock.monotonic_time,
+        )
+
+    def _delegated_provider(
+        self,
+        handler: Handler,
+        *,
+        cache_max_size: int = 512,
+        cache_skew_seconds: float = 30,
+    ) -> tokens.DelegatedTokenProvider:
+        client = self._client(handler)
+        service_provider = tokens.ServiceTokenProvider(
+            client,
+            self.credential_path,
+            cache_skew_seconds,
+            wall_time=self.clock.wall_time,
+            monotonic_time=self.clock.monotonic_time,
+        )
+        return tokens.DelegatedTokenProvider(
+            client,
+            service_provider,
+            cache_max_size,
+            cache_skew_seconds,
+            identity_resolver=self.request_identity.get,
+            wall_time=self.clock.wall_time,
+            monotonic_time=self.clock.monotonic_time,
+        )
+
+    async def _get_delegated_token(
+        self,
+        provider: tokens.DelegatedTokenProvider,
+        user_name: str,
+        request_id: str | None = None,
+    ) -> str:
+        context_token = self.request_identity.set(
+            identity.RequestIdentity(user_name, request_id))
+        try:
+            return await provider.get_token()
+        finally:
+            self.request_identity.reset(context_token)
+
+    async def _invalidate_delegated_token(
+        self,
+        provider: tokens.DelegatedTokenProvider,
+        user_name: str,
+        delegated_token: str,
+    ) -> bool:
+        context_token = self.request_identity.set(
+            identity.RequestIdentity(user_name, None))
+        try:
+            return await provider.invalidate(delegated_token)
+        finally:
+            self.request_identity.reset(context_token)
+
+    def _create_delegated_token_task(
+        self,
+        provider: tokens.DelegatedTokenProvider,
+        user_name: str,
+    ) -> asyncio.Task[str]:
+        context_token = self.request_identity.set(
+            identity.RequestIdentity(user_name, None))
+        try:
+            return asyncio.create_task(provider.get_token())
+        finally:
+            self.request_identity.reset(context_token)
+
+    def _client(self, handler: Handler) -> httpx.AsyncClient:
+        client = httpx.AsyncClient(
+            base_url='https://gateway.test',
+            transport=httpx.MockTransport(handler),
+            follow_redirects=False,
+            trust_env=False,
+        )
+        self.clients.append(client)
+        return client
+
+    def _token_response(self, token: str, *, lifetime: int) -> httpx.Response:
+        return httpx.Response(200, json={
+            'token': token,
+            'expires_at': int(self.clock.wall + lifetime),
+        })
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tokens.py
+++ b/src/service/mcp/tokens.py
@@ -1,0 +1,441 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import collections
+from collections.abc import AsyncIterator, Callable
+import contextlib
+import dataclasses
+import pathlib
+import ssl
+import time
+
+import httpx
+import pydantic
+
+from src.lib.utils import common
+from src.service.mcp import identity
+
+
+_ACCESS_TOKEN_PATH = '/api/auth/jwt/access_token'
+_DELEGATED_TOKEN_PATH = '/api/auth/jwt/delegated_access_token'
+_MAX_CREDENTIAL_BYTES = 16 * 1024
+_MAX_TOKEN_RESPONSE_BYTES = 128 * 1024
+
+
+class TokenProviderError(RuntimeError):
+    """Base class for sanitized token provider failures."""
+
+
+class CredentialError(TokenProviderError):
+    """The mounted service credential could not be read safely."""
+
+
+class GatewayUnavailableError(TokenProviderError):
+    """The Gateway could not be reached within the configured limits."""
+
+
+class GatewayTLSConfigurationError(TokenProviderError):
+    """The configured Gateway trust roots could not be loaded."""
+
+
+class GatewayResponseError(TokenProviderError):
+    """The Gateway returned a non-success status without exposing its body."""
+
+    def __init__(self, operation: str, status_code: int) -> None:
+        self.operation = operation
+        self.status_code = status_code
+        super().__init__(
+            f'Gateway {operation} failed with HTTP status {status_code}.')
+
+
+class InvalidGatewayResponseError(TokenProviderError):
+    """The Gateway response did not match the strict token contract."""
+
+
+def _is_visible_ascii(value: str) -> bool:
+    return bool(value) and all(0x21 <= ord(character) <= 0x7e for character in value)
+
+
+class _TokenResponse(pydantic.BaseModel):
+    """Strict token response accepted from Gateway endpoints."""
+
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    token: str = pydantic.Field(min_length=1, max_length=65536)
+    expires_at: int = pydantic.Field(gt=0, le=2**63 - 1)
+
+    @pydantic.field_validator('token')
+    @classmethod
+    def _validate_token(cls, token: str) -> str:
+        if not _is_visible_ascii(token):
+            raise ValueError('Token must contain visible ASCII characters only.')
+        return token
+
+
+@dataclasses.dataclass(frozen=True)
+class _CachedToken:
+    token: str
+    expires_at: int
+    cache_deadline: float
+
+    def is_valid(self, monotonic_time: float) -> bool:
+        return monotonic_time < self.cache_deadline
+
+
+class ServiceTokenProvider:
+    """Exchange a mounted PAT for a short-lived service JWT."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        credential_file: pathlib.Path,
+        cache_skew_seconds: float,
+        *,
+        wall_time: Callable[[], float] = time.time,
+        monotonic_time: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._client = client
+        self._credential_file = credential_file
+        self._cache_skew_seconds = cache_skew_seconds
+        self._wall_time = wall_time
+        self._monotonic_time = monotonic_time
+        self._lock = asyncio.Lock()
+        self._cached_token: _CachedToken | None = None
+        self._refresh_task: asyncio.Task[_CachedToken] | None = None
+
+    async def get_token(self, request_id: str | None = None) -> str:
+        """Return a cached service JWT, refreshing it at most once concurrently."""
+        if request_id is None:
+            request_id = identity.get_request_id()
+        async with self._lock:
+            if (self._cached_token is not None and
+                    self._cached_token.is_valid(self._monotonic_time())):
+                return self._cached_token.token
+            self._cached_token = None
+
+            if self._refresh_task is None:
+                self._refresh_task = asyncio.create_task(
+                    self._refresh(request_id), name='mcp-service-token-refresh')
+                self._refresh_task.add_done_callback(_consume_task_exception)
+            refresh_task = self._refresh_task
+
+        return (await asyncio.shield(refresh_task)).token
+
+    async def invalidate(self, token: str) -> bool:
+        """Delete the cache only when it still contains the rejected JWT."""
+        async with self._lock:
+            if self._cached_token is None or self._cached_token.token != token:
+                return False
+            self._cached_token = None
+            return True
+
+    async def _refresh(self, request_id: str | None) -> _CachedToken:
+        current_task = asyncio.current_task()
+        try:
+            credential = await asyncio.to_thread(self._read_credential)
+            response = await _request_token(
+                self._client,
+                operation='service token exchange',
+                path=_ACCESS_TOKEN_PATH,
+                json_body={'token': credential},
+                request_id=request_id,
+            )
+            cached_token = _to_cached_token(
+                response,
+                cache_skew_seconds=self._cache_skew_seconds,
+                wall_time=self._wall_time,
+                monotonic_time=self._monotonic_time,
+            )
+            async with self._lock:
+                self._cached_token = cached_token
+            return cached_token
+        finally:
+            async with self._lock:
+                if self._refresh_task is current_task:
+                    self._refresh_task = None
+
+    def _read_credential(self) -> str:
+        try:
+            with self._credential_file.open('rb') as credential_file:
+                credential_bytes = credential_file.read(_MAX_CREDENTIAL_BYTES + 1)
+        except OSError:
+            raise CredentialError('Service credential is unavailable.') from None
+
+        if len(credential_bytes) > _MAX_CREDENTIAL_BYTES:
+            raise CredentialError('Service credential exceeds the size limit.')
+        try:
+            credential = credential_bytes.decode('utf-8').strip()
+        except UnicodeDecodeError:
+            raise CredentialError('Service credential is not valid UTF-8.') from None
+        if not _is_visible_ascii(credential):
+            raise CredentialError('Service credential has an invalid format.')
+        return credential
+
+
+class DelegatedTokenProvider:
+    """Mint and cache bounded per-user delegated JWTs."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        service_tokens: ServiceTokenProvider,
+        cache_max_size: int,
+        cache_skew_seconds: float,
+        *,
+        identity_resolver: Callable[[], identity.RequestIdentity] = (
+            identity.get_request_identity),
+        wall_time: Callable[[], float] = time.time,
+        monotonic_time: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._client = client
+        self._service_tokens = service_tokens
+        self._cache_max_size = cache_max_size
+        self._cache_skew_seconds = cache_skew_seconds
+        self._identity_resolver = identity_resolver
+        self._wall_time = wall_time
+        self._monotonic_time = monotonic_time
+        self._lock = asyncio.Lock()
+        self._cache: collections.OrderedDict[str, _CachedToken] = (
+            collections.OrderedDict())
+        self._mint_tasks: dict[str, asyncio.Task[_CachedToken]] = {}
+
+    async def get_token(self) -> str:
+        """Return the exact user's delegated JWT with per-user single-flight."""
+        request_identity = self._identity_resolver()
+        subject_user = request_identity.user_name
+        request_id = request_identity.request_id
+        _validate_subject_user(subject_user)
+        async with self._lock:
+            cached_token = self._cache.get(subject_user)
+            if cached_token is not None:
+                if cached_token.is_valid(self._monotonic_time()):
+                    self._cache.move_to_end(subject_user)
+                    return cached_token.token
+                del self._cache[subject_user]
+
+            mint_task = self._mint_tasks.get(subject_user)
+            if mint_task is None:
+                mint_task = asyncio.create_task(
+                    self._mint_and_store(subject_user, request_id),
+                    name='mcp-delegated-token-mint',
+                )
+                mint_task.add_done_callback(_consume_task_exception)
+                self._mint_tasks[subject_user] = mint_task
+
+        return (await asyncio.shield(mint_task)).token
+
+    async def invalidate(self, token: str) -> bool:
+        """Delete only the exact user's exact rejected delegated JWT."""
+        request_identity = self._identity_resolver()
+        subject_user = request_identity.user_name
+        _validate_subject_user(subject_user)
+        async with self._lock:
+            cached_token = self._cache.get(subject_user)
+            if cached_token is None or cached_token.token != token:
+                return False
+            del self._cache[subject_user]
+            return True
+
+    async def _mint_and_store(
+        self,
+        subject_user: str,
+        request_id: str | None,
+    ) -> _CachedToken:
+        current_task = asyncio.current_task()
+        try:
+            cached_token = await self._mint(subject_user, request_id)
+            async with self._lock:
+                self._cache[subject_user] = cached_token
+                self._cache.move_to_end(subject_user)
+                while len(self._cache) > self._cache_max_size:
+                    self._cache.popitem(last=False)
+            return cached_token
+        finally:
+            async with self._lock:
+                if self._mint_tasks.get(subject_user) is current_task:
+                    del self._mint_tasks[subject_user]
+
+    async def _mint(
+        self,
+        subject_user: str,
+        request_id: str | None,
+    ) -> _CachedToken:
+        service_token = await self._service_tokens.get_token(request_id)
+        try:
+            response = await self._request_delegated_token(
+                subject_user, service_token, request_id)
+        except GatewayResponseError as error:
+            if error.status_code != 401:
+                raise
+            await self._service_tokens.invalidate(service_token)
+            service_token = await self._service_tokens.get_token(request_id)
+            response = await self._request_delegated_token(
+                subject_user, service_token, request_id)
+
+        return _to_cached_token(
+            response,
+            cache_skew_seconds=self._cache_skew_seconds,
+            wall_time=self._wall_time,
+            monotonic_time=self._monotonic_time,
+        )
+
+    async def _request_delegated_token(
+        self,
+        subject_user: str,
+        service_token: str,
+        request_id: str | None,
+    ) -> _TokenResponse:
+        return await _request_token(
+            self._client,
+            operation='delegated token exchange',
+            path=_DELEGATED_TOKEN_PATH,
+            json_body={'subject_user': subject_user},
+            request_id=request_id,
+            authorization=f'Bearer {service_token}',
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class AppContext:
+    """Shared MCP runtime exposed through FastMCP's lifespan context."""
+
+    http_client: httpx.AsyncClient
+    service_tokens: ServiceTokenProvider
+    delegated_tokens: DelegatedTokenProvider
+
+
+@contextlib.asynccontextmanager
+async def create_app_context(
+    *,
+    api_url: str,
+    service_token_file: pathlib.Path,
+    request_timeout_seconds: float,
+    token_cache_max_size: int,
+    token_cache_skew_seconds: float,
+    gateway_ca_file: pathlib.Path | None = None,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> AsyncIterator[AppContext]:
+    """Create the process-lifetime HTTP client and token providers."""
+    ssl_context = build_gateway_ssl_context(gateway_ca_file)
+    async with httpx.AsyncClient(
+        base_url=api_url,
+        timeout=httpx.Timeout(request_timeout_seconds),
+        follow_redirects=False,
+        trust_env=False,
+        verify=ssl_context,
+        transport=transport,
+    ) as client:
+        service_tokens = ServiceTokenProvider(
+            client,
+            service_token_file,
+            token_cache_skew_seconds,
+        )
+        delegated_tokens = DelegatedTokenProvider(
+            client,
+            service_tokens,
+            token_cache_max_size,
+            token_cache_skew_seconds,
+        )
+        yield AppContext(
+            http_client=client,
+            service_tokens=service_tokens,
+            delegated_tokens=delegated_tokens,
+        )
+
+
+def build_gateway_ssl_context(
+    gateway_ca_file: pathlib.Path | None,
+) -> ssl.SSLContext:
+    """Build explicit system trust, optionally augmented by a private CA."""
+    try:
+        ssl_context = ssl.create_default_context()
+        if gateway_ca_file is not None:
+            ssl_context.load_verify_locations(cafile=gateway_ca_file)
+        return ssl_context
+    except (OSError, ssl.SSLError):
+        raise GatewayTLSConfigurationError(
+            'Gateway TLS trust configuration is invalid.') from None
+
+
+async def _request_token(
+    client: httpx.AsyncClient,
+    *,
+    operation: str,
+    path: str,
+    json_body: dict[str, str],
+    request_id: str | None,
+    authorization: str | None = None,
+) -> _TokenResponse:
+    headers: dict[str, str] = {}
+    if request_id is not None:
+        headers['x-request-id'] = request_id
+    if authorization is not None:
+        headers['Authorization'] = authorization
+
+    try:
+        async with client.stream(
+            'POST', path, json=json_body, headers=headers,
+        ) as response:
+            if response.status_code != 200:
+                raise GatewayResponseError(operation, response.status_code)
+
+            response_body = bytearray()
+            async for chunk in response.aiter_bytes():
+                if len(response_body) + len(chunk) > _MAX_TOKEN_RESPONSE_BYTES:
+                    raise InvalidGatewayResponseError(
+                        f'Gateway {operation} response exceeds the size limit.')
+                response_body.extend(chunk)
+    except httpx.RequestError:
+        raise GatewayUnavailableError(
+            f'Gateway {operation} is unavailable.') from None
+
+    try:
+        return _TokenResponse.model_validate_json(response_body)
+    except (ValueError, pydantic.ValidationError):
+        raise InvalidGatewayResponseError(
+            f'Gateway {operation} returned an invalid response.') from None
+
+
+def _to_cached_token(
+    response: _TokenResponse,
+    *,
+    cache_skew_seconds: float,
+    wall_time: Callable[[], float],
+    monotonic_time: Callable[[], float],
+) -> _CachedToken:
+    remaining_seconds = response.expires_at - wall_time()
+    if remaining_seconds <= 0:
+        raise InvalidGatewayResponseError(
+            'Gateway token response is already expired.')
+    return _CachedToken(
+        token=response.token,
+        expires_at=response.expires_at,
+        cache_deadline=(
+            monotonic_time() + max(0.0, remaining_seconds - cache_skew_seconds)),
+    )
+
+
+def _validate_subject_user(subject_user: str) -> None:
+    if not common.is_valid_authenticated_user_id(subject_user):
+        raise ValueError('Delegated token subject is invalid.')
+
+
+def _consume_task_exception(task: asyncio.Task[_CachedToken]) -> None:
+    if not task.cancelled():
+        task.exception()

--- a/src/service/mcp/tokens.py
+++ b/src/service/mcp/tokens.py
@@ -28,7 +28,7 @@ import time
 import httpx
 import pydantic
 
-from src.lib.utils import common
+from src.lib.utils import common, login
 from src.service.mcp import identity
 
 
@@ -384,7 +384,7 @@ async def _request_token(
 ) -> _TokenResponse:
     headers: dict[str, str] = {}
     if request_id is not None:
-        headers['x-request-id'] = request_id
+        headers[login.REQUEST_ID_HEADER] = request_id
     if authorization is not None:
         headers['Authorization'] = authorization
 


### PR DESCRIPTION
## Description

Stack PR 3 of 7 for MCP Phase B. This PR depends on [stack PR 2](https://github.com/NVIDIA/OSMO/pull/1172) and is the required base for [stack PR 4](https://github.com/NVIDIA/OSMO/pull/1174).

Merge the stack bottom-up with merge commits. After each merge, retarget the next PR to `feature/mcp` and rerun its checks.

Adds the MCP-side delegated-token client foundation:

- captures the Gateway-authenticated user and request ID in request-local context using shared login header constants;
- splits MCP modules into per-file Bazel targets with explicit dependencies;
- exchanges the mounted service credential for a service JWT and mints per-user delegated JWTs;
- uses bounded per-user LRU caching, expiry skew, and single-flight refreshes;
- rereads the mounted credential during refresh so rotation is picked up without restart;
- retries delegation once after a rejected service JWT using compare-and-delete invalidation; and
- enforces strict credential, response, TLS, redirect, and error-sanitization boundaries.

Commits:

- `49b1efb7` (`Add MCP delegated token client`)
- `03c7f0a1` (`Reuse shared login header constants`)
- `da05820d` (`Split MCP Bazel targets by file`)

## Validation

Validation completed locally on the rebuilt stack:

- `//src/service/mcp/tests:test_tokens`
- `//src/service/mcp/tests:test_server`
- All 10 focused Phase B targets and both PostgreSQL-backed integration targets
- `git diff --check`

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.