### PR TITLE
Add osmo-deploy skill evals

### DIFF
--- a/skills/osmo-deploy/evals/.gitignore
+++ b/skills/osmo-deploy/evals/.gitignore
@@ -1,0 +1,5 @@
+# Eval run output — regenerated each run
+results/
+
+# macOS metadata
+.DS_Store

--- a/skills/osmo-deploy/evals/config.yml
+++ b/skills/osmo-deploy/evals/config.yml
@@ -1,0 +1,4 @@
+schema_version: 1
+
+harbor:
+  agent_workdir: /workspace/input

--- a/skills/osmo-deploy/evals/evals.json
+++ b/skills/osmo-deploy/evals/evals.json
@@ -1,0 +1,80 @@
+{
+  "skill_name": "osmo-deploy",
+  "evals": [
+    {
+      "id": "osmo-deploy-001",
+      "prompt": "I want to deploy OSMO to AKS, but I have not decided whether I need GPUs or where to put the cluster yet.",
+      "expected_output": "The agent activates osmo-deploy and gathers the deployment inputs before invoking the deploy script. It asks about GPU need, GPU count and SKU only if GPUs are needed, region, Azure subscription, and resource group.",
+      "assertions": [
+        "The agent reads the osmo-deploy SKILL.md.",
+        "The agent activates osmo-deploy for the AKS deployment request.",
+        "The agent asks whether GPUs are needed before assuming a GPU configuration.",
+        "The agent asks for GPU count, GPU type, and region only when GPUs are needed, or explains that those follow-up questions are conditional.",
+        "The agent asks for the Azure subscription ID and resource group when they have not been supplied.",
+        "The agent does not invoke deploy-osmo-minimal.sh before collecting the missing required inputs.",
+        "The agent does not recommend a 6.2 deployment or leave version compatibility unaddressed."
+      ],
+      "expected_skill": "osmo-deploy",
+      "expected_script": null
+    },
+    {
+      "id": "osmo-deploy-002",
+      "prompt": "Our kubectl context already points to a reachable Kubernetes cluster. The required BYO PostgreSQL and Redis environment variables are exported. Deploy a CPU-only OSMO instance with no storage backend, and proceed without asking me more questions.",
+      "expected_output": "The agent uses the BYO deployment path, discovers available chart versions, pins matching 6.3.x chart, image, and CLI releases, then runs the non-interactive CPU-only deployment with storage disabled.",
+      "assertions": [
+        "The agent reads the osmo-deploy SKILL.md.",
+        "The agent runs or prepares to run ./scripts/deploy-osmo-minimal.sh --list-chart-versions from the deployments directory before selecting version pins.",
+        "The agent sets OSMO_CHART_VERSION, OSMO_IMAGE_TAG, and OSMO_CLI_REF to matching 6.3.x release values before deployment.",
+        "The deployment invocation uses --provider byo, --no-gpu, --storage-backend none, and --non-interactive.",
+        "The agent does not rely on the latest/default version values or select any 6.2 release.",
+        "The agent does not run osmo config update, osmo credential set, or another CLI-write configuration path."
+      ],
+      "expected_skill": "osmo-deploy",
+      "expected_script": null
+    },
+    {
+      "id": "osmo-deploy-003",
+      "prompt": "Deploy OSMO on Azure with a three-GPU H100 pool and Azure Blob storage. My subscription ID and resource group are already set, but I do not know a region with quota. You can proceed.",
+      "expected_output": "The agent translates H100 to the documented Azure SKU, discovers a quota-compatible region, configures the requested GPU pool and Azure Blob storage, and still pins a matching 6.3.x chart, image, and CLI release before deployment.",
+      "assertions": [
+        "The agent activates osmo-deploy and reads its SKILL.md.",
+        "The agent maps H100 to Standard_NC40ads_H100_v5 for Azure.",
+        "The agent runs or prepares to run ./scripts/deploy-osmo-minimal.sh --find-gpu-region Standard_NC40ads_H100_v5 3 when the region is unknown.",
+        "The agent sets the selected region as TF_REGION and configures a GPU node pool with a count of three.",
+        "The deployment uses --provider azure, --gpu-node-pool, and --storage-backend azure-blob.",
+        "The agent discovers and pins matching OSMO_CHART_VERSION, OSMO_IMAGE_TAG, and OSMO_CLI_REF values from the 6.3.x release line before deployment.",
+        "If no candidate region has sufficient quota, the agent surfaces that failure and suggests expanding TF_REGION_CANDIDATES rather than guessing a region."
+      ],
+      "expected_skill": "osmo-deploy",
+      "expected_script": null
+    },
+    {
+      "id": "osmo-deploy-004",
+      "prompt": "Set up OSMO on our existing AKS cluster using Azure Blob with workload identity. We do not use static storage keys. The platform team says it will provide the identity details later.",
+      "expected_output": "The agent activates osmo-deploy but does not fall back to static credentials or run a partial workload-identity deploy. It identifies the caller-owned Azure Workload Identity prerequisites and asks for the UAMI client ID after those prerequisites are ready.",
+      "assertions": [
+        "The agent reads the osmo-deploy SKILL.md and activates osmo-deploy.",
+        "The agent identifies AKS OIDC and Workload Identity enablement, a UAMI, Storage Blob Data Contributor access, and a federated credential as prerequisites owned by the caller or platform team.",
+        "The agent asks for the workload identity client ID required for the Azure Blob deployment.",
+        "The agent does not create or request static storage account keys, connection strings, or Kubernetes credential secrets as a fallback.",
+        "The agent does not claim workload identity will work until the cloud-side prerequisites are complete.",
+        "The agent keeps the intended deployment mode as --storage-backend azure-blob --auth-method workload-identity."
+      ],
+      "expected_skill": "osmo-deploy",
+      "expected_script": null
+    },
+    {
+      "id": "osmo-deploy-005",
+      "prompt": "My workflow train-123 has been pending for an hour. Can you inspect its events and logs?",
+      "expected_output": "This is live workflow troubleshooting, not an OSMO deployment request. The osmo-deploy skill does not trigger.",
+      "assertions": [
+        "The agent does not activate osmo-deploy.",
+        "The agent routes to osmo-user or appropriate live workflow troubleshooting tooling.",
+        "The agent does not invoke deploy-osmo-minimal.sh, Helm installation, Terraform, or cluster bootstrap commands.",
+        "The agent does not make any deployment configuration changes."
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/skills/osmo-deploy/evals/evals.json
+++ b/skills/osmo-deploy/evals/evals.json
@@ -3,62 +3,61 @@
   "evals": [
     {
       "id": "osmo-deploy-001",
-      "prompt": "I want to deploy OSMO to AKS, but I have not decided whether I need GPUs or where to put the cluster yet.",
-      "expected_output": "The agent activates osmo-deploy and gathers the deployment inputs before invoking the deploy script. It asks about GPU need, GPU count and SKU only if GPUs are needed, region, Azure subscription, and resource group.",
+      "prompt": "I am planning an AKS deployment of OSMO, but I have not decided whether I need GPUs or where to put the cluster. What information do you need from me before deployment?",
+      "expected_output": "The agent activates osmo-deploy and asks for the required deployment inputs before proposing a command: whether GPUs are needed; GPU count, SKU, and region only when GPUs are needed; plus the Azure subscription and resource group.",
       "assertions": [
-        "The agent reads the osmo-deploy SKILL.md.",
-        "The agent activates osmo-deploy for the AKS deployment request.",
+        "The agent reads and activates osmo-deploy.",
         "The agent asks whether GPUs are needed before assuming a GPU configuration.",
-        "The agent asks for GPU count, GPU type, and region only when GPUs are needed, or explains that those follow-up questions are conditional.",
+        "The agent makes GPU count, GPU type, and region conditional on the user needing GPUs.",
         "The agent asks for the Azure subscription ID and resource group when they have not been supplied.",
-        "The agent does not invoke deploy-osmo-minimal.sh before collecting the missing required inputs.",
-        "The agent does not recommend a 6.2 deployment or leave version compatibility unaddressed."
+        "The agent does not invent deployment-specific values or run a deployment command before the missing inputs are collected.",
+        "The agent identifies the required OSMO 6.3.x version-pinning step rather than recommending an unpinned latest deployment."
       ],
       "expected_skill": "osmo-deploy",
       "expected_script": null
     },
     {
       "id": "osmo-deploy-002",
-      "prompt": "Our kubectl context already points to a reachable Kubernetes cluster. The required BYO PostgreSQL and Redis environment variables are exported. Deploy a CPU-only OSMO instance with no storage backend, and proceed without asking me more questions.",
-      "expected_output": "The agent uses the BYO deployment path, discovers available chart versions, pins matching 6.3.x chart, image, and CLI releases, then runs the non-interactive CPU-only deployment with storage disabled.",
+      "prompt": "Before I deploy a CPU-only OSMO instance to an existing Kubernetes cluster with the BYO provider and no storage backend, what version and command choices do I need to make?",
+      "expected_output": "The agent activates osmo-deploy and explains the safe BYO CPU-only deployment plan: discover published versions, pin matching 6.3.x chart, image, and CLI releases, then use the BYO, no-GPU, no-storage, non-interactive command shape after the required database and Redis variables are set.",
       "assertions": [
-        "The agent reads the osmo-deploy SKILL.md.",
-        "The agent runs or prepares to run ./scripts/deploy-osmo-minimal.sh --list-chart-versions from the deployments directory before selecting version pins.",
-        "The agent sets OSMO_CHART_VERSION, OSMO_IMAGE_TAG, and OSMO_CLI_REF to matching 6.3.x release values before deployment.",
-        "The deployment invocation uses --provider byo, --no-gpu, --storage-backend none, and --non-interactive.",
-        "The agent does not rely on the latest/default version values or select any 6.2 release.",
-        "The agent does not run osmo config update, osmo credential set, or another CLI-write configuration path."
+        "The agent reads and activates osmo-deploy.",
+        "The agent says to use --list-chart-versions before selecting pins.",
+        "The agent requires matching 6.3.x values for OSMO_CHART_VERSION, OSMO_IMAGE_TAG, and OSMO_CLI_REF.",
+        "The agent describes a command using --provider byo, --no-gpu, --storage-backend none, and --non-interactive.",
+        "The agent notes that BYO requires a reachable kubectl context and the PostgreSQL and Redis environment variables before deployment.",
+        "The agent does not recommend default/latest versions, a 6.2 release, osmo config update, or osmo credential set."
       ],
       "expected_skill": "osmo-deploy",
       "expected_script": null
     },
     {
       "id": "osmo-deploy-003",
-      "prompt": "Deploy OSMO on Azure with a three-GPU H100 pool and Azure Blob storage. My subscription ID and resource group are already set, but I do not know a region with quota. You can proceed.",
-      "expected_output": "The agent translates H100 to the documented Azure SKU, discovers a quota-compatible region, configures the requested GPU pool and Azure Blob storage, and still pins a matching 6.3.x chart, image, and CLI release before deployment.",
+      "prompt": "I am planning an Azure OSMO deployment with three H100 GPUs and Azure Blob storage, but I do not know which region has enough quota. What should the deployment plan do?",
+      "expected_output": "The agent activates osmo-deploy, maps H100 to the documented Azure SKU, discovers a quota-compatible region instead of guessing, configures the GPU pool and Azure Blob storage, and pins matching 6.3.x releases.",
       "assertions": [
-        "The agent activates osmo-deploy and reads its SKILL.md.",
+        "The agent reads and activates osmo-deploy.",
         "The agent maps H100 to Standard_NC40ads_H100_v5 for Azure.",
-        "The agent runs or prepares to run ./scripts/deploy-osmo-minimal.sh --find-gpu-region Standard_NC40ads_H100_v5 3 when the region is unknown.",
-        "The agent sets the selected region as TF_REGION and configures a GPU node pool with a count of three.",
-        "The deployment uses --provider azure, --gpu-node-pool, and --storage-backend azure-blob.",
-        "The agent discovers and pins matching OSMO_CHART_VERSION, OSMO_IMAGE_TAG, and OSMO_CLI_REF values from the 6.3.x release line before deployment.",
-        "If no candidate region has sufficient quota, the agent surfaces that failure and suggests expanding TF_REGION_CANDIDATES rather than guessing a region."
+        "The agent recommends --find-gpu-region Standard_NC40ads_H100_v5 3 when the region is unknown.",
+        "The agent explains that the selected result becomes TF_REGION and that the GPU node pool is configured for three GPUs.",
+        "The agent describes using --provider azure, --gpu-node-pool, and --storage-backend azure-blob.",
+        "The agent requires matching 6.3.x OSMO_CHART_VERSION, OSMO_IMAGE_TAG, and OSMO_CLI_REF pins.",
+        "The agent says to surface a no-quota result and expand TF_REGION_CANDIDATES rather than guessing a region."
       ],
       "expected_skill": "osmo-deploy",
       "expected_script": null
     },
     {
       "id": "osmo-deploy-004",
-      "prompt": "Set up OSMO on our existing AKS cluster using Azure Blob with workload identity. We do not use static storage keys. The platform team says it will provide the identity details later.",
-      "expected_output": "The agent activates osmo-deploy but does not fall back to static credentials or run a partial workload-identity deploy. It identifies the caller-owned Azure Workload Identity prerequisites and asks for the UAMI client ID after those prerequisites are ready.",
+      "prompt": "We plan to run OSMO on an existing AKS cluster with Azure Blob and workload identity. We do not use static storage keys, and the platform team has not supplied the identity details yet. What must be ready before deployment?",
+      "expected_output": "The agent activates osmo-deploy, explains the caller-owned Azure Workload Identity prerequisites, and requests the UAMI client ID. It retains workload identity mode and does not substitute static credentials.",
       "assertions": [
-        "The agent reads the osmo-deploy SKILL.md and activates osmo-deploy.",
+        "The agent reads and activates osmo-deploy.",
         "The agent identifies AKS OIDC and Workload Identity enablement, a UAMI, Storage Blob Data Contributor access, and a federated credential as prerequisites owned by the caller or platform team.",
         "The agent asks for the workload identity client ID required for the Azure Blob deployment.",
-        "The agent does not create or request static storage account keys, connection strings, or Kubernetes credential secrets as a fallback.",
-        "The agent does not claim workload identity will work until the cloud-side prerequisites are complete.",
-        "The agent keeps the intended deployment mode as --storage-backend azure-blob --auth-method workload-identity."
+        "The agent keeps the intended deployment mode as --storage-backend azure-blob --auth-method workload-identity.",
+        "The agent does not suggest static storage keys, connection strings, or Kubernetes credential secrets as a fallback.",
+        "The agent does not claim workload identity will work until the cloud-side prerequisites are complete."
       ],
       "expected_skill": "osmo-deploy",
       "expected_script": null
@@ -70,8 +69,8 @@
       "assertions": [
         "The agent does not activate osmo-deploy.",
         "The agent routes to osmo-user or appropriate live workflow troubleshooting tooling.",
-        "The agent does not invoke deploy-osmo-minimal.sh, Helm installation, Terraform, or cluster bootstrap commands.",
-        "The agent does not make any deployment configuration changes."
+        "The agent does not suggest deploy-osmo-minimal.sh, Helm installation, Terraform, or cluster bootstrap commands.",
+        "The agent does not make deployment configuration changes."
       ],
       "expected_skill": null,
       "expected_script": null


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description

Adds a compact eval suite for the `osmo-deploy` skill, covering deployment intake, 6.3 version pinning, GPU-region discovery, workload-identity prerequisites, and workflow-support routing.

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new evaluation scenarios for deployment guidance, covering missing inputs, CPU-only deployments, Azure GPU deployments, Blob deployments, and unrelated troubleshooting cases.
  * Expanded evaluation settings to support the new test setup.
* **Chores**
  * Updated ignored files to keep generated eval results and macOS metadata out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->