### PR TITLE
Add Gateway-backed MCP profile tool

### DIFF
--- a/src/service/core/profile/profile_service.py
+++ b/src/service/core/profile/profile_service.py
@@ -56,7 +56,9 @@ def get_notification_settings(
         token_identity = objects.TokenIdentity(
             name=token_name_header, expires_at=expires_at)
     return objects.ProfileResponse(
-        profile=connectors.UserProfile.fetch_from_db(postgres, user_name),
+        # GET remains side-effect-free when a profile has not been customized.
+        profile=connectors.UserProfile.fetch_from_db(
+            postgres, user_name, create_if_missing=False),
         roles=roles,
         pools=pools,
         token=token_identity,

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -47,6 +47,19 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "tools",
+    srcs = ["tools.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("mcp"),
+        requirement("pydantic"),
+        ":identity",
+        ":tokens",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "server",
     srcs = ["server.py"],
     deps = [
@@ -57,6 +70,7 @@ osmo_py_library(
         requirement("uvicorn"),
         ":identity",
         ":tokens",
+        ":tools",
         "//src/utils:ssl_config",
         "//src/utils:static_config",
     ],

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -30,7 +30,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 import uvicorn  # type: ignore
 
-from src.service.mcp import identity, tokens
+from src.service.mcp import identity, tokens, tools as mcp_tools
 from src.utils import ssl_config, static_config
 
 
@@ -101,7 +101,7 @@ def _create_mcp_server(
     ],
     configure_server: ServerConfigurer | None = None,
 ) -> FastMCP[tokens.AppContext]:
-    """Create the MCP protocol server without registering production tools."""
+    """Create the MCP protocol server and register its production catalog."""
     server: FastMCP[tokens.AppContext] = FastMCP(
         name='OSMO MCP',
         host='0.0.0.0',
@@ -124,6 +124,7 @@ def _create_mcp_server(
     async def health_ready(request: Request) -> JSONResponse:  # pylint: disable=unused-argument
         return JSONResponse({'status': 'ok'})
 
+    mcp_tools.register_tools(server)
     if configure_server is not None:
         configure_server(server)
 

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -41,3 +41,12 @@ osmo_py_test(
         "//src/service/mcp:tokens",
     ],
 )
+
+osmo_py_test(
+    name = "test_tools",
+    srcs = ["test_tools.py"],
+    deps = [
+        requirement("httpx"),
+        "//src/service/mcp:server",
+    ],
+)

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -85,7 +85,7 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ready_response.status_code, 200)
         self.assertEqual(ready_response.json(), {'status': 'ok'})
 
-    async def test_initialize_and_empty_tool_catalog(self) -> None:
+    async def test_initialize_and_production_tool_catalog(self) -> None:
         application = server.create_application(self.config)
         mcp_server = application.state.mcp_server
         self.assertTrue(mcp_server.settings.stateless_http)
@@ -140,7 +140,17 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn('mcp-session-id', initialize_response.headers)
         self.assertEqual(initialized_response.status_code, 202)
         self.assertEqual(list_tools_response.status_code, 200)
-        self.assertEqual(list_tools_response.json()['result']['tools'], [])
+        tool_catalog = list_tools_response.json()['result']['tools']
+        self.assertEqual(len(tool_catalog), 1)
+        self.assertEqual(tool_catalog[0]['name'], 'get_current_profile')
+        self.assertEqual(tool_catalog[0]['title'], 'Get Current OSMO Profile')
+        self.assertEqual(tool_catalog[0]['inputSchema']['properties'], {})
+        self.assertEqual(tool_catalog[0]['annotations'], {
+            'readOnlyHint': True,
+            'destructiveHint': False,
+            'idempotentHint': True,
+            'openWorldHint': False,
+        })
 
     async def test_mcp_rejects_missing_empty_and_duplicate_identity(self) -> None:
         application = server.create_application(self.config)
@@ -523,32 +533,8 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
             return httpx.Response(404)
 
-        def configure(mcp_server: FastMCP[tokens.AppContext]) -> None:
-            @mcp_server.tool()
-            async def delegated_profile_probe(context: Context) -> str:
-                """Test-only bridge from the trusted MCP identity to an OSMO API."""
-                request_identity = identity.get_request_identity()
-                app_context = context.request_context.lifespan_context
-                if not isinstance(app_context, tokens.AppContext):
-                    raise RuntimeError('Unexpected lifespan context.')
-
-                delegated_token = await app_context.delegated_tokens.get_token()
-                response = await app_context.http_client.get(
-                    '/api/profile/settings',
-                    headers={
-                        'Authorization': f'Bearer {delegated_token}',
-                        'x-request-id': request_identity.request_id or '',
-                    },
-                )
-                response.raise_for_status()
-                verified_user = response.json().get('profile', {}).get('username')
-                if verified_user != request_identity.user_name:
-                    raise RuntimeError('Gateway response identity does not match request.')
-                return request_identity.user_name
-
         application = server.create_application(
             self.config,
-            configure_server=configure,
             http_transport=httpx.MockTransport(gateway_handler),
         )
         def tool_request(request_id: int) -> dict[str, object]:
@@ -557,7 +543,7 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
                 'id': request_id,
                 'method': 'tools/call',
                 'params': {
-                    'name': 'delegated_profile_probe',
+                    'name': 'get_current_profile',
                     'arguments': {},
                 },
             }
@@ -585,10 +571,39 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
         responses = (alice_response, bob_response, cached_alice_response)
         self.assertTrue(all(response.status_code == 200 for response in responses))
-        self.assertEqual(
-            [response.json()['result']['content'][0]['text'] for response in responses],
-            ['alice', 'bob', 'alice'],
-        )
+        self.assertEqual([
+            response.json()['result']['structuredContent']
+            for response in responses
+        ], [
+            {
+                'username': 'alice',
+                'email_notification': False,
+                'slack_notification': False,
+                'pool': None,
+                'roles': ['osmo-user'],
+                'pools': [],
+            },
+            {
+                'username': 'bob',
+                'email_notification': False,
+                'slack_notification': False,
+                'pool': None,
+                'roles': ['osmo-user'],
+                'pools': [],
+            },
+            {
+                'username': 'alice',
+                'email_notification': False,
+                'slack_notification': False,
+                'pool': None,
+                'roles': ['osmo-user'],
+                'pools': [],
+            },
+        ])
+        self.assertTrue(all(
+            'token' not in response.json()['result']['structuredContent']
+            for response in responses
+        ))
         self.assertEqual(
             [request.url.path for request in gateway_requests],
             [
@@ -618,6 +633,8 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
             'token': 'service-pat',
         })
         self.assertNotIn('authorization', service_requests[0].headers)
+        self.assertEqual(
+            service_requests[0].headers['x-request-id'], 'request-alice')
         self.assertTrue(all(
             request.method == 'POST' for request in delegated_requests
         ))

--- a/src/service/mcp/tests/test_tokens.py
+++ b/src/service/mcp/tests/test_tokens.py
@@ -628,6 +628,17 @@ class TokenProviderTest(unittest.IsolatedAsyncioTestCase):
                     await provider.get_token()
                 self.assertNotIn(secret, str(raised.exception))
 
+    async def test_gateway_token_exchange_has_a_total_deadline(self) -> None:
+        async def handler(unused_request: httpx.Request) -> httpx.Response:
+            del unused_request
+            await asyncio.sleep(1)
+            return self._token_response('late-token', lifetime=300)
+
+        provider = self._service_provider(
+            handler, request_timeout_seconds=0.01)
+        with self.assertRaises(tokens.GatewayUnavailableError):
+            await provider.get_token()
+
     async def test_gateway_redirect_is_not_followed(self) -> None:
         requests: list[httpx.Request] = []
 
@@ -798,12 +809,14 @@ class TokenProviderTest(unittest.IsolatedAsyncioTestCase):
         handler: Handler,
         *,
         cache_skew_seconds: float = 30,
+        request_timeout_seconds: float | None = None,
     ) -> tokens.ServiceTokenProvider:
         client = self._client(handler)
         return tokens.ServiceTokenProvider(
             client,
             self.credential_path,
             cache_skew_seconds,
+            request_timeout_seconds=request_timeout_seconds,
             wall_time=self.clock.wall_time,
             monotonic_time=self.clock.monotonic_time,
         )

--- a/src/service/mcp/tests/test_tools.py
+++ b/src/service/mcp/tests/test_tools.py
@@ -1,0 +1,382 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from collections.abc import Callable, Coroutine
+import json
+import logging
+import pathlib
+import shutil
+import tempfile
+import unittest
+
+import httpx
+
+from src.service.mcp import server
+
+
+GatewayHandler = (
+    Callable[[httpx.Request], httpx.Response] |
+    Callable[[httpx.Request], Coroutine[None, None, httpx.Response]]
+)
+
+
+class _LogCapture(logging.Handler):
+    """Capture formatted messages, including chained exceptions."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setFormatter(logging.Formatter(
+            '%(levelname)s:%(name)s:%(message)s'))
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(self.format(record))
+
+
+class MCPToolsTest(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self) -> None:
+        temporary_directory = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temporary_directory)
+        self.credential_path = temporary_directory / 'service-token'
+        self.credential_path.write_text('service-pat', encoding='utf-8')
+        self.config = server.MCPServiceConfig(
+            api_url='https://gateway.test',
+            service_token_file=self.credential_path,
+            request_timeout_seconds=1,
+        )
+
+    async def test_profile_401_refreshes_delegated_token_and_retries_once(self) -> None:
+        requests: list[httpx.Request] = []
+        delegated_mints = 0
+
+        def gateway_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal delegated_mints
+            requests.append(request)
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt')
+            if request.url.path == '/api/auth/jwt/delegated_access_token':
+                delegated_mints += 1
+                return self._token_response(f'delegated-{delegated_mints}')
+            if request.headers['authorization'] == 'Bearer delegated-1':
+                return httpx.Response(401, text='expired-secret')
+            return self._profile_response('alice')
+
+        response = await self._call_tool(gateway_handler)
+
+        self.assertFalse(response.json()['result']['isError'])
+        self.assertEqual(
+            response.json()['result']['structuredContent']['username'], 'alice')
+        self.assertEqual(delegated_mints, 2)
+        profile_requests = self._requests_for(requests, '/api/profile/settings')
+        self.assertEqual(
+            [request.headers['authorization'] for request in profile_requests],
+            ['Bearer delegated-1', 'Bearer delegated-2'],
+        )
+        self.assertNotIn('expired-secret', response.text)
+        self.assertNotIn('delegated-1', response.text)
+        self.assertNotIn('delegated-2', response.text)
+
+    async def test_second_profile_401_stops_after_one_retry(self) -> None:
+        requests: list[httpx.Request] = []
+        delegated_mints = 0
+
+        def gateway_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal delegated_mints
+            requests.append(request)
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt')
+            if request.url.path == '/api/auth/jwt/delegated_access_token':
+                delegated_mints += 1
+                return self._token_response(f'delegated-{delegated_mints}')
+            if request.headers['authorization'] in (
+                'Bearer delegated-1', 'Bearer delegated-2',
+            ):
+                return httpx.Response(401, text='persistent-401-secret')
+            return self._profile_response('alice')
+
+        first_response, second_response = await self._call_tools(
+            gateway_handler, argument_sets=[{}, {}])
+
+        self._assert_sanitized_error(
+            first_response, 'persistent-401-secret')
+        self.assertFalse(second_response.json()['result']['isError'])
+        self.assertEqual(delegated_mints, 3)
+        self.assertEqual(
+            [
+                request.headers['authorization']
+                for request in self._requests_for(
+                    requests, '/api/profile/settings')
+            ],
+            [
+                'Bearer delegated-1',
+                'Bearer delegated-2',
+                'Bearer delegated-3',
+            ],
+        )
+
+    async def test_profile_403_is_not_retried_and_logs_are_sanitized(self) -> None:
+        requests: list[httpx.Request] = []
+        upstream_secret = 'forbidden-upstream-secret'
+
+        def gateway_handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt')
+            if request.url.path == '/api/auth/jwt/delegated_access_token':
+                return self._token_response('delegated-jwt')
+            return httpx.Response(403, text=upstream_secret)
+
+        log_capture = _LogCapture()
+        root_logger = logging.getLogger()
+        previous_level = root_logger.level
+        root_logger.addHandler(log_capture)
+        root_logger.setLevel(logging.DEBUG)
+        try:
+            response = await self._call_tool(gateway_handler)
+        finally:
+            root_logger.removeHandler(log_capture)
+            root_logger.setLevel(previous_level)
+
+        self._assert_sanitized_error(response, upstream_secret)
+        self.assertEqual(
+            len(self._requests_for(
+                requests, '/api/auth/jwt/delegated_access_token')), 1)
+        self.assertEqual(
+            len(self._requests_for(requests, '/api/profile/settings')), 1)
+        serialized_logs = repr(log_capture.messages)
+        for secret in (upstream_secret, 'service-pat', 'service-jwt', 'delegated-jwt'):
+            self.assertNotIn(secret, serialized_logs)
+
+    async def test_profile_rejects_mismatched_or_malformed_gateway_data(self) -> None:
+        invalid_responses = (
+            self._profile_response('bob'),
+            httpx.Response(200, json={
+                'profile': {
+                    'email_notification': False,
+                    'slack_notification': False,
+                    'pool': None,
+                },
+                'roles': ['osmo-user'],
+                'pools': [],
+                'token': None,
+            }),
+            httpx.Response(200, json={
+                'profile': {
+                    'username': 'alice',
+                    'email_notification': 'false',
+                    'slack_notification': False,
+                    'pool': None,
+                },
+                'roles': ['osmo-user'],
+                'pools': [],
+                'token': None,
+            }),
+            httpx.Response(200, text='not-json'),
+        )
+
+        for invalid_response in invalid_responses:
+            with self.subTest(body=invalid_response.text[:80]):
+                def gateway_handler(
+                    request: httpx.Request,
+                    response: httpx.Response = invalid_response,
+                ) -> httpx.Response:
+                    if request.url.path == '/api/auth/jwt/access_token':
+                        return self._token_response('service-jwt')
+                    if request.url.path == '/api/auth/jwt/delegated_access_token':
+                        return self._token_response('delegated-jwt')
+                    return response
+
+                response = await self._call_tool(gateway_handler)
+                self._assert_sanitized_error(response, invalid_response.text)
+
+    async def test_profile_response_has_a_size_limit(self) -> None:
+        oversized_secret = 'oversized-profile-secret'
+
+        def gateway_handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt')
+            if request.url.path == '/api/auth/jwt/delegated_access_token':
+                return self._token_response('delegated-jwt')
+            return httpx.Response(
+                200,
+                content=(oversized_secret.encode() + b'x' * (128 * 1024)),
+            )
+
+        response = await self._call_tool(gateway_handler)
+        self._assert_sanitized_error(response, oversized_secret)
+
+    async def test_profile_request_has_a_total_deadline(self) -> None:
+        async def gateway_handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt')
+            if request.url.path == '/api/auth/jwt/delegated_access_token':
+                return self._token_response('delegated-jwt')
+            await asyncio.sleep(1)
+            return self._profile_response('alice')
+
+        short_timeout_config = server.MCPServiceConfig(
+            api_url='https://gateway.test',
+            service_token_file=self.credential_path,
+            request_timeout_seconds=0.01,
+        )
+        response = await self._call_tool(
+            gateway_handler, config=short_timeout_config)
+        self._assert_sanitized_error(response)
+
+    async def test_missing_request_id_is_omitted_from_every_gateway_call(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def gateway_handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt')
+            if request.url.path == '/api/auth/jwt/delegated_access_token':
+                return self._token_response('delegated-jwt')
+            return self._profile_response('alice')
+
+        response = await self._call_tool(gateway_handler, request_id=None)
+
+        self.assertFalse(response.json()['result']['isError'])
+        self.assertTrue(all('x-request-id' not in request.headers for request in requests))
+
+    async def test_caller_identity_argument_cannot_override_trusted_user(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def gateway_handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            if request.url.path == '/api/auth/jwt/access_token':
+                return self._token_response('service-jwt')
+            if request.url.path == '/api/auth/jwt/delegated_access_token':
+                return self._token_response('delegated-jwt')
+            return self._profile_response('alice')
+
+        response = await self._call_tool(
+            gateway_handler, arguments={'username': 'bob'})
+
+        self.assertFalse(response.json()['result']['isError'])
+        self.assertEqual(
+            response.json()['result']['structuredContent']['username'], 'alice')
+        delegated_request = self._requests_for(
+            requests, '/api/auth/jwt/delegated_access_token')[0]
+        self.assertEqual(
+            json.loads(delegated_request.content), {'subject_user': 'alice'})
+
+    async def _call_tool(
+        self,
+        gateway_handler: GatewayHandler,
+        *,
+        user_name: str = 'alice',
+        request_id: str | None = 'request-123',
+        arguments: dict[str, object] | None = None,
+        config: server.MCPServiceConfig | None = None,
+    ) -> httpx.Response:
+        return (await self._call_tools(
+            gateway_handler,
+            user_name=user_name,
+            request_id=request_id,
+            argument_sets=[arguments or {}],
+            config=config,
+        ))[0]
+
+    async def _call_tools(
+        self,
+        gateway_handler: GatewayHandler,
+        *,
+        argument_sets: list[dict[str, object]],
+        user_name: str = 'alice',
+        request_id: str | None = 'request-123',
+        config: server.MCPServiceConfig | None = None,
+    ) -> list[httpx.Response]:
+        application = server.create_application(
+            config or self.config,
+            http_transport=httpx.MockTransport(gateway_handler),
+        )
+        headers = {
+            'Accept': 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            'x-osmo-user': user_name,
+        }
+        if request_id is not None:
+            headers['x-request-id'] = request_id
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                    transport=httpx.ASGITransport(app=application),
+                    base_url='http://mcp.test') as client:
+                responses = []
+                for request_number, arguments in enumerate(argument_sets, start=1):
+                    request = {
+                        'jsonrpc': '2.0',
+                        'id': request_number,
+                        'method': 'tools/call',
+                        'params': {
+                            'name': 'get_current_profile',
+                            'arguments': arguments,
+                        },
+                    }
+                    responses.append(await client.post(
+                        '/mcp', headers=headers, json=request))
+                return responses
+
+    @staticmethod
+    def _token_response(token: str) -> httpx.Response:
+        return httpx.Response(
+            200, json={'token': token, 'expires_at': 4102444800})
+
+    @staticmethod
+    def _profile_response(user_name: str) -> httpx.Response:
+        return httpx.Response(200, json={
+            'profile': {
+                'username': user_name,
+                'email_notification': False,
+                'slack_notification': False,
+                'pool': None,
+            },
+            'roles': ['osmo-user'],
+            'pools': ['pool-a'],
+            'token': {
+                'name': 'delegated-svc-mcp',
+                'expires_at': None,
+            },
+        })
+
+    @staticmethod
+    def _requests_for(
+        requests: list[httpx.Request],
+        path: str,
+    ) -> list[httpx.Request]:
+        return [request for request in requests if request.url.path == path]
+
+    def _assert_sanitized_error(
+        self,
+        response: httpx.Response,
+        secret: str | None = None,
+    ) -> None:
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn(
+            'Unable to retrieve the current OSMO profile.', response.text)
+        if secret:
+            self.assertNotIn(secret, response.text)
+        for token in ('service-pat', 'service-jwt', 'delegated-jwt'):
+            self.assertNotIn(token, response.text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tokens.py
+++ b/src/service/mcp/tokens.py
@@ -102,12 +102,14 @@ class ServiceTokenProvider:
         credential_file: pathlib.Path,
         cache_skew_seconds: float,
         *,
+        request_timeout_seconds: float | None = None,
         wall_time: Callable[[], float] = time.time,
         monotonic_time: Callable[[], float] = time.monotonic,
     ) -> None:
         self._client = client
         self._credential_file = credential_file
         self._cache_skew_seconds = cache_skew_seconds
+        self._request_timeout_seconds = request_timeout_seconds
         self._wall_time = wall_time
         self._monotonic_time = monotonic_time
         self._lock = asyncio.Lock()
@@ -150,6 +152,7 @@ class ServiceTokenProvider:
                 path=_ACCESS_TOKEN_PATH,
                 json_body={'token': credential},
                 request_id=request_id,
+                timeout_seconds=self._request_timeout_seconds,
             )
             cached_token = _to_cached_token(
                 response,
@@ -193,6 +196,7 @@ class DelegatedTokenProvider:
         cache_max_size: int,
         cache_skew_seconds: float,
         *,
+        request_timeout_seconds: float | None = None,
         identity_resolver: Callable[[], identity.RequestIdentity] = (
             identity.get_request_identity),
         wall_time: Callable[[], float] = time.time,
@@ -202,6 +206,7 @@ class DelegatedTokenProvider:
         self._service_tokens = service_tokens
         self._cache_max_size = cache_max_size
         self._cache_skew_seconds = cache_skew_seconds
+        self._request_timeout_seconds = request_timeout_seconds
         self._identity_resolver = identity_resolver
         self._wall_time = wall_time
         self._monotonic_time = monotonic_time
@@ -303,6 +308,7 @@ class DelegatedTokenProvider:
             json_body={'subject_user': subject_user},
             request_id=request_id,
             authorization=f'Bearer {service_token}',
+            timeout_seconds=self._request_timeout_seconds,
         )
 
 
@@ -313,6 +319,7 @@ class AppContext:
     http_client: httpx.AsyncClient
     service_tokens: ServiceTokenProvider
     delegated_tokens: DelegatedTokenProvider
+    request_timeout_seconds: float
 
 
 @contextlib.asynccontextmanager
@@ -338,17 +345,20 @@ async def create_app_context(
             client,
             service_token_file,
             token_cache_skew_seconds,
+            request_timeout_seconds=request_timeout_seconds,
         )
         delegated_tokens = DelegatedTokenProvider(
             client,
             service_tokens,
             token_cache_max_size,
             token_cache_skew_seconds,
+            request_timeout_seconds=request_timeout_seconds,
         )
         yield AppContext(
             http_client=client,
             service_tokens=service_tokens,
             delegated_tokens=delegated_tokens,
+            request_timeout_seconds=request_timeout_seconds,
         )
 
 async def _request_token(
@@ -359,6 +369,7 @@ async def _request_token(
     json_body: dict[str, str],
     request_id: str | None,
     authorization: str | None = None,
+    timeout_seconds: float | None = None,
 ) -> _TokenResponse:
     headers: dict[str, str] = {}
     if request_id is not None:
@@ -367,19 +378,22 @@ async def _request_token(
         headers['Authorization'] = authorization
 
     try:
-        async with client.stream(
-            'POST', path, json=json_body, headers=headers,
-        ) as response:
-            if response.status_code != 200:
-                raise GatewayResponseError(operation, response.status_code)
+        # HTTPX timeouts apply to individual I/O phases. The outer deadline also
+        # bounds peers that continually trickle bytes without timing out a read.
+        async with asyncio.timeout(timeout_seconds):
+            async with client.stream(
+                'POST', path, json=json_body, headers=headers,
+            ) as response:
+                if response.status_code != 200:
+                    raise GatewayResponseError(operation, response.status_code)
 
-            response_body = bytearray()
-            async for chunk in response.aiter_bytes():
-                if len(response_body) + len(chunk) > _MAX_TOKEN_RESPONSE_BYTES:
-                    raise InvalidGatewayResponseError(
-                        f'Gateway {operation} response exceeds the size limit.')
-                response_body.extend(chunk)
-    except httpx.RequestError:
+                response_body = bytearray()
+                async for chunk in response.aiter_bytes():
+                    if len(response_body) + len(chunk) > _MAX_TOKEN_RESPONSE_BYTES:
+                        raise InvalidGatewayResponseError(
+                            f'Gateway {operation} response exceeds the size limit.')
+                    response_body.extend(chunk)
+    except (TimeoutError, httpx.RequestError):
         raise GatewayUnavailableError(
             f'Gateway {operation} is unavailable.') from None
 

--- a/src/service/mcp/tools.py
+++ b/src/service/mcp/tools.py
@@ -1,0 +1,172 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+
+import httpx
+from mcp import types as mcp_types
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+import pydantic
+
+from src.service.mcp import identity, tokens
+
+
+_PROFILE_PATH = '/api/profile/settings'
+_MAX_PROFILE_RESPONSE_BYTES = 128 * 1024
+_PROFILE_ERROR = 'Unable to retrieve the current OSMO profile.'
+
+
+class CurrentProfile(pydantic.BaseModel):
+    """Safe subset of the signed-in user's OSMO profile."""
+
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    username: str
+    email_notification: bool | None
+    slack_notification: bool | None
+    pool: str | None
+    roles: list[str]
+    pools: list[str]
+
+
+class _ProfileSettings(pydantic.BaseModel):
+    """Strict profile fields expected from Core."""
+
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    username: str
+    email_notification: bool | None
+    slack_notification: bool | None
+    pool: str | None
+
+
+class _ProfileResponse(pydantic.BaseModel):
+    """Strict Core response; token identity metadata is never returned."""
+
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    profile: _ProfileSettings
+    roles: list[str]
+    pools: list[str]
+    token: dict[str, object] | None = None
+
+
+class _ProfileRequestError(RuntimeError):
+    """Sanitized internal profile request failure."""
+
+
+class _ProfileUnauthorizedError(_ProfileRequestError):
+    """The delegated token was rejected by Gateway."""
+
+
+def register_tools(server: FastMCP[tokens.AppContext]) -> None:
+    """Register the production OSMO MCP tool catalog."""
+
+    @server.tool(
+        name='get_current_profile',
+        title='Get Current OSMO Profile',
+        description=(
+            'Return the authenticated user\'s OSMO profile, roles, and accessible '
+            'pools. The user identity is supplied by the trusted OSMO Gateway.'),
+        annotations=mcp_types.ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_current_profile(context: Context) -> CurrentProfile:
+        """Return the trusted caller's profile through a delegated Gateway call."""
+        request_identity = identity.get_request_identity()
+        app_context = context.request_context.lifespan_context
+        if not isinstance(app_context, tokens.AppContext):
+            raise ToolError(_PROFILE_ERROR) from None
+
+        try:
+            delegated_token = await app_context.delegated_tokens.get_token()
+            try:
+                profile_response = await _request_profile(
+                    app_context, delegated_token, request_identity.request_id)
+            except _ProfileUnauthorizedError:
+                # Compare-and-delete prevents a stale 401 from removing a newer
+                # token installed by another request. Retry the API call only once.
+                await app_context.delegated_tokens.invalidate(delegated_token)
+                delegated_token = await app_context.delegated_tokens.get_token()
+                try:
+                    profile_response = await _request_profile(
+                        app_context, delegated_token, request_identity.request_id)
+                except _ProfileUnauthorizedError:
+                    # Never leave a token cached after Gateway has rejected it.
+                    await app_context.delegated_tokens.invalidate(delegated_token)
+                    raise
+
+            if profile_response.profile.username != request_identity.user_name:
+                raise _ProfileRequestError(
+                    'Gateway profile identity does not match the MCP caller.')
+        except (tokens.TokenProviderError, _ProfileRequestError):
+            raise ToolError(_PROFILE_ERROR) from None
+
+        return CurrentProfile(
+            username=profile_response.profile.username,
+            email_notification=profile_response.profile.email_notification,
+            slack_notification=profile_response.profile.slack_notification,
+            pool=profile_response.profile.pool,
+            roles=profile_response.roles,
+            pools=profile_response.pools,
+        )
+
+
+async def _request_profile(
+    app_context: tokens.AppContext,
+    delegated_token: str,
+    request_id: str | None,
+) -> _ProfileResponse:
+    headers = {'Authorization': f'Bearer {delegated_token}'}
+    if request_id is not None:
+        headers['x-request-id'] = request_id
+
+    try:
+        # Bound the complete exchange in addition to HTTPX's per-phase timeouts.
+        async with asyncio.timeout(app_context.request_timeout_seconds):
+            async with app_context.http_client.stream(
+                'GET', _PROFILE_PATH, headers=headers,
+            ) as response:
+                if response.status_code == 401:
+                    raise _ProfileUnauthorizedError(
+                        'Gateway rejected the delegated token.')
+                if response.status_code != 200:
+                    raise _ProfileRequestError(
+                        f'Gateway profile request failed with status '
+                        f'{response.status_code}.')
+
+                response_body = bytearray()
+                async for chunk in response.aiter_bytes():
+                    if len(response_body) + len(chunk) > _MAX_PROFILE_RESPONSE_BYTES:
+                        raise _ProfileRequestError(
+                            'Gateway profile response exceeds the size limit.')
+                    response_body.extend(chunk)
+    except (TimeoutError, httpx.RequestError):
+        raise _ProfileRequestError(
+            'Gateway profile request is unavailable.') from None
+
+    try:
+        return _ProfileResponse.model_validate_json(response_body)
+    except (ValueError, pydantic.ValidationError):
+        raise _ProfileRequestError(
+            'Gateway profile response is invalid.') from None

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1676,15 +1676,16 @@ class UserProfile(pydantic.BaseModel):
 
     @classmethod
     def fetch_from_db(cls, database: PostgresConnector,
-                      user_name: str) -> 'UserProfile':
+                      user_name: str,
+                      create_if_missing: bool = True) -> 'UserProfile':
         fetch_cmd = 'SELECT * FROM profile WHERE user_name = %s;'
         rows = database.execute_fetch_command(fetch_cmd, (user_name,))
         default_profile = UserProfile.default_profile(user_name)
         try:
             row = rows[0]
         except IndexError as _:
-            # Default values
-            UserProfile.insert_default_profile(database, user_name)
+            if create_if_missing:
+                UserProfile.insert_default_profile(database, user_name)
             return default_profile
 
         if row.email_notification is None:

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -59,6 +59,16 @@ py_test(
     size = "small"
 )
 
+py_test(
+    name = "test_user_profile",
+    srcs = ["test_user_profile.py"],
+    deps = [
+        "//src/utils/connectors:connectors",
+    ],
+    size = "small",
+    tags = ["exclusive"],
+)
+
 osmo_py_test(
     name = "test_default_roles_integration",
     srcs = ["test_default_roles_integration.py"],

--- a/src/utils/connectors/tests/test_user_profile.py
+++ b/src/utils/connectors/tests/test_user_profile.py
@@ -1,0 +1,56 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+from unittest import mock
+
+from src.utils import connectors
+
+
+class UserProfileTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.database = mock.create_autospec(
+            connectors.PostgresConnector, instance=True)
+        self.database.execute_fetch_command.return_value = []
+
+    def test_read_only_fetch_returns_defaults_without_inserting(self) -> None:
+        with mock.patch.object(
+            connectors.UserProfile, 'insert_default_profile',
+        ) as insert_default_profile:
+            profile = connectors.UserProfile.fetch_from_db(
+                self.database, 'alice', create_if_missing=False)
+
+        self.assertEqual(
+            profile, connectors.UserProfile.default_profile('alice'))
+        insert_default_profile.assert_not_called()
+
+    def test_default_fetch_preserves_lazy_profile_creation(self) -> None:
+        with mock.patch.object(
+            connectors.UserProfile, 'insert_default_profile',
+        ) as insert_default_profile:
+            profile = connectors.UserProfile.fetch_from_db(
+                self.database, 'alice')
+
+        self.assertEqual(
+            profile, connectors.UserProfile.default_profile('alice'))
+        insert_default_profile.assert_called_once_with(self.database, 'alice')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Stack PR 5 of 7 for MCP Phase B. This PR depends on [stack PR 4](https://github.com/NVIDIA/OSMO/pull/1174) and is the required base for [stack PR 6](https://github.com/NVIDIA/OSMO/pull/1176).

Merge the stack bottom-up with merge commits. After each merge, retarget the next PR to `feature/mcp` and rerun its checks.

Adds the production read-only `get_current_profile` tool. It retrieves the signed-in caller's profile through Gateway with a delegated token, retries one rejected token safely, applies strict deadlines and response validation, verifies the returned identity, and exposes only safe profile, role, and pool fields. Profile reads remain side-effect-free when no customized profile exists.

Commit: `43ad7994` (`Add Gateway-backed MCP profile tool`).

## Validation

Validation completed locally on the rebuilt stack:

- `//src/service/mcp/tests:test_tools`
- `//src/service/mcp/tests:test_server`
- `//src/service/mcp/tests:test_tokens`
- `//src/utils/connectors/tests:test_user_profile`
- All 10 focused Phase B targets and both PostgreSQL-backed integration targets
- `git diff --check`
- End-to-end validation returned HTTP 200 for all three Gateway calls; the tool executed successfully and exposed no token

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.