### PR TITLE
Document and validate MCP token relay

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -371,6 +371,30 @@ Envoy uses filesystem-based dynamic configuration (LDS/CDS). When the ConfigMap 
 | `gateway.upstreams.logger.host` | osmo-logger K8s DNS name | `osmo-logger` |
 | `gateway.upstreams.logger.port` | osmo-logger port | `80` |
 
+#### Self-hosted MCP
+
+The optional MCP workload reuses Gateway authentication and OSMO RBAC. The
+Gateway forwards the bearer it validated for `/mcp`; MCP binds it to the active
+request and uses it only for fixed-origin calls back through the Gateway. MCP
+does not exchange, mint, refresh, cache, or persist tokens, and the chart does
+not create a service user or credential Secret.
+
+The downstream API origin is derived from `services.mcp.resourceUrl`, so there
+is no separate API URL value. Enabling MCP always renders a NetworkPolicy that
+permits ingress only from Gateway Envoy pods. The cluster CNI must enforce
+Kubernetes NetworkPolicy for that boundary to be effective.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `services.mcp.enabled` | Deploy the MCP workload and Gateway routes. | `false` |
+| `services.mcp.resourceUrl` | External HTTPS MCP resource URL ending in `/mcp`; its origin is reused for downstream OSMO API calls. | `""` |
+| `services.mcp.authorizationServers` | OAuth issuer identifiers advertised by protected-resource discovery. | `[]` |
+| `services.mcp.scopes` | OAuth scopes advertised to MCP clients. | `[]` |
+| `services.mcp.allowedOrigins` | Browser Origins allowed to call `/mcp`; native clients may omit Origin. | `[]` |
+| `services.mcp.imageName` | MCP image name. | `mcp-self-hosted` |
+| `services.mcp.imageTag` | MCP image tag override; empty uses `global.osmoImageTag`. | `""` |
+| `services.mcp.replicas` | MCP Deployment replica count. | `1` |
+
 #### Gateway OAuth2 Proxy
 
 When enabled, the gateway exposes `/signout` and redirects it to `/oauth2/sign_out`. If `services.service.auth.logout_endpoint` is set, the gateway includes it as OAuth2 Proxy's `rd` target so logout clears both the local session cookie and the IDP SSO session. The IDP logout host must be allowed by `gateway.oauth2Proxy.extraArgs`, for example with `--whitelist-domain=<idp-domain>`.
@@ -415,6 +439,11 @@ The chart does not create Redis credentials. Secret controllers such as External
 | `gateway.rateLimit.extraEnv` | Additional rate-limit container environment variables, including Secret references such as `REDIS_AUTH` | `[]` |
 
 #### Network Policies
+
+`gateway.networkPolicies.enabled` controls the general upstream policies in
+`gateway.networkPolicies.upstreams`. The MCP policy is separate and is always
+rendered when `services.mcp.enabled=true`, because direct MCP access would
+bypass the Gateway's `mcp:Access`, Origin, and rate-limit checks.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -151,8 +151,8 @@ services:
     authorizationServers: []
 
     ## OAuth scopes requested by MCP clients. These values are advertised as
-    ## scopes_supported in RFC 9728 protected-resource metadata and should
-    ## include the delegated scope required to access this MCP resource.
+    ## scopes_supported in RFC 9728 protected-resource metadata. Include the
+    ## resource-qualified access scope required by the configured IdP.
     ##
     scopes: []
 

--- a/docs/deployment_guide/getting_started/deploy_service.rst
+++ b/docs/deployment_guide/getting_started/deploy_service.rst
@@ -688,6 +688,51 @@ Step 7: Post-deployment Configuration
    options apply only to this command; they do not modify ``config.toml`` or
    other MCPs. MCP Inspector uses a separate callback URI.
 
+6. Verify the combined MCP authentication and token-relay flow.
+
+   After the Gateway accepts and authorizes a bearer for ``/mcp``, MCP binds
+   that exact bearer to the current request and uses it only for calls back
+   through the same Gateway origin. The downstream Gateway validates it again,
+   and existing OSMO RBAC remains authoritative. No MCP service user, service
+   token Secret, token exchange, or token cache is required.
+
+   First confirm that the workload, Service, and Gateway-only ingress policy
+   exist and that the Deployment is ready:
+
+   .. code-block:: bash
+
+      $ kubectl get deployment/osmo-mcp service/osmo-mcp \
+          networkpolicy/osmo-mcp-allow-gateway-envoy -n <namespace>
+      $ kubectl rollout status deployment/osmo-mcp -n <namespace>
+
+   Run the focused OETF smoke test against an environment configured with MCP
+   and token authentication:
+
+   .. code-block:: bash
+
+      $ bazel run //test/oetf:run -- \
+          --env <configured-environment> \
+          --name test_profile_tool_relays_authenticated_identity
+
+   The test retrieves the caller's existing ``/api/profile/settings`` response,
+   calls the MCP ``get_current_profile`` tool, and requires the safe profile,
+   role, and pool fields to match exactly. It therefore exercises the Phase A
+   Gateway route and the Phase B downstream relay in one deployed test.
+
+   To verify the browser OAuth experience, start MCP Inspector:
+
+   .. code-block:: bash
+
+      $ npx @modelcontextprotocol/inspector
+
+   In the Inspector UI, choose Streamable HTTP, enter
+   ``https://osmo.example.com/mcp``, connect, and complete the browser login
+   using the callback registered for Inspector. List tools, select
+   ``get_current_profile``, and run it with no input. The result must contain
+   the signed-in username plus that user's OSMO roles and allowed pools, and it
+   must not contain a token. An expired or unauthorized bearer must fail rather
+   than falling back to a service identity.
+
 
 Troubleshooting
 ===============

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -292,6 +292,7 @@ stateful
 stderr
 stdin
 stdout
+Streamable
 sts
 subfolder
 subnet

--- a/test/smoke/BUILD
+++ b/test/smoke/BUILD
@@ -33,6 +33,12 @@ oetf_smoke_test(
 )
 
 oetf_smoke_test(
+    name = "mcp-checks",
+    src = "mcp_checks.py",
+    tags = ["auth", "mcp"],
+)
+
+oetf_smoke_test(
     name = "websocket-checks",
     src = "websocket_checks.py",
     tags = ["websocket", "kind"],

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -1,0 +1,64 @@
+"""
+Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+NVIDIA CORPORATION and its licensors retain all intellectual property
+and proprietary rights in and to this software, related documentation
+and any modifications thereto. Any use, reproduction, disclosure or
+distribution of this software and related documentation without an express
+license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""
+
+# Smoke: the MCP profile tool relays the authenticated OSMO caller.
+
+import unittest
+
+from src.lib.utils.client import RequestMethod
+from test.oetf.smoke_fixture import SmokeFixture
+
+
+class McpChecks(SmokeFixture):
+    """Validate the deployed Gateway-to-MCP-to-OSMO authentication path."""
+
+    def test_profile_tool_relays_authenticated_identity(self):
+        api_profile = self.http(
+            "GET", "/api/profile/settings"
+        ).expect_body_contains("profile")
+        user_name = api_profile["profile"]["username"]
+        self.assertIsInstance(user_name, str)
+        self.assertTrue(user_name)
+
+        mcp_response = self.service_client.request(
+            method=RequestMethod.POST,
+            endpoint="mcp",
+            headers={"Accept": "application/json, text/event-stream"},
+            payload={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "get_current_profile",
+                    "arguments": {},
+                },
+            },
+            version_header=False,
+        )
+
+        self.assertIsInstance(mcp_response, dict)
+        result = mcp_response.get("result")
+        self.assertIsInstance(result, dict)
+        self.assertFalse(result.get("isError"), mcp_response)
+
+        expected_profile = {
+            "username": user_name,
+            "email_notification": api_profile["profile"]["email_notification"],
+            "slack_notification": api_profile["profile"]["slack_notification"],
+            "pool": api_profile["profile"]["pool"],
+            "roles": api_profile["roles"],
+            "pools": api_profile["pools"],
+        }
+        self.assertEqual(result.get("structuredContent"), expected_profile)
+        self.assertNotIn("token", result["structuredContent"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

PR 3 of 3 for the redesigned MCP Phase B. This PR is stacked on #1182; its base will move to `feature/mcp` after the relay implementation PR merges.

Adds an authenticated OETF smoke test for the combined Phase A and Phase B path. The test uses one signed-in OSMO caller to read `GET /api/profile/settings`, invokes the MCP `get_current_profile` tool, and requires the safe profile, role, and pool fields to match exactly. It also verifies that MCP never returns a token. Removing the outbound Authorization relay makes this test fail at downstream authentication, so the assertion is load-bearing for the new design.

Updates the service chart reference and deployment guide to document request-scoped bearer relay, the API origin derived from `services.mcp.resourceUrl`, the unconditional Gateway-only MCP ingress NetworkPolicy, CNI enforcement, and the end-to-end validation flow. The documentation removes the former OBO setup and aligns Phases A-D with the implemented relay architecture.

This PR does not change production runtime behavior. It does not add OBO, token exchange, a service identity, credential Secret, token minting, token caching, custom CA configuration, or a new Core API.

End-to-end OETF execution is required for the combined B3 head before merge; this PR documents the expected validation flow.

## Validation

- `bazel test //test/smoke:mcp-checks-pylint`
- `bazel build //test/smoke:mcp-checks`
- `helm lint deployments/charts/service`
- MCP-enabled Helm lint with a valid Phase A JWT configuration
- `make -C docs build` with empty Sphinx warning logs
- `make -C docs spelling` with an empty spelling warning log
- `git diff --check`

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
