### PR TITLE
Add MCP profile token relay

### DIFF
--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -77,6 +77,8 @@ spec:
           value: "0.0.0.0"
         - name: OSMO_MCP_PORT
           value: {{ $mcp.port | quote }}
+        - name: OSMO_API_URL
+          value: {{ trimSuffix "/mcp" $mcp.resourceUrl | quote }}
         {{- with $mcp.extraEnv }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -116,7 +118,6 @@ spec:
   selector:
     app: {{ $mcp.serviceName }}
 
-{{- if .Values.gateway.networkPolicies.enabled }}
 ---
 
 apiVersion: networking.k8s.io/v1
@@ -137,5 +138,4 @@ spec:
     ports:
     - port: {{ $mcp.port }}
       protocol: TCP
-{{- end }}
 {{- end }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -115,6 +115,9 @@ services:
   ##
   mcp:
     ## Enable the MCP workload and its gateway routes. Disabled by default.
+    ## When enabled, the chart always renders a NetworkPolicy that permits
+    ## MCP ingress only from Gateway Envoy pods. The cluster CNI must enforce
+    ## Kubernetes NetworkPolicy for this access boundary to be effective.
     ##
     enabled: false
 
@@ -136,7 +139,8 @@ services:
 
     ## Canonical RFC 9728 protected resource identifier. This must be the
     ## externally reachable HTTPS MCP URL ending in /mcp, for example:
-    ## https://osmo.example.com/mcp
+    ## https://osmo.example.com/mcp. Its origin is also used for authenticated
+    ## downstream OSMO API requests; no separate API URL is configured.
     ##
     resourceUrl: ""
 

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -33,14 +33,40 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "gateway",
+    srcs = ["gateway.py"],
+    deps = [
+        requirement("httpx"),
+        ":request_context",
+        "//src/lib/utils:login",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "tools",
+    srcs = ["tools.py"],
+    deps = [
+        requirement("mcp"),
+        requirement("pydantic"),
+        ":gateway",
+        ":request_context",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "mcp_service_lib",
     srcs = ["server.py"],
     deps = [
+        requirement("httpx"),
         requirement("mcp"),
         requirement("pydantic"),
         requirement("starlette"),
         requirement("uvicorn"),
+        ":gateway",
         ":request_context",
+        ":tools",
         "//src/utils:ssl_config",
         "//src/utils:static_config",
     ],

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -1,0 +1,157 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+import contextlib
+import dataclasses
+from urllib import parse
+
+import httpx
+
+from src.lib.utils import login
+from src.service.mcp import request_context
+
+
+_USER_AGENT = 'osmo-mcp'
+
+
+class GatewayClientError(RuntimeError):
+    """A sanitized failure while calling the configured OSMO Gateway."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GatewayResponse:
+    """Bounded Gateway response safe for tool-specific validation."""
+
+    status_code: int
+    body: bytes = dataclasses.field(repr=False)
+
+
+class GatewayClient:
+    """Send request-scoped authenticated calls to one fixed Gateway origin."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        request_timeout_seconds: float,
+    ) -> None:
+        self._client = client
+        self._request_timeout_seconds = request_timeout_seconds
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        max_response_bytes: int,
+    ) -> GatewayResponse:
+        """Call a fixed OSMO API path with the active request's bearer header."""
+        _validate_api_path(path)
+        if max_response_bytes < 1:
+            raise ValueError('max_response_bytes must be positive.')
+
+        credentials = request_context.get_request_credentials()
+        headers = {
+            login.OSMO_AUTH_HEADER: credentials.authorization_header,
+            'User-Agent': _USER_AGENT,
+        }
+        if credentials.request_id is not None:
+            headers[login.REQUEST_ID_HEADER] = credentials.request_id
+
+        request = self._client.build_request(method, path, headers=headers)
+        # AsyncClient retains response cookies process-wide. Never let that
+        # shared state become credentials on another caller's request.
+        request.headers.pop('cookie', None)
+
+        try:
+            # HTTPX timeouts cover individual I/O phases. This outer deadline
+            # also bounds peers that continually return data without finishing.
+            async with asyncio.timeout(self._request_timeout_seconds):
+                response = await self._client.send(request, stream=True)
+                try:
+                    if not response.is_success:
+                        return GatewayResponse(response.status_code, b'')
+
+                    response_body = bytearray()
+                    async for chunk in response.aiter_bytes():
+                        if len(response_body) + len(chunk) > max_response_bytes:
+                            raise GatewayClientError(
+                                'OSMO Gateway response exceeds the size limit.')
+                        response_body.extend(chunk)
+                finally:
+                    await response.aclose()
+        except (TimeoutError, httpx.RequestError):
+            raise GatewayClientError('OSMO Gateway is unavailable.') from None
+
+        return GatewayResponse(response.status_code, bytes(response_body))
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AppContext:
+    """Process-lifetime dependencies shared by MCP tool calls."""
+
+    gateway: GatewayClient
+
+
+@contextlib.asynccontextmanager
+async def create_app_context(
+    *,
+    api_url: str,
+    request_timeout_seconds: float,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> AsyncIterator[AppContext]:
+    """Create one headerless HTTP connection pool for the MCP process."""
+    async with httpx.AsyncClient(
+        base_url=api_url,
+        follow_redirects=False,
+        timeout=httpx.Timeout(request_timeout_seconds),
+        transport=transport,
+        trust_env=False,
+    ) as client:
+        yield AppContext(
+            gateway=GatewayClient(
+                client,
+                request_timeout_seconds=request_timeout_seconds,
+            ),
+        )
+
+
+def _validate_api_path(path: str) -> None:
+    parsed_path = parse.urlsplit(path)
+    if (
+        parsed_path.scheme or
+        parsed_path.netloc or
+        parsed_path.query or
+        parsed_path.fragment or
+        not parsed_path.path.startswith('/api/')
+    ):
+        raise ValueError('Gateway requests require a relative OSMO API path.')
+
+    decoded_path = parsed_path.path
+    while True:
+        next_decoded_path = parse.unquote(decoded_path)
+        if next_decoded_path == decoded_path:
+            break
+        decoded_path = next_decoded_path
+    if (
+        '\\' in decoded_path or
+        any(segment in ('.', '..') for segment in decoded_path.split('/'))
+    ):
+        raise ValueError('Gateway requests require a relative OSMO API path.')

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -17,7 +17,11 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import asyncio
+from collections.abc import AsyncIterator, Callable
+import contextlib
+import dataclasses
 
+import httpx
 from mcp.server.fastmcp import FastMCP
 import pydantic
 from starlette.applications import Starlette
@@ -25,7 +29,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 import uvicorn  # type: ignore
 
-from src.service.mcp import request_context
+from src.service.mcp import gateway, request_context, tools as mcp_tools
 from src.utils import ssl_config, static_config
 
 
@@ -42,17 +46,57 @@ class MCPServiceConfig(static_config.StaticConfig, ssl_config.SSLConfig):
         le=65535,
         description='The TCP port to bind to when serving the MCP service.',
         json_schema_extra={'command_line': 'port', 'env': 'OSMO_MCP_PORT'})
+    api_url: pydantic.AnyHttpUrl = pydantic.Field(
+        description='HTTPS origin of the OSMO API Gateway.',
+        json_schema_extra={'env': 'OSMO_API_URL'})
+    request_timeout_seconds: float = pydantic.Field(
+        default=10,
+        gt=0,
+        le=60,
+        description='Total timeout for each OSMO Gateway request.',
+        json_schema_extra={'env': 'OSMO_MCP_REQUEST_TIMEOUT_SECONDS'})
+
+    @pydantic.model_validator(mode='after')
+    def _validate_api_url(self) -> 'MCPServiceConfig':
+        if self.api_url.scheme != 'https':
+            raise ValueError('api_url must use HTTPS.')
+        if (
+            self.api_url.username is not None or
+            self.api_url.password is not None or
+            self.api_url.query is not None or
+            self.api_url.fragment is not None or
+            self.api_url.path not in ('', '/')
+        ):
+            raise ValueError(
+                'api_url must be an HTTPS origin without credentials, path, '
+                'query, or fragment.')
+        return self
 
 
-def create_mcp_server() -> FastMCP:
-    """Create the authentication-agnostic Phase A MCP server."""
-    server = FastMCP(
+@dataclasses.dataclass
+class _AppContextHolder:
+    context: gateway.AppContext | None = None
+
+
+ServerLifespan = Callable[
+    [FastMCP[gateway.AppContext]],
+    contextlib.AbstractAsyncContextManager[gateway.AppContext],
+]
+
+
+def create_mcp_server(
+    lifespan: ServerLifespan | None = None,
+) -> FastMCP[gateway.AppContext]:
+    """Create the MCP protocol server and register its Phase B catalog."""
+    server: FastMCP[gateway.AppContext] = FastMCP(
         name='OSMO MCP',
+        tools=mcp_tools.create_tools(),
         host='0.0.0.0',
         port=8000,
         streamable_http_path='/mcp',
         stateless_http=True,
         json_response=True,
+        lifespan=lifespan,
     )
 
     @server.custom_route('/health/live', methods=['GET'], include_in_schema=False)
@@ -70,27 +114,59 @@ def create_mcp_server() -> FastMCP:
     return server
 
 
-mcp_server = create_mcp_server()
+def create_application(
+    config: MCPServiceConfig,
+    *,
+    http_transport: httpx.AsyncBaseTransport | None = None,
+) -> Starlette:
+    """Create the MCP ASGI application and process-lifetime Gateway client."""
+    context_holder = _AppContextHolder()
 
+    @contextlib.asynccontextmanager
+    async def mcp_lifespan(
+        unused_server: FastMCP[gateway.AppContext],
+    ) -> AsyncIterator[gateway.AppContext]:
+        del unused_server
+        if context_holder.context is None:
+            raise RuntimeError('MCP application lifespan is not running.')
+        yield context_holder.context
 
-def create_application(server: FastMCP | None = None) -> Starlette:
-    """Create the MCP ASGI application with request-scoped credentials."""
-    mcp_application = server if server is not None else create_mcp_server()
-    application = mcp_application.streamable_http_app()
+    mcp_server = create_mcp_server(mcp_lifespan)
+    application = mcp_server.streamable_http_app()
+
+    @contextlib.asynccontextmanager
+    async def application_lifespan(
+        unused_application: Starlette,
+    ) -> AsyncIterator[None]:
+        del unused_application
+        async with gateway.create_app_context(
+            api_url=str(config.api_url),
+            request_timeout_seconds=config.request_timeout_seconds,
+            transport=http_transport,
+        ) as app_context:
+            context_holder.context = app_context
+            try:
+                # FastMCP owns the session manager. The outer lifespan keeps
+                # the Gateway connection pool alive across stateless requests.
+                async with mcp_server.session_manager.run():
+                    yield
+            finally:
+                context_holder.context = None
+
+    application.router.lifespan_context = application_lifespan
     application.add_middleware(request_context.RequestContextMiddleware, path='/mcp')
+    application.state.mcp_server = mcp_server
     return application
-
-
-app = create_application(mcp_server)
 
 
 def main() -> None:
     """Run the MCP ASGI application with the repository's Uvicorn/TLS pattern."""
     config = MCPServiceConfig.load()
+    application = create_application(config)
 
     async def run_server() -> None:
         uvicorn_config = uvicorn.Config(
-            app,
+            application,
             host=config.host,
             port=config.port,
             log_config=None,

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -20,6 +20,17 @@ load("//bzl:py.bzl", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_test(
+    name = "test_gateway",
+    srcs = ["test_gateway.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("starlette"),
+        "//src/service/mcp:gateway",
+        "//src/service/mcp:request_context",
+    ],
+)
+
+osmo_py_test(
     name = "test_request_context",
     srcs = ["test_request_context.py"],
     deps = [
@@ -35,6 +46,16 @@ osmo_py_test(
     deps = [
         requirement("httpx"),
         requirement("mcp"),
+        requirement("pydantic"),
+        "//src/service/mcp:mcp_service_lib",
+    ],
+)
+
+osmo_py_test(
+    name = "test_tools",
+    srcs = ["test_tools.py"],
+    deps = [
+        requirement("httpx"),
         "//src/service/mcp:mcp_service_lib",
     ],
 )

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -1,0 +1,305 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+import unittest
+
+import httpx
+from starlette.responses import JSONResponse
+
+from src.service.mcp import gateway, request_context
+
+
+class _ChunkStream(httpx.AsyncByteStream):  # pylint: disable=too-few-public-methods
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+        self.was_read = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        self.was_read = True
+        for chunk in self._chunks:
+            yield chunk
+
+
+class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_request_relays_only_the_active_credentials(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, content=b'{"ok":true}')
+
+        async with gateway.create_app_context(
+            api_url='https://gateway.test',
+            request_timeout_seconds=1,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            response = await self._call_in_request(
+                app_context.gateway,
+                inbound_headers=[
+                    ('Authorization', 'Bearer caller-token'),
+                    ('x-osmo-user', 'alice@example.com'),
+                    ('x-request-id', 'request-123'),
+                    ('x-osmo-roles', 'osmo-admin'),
+                    ('Cookie', 'session=secret'),
+                    ('Origin', 'https://client.test'),
+                ],
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b'{"ok":true}')
+        self.assertEqual(len(requests), 1)
+        request = requests[0]
+        self.assertEqual(request.url, 'https://gateway.test/api/profile/settings')
+        self.assertEqual(request.headers['authorization'], 'Bearer caller-token')
+        self.assertEqual(request.headers['x-request-id'], 'request-123')
+        self.assertEqual(request.headers['user-agent'], 'osmo-mcp')
+        for header in ('x-osmo-user', 'x-osmo-roles', 'cookie', 'origin'):
+            self.assertNotIn(header, request.headers)
+
+    async def test_shared_client_has_no_default_credentials(self) -> None:
+        authorizations: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            authorizations.append(request.headers['authorization'])
+            return httpx.Response(200, content=b'{}')
+
+        async with gateway.create_app_context(
+            api_url='https://gateway.test',
+            request_timeout_seconds=1,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            self.assertNotIn(
+                'authorization',
+                app_context.gateway._client.headers,  # pylint: disable=protected-access
+            )
+            await self._call_in_request(
+                app_context.gateway,
+                inbound_headers=self._headers('token-alice', 'alice@example.com'),
+            )
+            await self._call_in_request(
+                app_context.gateway,
+                inbound_headers=self._headers('token-bob', 'bob@example.com'),
+            )
+
+        self.assertEqual(
+            authorizations,
+            ['Bearer token-alice', 'Bearer token-bob'],
+        )
+
+    async def test_shared_client_never_replays_gateway_cookies(self) -> None:
+        cookies: list[str | None] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            cookies.append(request.headers.get('cookie'))
+            return httpx.Response(
+                200,
+                headers={'Set-Cookie': 'session=upstream-secret; Path=/'},
+                content=b'{}',
+            )
+
+        async with gateway.create_app_context(
+            api_url='https://gateway.test',
+            request_timeout_seconds=1,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            await self._call_in_request(
+                app_context.gateway,
+                inbound_headers=self._headers('token-alice', 'alice@example.com'),
+            )
+            await self._call_in_request(
+                app_context.gateway,
+                inbound_headers=self._headers('token-bob', 'bob@example.com'),
+            )
+
+        self.assertEqual(cookies, [None, None])
+
+    async def test_untrusted_paths_fail_before_credentials_are_attached(self) -> None:
+        upstream_calls = 0
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal upstream_calls
+            upstream_calls += 1
+            return httpx.Response(200, content=b'{}')
+
+        invalid_paths = (
+            'https://evil.test/api/profile/settings',
+            '//evil.test/api/profile/settings',
+            '/not-api/profile',
+            '/api/profile/settings#fragment',
+            '/api/profile/settings?redirect=https://evil.test',
+            '/api/../mcp',
+            '/api/%2e%2e/mcp',
+            '/api/%252e%252e/mcp',
+            '/api/..%5cmcp',
+        )
+        async with gateway.create_app_context(
+            api_url='https://gateway.test',
+            request_timeout_seconds=1,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for path in invalid_paths:
+                with self.subTest(path=path):
+                    with self.assertRaisesRegex(ValueError, 'relative OSMO API path'):
+                        await self._call_in_request(
+                            app_context.gateway,
+                            inbound_headers=self._headers(
+                                'secret-token', 'alice@example.com'),
+                            path=path,
+                        )
+
+        self.assertEqual(upstream_calls, 0)
+
+    async def test_error_responses_are_not_followed_read_or_retried(self) -> None:
+        for status_code in (301, 401, 403, 429, 500):
+            with self.subTest(status_code=status_code):
+                requests: list[httpx.Request] = []
+                response_stream = _ChunkStream([b'upstream-secret'])
+                handler = self._error_handler(
+                    status_code, requests, response_stream)
+
+                async with gateway.create_app_context(
+                    api_url='https://gateway.test',
+                    request_timeout_seconds=1,
+                    transport=httpx.MockTransport(handler),
+                ) as app_context:
+                    response = await self._call_in_request(
+                        app_context.gateway,
+                        inbound_headers=self._headers(
+                            'caller-token', 'alice@example.com'),
+                    )
+
+                self.assertEqual(response.status_code, status_code)
+                self.assertEqual(response.body, b'')
+                self.assertEqual(len(requests), 1)
+                self.assertEqual(requests[0].url.host, 'gateway.test')
+                self.assertFalse(response_stream.was_read)
+
+    async def test_response_size_and_total_deadline_are_bounded(self) -> None:
+        def oversized_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(
+                200,
+                stream=_ChunkStream([b'secret', b'x' * 4, b'x' * 8]),
+            )
+
+        async with gateway.create_app_context(
+            api_url='https://gateway.test',
+            request_timeout_seconds=1,
+            transport=httpx.MockTransport(oversized_handler),
+        ) as app_context:
+            with self.assertRaisesRegex(gateway.GatewayClientError, 'size limit') as ctx:
+                await self._call_in_request(
+                    app_context.gateway,
+                    inbound_headers=self._headers(
+                        'caller-token', 'alice@example.com'),
+                    max_response_bytes=8,
+                )
+        self.assertNotIn('secret', str(ctx.exception))
+
+        async def slow_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            await asyncio.sleep(1)
+            return httpx.Response(200, content=b'{}')
+
+        async with gateway.create_app_context(
+            api_url='https://gateway.test',
+            request_timeout_seconds=0.01,
+            transport=httpx.MockTransport(slow_handler),
+        ) as app_context:
+            with self.assertRaisesRegex(gateway.GatewayClientError, 'unavailable'):
+                await self._call_in_request(
+                    app_context.gateway,
+                    inbound_headers=self._headers(
+                        'caller-token', 'alice@example.com'),
+                )
+
+    async def test_request_requires_an_active_mcp_context(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            self.fail('A request without MCP credentials must not reach Gateway.')
+
+        async with gateway.create_app_context(
+            api_url='https://gateway.test',
+            request_timeout_seconds=1,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(RuntimeError, 'unavailable'):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    max_response_bytes=1024,
+                )
+
+    async def _call_in_request(
+        self,
+        gateway_client: gateway.GatewayClient,
+        *,
+        inbound_headers: list[tuple[str, str]],
+        path: str = '/api/profile/settings',
+        max_response_bytes: int = 1024,
+    ) -> gateway.GatewayResponse:
+        result: gateway.GatewayResponse | None = None
+
+        async def application(scope, receive, send) -> None:
+            nonlocal result
+            result = await gateway_client.request(
+                'GET', path, max_response_bytes=max_response_bytes)
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(application)
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=middleware),
+            base_url='http://mcp.test',
+        ) as client:
+            response = await client.post('/mcp', headers=inbound_headers)
+        self.assertEqual(response.status_code, 200)
+        if result is None:
+            self.fail('Gateway request did not produce a response.')
+        return result
+
+    @staticmethod
+    def _headers(token: str, user_name: str) -> list[tuple[str, str]]:
+        return [
+            ('Authorization', f'Bearer {token}'),
+            ('x-osmo-user', user_name),
+        ]
+
+    @staticmethod
+    def _error_handler(
+        status_code: int,
+        requests: list[httpx.Request],
+        response_stream: httpx.AsyncByteStream,
+    ) -> Callable[[httpx.Request], httpx.Response]:
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(
+                status_code,
+                headers={'Location': 'https://evil.test/steal'},
+                stream=response_stream,
+            )
+
+        return handler
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -22,14 +22,18 @@ from unittest import mock
 
 import httpx
 from mcp.types import LATEST_PROTOCOL_VERSION
+import pydantic
 
 from src.service.mcp import server
 
 
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
+    def setUp(self) -> None:
+        self.config = server.MCPServiceConfig(api_url='https://gateway.test')
+
     async def test_health_endpoints(self) -> None:
-        application = server.create_application()
+        application = server.create_application(self.config)
         async with application.router.lifespan_context(application):
             async with httpx.AsyncClient(
                     transport=httpx.ASGITransport(app=application),
@@ -45,13 +49,13 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ready_response.status_code, 200)
         self.assertEqual(ready_response.json(), {'status': 'ok'})
 
-    async def test_initialize_and_empty_tool_catalog(self) -> None:
-        mcp_server = server.create_mcp_server()
+    async def test_initialize_and_profile_tool_catalog(self) -> None:
+        application = server.create_application(self.config)
+        mcp_server = application.state.mcp_server
         self.assertTrue(mcp_server.settings.stateless_http)
         self.assertTrue(mcp_server.settings.json_response)
         self.assertEqual(mcp_server.settings.streamable_http_path, '/mcp')
 
-        application = server.create_application(mcp_server)
         headers = {
             'Accept': 'application/json, text/event-stream',
             'Authorization': 'Bearer test-token',
@@ -101,7 +105,24 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn('mcp-session-id', initialize_response.headers)
         self.assertEqual(initialized_response.status_code, 202)
         self.assertEqual(list_tools_response.status_code, 200)
-        self.assertEqual(list_tools_response.json()['result']['tools'], [])
+        tools = list_tools_response.json()['result']['tools']
+        self.assertEqual([tool['name'] for tool in tools], ['get_current_profile'])
+        self.assertEqual(tools[0]['inputSchema']['properties'], {})
+        self.assertIs(tools[0]['inputSchema']['additionalProperties'], False)
+
+    def test_runtime_config_requires_an_https_gateway_origin(self) -> None:
+        invalid_urls = (
+            'http://gateway.test',
+            'https://user@gateway.test',
+            'https://gateway.test/api',
+            'https://gateway.test?query=value',
+            'https://gateway.test#fragment',
+        )
+
+        for api_url in invalid_urls:
+            with self.subTest(api_url=api_url):
+                with self.assertRaises(pydantic.ValidationError):
+                    server.MCPServiceConfig(api_url=api_url)
 
 
 class MCPMainTest(unittest.TestCase):
@@ -114,12 +135,16 @@ class MCPMainTest(unittest.TestCase):
                 return_value={'ssl_certfile': '/tmp/mcp-cert.pem'}),
         )
         uvicorn_config = object()
+        application = object()
         uvicorn_server = mock.Mock()
         uvicorn_server.serve = mock.AsyncMock()
 
         with (
             mock.patch.object(
                 server.MCPServiceConfig, 'load', return_value=config),
+            mock.patch.object(
+                server, 'create_application', return_value=application,
+            ) as application_factory,
             mock.patch.object(
                 server.uvicorn,
                 'Config',
@@ -134,7 +159,7 @@ class MCPMainTest(unittest.TestCase):
             server.main()
 
         config_factory.assert_called_once_with(
-            server.app,
+            application,
             host='127.0.0.1',
             port=9000,
             log_config=None,
@@ -143,6 +168,7 @@ class MCPMainTest(unittest.TestCase):
         server_factory.assert_called_once_with(config=uvicorn_config)
         uvicorn_server.serve.assert_awaited_once_with()
         config.uvicorn_ssl_kwargs.assert_called_once_with()
+        application_factory.assert_called_once_with(config)
 
     def test_main_handles_keyboard_interrupt(self) -> None:
         config = types.SimpleNamespace(
@@ -156,6 +182,7 @@ class MCPMainTest(unittest.TestCase):
         with (
             mock.patch.object(
                 server.MCPServiceConfig, 'load', return_value=config),
+            mock.patch.object(server, 'create_application', return_value=object()),
             mock.patch.object(server.uvicorn, 'Config', return_value=object()),
             mock.patch.object(
                 server.uvicorn,

--- a/src/service/mcp/tests/test_tools.py
+++ b/src/service/mcp/tests/test_tools.py
@@ -1,0 +1,363 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from collections.abc import Callable, Coroutine
+import unittest
+
+import httpx
+
+from src.service.mcp import server
+
+
+GatewayHandler = (
+    Callable[[httpx.Request], httpx.Response] |
+    Callable[[httpx.Request], Coroutine[None, None, httpx.Response]]
+)
+_TEST_TIMEOUT_SECONDS = 1
+
+
+class MCPToolsTest(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self) -> None:
+        self.config = server.MCPServiceConfig(
+            api_url='https://gateway.test',
+            request_timeout_seconds=1,
+        )
+
+    async def test_profile_relays_exact_token_and_returns_safe_fields(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return self._profile_response('alice@example.com')
+
+        response = await self._call_tool(
+            handler,
+            token='caller-token',
+            user_name='alice@example.com',
+            request_id='request-123',
+        )
+
+        self.assertFalse(response.json()['result']['isError'])
+        self.assertEqual(
+            response.json()['result']['structuredContent'],
+            {
+                'username': 'alice@example.com',
+                'email_notification': False,
+                'slack_notification': False,
+                'pool': None,
+                'roles': ['osmo-user'],
+                'pools': ['default'],
+            },
+        )
+        self.assertEqual(len(requests), 1)
+        request = requests[0]
+        self.assertEqual(request.method, 'GET')
+        self.assertEqual(request.url, 'https://gateway.test/api/profile/settings')
+        self.assertEqual(request.headers['authorization'], 'Bearer caller-token')
+        self.assertEqual(request.headers['x-request-id'], 'request-123')
+        self.assertEqual(request.headers['user-agent'], 'osmo-mcp')
+        for header in ('x-osmo-user', 'x-osmo-roles', 'cookie', 'origin'):
+            self.assertNotIn(header, request.headers)
+        self.assertNotIn('caller-token', response.text)
+        self.assertNotIn('token-name-not-exposed', response.text)
+
+    async def test_profile_authentication_and_permission_errors_are_not_retried(self) -> None:
+        cases = (
+            (401, 'OSMO authentication was rejected.'),
+            (403, 'OSMO denied access to the current profile.'),
+        )
+        for status_code, expected_error in cases:
+            with self.subTest(status_code=status_code):
+                requests: list[httpx.Request] = []
+                handler = self._status_handler(status_code, requests)
+
+                response = await self._call_tool(
+                    handler,
+                    token='caller-secret-token',
+                    user_name='alice@example.com',
+                )
+
+                self._assert_tool_error(response, expected_error)
+                self.assertEqual(len(requests), 1)
+                self.assertNotIn('upstream-secret', response.text)
+                self.assertNotIn('caller-secret-token', response.text)
+
+    async def test_profile_rejects_mismatched_or_malformed_gateway_data(self) -> None:
+        invalid_responses = (
+            self._profile_response('bob@example.com'),
+            httpx.Response(200, json={
+                'profile': {
+                    'username': 'alice@example.com',
+                    'email_notification': 'false',
+                    'slack_notification': False,
+                    'pool': None,
+                },
+                'roles': ['osmo-user'],
+                'pools': [],
+                'token': None,
+            }),
+            httpx.Response(200, text='not-json-secret'),
+        )
+
+        for invalid_response in invalid_responses:
+            with self.subTest(body=invalid_response.text[:80]):
+                def handler(
+                    request: httpx.Request,
+                    response: httpx.Response = invalid_response,
+                ) -> httpx.Response:
+                    del request
+                    return response
+
+                response = await self._call_tool(
+                    handler,
+                    token='caller-token',
+                    user_name='alice@example.com',
+                )
+                self._assert_tool_error(
+                    response, 'Unable to retrieve the current OSMO profile.')
+                self.assertNotIn('not-json-secret', response.text)
+
+    async def test_profile_response_size_and_deadline_are_bounded(self) -> None:
+        def oversized_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(
+                200,
+                content=b'oversized-secret' + b'x' * (128 * 1024),
+            )
+
+        response = await self._call_tool(
+            oversized_handler,
+            token='caller-token',
+            user_name='alice@example.com',
+        )
+        self._assert_tool_error(
+            response, 'Unable to retrieve the current OSMO profile.')
+        self.assertNotIn('oversized-secret', response.text)
+
+        async def slow_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            await asyncio.sleep(1)
+            return self._profile_response('alice@example.com')
+
+        short_timeout_config = server.MCPServiceConfig(
+            api_url='https://gateway.test',
+            request_timeout_seconds=0.01,
+        )
+        response = await self._call_tool(
+            slow_handler,
+            token='caller-token',
+            user_name='alice@example.com',
+            config=short_timeout_config,
+        )
+        self._assert_tool_error(
+            response, 'Unable to retrieve the current OSMO profile.')
+
+    async def test_profile_transport_errors_do_not_expose_request_details(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError('transport-secret', request=request)
+
+        response = await self._call_tool(
+            handler,
+            token='caller-secret-token',
+            user_name='alice@example.com',
+        )
+
+        self._assert_tool_error(
+            response, 'Unable to retrieve the current OSMO profile.')
+        self.assertNotIn('transport-secret', response.text)
+        self.assertNotIn('caller-secret-token', response.text)
+
+    async def test_tool_rejects_undeclared_identity_input(self) -> None:
+        requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return self._profile_response('alice@example.com')
+
+        response = await self._call_tool(
+            handler,
+            token='caller-token',
+            user_name='alice@example.com',
+            arguments={'username': 'bob@example.com'},
+        )
+
+        self._assert_tool_error(response, 'Error executing tool get_current_profile')
+        self.assertEqual(requests, [])
+
+    async def test_concurrent_tool_calls_keep_tokens_and_users_isolated(self) -> None:
+        both_started = asyncio.Event()
+        requests: list[tuple[str, str]] = []
+        started_count = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal started_count
+            authorization = request.headers['authorization']
+            request_id = request.headers['x-request-id']
+            requests.append((authorization, request_id))
+            started_count += 1
+            if started_count == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), _TEST_TIMEOUT_SECONDS)
+            user_name = (
+                'alice@example.com'
+                if authorization == 'Bearer token-alice'
+                else 'bob@example.com'
+            )
+            return self._profile_response(user_name)
+
+        application = server.create_application(
+            self.config,
+            http_transport=httpx.MockTransport(handler),
+        )
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                responses = await asyncio.gather(
+                    client.post(
+                        '/mcp',
+                        headers=self._headers(
+                            'token-alice', 'alice@example.com', 'request-alice'),
+                        json=self._tool_request(1, {}),
+                    ),
+                    client.post(
+                        '/mcp',
+                        headers=self._headers(
+                            'token-bob', 'bob@example.com', 'request-bob'),
+                        json=self._tool_request(2, {}),
+                    ),
+                )
+
+        profiles = {
+            response.json()['result']['structuredContent']['username']
+            for response in responses
+        }
+        self.assertEqual(profiles, {'alice@example.com', 'bob@example.com'})
+        self.assertEqual(
+            set(requests),
+            {
+                ('Bearer token-alice', 'request-alice'),
+                ('Bearer token-bob', 'request-bob'),
+            },
+        )
+        for response in responses:
+            self.assertNotIn('token-alice', response.text)
+            self.assertNotIn('token-bob', response.text)
+
+    async def _call_tool(
+        self,
+        handler: GatewayHandler,
+        *,
+        token: str,
+        user_name: str,
+        request_id: str | None = None,
+        arguments: dict[str, object] | None = None,
+        config: server.MCPServiceConfig | None = None,
+    ) -> httpx.Response:
+        application = server.create_application(
+            config or self.config,
+            http_transport=httpx.MockTransport(handler),
+        )
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                return await client.post(
+                    '/mcp',
+                    headers=self._headers(token, user_name, request_id),
+                    json=self._tool_request(1, arguments or {}),
+                )
+
+    @staticmethod
+    def _headers(
+        token: str,
+        user_name: str,
+        request_id: str | None = None,
+    ) -> list[tuple[str, str]]:
+        headers = [
+            ('Accept', 'application/json, text/event-stream'),
+            ('Content-Type', 'application/json'),
+            ('Authorization', f'Bearer {token}'),
+            ('x-osmo-user', user_name),
+            ('x-osmo-roles', 'untrusted-client-role'),
+            ('Cookie', 'untrusted-client-cookie'),
+            ('Origin', 'https://client.test'),
+        ]
+        if request_id is not None:
+            headers.append(('x-request-id', request_id))
+        return headers
+
+    @staticmethod
+    def _tool_request(
+        request_id: int,
+        arguments: dict[str, object],
+    ) -> dict[str, object]:
+        return {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'method': 'tools/call',
+            'params': {
+                'name': 'get_current_profile',
+                'arguments': arguments,
+            },
+        }
+
+    @staticmethod
+    def _profile_response(user_name: str) -> httpx.Response:
+        return httpx.Response(200, json={
+            'profile': {
+                'username': user_name,
+                'email_notification': False,
+                'slack_notification': False,
+                'pool': None,
+            },
+            'roles': ['osmo-user'],
+            'pools': ['default'],
+            'token': {
+                'name': 'token-name-not-exposed',
+                'expires_at': None,
+            },
+        })
+
+    @staticmethod
+    def _status_handler(
+        status_code: int,
+        requests: list[httpx.Request],
+    ) -> Callable[[httpx.Request], httpx.Response]:
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(status_code, text='upstream-secret')
+
+        return handler
+
+    def _assert_tool_error(
+        self,
+        response: httpx.Response,
+        expected_error: str,
+    ) -> None:
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn(expected_error, response.text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tools.py
+++ b/src/service/mcp/tools.py
@@ -1,0 +1,147 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import datetime
+
+from mcp import types as mcp_types
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.server.fastmcp.tools import Tool
+import pydantic
+
+from src.service.mcp import gateway, request_context
+
+
+_PROFILE_PATH = '/api/profile/settings'
+_MAX_PROFILE_RESPONSE_BYTES = 128 * 1024
+_PROFILE_ERROR = 'Unable to retrieve the current OSMO profile.'
+_PROFILE_AUTH_ERROR = 'OSMO authentication was rejected. Reauthenticate and try again.'
+_PROFILE_PERMISSION_ERROR = 'OSMO denied access to the current profile.'
+
+
+class CurrentProfile(pydantic.BaseModel):
+    """Safe subset of the signed-in user's OSMO profile."""
+
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    username: str
+    email_notification: bool | None
+    slack_notification: bool | None
+    pool: str | None
+    roles: list[str]
+    pools: list[str]
+
+
+class _ProfileSettings(pydantic.BaseModel):
+    """Strict profile fields expected from the existing OSMO API."""
+
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    username: str
+    email_notification: bool | None
+    slack_notification: bool | None
+    pool: str | None
+
+
+class _TokenIdentity(pydantic.BaseModel):
+    """Identity metadata returned by Core but never exposed by the MCP tool."""
+
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    name: str
+    expires_at: datetime.datetime | None
+
+
+class _ProfileResponse(pydantic.BaseModel):
+    """Strict response contract for the existing profile endpoint."""
+
+    model_config = pydantic.ConfigDict(extra='forbid', strict=True)
+
+    profile: _ProfileSettings
+    roles: list[str]
+    pools: list[str]
+    token: _TokenIdentity | None = None
+
+
+def create_tools() -> list[Tool]:
+    """Create the Phase B OSMO MCP tool catalog."""
+    profile_tool = Tool.from_function(
+        get_current_profile,
+        name='get_current_profile',
+        title='Get Current OSMO Profile',
+        description=(
+            'Return the authenticated user\'s OSMO profile, roles, and accessible '
+            'pools. Identity and permissions come from the OSMO Gateway.'),
+        annotations=mcp_types.ToolAnnotations(
+            # The existing GET endpoint may initialize a missing default profile.
+            readOnlyHint=False,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+
+    # FastMCP has no public strict-arguments switch and ignores extras by
+    # default. Tighten its generated model so schema and runtime both reject
+    # caller-supplied identity fields.
+    argument_model = profile_tool.fn_metadata.arg_model
+    argument_model.model_config['extra'] = 'forbid'
+    argument_model.model_rebuild(force=True)
+    profile_tool.parameters = argument_model.model_json_schema(by_alias=True)
+    return [profile_tool]
+
+
+async def get_current_profile(context: Context) -> CurrentProfile:
+    """Return the signed-in caller's profile through the OSMO Gateway."""
+    app_context = context.request_context.lifespan_context
+    if not isinstance(app_context, gateway.AppContext):
+        raise ToolError(_PROFILE_ERROR) from None
+
+    credentials = request_context.get_request_credentials()
+    try:
+        response = await app_context.gateway.request(
+            'GET',
+            _PROFILE_PATH,
+            max_response_bytes=_MAX_PROFILE_RESPONSE_BYTES,
+        )
+    except (gateway.GatewayClientError, ValueError):
+        raise ToolError(_PROFILE_ERROR) from None
+
+    if response.status_code == 401:
+        raise ToolError(_PROFILE_AUTH_ERROR) from None
+    if response.status_code == 403:
+        raise ToolError(_PROFILE_PERMISSION_ERROR) from None
+    if response.status_code != 200:
+        raise ToolError(_PROFILE_ERROR) from None
+
+    try:
+        profile_response = _ProfileResponse.model_validate_json(response.body)
+    except (ValueError, pydantic.ValidationError):
+        raise ToolError(_PROFILE_ERROR) from None
+
+    if profile_response.profile.username != credentials.user_name:
+        raise ToolError(_PROFILE_ERROR) from None
+
+    return CurrentProfile(
+        username=profile_response.profile.username,
+        email_notification=profile_response.profile.email_notification,
+        slack_notification=profile_response.profile.slack_notification,
+        pool=profile_response.profile.pool,
+        roles=profile_response.roles,
+        pools=profile_response.pools,
+    )


### PR DESCRIPTION
## Description

PR 2 of 3 for the redesigned MCP Phase B. This PR is stacked on #1181; its base will move to `feature/mcp` after the request-context PR merges.

Adds bearer-token relay for the first production MCP tool, `get_current_profile`. The MCP service reuses the bearer authenticated by the OSMO Gateway for the active request and calls the existing `GET /api/profile/settings` endpoint. The Phase A OAuth flow remains the supported client path; Phase B deliberately accepts the Gateway-validated bearer it receives and does not decode the token or select an identity provider itself.

The downstream client is shared for connection pooling but stores no default credentials. Each call attaches only the active request's Authorization header, optional request ID, and a fixed user agent. It uses one HTTPS Gateway origin derived from `services.mcp.resourceUrl`, rejects absolute, query-bearing, and traversal paths, disables redirects and environment proxies, never replays cookies, preserves normal TLS verification, applies a total deadline and response-size limit, and does not retry authenticated requests.

The profile tool accepts no identity input, returns only the profile, roles, and pools of the authenticated caller, verifies the returned username against the Gateway-owned request context, and sanitizes upstream failures. Helm injects the derived `OSMO_API_URL` and always renders a NetworkPolicy limiting MCP ingress to Gateway Envoy pods; the deployment CNI must enforce Kubernetes NetworkPolicy.

This PR does not add token exchange, OBO, service users, service-token Secrets, token minting, token caches, custom CA handling, or new Core APIs.

The implementation and tests are separate commits for review. Coverage includes exact header relay, concurrent and sequential caller isolation, cookie isolation, fixed-origin and path enforcement, redirects, retries, timeouts, cumulative response limits, unread error bodies, transport-error redaction, strict zero-input behavior, malformed and mismatched profile payloads, safe output fields, runtime configuration, and the MCP tool catalog.

## Validation

- `bazel test //src/service/mcp/tests/... //src/service/mcp:gateway-pylint //src/service/mcp:tools-pylint //src/service/mcp:mcp_service_lib-pylint`
- `bazel build //src/service/mcp:mcp_binary`
- `helm lint deployments/charts/service`
- MCP-enabled Helm lint/template with a valid Phase A JWT configuration
- Render verification for the derived API origin and unconditional Gateway-only MCP NetworkPolicy
- Bazel Mypy aspects for the MCP library and test targets
- `git diff --check`

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
