### PR TITLE
Reject escaped slashes at the gateway

### DIFF
--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -101,6 +101,7 @@ data:
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
             stat_prefix: ingress_http
+            path_with_escaped_slashes_action: REJECT_REQUEST
             access_log:
             - name: envoy.access_loggers.file
               typed_config:


### PR DESCRIPTION
## Summary

- reject escaped slash and backslash sequences in the gateway HTTP connection manager
- prevent path interpretation differences between authorization and upstream routing

## Testing

- `helm lint deployments/charts/service`
- `helm template test-release deployments/charts/service --show-only templates/gateway.yaml`
- `helm template test-release deployments/charts/service`
- `git diff --check`

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests containing escaped slashes in the path are now rejected by the gateway, improving request handling consistency and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->