### PR TITLE
Document MCP delegated authentication

### DIFF
--- a/docs/deployment_guide/appendix/authentication/authentication_flow.rst
+++ b/docs/deployment_guide/appendix/authentication/authentication_flow.rst
@@ -36,7 +36,12 @@ The main pieces involved are:
 
 3. **Identity provider (IdP)** — Optional. Your organization's login system (e.g., Microsoft Entra ID, Google, AWS IAM Identity Center). When used, Envoy talks to it directly and the IdP issues JWTs that Envoy validates.
 
-4. **OSMO service** — The backend. It trusts the ``x-osmo-user`` and ``x-osmo-roles`` headers set by Envoy (or by an internal path that bypasses Envoy). It does **not** validate the original JWT itself; Envoy is responsible for that. The service uses the user and roles to resolve policies and allow or deny the request.
+4. **OSMO service** — The backend. Most endpoints trust the
+   ``x-osmo-user`` and ``x-osmo-roles`` headers set by Envoy. The MCP
+   delegation endpoint additionally verifies its OSMO-issued service JWT
+   locally and requires its identity to match Envoy's header before minting a
+   delegated token. The service uses the user and roles to resolve policies
+   and allow or deny the request.
 
 So in practice: the client gets a token (JWT from IdP or access token), Envoy validates it and sets user/roles headers, and the OSMO service authorizes based on those headers and its role/policy database.
 
@@ -83,6 +88,37 @@ Envoy must be configured to accept JWTs issued by OSMO (e.g. via ``osmoauth`` an
       curl -X POST "$GATEWAY/api/auth/jwt/access_token" \
           -H "Content-Type: application/json" \
           -d '{"token":"<access-token-value>"}'
+
+MCP delegated tokens
+--------------------
+
+The MCP service conventionally uses a dedicated ``svc-mcp`` access token,
+restricted to the immutable ``osmo-mcp-delegator`` role, to act for an
+authenticated MCP caller. The account name is not an authorization boundary;
+Gateway evaluates the caller's role policies.
+
+1. Envoy validates the caller's JWT, authorizes MCP access, removes the
+   caller's bearer credential and role headers, and forwards only the trusted
+   ``x-osmo-user`` identity to MCP.
+2. MCP exchanges its mounted service access token for a five-minute
+   OSMO-issued service JWT.
+3. MCP sends that JWT and the caller's user ID to
+   ``POST /api/auth/jwt/delegated_access_token``. AuthZ requires a role policy
+   that allows ``auth:Delegate``. The built-in ``osmo-admin`` role explicitly
+   denies that action despite its wildcard allow policy.
+4. Core verifies the service JWT again, compares it with Envoy's identity,
+   resolves the caller's database-backed roles, and returns a JWT valid for at
+   most five minutes, never beyond the service JWT's expiration. The token is
+   tagged with ``act.sub=<service-account-user>`` for audit attribution.
+
+The MCP process caches both token types only until shortly before expiration.
+The built-in read-only ``get_current_profile`` tool exercises this path through
+the public gateway, verifies that Core returns the trusted caller's identity,
+and omits token identity metadata from its result.
+The caller's credential never reaches the MCP pod. The service access token is
+sent only to the gateway exchange endpoint and is never exposed to the MCP
+caller or written to logs. See :ref:`deploy_service` for the required Secret,
+NetworkPolicy, and gateway configuration.
 
 Operating with an identity provider
 ===================================
@@ -131,7 +167,10 @@ Envoy (or the component in front of the OSMO service) is responsible for:
 - **Expiration** — The token is not expired.
 - **Claims** — ``iss`` (issuer), ``aud`` (audience), and the claim used as username (e.g. ``preferred_username``, ``email``) match the configuration.
 
-The OSMO service does **not** validate the raw JWT. It trusts the ``x-osmo-user`` and ``x-osmo-roles`` headers. Therefore, in production you must only expose the OSMO service through Envoy (or another gateway) that:
+Except for the defense-in-depth verification on MCP delegation described
+above, the OSMO service trusts the ``x-osmo-user`` and ``x-osmo-roles`` headers.
+Therefore, in production you must only expose the OSMO service through Envoy
+(or another gateway) that:
 
 - Validates the JWT or access token.
 - Strips or ignores any downstream ``x-osmo-user`` and ``x-osmo-roles`` from the client.

--- a/docs/deployment_guide/appendix/authentication/roles_policies.rst
+++ b/docs/deployment_guide/appendix/authentication/roles_policies.rst
@@ -83,6 +83,13 @@ OSMO includes the following roles by default. No configuration is required — t
        * View the service version
        * Fetch new JWT tokens from service/user access tokens
 
+   * - ``osmo-mcp-delegator``
+     - Internal role for MCP service accounts. It can mint a short-lived access
+       token delegated to the authenticated MCP caller. ``svc-mcp`` is the
+       recommended account name, but authorization is determined by the
+       ``auth:Delegate`` role policy. The built-in ``osmo-admin`` role has an
+       explicit deny policy for this action.
+
 .. note::
 
    The ``osmo-admin`` role is immutable and cannot be modified.
@@ -110,7 +117,7 @@ Each role has the following fields:
      - List of policies that define what this role can do. See :ref:`custom_roles_policies` for details.
    * - ``immutable``
      - ``false``
-     - If ``true``, the role cannot be modified or deleted. The preconfigured ``osmo-admin``, ``osmo-backend``, ``osmo-ctrl``, and ``osmo-default`` roles are immutable.
+     - If ``true``, the role cannot be modified or deleted. The preconfigured ``osmo-admin``, ``osmo-backend``, ``osmo-ctrl``, ``osmo-default``, and ``osmo-mcp-delegator`` roles are immutable.
    * - ``sync_mode``
      - ``"import"``
      - Controls how IdP role sync affects this role. One of:
@@ -130,7 +137,13 @@ Each role has the following fields:
 
        See :doc:`identity_provider_setup` for configuring IdP integration.
 
-All preconfigured roles use the defaults (``sync_mode: "import"``, ``external_roles: null``), which means each is automatically mapped 1:1 from its own name in IdP claims. For example, if your IdP sends a group claim containing ``osmo-user``, that user will automatically receive the ``osmo-user`` role in OSMO without any additional configuration.
+User-facing preconfigured roles use the defaults (``sync_mode: "import"``,
+``external_roles: null``), which means each is automatically mapped 1:1 from its own
+name in IdP claims. For example, if your IdP sends a group claim containing
+``osmo-user``, that user will automatically receive the ``osmo-user`` role in OSMO
+without any additional configuration. The internal ``osmo-mcp-delegator`` role is
+the exception: it uses ``sync_mode: "ignore"`` with no external mappings so only
+explicit OSMO user and token management can assign it to a service account.
 
 .. tip::
 
@@ -650,6 +663,10 @@ All actions follow the format ``<resource_type>:<action_name>``. When writing po
       * - ``auth:Token``
         - Create and manage access tokens.
         - ``user/<user_id>`` or Global
+      * - ``auth:Delegate``
+        - Mint a short-lived delegated token. Reserved for the MCP service
+          principal and enforced in addition to role authorization.
+        - Global
 
 .. dropdown:: System Actions
    :color: info

--- a/docs/deployment_guide/getting_started/deploy_service.rst
+++ b/docs/deployment_guide/getting_started/deploy_service.rst
@@ -48,6 +48,8 @@ OSMO deployment consists of several main components:
      - Client communication and status updates
    * - Delayed Job Monitor
      - Monitoring and managing delayed background jobs
+   * - MCP Service (optional)
+     - Authenticated Model Context Protocol endpoint with delegated OSMO access
 
 .. image:: service_components.svg
    :width: 80%
@@ -288,7 +290,7 @@ Create ``osmo_values.yaml`` for the OSMO service with the following sample.
   :icon: file
 
   .. code-block:: yaml
-    :emphasize-lines: 4, 21-23, 34, 36, 42, 51, 54-59, 74, 88, 90-91, 96, 163-164, 168-169, 175, 179, 193-195, 232-234
+    :emphasize-lines: 4, 21-23, 34, 36, 42, 51, 54-59, 74, 90, 92, 94, 99, 180, 198-200, 243-245
 
     # Global configuration shared across all OSMO services
     global:
@@ -377,6 +379,10 @@ Create ``osmo_values.yaml`` for the OSMO service with the following sample.
       # client ID to users out of band.
       mcp:
         enabled: false
+        # Delegated MCP access requires the public gateway origin and a Secret
+        # containing the svc-mcp access token under the "token" key.
+        apiUrl: https://<your-domain>
+        serviceTokenSecretName: osmo-mcp-service-token
         resourceUrl: https://<your-domain>/mcp
         authorizationServers:
         - <idp-issuer-url>
@@ -441,6 +447,8 @@ Create ``osmo_values.yaml`` for the OSMO service with the following sample.
 
       # OSMO configs (storage credentials for the service and worker pods).
       # Pods get cloud credentials via the annotated ServiceAccount above.
+      # If you plan to enable MCP, use database-backed configuration
+      # (enabled: false) from the first deployment.
       configs:
         enabled: true
         # Static credentials path: # (4)
@@ -515,6 +523,11 @@ Create ``osmo_values.yaml`` for the OSMO service with the following sample.
         #   logger:  osmo-logger-tls
         #   mcp:     osmo-mcp-tls
         # caSecret: osmo-gateway-ca
+
+      # Required when MCP is enabled. The cluster CNI must enforce
+      # NetworkPolicy so only Envoy can connect directly to the MCP pod.
+      networkPolicies:
+        enabled: false
 
       # OAuth2 Proxy configuration
       # Set OIDC issuer URL and client ID from your IdP (e.g. Microsoft Entra ID, Google). See identity_provider_setup.
@@ -651,9 +664,73 @@ Step 7: Post-deployment Configuration
 
 4. Verify access to the UI at https://osmo.example.com through your domain
 
-5. If the MCP service is enabled, distribute its public OAuth client
-   configuration to users. For example, configure Codex and start its browser
-   login flow:
+5. To enable the MCP service, first deploy this release with
+   ``services.configs.enabled=false`` and ``services.mcp.enabled=false`` so the
+   built-in ``osmo-mcp-delegator`` role is seeded into PostgreSQL. Create the
+   dedicated service user and an access token containing only that role:
+
+   .. code-block:: bash
+
+      $ osmo user create svc-mcp --roles osmo-mcp-delegator
+      $ osmo token set mcp-delegator \
+          --user svc-mcp \
+          --expires-at <YYYY-MM-DD> \
+          --roles osmo-mcp-delegator
+
+   Save the token when it is displayed, then store it under the ``token`` key
+   in the Secret referenced by ``services.mcp.serviceTokenSecretName``. For
+   example, if a protected local file contains only the token:
+
+   .. code-block:: bash
+
+      $ kubectl create secret generic osmo-mcp-service-token \
+          --from-file=token=<path-to-token-file> \
+          --namespace osmo
+
+   Update ``osmo_values.yaml`` with the following settings and upgrade the
+   release:
+
+   .. code-block:: yaml
+
+      services:
+        # Delegated roles are resolved from PostgreSQL.
+        configs:
+          enabled: false
+        mcp:
+          enabled: true
+          apiUrl: https://osmo.example.com
+          serviceTokenSecretName: osmo-mcp-service-token
+          osmoJwtIssuer: osmo
+          osmoJwtAudience: osmo
+          resourceUrl: https://osmo.example.com/mcp
+          authorizationServers:
+          - <idp-issuer-url>
+          scopes:
+          - openid
+          - profile
+          - email
+          - https://osmo.example.com/mcp/access_as_user
+
+      gateway:
+        networkPolicies:
+          enabled: true
+
+   .. important::
+
+      MCP delegation requires database-backed roles, an OSMO-issued JWT
+      provider using the gateway's internal JWKS cluster, and a CNI that
+      enforces Kubernetes NetworkPolicy. The chart rejects a configuration
+      with MCP enabled that omits these controls. Keep
+      ``osmo-mcp-delegator`` limited to dedicated service accounts and scope
+      the MCP access token to only that role. ``svc-mcp`` is a naming
+      convention; Gateway authorizes delegation through role policies, and the
+      built-in ``osmo-admin`` role explicitly denies ``auth:Delegate``. If
+      Core's ``service_auth`` issuer or audience is customized, set
+      ``services.mcp.osmoJwtIssuer`` and
+      ``services.mcp.osmoJwtAudience`` to the same values.
+
+6. Distribute the MCP service's public OAuth client configuration to users.
+   For example, configure Codex and start its browser login flow:
 
    .. code-block:: bash
 
@@ -687,6 +764,13 @@ Step 7: Post-deployment Configuration
    ``http://localhost:53682/oauth/callback/<server-specific-id>``. The ``-c``
    options apply only to this command; they do not modify ``config.toml`` or
    other MCPs. MCP Inspector uses a separate callback URI.
+
+   To rotate the service credential, create a replacement token for the
+   configured MCP service account (``svc-mcp`` in this example) with only
+   ``osmo-mcp-delegator``, update the Secret's ``token`` key, verify MCP
+   requests, and then revoke the old token. The projected Secret is refreshed
+   without a pod restart; an already-issued service JWT can remain valid for up
+   to five minutes.
 
 
 Troubleshooting


### PR DESCRIPTION
## Description

Stack PR 6 of 7 for MCP Phase B. This PR depends on [stack PR 5](https://github.com/NVIDIA/OSMO/pull/1175) and is the required base for [stack PR 7](https://github.com/NVIDIA/OSMO/pull/1169).

Merge the stack bottom-up with merge commits. After this PR merges, retarget stack PR 7 to `feature/mcp` and rerun its checks.

Documents MCP delegated authentication and deployment, including policy-based authorization, the recommended `svc-mcp` naming convention, immutable delegator role, explicit administrator deny policy, two-step enablement process, service credential and Kubernetes Secret setup, database-backed role and JWKS requirements, NetworkPolicy, OAuth configuration, and credential rotation.

Commit: `0b95f780` (`Document MCP delegated authentication`).

## Validation

Validation completed locally on the rebuilt stack:

- All 10 focused Phase B targets and both PostgreSQL-backed integration targets
- Service-chart Helm lint and template rendering
- `git diff --check`

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.