### PR TITLE
Add MCP request-scoped authentication context

### DIFF
--- a/src/lib/utils/login.py
+++ b/src/lib/utils/login.py
@@ -36,6 +36,7 @@ OSMO_USER_HEADER = 'x-osmo-user'
 OSMO_USER_ROLES = 'x-osmo-roles'
 OSMO_TOKEN_NAME_HEADER = 'x-osmo-token-name'
 OSMO_ALLOWED_POOLS = 'x-osmo-allowed-pools'
+REQUEST_ID_HEADER = 'x-request-id'
 # Don't use a token that will expire within the next N seconds
 EXPIRE_WINDOW = 3
 TIMEOUT = 60
@@ -293,5 +294,4 @@ def parse_allowed_pools(allowed_pools_header: str | None) -> List[str]:
     if not allowed_pools_header:
         return []
     return [pool.strip() for pool in allowed_pools_header.split(',') if pool.strip()]
-
 

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -23,6 +23,16 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@osmo_constants//:constants.bzl", "BASE_IMAGE_URL", "IMAGE_TAG")
 
 osmo_py_library(
+    name = "request_context",
+    srcs = ["request_context.py"],
+    deps = [
+        requirement("starlette"),
+        "//src/lib/utils:login",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "mcp_service_lib",
     srcs = ["server.py"],
     deps = [
@@ -30,6 +40,7 @@ osmo_py_library(
         requirement("pydantic"),
         requirement("starlette"),
         requirement("uvicorn"),
+        ":request_context",
         "//src/utils:ssl_config",
         "//src/utils:static_config",
     ],

--- a/src/service/mcp/request_context.py
+++ b/src/service/mcp/request_context.py
@@ -1,0 +1,155 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import contextvars
+import dataclasses
+import re
+from typing import Iterable
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from src.lib.utils import login
+
+
+_AUTHORIZATION_HEADER = login.OSMO_AUTH_HEADER.lower().encode('ascii')
+_USER_HEADER = login.OSMO_USER_HEADER.lower().encode('ascii')
+_REQUEST_ID_HEADER = login.REQUEST_ID_HEADER.lower().encode('ascii')
+_BEARER_VALUE = re.compile(r'Bearer [!-~]+')
+_REQUEST_ID = re.compile(r'[A-Za-z0-9][A-Za-z0-9._:-]{0,127}')
+_MAX_AUTHORIZATION_BYTES = 128 * 1024
+_MAX_USER_BYTES = 256
+_INVALID_CONTEXT_RESPONSE = {'error': 'Invalid MCP authentication context.'}
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RequestCredentials:
+    """Gateway-authenticated credentials owned by one MCP HTTP request."""
+
+    authorization_header: str = dataclasses.field(repr=False)
+    user_name: str
+    request_id: str | None
+
+
+_request_credentials: contextvars.ContextVar[RequestCredentials | None] = (
+    contextvars.ContextVar('mcp_request_credentials', default=None))
+
+
+class RequestContextMiddleware:
+    """Establish request-local credentials from Gateway-owned headers."""
+
+    def __init__(self, application: ASGIApp, path: str = '/mcp') -> None:
+        self._application = application
+        self._path = path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope['type'] != 'http' or scope.get('path') != self._path:
+            await self._application(scope, receive, send)
+            return
+
+        credentials = _parse_credentials(scope.get('headers', []))
+        if credentials is None:
+            response = JSONResponse(_INVALID_CONTEXT_RESPONSE, status_code=401)
+            await response(scope, receive, send)
+            return
+
+        context_token = _request_credentials.set(credentials)
+        try:
+            await self._application(scope, receive, send)
+        finally:
+            _request_credentials.reset(context_token)
+
+
+def get_request_credentials() -> RequestCredentials:
+    """Return credentials for the active MCP request."""
+    credentials = _request_credentials.get()
+    if credentials is None:
+        raise RuntimeError('MCP request credentials are unavailable.')
+    return credentials
+
+
+def _parse_credentials(
+    raw_headers: Iterable[tuple[bytes, bytes]],
+) -> RequestCredentials | None:
+    relevant_headers: dict[bytes, list[bytes]] = {}
+    for name, value in raw_headers:
+        normalized_name = name.lower()
+        if normalized_name in (
+            _AUTHORIZATION_HEADER, _USER_HEADER, _REQUEST_ID_HEADER,
+        ):
+            relevant_headers.setdefault(normalized_name, []).append(value)
+
+    authorization_values = relevant_headers.get(_AUTHORIZATION_HEADER, [])
+    user_values = relevant_headers.get(_USER_HEADER, [])
+    request_id_values = relevant_headers.get(_REQUEST_ID_HEADER, [])
+    if (
+        len(authorization_values) != 1 or
+        len(user_values) != 1 or
+        len(request_id_values) > 1 or
+        len(authorization_values[0]) > _MAX_AUTHORIZATION_BYTES
+    ):
+        return None
+
+    authorization = _decode_ascii(authorization_values[0])
+    user_name = _decode_utf8(user_values[0])
+    if (
+        authorization is None or
+        _BEARER_VALUE.fullmatch(authorization) is None or
+        user_name is None or
+        not _is_valid_user_name(user_name)
+    ):
+        return None
+
+    request_id: str | None = None
+    if request_id_values:
+        request_id = _decode_ascii(request_id_values[0])
+        if request_id is None or _REQUEST_ID.fullmatch(request_id) is None:
+            return None
+
+    return RequestCredentials(
+        authorization_header=authorization,
+        user_name=user_name,
+        request_id=request_id,
+    )
+
+
+def _decode_ascii(value: bytes) -> str | None:
+    try:
+        return value.decode('ascii')
+    except UnicodeDecodeError:
+        return None
+
+
+def _decode_utf8(value: bytes) -> str | None:
+    try:
+        return value.decode('utf-8')
+    except UnicodeDecodeError:
+        return None
+
+
+def _is_valid_user_name(user_name: str) -> bool:
+    try:
+        encoded_length = len(user_name.encode('utf-8'))
+    except UnicodeEncodeError:
+        return False
+    return (
+        bool(user_name) and
+        user_name == user_name.strip() and
+        encoded_length <= _MAX_USER_BYTES and
+        all(character.isprintable() for character in user_name)
+    )

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -25,6 +25,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 import uvicorn  # type: ignore
 
+from src.service.mcp import request_context
 from src.utils import ssl_config, static_config
 
 
@@ -70,7 +71,17 @@ def create_mcp_server() -> FastMCP:
 
 
 mcp_server = create_mcp_server()
-app: Starlette = mcp_server.streamable_http_app()
+
+
+def create_application(server: FastMCP | None = None) -> Starlette:
+    """Create the MCP ASGI application with request-scoped credentials."""
+    mcp_application = server if server is not None else create_mcp_server()
+    application = mcp_application.streamable_http_app()
+    application.add_middleware(request_context.RequestContextMiddleware, path='/mcp')
+    return application
+
+
+app = create_application(mcp_server)
 
 
 def main() -> None:

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -20,6 +20,16 @@ load("//bzl:py.bzl", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_test(
+    name = "test_request_context",
+    srcs = ["test_request_context.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("starlette"),
+        "//src/service/mcp:request_context",
+    ],
+)
+
+osmo_py_test(
     name = "test_server",
     srcs = ["test_server.py"],
     deps = [

--- a/src/service/mcp/tests/test_request_context.py
+++ b/src/service/mcp/tests/test_request_context.py
@@ -1,0 +1,301 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import unittest
+
+import httpx
+from starlette.responses import JSONResponse
+from starlette.types import Message
+
+from src.service.mcp import request_context
+
+
+class RequestContextTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_valid_headers_establish_request_credentials(self) -> None:
+        observed: list[request_context.RequestCredentials] = []
+
+        async def application(scope, receive, send) -> None:
+            observed.append(request_context.get_request_credentials())
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        response = await self._request(
+            application,
+            headers=self._headers(request_id='request-123'),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(observed[0].authorization_header, 'Bearer token-alice')
+        self.assertEqual(observed[0].user_name, 'alice@example.com')
+        self.assertEqual(observed[0].request_id, 'request-123')
+        with self.assertRaisesRegex(RuntimeError, 'unavailable'):
+            request_context.get_request_credentials()
+
+    async def test_invalid_authentication_headers_fail_closed(self) -> None:
+        invalid_headers = (
+            [('x-osmo-user', 'alice@example.com')],
+            [('Authorization', ''), ('x-osmo-user', 'alice@example.com')],
+            [('Authorization', 'Basic secret'), ('x-osmo-user', 'alice@example.com')],
+            [('Authorization', 'Bearer'), ('x-osmo-user', 'alice@example.com')],
+            [('Authorization', 'Bearer token with-space'),
+             ('x-osmo-user', 'alice@example.com')],
+            [('Authorization', 'Bearer first'), ('Authorization', 'Bearer second'),
+             ('x-osmo-user', 'alice@example.com')],
+        )
+        calls = 0
+
+        async def application(scope, receive, send) -> None:
+            del scope, receive, send
+            nonlocal calls
+            calls += 1
+
+        for headers in invalid_headers:
+            with self.subTest(headers=headers):
+                response = await self._request(application, headers=headers)
+                self.assertEqual(response.status_code, 401)
+                self.assertEqual(
+                    response.json(), {'error': 'Invalid MCP authentication context.'})
+                self.assertNotIn('secret', response.text)
+                self.assertNotIn('first', response.text)
+                self.assertNotIn('second', response.text)
+        self.assertEqual(calls, 0)
+
+    async def test_authorization_header_size_and_encoding_are_bounded(self) -> None:
+        max_token_bytes = request_context._MAX_AUTHORIZATION_BYTES - len(b'Bearer ')  # pylint: disable=protected-access
+
+        async def application(scope, receive, send) -> None:
+            self.assertEqual(
+                len(request_context.get_request_credentials().authorization_header),
+                request_context._MAX_AUTHORIZATION_BYTES,  # pylint: disable=protected-access
+            )
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        valid_status = await self._raw_request_status(
+            application,
+            headers=[
+                (b'authorization', b'Bearer ' + b'a' * max_token_bytes),
+                (b'x-osmo-user', b'alice@example.com'),
+            ],
+        )
+        oversized_status = await self._raw_request_status(
+            application,
+            headers=[
+                (b'authorization', b'Bearer ' + b'a' * (max_token_bytes + 1)),
+                (b'x-osmo-user', b'alice@example.com'),
+            ],
+        )
+        invalid_encoding_status = await self._raw_request_status(
+            application,
+            headers=[
+                (b'authorization', b'Bearer token-\xff'),
+                (b'x-osmo-user', b'alice@example.com'),
+            ],
+        )
+
+        self.assertEqual(valid_status, 200)
+        self.assertEqual(oversized_status, 401)
+        self.assertEqual(invalid_encoding_status, 401)
+
+    async def test_invalid_identity_or_request_id_fails_closed(self) -> None:
+        invalid_headers = (
+            [('Authorization', 'Bearer token')],
+            self._headers(user_name=' alice@example.com'),
+            self._headers(user_name='alice\n@example.com'),
+            self._headers(user_name='a' * 257),
+            self._headers() + [('x-osmo-user', 'bob@example.com')],
+            self._headers(request_id='contains space'),
+            self._headers(request_id='request-1') + [('x-request-id', 'request-2')],
+        )
+
+        async def application(scope, receive, send) -> None:
+            del scope, receive, send
+            self.fail('Invalid credentials must not reach the MCP application.')
+
+        for headers in invalid_headers:
+            with self.subTest(headers=headers):
+                response = await self._request(application, headers=headers)
+                self.assertEqual(response.status_code, 401)
+
+    async def test_unrelated_paths_do_not_require_credentials(self) -> None:
+        context_available = True
+
+        async def application(scope, receive, send) -> None:
+            nonlocal context_available
+            try:
+                request_context.get_request_credentials()
+            except RuntimeError:
+                context_available = False
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        response = await self._request(application, path='/health', headers=[])
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(context_available)
+
+    async def test_context_is_reset_after_application_error(self) -> None:
+        async def application(scope, receive, send) -> None:
+            del scope, receive, send
+            self.assertEqual(
+                request_context.get_request_credentials().user_name,
+                'alice@example.com',
+            )
+            raise ValueError('test failure')
+
+        with self.assertRaisesRegex(ValueError, 'test failure'):
+            await self._request(application, headers=self._headers())
+        with self.assertRaisesRegex(RuntimeError, 'unavailable'):
+            request_context.get_request_credentials()
+
+    async def test_context_is_reset_after_cancellation(self) -> None:
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def application(scope, receive, send) -> None:
+            del scope, receive, send
+            self.assertEqual(
+                request_context.get_request_credentials().authorization_header,
+                'Bearer token-alice',
+            )
+            started.set()
+            await release.wait()
+
+        async def cancelled_request() -> None:
+            try:
+                await self._request(application, headers=self._headers())
+            except asyncio.CancelledError:
+                # ASGITransport invokes the middleware in this task, so this
+                # assertion observes the same ContextVar after its finally block.
+                with self.assertRaisesRegex(RuntimeError, 'unavailable'):
+                    request_context.get_request_credentials()
+                raise
+
+        task = asyncio.create_task(cancelled_request())
+        await started.wait()
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+        with self.assertRaisesRegex(RuntimeError, 'unavailable'):
+            request_context.get_request_credentials()
+
+    async def test_concurrent_requests_keep_credentials_isolated(self) -> None:
+        both_started = asyncio.Event()
+        observations: dict[str, list[request_context.RequestCredentials]] = {}
+        started_count = 0
+
+        async def application(scope, receive, send) -> None:
+            nonlocal started_count
+            before = request_context.get_request_credentials()
+            started_count += 1
+            if started_count == 2:
+                both_started.set()
+            await both_started.wait()
+            after = request_context.get_request_credentials()
+            observations[before.user_name] = [before, after]
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        await asyncio.gather(
+            self._request(
+                application,
+                headers=self._headers(
+                    user_name='alice@example.com', token='token-alice')),
+            self._request(
+                application,
+                headers=self._headers(
+                    user_name='bob@example.com', token='token-bob')),
+        )
+
+        self.assertEqual(set(observations), {'alice@example.com', 'bob@example.com'})
+        for user_name, credentials in observations.items():
+            expected_token = 'token-alice' if user_name.startswith('alice') else 'token-bob'
+            self.assertTrue(all(item.user_name == user_name for item in credentials))
+            self.assertTrue(all(
+                item.authorization_header == f'Bearer {expected_token}'
+                for item in credentials
+            ))
+
+    def test_credentials_repr_does_not_expose_authorization(self) -> None:
+        credentials = request_context.RequestCredentials(
+            authorization_header='Bearer secret-token',
+            user_name='alice@example.com',
+            request_id='request-123',
+        )
+
+        self.assertNotIn('secret-token', repr(credentials))
+        self.assertNotIn('secret-token', str(credentials))
+
+    async def _request(
+        self,
+        application,
+        *,
+        headers: list[tuple[str, str]],
+        path: str = '/mcp',
+    ) -> httpx.Response:
+        middleware = request_context.RequestContextMiddleware(application)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=middleware),
+            base_url='http://mcp.test',
+        ) as client:
+            return await client.post(path, headers=headers)
+
+    async def _raw_request_status(
+        self,
+        application,
+        *,
+        headers: list[tuple[bytes, bytes]],
+    ) -> int:
+        messages: list[Message] = []
+
+        async def receive() -> Message:
+            return {'type': 'http.disconnect'}
+
+        async def send(message: Message) -> None:
+            messages.append(message)
+
+        middleware = request_context.RequestContextMiddleware(application)
+        await middleware(
+            {
+                'type': 'http',
+                'method': 'POST',
+                'path': '/mcp',
+                'headers': headers,
+            },
+            receive,
+            send,
+        )
+        return messages[0]['status']
+
+    @staticmethod
+    def _headers(
+        *,
+        user_name: str = 'alice@example.com',
+        token: str = 'token-alice',
+        request_id: str | None = None,
+    ) -> list[tuple[str, str]]:
+        headers = [
+            ('Authorization', f'Bearer {token}'),
+            ('x-osmo-user', user_name),
+        ]
+        if request_id is not None:
+            headers.append(('x-request-id', request_id))
+        return headers
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_request_context.py
+++ b/src/service/mcp/tests/test_request_context.py
@@ -26,6 +26,9 @@ from starlette.types import Message
 from src.service.mcp import request_context
 
 
+_TEST_TIMEOUT_SECONDS = 1
+
+
 class RequestContextTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_valid_headers_establish_request_credentials(self) -> None:
@@ -187,7 +190,7 @@ class RequestContextTest(unittest.IsolatedAsyncioTestCase):
                 raise
 
         task = asyncio.create_task(cancelled_request())
-        await started.wait()
+        await asyncio.wait_for(started.wait(), _TEST_TIMEOUT_SECONDS)
         task.cancel()
         with self.assertRaises(asyncio.CancelledError):
             await task
@@ -205,7 +208,7 @@ class RequestContextTest(unittest.IsolatedAsyncioTestCase):
             started_count += 1
             if started_count == 2:
                 both_started.set()
-            await both_started.wait()
+            await asyncio.wait_for(both_started.wait(), _TEST_TIMEOUT_SECONDS)
             after = request_context.get_request_credentials()
             observations[before.user_name] = [before, after]
             await JSONResponse({'status': 'ok'})(scope, receive, send)

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -29,7 +29,7 @@ from src.service.mcp import server
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_health_endpoints(self) -> None:
-        application = server.create_mcp_server().streamable_http_app()
+        application = server.create_application()
         async with application.router.lifespan_context(application):
             async with httpx.AsyncClient(
                     transport=httpx.ASGITransport(app=application),
@@ -51,10 +51,12 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(mcp_server.settings.json_response)
         self.assertEqual(mcp_server.settings.streamable_http_path, '/mcp')
 
-        application = mcp_server.streamable_http_app()
+        application = server.create_application(mcp_server)
         headers = {
             'Accept': 'application/json, text/event-stream',
+            'Authorization': 'Bearer test-token',
             'Content-Type': 'application/json',
+            'x-osmo-user': 'alice@example.com',
         }
         initialize_request = {
             'jsonrpc': '2.0',


### PR DESCRIPTION
## Description

PR 1 of 3 for the redesigned MCP Phase B. This PR targets `feature/mcp`; the token-relay profile PR will build on this branch while it is under review.

Adds the request-scoped authentication boundary used by MCP token relay. Middleware on the exact `/mcp` path requires one standard bearer header and one Gateway-owned user header, accepts an optional bounded request ID, and stores them in an immutable `ContextVar` value for only the active HTTP request. The bearer value is redacted from object representations and the context is reset on normal completion, errors, and cancellation.

The implementation reuses the existing OSMO header constants and Phase A Gateway contract. It does not validate or decode tokens, call OSMO APIs, register production tools, change Helm, cache credentials, or restore any OBO behavior.

Focused tests cover malformed, missing, duplicate, oversized, and invalidly encoded headers; trusted-user and request-ID validation; health-path bypass; error and cancellation cleanup; redacted representations; and concurrent user/token isolation.

## Validation

- `bazel test //src/service/mcp/tests:test_request_context //src/service/mcp/tests:test_server`
- `bazel test //src/service/mcp:request_context-pylint //src/service/mcp:mcp_service_lib-pylint //src/service/mcp/tests:test_request_context-pylint //src/service/mcp/tests:test_server-pylint`
- Bazel Mypy aspects for both MCP test targets
- `git diff --check`

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
