### PR TITLE
Add Phase B MCP request relay

### DIFF
--- a/.github/workflows/helm-chart-lint.yaml
+++ b/.github/workflows/helm-chart-lint.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -123,3 +123,6 @@ jobs:
           fi
           echo "✓ Template rendering successful"
 
+      - name: Validate MCP-enabled service chart
+        if: matrix.chart == 'service'
+        run: bash deployments/charts/service/ci/validate-mcp-chart.sh

--- a/deployments/charts/service/.helmignore
+++ b/deployments/charts/service/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# Chart validation fixtures and scripts
+ci/

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -69,6 +69,56 @@ See [../README.md](../README.md) for the full two-chart flow.
 | `services.configs.enabled` | Enable ConfigMap-backed dynamic configuration | `false` |
 | `services.configs.extraAnnotations` | Annotations on the generated configs ConfigMap (e.g., ArgoCD sync options) | `{}` |
 
+### Self-hosted MCP service
+
+The optional MCP workload exposes predefined OSMO operations to compatible
+native or desktop MCP clients. The Gateway authenticates and authorizes every
+`/mcp` request, and the MCP service relays the unchanged caller bearer through
+the same Gateway for each mapped OSMO API request. The second Gateway pass
+applies the API-specific action; `mcp:Access` alone grants no API permission.
+
+`services.mcp.resourceUrl` is the single source of truth for the public MCP
+resource and the outbound Gateway origin. It must be an externally reachable
+HTTPS URL with the exact `/mcp` path. For example,
+`https://osmo.example.com/mcp` produces the fixed outbound origin
+`https://osmo.example.com`. The MCP pod must be able to resolve and reach that
+public origin, and operators must ensure its DNS and routing lead to this
+release's Gateway. Derivation removes a second independently configured
+destination, but it cannot validate external DNS.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `services.mcp.enabled` | Deploy the MCP workload and Gateway routes. | `false` |
+| `services.mcp.resourceUrl` | Canonical public HTTPS MCP URL ending in exact `/mcp`; also determines the fixed outbound Gateway origin. | `""` |
+| `services.mcp.authorizationServers` | OAuth/OIDC issuer identifiers advertised in protected-resource metadata. At least one is required when enabled. | `[]` |
+| `services.mcp.scopes` | OAuth scopes advertised in protected-resource metadata. | `[]` |
+| `services.mcp.allowedOrigins` | Exact browser origins permitted on `/mcp`; native clients normally omit `Origin`. | `[]` |
+| `services.mcp.requestTimeoutSeconds` | Total timeout for each MCP-initiated Gateway request, from 1 through 60 seconds. | `10` |
+| `services.mcp.replicas` | Number of stateless MCP replicas. | `1` |
+| `services.mcp.extraEnv` | Additional non-managed environment variables. It cannot override MCP host, port, Gateway origin, or request timeout. | `[]` |
+
+Enabling MCP always renders an ingress NetworkPolicy whose allow rule selects
+only this release's Gateway Envoy pods, even when
+`gateway.networkPolicies.enabled` is false for other upstreams. This is
+required because MCP trusts the identity context created by Gateway.
+NetworkPolicies require enforcement by the cluster CNI and are additive, so
+operators must also ensure no other policy grants MCP ingress. The pod does
+not mount a service-account token, and the chart creates no MCP credential
+Secret. Gateway-to-MCP TLS continues to use the shared `gateway.tls`
+configuration described below.
+
+The current `osmo_get_profile` tool maps only to
+`GET /api/profile/settings`, accepts no caller-selected route or headers, and
+requires `profile:Read`. MCP health probes do not call this API; a tool-level
+authentication, authorization, timeout, or dependency error does not by
+itself make the pod unhealthy.
+
+Run the enabled and disabled rendering checks locally with:
+
+```bash
+bash deployments/charts/service/ci/validate-mcp-chart.sh
+```
+
 ### Database Migration Settings (pgroll)
 
 | Parameter | Description | Default |

--- a/deployments/charts/service/ci/mcp-values.yaml
+++ b/deployments/charts/service/ci/mcp-values.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Synthetic values used only to validate the optional MCP chart surface.
+services:
+  mcp:
+    enabled: true
+    resourceUrl: https://osmo.example.com/mcp
+    authorizationServers:
+    - https://issuer.example.com
+    scopes:
+    - mcp:Access
+
+gateway:
+  # MCP remains isolated even when policies for other upstreams are disabled.
+  networkPolicies:
+    enabled: false
+  envoy:
+    idp:
+      host: issuer.example.com
+    jwt:
+      providers:
+      - issuer: https://issuer.example.com
+        audience: osmo-mcp
+        jwks_uri: https://issuer.example.com/.well-known/jwks.json
+        cluster: idp
+        user_claim: preferred_username

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -135,4 +135,15 @@ expect_render_failure \
   'overlaps a protected MCP path' \
   --set 'gateway.envoy.extraSkipAuthPaths[0]=/mcp'
 
+expect_render_failure \
+  'query-prefixed MCP authentication bypass' \
+  'overlaps a protected MCP path' \
+  --set-string 'gateway.envoy.extraSkipAuthPaths[0]=/mcp?bypass=true'
+
+expect_render_failure \
+  'query-prefixed MCP metadata authentication bypass' \
+  'overlaps a protected MCP path' \
+  --set-string \
+  'gateway.envoy.extraSkipAuthPaths[0]=/.well-known/oauth-protected-resource/mcp?bypass=true'
+
 echo 'MCP chart validation passed'

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(dirname -- "$SCRIPT_DIR")"
+VALUES_FILE="$SCRIPT_DIR/mcp-values.yaml"
+RENDERED_MANIFEST="$(mktemp)"
+MCP_MANIFEST="$(mktemp)"
+DISABLED_MANIFEST="$(mktemp)"
+trap 'rm -f "$RENDERED_MANIFEST" "$MCP_MANIFEST" "$DISABLED_MANIFEST"' EXIT
+
+fail() {
+  echo "MCP chart validation failed: $*" >&2
+  exit 1
+}
+
+assert_rendered() {
+  local expected="$1"
+  grep -F -- "$expected" "$RENDERED_MANIFEST" >/dev/null || \
+    fail "rendered manifest is missing: $expected"
+}
+
+assert_mcp_rendered() {
+  local expected="$1"
+  grep -F -- "$expected" "$MCP_MANIFEST" >/dev/null || \
+    fail "rendered MCP manifest is missing: $expected"
+}
+
+assert_env_value() {
+  local name="$1"
+  local value="$2"
+  grep -A1 -F -- "name: $name" "$MCP_MANIFEST" | \
+    grep -F -- "value: \"$value\"" >/dev/null || \
+    fail "managed environment variable $name does not equal $value"
+}
+
+expect_render_failure() {
+  local description="$1"
+  local expected_error="$2"
+  shift 2
+
+  local output
+  if output=$(helm template mcp-validation "$CHART_DIR" \
+      --values "$VALUES_FILE" "$@" 2>&1); then
+    fail "$description unexpectedly rendered successfully"
+  fi
+  case "$output" in
+    *"$expected_error"*) ;;
+    *) fail "$description returned an unexpected error: $output" ;;
+  esac
+}
+
+helm lint "$CHART_DIR" --values "$VALUES_FILE"
+helm template mcp-disabled "$CHART_DIR" >"$DISABLED_MANIFEST"
+helm template mcp-validation "$CHART_DIR" \
+  --values "$VALUES_FILE" >"$RENDERED_MANIFEST"
+helm template mcp-validation "$CHART_DIR" \
+  --values "$VALUES_FILE" \
+  --show-only templates/mcp-service.yaml >"$MCP_MANIFEST"
+
+for forbidden in \
+    'name: osmo-mcp' \
+    'cluster: osmo-mcp' \
+    'path: /mcp' \
+    'path: /.well-known/oauth-protected-resource/mcp'; do
+  if grep -F -- "$forbidden" "$DISABLED_MANIFEST" >/dev/null; then
+    fail "disabled mode rendered MCP configuration: $forbidden"
+  fi
+done
+
+assert_mcp_rendered 'kind: Deployment'
+assert_mcp_rendered 'kind: Service'
+assert_mcp_rendered 'name: osmo-mcp'
+assert_mcp_rendered 'name: OSMO_GATEWAY_URL'
+assert_mcp_rendered 'name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS'
+assert_mcp_rendered 'kind: NetworkPolicy'
+assert_mcp_rendered 'name: osmo-mcp-allow-gateway-envoy'
+assert_mcp_rendered 'app.kubernetes.io/component: envoy'
+assert_mcp_rendered 'livenessProbe:'
+assert_mcp_rendered 'readinessProbe:'
+assert_mcp_rendered 'startupProbe:'
+assert_mcp_rendered 'automountServiceAccountToken: false'
+assert_rendered 'path: /mcp'
+assert_rendered 'path: /.well-known/oauth-protected-resource/mcp'
+assert_rendered '\"authorization_servers\":[\"https://issuer.example.com\"]'
+assert_rendered '\"bearer_methods_supported\":[\"header\"]'
+assert_rendered '\"resource\":\"https://osmo.example.com/mcp\"'
+assert_rendered '\"scopes_supported\":[\"mcp:Access\"]'
+assert_env_value 'OSMO_GATEWAY_URL' 'https://osmo.example.com'
+assert_env_value 'OSMO_MCP_REQUEST_TIMEOUT_SECONDS' '10'
+
+if grep -A12 -B2 -F 'kind: Secret' "$MCP_MANIFEST" | \
+    grep -i -F 'mcp' >/dev/null; then
+  fail 'enabled mode rendered an MCP credential Secret'
+fi
+if grep -E 'OSMO_MCP_(TOKEN|CREDENTIAL|SECRET)' \
+    "$MCP_MANIFEST" >/dev/null; then
+  fail 'enabled mode rendered an MCP credential environment variable'
+fi
+
+expect_render_failure \
+  'encoded alternate Gateway origin' \
+  'services.mcp.resourceUrl must be a valid HTTPS origin' \
+  --set 'services.mcp.resourceUrl=https://osmo.example.com%40evil.example.com/mcp'
+
+expect_render_failure \
+  'non-integer timeout' \
+  'services.mcp.requestTimeoutSeconds must be between 1 and 60' \
+  --set 'services.mcp.requestTimeoutSeconds=true'
+
+expect_render_failure \
+  'managed Gateway URL override' \
+  'services.mcp.extraEnv must not override managed variable OSMO_GATEWAY_URL' \
+  --set-json \
+  'services.mcp.extraEnv=[{"name":"OSMO_GATEWAY_URL","value":"https://evil.example.com"}]'
+
+expect_render_failure \
+  'MCP authentication bypass' \
+  'overlaps a protected MCP path' \
+  --set 'gateway.envoy.extraSkipAuthPaths[0]=/mcp'
+
+echo 'MCP chart validation passed'

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -101,6 +101,7 @@ data:
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
             stat_prefix: ingress_http
+            path_with_escaped_slashes_action: REJECT_REQUEST
             access_log:
             - name: envoy.access_loggers.file
               typed_config:

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -84,7 +84,9 @@ setting detects this rotation and triggers Envoy to reload.
 {{- end }}
 {{- end }}
 {{- range $skipPath := $skipAuthPaths }}
-{{- if or (hasPrefix $skipPath $mcpPath) (hasPrefix $skipPath $mcpMetadataPath) }}
+{{- $overlapsMcpPath := or (hasPrefix $skipPath $mcpPath) (hasPrefix $mcpPath $skipPath) }}
+{{- $overlapsMcpMetadataPath := or (hasPrefix $skipPath $mcpMetadataPath) (hasPrefix $mcpMetadataPath $skipPath) }}
+{{- if or $overlapsMcpPath $overlapsMcpMetadataPath }}
 {{- fail (printf "gateway auth bypass prefix %q overlaps a protected MCP path" $skipPath) }}
 {{- end }}
 {{- end }}

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -49,10 +49,7 @@ setting detects this rotation and triggers Envoy to reload.
 {{- if not $envoy.jwt.providers }}
 {{- fail "services.mcp.enabled requires at least one gateway.envoy.jwt.providers entry" }}
 {{- end }}
-{{- $mcpResourceUrl = required "services.mcp.resourceUrl is required when MCP is enabled" $mcp.resourceUrl }}
-{{- if not (regexMatch "^https://[^/?#]+/mcp$" $mcpResourceUrl) }}
-{{- fail "services.mcp.resourceUrl must be an HTTPS origin followed by the exact /mcp path" }}
-{{- end }}
+{{- $mcpResourceUrl = include "osmo.mcp-resource-url" . }}
 {{- if not (kindIs "slice" $mcp.authorizationServers) }}
 {{- fail "services.mcp.authorizationServers must be a list" }}
 {{- end }}

--- a/deployments/charts/service/templates/_helpers.tpl
+++ b/deployments/charts/service/templates/_helpers.tpl
@@ -204,3 +204,21 @@ OSMO_CONFIGMAP_NAME deliberately references services.service.serviceName
 {{- end }}
 {{- end -}}
 
+{{/*
+Validate and return the canonical public MCP resource URL. The Gateway
+origin used for bearer relay is derived from this single source of truth.
+*/}}
+{{- define "osmo.mcp-resource-url" -}}
+{{- $resourceUrl := required "services.mcp.resourceUrl is required when MCP is enabled" .Values.services.mcp.resourceUrl -}}
+{{- if not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?/mcp$" $resourceUrl) -}}
+{{- fail "services.mcp.resourceUrl must be a valid HTTPS origin followed by the exact /mcp path" -}}
+{{- end -}}
+{{- $portSuffix := regexFind ":[0-9]+/mcp$" $resourceUrl -}}
+{{- if $portSuffix -}}
+{{- $port := trimSuffix "/mcp" (trimPrefix ":" $portSuffix) | int -}}
+{{- if or (lt $port 1) (gt $port 65535) -}}
+{{- fail "services.mcp.resourceUrl port must be between 1 and 65535" -}}
+{{- end -}}
+{{- end -}}
+{{- $resourceUrl -}}
+{{- end -}}

--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -17,6 +17,18 @@
 {{- if .Values.services.mcp.enabled }}
 {{- $mcp := .Values.services.mcp }}
 {{- $imageTag := $mcp.imageTag | default .Values.global.osmoImageTag }}
+{{- $mcpResourceUrl := include "osmo.mcp-resource-url" . }}
+{{- $gatewayUrl := trimSuffix "/mcp" $mcpResourceUrl }}
+{{- $requestTimeoutSeconds := toString $mcp.requestTimeoutSeconds }}
+{{- if not (regexMatch "^([1-9]|[1-5][0-9]|60)$" $requestTimeoutSeconds) }}
+{{- fail "services.mcp.requestTimeoutSeconds must be between 1 and 60" }}
+{{- end }}
+{{- $reservedEnvNames := list "OSMO_MCP_HOST" "OSMO_MCP_PORT" "OSMO_GATEWAY_URL" "OSMO_MCP_REQUEST_TIMEOUT_SECONDS" }}
+{{- range $env := $mcp.extraEnv }}
+{{- if has (toString (default "" $env.name)) $reservedEnvNames }}
+{{- fail (printf "services.mcp.extraEnv must not override managed variable %s" $env.name) }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -77,6 +89,10 @@ spec:
           value: "0.0.0.0"
         - name: OSMO_MCP_PORT
           value: {{ $mcp.port | quote }}
+        - name: OSMO_GATEWAY_URL
+          value: {{ $gatewayUrl | quote }}
+        - name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS
+          value: {{ $requestTimeoutSeconds | quote }}
         {{- with $mcp.extraEnv }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -116,7 +132,6 @@ spec:
   selector:
     app: {{ $mcp.serviceName }}
 
-{{- if .Values.gateway.networkPolicies.enabled }}
 ---
 
 apiVersion: networking.k8s.io/v1
@@ -137,5 +152,4 @@ spec:
     ports:
     - port: {{ $mcp.port }}
       protocol: TCP
-{{- end }}
 {{- end }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -115,6 +115,8 @@ services:
   ##
   mcp:
     ## Enable the MCP workload and its gateway routes. Disabled by default.
+    ## When enabled, the chart always renders an ingress NetworkPolicy for
+    ## MCP because only Gateway-authenticated requests may reach the service.
     ##
     enabled: false
 
@@ -136,9 +138,15 @@ services:
 
     ## Canonical RFC 9728 protected resource identifier. This must be the
     ## externally reachable HTTPS MCP URL ending in /mcp, for example:
-    ## https://osmo.example.com/mcp
+    ## https://osmo.example.com/mcp. The MCP service derives its fixed OSMO
+    ## Gateway origin from this value so bearer tokens cannot be relayed to a
+    ## separately configured origin.
     ##
     resourceUrl: ""
+
+    ## Total timeout in seconds for each MCP request to the OSMO Gateway.
+    ##
+    requestTimeoutSeconds: 10
 
     ## OAuth authorization-server issuer identifiers advertised by the public
     ## protected-resource metadata document. Configure the issuer for the

--- a/docs/deployment_guide/getting_started/deploy_service.rst
+++ b/docs/deployment_guide/getting_started/deploy_service.rst
@@ -374,10 +374,12 @@ Create ``osmo_values.yaml`` for the OSMO service with the following sample.
 
       # Optional self-hosted MCP endpoint. Register the public OAuth client
       # separately with the identity provider and distribute its non-secret
-      # client ID to users out of band.
+      # client ID to users out of band. The fixed outbound Gateway origin is
+      # derived from resourceUrl; do not configure a second destination.
       mcp:
         enabled: false
         resourceUrl: https://<your-domain>/mcp
+        requestTimeoutSeconds: 10
         authorizationServers:
         - <idp-issuer-url>
         scopes:
@@ -688,6 +690,13 @@ Step 7: Post-deployment Configuration
    options apply only to this command; they do not modify ``config.toml`` or
    other MCPs. MCP Inspector uses a separate callback URI.
 
+   After login, invoke ``osmo_get_profile`` from the MCP client to verify the
+   complete request path. The request must pass through the Gateway a second
+   time and requires ``profile:Read`` in addition to ``mcp:Access``. An MCP
+   tool error reporting ``HTTP 401`` or ``HTTP 403`` indicates an
+   authentication or API-authorization failure, not a Kubernetes health-probe
+   failure.
+
 
 Troubleshooting
 ===============
@@ -706,6 +715,9 @@ Troubleshooting
    * **Database connection failures**: Verify the database is running and accessible
    * **Authentication configuration issues**: Verify the authentication configuration is correct
    * **Gateway routing problems**: Verify the gateway pods are running and the ``osmo-gateway`` service has an external IP (``kubectl get svc osmo-gateway -n osmo``)
+   * **MCP tools time out or report a Gateway dependency failure**: Verify that ``services.mcp.resourceUrl`` is the public HTTPS URL ending in exact ``/mcp`` and that the MCP pod can resolve and reach its origin. The chart derives the outbound Gateway origin from this value.
+   * **MCP access succeeds but** ``osmo_get_profile`` **returns 403**: Grant the user an OSMO role containing ``profile:Read``. The initial ``mcp:Access`` check does not grant access to the underlying API.
+   * **Direct in-cluster MCP requests fail**: This is expected when the cluster CNI enforces NetworkPolicy and no additional policy grants MCP ingress. The chart's MCP policy adds an allow rule selecting the release's Gateway Envoy pods because MCP trusts Gateway-created identity.
    * **Repeated** ``Jwks async fetching ... failed`` **in the gateway logs**: the OSMO-issued-JWT provider's ``jwks_uri`` scheme must match ``gateway.tls.enabled`` (``https://`` when on, ``http://`` when off). Verify with the Envoy admin endpoint: ``cluster.osmo-service-jwks.ssl.handshake`` should grow alongside ``upstream_cx_total``; if it stays at ``0``, the upstream was not restarted to pick up its TLS config.
    * **Resource constraints**: Verify the resource limits are set correctly
    * **Missing secrets or incorrect configurations**: Verify the secrets are created correctly and the configurations are correct

--- a/skills/osmo-deploy/evals/.gitignore
+++ b/skills/osmo-deploy/evals/.gitignore
@@ -1,0 +1,5 @@
+# Eval run output — regenerated each run
+results/
+
+# macOS metadata
+.DS_Store

--- a/skills/osmo-deploy/evals/config.yml
+++ b/skills/osmo-deploy/evals/config.yml
@@ -1,0 +1,4 @@
+schema_version: 1
+
+harbor:
+  agent_workdir: /workspace/input

--- a/skills/osmo-deploy/evals/evals.json
+++ b/skills/osmo-deploy/evals/evals.json
@@ -1,0 +1,79 @@
+{
+  "skill_name": "osmo-deploy",
+  "evals": [
+    {
+      "id": "osmo-deploy-001",
+      "prompt": "I am planning an AKS deployment of OSMO, but I have not decided whether I need GPUs or where to put the cluster. What information do you need from me before deployment?",
+      "expected_output": "The agent activates osmo-deploy and asks for the required deployment inputs before proposing a command: whether GPUs are needed; GPU count, SKU, and region only when GPUs are needed; plus the Azure subscription and resource group.",
+      "assertions": [
+        "The agent reads and activates osmo-deploy.",
+        "The agent asks whether GPUs are needed before assuming a GPU configuration.",
+        "The agent makes GPU count, GPU type, and region conditional on the user needing GPUs.",
+        "The agent asks for the Azure subscription ID and resource group when they have not been supplied.",
+        "The agent does not invent deployment-specific values or run a deployment command before the missing inputs are collected.",
+        "The agent identifies the required OSMO 6.3.x version-pinning step rather than recommending an unpinned latest deployment."
+      ],
+      "expected_skill": "osmo-deploy",
+      "expected_script": null
+    },
+    {
+      "id": "osmo-deploy-002",
+      "prompt": "Before I deploy a CPU-only OSMO instance to an existing Kubernetes cluster with the BYO provider and no storage backend, what version and command choices do I need to make?",
+      "expected_output": "The agent activates osmo-deploy and explains the safe BYO CPU-only deployment plan: discover published versions, pin matching 6.3.x chart, image, and CLI releases, then use the BYO, no-GPU, no-storage, non-interactive command shape after the required database and Redis variables are set.",
+      "assertions": [
+        "The agent reads and activates osmo-deploy.",
+        "The agent says to use --list-chart-versions before selecting pins.",
+        "The agent requires matching 6.3.x values for OSMO_CHART_VERSION, OSMO_IMAGE_TAG, and OSMO_CLI_REF.",
+        "The agent describes a command using --provider byo, --no-gpu, --storage-backend none, and --non-interactive.",
+        "The agent notes that BYO requires a reachable kubectl context and the PostgreSQL and Redis environment variables before deployment.",
+        "The agent does not recommend default/latest versions, a 6.2 release, osmo config update, or osmo credential set."
+      ],
+      "expected_skill": "osmo-deploy",
+      "expected_script": null
+    },
+    {
+      "id": "osmo-deploy-003",
+      "prompt": "I am planning an Azure OSMO deployment with three H100 GPUs and Azure Blob storage, but I do not know which region has enough quota. What should the deployment plan do?",
+      "expected_output": "The agent activates osmo-deploy, maps H100 to the documented Azure SKU, discovers a quota-compatible region instead of guessing, configures the GPU pool and Azure Blob storage, and pins matching 6.3.x releases.",
+      "assertions": [
+        "The agent reads and activates osmo-deploy.",
+        "The agent maps H100 to Standard_NC40ads_H100_v5 for Azure.",
+        "The agent recommends --find-gpu-region Standard_NC40ads_H100_v5 3 when the region is unknown.",
+        "The agent explains that the selected result becomes TF_REGION and that the GPU node pool is configured for three GPUs.",
+        "The agent describes using --provider azure, --gpu-node-pool, and --storage-backend azure-blob.",
+        "The agent requires matching 6.3.x OSMO_CHART_VERSION, OSMO_IMAGE_TAG, and OSMO_CLI_REF pins.",
+        "The agent says to surface a no-quota result and expand TF_REGION_CANDIDATES rather than guessing a region."
+      ],
+      "expected_skill": "osmo-deploy",
+      "expected_script": null
+    },
+    {
+      "id": "osmo-deploy-004",
+      "prompt": "We plan to run OSMO on an existing AKS cluster with Azure Blob and workload identity. We do not use static storage keys, and the platform team has not supplied the identity details yet. What must be ready before deployment?",
+      "expected_output": "The agent activates osmo-deploy, explains the caller-owned Azure Workload Identity prerequisites, and requests the UAMI client ID. It retains workload identity mode and does not substitute static credentials.",
+      "assertions": [
+        "The agent reads and activates osmo-deploy.",
+        "The agent identifies AKS OIDC and Workload Identity enablement, a UAMI, Storage Blob Data Contributor access, and a federated credential as prerequisites owned by the caller or platform team.",
+        "The agent asks for the workload identity client ID required for the Azure Blob deployment.",
+        "The agent keeps the intended deployment mode as --storage-backend azure-blob --auth-method workload-identity.",
+        "The agent does not suggest static storage keys, connection strings, or Kubernetes credential secrets as a fallback.",
+        "The agent does not claim workload identity will work until the cloud-side prerequisites are complete."
+      ],
+      "expected_skill": "osmo-deploy",
+      "expected_script": null
+    },
+    {
+      "id": "osmo-deploy-005",
+      "prompt": "My workflow train-123 has been pending for an hour. Can you inspect its events and logs?",
+      "expected_output": "This is live workflow troubleshooting, not an OSMO deployment request. The osmo-deploy skill does not trigger.",
+      "assertions": [
+        "The agent does not activate osmo-deploy.",
+        "The agent routes to osmo-user or appropriate live workflow troubleshooting tooling.",
+        "The agent does not suggest deploy-osmo-minimal.sh, Helm installation, Terraform, or cluster bootstrap commands.",
+        "The agent does not make deployment configuration changes."
+      ],
+      "expected_skill": null,
+      "expected_script": null
+    }
+  ]
+}

--- a/src/lib/api/BUILD
+++ b/src/lib/api/BUILD
@@ -1,5 +1,5 @@
 """
-SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,11 +16,15 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from src.lib.api.profile import ProfileResponse, TokenIdentity, UserProfile
+load("//bzl:py.bzl", "osmo_py_library")
+load("@osmo_python_deps//:requirements.bzl", "requirement")
 
-
-__all__ = [
-    'ProfileResponse',
-    'TokenIdentity',
-    'UserProfile',
-]
+osmo_py_library(
+    name = "profile",
+    srcs = [
+        "__init__.py",
+        "profile.py",
+    ],
+    deps = [requirement("pydantic")],
+    visibility = ["//visibility:public"],
+)

--- a/src/lib/api/__init__.py
+++ b/src/lib/api/__init__.py
@@ -1,5 +1,5 @@
 """
-SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,12 +15,3 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
-
-from src.lib.api.profile import ProfileResponse, TokenIdentity, UserProfile
-
-
-__all__ = [
-    'ProfileResponse',
-    'TokenIdentity',
-    'UserProfile',
-]

--- a/src/lib/api/profile.py
+++ b/src/lib/api/profile.py
@@ -1,0 +1,53 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import datetime
+
+import pydantic
+
+
+class UserProfile(pydantic.BaseModel):
+    """ Provides all User Profile Information """
+
+    username: str | None = None
+    email_notification: bool | None = None
+    slack_notification: bool | None = None
+    pool: str | None = None
+
+
+class TokenIdentity(pydantic.BaseModel):
+    """ Identity when the request is authenticated with an access token. """
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    name: str
+    expires_at: datetime.datetime | None = None
+
+
+class ProfileResponse(pydantic.BaseModel):
+    """
+    Profile and identity info. When token header is set, roles/pools are the
+    token's; otherwise they are the user's. JSON is self-explanatory for CLI.
+    """
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    profile: UserProfile
+    roles: list[str]
+    pools: list[str]
+    token: TokenIdentity | None = None

--- a/src/service/core/profile/BUILD
+++ b/src/service/core/profile/BUILD
@@ -27,6 +27,7 @@ osmo_py_library(
     ],
     deps = [
         requirement("fastapi"),
+        "//src/lib/api:profile",
         "//src/utils/connectors",
         "//src/service/core/auth",
         "//src/service/core/workflow",

--- a/src/service/core/profile/profile_service.py
+++ b/src/service/core/profile/profile_service.py
@@ -56,7 +56,9 @@ def get_notification_settings(
         token_identity = objects.TokenIdentity(
             name=token_name_header, expires_at=expires_at)
     return objects.ProfileResponse(
-        profile=connectors.UserProfile.fetch_from_db(postgres, user_name),
+        profile=objects.UserProfile.model_validate(
+            connectors.UserProfile.fetch_from_db(postgres, user_name).model_dump()
+        ),
         roles=roles,
         pools=pools,
         token=token_identity,
@@ -65,7 +67,7 @@ def get_notification_settings(
 
 @router.post('/api/profile/settings')
 def set_notification_settings(
-    preferences: connectors.UserProfile,
+    preferences: objects.UserProfile,
     set_default_backend: bool = False,
     user_header: Optional[str] = fastapi.Header(alias=login.OSMO_USER_HEADER, default=None)):
     fields = preferences.model_dump(exclude_none=True)

--- a/src/service/core/workflow/tests/BUILD
+++ b/src/service/core/workflow/tests/BUILD
@@ -60,8 +60,11 @@ py_test(
     name = "test_helpers",
     srcs = ["test_helpers.py"],
     deps = [
+        "//src/lib/utils:common",
         "//src/lib/utils:osmo_errors",
+        "//src/lib/utils:priority",
         "//src/service/core/workflow",
+        "//src/utils/connectors",
         "//src/utils/job",
     ],
 )

--- a/src/service/core/workflow/tests/BUILD
+++ b/src/service/core/workflow/tests/BUILD
@@ -66,3 +66,13 @@ py_test(
     ],
 )
 
+py_test(
+    name = "test_workflow_service_units",
+    srcs = ["test_workflow_service_units.py"],
+    deps = [
+        "//src/lib/utils:osmo_errors",
+        "//src/service/core/workflow",
+        "//src/utils/job",
+    ],
+)
+

--- a/src/service/core/workflow/tests/test_helpers.py
+++ b/src/service/core/workflow/tests/test_helpers.py
@@ -15,6 +15,7 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+import contextlib
 import datetime
 import hashlib
 import http
@@ -23,9 +24,20 @@ import types
 import unittest
 from unittest import mock
 
-from src.lib.utils import common, osmo_errors
+from src.lib.utils import common, osmo_errors, priority as wf_priority
 from src.service.core.workflow import helpers, objects
-from src.utils.job import task
+from src.utils import connectors
+from src.utils.job import task, workflow as job_workflow
+
+
+@contextlib.contextmanager
+def _patch_context(database):
+    """Patch WorkflowServiceContext.get() with a namespace exposing `database`."""
+    fake_context = types.SimpleNamespace(database=database)
+    with mock.patch.object(
+        objects.WorkflowServiceContext, 'get', return_value=fake_context,
+    ):
+        yield fake_context
 
 
 class _FakeListedObject:
@@ -638,6 +650,545 @@ class TestGetRecentTasks(unittest.TestCase):
             cutoff,
             fixed_now - datetime.timedelta(minutes=5),
         )
+
+
+class TestGetWorkflows(unittest.TestCase):
+    """Covers get_workflows SQL construction (lines 50-112)."""
+
+    def _run(self, database, **kwargs):
+        with _patch_context(database):
+            return helpers.get_workflows(**kwargs)
+
+    def test_get_workflows_no_filters_uses_default_status_exclusion(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        result = self._run(database, order=connectors.ListOrder.ASC)
+
+        self.assertEqual(result, [])
+        args, _ = database.execute_fetch_command.call_args
+        cmd, params, return_raw = args
+        # Default (no statuses supplied) excludes FAILED_SUBMISSION.
+        self.assertIn(f'status != %s', cmd)
+        self.assertIn(job_workflow.WorkflowStatus.FAILED_SUBMISSION.name, params)
+        self.assertNotIn('workflow_tags', cmd)
+        self.assertIn('ORDER BY submit_time ASC', cmd)
+        # Trailing ORDER BY on the wrapper query.
+        self.assertTrue(cmd.rstrip().endswith(';'))
+        # Ends with LIMIT/OFFSET.
+        self.assertEqual(params[-2:], (20, 0))
+        self.assertFalse(return_raw)
+
+    def test_get_workflows_with_tags_joins_workflow_tags(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, tags=['t1', 't2'])
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('workflow_tags', cmd)
+        self.assertIn(('t1', 't2'), params)
+
+    def test_get_workflows_with_app_info_adds_name_and_version(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+        app_info = common.AppStructure('my-app:3')
+
+        self._run(database, app_info=app_info)
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('apps.name = %s', cmd)
+        self.assertIn('workflows.app_version = %s', cmd)
+        self.assertIn('my-app', params)
+        self.assertIn(3, params)
+
+    def test_get_workflows_with_app_info_no_version_omits_version(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+        app_info = common.AppStructure('my-app')
+
+        self._run(database, app_info=app_info)
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('apps.name = %s', cmd)
+        self.assertNotIn('workflows.app_version = %s', cmd)
+        self.assertIn('my-app', params)
+
+    def test_get_workflows_with_users_uses_fetch_user_names(self):
+        database = mock.Mock()
+        database.fetch_user_names.return_value = ['alice', 'bob']
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, users=['alice', 'bob'])
+
+        database.fetch_user_names.assert_called_once_with(['alice', 'bob'])
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('submitted_by IN %s', cmd)
+        self.assertIn(('alice', 'bob'), params)
+
+    def test_get_workflows_with_pools_adds_pool_filter(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, pools=['pool-a', 'pool-b'])
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('pool IN %s', cmd)
+        self.assertIn(('pool-a', 'pool-b'), params)
+
+    def test_get_workflows_with_name_escapes_special_chars(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, name='foo_bar%baz')
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('workflow_id LIKE %s', cmd)
+        self.assertIn(r'%foo\_bar\%baz%', params)
+
+    def test_get_workflows_with_statuses_uses_status_in(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, statuses=[job_workflow.WorkflowStatus.RUNNING,
+                                      job_workflow.WorkflowStatus.COMPLETED])
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('status IN %s', cmd)
+        # Default exclusion should NOT appear when statuses supplied.
+        self.assertNotIn('status != %s', cmd)
+        self.assertIn(('RUNNING', 'COMPLETED'), params)
+
+    def test_get_workflows_with_submitted_after_and_before(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+        after = datetime.datetime(2026, 1, 1, 12, 0, 0)
+        before = datetime.datetime(2026, 2, 1, 12, 0, 0)
+
+        self._run(database, submitted_after=after, submitted_before=before)
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('submit_time >= %s', cmd)
+        self.assertIn('submit_time < %s', cmd)
+        self.assertIn(after.replace(microsecond=0).isoformat(), params)
+        self.assertIn(before.replace(microsecond=0).isoformat(), params)
+
+    def test_get_workflows_with_priority_adds_priority_in(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, priority=[wf_priority.WorkflowPriority.HIGH])
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('priority IN %s', cmd)
+        self.assertIn(('HIGH',), params)
+
+    def test_get_workflows_desc_order_uses_desc_in_sql(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, order=connectors.ListOrder.DESC)
+
+        cmd, _, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('ORDER BY submit_time DESC', cmd)
+
+    def test_get_workflows_return_raw_passed_through(self):
+        database = mock.Mock()
+        raw_rows = [{'workflow_id': 'wf-1'}]
+        database.execute_fetch_command.return_value = raw_rows
+
+        result = self._run(database, return_raw=True)
+
+        self.assertEqual(result, raw_rows)
+        _, _, return_raw = database.execute_fetch_command.call_args[0]
+        self.assertTrue(return_raw)
+
+
+class TestGetTasks(unittest.TestCase):
+    """Covers get_tasks SQL construction (lines 130-227)."""
+
+    def _run(self, database, **kwargs):
+        with _patch_context(database):
+            return helpers.get_tasks(**kwargs)
+
+    def test_get_tasks_summary_selects_sums_and_filters_null_pool(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, summary=True)
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('SUM(tasks.disk_count)', cmd)
+        self.assertIn('workflows.pool IS NOT NULL', cmd)
+        self.assertIn('GROUP BY workflows.submitted_by, workflows.pool, workflows.priority', cmd)
+        # Summary limits are clamped to 1000.
+        self.assertEqual(params[-2:], (20, 0))
+        # ROW_NUMBER wrapper is always applied.
+        self.assertIn('ROW_NUMBER() OVER ()', cmd)
+
+    def test_get_tasks_aggregate_by_workflow_selects_workflow_id(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, aggregate_by_workflow=True, limit=5000)
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('workflows.workflow_id', cmd)
+        self.assertIn('SUM(tasks.disk_count)', cmd)
+        self.assertIn(
+            'GROUP BY workflows.workflow_id, workflows.submitted_by, '
+            'workflows.pool, workflows.priority',
+            cmd,
+        )
+        # Limit is clamped to 1000 for aggregate mode.
+        self.assertEqual(params[-2:], (1000, 0))
+
+    def test_get_tasks_default_selects_task_columns(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database)
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('tasks.*', cmd)
+        # Default mode uses CASE-based status ordering.
+        self.assertIn("WHEN tasks.status = 'SCHEDULING' THEN 1", cmd)
+        self.assertIn("WHEN tasks.status = 'RUNNING' THEN 3", cmd)
+        # Default mode does not require pool to be not null.
+        self.assertNotIn('workflows.pool IS NOT NULL', cmd)
+        self.assertEqual(params[-2:], (20, 0))
+
+    def test_get_tasks_with_workflow_id_escapes_special_chars(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, workflow_id='wf_100%foo')
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('tasks.workflow_id LIKE %s', cmd)
+        self.assertIn(r'%wf\_100\%foo%', params)
+
+    def test_get_tasks_with_statuses_uses_status_in(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, statuses=[task.TaskGroupStatus.RUNNING])
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('tasks.status IN %s', cmd)
+        self.assertIn(('RUNNING',), params)
+
+    def test_get_tasks_with_users_uses_fetch_user_names(self):
+        database = mock.Mock()
+        database.fetch_user_names.return_value = ['alice']
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, users=['alice'])
+
+        database.fetch_user_names.assert_called_once_with(['alice'])
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('workflows.submitted_by IN %s', cmd)
+        self.assertIn(('alice',), params)
+
+    def test_get_tasks_with_pools_and_nodes(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, pools=['pool-a'], nodes=['node-1', 'node-2'])
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('workflows.pool IN %s', cmd)
+        self.assertIn('tasks.node_name IN %s', cmd)
+        self.assertIn(('pool-a',), params)
+        self.assertIn(('node-1', 'node-2'), params)
+
+    def test_get_tasks_with_started_after_and_before(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+        after = datetime.datetime(2026, 1, 1, 12, 0, 0)
+        before = datetime.datetime(2026, 2, 1, 12, 0, 0)
+
+        self._run(database, started_after=after, started_before=before)
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('tasks.start_time >= %s OR tasks.start_time is NULL', cmd)
+        self.assertIn('tasks.start_time < %s AND tasks.start_time is not NULL', cmd)
+        self.assertIn(after.replace(microsecond=0).isoformat(), params)
+        self.assertIn(before.replace(microsecond=0).isoformat(), params)
+
+    def test_get_tasks_with_priority_filter(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, priority=[wf_priority.WorkflowPriority.LOW])
+
+        cmd, params, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('workflows.priority IN %s', cmd)
+        self.assertIn(('LOW',), params)
+
+    def test_get_tasks_asc_order_uses_rn_desc(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, order=connectors.ListOrder.ASC)
+
+        cmd, _, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('ORDER BY rn DESC', cmd)
+
+    def test_get_tasks_desc_order_uses_rn_asc(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        self._run(database, order=connectors.ListOrder.DESC)
+
+        cmd, _, _ = database.execute_fetch_command.call_args[0]
+        self.assertIn('ORDER BY rn ASC', cmd)
+
+
+class TestGetPoolResources(unittest.TestCase):
+    """Covers get_pool_resources (lines 240-310)."""
+
+    def test_get_pool_resources_empty_returns_empty_response(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        with _patch_context(database):
+            result = helpers.get_pool_resources()
+
+        self.assertEqual(result.pools, [])
+        cmd, params = database.execute_fetch_command.call_args[0]
+        # No pool filter: WHERE clause is absent.
+        self.assertNotIn('pools.name IN', cmd)
+        self.assertEqual(params, ())
+
+    def test_get_pool_resources_with_pools_filters_pool_names(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        with _patch_context(database):
+            helpers.get_pool_resources(pools=['pool-a'])
+
+        cmd, params = database.execute_fetch_command.call_args[0]
+        self.assertIn('pools.name IN %s', cmd)
+        self.assertIn(('pool-a',), params)
+
+    def test_get_pool_resources_with_pools_and_platforms_filters_both(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        with _patch_context(database):
+            helpers.get_pool_resources(pools=['pool-a'], platforms=['gpu-a100'])
+
+        cmd, params = database.execute_fetch_command.call_args[0]
+        self.assertIn('pools.name IN %s', cmd)
+        self.assertIn('keys IN %s', cmd)
+        self.assertIn(('pool-a',), params)
+        self.assertIn(('gpu-a100',), params)
+
+    def test_get_pool_resources_with_platforms_only_ignores_platforms(self):
+        # Platforms is only applied when pools is truthy (per implementation).
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        with _patch_context(database):
+            helpers.get_pool_resources(platforms=['gpu-a100'])
+
+        cmd, params = database.execute_fetch_command.call_args[0]
+        self.assertNotIn('keys IN', cmd)
+        self.assertEqual(params, ())
+
+    def test_get_pool_resources_maintenance_status(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = [{
+            'name': 'pool-m',
+            'platform': 'gpu',
+            'backend': 'k8s-1',
+            'last_heartbeat': None,
+            'enable_maintenance': True,
+            'usage_fields': [],
+            'allocatable_fields': [],
+        }]
+
+        with _patch_context(database):
+            response = helpers.get_pool_resources()
+
+        self.assertEqual(len(response.pools), 1)
+        entry = response.pools[0]
+        self.assertEqual(entry.status, connectors.PoolStatus.MAINTENANCE)
+        self.assertEqual(entry.pool, 'pool-m')
+        self.assertEqual(entry.platform, 'gpu')
+        self.assertEqual(entry.backend, 'k8s-1')
+        # Empty usage/allocatable defaults to zeros for each label.
+        for label in common.ALLOCATABLE_RESOURCES_LABELS:
+            self.assertEqual(entry.usage_fields[label.name], 0)
+            self.assertEqual(entry.allocatable_fields[label.name], 0)
+
+    def test_get_pool_resources_offline_status_when_no_heartbeat(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = [{
+            'name': 'pool-o',
+            'platform': 'gpu',
+            'backend': 'k8s-1',
+            'last_heartbeat': None,
+            'enable_maintenance': False,
+            'usage_fields': [],
+            'allocatable_fields': [],
+        }]
+
+        with _patch_context(database):
+            response = helpers.get_pool_resources()
+
+        self.assertEqual(response.pools[0].status, connectors.PoolStatus.OFFLINE)
+
+    def test_get_pool_resources_online_when_heartbeat_recent(self):
+        database = mock.Mock()
+        # common.current_time() returns a naive UTC datetime, so match that.
+        recent = datetime.datetime.utcnow()
+        database.execute_fetch_command.return_value = [{
+            'name': 'pool-online',
+            'platform': 'gpu',
+            'backend': 'k8s-1',
+            'last_heartbeat': recent,
+            'enable_maintenance': False,
+            'usage_fields': [],
+            'allocatable_fields': [],
+        }]
+
+        with _patch_context(database):
+            response = helpers.get_pool_resources()
+
+        self.assertEqual(response.pools[0].status, connectors.PoolStatus.ONLINE)
+
+    def test_get_pool_resources_accumulates_usage_and_allocatable(self):
+        # Cover the resource-aggregation loop (lines 290-302). Patch the
+        # underlying conversion helpers so we control the numeric output.
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = [{
+            'name': 'pool-agg',
+            'platform': 'gpu',
+            'backend': 'k8s-1',
+            'last_heartbeat': None,
+            'enable_maintenance': False,
+            # Two non-empty jsonb aggregate entries — the loop should
+            # accumulate over both.
+            'usage_fields': [{'cpu': '2'}, {'cpu': '3'}],
+            'allocatable_fields': [{'cpu': '4'}, {'cpu': '5'}],
+        }]
+
+        # convert_allocatable is a classmethod on BackendResource; the loop
+        # feeds its return value into convert_allocatable_request_fields.
+        with _patch_context(database), \
+             mock.patch.object(
+                 helpers.connectors.BackendResource, 'convert_allocatable',
+                 side_effect=lambda x: dict(x)), \
+             mock.patch.object(
+                 helpers.common, 'convert_allocatable_request_fields',
+                 return_value=(10, 1)):
+            response = helpers.get_pool_resources()
+
+        entry = response.pools[0]
+        # Two iterations of the outer zip, four resource labels per iteration
+        # -> each label ends up with 2 * 1 usage and 2 * 10 allocatable.
+        self.assertEqual(entry.usage_fields['cpu'], 2)
+        self.assertEqual(entry.allocatable_fields['cpu'], 20)
+
+    def test_get_pool_resources_skips_empty_usage_or_allocatable(self):
+        # None fields inside the jsonb aggregates are skipped by the loop.
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = [{
+            'name': 'pool-skip',
+            'platform': 'gpu',
+            'backend': 'k8s-1',
+            'last_heartbeat': None,
+            'enable_maintenance': False,
+            'usage_fields': [None, None],
+            'allocatable_fields': [None, None],
+        }]
+
+        with _patch_context(database):
+            response = helpers.get_pool_resources()
+
+        entry = response.pools[0]
+        for label in common.ALLOCATABLE_RESOURCES_LABELS:
+            self.assertEqual(entry.usage_fields[label.name], 0)
+            self.assertEqual(entry.allocatable_fields[label.name], 0)
+
+
+class TestSetWorkflowTags(unittest.TestCase):
+    """Covers set_workflow_tags (lines 404-449)."""
+
+    def _database_with_tags(self, allowed_tags):
+        database = mock.Mock()
+        workflow_configs = mock.Mock()
+        workflow_configs.workflow_info.tags = list(allowed_tags)
+        database.get_workflow_configs.return_value = workflow_configs
+        return database
+
+    def test_set_workflow_tags_invalid_add_tag_raises_user_error(self):
+        database = self._database_with_tags(['approved'])
+
+        with _patch_context(database):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                helpers.set_workflow_tags('wf-1', add_tags=['not-allowed'],
+                                          remove_tags=None)
+
+        self.assertIn('Invalid tag detected', ctx.exception.message)
+        database.execute_commit_command.assert_not_called()
+
+    def test_set_workflow_tags_add_only_builds_insert_command(self):
+        database = self._database_with_tags(['approved', 'reviewed'])
+
+        with _patch_context(database):
+            helpers.set_workflow_tags('wf-1', add_tags=['approved'], remove_tags=None)
+
+        database.execute_commit_command.assert_called_once()
+        cmd, params = database.execute_commit_command.call_args[0]
+        self.assertIn('INSERT INTO workflow_tags', cmd)
+        self.assertNotIn('DELETE FROM workflow_tags', cmd)
+        self.assertEqual(params, ('wf-1', 'approved'))
+
+    def test_set_workflow_tags_remove_only_builds_delete_command(self):
+        database = self._database_with_tags(['approved'])
+
+        with _patch_context(database):
+            helpers.set_workflow_tags('wf-1', add_tags=None,
+                                      remove_tags=['approved', 'stale'])
+
+        cmd, params = database.execute_commit_command.call_args[0]
+        self.assertIn('DELETE FROM workflow_tags', cmd)
+        self.assertNotIn('INSERT INTO workflow_tags', cmd)
+        # Params: workflow_id, workflow_id, tuple(remove_tags)
+        self.assertEqual(params, ('wf-1', 'wf-1', ('approved', 'stale')))
+
+    def test_set_workflow_tags_add_and_remove_combined(self):
+        database = self._database_with_tags(['approved', 'reviewed'])
+
+        with _patch_context(database):
+            helpers.set_workflow_tags('wf-1', add_tags=['approved', 'reviewed'],
+                                      remove_tags=['stale'])
+
+        cmd, params = database.execute_commit_command.call_args[0]
+        self.assertIn('DELETE FROM workflow_tags', cmd)
+        self.assertIn('INSERT INTO workflow_tags', cmd)
+        # First: delete params (workflow_id, workflow_id, tuple(remove_tags))
+        # Then: insert params expanded from add_tags pairs.
+        self.assertEqual(
+            params,
+            ('wf-1', 'wf-1', ('stale',), 'wf-1', 'approved', 'wf-1', 'reviewed'),
+        )
+
+    def test_set_workflow_tags_no_add_no_remove_still_commits(self):
+        database = self._database_with_tags(['approved'])
+
+        with _patch_context(database):
+            helpers.set_workflow_tags('wf-1', add_tags=None, remove_tags=None)
+
+        cmd, params = database.execute_commit_command.call_args[0]
+        self.assertIn('BEGIN;', cmd)
+        self.assertIn('COMMIT;', cmd)
+        self.assertNotIn('INSERT INTO workflow_tags', cmd)
+        self.assertNotIn('DELETE FROM workflow_tags', cmd)
+        self.assertEqual(params, ())
 
 
 if __name__ == '__main__':

--- a/src/service/core/workflow/tests/test_workflow_service_units.py
+++ b/src/service/core/workflow/tests/test_workflow_service_units.py
@@ -1,0 +1,1975 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import http
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from src.lib.utils import osmo_errors
+from src.service.core.workflow import objects, workflow_service
+from src.utils.job import task, workflow as job_workflow
+
+
+def _make_workflow_response(name='wf-1', uuid='uuid-1', status=None, backend='k8s-1',
+                            plugins=None, queue_timeout=None, exec_timeout=None):
+    """Construct a minimal WorkflowQueryResponse for tests."""
+    # Using SimpleNamespace avoids Pydantic strict-field checking that mypy trips on;
+    # callers use attribute access, so a namespace suffices.
+    return SimpleNamespace(
+        name=name,
+        uuid=uuid,
+        status=status if status is not None else job_workflow.WorkflowStatus.RUNNING,
+        backend=backend,
+        plugins=plugins if plugins is not None else SimpleNamespace(rsync=False),
+        queue_timeout=queue_timeout,
+        exec_timeout=exec_timeout,
+    )
+
+
+def _make_task_query(name='t1', retry_id=0, status=None):
+    return SimpleNamespace(
+        name=name,
+        retry_id=retry_id,
+        status=status if status is not None else task.TaskGroupStatus.RUNNING,
+        logs='',
+        events='',
+        pod_name=f'pod-{name}',
+        task_uuid=f'uuid-{name}',
+    )
+
+
+class TestNodeSetIter(unittest.TestCase):
+    """Covers NodeSet.__iter__ (lines 82-83)."""
+
+    def test_iter_yields_backend_node_tuples(self):
+        nodeset = workflow_service.NodeSet(
+            backend='k8s-1', nodes=frozenset({'node-a', 'node-b'}))
+
+        result = sorted(nodeset)
+
+        self.assertEqual(result, [('k8s-1', 'node-a'), ('k8s-1', 'node-b')])
+
+    def test_iter_empty_nodeset_yields_nothing(self):
+        nodeset = workflow_service.NodeSet(backend='k8s-1', nodes=frozenset())
+
+        result = list(nodeset)
+
+        self.assertEqual(result, [])
+
+
+class TestGetPools(unittest.TestCase):
+    """Covers get_pools (lines 109-110)."""
+
+    def test_get_pools_delegates_to_fetch_minimal_pool_config(self):
+        sentinel_config = mock.Mock(name='MinimalPoolConfig')
+        postgres_instance = mock.Mock(name='postgres')
+
+        with mock.patch.object(workflow_service.connectors,
+                               'PostgresConnector') as postgres_cls, \
+             mock.patch.object(workflow_service.connectors,
+                               'fetch_minimal_pool_config',
+                               return_value=sentinel_config) as fetch:
+            postgres_cls.get_instance.return_value = postgres_instance
+            result = workflow_service.get_pools(all_pools=True, pools=None)
+
+        self.assertIs(result, sentinel_config)
+        fetch.assert_called_once_with(postgres_instance, pools=None, all_pools=True)
+
+    def test_get_pools_passes_pool_names_and_flag(self):
+        sentinel_config = mock.Mock()
+        postgres_instance = mock.Mock()
+
+        with mock.patch.object(workflow_service.connectors,
+                               'PostgresConnector') as postgres_cls, \
+             mock.patch.object(workflow_service.connectors,
+                               'fetch_minimal_pool_config',
+                               return_value=sentinel_config) as fetch:
+            postgres_cls.get_instance.return_value = postgres_instance
+            workflow_service.get_pools(all_pools=False, pools=['p-1', 'p-2'])
+
+        fetch.assert_called_once_with(
+            postgres_instance, pools=['p-1', 'p-2'], all_pools=False)
+
+
+class TestGetPoolQuotas(unittest.TestCase):
+    """Covers get_pool_quotas (lines 300-330)."""
+
+    def test_get_pool_quotas_paginates_and_stops_on_short_page(self):
+        pool_configs_container = mock.Mock()
+        pool_configs_container.pools = {}
+        empty_response = objects.PoolResponse(
+            node_sets=[],
+            resource_sum=objects.ResourceUsage(
+                quota_used='0', quota_free='0', quota_limit='0',
+                total_usage='0', total_capacity='0', total_free='0'))
+
+        with mock.patch.object(workflow_service.connectors,
+                               'PostgresConnector') as postgres_cls, \
+             mock.patch.object(workflow_service.connectors,
+                               'fetch_minimal_pool_config',
+                               return_value=pool_configs_container) as fetch, \
+             mock.patch.object(workflow_service.helpers,
+                               'get_tasks', return_value=[]) as get_tasks, \
+             mock.patch.object(workflow_service.objects,
+                               'get_resources') as get_resources, \
+             mock.patch.object(workflow_service, 'calculate_pool_quotas',
+                               return_value=empty_response) as calc:
+            postgres_cls.get_instance.return_value = mock.Mock()
+            get_resources.return_value = objects.ResourcesResponse(resources=[])
+            result = workflow_service.get_pool_quotas(
+                all_pools=False, pools=['p-1'])
+
+        self.assertIs(result, empty_response)
+        fetch.assert_called_once()
+        # Only one page since the returned summary count < FETCH_TASK_LIMIT
+        self.assertEqual(get_tasks.call_count, 1)
+        # calculate_pool_quotas invoked with the empty results
+        calc.assert_called_once()
+        _, kwargs = calc.call_args
+        self.assertEqual(kwargs['pool_configs'], {})
+        self.assertEqual(kwargs['all_pools'], False)
+
+
+class TestSubmitWorkflow(unittest.TestCase):
+    """Covers submit_workflow branches (lines 355-450)."""
+
+    def test_submit_workflow_rejects_both_spec_and_id(self):
+        template_spec = mock.Mock(name='TemplateSpec')
+
+        with self.assertRaises(osmo_errors.OSMOUsageError) as ctx:
+            workflow_service.submit_workflow(
+                pool_name='p-1',
+                template_spec=template_spec,
+                workflow_id='wf-1')
+
+        self.assertIn('not both', ctx.exception.message)
+
+    def test_submit_workflow_rejects_neither_spec_nor_id(self):
+        with self.assertRaises(osmo_errors.OSMOUsageError) as ctx:
+            workflow_service.submit_workflow(
+                pool_name='p-1',
+                template_spec=None,
+                workflow_id=None)
+
+        self.assertIn('Need to provide', ctx.exception.message)
+
+    def test_submit_workflow_dry_run_returns_yaml_spec(self):
+        template_spec = mock.Mock(name='TemplateSpec')
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'wf-name'
+        submit_info.construct_workflow_dict.return_value = {'workflow': {'name': 'wf-name'}}
+        context = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'):
+            response = workflow_service.submit_workflow(
+                pool_name='p-1',
+                template_spec=template_spec,
+                dry_run=True,
+                env_vars=[],
+                roles_header=None)
+
+        self.assertEqual(response.name, 'wf-name')
+        self.assertIn('workflow', response.spec or '')
+
+    def test_submit_workflow_malformed_env_var_raises(self):
+        template_spec = mock.Mock(name='TemplateSpec')
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'wf-name'
+        submit_info.construct_workflow_dict.return_value = {'workflow': {'name': 'wf-name'}}
+        # workflow_spec with no groups (uses tasks path)
+        workflow_spec = mock.Mock()
+        workflow_spec.groups = []
+        workflow_spec.tasks = []
+        submit_info.construct_workflow_spec_from_dict.return_value = workflow_spec
+        context = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'):
+            with self.assertRaises(osmo_errors.OSMOUsageError) as ctx:
+                workflow_service.submit_workflow(
+                    pool_name='p-1',
+                    template_spec=template_spec,
+                    env_vars=['NO_EQUALS_HERE'],
+                    roles_header=None)
+
+        self.assertIn('incorrectly formatted', ctx.exception.message)
+
+    def test_submit_workflow_env_vars_applied_to_tasks(self):
+        template_spec = mock.Mock(name='TemplateSpec')
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'wf-name'
+        submit_info.construct_workflow_dict.return_value = {'workflow': {'name': 'wf-name'}}
+        # workflow_spec with no groups but tasks
+        task_a = mock.Mock()
+        task_a.environment = {}
+        workflow_spec = mock.Mock()
+        workflow_spec.groups = []
+        workflow_spec.tasks = [task_a]
+        workflow_spec.get_num_tasks.return_value = 1
+        submit_info.construct_workflow_spec_from_dict.return_value = workflow_spec
+        rendered_spec = mock.Mock()
+        rendered_spec.get_num_tasks.return_value = 1
+        workflow_spec.parse.return_value = rendered_spec
+        workflow_config = mock.Mock()
+        workflow_config.max_num_tasks = 100
+        workflow_config.user_workflow_limits.max_num_workflows = 0
+        workflow_config.user_workflow_limits.max_num_tasks = 0
+        context = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        submit_info.send_submit_workflow_to_queue.return_value = objects.SubmitResponse(
+            name='wf-name', logs='ok')
+
+        with mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'):
+            response = workflow_service.submit_workflow(
+                pool_name='p-1',
+                template_spec=template_spec,
+                env_vars=['FOO=bar'],
+                roles_header=None)
+
+        self.assertEqual(response.name, 'wf-name')
+        self.assertEqual(task_a.environment, {'FOO': 'bar'})
+
+    def test_submit_workflow_exceeds_max_num_tasks(self):
+        template_spec = mock.Mock(name='TemplateSpec')
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'wf-name'
+        submit_info.construct_workflow_dict.return_value = {'workflow': {'name': 'wf-name'}}
+        workflow_spec = mock.Mock()
+        workflow_spec.groups = []
+        workflow_spec.tasks = []
+        submit_info.construct_workflow_spec_from_dict.return_value = workflow_spec
+        rendered_spec = mock.Mock()
+        rendered_spec.get_num_tasks.return_value = 200
+        workflow_spec.parse.return_value = rendered_spec
+        workflow_config = mock.Mock()
+        workflow_config.max_num_tasks = 100
+        context = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.submit_workflow(
+                    pool_name='p-1',
+                    template_spec=template_spec,
+                    env_vars=[],
+                    roles_header=None)
+
+        self.assertIn('more than 100 tasks', ctx.exception.message)
+
+    def test_submit_workflow_validation_only_returns_early(self):
+        template_spec = mock.Mock(name='TemplateSpec')
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'wf-name'
+        submit_info.construct_workflow_dict.return_value = {'workflow': {'name': 'wf-name'}}
+        workflow_spec = mock.Mock()
+        workflow_spec.groups = []
+        workflow_spec.tasks = []
+        submit_info.construct_workflow_spec_from_dict.return_value = workflow_spec
+        rendered_spec = mock.Mock()
+        rendered_spec.get_num_tasks.return_value = 1
+        workflow_spec.parse.return_value = rendered_spec
+        workflow_config = mock.Mock()
+        workflow_config.max_num_tasks = 100
+        context = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'):
+            response = workflow_service.submit_workflow(
+                pool_name='p-1',
+                template_spec=template_spec,
+                validation_only=True,
+                env_vars=[],
+                roles_header=None)
+
+        self.assertEqual(response.name, 'wf-name')
+        self.assertIn('validation succeeded', response.logs or '')
+        submit_info.send_submit_workflow_to_queue.assert_not_called()
+
+    def test_submit_workflow_exceeds_max_workflows_per_user(self):
+        template_spec = mock.Mock(name='TemplateSpec')
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'wf-name'
+        submit_info.user = 'user-1'
+        submit_info.construct_workflow_dict.return_value = {'workflow': {'name': 'wf-name'}}
+        workflow_spec = mock.Mock()
+        workflow_spec.groups = []
+        workflow_spec.tasks = []
+        submit_info.construct_workflow_spec_from_dict.return_value = workflow_spec
+        rendered_spec = mock.Mock()
+        rendered_spec.get_num_tasks.return_value = 1
+        workflow_spec.parse.return_value = rendered_spec
+        workflow_config = mock.Mock()
+        workflow_config.max_num_tasks = 100
+        workflow_config.user_workflow_limits.max_num_workflows = 5
+        workflow_config.user_workflow_limits.max_num_tasks = 0
+        context = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'), \
+             mock.patch.object(workflow_service.workflow,
+                               'get_num_workflows_and_tasks',
+                               return_value=(5, 0)):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.submit_workflow(
+                    pool_name='p-1',
+                    template_spec=template_spec,
+                    env_vars=[],
+                    roles_header=None)
+
+        self.assertIn('more than 5 ongoing workflows', ctx.exception.message)
+
+    def test_submit_workflow_exceeds_max_tasks_per_user(self):
+        template_spec = mock.Mock(name='TemplateSpec')
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'wf-name'
+        submit_info.user = 'user-1'
+        submit_info.construct_workflow_dict.return_value = {'workflow': {'name': 'wf-name'}}
+        workflow_spec = mock.Mock()
+        workflow_spec.groups = []
+        workflow_spec.tasks = []
+        workflow_spec.get_num_tasks.return_value = 3
+        submit_info.construct_workflow_spec_from_dict.return_value = workflow_spec
+        rendered_spec = mock.Mock()
+        rendered_spec.get_num_tasks.return_value = 3
+        workflow_spec.parse.return_value = rendered_spec
+        workflow_config = mock.Mock()
+        workflow_config.max_num_tasks = 100
+        workflow_config.user_workflow_limits.max_num_workflows = 0
+        workflow_config.user_workflow_limits.max_num_tasks = 10
+        context = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'), \
+             mock.patch.object(workflow_service.workflow,
+                               'get_num_workflows_and_tasks',
+                               return_value=(0, 8)):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.submit_workflow(
+                    pool_name='p-1',
+                    template_spec=template_spec,
+                    env_vars=[],
+                    roles_header=None)
+
+        self.assertIn('more than 10 ongoing tasks', ctx.exception.message)
+
+    def test_submit_workflow_env_vars_applied_to_groups(self):
+        template_spec = mock.Mock(name='TemplateSpec')
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'wf-name'
+        submit_info.construct_workflow_dict.return_value = {'workflow': {'name': 'wf-name'}}
+        # workflow_spec with groups, each with tasks
+        task_a = mock.Mock()
+        task_a.environment = {}
+        task_b = mock.Mock()
+        task_b.environment = {}
+        group_1 = mock.Mock()
+        group_1.tasks = [task_a, task_b]
+        workflow_spec = mock.Mock()
+        workflow_spec.groups = [group_1]
+        workflow_spec.tasks = []
+        submit_info.construct_workflow_spec_from_dict.return_value = workflow_spec
+        rendered_spec = mock.Mock()
+        rendered_spec.get_num_tasks.return_value = 2
+        workflow_spec.parse.return_value = rendered_spec
+        workflow_config = mock.Mock()
+        workflow_config.max_num_tasks = 100
+        workflow_config.user_workflow_limits.max_num_workflows = 0
+        workflow_config.user_workflow_limits.max_num_tasks = 0
+        context = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        submit_info.send_submit_workflow_to_queue.return_value = objects.SubmitResponse(
+            name='wf-name', logs='ok')
+
+        with mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'):
+            workflow_service.submit_workflow(
+                pool_name='p-1',
+                template_spec=template_spec,
+                env_vars=['A=1', 'B=2'],
+                roles_header=None)
+
+        self.assertEqual(task_a.environment, {'A': '1', 'B': '2'})
+        self.assertEqual(task_b.environment, {'A': '1', 'B': '2'})
+
+    def test_submit_workflow_from_workflow_id_downloads_spec(self):
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'wf-name'
+        submit_info.construct_workflow_dict.return_value = {'workflow': {'name': 'wf-name'}}
+        context = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'), \
+             mock.patch.object(workflow_service, 'download_workflow_spec',
+                               return_value=iter(['w:', 'orkflow'])) as dl, \
+             mock.patch.object(workflow_service.helpers,
+                               'gather_stream_content',
+                               return_value='workflow:\n  name: wf-name') as gather, \
+             mock.patch.object(workflow_service.workflow, 'TemplateSpec') as ts_cls:
+            ts_cls.return_value = mock.Mock()
+            workflow_service.submit_workflow(
+                pool_name='p-1',
+                workflow_id='parent-wf',
+                dry_run=True,
+                env_vars=[],
+                roles_header=None)
+
+        dl.assert_called_once_with('parent-wf')
+        gather.assert_called_once()
+        ts_cls.assert_called_once()
+
+
+class TestRestartWorkflow(unittest.TestCase):
+    """Covers restart_workflow (lines 467-541)."""
+
+    def test_restart_workflow_rejects_non_failed(self):
+        # A COMPLETED workflow is not failed → OSMOSubmissionError
+        workflow_obj = mock.Mock()
+        workflow_obj.workflow_id = 'wf-1'
+        workflow_obj.status.failed.return_value = False
+        workflow_obj.status.__str__ = lambda self: 'COMPLETED'  # type: ignore
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.workflow.Workflow, 'fetch_from_db',
+                               return_value=workflow_obj):
+            with self.assertRaises(osmo_errors.OSMOSubmissionError) as ctx:
+                workflow_service.restart_workflow(
+                    pool_name='p-1', workflow_id='wf-1',
+                    user_header=None, roles_header=None)
+
+        self.assertIn('FAILED workflows', ctx.exception.message)
+
+    def test_restart_workflow_rewrites_groups_and_tasks(self):
+        # workflow with 2 groups: g1 completed, g2 failed. Verify:
+        # - g2 remains in new_groups but g1 excluded
+        # - Inputs referencing g1's tasks get workflow_id prefix (parent succeeded)
+        # - Inputs referencing g2's tasks are left unprefixed (parent failed → rerun)
+        workflow_obj = mock.Mock()
+        workflow_obj.workflow_id = 'parent-wf'
+        workflow_obj.status.failed.return_value = True
+        workflow_obj.priority = 'NORMAL'
+        # First group succeeded, second failed
+        g1_task = SimpleNamespace(name='g1-t1')
+        g1 = SimpleNamespace(
+            name='g1', tasks=[g1_task],
+            status=SimpleNamespace(failed=lambda: False))
+        g2_task = SimpleNamespace(name='g2-t1')
+        g2 = SimpleNamespace(
+            name='g2', tasks=[g2_task],
+            status=SimpleNamespace(failed=lambda: True))
+        workflow_obj.groups = [g1, g2]
+
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'restart-wf'
+        submit_info.construct_workflow_dict.return_value = {
+            'workflow': {'name': 'restart-wf'}}
+
+        # Build spec object with matching groups/tasks - g2 will be rewritten
+        # Input pointing to g1's task -> should be rewritten with prefix
+        # Input pointing to g2's task -> should NOT be rewritten
+        parent_input = task.TaskInputOutput(task='g1-t1')
+        sibling_input = task.TaskInputOutput(task='g2-t1')
+        prev_workflow_input = task.TaskInputOutput(task='old-wf:some-task')
+
+        g2_spec_task = mock.Mock()
+        g2_spec_task.inputs = [parent_input, sibling_input, prev_workflow_input]
+        g2_spec = mock.Mock()
+        g2_spec.name = 'g2'
+        g2_spec.tasks = [g2_spec_task]
+
+        # g1 will be filtered out (completed)
+        g1_spec_task = mock.Mock()
+        g1_spec_task.inputs = []
+        g1_spec = mock.Mock()
+        g1_spec.name = 'g1'
+        g1_spec.tasks = [g1_spec_task]
+
+        workflow_spec = mock.Mock()
+        workflow_spec.groups = [g1_spec, g2_spec]
+        workflow_spec.tasks = []
+        submit_info.construct_workflow_spec_from_dict.return_value = workflow_spec
+        rendered_spec = mock.Mock()
+        workflow_spec.parse.return_value = rendered_spec
+        submit_info.send_submit_workflow_to_queue.return_value = objects.SubmitResponse(
+            name='restart-wf', logs='ok')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.workflow.Workflow, 'fetch_from_db',
+                               return_value=workflow_obj), \
+             mock.patch.object(workflow_service, 'download_workflow_spec',
+                               return_value=iter(['spec'])), \
+             mock.patch.object(workflow_service.helpers, 'gather_stream_content',
+                               return_value='spec'), \
+             mock.patch.object(workflow_service.workflow, 'TemplateSpec'), \
+             mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'):
+            workflow_service.restart_workflow(
+                pool_name='p-1', workflow_id='parent-wf',
+                user_header=None, roles_header=None)
+
+        # g1 was completed so it's excluded; only g2 remains
+        self.assertEqual(workflow_spec.groups, [g2_spec])
+        # parent_input (references succeeded g1) -> prefixed
+        self.assertEqual(parent_input.task, 'parent-wf:g1-t1')
+        # sibling_input (references failed g2) -> left unchanged
+        self.assertEqual(sibling_input.task, 'g2-t1')
+        # prev_workflow_input (already has workflow prefix) -> unchanged
+        self.assertEqual(prev_workflow_input.task, 'old-wf:some-task')
+
+    def test_restart_workflow_rewrites_top_level_tasks(self):
+        # workflow_spec.tasks path (top-level tasks, no groups)
+        workflow_obj = mock.Mock()
+        workflow_obj.workflow_id = 'parent-wf'
+        workflow_obj.status.failed.return_value = True
+        workflow_obj.priority = 'NORMAL'
+        # Completed groups map for the tasks: t1 was succeeded, t2 failed
+        t1_status = SimpleNamespace(failed=lambda: False)
+        t2_status = SimpleNamespace(failed=lambda: True)
+        g_succ = SimpleNamespace(
+            name='g0',
+            tasks=[SimpleNamespace(name='t1'), SimpleNamespace(name='t2')],
+            status=t1_status)
+        # Use two groups so that per-task completion is derived from group failure
+        g_fail = SimpleNamespace(
+            name='g1',
+            tasks=[SimpleNamespace(name='t3')],
+            status=t2_status)
+        workflow_obj.groups = [g_succ, g_fail]
+
+        submit_info = mock.Mock(name='WorkflowSubmitInfo')
+        submit_info.name = 'restart-wf'
+        submit_info.construct_workflow_dict.return_value = {
+            'workflow': {'name': 'restart-wf'}}
+
+        # Only task t3 is not completed
+        t3_input = task.TaskInputOutput(task='t1')  # parent succeeded → prefixed
+        t3_spec = mock.Mock()
+        t3_spec.name = 't3'
+        t3_spec.inputs = [t3_input]
+
+        workflow_spec = mock.Mock()
+        workflow_spec.groups = []
+        workflow_spec.tasks = [
+            mock.Mock(name='t1_spec', spec=[], inputs=[]),
+            t3_spec]
+        workflow_spec.tasks[0].name = 't1'  # will be filtered out
+        submit_info.construct_workflow_spec_from_dict.return_value = workflow_spec
+        rendered_spec = mock.Mock()
+        workflow_spec.parse.return_value = rendered_spec
+        submit_info.send_submit_workflow_to_queue.return_value = objects.SubmitResponse(
+            name='restart-wf', logs='ok')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.workflow.Workflow, 'fetch_from_db',
+                               return_value=workflow_obj), \
+             mock.patch.object(workflow_service, 'download_workflow_spec',
+                               return_value=iter(['spec'])), \
+             mock.patch.object(workflow_service.helpers, 'gather_stream_content',
+                               return_value='spec'), \
+             mock.patch.object(workflow_service.workflow, 'TemplateSpec'), \
+             mock.patch.object(workflow_service.objects, 'WorkflowSubmitInfo',
+                               return_value=submit_info), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-1'), \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='abc'):
+            workflow_service.restart_workflow(
+                pool_name='p-1', workflow_id='parent-wf',
+                user_header=None, roles_header=None)
+
+        # After rewrite: only t3 is kept (t1 is completed)
+        self.assertEqual(workflow_spec.tasks, [t3_spec])
+        # t3's input references t1 which succeeded → workflow-id prefixed
+        self.assertEqual(t3_input.task, 'parent-wf:t1')
+
+
+class TestCancelWorkflow(unittest.TestCase):
+    """Covers cancel_workflow (lines 554-572)."""
+
+    def test_cancel_workflow_already_finished_without_force_raises(self):
+        workflow_response = _make_workflow_response(
+            name='wf-1', status=job_workflow.WorkflowStatus.COMPLETED)
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_response):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.cancel_workflow(name='wf-1', user='user-1')
+
+        self.assertIn('already finished', ctx.exception.message)
+
+    def test_cancel_workflow_running_sends_cancel_job(self):
+        workflow_response = _make_workflow_response(
+            name='wf-1', uuid='uuid-1',
+            status=job_workflow.WorkflowStatus.RUNNING)
+
+        cancel_job = mock.Mock()
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_response), \
+             mock.patch.object(workflow_service.jobs, 'CancelWorkflow',
+                               return_value=cancel_job) as cancel_cls:
+            response = workflow_service.cancel_workflow(
+                name='wf-1', message='stopping', user='user-1')
+
+        self.assertEqual(response.name, 'wf-1')
+        _, kwargs = cancel_cls.call_args
+        self.assertEqual(kwargs['job_id'], 'uuid-1-cancel')
+        self.assertEqual(kwargs['force'], False)
+        cancel_job.send_job_to_queue.assert_called_once()
+
+    def test_cancel_workflow_force_uses_unique_job_id(self):
+        workflow_response = _make_workflow_response(
+            name='wf-1', uuid='uuid-1',
+            status=job_workflow.WorkflowStatus.COMPLETED)
+
+        cancel_job = mock.Mock()
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_response), \
+             mock.patch.object(workflow_service.jobs, 'CancelWorkflow',
+                               return_value=cancel_job) as cancel_cls, \
+             mock.patch.object(workflow_service.common, 'generate_unique_id',
+                               return_value='RAND1'):
+            workflow_service.cancel_workflow(
+                name='wf-1', force=True, user='user-1')
+
+        _, kwargs = cancel_cls.call_args
+        self.assertEqual(kwargs['job_id'], 'uuid-1-RAND1-force-cancel')
+        self.assertEqual(kwargs['force'], True)
+
+
+class TestListWorkflow(unittest.TestCase):
+    """Covers list_workflow (lines 598-624)."""
+
+    def _kwargs(self, **overrides):
+        base = {
+            'users': None,
+            'name': None,
+            'statuses': None,
+            'pools': None,
+            'all_users': False,
+            'all_pools': False,
+            'offset': 0,
+            'limit': 20,
+            'order': workflow_service.connectors.ListOrder.ASC,
+            'submitted_before': None,
+            'submitted_after': None,
+            'tags': None,
+            'app': None,
+            'priority': None,
+            'user_header': None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_list_workflow_negative_offset_raises(self):
+        with self.assertRaises(osmo_errors.OSMOUsageError):
+            workflow_service.list_workflow(**self._kwargs(offset=-1))
+
+    def test_list_workflow_limit_too_large_raises(self):
+        with self.assertRaises(osmo_errors.OSMOUserError):
+            workflow_service.list_workflow(**self._kwargs(limit=1001))
+
+    def test_list_workflow_uses_user_header_when_no_users(self):
+        context = mock.Mock()
+        context.database.get_workflow_service_url.return_value = 'http://svc'
+        list_response = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors.UserProfile,
+                               'fetch_from_db',
+                               return_value=SimpleNamespace(pool='user-pool')), \
+             mock.patch.object(workflow_service.helpers, 'get_workflows',
+                               return_value=[]), \
+             mock.patch.object(workflow_service.objects.ListResponse,
+                               'from_db_rows',
+                               return_value=list_response) as from_rows:
+            result = workflow_service.list_workflow(**self._kwargs(user_header='user-x'))
+
+        self.assertIs(result, list_response)
+        from_rows.assert_called_once()
+
+    def test_list_workflow_no_pool_raises_when_not_all_pools(self):
+        context = mock.Mock()
+        context.database.get_workflow_service_url.return_value = 'http://svc'
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors.UserProfile,
+                               'fetch_from_db',
+                               return_value=SimpleNamespace(pool='')):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.list_workflow(**self._kwargs(user_header='user-x'))
+
+        self.assertIn('No pool selected', ctx.exception.message)
+
+    def test_list_workflow_all_pools_clears_pools(self):
+        context = mock.Mock()
+        context.database.get_workflow_service_url.return_value = 'http://svc'
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.helpers, 'get_workflows',
+                               return_value=[]) as get_workflows, \
+             mock.patch.object(workflow_service.objects.ListResponse,
+                               'from_db_rows',
+                               return_value=mock.Mock()):
+            workflow_service.list_workflow(
+                **self._kwargs(all_users=True, all_pools=True))
+
+        # Verify get_workflows called with empty list for pools
+        args, _ = get_workflows.call_args
+        # signature: users, name, statuses, pools, offset, limit+1, order,
+        # submitted_after, submitted_before, tags, app_info
+        pools_arg = args[3]
+        self.assertEqual(pools_arg, [])
+
+    def test_list_workflow_truncates_when_has_more(self):
+        context = mock.Mock()
+        context.database.get_workflow_service_url.return_value = 'http://svc'
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors.UserProfile,
+                               'fetch_from_db',
+                               return_value=SimpleNamespace(pool='p1')), \
+             mock.patch.object(workflow_service.helpers, 'get_workflows',
+                               return_value=[{'row': i} for i in range(21)]), \
+             mock.patch.object(workflow_service.objects.ListResponse,
+                               'from_db_rows',
+                               return_value=mock.Mock()) as from_rows:
+            workflow_service.list_workflow(
+                **self._kwargs(user_header='u', limit=20))
+
+        args, kwargs = from_rows.call_args
+        # rows arg limited to 20 (since 21 > 20 -> more entries True)
+        self.assertEqual(len(args[0]), 20)
+        self.assertTrue(kwargs['more_entries'])
+
+
+class TestListTask(unittest.TestCase):
+    """Covers list_task (lines 666-690)."""
+
+    def _kwargs(self, **overrides):
+        base = {
+            'workflow_id': None,
+            'statuses': None,
+            'users': None,
+            'all_users': False,
+            'pools': None,
+            'all_pools': False,
+            'nodes': None,
+            'started_after': None,
+            'started_before': None,
+            'offset': 0,
+            'limit': 20,
+            'order': workflow_service.connectors.ListOrder.ASC,
+            'summary': False,
+            'aggregate_by_workflow': False,
+            'priority': None,
+            'user_header': None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_list_task_zero_limit_raises(self):
+        with self.assertRaises(osmo_errors.OSMOUserError):
+            workflow_service.list_task(**self._kwargs(limit=0))
+
+    def test_list_task_negative_offset_raises(self):
+        with self.assertRaises(osmo_errors.OSMOUsageError):
+            workflow_service.list_task(**self._kwargs(offset=-1))
+
+    def test_list_task_no_pool_raises(self):
+        context = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors.UserProfile,
+                               'fetch_from_db',
+                               return_value=SimpleNamespace(pool=None)):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.list_task(**self._kwargs(user_header='user-x'))
+
+        self.assertIn('No pool selected', ctx.exception.message)
+
+    def test_list_task_summary_response(self):
+        context = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.helpers, 'get_tasks',
+                               return_value=[]), \
+             mock.patch.object(workflow_service.objects.ListTaskSummaryResponse,
+                               'from_db_rows',
+                               return_value=mock.sentinel.summary) as from_rows:
+            result = workflow_service.list_task(
+                **self._kwargs(summary=True, all_users=True, all_pools=True))
+
+        self.assertIs(result, mock.sentinel.summary)
+        from_rows.assert_called_once()
+
+    def test_list_task_aggregated_response(self):
+        context = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.helpers, 'get_tasks',
+                               return_value=[]), \
+             mock.patch.object(workflow_service.objects.ListTaskAggregatedResponse,
+                               'from_db_rows',
+                               return_value=mock.sentinel.aggregated) as from_rows:
+            result = workflow_service.list_task(
+                **self._kwargs(aggregate_by_workflow=True, all_users=True,
+                               all_pools=True))
+
+        self.assertIs(result, mock.sentinel.aggregated)
+        from_rows.assert_called_once()
+
+    def test_list_task_full_response(self):
+        context = mock.Mock()
+        context.database.get_workflow_service_url.return_value = 'http://svc'
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.helpers, 'get_tasks',
+                               return_value=[]), \
+             mock.patch.object(workflow_service.objects.ListTaskResponse,
+                               'from_db_rows',
+                               return_value=mock.sentinel.full) as from_rows:
+            result = workflow_service.list_task(
+                **self._kwargs(all_users=True, all_pools=True))
+
+        self.assertIs(result, mock.sentinel.full)
+        from_rows.assert_called_once()
+
+
+class TestGetWorkflow(unittest.TestCase):
+    """Covers get_workflow (lines 700-701) and get_workflow_task (lines 634-636)."""
+
+    def test_get_workflow_delegates_to_query_response(self):
+        context = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.objects.WorkflowQueryResponse,
+                               'fetch_from_db',
+                               return_value=mock.sentinel.wf) as fetch:
+            result = workflow_service.get_workflow('wf-1')
+
+        self.assertIs(result, mock.sentinel.wf)
+        fetch.assert_called_once_with(context.database, 'wf-1',
+                                      skip_groups=False, verbose=False)
+
+    def test_get_workflow_task_delegates_to_task_entry(self):
+        context = mock.Mock()
+        row = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.task.Task, 'fetch_row_from_db',
+                               return_value=row), \
+             mock.patch.object(workflow_service.objects.TaskEntry, 'from_db_row',
+                               return_value=mock.sentinel.entry) as from_row:
+            result = workflow_service.get_workflow_task('wf-1', 't1')
+
+        self.assertIs(result, mock.sentinel.entry)
+        from_row.assert_called_once_with(row)
+
+
+class TestTagWorkflow(unittest.TestCase):
+    """Covers tag_workflow (lines 934-937)."""
+
+    def test_tag_workflow_no_add_no_remove_raises(self):
+        with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+            workflow_service.tag_workflow(name='wf-1', add=None, remove=None)
+
+        self.assertIn('No tags specified', ctx.exception.message)
+
+    def test_tag_workflow_calls_set_workflow_tags(self):
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.helpers,
+                               'set_workflow_tags') as set_tags:
+            workflow_service.tag_workflow(name='wf-1', add=['a'], remove=None)
+
+        set_tags.assert_called_once_with('wf-1', ['a'], None)
+
+
+class TestGetResources(unittest.TestCase):
+    """Covers get_resources (lines 953-962)."""
+
+    def test_get_resources_concise_returns_pool_resources(self):
+        with mock.patch.object(workflow_service.helpers,
+                               'get_pool_resources',
+                               return_value=mock.sentinel.pool_res) as pr:
+            result = workflow_service.get_resources(
+                pools=['p1'], platforms=['plat'], concise=True)
+
+        self.assertIs(result, mock.sentinel.pool_res)
+        pr.assert_called_once_with(pools=['p1'], platforms=['plat'])
+
+    def test_get_resources_non_concise_uses_objects_get_resources(self):
+        with mock.patch.object(workflow_service.objects, 'get_resources',
+                               return_value=mock.sentinel.full) as gr:
+            result = workflow_service.get_resources(
+                pools=['p1'], platforms=['plat'], concise=False)
+
+        self.assertIs(result, mock.sentinel.full)
+        gr.assert_called_once_with(pools=['p1'], platforms=['plat'])
+
+    def test_get_resources_all_pools_calls_get_all_pool_names(self):
+        with mock.patch.object(workflow_service.connectors.Pool,
+                               'get_all_pool_names',
+                               return_value=['p1', 'p2']), \
+             mock.patch.object(workflow_service.objects, 'get_resources',
+                               return_value=mock.sentinel.full) as gr:
+            workflow_service.get_resources(all_pools=True)
+
+        # pools arg came from get_all_pool_names
+        _, kwargs = gr.call_args
+        self.assertEqual(kwargs['pools'], ['p1', 'p2'])
+
+    def test_get_resources_platforms_only_used_when_pools_set(self):
+        with mock.patch.object(workflow_service.objects, 'get_resources',
+                               return_value=mock.sentinel.full) as gr:
+            workflow_service.get_resources(
+                pools=None, platforms=['plat'],
+                allowed_pools_header='allowed-1,allowed-2')
+
+        _, kwargs = gr.call_args
+        self.assertEqual(kwargs['pools'], ['allowed-1', 'allowed-2'])
+        # platforms=None because pools is falsy → platforms arg becomes None
+        self.assertIsNone(kwargs['platforms'])
+
+
+class TestGetOneResource(unittest.TestCase):
+    """Covers get_one_resource (lines 972-975)."""
+
+    def test_get_one_resource_returns_when_present(self):
+        result_container = SimpleNamespace(resources=[mock.Mock()])
+
+        with mock.patch.object(workflow_service.objects, 'get_resources',
+                               return_value=result_container):
+            result = workflow_service.get_one_resource('node-1')
+
+        self.assertIs(result, result_container)
+
+    def test_get_one_resource_missing_raises_not_found(self):
+        result_container = SimpleNamespace(resources=[])
+
+        with mock.patch.object(workflow_service.objects, 'get_resources',
+                               return_value=result_container):
+            with self.assertRaises(osmo_errors.OSMONotFoundError) as ctx:
+                workflow_service.get_one_resource('node-1')
+
+        self.assertIn('Resource node-1 does not exist', ctx.exception.message)
+
+
+class TestSetUserCredential(unittest.TestCase):
+    """Covers set_user_credential (lines 1004-1025)."""
+
+    def test_set_user_credential_invalid_name_raises(self):
+        cred_option = mock.Mock()
+        with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+            workflow_service.set_user_credential(
+                cred_name='has spaces!', credential_option=cred_option)
+
+        self.assertIn('Invalid name', ctx.exception.message)
+
+    def test_set_user_credential_new_user_adds_secret(self):
+        context = mock.Mock()
+        context.database.execute_fetch_command.return_value = []
+        cred_option = mock.Mock()
+        credential = mock.Mock()
+        cred_option.get_credential.return_value = credential
+        credential.to_db_row.return_value = ('a', 'b')
+        workflow_config = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        postgres_instance = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-x'), \
+             mock.patch.object(workflow_service.connectors,
+                               'PostgresConnector') as postgres_cls, \
+             mock.patch.object(workflow_service.connectors.UserProfile,
+                               'fetch_from_db', return_value=mock.Mock()):
+            postgres_cls.get_instance.return_value = postgres_instance
+            workflow_service.set_user_credential(
+                cred_name='validname', credential_option=cred_option)
+
+        credential.valid_cred.assert_called_once_with(workflow_config)
+        context.database.secret_manager.add_new_user.assert_called_once_with('user-x')
+        context.database.execute_commit_command.assert_called_once()
+
+    def test_set_user_credential_existing_user_skips_add_new(self):
+        context = mock.Mock()
+        context.database.execute_fetch_command.return_value = [{'uid': 'user-x'}]
+        cred_option = mock.Mock()
+        credential = mock.Mock()
+        cred_option.get_credential.return_value = credential
+        credential.to_db_row.return_value = ('a',)
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-x'):
+            workflow_service.set_user_credential(
+                cred_name='validname', credential_option=cred_option)
+
+        context.database.secret_manager.add_new_user.assert_not_called()
+
+    def test_set_user_credential_database_error_maps_to_user_error(self):
+        context = mock.Mock()
+        context.database.execute_fetch_command.return_value = [{'uid': 'user-x'}]
+        cred_option = mock.Mock()
+        credential = mock.Mock()
+        cred_option.get_credential.return_value = credential
+        credential.to_db_row.return_value = ('a',)
+        context.database.execute_commit_command.side_effect = \
+            osmo_errors.OSMODatabaseError('DB: table not found')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-x'):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.set_user_credential(
+                    cred_name='validname', credential_option=cred_option)
+
+        self.assertIn('table not found', ctx.exception.message)
+
+
+class TestDeleteUsersCredential(unittest.TestCase):
+    """Covers delete_users_credential (lines 1034-1055)."""
+
+    def test_delete_users_credential_invalid_name_raises(self):
+        with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+            workflow_service.delete_users_credential(cred_name='has space')
+
+        self.assertIn('Invalid name', ctx.exception.message)
+
+    def test_delete_users_credential_no_rows_raises(self):
+        context = mock.Mock()
+        context.database.execute_fetch_command.return_value = []
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-x'):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.delete_users_credential(cred_name='validname')
+
+        self.assertIn('does not exits', ctx.exception.message)
+
+    def test_delete_users_credential_deletes_and_returns_row(self):
+        context = mock.Mock()
+        row = mock.Mock()
+        context.database.execute_fetch_command.return_value = [row]
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-x'), \
+             mock.patch.object(workflow_service.objects.UserCredential,
+                               'from_db_row', return_value=[]) as from_row:
+            response = workflow_service.delete_users_credential(cred_name='validname')
+
+        context.database.execute_commit_command.assert_called_once()
+        self.assertEqual(response.credentials, [])
+        from_row.assert_called_once_with([row])
+
+    def test_delete_users_credential_database_error_maps_to_user_error(self):
+        context = mock.Mock()
+        row = mock.Mock()
+        context.database.execute_fetch_command.return_value = [row]
+        context.database.execute_commit_command.side_effect = \
+            osmo_errors.OSMODatabaseError('DB: fk violation')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-x'):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.delete_users_credential(cred_name='validname')
+
+        self.assertIn('fk violation', ctx.exception.message)
+
+
+class TestGetUserCredential(unittest.TestCase):
+    """Covers get_user_credential (lines 987-993)."""
+
+    def test_get_user_credential_returns_response_from_rows(self):
+        context = mock.Mock()
+        rows = [mock.Mock()]
+        context.database.execute_fetch_command.return_value = rows
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.connectors, 'parse_username',
+                               return_value='user-x'), \
+             mock.patch.object(workflow_service.objects.UserCredential,
+                               'from_db_row',
+                               return_value=[]) as from_row:
+            response = workflow_service.get_user_credential(user_header='u')
+
+        self.assertEqual(response.credentials, [])
+        from_row.assert_called_once_with(rows)
+
+
+class TestActionRequestHelper(unittest.TestCase):
+    """Covers action_request_helper (lines 1064-1130)."""
+
+    def test_action_helper_no_backend_raises_not_found(self):
+        workflow_result = _make_workflow_response(
+            name='wf-1', backend=None,
+            status=job_workflow.WorkflowStatus.RUNNING)
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_result):
+            with self.assertRaises(osmo_errors.OSMONotFoundError) as ctx:
+                workflow_service.action_request_helper(
+                    workflow_service.ActionType.EXEC, {}, 'wf-1')
+
+        self.assertEqual(ctx.exception.status_code,
+                         http.HTTPStatus.UNPROCESSABLE_ENTITY.value)
+
+    def test_action_helper_finished_workflow_raises(self):
+        workflow_result = _make_workflow_response(
+            name='wf-1', status=job_workflow.WorkflowStatus.COMPLETED)
+
+        with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+            workflow_service.action_request_helper(
+                workflow_service.ActionType.EXEC, {}, 'wf-1',
+                cached_workflow_response=workflow_result)
+
+        self.assertEqual(ctx.exception.status_code,
+                         http.HTTPStatus.GONE.value)
+        self.assertIn('is not running', ctx.exception.message)
+
+    def test_action_helper_pending_workflow_raises_too_early(self):
+        workflow_result = _make_workflow_response(
+            name='wf-1', status=job_workflow.WorkflowStatus.PENDING)
+
+        with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+            workflow_service.action_request_helper(
+                workflow_service.ActionType.EXEC, {}, 'wf-1',
+                cached_workflow_response=workflow_result)
+
+        self.assertEqual(ctx.exception.status_code,
+                         http.HTTPStatus.TOO_EARLY.value)
+
+    def test_action_helper_no_router_address_raises(self):
+        workflow_result = _make_workflow_response(
+            name='wf-1', status=job_workflow.WorkflowStatus.RUNNING)
+        backend_config = SimpleNamespace(router_address='')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.connectors.Backend,
+                               'fetch_from_db',
+                               return_value=backend_config):
+            with self.assertRaises(osmo_errors.OSMONotFoundError) as ctx:
+                workflow_service.action_request_helper(
+                    workflow_service.ActionType.EXEC, {}, 'wf-1',
+                    cached_workflow_response=workflow_result)
+
+        self.assertEqual(ctx.exception.status_code,
+                         http.HTTPStatus.UNPROCESSABLE_ENTITY.value)
+
+    def test_action_helper_task_dispatches_single_task(self):
+        workflow_result = _make_workflow_response(
+            name='wf-1', status=job_workflow.WorkflowStatus.RUNNING)
+        backend_config = SimpleNamespace(router_address='wss://router')
+        redis_client = mock.Mock()
+        redis_instance = SimpleNamespace(client=redis_client)
+        target_task = _make_task_query(name='t1', retry_id=2)
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.connectors.Backend,
+                               'fetch_from_db',
+                               return_value=backend_config), \
+             mock.patch.object(workflow_service.helpers, 'get_running_task',
+                               return_value=target_task) as get_task, \
+             mock.patch.object(workflow_service.connectors.RedisConnector,
+                               'get_instance',
+                               return_value=redis_instance), \
+             mock.patch.object(workflow_service.job_common,
+                               'calculate_total_timeout',
+                               return_value=60), \
+             mock.patch.object(workflow_service.helpers, 'get_router_cookie',
+                               return_value='c=v'), \
+             mock.patch.object(workflow_service.common,
+                               'generate_unique_id',
+                               return_value='ID1'):
+            result = workflow_service.action_request_helper(
+                workflow_service.ActionType.EXEC, {'entry_command': 'ls'},
+                'wf-1', task_name='t1',
+                cached_workflow_response=workflow_result)
+
+        self.assertIn('t1', result)
+        self.assertEqual(result['t1'].router_address, 'wss://router')
+        self.assertEqual(result['t1'].key, 'EXEC-ID1')
+        self.assertEqual(result['t1'].cookie, 'c=v')
+        get_task.assert_called_once_with(workflow_result, 't1')
+        redis_client.set.assert_called_once()
+        redis_client.lpush.assert_called_once()
+
+    def test_action_helper_group_dispatches_group_tasks(self):
+        workflow_result = _make_workflow_response(
+            name='wf-1', status=job_workflow.WorkflowStatus.RUNNING)
+        backend_config = SimpleNamespace(router_address='wss://router')
+        redis_client = mock.Mock()
+        redis_instance = SimpleNamespace(client=redis_client)
+        task_1 = _make_task_query(name='t1', retry_id=0)
+        task_2 = _make_task_query(name='t2', retry_id=0)
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.connectors.Backend,
+                               'fetch_from_db',
+                               return_value=backend_config), \
+             mock.patch.object(workflow_service.helpers,
+                               'get_running_tasks_from_group',
+                               return_value=[task_1, task_2]) as get_group, \
+             mock.patch.object(workflow_service.connectors.RedisConnector,
+                               'get_instance',
+                               return_value=redis_instance), \
+             mock.patch.object(workflow_service.job_common,
+                               'calculate_total_timeout',
+                               return_value=60), \
+             mock.patch.object(workflow_service.helpers, 'get_router_cookie',
+                               return_value=''), \
+             mock.patch.object(workflow_service.common,
+                               'generate_unique_id',
+                               return_value='ID'):
+            result = workflow_service.action_request_helper(
+                workflow_service.ActionType.EXEC, {'entry_command': 'ls'},
+                'wf-1', group_name='g1',
+                cached_workflow_response=workflow_result)
+
+        self.assertEqual(set(result.keys()), {'t1', 't2'})
+        get_group.assert_called_once_with(workflow_result, 'g1')
+
+    def test_action_helper_no_task_or_group_dispatches_all(self):
+        workflow_result = _make_workflow_response(
+            name='wf-1', status=job_workflow.WorkflowStatus.RUNNING)
+        backend_config = SimpleNamespace(router_address='wss://router')
+        redis_client = mock.Mock()
+        redis_instance = SimpleNamespace(client=redis_client)
+        wf_task = _make_task_query(name='wf-task', retry_id=1)
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.connectors.Backend,
+                               'fetch_from_db',
+                               return_value=backend_config), \
+             mock.patch.object(workflow_service.helpers,
+                               'get_running_tasks_from_workflow',
+                               return_value=[wf_task]) as get_all, \
+             mock.patch.object(workflow_service.connectors.RedisConnector,
+                               'get_instance',
+                               return_value=redis_instance), \
+             mock.patch.object(workflow_service.job_common,
+                               'calculate_total_timeout',
+                               return_value=60), \
+             mock.patch.object(workflow_service.helpers, 'get_router_cookie',
+                               return_value=''), \
+             mock.patch.object(workflow_service.common,
+                               'generate_unique_id',
+                               return_value='ID'):
+            result = workflow_service.action_request_helper(
+                workflow_service.ActionType.EXEC, {}, 'wf-1',
+                cached_workflow_response=workflow_result)
+
+        self.assertIn('wf-task', result)
+        get_all.assert_called_once_with(workflow_result)
+
+
+class TestExecPortForwardRsyncHelpers(unittest.TestCase):
+    """Covers exec_into_*, port_forward_*, rsync_task (lines 1137-1210)."""
+
+    def test_exec_into_group_calls_helper_with_group_name(self):
+        workflow_result = _make_workflow_response(name='wf-1')
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_result), \
+             mock.patch.object(workflow_service, 'action_request_helper',
+                               return_value=mock.sentinel.result) as helper:
+            result = workflow_service.exec_into_group('wf-1', 'g1', 'ls')
+
+        self.assertIs(result, mock.sentinel.result)
+        args, kwargs = helper.call_args
+        self.assertEqual(args[0], workflow_service.ActionType.EXEC)
+        self.assertEqual(args[1], {'entry_command': 'ls'})
+        self.assertEqual(kwargs['group_name'], 'g1')
+
+    def test_exec_into_task_returns_task_key_from_helper(self):
+        workflow_result = _make_workflow_response(name='wf-1')
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_result), \
+             mock.patch.object(workflow_service, 'action_request_helper',
+                               return_value={'t1': mock.sentinel.info}) as helper:
+            result = workflow_service.exec_into_task('wf-1', 't1', 'ls')
+
+        self.assertIs(result, mock.sentinel.info)
+        _, kwargs = helper.call_args
+        self.assertEqual(kwargs['task_name'], 't1')
+
+    def test_port_forward_task_no_ports_raises(self):
+        workflow_result = _make_workflow_response(name='wf-1')
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_result):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.port_forward_task('wf-1', 't1', task_ports=None)
+
+        self.assertIn('No port is provided', ctx.exception.message)
+
+    def test_port_forward_task_exceeds_max_ports(self):
+        workflow_result = _make_workflow_response(name='wf-1')
+        workflow_config = mock.Mock()
+        workflow_config.max_num_ports_per_task = 2
+        context = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_result), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.port_forward_task(
+                    'wf-1', 't1', task_ports=[80, 443, 8080])
+
+        self.assertIn('exceeds the maximum', ctx.exception.message)
+
+    def test_port_forward_task_returns_one_router_info_per_port(self):
+        workflow_result = _make_workflow_response(name='wf-1')
+        workflow_config = mock.Mock()
+        workflow_config.max_num_ports_per_task = 10
+        context = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_result), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service, 'action_request_helper',
+                               return_value={'t1': mock.sentinel.router}) as helper:
+            result = workflow_service.port_forward_task(
+                'wf-1', 't1', task_ports=[80, 443])
+
+        self.assertEqual(result, [mock.sentinel.router, mock.sentinel.router])
+        self.assertEqual(helper.call_count, 2)
+        # First call carries port=80 in payload
+        first_args = helper.call_args_list[0]
+        self.assertEqual(first_args[0][1]['task_port'], 80)
+
+    def test_port_forward_webserver_returns_router_info(self):
+        workflow_result = _make_workflow_response(name='wf-1')
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_result), \
+             mock.patch.object(workflow_service, 'action_request_helper',
+                               return_value={'t1': mock.sentinel.router}) as helper:
+            result = workflow_service.port_forward_webserver(
+                'wf-1', 't1', task_port=8080)
+
+        self.assertIs(result, mock.sentinel.router)
+        args, kwargs = helper.call_args
+        self.assertEqual(args[0], workflow_service.ActionType.WEBSERVER)
+        self.assertEqual(args[1], {'task_port': 8080})
+        self.assertEqual(kwargs['task_name'], 't1')
+
+    def test_rsync_task_without_rsync_plugin_raises(self):
+        workflow_result = _make_workflow_response(
+            name='wf-1', plugins=SimpleNamespace(rsync=False))
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_result):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.rsync_task('wf-1', 't1')
+
+        self.assertEqual(ctx.exception.status_code,
+                         http.HTTPStatus.FORBIDDEN.value)
+        self.assertIn('Rsync is not enabled', ctx.exception.message)
+
+    def test_rsync_task_calls_helper_with_telemetry_flag(self):
+        workflow_result = _make_workflow_response(
+            name='wf-1', plugins=SimpleNamespace(rsync=True))
+        workflow_config = mock.Mock()
+        workflow_config.plugins_config.rsync.enable_telemetry = True
+        context = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_result), \
+             mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service, 'action_request_helper',
+                               return_value={'t1': mock.sentinel.router}) as helper:
+            result = workflow_service.rsync_task('wf-1', 't1')
+
+        self.assertIs(result, mock.sentinel.router)
+        args, _ = helper.call_args
+        self.assertEqual(args[0], workflow_service.ActionType.RSYNC)
+        self.assertEqual(args[1], {'enable_telemetry': True})
+
+
+class TestDownloadWorkflowSpec(unittest.TestCase):
+    """Covers download_workflow_spec (lines 887-898)."""
+
+    def test_download_workflow_spec_raises_when_no_credential(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = None
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context):
+            with self.assertRaises(osmo_errors.OSMOServerError) as ctx:
+                workflow_service.download_workflow_spec('wf-1')
+
+        self.assertIn('credential is not set', ctx.exception.message)
+
+    def test_download_workflow_spec_returns_workflow_file(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        storage_client = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=storage_client), \
+             mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=_make_workflow_response(name='wf-1')), \
+             mock.patch.object(workflow_service.helpers, 'get_workflow_file',
+                               return_value=mock.sentinel.stream) as get_file:
+            result = workflow_service.download_workflow_spec(
+                'wf-1', use_template=True)
+
+        self.assertIs(result, mock.sentinel.stream)
+        # use_template=True uses TEMPLATED_WORKFLOW_SPEC_FILE_NAME
+        args, _ = get_file.call_args
+        self.assertEqual(
+            args[0], workflow_service.common.TEMPLATED_WORKFLOW_SPEC_FILE_NAME)
+
+
+class TestGetWorkflowLogs(unittest.TestCase):
+    """Covers get_workflow_logs (lines 776-805)."""
+
+    def test_get_workflow_logs_no_credential_raises_server_error(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = None
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context):
+            with self.assertRaises(osmo_errors.OSMOServerError) as ctx:
+                workflow_service.get_workflow_logs('wf-1')
+
+        self.assertIn('credential is not set', ctx.exception.message)
+
+    def test_get_workflow_logs_no_task_uses_workflow_defaults(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        storage_client = mock.Mock()
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=storage_client), \
+             mock.patch.object(workflow_service, 'get_file_info',
+                               return_value=mock.sentinel.resp) as get_info:
+            result = workflow_service.get_workflow_logs('wf-1', query='ERR')
+
+        self.assertIs(result, mock.sentinel.resp)
+        _, kwargs = get_info.call_args
+        self.assertEqual(kwargs['regexes'], ['ERR'])
+
+    def test_get_workflow_logs_with_task_uses_task_log_file_when_exists(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        storage_client = mock.Mock()
+        task_obj = SimpleNamespace(retry_id=0, name='t1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=storage_client), \
+             mock.patch.object(workflow_service.task.Task, 'fetch_from_db',
+                               return_value=task_obj), \
+             mock.patch.object(workflow_service.helpers,
+                               'workflow_file_exists', return_value=True), \
+             mock.patch.object(workflow_service, 'get_file_info',
+                               return_value=mock.sentinel.resp) as get_info:
+            workflow_service.get_workflow_logs(
+                'wf-1', task_name='t1', retry_id=None)
+
+        _, kwargs = get_info.call_args
+        # Task log file was found, so no regex fallback added
+        self.assertEqual(kwargs['regexes'], [])
+
+    def test_get_workflow_logs_task_no_file_falls_back_to_regex(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        storage_client = mock.Mock()
+        task_obj = SimpleNamespace(retry_id=2, name='t1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=storage_client), \
+             mock.patch.object(workflow_service.task.Task, 'fetch_from_db',
+                               return_value=task_obj), \
+             mock.patch.object(workflow_service.helpers,
+                               'workflow_file_exists', return_value=False), \
+             mock.patch.object(workflow_service, 'get_file_info',
+                               return_value=mock.sentinel.resp) as get_info:
+            workflow_service.get_workflow_logs(
+                'wf-1', task_name='t1', retry_id=None)
+
+        _, kwargs = get_info.call_args
+        # Regex includes retry- prefix since retry_id > 0
+        self.assertEqual(len(kwargs['regexes']), 1)
+        self.assertIn('retry-2', kwargs['regexes'][0])
+
+    def test_get_workflow_logs_task_no_retry_uses_bare_regex(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        task_obj = SimpleNamespace(retry_id=0, name='t1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.task.Task, 'fetch_from_db',
+                               return_value=task_obj), \
+             mock.patch.object(workflow_service.helpers,
+                               'workflow_file_exists', return_value=False), \
+             mock.patch.object(workflow_service, 'get_file_info',
+                               return_value=mock.sentinel.resp) as get_info:
+            workflow_service.get_workflow_logs(
+                'wf-1', task_name='t1')
+
+        _, kwargs = get_info.call_args
+        self.assertEqual(len(kwargs['regexes']), 1)
+        self.assertNotIn('retry-', kwargs['regexes'][0])
+
+
+class TestGetWorkflowPodConditions(unittest.TestCase):
+    """Covers get_workflow_pod_conditions (lines 816-835)."""
+
+    def test_no_credential_raises_server_error(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = None
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context):
+            with self.assertRaises(osmo_errors.OSMOServerError):
+                workflow_service.get_workflow_pod_conditions('wf-1')
+
+    def test_no_task_returns_events_stream(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        # get_workflow_events_redis_name asserts a 32-char hex uuid.
+        valid_uuid = '0' * 31 + '1'
+        workflow_response = _make_workflow_response(name='wf-1', uuid=valid_uuid)
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=mock.Mock()), \
+             mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_response), \
+             mock.patch.object(workflow_service, 'get_file_info',
+                               return_value=mock.sentinel.resp) as get_info:
+            result = workflow_service.get_workflow_pod_conditions('wf-1')
+
+        self.assertIs(result, mock.sentinel.resp)
+        _, kwargs = get_info.call_args
+        self.assertEqual(kwargs['regexes'], [])
+
+    def test_with_task_adds_task_regex(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        valid_uuid = '0' * 31 + '1'
+        workflow_response = _make_workflow_response(name='wf-1', uuid=valid_uuid)
+        task_obj = SimpleNamespace(retry_id=3, name='t1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=mock.Mock()), \
+             mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_response), \
+             mock.patch.object(workflow_service.task.Task, 'fetch_from_db',
+                               return_value=task_obj), \
+             mock.patch.object(workflow_service, 'get_file_info',
+                               return_value=mock.sentinel.resp) as get_info:
+            workflow_service.get_workflow_pod_conditions('wf-1', task_name='t1')
+
+        _, kwargs = get_info.call_args
+        self.assertEqual(len(kwargs['regexes']), 1)
+        self.assertIn('retry-3', kwargs['regexes'][0])
+
+
+class TestGetWorkflowErrorLogs(unittest.TestCase):
+    """Covers get_workflow_error_logs (lines 848-877)."""
+
+    def test_no_task_returns_json_table(self):
+        # Ensure that when task_name is None, the JSON summary is returned.
+        wf_task = SimpleNamespace(name='t1', retry_id=0, error_logs='err-url')
+        group = SimpleNamespace(tasks=[wf_task])
+        workflow_response = SimpleNamespace(groups=[group])
+
+        with mock.patch.object(workflow_service, 'get_workflow',
+                               return_value=workflow_response):
+            result = workflow_service.get_workflow_error_logs('wf-1')
+
+        self.assertIn('Specify task', result)
+        self.assertIn('err-url', result)
+
+    def test_no_credential_raises(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = None
+        context.database.get_workflow_configs.return_value = workflow_config
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context):
+            with self.assertRaises(osmo_errors.OSMOServerError):
+                workflow_service.get_workflow_error_logs(
+                    'wf-1', task_name='t1')
+
+    def test_old_error_logs_file_takes_precedence(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        task_obj = SimpleNamespace(retry_id=1, name='t1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.task.Task, 'fetch_from_db',
+                               return_value=task_obj), \
+             mock.patch.object(workflow_service.helpers, 'workflow_file_exists',
+                               return_value=True), \
+             mock.patch.object(workflow_service, 'get_file_info',
+                               return_value=mock.sentinel.resp) as get_info:
+            workflow_service.get_workflow_error_logs(
+                'wf-1', task_name='t1', query='ERROR')
+
+        args, kwargs = get_info.call_args
+        # file_name should be the OLD error logs file when it exists
+        self.assertEqual(args[2],
+                         workflow_service.common.OLD_WORKFLOW_ERROR_LOGS_FILE_NAME)
+        self.assertEqual(kwargs['regexes'], ['ERROR'])
+
+    def test_retry_id_zero_uses_legacy_file(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        task_obj = SimpleNamespace(retry_id=0, name='t1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.task.Task, 'fetch_from_db',
+                               return_value=task_obj), \
+             mock.patch.object(workflow_service.helpers, 'workflow_file_exists',
+                               return_value=False), \
+             mock.patch.object(workflow_service, 'get_file_info',
+                               return_value=mock.sentinel.resp) as get_info:
+            workflow_service.get_workflow_error_logs(
+                'wf-1', task_name='t1')
+
+        args, _ = get_info.call_args
+        self.assertTrue(args[2].startswith('t1'))
+        self.assertNotIn('_0', args[2])
+
+    def test_retry_id_positive_appends_retry_suffix(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.workflow_log.credential = mock.Mock()
+        context.database.get_workflow_configs.return_value = workflow_config
+        task_obj = SimpleNamespace(retry_id=2, name='t1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.storage.Client, 'create',
+                               return_value=mock.Mock()), \
+             mock.patch.object(workflow_service.task.Task, 'fetch_from_db',
+                               return_value=task_obj), \
+             mock.patch.object(workflow_service.helpers, 'workflow_file_exists',
+                               return_value=False), \
+             mock.patch.object(workflow_service, 'get_file_info',
+                               return_value=mock.sentinel.resp) as get_info:
+            workflow_service.get_workflow_error_logs(
+                'wf-1', task_name='t1')
+
+        args, _ = get_info.call_args
+        self.assertIn('t1_2', args[2])
+
+
+class TestGetFileInfo(unittest.TestCase):
+    """Covers get_file_info (lines 711-716, 720-766)."""
+
+    def test_negative_last_n_lines_raises(self):
+        context = mock.Mock()
+        log_info = SimpleNamespace(logs='redis://localhost/wf-1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.workflow.LogInfo,
+                               'fetch_log_info_from_db',
+                               return_value=log_info):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.get_file_info(
+                    'wf-1', 'redis-key', 'log.txt',
+                    storage_client=mock.Mock(),
+                    last_n_lines=-1)
+
+        self.assertIn('positive value', ctx.exception.message)
+
+    def test_invalid_regex_raises(self):
+        context = mock.Mock()
+        log_info = SimpleNamespace(logs='redis://localhost/wf-1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.workflow.LogInfo,
+                               'fetch_log_info_from_db',
+                               return_value=log_info):
+            with self.assertRaises(osmo_errors.OSMOUserError) as ctx:
+                workflow_service.get_file_info(
+                    'wf-1', 'redis-key', 'log.txt',
+                    storage_client=mock.Mock(),
+                    regexes=['[invalid'])
+
+        self.assertIn('Invalid regex', ctx.exception.message)
+
+    def test_redis_scheme_uses_redis_formatter(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.max_log_lines = 1000
+        context.database.get_workflow_configs.return_value = workflow_config
+        log_info = SimpleNamespace(logs='redis://localhost/wf-1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.workflow.LogInfo,
+                               'fetch_log_info_from_db',
+                               return_value=log_info), \
+             mock.patch.object(workflow_service.connectors,
+                               'redis_log_formatter',
+                               return_value=iter([])) as redis_fmt:
+            response = workflow_service.get_file_info(
+                'wf-1', 'redis-key', 'log.txt',
+                storage_client=mock.Mock(),
+                last_n_lines=10)
+
+        # Redis formatter was invoked
+        redis_fmt.assert_called_once()
+        self.assertEqual(response.headers['Content-type'],
+                         'text/plain; charset=us-ascii')
+        self.assertEqual(response.headers['X-Content-Type-Options'], 'nosniff')
+
+    def test_download_forces_storage_path(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.max_log_lines = 1000
+        context.database.get_workflow_configs.return_value = workflow_config
+        log_info = SimpleNamespace(logs='redis://localhost/wf-1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.workflow.LogInfo,
+                               'fetch_log_info_from_db',
+                               return_value=log_info), \
+             mock.patch.object(workflow_service.helpers, 'get_workflow_file',
+                               return_value=iter([])) as get_file:
+            workflow_service.get_file_info(
+                'wf-1', 'redis-key', 'log.txt',
+                storage_client=mock.Mock(),
+                download=True)
+
+        # Even though scheme is redis, download=True routes to storage path
+        get_file.assert_called_once()
+
+    def test_max_log_lines_clamps_last_n_lines(self):
+        context = mock.Mock()
+        workflow_config = mock.Mock()
+        workflow_config.max_log_lines = 5
+        context.database.get_workflow_configs.return_value = workflow_config
+        log_info = SimpleNamespace(logs='redis://localhost/wf-1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.workflow.LogInfo,
+                               'fetch_log_info_from_db',
+                               return_value=log_info), \
+             mock.patch.object(workflow_service.connectors,
+                               'redis_log_formatter',
+                               return_value=iter([])) as redis_fmt:
+            workflow_service.get_file_info(
+                'wf-1', 'redis-key', 'log.txt',
+                storage_client=mock.Mock(),
+                last_n_lines=100)
+
+        # last_n_lines should have been clamped to None when >= max_log_lines
+        args, _ = redis_fmt.call_args
+        self.assertIsNone(args[2])
+
+    def test_backend_error_is_swallowed(self):
+        context = mock.Mock()
+        context.database.get_workflow_configs.side_effect = \
+            osmo_errors.OSMOBackendError('backend down')
+        log_info = SimpleNamespace(logs='redis://localhost/wf-1')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.workflow.LogInfo,
+                               'fetch_log_info_from_db',
+                               return_value=log_info), \
+             mock.patch.object(workflow_service.connectors,
+                               'redis_log_formatter',
+                               return_value=iter([])):
+            # Should not raise; the OSMOBackendError is swallowed.
+            response = workflow_service.get_file_info(
+                'wf-1', 'redis-key', 'log.txt',
+                storage_client=mock.Mock(),
+                last_n_lines=10)
+        self.assertIsNotNone(response)
+
+
+class TestGetWorkflowSpec(unittest.TestCase):
+    """Covers get_workflow_spec (lines 905-923)."""
+
+    def test_get_workflow_spec_returns_streaming_response(self):
+        context = mock.Mock()
+        # execute_fetch_command returns rows with .name attribute
+        context.database.execute_fetch_command.return_value = [
+            SimpleNamespace(name='cred-a'), SimpleNamespace(name='cred-b')]
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service, 'download_workflow_spec',
+                               return_value=iter(['spec'])), \
+             mock.patch.object(workflow_service, 'redact_secrets',
+                               return_value=iter(['redacted'])) as redact:
+            response = workflow_service.get_workflow_spec('wf-1')
+
+        self.assertEqual(response.media_type, 'text/plain; charset=utf-8')
+        # frozenset containing the fetched cred names is passed to redact_secrets
+        args, _ = redact.call_args
+        self.assertEqual(args[1], frozenset({'cred-a', 'cred-b'}))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -23,6 +23,16 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@osmo_constants//:constants.bzl", "BASE_IMAGE_URL", "IMAGE_TAG")
 
 osmo_py_library(
+    name = "request_context",
+    srcs = ["request_context.py"],
+    deps = [
+        requirement("starlette"),
+        "//src/lib/utils:login",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "mcp_service_lib",
     srcs = ["server.py"],
     deps = [
@@ -30,6 +40,7 @@ osmo_py_library(
         requirement("pydantic"),
         requirement("starlette"),
         requirement("uvicorn"),
+        ":request_context",
         "//src/utils:ssl_config",
         "//src/utils:static_config",
     ],

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -63,6 +63,7 @@ osmo_py_library(
     deps = [
         requirement("mcp"),
         requirement("pydantic"),
+        ":request_context",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -44,6 +44,30 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "profile_tools",
+    srcs = ["profile.py"],
+    deps = [
+        requirement("mcp"),
+        requirement("pydantic"),
+        requirement("starlette"),
+        ":gateway",
+        ":request_context",
+        "//src/lib/api:profile",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "protocol",
+    srcs = ["protocol.py"],
+    deps = [
+        requirement("mcp"),
+        requirement("pydantic"),
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "mcp_service_lib",
     srcs = ["server.py"],
     deps = [
@@ -53,6 +77,8 @@ osmo_py_library(
         requirement("starlette"),
         requirement("uvicorn"),
         ":gateway",
+        ":profile_tools",
+        ":protocol",
         ":request_context",
         "//src/utils:ssl_config",
         "//src/utils:static_config",

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -47,10 +47,12 @@ osmo_py_library(
     name = "mcp_service_lib",
     srcs = ["server.py"],
     deps = [
+        requirement("httpx"),
         requirement("mcp"),
         requirement("pydantic"),
         requirement("starlette"),
         requirement("uvicorn"),
+        ":gateway",
         ":request_context",
         "//src/utils:ssl_config",
         "//src/utils:static_config",

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -33,6 +33,17 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "gateway",
+    srcs = ["gateway.py"],
+    deps = [
+        requirement("httpx"),
+        ":request_context",
+        "//src/lib/utils:login",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "mcp_service_lib",
     srcs = ["server.py"],
     deps = [

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -48,9 +48,9 @@ The relay boundary has these invariants:
 - Tools select a fixed HTTP method and `/api/...` path. Unknown tool arguments,
   alternate URLs, queries, fragments, redirects, and path traversal fail
   closed.
-- Only the unchanged authorization value and optional request ID cross the
-  second Gateway pass. MCP does not copy `x-osmo-*`, cookies, proxy headers, or
-  inbound request headers.
+- The unchanged authorization value and optional request ID are the only
+  caller-derived headers forwarded on the second Gateway pass. MCP does not
+  copy `x-osmo-*`, cookies, proxy headers, or other inbound request headers.
 - MCP does not exchange, refresh, modify, cache, persist, log, or return the
   bearer token. It clears request context and upstream cookies on completion,
   failure, timeout, or cancellation.

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -1,0 +1,112 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# OSMO MCP service
+
+The self-hosted MCP service is a stateless, thin adapter over predefined OSMO
+REST APIs. It does not authenticate users itself. The deployment contract
+requires every MCP request and every resulting API request to pass through the
+same deployment's Gateway.
+
+## Request flow and trust boundary
+
+```text
+MCP client
+  -> Gateway (token validation + mcp:Access)
+  -> MCP (request-local token reference + fixed tool mapping)
+  -> same Gateway (second token validation + API-specific action)
+  -> OSMO API
+```
+
+The Gateway supplies one `Authorization: Bearer ...` header and trusted
+`x-osmo-user` identity to the MCP request. The MCP middleware validates the
+forwarded context, removes those headers from the downstream ASGI scope, and
+holds the exact authorization value only in request-local context. A tool must
+pass those credentials explicitly to `GatewayClient`; the shared HTTP client
+contains no caller credentials.
+
+The relay boundary has these invariants:
+
+- The outbound origin is deployment configuration, never tool input. The Helm
+  chart derives it from the public `services.mcp.resourceUrl` by removing the
+  exact `/mcp` suffix.
+- Tools select a fixed HTTP method and `/api/...` path. Unknown tool arguments,
+  alternate URLs, queries, fragments, redirects, and path traversal fail
+  closed.
+- Only the unchanged authorization value and optional request ID cross the
+  second Gateway pass. MCP does not copy `x-osmo-*`, cookies, proxy headers, or
+  inbound request headers.
+- MCP does not exchange, refresh, modify, cache, persist, log, or return the
+  bearer token. It clears request context and upstream cookies on completion,
+  failure, timeout, or cancellation.
+- Outbound calls have a total timeout, bounded response size, identity content
+  encoding, no redirects, and no automatic retries. Upstream error bodies are
+  discarded.
+- Receiving APIs remain authoritative for API-specific authorization,
+  validation, and side effects. MCP returns bounded tool errors that can
+  identify a safe upstream HTTP status and never include the upstream body.
+
+The Gateway, MCP process, receiving OSMO APIs, and applicable middleware are
+inside the bearer-token handling boundary. None of them may log or persist the
+authorization value.
+
+## Current tool
+
+`osmo_get_profile` maps to `GET /api/profile/settings`, requires the existing
+`profile:Read` action on the second Gateway pass, accepts no tool arguments,
+and limits the response to 64 KiB. Its structured result uses the same
+lightweight profile API contract as Core.
+
+The Kubernetes `/health`, `/health/live`, and `/health/ready` endpoints only
+report MCP process health. They do not relay a token or test Gateway/API
+authorization. A failed `osmo_get_profile` call therefore does not necessarily
+mean the MCP pod is unhealthy.
+
+## Adding a tool
+
+Keep each new tool a narrow adapter:
+
+1. Confirm the external OSMO API method, path, request model, response model,
+   RBAC action, pagination, and side effects in the current codebase.
+2. Do not accept a token, identity, origin, route, method, or headers as tool
+   input. Validate every legitimate argument and encode path segments safely.
+3. Reuse or extract a lightweight external API contract. Do not pull Core,
+   database, Kubernetes, or CLI client dependencies into the MCP image.
+4. Obtain `AppContext` from the injected FastMCP `Context`, obtain credentials
+   from `request_context`, and pass both explicitly to `GatewayClient`.
+5. Set a tool-specific response ceiling and validate the complete success
+   response before returning it. Never return an upstream error body.
+6. Set accurate MCP annotations. Only operations with no observable side
+   effects are read-only. Do not retry a state-changing operation whose result
+   is uncertain.
+7. Add real Streamable HTTP protocol tests for the success path, fixed mapping,
+   annotations/schema, authorization and request-ID relay, API errors,
+   malformed/oversized responses, forbidden inputs, and sensitive-data
+   absence.
+
+## Local validation
+
+```bash
+bazel test --test_output=errors //src/service/mcp/...
+bazel build //src/service/mcp:mcp_binary
+bash deployments/charts/service/ci/validate-mcp-chart.sh
+```
+
+The chart validation covers MCP-disabled and MCP-enabled renders, the derived
+Gateway origin, OAuth metadata, probes, ingress isolation, absence of MCP
+credential material, and expected configuration failures.

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -1,0 +1,244 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+import contextlib
+import dataclasses
+import math
+from urllib import parse
+
+import httpx
+
+from src.lib.utils import login
+from src.service.mcp import request_context
+
+
+_ALLOWED_METHODS = frozenset(('GET', 'POST', 'PATCH', 'DELETE'))
+_REQUEST_ID_HEADER = 'x-request-id'
+_USER_AGENT = 'osmo-mcp'
+_IDENTITY_ENCODING = 'identity'
+_HTTP_LIMITS = httpx.Limits(
+    max_connections=100,
+    max_keepalive_connections=20,
+    keepalive_expiry=30,
+)
+
+
+class GatewayClientError(RuntimeError):
+    """A sanitized failure while calling the configured OSMO Gateway."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GatewayResponse:
+    """A bounded Gateway response safe for tool-specific validation."""
+
+    status_code: int
+    body: bytes = dataclasses.field(repr=False)
+
+
+class GatewayClient:
+    """Send caller-bound requests to one configured OSMO Gateway origin."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        request_timeout_seconds: float,
+    ) -> None:
+        self._client = client
+        self._request_timeout_seconds = request_timeout_seconds
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        credentials: request_context.RequestCredentials,
+        max_response_bytes: int,
+    ) -> GatewayResponse:
+        """Call a fixed API path with credentials from the active MCP request."""
+        if method not in _ALLOWED_METHODS:
+            raise ValueError('Gateway request method is not allowed.')
+        _validate_api_path(path)
+        if max_response_bytes < 1:
+            raise ValueError('max_response_bytes must be positive.')
+
+        headers = {
+            login.OSMO_AUTH_HEADER: credentials.authorization_header,
+            'Accept-Encoding': _IDENTITY_ENCODING,
+            'User-Agent': _USER_AGENT,
+        }
+        if credentials.request_id is not None:
+            headers[_REQUEST_ID_HEADER] = credentials.request_id
+
+        request = self._client.build_request(method, path, headers=headers)
+        # HTTPX stores response cookies on the process-wide client. Never let
+        # that shared state become credentials on a later caller's request.
+        request.headers.pop('cookie', None)
+
+        try:
+            async with asyncio.timeout(self._request_timeout_seconds):
+                response = await self._client.send(request, stream=True)
+                try:
+                    if 300 <= response.status_code < 400:
+                        raise GatewayClientError(
+                            'OSMO Gateway returned an unsafe redirect.')
+                    if not response.is_success:
+                        return GatewayResponse(response.status_code, b'')
+
+                    if response.headers.get(
+                        'content-encoding', _IDENTITY_ENCODING
+                    ).lower() != _IDENTITY_ENCODING:
+                        raise GatewayClientError(
+                            'OSMO Gateway returned an invalid response.')
+                    _validate_content_length(response, max_response_bytes)
+                    response_body = bytearray()
+                    async for chunk in response.aiter_bytes():
+                        if len(response_body) + len(chunk) > max_response_bytes:
+                            raise GatewayClientError(
+                                'OSMO Gateway response exceeds the size limit.')
+                        response_body.extend(chunk)
+                finally:
+                    await response.aclose()
+        except (TimeoutError, httpx.RequestError):
+            raise GatewayClientError('OSMO Gateway is unavailable.') from None
+        finally:
+            # Set-Cookie is upstream response data, never caller-independent
+            # client state. Clear it even when streaming or decoding fails.
+            self._client.cookies.clear()
+
+        return GatewayResponse(response.status_code, bytes(response_body))
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AppContext:
+    """Process-lifetime dependencies shared by MCP tool calls."""
+
+    gateway: GatewayClient
+
+
+@contextlib.asynccontextmanager
+async def create_app_context(
+    *,
+    gateway_url: str,
+    request_timeout_seconds: float,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> AsyncIterator[AppContext]:
+    """Create one credential-free HTTP connection pool for the MCP process."""
+    validate_gateway_origin(gateway_url)
+    if (
+        not math.isfinite(request_timeout_seconds)
+        or request_timeout_seconds <= 0
+        or request_timeout_seconds > 60
+    ):
+        raise ValueError(
+            'Gateway request timeout must be greater than 0 and at most 60 seconds.')
+    async with httpx.AsyncClient(
+        base_url=gateway_url,
+        follow_redirects=False,
+        limits=_HTTP_LIMITS,
+        timeout=httpx.Timeout(request_timeout_seconds),
+        transport=transport,
+        trust_env=False,
+        verify=True,
+    ) as client:
+        yield AppContext(
+            gateway=GatewayClient(
+                client,
+                request_timeout_seconds=request_timeout_seconds,
+            ),
+        )
+
+
+def validate_gateway_origin(gateway_url: str) -> None:
+    """Reject any Gateway base URL that is not one fixed HTTPS origin."""
+    try:
+        parsed_url = parse.urlsplit(gateway_url)
+        _ = parsed_url.port
+    except ValueError:
+        raise ValueError(
+            'gateway_url must be a valid HTTPS origin.') from None
+
+    if (
+        any(ord(character) <= 0x20 or ord(character) == 0x7F
+            for character in gateway_url)
+        or '\\' in gateway_url
+        or '%' in parsed_url.netloc
+        or parsed_url.scheme != 'https'
+        or not parsed_url.hostname
+        or parsed_url.username is not None
+        or parsed_url.password is not None
+        or parsed_url.path not in ('', '/')
+        or parsed_url.query
+        or parsed_url.fragment
+    ):
+        raise ValueError(
+            'gateway_url must be an HTTPS origin without credentials, '
+            'path, query, or fragment.')
+
+
+def _validate_api_path(path: str) -> None:
+    parsed_path = parse.urlsplit(path)
+    if (
+        any(ord(character) < 0x20 or ord(character) == 0x7F for character in path)
+        or parsed_path.scheme
+        or parsed_path.netloc
+        or parsed_path.query
+        or parsed_path.fragment
+        or not parsed_path.path.startswith('/api/')
+        or '//' in parsed_path.path
+    ):
+        raise ValueError('Gateway requests require a relative OSMO API path.')
+
+    decoded_path = parsed_path.path
+    while True:
+        next_decoded_path = parse.unquote(decoded_path)
+        if next_decoded_path == decoded_path:
+            break
+        decoded_path = next_decoded_path
+    if (
+        not decoded_path.startswith('/api/')
+        or '//' in decoded_path
+        or '\\' in decoded_path
+        or any(
+            ord(character) < 0x20 or ord(character) == 0x7F
+            for character in decoded_path
+        )
+        or any(segment in ('.', '..') for segment in decoded_path.split('/'))
+    ):
+        raise ValueError('Gateway requests require a relative OSMO API path.')
+
+
+def _validate_content_length(
+    response: httpx.Response,
+    max_response_bytes: int,
+) -> None:
+    content_length_header = response.headers.get('content-length')
+    if content_length_header is None:
+        return
+    try:
+        content_length = int(content_length_header)
+    except ValueError:
+        raise GatewayClientError(
+            'OSMO Gateway returned an invalid response.') from None
+    if content_length < 0:
+        raise GatewayClientError('OSMO Gateway returned an invalid response.')
+    if content_length > max_response_bytes:
+        raise GatewayClientError(
+            'OSMO Gateway response exceeds the size limit.')

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -123,7 +123,11 @@ class GatewayClient:
             # client state. Clear it even when streaming or decoding fails.
             self._client.cookies.clear()
 
-        return GatewayResponse(response.status_code, bytes(response_body))
+        response_body_bytes = bytes(response_body)
+        if _contains_relayed_credentials(response_body_bytes, credentials):
+            raise GatewayClientError(
+                'OSMO Gateway returned an invalid response.')
+        return GatewayResponse(response.status_code, response_body_bytes)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -242,3 +246,15 @@ def _validate_content_length(
     if content_length > max_response_bytes:
         raise GatewayClientError(
             'OSMO Gateway response exceeds the size limit.')
+
+
+def _contains_relayed_credentials(
+    response_body: bytes,
+    credentials: request_context.RequestCredentials,
+) -> bool:
+    authorization_header = credentials.authorization_header.encode('ascii')
+    _, _, bearer_token = authorization_header.partition(b' ')
+    return (
+        authorization_header in response_body
+        or (len(bearer_token) >= 16 and bearer_token in response_body)
+    )

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -256,5 +256,9 @@ def _contains_relayed_credentials(
     _, _, bearer_token = authorization_header.partition(b' ')
     return (
         authorization_header in response_body
-        or (len(bearer_token) >= 16 and bearer_token in response_body)
+        or (
+            len(bearer_token)
+            >= request_context.MIN_BEARER_TOKEN_SUBSTRING_BYTES
+            and bearer_token in response_body
+        )
     )

--- a/src/service/mcp/profile.py
+++ b/src/service/mcp/profile.py
@@ -1,0 +1,112 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import ToolAnnotations
+import pydantic
+from starlette.requests import Request
+
+from src.lib.api import profile as profile_contract
+from src.service.mcp import gateway, request_context
+
+
+_PROFILE_PATH = '/api/profile/settings'
+_MAX_PROFILE_RESPONSE_BYTES = 64 * 1024
+
+
+async def osmo_get_profile(context: Context) -> profile_contract.ProfileResponse:
+    """Get the active user's OSMO profile, roles, and accessible pools."""
+    app_context = _get_app_context(context)
+    try:
+        credentials = request_context.get_request_credentials()
+    except RuntimeError:
+        raise ToolError(
+            'MCP request authentication context is unavailable.') from None
+
+    try:
+        response = await app_context.gateway.request(
+            'GET',
+            _PROFILE_PATH,
+            credentials=credentials,
+            max_response_bytes=_MAX_PROFILE_RESPONSE_BYTES,
+        )
+    except gateway.GatewayClientError as error:
+        raise ToolError(str(error)) from None
+
+    if response.status_code != 200:
+        raise ToolError(_profile_error(response.status_code))
+
+    try:
+        return profile_contract.ProfileResponse.model_validate_json(
+            response.body,
+            strict=True,
+        )
+    except pydantic.ValidationError:
+        raise ToolError('OSMO returned an invalid profile response.') from None
+
+
+def register_tools(server: FastMCP) -> None:
+    """Register profile tools on one FastMCP server instance."""
+    server.add_tool(
+        osmo_get_profile,
+        name='osmo_get_profile',
+        title='Get OSMO profile',
+        description=(
+            'Get the active user\'s OSMO profile settings, roles, accessible '
+            'pools, and non-secret token identity metadata.'
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+        structured_output=True,
+    )
+
+
+def _get_app_context(context: Context) -> gateway.AppContext:
+    try:
+        request = context.request_context.request
+    except ValueError:
+        raise ToolError('MCP runtime context is unavailable.') from None
+    if not isinstance(request, Request):
+        raise ToolError('MCP runtime context is unavailable.')
+
+    try:
+        app_context = request.app.state.mcp_app_context
+    except (AttributeError, KeyError):
+        raise ToolError('MCP runtime context is unavailable.') from None
+    if not isinstance(app_context, gateway.AppContext):
+        raise ToolError('MCP runtime context is unavailable.')
+    return app_context
+
+
+def _profile_error(status_code: int) -> str:
+    if status_code == 401:
+        message = 'OSMO rejected the active authentication'
+    elif status_code == 403:
+        message = 'OSMO authorization denied profile access'
+    elif status_code == 429:
+        message = 'OSMO profile access is rate limited'
+    elif 500 <= status_code < 600:
+        message = 'OSMO profile service is unavailable'
+    else:
+        message = 'OSMO profile request failed'
+    return f'{message} (HTTP {status_code}).'

--- a/src/service/mcp/protocol.py
+++ b/src/service/mcp/protocol.py
@@ -1,0 +1,60 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Sequence
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import ContentBlock
+from mcp.types import Tool as MCPTool
+import pydantic
+
+
+class OSMOFastMCP(FastMCP):
+    """FastMCP server with fail-closed, non-reflective tool validation."""
+
+    async def list_tools(self) -> list[MCPTool]:
+        tools = await super().list_tools()
+        for tool in tools:
+            tool.inputSchema['additionalProperties'] = False
+        return tools
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> Sequence[ContentBlock] | dict[str, Any]:
+        tools_by_name = {
+            tool.name: tool
+            for tool in await super().list_tools()
+        }
+        tool = tools_by_name.get(name)
+        if tool is None:
+            raise ToolError('Unknown MCP tool.')
+
+        allowed_arguments = set(tool.inputSchema.get('properties', {}))
+        if not arguments.keys() <= allowed_arguments:
+            raise ToolError('Invalid MCP tool arguments.')
+
+        try:
+            return await super().call_tool(name, arguments)
+        except ToolError as error:
+            if isinstance(error.__cause__, pydantic.ValidationError):
+                raise ToolError('MCP tool validation failed.') from None
+            raise

--- a/src/service/mcp/protocol.py
+++ b/src/service/mcp/protocol.py
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -24,6 +24,8 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ContentBlock
 from mcp.types import Tool as MCPTool
 import pydantic
+
+from src.service.mcp import request_context
 
 
 class OSMOFastMCP(FastMCP):
@@ -53,8 +55,77 @@ class OSMOFastMCP(FastMCP):
             raise ToolError('Invalid MCP tool arguments.')
 
         try:
-            return await super().call_tool(name, arguments)
-        except ToolError as error:
-            if isinstance(error.__cause__, pydantic.ValidationError):
-                raise ToolError('MCP tool validation failed.') from None
-            raise
+            with request_context.track_request_task() as credentials:
+                try:
+                    result = await super().call_tool(name, arguments)
+                except ToolError as error:
+                    if isinstance(error.__cause__, pydantic.ValidationError):
+                        raise ToolError('MCP tool validation failed.') from None
+                    if _contains_relayed_credentials(str(error), credentials):
+                        raise ToolError('MCP tool failed.') from None
+                    raise
+
+                if _contains_relayed_credentials(result, credentials):
+                    raise ToolError('MCP tool returned an invalid response.')
+                return result
+        except request_context.RequestContextUnavailable:
+            raise ToolError(
+                'MCP request authentication context is unavailable.') from None
+
+
+def _contains_relayed_credentials(
+    value: object,
+    credentials: request_context.RequestCredentials,
+) -> bool:
+    authorization_header = credentials.authorization_header
+    _, _, bearer_token = authorization_header.partition(' ')
+    sensitive_values = (authorization_header, bearer_token)
+    return _contains_sensitive_value(value, sensitive_values)
+
+
+def _contains_sensitive_value(
+    value: object,
+    sensitive_values: tuple[str, str],
+) -> bool:
+    if isinstance(value, str):
+        authorization_header, bearer_token = sensitive_values
+        return (
+            authorization_header in value
+            or (
+                bearer_token in value
+                if len(bearer_token)
+                >= request_context.MIN_BEARER_TOKEN_SUBSTRING_BYTES
+                else value == bearer_token
+            )
+        )
+    if isinstance(value, bytes):
+        authorization_header_bytes, bearer_token_bytes = (
+            sensitive_value.encode('ascii')
+            for sensitive_value in sensitive_values
+        )
+        return (
+            authorization_header_bytes in value
+            or (
+                bearer_token_bytes in value
+                if len(bearer_token_bytes)
+                >= request_context.MIN_BEARER_TOKEN_SUBSTRING_BYTES
+                else value == bearer_token_bytes
+            )
+        )
+    if isinstance(value, pydantic.BaseModel):
+        return _contains_sensitive_value(
+            value.model_dump(mode='json', by_alias=True),
+            sensitive_values,
+        )
+    if isinstance(value, Mapping):
+        return any(
+            _contains_sensitive_value(item, sensitive_values)
+            for pair in value.items()
+            for item in pair
+        )
+    if isinstance(value, Sequence):
+        return any(
+            _contains_sensitive_value(item, sensitive_values)
+            for item in value
+        )
+    return False

--- a/src/service/mcp/request_context.py
+++ b/src/service/mcp/request_context.py
@@ -1,0 +1,184 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Iterable
+import contextvars
+import dataclasses
+import re
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from src.lib.utils import login
+
+
+_AUTHORIZATION_HEADER = login.OSMO_AUTH_HEADER.lower().encode('ascii')
+_USER_HEADER = login.OSMO_USER_HEADER.lower().encode('ascii')
+_REQUEST_ID_HEADER = b'x-request-id'
+_CONTEXT_HEADERS = frozenset((
+    _AUTHORIZATION_HEADER,
+    _USER_HEADER,
+    _REQUEST_ID_HEADER,
+))
+_BEARER_VALUE = re.compile(
+    r'Bearer [A-Za-z0-9._~+/-]+=*',
+    flags=re.IGNORECASE,
+)
+_REQUEST_ID = re.compile(r'[A-Za-z0-9][A-Za-z0-9._:-]*')
+MAX_AUTHORIZATION_HEADER_BYTES = 128 * 1024
+MAX_USER_HEADER_BYTES = 256
+MAX_REQUEST_ID_HEADER_BYTES = 128
+_INVALID_CONTEXT_RESPONSE = {'error': 'Invalid MCP authentication context.'}
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RequestCredentials:
+    """Gateway-authenticated credentials owned by one MCP request."""
+
+    authorization_header: str = dataclasses.field(repr=False)
+    user_name: str
+    request_id: str | None
+
+
+@dataclasses.dataclass(slots=True)
+class _RequestState:
+    credentials: RequestCredentials | None
+
+
+_request_state: contextvars.ContextVar[_RequestState | None] = (
+    contextvars.ContextVar('mcp_request_state', default=None))
+
+
+class RequestContextMiddleware:
+    """Bind Gateway-owned authentication headers to one MCP request."""
+
+    def __init__(self, application: ASGIApp, path: str = '/mcp') -> None:
+        self._application = application
+        self._path = path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        mask_token = _request_state.set(None)
+        try:
+            if scope['type'] != 'http' or scope.get('path') != self._path:
+                await self._application(scope, receive, send)
+                return
+
+            credentials = _parse_credentials(scope.get('headers', []))
+            if credentials is None:
+                response = JSONResponse(_INVALID_CONTEXT_RESPONSE, status_code=400)
+                await response(scope, receive, send)
+                return
+
+            downstream_scope = dict(scope)
+            downstream_scope['headers'] = [
+                (name, value)
+                for name, value in scope.get('headers', [])
+                if name.lower() not in _CONTEXT_HEADERS
+            ]
+            request_state = _RequestState(credentials=credentials)
+            context_token = _request_state.set(request_state)
+            try:
+                await self._application(downstream_scope, receive, send)
+            finally:
+                request_state.credentials = None
+                _request_state.reset(context_token)
+        finally:
+            _request_state.reset(mask_token)
+
+
+def get_request_credentials() -> RequestCredentials:
+    """Return credentials for the active MCP request."""
+    request_state = _request_state.get()
+    if request_state is None or request_state.credentials is None:
+        raise RuntimeError('MCP request credentials are unavailable.')
+    return request_state.credentials
+
+
+def _parse_credentials(
+    raw_headers: Iterable[tuple[bytes, bytes]],
+) -> RequestCredentials | None:
+    relevant_headers: dict[bytes, list[bytes]] = {}
+    for name, value in raw_headers:
+        normalized_name = name.lower()
+        if normalized_name in _CONTEXT_HEADERS:
+            relevant_headers.setdefault(normalized_name, []).append(value)
+
+    authorization_values = relevant_headers.get(_AUTHORIZATION_HEADER, [])
+    user_values = relevant_headers.get(_USER_HEADER, [])
+    request_id_values = relevant_headers.get(_REQUEST_ID_HEADER, [])
+    if (
+        len(authorization_values) != 1
+        or len(user_values) != 1
+        or len(request_id_values) > 1
+        or len(authorization_values[0]) > MAX_AUTHORIZATION_HEADER_BYTES
+        or len(user_values[0]) > MAX_USER_HEADER_BYTES
+        or (
+            request_id_values
+            and len(request_id_values[0]) > MAX_REQUEST_ID_HEADER_BYTES
+        )
+    ):
+        return None
+
+    authorization_header = _decode_ascii(authorization_values[0])
+    user_name = _decode_utf8(user_values[0])
+    if (
+        authorization_header is None
+        or _BEARER_VALUE.fullmatch(authorization_header) is None
+        or user_name is None
+        or not _is_valid_user_name(user_name)
+    ):
+        return None
+
+    request_id: str | None = None
+    if request_id_values:
+        request_id = _decode_ascii(request_id_values[0])
+        if request_id is None or _REQUEST_ID.fullmatch(request_id) is None:
+            return None
+
+    return RequestCredentials(
+        authorization_header=authorization_header,
+        user_name=user_name,
+        request_id=request_id,
+    )
+
+
+def _decode_ascii(value: bytes) -> str | None:
+    try:
+        return value.decode('ascii')
+    except UnicodeDecodeError:
+        return None
+
+
+def _decode_utf8(value: bytes) -> str | None:
+    try:
+        return value.decode('utf-8')
+    except UnicodeDecodeError:
+        return None
+
+
+def _is_valid_user_name(user_name: str) -> bool:
+    try:
+        encoded_length = len(user_name.encode('utf-8'))
+    except UnicodeEncodeError:
+        return False
+    return (
+        bool(user_name)
+        and user_name == user_name.strip()
+        and encoded_length <= MAX_USER_HEADER_BYTES
+        and all(character.isprintable() for character in user_name)
+    )

--- a/src/service/mcp/request_context.py
+++ b/src/service/mcp/request_context.py
@@ -16,7 +16,10 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import asyncio
 from collections.abc import Iterable
+from collections.abc import Iterator
+import contextlib
 import contextvars
 import dataclasses
 import re
@@ -43,7 +46,12 @@ _REQUEST_ID = re.compile(r'[A-Za-z0-9][A-Za-z0-9._:-]*')
 MAX_AUTHORIZATION_HEADER_BYTES = 128 * 1024
 MAX_USER_HEADER_BYTES = 256
 MAX_REQUEST_ID_HEADER_BYTES = 128
+MIN_BEARER_TOKEN_SUBSTRING_BYTES = 16
 _INVALID_CONTEXT_RESPONSE = {'error': 'Invalid MCP authentication context.'}
+
+
+class RequestContextUnavailable(RuntimeError):
+    """The current task is not owned by an active MCP request."""
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -58,6 +66,9 @@ class RequestCredentials:
 @dataclasses.dataclass(slots=True)
 class _RequestState:
     credentials: RequestCredentials | None
+    active_tasks: set[asyncio.Task[object]] = dataclasses.field(
+        default_factory=set,
+    )
 
 
 _request_state: contextvars.ContextVar[_RequestState | None] = (
@@ -96,6 +107,9 @@ class RequestContextMiddleware:
                 await self._application(downstream_scope, receive, send)
             finally:
                 request_state.credentials = None
+                for active_task in tuple(request_state.active_tasks):
+                    active_task.cancel()
+                request_state.active_tasks.clear()
                 _request_state.reset(context_token)
         finally:
             _request_state.reset(mask_token)
@@ -105,8 +119,30 @@ def get_request_credentials() -> RequestCredentials:
     """Return credentials for the active MCP request."""
     request_state = _request_state.get()
     if request_state is None or request_state.credentials is None:
-        raise RuntimeError('MCP request credentials are unavailable.')
+        raise RequestContextUnavailable(
+            'MCP request credentials are unavailable.')
     return request_state.credentials
+
+
+@contextlib.contextmanager
+def track_request_task() -> Iterator[RequestCredentials]:
+    """Cancel the current tool task when its owning MCP request ends."""
+    request_state = _request_state.get()
+    current_task = asyncio.current_task()
+    if (
+        request_state is None
+        or request_state.credentials is None
+        or current_task is None
+    ):
+        raise RequestContextUnavailable(
+            'MCP request credentials are unavailable.')
+
+    credentials = request_state.credentials
+    request_state.active_tasks.add(current_task)
+    try:
+        yield credentials
+    finally:
+        request_state.active_tasks.discard(current_task)
 
 
 def _parse_credentials(

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -64,7 +64,7 @@ class MCPServiceConfig(static_config.StaticConfig, ssl_config.SSLConfig):
 
 
 def create_mcp_server() -> FastMCP:
-    """Create the authentication-agnostic Phase A MCP server."""
+    """Create the stateless OSMO MCP protocol server."""
     server = protocol.OSMOFastMCP(
         name='OSMO MCP',
         host='0.0.0.0',

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -28,7 +28,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 import uvicorn  # type: ignore
 
-from src.service.mcp import gateway, request_context
+from src.service.mcp import gateway, profile, protocol, request_context
 from src.utils import ssl_config, static_config
 
 
@@ -65,7 +65,7 @@ class MCPServiceConfig(static_config.StaticConfig, ssl_config.SSLConfig):
 
 def create_mcp_server() -> FastMCP:
     """Create the authentication-agnostic Phase A MCP server."""
-    server = FastMCP(
+    server = protocol.OSMOFastMCP(
         name='OSMO MCP',
         host='0.0.0.0',
         port=8000,
@@ -73,6 +73,7 @@ def create_mcp_server() -> FastMCP:
         stateless_http=True,
         json_response=True,
     )
+    profile.register_tools(server)
 
     @server.custom_route('/health/live', methods=['GET'], include_in_schema=False)
     async def health_live(request: Request) -> JSONResponse:  # pylint: disable=unused-argument

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -69,8 +69,13 @@ def create_mcp_server() -> FastMCP:
     return server
 
 
+def create_application(protocol_server: FastMCP) -> Starlette:
+    """Create the ASGI application for an MCP protocol server."""
+    return protocol_server.streamable_http_app()
+
+
 mcp_server = create_mcp_server()
-app: Starlette = mcp_server.streamable_http_app()
+app: Starlette = create_application(mcp_server)
 
 
 def main() -> None:

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -25,6 +25,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 import uvicorn  # type: ignore
 
+from src.service.mcp import request_context
 from src.utils import ssl_config, static_config
 
 
@@ -71,7 +72,12 @@ def create_mcp_server() -> FastMCP:
 
 def create_application(protocol_server: FastMCP) -> Starlette:
     """Create the ASGI application for an MCP protocol server."""
-    return protocol_server.streamable_http_app()
+    application = protocol_server.streamable_http_app()
+    application.add_middleware(
+        request_context.RequestContextMiddleware,
+        path='/mcp',
+    )
+    return application
 
 
 mcp_server = create_mcp_server()

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -17,7 +17,10 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import asyncio
+from collections.abc import AsyncIterator
+import contextlib
 
+import httpx
 from mcp.server.fastmcp import FastMCP
 import pydantic
 from starlette.applications import Starlette
@@ -25,12 +28,14 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 import uvicorn  # type: ignore
 
-from src.service.mcp import request_context
+from src.service.mcp import gateway, request_context
 from src.utils import ssl_config, static_config
 
 
 class MCPServiceConfig(static_config.StaticConfig, ssl_config.SSLConfig):
     """Runtime configuration for the MCP service."""
+
+    model_config = pydantic.ConfigDict(hide_input_in_errors=True)
 
     host: str = pydantic.Field(
         default='0.0.0.0',
@@ -42,6 +47,20 @@ class MCPServiceConfig(static_config.StaticConfig, ssl_config.SSLConfig):
         le=65535,
         description='The TCP port to bind to when serving the MCP service.',
         json_schema_extra={'command_line': 'port', 'env': 'OSMO_MCP_PORT'})
+    gateway_url: pydantic.AnyHttpUrl = pydantic.Field(
+        description='HTTPS origin of the same-deployment OSMO Gateway.',
+        json_schema_extra={'env': 'OSMO_GATEWAY_URL'})
+    request_timeout_seconds: int = pydantic.Field(
+        default=10,
+        ge=1,
+        le=60,
+        description='Total timeout for each OSMO Gateway request.',
+        json_schema_extra={'env': 'OSMO_MCP_REQUEST_TIMEOUT_SECONDS'})
+
+    @pydantic.model_validator(mode='after')
+    def _validate_gateway_url(self) -> 'MCPServiceConfig':
+        gateway.validate_gateway_origin(str(self.gateway_url))
+        return self
 
 
 def create_mcp_server() -> FastMCP:
@@ -80,17 +99,44 @@ def create_application(protocol_server: FastMCP) -> Starlette:
     return application
 
 
-mcp_server = create_mcp_server()
-app: Starlette = create_application(mcp_server)
+def create_runtime_application(
+    config: MCPServiceConfig,
+    *,
+    http_transport: httpx.AsyncBaseTransport | None = None,
+) -> Starlette:
+    """Create the production application and process-lifetime Gateway client."""
+    protocol_server = create_mcp_server()
+    application = create_application(protocol_server)
+    protocol_lifespan = application.router.lifespan_context
+
+    @contextlib.asynccontextmanager
+    async def application_lifespan(
+        lifespan_application: Starlette,
+    ) -> AsyncIterator[None]:
+        async with gateway.create_app_context(
+            gateway_url=str(config.gateway_url),
+            request_timeout_seconds=config.request_timeout_seconds,
+            transport=http_transport,
+        ) as app_context:
+            lifespan_application.state.mcp_app_context = app_context
+            try:
+                async with protocol_lifespan(lifespan_application):
+                    yield
+            finally:
+                del lifespan_application.state.mcp_app_context
+
+    application.router.lifespan_context = application_lifespan
+    return application
 
 
 def main() -> None:
     """Run the MCP ASGI application with the repository's Uvicorn/TLS pattern."""
     config = MCPServiceConfig.load()
+    application = create_runtime_application(config)
 
     async def run_server() -> None:
         uvicorn_config = uvicorn.Config(
-            app,
+            application,
             host=config.host,
             port=config.port,
             log_config=None,

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -20,11 +20,22 @@ load("//bzl:py.bzl", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_test(
+    name = "test_request_context",
+    srcs = ["test_request_context.py"],
+    deps = [
+        requirement("starlette"),
+        "//src/service/mcp:request_context",
+    ],
+)
+
+osmo_py_test(
     name = "test_server",
     srcs = ["test_server.py"],
     deps = [
         requirement("httpx"),
         requirement("mcp"),
+        "//src/lib/utils:login",
+        "//src/service/mcp:request_context",
         "//src/service/mcp:mcp_service_lib",
     ],
 )

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -20,6 +20,16 @@ load("//bzl:py.bzl", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_test(
+    name = "test_gateway",
+    srcs = ["test_gateway.py"],
+    deps = [
+        requirement("httpx"),
+        "//src/service/mcp:gateway",
+        "//src/service/mcp:request_context",
+    ],
+)
+
+osmo_py_test(
     name = "test_request_context",
     srcs = ["test_request_context.py"],
     deps = [

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -30,6 +30,16 @@ osmo_py_test(
 )
 
 osmo_py_test(
+    name = "test_profile",
+    srcs = ["test_profile.py"],
+    deps = [
+        requirement("httpx"),
+        "//src/lib/utils:login",
+        "//src/service/mcp:mcp_service_lib",
+    ],
+)
+
+osmo_py_test(
     name = "test_request_context",
     srcs = ["test_request_context.py"],
     deps = [

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -44,7 +44,10 @@ osmo_py_test(
     deps = [
         requirement("httpx"),
         requirement("mcp"),
+        requirement("pydantic"),
+        requirement("starlette"),
         "//src/lib/utils:login",
+        "//src/service/mcp:gateway",
         "//src/service/mcp:request_context",
         "//src/service/mcp:mcp_service_lib",
     ],

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -1,0 +1,553 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from collections.abc import AsyncIterator, Callable, Coroutine
+import unittest
+
+import httpx
+
+from src.service.mcp import gateway, request_context
+
+
+_Handler = Callable[[httpx.Request], Coroutine[None, None, httpx.Response]]
+
+
+class _TrackingStream(httpx.AsyncByteStream):
+    """Track streaming iteration and cleanup for response-bound tests."""
+
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        block_after_chunks: bool = False,
+    ) -> None:
+        self._chunks = chunks
+        self._block_after_chunks = block_after_chunks
+        self.iterated_chunks = 0
+        self.close_count = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            self.iterated_chunks += 1
+            yield chunk
+        if self._block_after_chunks:
+            await asyncio.Future()
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+
+class _TrackingTransport(httpx.MockTransport):
+    """Track connection-pool cleanup through the HTTPX transport seam."""
+
+    def __init__(self, handler: _Handler) -> None:
+        super().__init__(handler)
+        self.close_count = 0
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+        await super().aclose()
+
+
+class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
+    """Validate fixed-origin Gateway request and response boundaries."""
+
+    @staticmethod
+    def _credentials(
+        *,
+        authorization_header: str = 'Bearer original.token+/_==',
+        request_id: str | None = 'request-123',
+    ) -> request_context.RequestCredentials:
+        return request_context.RequestCredentials(
+            authorization_header=authorization_header,
+            user_name='alice@example.com',
+            request_id=request_id,
+        )
+
+    async def test_request_uses_fixed_origin_and_approved_headers(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, content=b'{"status":"ok"}')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            response = await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(
+                    authorization_header='bEaReR original.token+/_=='
+                ),
+                max_response_bytes=1024,
+            )
+            response_without_request_id = await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(request_id=None),
+                max_response_bytes=1024,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b'{"status":"ok"}')
+        self.assertEqual(response_without_request_id.status_code, 200)
+        self.assertEqual(len(captured_requests), 2)
+        self.assertEqual(
+            str(captured_requests[0].url),
+            'https://gateway.test/api/profile/settings',
+        )
+        self.assertEqual(
+            captured_requests[0].headers['authorization'],
+            'bEaReR original.token+/_==',
+        )
+        self.assertEqual(
+            captured_requests[0].headers['x-request-id'],
+            'request-123',
+        )
+        self.assertEqual(captured_requests[0].headers['accept-encoding'], 'identity')
+        self.assertEqual(captured_requests[0].headers['user-agent'], 'osmo-mcp')
+        self.assertNotIn('x-osmo-user', captured_requests[0].headers)
+        self.assertNotIn('cookie', captured_requests[0].headers)
+        self.assertNotIn('proxy-authorization', captured_requests[0].headers)
+        self.assertNotIn('x-request-id', captured_requests[1].headers)
+
+    async def test_only_fixed_api_paths_and_methods_are_allowed(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(200, content=b'{}')
+
+        invalid_paths = (
+            '',
+            'api/profile/settings',
+            '/profile/settings',
+            'https://evil.test/api/profile/settings',
+            '//evil.test/api/profile/settings',
+            '/api/../profile/settings',
+            '/api/%2e%2e/profile/settings',
+            '/api/%252e%252e/profile/settings',
+            '/api\\profile',
+            '/api//profile',
+            '/api/profile?user=alice',
+            '/api/profile#fragment',
+            '/api/profile%00suffix',
+        )
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for invalid_path in invalid_paths:
+                with self.subTest(path=invalid_path):
+                    with self.assertRaises(ValueError):
+                        await app_context.gateway.request(
+                            'GET',
+                            invalid_path,
+                            credentials=self._credentials(),
+                            max_response_bytes=1024,
+                        )
+
+            for invalid_method in ('get', 'PUT', 'OPTIONS'):
+                with self.subTest(method=invalid_method):
+                    with self.assertRaises(ValueError):
+                        await app_context.gateway.request(
+                            invalid_method,
+                            '/api/profile/settings',
+                            credentials=self._credentials(),
+                            max_response_bytes=1024,
+                        )
+
+            with self.assertRaises(ValueError):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=0,
+                )
+
+        self.assertEqual(transport_calls, 0)
+
+    async def test_response_cookies_are_never_replayed(self) -> None:
+        captured_cookies: list[str | None] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_cookies.append(request.headers.get('cookie'))
+            if len(captured_cookies) == 1:
+                return httpx.Response(
+                    200,
+                    headers={'set-cookie': 'session=upstream-secret; Secure'},
+                    content=b'{}',
+                )
+            return httpx.Response(200, content=b'{}')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for _ in range(2):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                )
+                self.assertEqual(
+                    len(app_context.gateway._client.cookies),  # pylint: disable=protected-access
+                    0,
+                )
+
+        self.assertEqual(captured_cookies, [None, None])
+
+    async def test_concurrent_callers_keep_authorization_headers_isolated(self) -> None:
+        captured_authorization_headers: list[str] = []
+        both_requests_arrived = asyncio.Event()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_authorization_headers.append(request.headers['authorization'])
+            if len(captured_authorization_headers) == 2:
+                both_requests_arrived.set()
+            await asyncio.wait_for(both_requests_arrived.wait(), timeout=1)
+            return httpx.Response(200, content=b'{}')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            await asyncio.gather(*(
+                app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(
+                        authorization_header=f'Bearer caller-{caller}'
+                    ),
+                    max_response_bytes=1024,
+                )
+                for caller in ('alice', 'bob')
+            ))
+
+        self.assertCountEqual(
+            captured_authorization_headers,
+            ['Bearer caller-alice', 'Bearer caller-bob'],
+        )
+
+    async def test_redirect_is_rejected_without_following(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(
+                307,
+                headers={'location': 'https://evil.test/upstream-secret'},
+            )
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'unsafe redirect',
+            ) as raised:
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                )
+
+        self.assertEqual(transport_calls, 1)
+        self.assertNotIn('evil.test', str(raised.exception))
+        self.assertNotIn('upstream-secret', repr(raised.exception))
+
+    async def test_transport_failure_is_sanitized_and_not_retried(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal transport_calls
+            transport_calls += 1
+            raise httpx.ConnectError('connection-upstream-secret', request=request)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'Gateway is unavailable',
+            ) as raised:
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                )
+
+        self.assertEqual(transport_calls, 1)
+        self.assertNotIn('connection-upstream-secret', str(raised.exception))
+        self.assertIsNone(raised.exception.__cause__)
+
+    async def test_error_status_body_is_not_read_or_exposed(self) -> None:
+        stream = _TrackingStream([b'upstream-body-secret'])
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(403, stream=stream)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            response = await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(),
+                max_response_bytes=1024,
+            )
+
+        self.assertEqual(response, gateway.GatewayResponse(403, b''))
+        self.assertEqual(stream.iterated_chunks, 0)
+        self.assertEqual(stream.close_count, 1)
+        self.assertNotIn('upstream-body-secret', repr(response))
+
+    async def test_streaming_response_is_cumulatively_bounded(self) -> None:
+        exact_stream = _TrackingStream([b'ab', b'cd'])
+        oversized_stream = _TrackingStream([
+            b'ab',
+            b'cde',
+            b'later-upstream-secret',
+        ])
+        streams = [exact_stream, oversized_stream]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, stream=streams.pop(0))
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            response = await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(),
+                max_response_bytes=4,
+            )
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'exceeds the size limit',
+            ) as raised:
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=4,
+                )
+
+        self.assertEqual(response.body, b'abcd')
+        self.assertEqual(exact_stream.close_count, 1)
+        self.assertEqual(oversized_stream.iterated_chunks, 2)
+        self.assertEqual(oversized_stream.close_count, 1)
+        self.assertNotIn('later-upstream-secret', str(raised.exception))
+
+    async def test_content_length_is_validated_before_streaming(self) -> None:
+        oversized_stream = _TrackingStream([b'upstream-secret'])
+        invalid_stream = _TrackingStream([b'upstream-secret'])
+        streams_and_headers = [
+            (oversized_stream, {'content-length': '5'}),
+            (invalid_stream, {'content-length': '-1'}),
+        ]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            stream, headers = streams_and_headers.pop(0)
+            return httpx.Response(200, headers=headers, stream=stream)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for expected_error in ('exceeds the size limit', 'invalid response'):
+                with self.subTest(error=expected_error):
+                    with self.assertRaisesRegex(
+                        gateway.GatewayClientError,
+                        expected_error,
+                    ):
+                        await app_context.gateway.request(
+                            'GET',
+                            '/api/profile/settings',
+                            credentials=self._credentials(),
+                            max_response_bytes=4,
+                        )
+
+        self.assertEqual(oversized_stream.iterated_chunks, 0)
+        self.assertEqual(invalid_stream.iterated_chunks, 0)
+        self.assertEqual(oversized_stream.close_count, 1)
+        self.assertEqual(invalid_stream.close_count, 1)
+
+    async def test_compressed_response_is_rejected_before_decoding(self) -> None:
+        stream = _TrackingStream([b'compressed-upstream-secret'])
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(
+                200,
+                headers={'content-encoding': 'gzip'},
+                stream=stream,
+            )
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'invalid response',
+            ):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=100,
+                )
+
+        self.assertEqual(stream.iterated_chunks, 0)
+        self.assertEqual(stream.close_count, 1)
+
+    async def test_app_context_rejects_unsafe_origins_and_timeouts(self) -> None:
+        invalid_origins = (
+            'http://gateway.test',
+            'https://user:secret@gateway.test',
+            'https://gateway.test/api',
+            'https://gateway.test?query=value',
+            'https://gateway.test#fragment',
+            'https://gateway.test\\@evil.test',
+            'https://gateway.test%40evil.test',
+        )
+        for invalid_origin in invalid_origins:
+            with self.subTest(origin=invalid_origin):
+                with self.assertRaises(ValueError):
+                    async with gateway.create_app_context(
+                        gateway_url=invalid_origin,
+                        request_timeout_seconds=5,
+                    ):
+                        self.fail('unsafe Gateway origin was accepted')
+
+        for invalid_timeout in (0, -1, 61, float('inf'), float('nan')):
+            with self.subTest(timeout=invalid_timeout):
+                with self.assertRaises(ValueError):
+                    async with gateway.create_app_context(
+                        gateway_url='https://gateway.test',
+                        request_timeout_seconds=invalid_timeout,
+                    ):
+                        self.fail('unsafe Gateway timeout was accepted')
+
+    async def test_total_timeout_bounds_headers_and_streaming(self) -> None:
+        streaming_response = False
+        blocked_stream = _TrackingStream(
+            [b'a'],
+            block_after_chunks=True,
+        )
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            if streaming_response:
+                return httpx.Response(200, stream=blocked_stream)
+            await asyncio.Future()
+            raise AssertionError('unreachable')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=0.01,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'Gateway is unavailable',
+            ):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=4,
+                )
+
+            streaming_response = True
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'Gateway is unavailable',
+            ):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=4,
+                )
+
+        self.assertEqual(blocked_stream.iterated_chunks, 1)
+        self.assertEqual(blocked_stream.close_count, 1)
+
+    async def test_app_context_owns_and_closes_transport(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'{}')
+
+        transport = _TrackingTransport(handler)
+        self.assertEqual(transport.close_count, 0)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=transport,
+        ) as app_context:
+            self.assertIsInstance(app_context.gateway, gateway.GatewayClient)
+            await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(),
+                max_response_bytes=4,
+            )
+            self.assertEqual(transport.close_count, 0)
+
+        self.assertEqual(transport.close_count, 1)
+
+    def test_gateway_response_repr_hides_body(self) -> None:
+        response = gateway.GatewayResponse(200, b'upstream-body-secret')
+        self.assertNotIn('upstream-body-secret', repr(response))
+        self.assertNotIn('upstream-body-secret', str(response))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -339,6 +339,37 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(stream.close_count, 1)
         self.assertNotIn('upstream-body-secret', repr(response))
 
+    async def test_success_response_cannot_reflect_relayed_credentials(self) -> None:
+        bearer_token = 'reflected-bearer-token-secret'
+        reflected_bodies = [
+            f'{{"authorization":"Bearer {bearer_token}"}}'.encode(),
+            f'{{"token":"{bearer_token}"}}'.encode(),
+        ]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=reflected_bodies.pop(0))
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for _ in range(2):
+                with self.assertRaisesRegex(
+                    gateway.GatewayClientError,
+                    'invalid response',
+                ) as raised:
+                    await app_context.gateway.request(
+                        'GET',
+                        '/api/profile/settings',
+                        credentials=self._credentials(
+                            authorization_header=f'Bearer {bearer_token}'
+                        ),
+                        max_response_bytes=1024,
+                    )
+                self.assertNotIn(bearer_token, str(raised.exception))
+
     async def test_streaming_response_is_cumulatively_bounded(self) -> None:
         exact_stream = _TrackingStream([b'ab', b'cd'])
         oversized_stream = _TrackingStream([

--- a/src/service/mcp/tests/test_profile.py
+++ b/src/service/mcp/tests/test_profile.py
@@ -1,0 +1,333 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Callable, Coroutine
+import json
+import unittest
+
+import httpx
+
+from src.lib.utils import login
+from src.service.mcp import server
+
+
+_Handler = Callable[[httpx.Request], Coroutine[None, None, httpx.Response]]
+_BEARER_SECRET = 'profile-tool-bearer-secret'
+_PROFILE_RESULT = {
+    'profile': {
+        'username': 'alice@example.com',
+        'email_notification': True,
+        'slack_notification': None,
+        'pool': 'default',
+    },
+    'roles': ['osmo-user'],
+    'pools': ['default', 'shared'],
+    'token': {
+        'name': 'desktop-client-token',
+        'expires_at': '2026-07-10T12:30:00Z',
+    },
+}
+
+
+def _error_response_handler(
+    status_code: int,
+    captured_requests: list[httpx.Request],
+) -> _Handler:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(
+            status_code,
+            content=b'upstream-profile-body-secret',
+        )
+
+    return handler
+
+
+class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
+    """Exercise the profile tool through the real Streamable HTTP protocol."""
+
+    @staticmethod
+    def _headers() -> dict[str, str]:
+        return {
+            'Accept': 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            login.OSMO_AUTH_HEADER: f'Bearer {_BEARER_SECRET}',
+            login.OSMO_USER_HEADER: 'alice@example.com',
+            'x-request-id': 'profile-request-123',
+        }
+
+    @staticmethod
+    def _tool_call(
+        arguments: dict[str, object] | None = None,
+        *,
+        tool_name: str = 'osmo_get_profile',
+    ) -> dict[str, object]:
+        return {
+            'jsonrpc': '2.0',
+            'id': 1,
+            'method': 'tools/call',
+            'params': {
+                'name': tool_name,
+                'arguments': arguments or {},
+            },
+        }
+
+    async def _invoke_tool(
+        self,
+        handler: _Handler,
+        *,
+        include_catalog: bool = False,
+        arguments: dict[str, object] | None = None,
+        tool_name: str = 'osmo_get_profile',
+    ) -> tuple[httpx.Response, httpx.Response | None]:
+        application = server.create_runtime_application(
+            server.MCPServiceConfig(gateway_url='https://gateway.test'),
+            http_transport=httpx.MockTransport(handler),
+        )
+        catalog_response = None
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                if include_catalog:
+                    catalog_response = await client.post(
+                        '/mcp',
+                        headers=self._headers(),
+                        json={
+                            'jsonrpc': '2.0',
+                            'id': 2,
+                            'method': 'tools/list',
+                            'params': {},
+                        },
+                    )
+                tool_response = await client.post(
+                    '/mcp',
+                    headers=self._headers(),
+                    json=self._tool_call(arguments, tool_name=tool_name),
+                )
+        return tool_response, catalog_response
+
+    async def test_get_profile_relays_credentials_and_returns_typed_result(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=_PROFILE_RESULT)
+
+        response, catalog_response = await self._invoke_tool(
+            handler,
+            include_catalog=True,
+        )
+
+        self.assertIsNotNone(catalog_response)
+        assert catalog_response is not None
+        self.assertEqual(catalog_response.status_code, 200)
+        tools = catalog_response.json()['result']['tools']
+        self.assertEqual(len(tools), 1)
+        self.assertEqual(tools[0]['name'], 'osmo_get_profile')
+        self.assertEqual(tools[0]['title'], 'Get OSMO profile')
+        self.assertEqual(tools[0]['inputSchema']['properties'], {})
+        self.assertFalse(tools[0]['inputSchema']['additionalProperties'])
+        self.assertEqual(tools[0]['annotations'], {
+            'readOnlyHint': True,
+            'destructiveHint': False,
+            'idempotentHint': True,
+            'openWorldHint': False,
+        })
+        self.assertEqual(tools[0]['outputSchema']['type'], 'object')
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], _PROFILE_RESULT)
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+        self.assertEqual(len(captured_requests), 1)
+        upstream_request = captured_requests[0]
+        self.assertEqual(upstream_request.method, 'GET')
+        self.assertEqual(
+            str(upstream_request.url),
+            'https://gateway.test/api/profile/settings',
+        )
+        self.assertEqual(
+            upstream_request.headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+        self.assertEqual(
+            upstream_request.headers['x-request-id'],
+            'profile-request-123',
+        )
+        self.assertNotIn(login.OSMO_USER_HEADER, upstream_request.headers)
+        self.assertNotIn('cookie', upstream_request.headers)
+
+    async def test_get_profile_maps_api_statuses_without_exposing_body(self) -> None:
+        cases = (
+            (401, 'rejected the active authentication'),
+            (403, 'authorization denied profile access'),
+            (429, 'profile access is rate limited'),
+            (500, 'profile service is unavailable'),
+            (418, 'profile request failed'),
+        )
+        for status_code, expected_error in cases:
+            with self.subTest(status_code=status_code):
+                captured_requests: list[httpx.Request] = []
+                response, _ = await self._invoke_tool(
+                    _error_response_handler(status_code, captured_requests)
+                )
+
+                self.assertEqual(len(captured_requests), 1)
+                result = response.json()['result']
+                self.assertTrue(result['isError'])
+                result_text = json.dumps(result)
+                self.assertIn(expected_error, result_text)
+                self.assertIn(f'HTTP {status_code}', result_text)
+                self.assertNotIn('upstream-profile-body-secret', result_text)
+                self.assertNotIn(_BEARER_SECRET, result_text)
+
+    async def test_get_profile_sanitizes_transport_and_schema_failures(self) -> None:
+        async def transport_failure(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError(
+                'upstream-transport-secret',
+                request=request,
+            )
+
+        transport_response, _ = await self._invoke_tool(transport_failure)
+        transport_result = transport_response.json()['result']
+        self.assertTrue(transport_result['isError'])
+        self.assertIn('Gateway is unavailable', json.dumps(transport_result))
+        self.assertNotIn('upstream-transport-secret', json.dumps(transport_result))
+
+        invalid_profile: dict[str, object] = dict(_PROFILE_RESULT)
+        invalid_profile['internal_secret'] = 'upstream-schema-secret'
+
+        async def invalid_schema(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, json=invalid_profile)
+
+        schema_response, _ = await self._invoke_tool(invalid_schema)
+        schema_result = schema_response.json()['result']
+        self.assertTrue(schema_result['isError'])
+        self.assertIn('invalid profile response', json.dumps(schema_result))
+        self.assertNotIn('upstream-schema-secret', json.dumps(schema_result))
+        self.assertNotIn(_BEARER_SECRET, json.dumps(schema_result))
+
+    async def test_get_profile_does_not_expose_internal_profile_fields(self) -> None:
+        upstream_profile: dict[str, object] = dict(_PROFILE_RESULT)
+        upstream_profile['profile'] = {
+            'username': 'alice@example.com',
+            'email_notification': True,
+            'slack_notification': False,
+            'pool': 'default',
+            'internal_secret': 'upstream-internal-profile-secret',
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, json=upstream_profile)
+
+        response, _ = await self._invoke_tool(handler)
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertNotIn(
+            'upstream-internal-profile-secret',
+            json.dumps(result),
+        )
+
+    async def test_get_profile_bounds_and_sanitizes_invalid_bodies(self) -> None:
+        async def malformed_body(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'upstream-malformed-body-secret')
+
+        malformed_response, _ = await self._invoke_tool(malformed_body)
+        malformed_result = malformed_response.json()['result']
+        self.assertTrue(malformed_result['isError'])
+        self.assertIn('invalid profile response', json.dumps(malformed_result))
+        self.assertNotIn(
+            'upstream-malformed-body-secret',
+            json.dumps(malformed_result),
+        )
+
+        oversized_body = b'upstream-oversized-body-secret' + (b'x' * (65 * 1024))
+
+        async def oversized_response(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=oversized_body)
+
+        oversized_response_result, _ = await self._invoke_tool(oversized_response)
+        oversized_result = oversized_response_result.json()['result']
+        self.assertTrue(oversized_result['isError'])
+        self.assertIn('exceeds the size limit', json.dumps(oversized_result))
+        self.assertNotIn(
+            'upstream-oversized-body-secret',
+            json.dumps(oversized_result),
+        )
+        self.assertNotIn(_BEARER_SECRET, json.dumps(oversized_result))
+
+    async def test_get_profile_rejects_unmapped_inputs_before_transport(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=_PROFILE_RESULT)
+
+        response, _ = await self._invoke_tool(
+            handler,
+            arguments={
+                'authorization': 'Bearer tool-input-secret',
+                'url': 'https://evil.example.com/api/profile/settings',
+                'headers': {'x-osmo-user': 'mallory@example.com'},
+            },
+        )
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertEqual(captured_requests, [])
+        self.assertNotIn('tool-input-secret', json.dumps(result))
+        self.assertNotIn(_BEARER_SECRET, json.dumps(result))
+
+        unknown_response, _ = await self._invoke_tool(
+            handler,
+            tool_name='unknown-tool-input-secret',
+        )
+        unknown_result = unknown_response.json()['result']
+        self.assertTrue(unknown_result['isError'])
+        self.assertEqual(captured_requests, [])
+        self.assertNotIn('unknown-tool-input-secret', json.dumps(unknown_result))
+
+    async def test_get_profile_fails_closed_without_runtime_context(self) -> None:
+        application = server.create_application(server.create_mcp_server())
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                response = await client.post(
+                    '/mcp',
+                    headers=self._headers(),
+                    json=self._tool_call(),
+                )
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertIn('runtime context is unavailable', json.dumps(result))
+        self.assertNotIn(_BEARER_SECRET, json.dumps(result))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_profile.py
+++ b/src/service/mcp/tests/test_profile.py
@@ -16,6 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import asyncio
 from collections.abc import Callable, Coroutine
 import json
 import unittest
@@ -62,13 +63,18 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
     """Exercise the profile tool through the real Streamable HTTP protocol."""
 
     @staticmethod
-    def _headers() -> dict[str, str]:
+    def _headers(
+        *,
+        bearer_secret: str = _BEARER_SECRET,
+        user_name: str = 'alice@example.com',
+        request_id: str = 'profile-request-123',
+    ) -> dict[str, str]:
         return {
             'Accept': 'application/json, text/event-stream',
             'Content-Type': 'application/json',
-            login.OSMO_AUTH_HEADER: f'Bearer {_BEARER_SECRET}',
-            login.OSMO_USER_HEADER: 'alice@example.com',
-            'x-request-id': 'profile-request-123',
+            login.OSMO_AUTH_HEADER: f'Bearer {bearer_secret}',
+            login.OSMO_USER_HEADER: user_name,
+            'x-request-id': request_id,
         }
 
     @staticmethod
@@ -175,6 +181,73 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn(login.OSMO_USER_HEADER, upstream_request.headers)
         self.assertNotIn('cookie', upstream_request.headers)
+
+    async def test_concurrent_profile_calls_keep_requests_and_results_isolated(self) -> None:
+        captured_credentials: list[tuple[str, str | None]] = []
+        both_requests_arrived = asyncio.Event()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            authorization = request.headers['authorization']
+            captured_credentials.append((
+                authorization,
+                request.headers.get('x-request-id'),
+            ))
+            if len(captured_credentials) == 2:
+                both_requests_arrived.set()
+            await asyncio.wait_for(both_requests_arrived.wait(), timeout=1)
+
+            caller = authorization.removeprefix('Bearer concurrent-').removesuffix(
+                '-secret'
+            )
+            result: dict[str, object] = dict(_PROFILE_RESULT)
+            result['profile'] = {
+                'username': f'{caller}@example.com',
+                'email_notification': False,
+                'slack_notification': False,
+                'pool': caller,
+            }
+            result['token'] = None
+            return httpx.Response(200, json=result)
+
+        application = server.create_runtime_application(
+            server.MCPServiceConfig(gateway_url='https://gateway.test'),
+            http_transport=httpx.MockTransport(handler),
+        )
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                responses = await asyncio.gather(*(
+                    client.post(
+                        '/mcp',
+                        headers=self._headers(
+                            bearer_secret=f'concurrent-{caller}-secret',
+                            user_name=f'{caller}@example.com',
+                            request_id=f'request-{caller}',
+                        ),
+                        json=self._tool_call(),
+                    )
+                    for caller in ('alice', 'bob')
+                ))
+
+        for caller, response in zip(('alice', 'bob'), responses, strict=True):
+            result = response.json()['result']
+            other_caller = 'bob' if caller == 'alice' else 'alice'
+            self.assertFalse(result['isError'])
+            self.assertEqual(
+                result['structuredContent']['profile']['username'],
+                f'{caller}@example.com',
+            )
+            self.assertNotIn(
+                f'concurrent-{other_caller}-secret',
+                response.text,
+            )
+
+        self.assertCountEqual(captured_credentials, [
+            ('Bearer concurrent-alice-secret', 'request-alice'),
+            ('Bearer concurrent-bob-secret', 'request-bob'),
+        ])
 
     async def test_get_profile_maps_api_statuses_without_exposing_body(self) -> None:
         cases = (

--- a/src/service/mcp/tests/test_profile.py
+++ b/src/service/mcp/tests/test_profile.py
@@ -100,6 +100,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         include_catalog: bool = False,
         arguments: dict[str, object] | None = None,
         tool_name: str = 'osmo_get_profile',
+        bearer_secret: str = _BEARER_SECRET,
     ) -> tuple[httpx.Response, httpx.Response | None]:
         application = server.create_runtime_application(
             server.MCPServiceConfig(gateway_url='https://gateway.test'),
@@ -114,7 +115,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
                 if include_catalog:
                     catalog_response = await client.post(
                         '/mcp',
-                        headers=self._headers(),
+                        headers=self._headers(bearer_secret=bearer_secret),
                         json={
                             'jsonrpc': '2.0',
                             'id': 2,
@@ -124,7 +125,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
                     )
                 tool_response = await client.post(
                     '/mcp',
-                    headers=self._headers(),
+                    headers=self._headers(bearer_secret=bearer_secret),
                     json=self._tool_call(arguments, tool_name=tool_name),
                 )
         return tool_response, catalog_response
@@ -249,6 +250,67 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
             ('Bearer concurrent-bob-secret', 'request-bob'),
         ])
 
+    async def test_cancelled_mcp_request_cancels_active_gateway_relay(self) -> None:
+        handler_entered = asyncio.Event()
+        release_handler = asyncio.Event()
+        handler_cancelled = asyncio.Event()
+        handler_completed = asyncio.Event()
+        captured_authorization: list[str] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_authorization.append(request.headers['authorization'])
+            handler_entered.set()
+            try:
+                await release_handler.wait()
+            except asyncio.CancelledError:
+                handler_cancelled.set()
+                raise
+            handler_completed.set()
+            return httpx.Response(200, json=_PROFILE_RESULT)
+
+        application = server.create_runtime_application(
+            server.MCPServiceConfig(gateway_url='https://gateway.test'),
+            http_transport=httpx.MockTransport(handler),
+        )
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                request_task = asyncio.create_task(client.post(
+                    '/mcp',
+                    headers=self._headers(),
+                    json=self._tool_call(),
+                ))
+                try:
+                    await asyncio.wait_for(handler_entered.wait(), timeout=1)
+                    request_task.cancel()
+                    with self.assertRaises(asyncio.CancelledError):
+                        await request_task
+                    await asyncio.wait_for(handler_cancelled.wait(), timeout=1)
+                    self.assertFalse(handler_completed.is_set())
+                    release_handler.set()
+                    followup_response = await client.post(
+                        '/mcp',
+                        headers=self._headers(),
+                        json=self._tool_call(),
+                    )
+                    self.assertFalse(
+                        followup_response.json()['result']['isError'])
+                finally:
+                    release_handler.set()
+                    if not request_task.done():
+                        request_task.cancel()
+                        await asyncio.gather(
+                            request_task,
+                            return_exceptions=True,
+                        )
+
+        self.assertEqual(
+            captured_authorization,
+            [f'Bearer {_BEARER_SECRET}', f'Bearer {_BEARER_SECRET}'],
+        )
+
     async def test_get_profile_maps_api_statuses_without_exposing_body(self) -> None:
         cases = (
             (401, 'rejected the active authentication'),
@@ -321,6 +383,54 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
             'upstream-internal-profile-secret',
             json.dumps(result),
         )
+
+    async def test_get_profile_rejects_semantically_reflected_credentials(
+        self,
+    ) -> None:
+        short_secret = 'a'
+        short_reflection: dict[str, object] = dict(_PROFILE_RESULT)
+        short_reflection['token'] = {
+            'name': short_secret,
+            'expires_at': None,
+        }
+
+        long_secret = 'escaped-profile-bearer-secret'
+        escaped_reflection: dict[str, object] = dict(_PROFILE_RESULT)
+        escaped_reflection['token'] = {
+            'name': long_secret,
+            'expires_at': None,
+        }
+        escaped_body = json.dumps(escaped_reflection).replace(
+            long_secret,
+            ''.join(f'\\u{ord(character):04x}' for character in long_secret),
+        ).encode()
+        self.assertNotIn(long_secret.encode(), escaped_body)
+
+        cases = (
+            (short_secret, json.dumps(short_reflection).encode()),
+            (long_secret, escaped_body),
+        )
+
+        def response_handler(response_body: bytes) -> _Handler:
+            async def handler(request: httpx.Request) -> httpx.Response:
+                del request
+                return httpx.Response(200, content=response_body)
+
+            return handler
+
+        for bearer_secret, response_body in cases:
+            with self.subTest(bearer_secret=bearer_secret):
+                response, _ = await self._invoke_tool(
+                    response_handler(response_body),
+                    bearer_secret=bearer_secret,
+                )
+
+                result = response.json()['result']
+                self.assertTrue(result['isError'])
+                self.assertIn('invalid response', json.dumps(result))
+                self.assertNotIn(f'Bearer {bearer_secret}', json.dumps(result))
+                if len(bearer_secret) >= 16:
+                    self.assertNotIn(bearer_secret, json.dumps(result))
 
     async def test_get_profile_bounds_and_sanitizes_invalid_bodies(self) -> None:
         async def malformed_body(request: httpx.Request) -> httpx.Response:

--- a/src/service/mcp/tests/test_request_context.py
+++ b/src/service/mcp/tests/test_request_context.py
@@ -1,0 +1,521 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import json
+import unittest
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from src.service.mcp import request_context
+
+
+class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):
+
+    @staticmethod
+    def _headers(
+        authorization: bytes = b'Bearer test-token',
+        user_name: bytes = b'alice@example.com',
+        request_id: bytes | None = b'request-123',
+    ) -> list[tuple[bytes, bytes]]:
+        headers = [
+            (b'Authorization', authorization),
+            (b'X-Osmo-User', user_name),
+        ]
+        if request_id is not None:
+            headers.append((b'X-Request-ID', request_id))
+        return headers
+
+    @staticmethod
+    async def _invoke(
+        application: ASGIApp,
+        headers: list[tuple[bytes, bytes]],
+        *,
+        path: str = '/mcp',
+        query_string: bytes = b'',
+        scope_type: str = 'http',
+    ) -> list[Message]:
+        scope: Scope = {
+            'type': scope_type,
+            'asgi': {'version': '3.0', 'spec_version': '2.3'},
+            'http_version': '1.1',
+            'method': 'POST',
+            'scheme': 'http',
+            'path': path,
+            'raw_path': path.encode('ascii'),
+            'query_string': query_string,
+            'root_path': '',
+            'headers': headers,
+            'server': ('mcp.test', 80),
+            'client': ('test-client', 1234),
+            'state': {},
+        }
+        messages: list[Message] = []
+
+        async def receive() -> Message:
+            return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+        async def send(message: Message) -> None:
+            messages.append(message)
+
+        await application(scope, receive, send)
+        return messages
+
+    @staticmethod
+    def _status(messages: list[Message]) -> int:
+        starts = [
+            message for message in messages
+            if message['type'] == 'http.response.start'
+        ]
+        if len(starts) != 1:
+            raise AssertionError(f'Expected one response start, got {starts!r}.')
+        return starts[0]['status']
+
+    @staticmethod
+    def _body(messages: list[Message]) -> bytes:
+        return b''.join(
+            message.get('body', b'')
+            for message in messages
+            if message['type'] == 'http.response.body'
+        )
+
+    async def test_valid_headers_create_context_and_are_consumed(self) -> None:
+        captured: list[request_context.RequestCredentials] = []
+        downstream_headers: list[tuple[bytes, bytes]] = []
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            captured.append(request_context.get_request_credentials())
+            downstream_headers.extend(scope['headers'])
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        headers = self._headers(
+            authorization=b'bEaReR opaque.a-b_c~+/==',
+            user_name=b'alice+tag#EXT#@example.com',
+            request_id=b'req-123_ABC.trace:span',
+        )
+        headers.append((b'x-unrelated', b'kept'))
+
+        messages = await self._invoke(middleware, headers)
+
+        self.assertEqual(self._status(messages), 200)
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(
+            captured[0].authorization_header,
+            'bEaReR opaque.a-b_c~+/==',
+        )
+        self.assertEqual(captured[0].user_name, 'alice+tag#EXT#@example.com')
+        self.assertEqual(captured[0].request_id, 'req-123_ABC.trace:span')
+        self.assertEqual(downstream_headers, [(b'x-unrelated', b'kept')])
+        with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+            request_context.get_request_credentials()
+
+    async def test_optional_request_id_is_absent(self) -> None:
+        captured: list[request_context.RequestCredentials] = []
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            captured.append(request_context.get_request_credentials())
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        messages = await self._invoke(
+            middleware,
+            self._headers(request_id=None),
+        )
+
+        self.assertEqual(self._status(messages), 200)
+        self.assertIsNone(captured[0].request_id)
+
+    async def test_duplicate_context_headers_are_rejected(self) -> None:
+        downstream_calls = 0
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            del scope, receive, send
+            nonlocal downstream_calls
+            downstream_calls += 1
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        duplicate_headers = (
+            (b'authorization', b'Bearer test-token'),
+            (b'x-osmo-user', b'alice@example.com'),
+            (b'x-request-id', b'request-123'),
+        )
+
+        for duplicate_name, duplicate_value in duplicate_headers:
+            with self.subTest(header=duplicate_name):
+                headers = self._headers()
+                headers.append((duplicate_name.upper(), duplicate_value))
+                messages = await self._invoke(middleware, headers)
+                self.assertEqual(self._status(messages), 400)
+                self.assertEqual(
+                    json.loads(self._body(messages)),
+                    {'error': 'Invalid MCP authentication context.'},
+                )
+
+        self.assertEqual(downstream_calls, 0)
+
+    async def test_malformed_authorization_headers_are_rejected(self) -> None:
+        invalid_values = (
+            b'',
+            b'Bearer',
+            b'Bearer ',
+            b'Basic token',
+            b' Bearer token',
+            b'Bearer\ttoken',
+            b'Bearer token extra',
+            b'Bearer token\x00',
+            b'Bearer \xff',
+            b'Bearer token=middle=value',
+            b'a' * (request_context.MAX_AUTHORIZATION_HEADER_BYTES + 1),
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(value=invalid_value[:32]):
+                middleware = request_context.RequestContextMiddleware(
+                    self._success_application,
+                )
+                messages = await self._invoke(
+                    middleware,
+                    self._headers(authorization=invalid_value),
+                )
+                self.assertEqual(self._status(messages), 400)
+                response_body = self._body(messages)
+                if invalid_value:
+                    self.assertNotIn(invalid_value, response_body)
+
+        middleware = request_context.RequestContextMiddleware(
+            self._success_application,
+        )
+        messages = await self._invoke(
+            middleware,
+            [(b'x-osmo-user', b'alice@example.com')],
+        )
+        self.assertEqual(self._status(messages), 400)
+
+    async def test_malformed_user_headers_are_rejected(self) -> None:
+        invalid_values = (
+            b'',
+            b' ',
+            b' alice@example.com',
+            b'alice@example.com ',
+            b'alice\x00@example.com',
+            b'alice\n@example.com',
+            b'\xff',
+            b'a' * (request_context.MAX_USER_HEADER_BYTES + 1),
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(value=invalid_value[:32]):
+                middleware = request_context.RequestContextMiddleware(
+                    self._success_application,
+                )
+                messages = await self._invoke(
+                    middleware,
+                    self._headers(user_name=invalid_value),
+                )
+                self.assertEqual(self._status(messages), 400)
+
+        middleware = request_context.RequestContextMiddleware(
+            self._success_application,
+        )
+        messages = await self._invoke(
+            middleware,
+            [(b'authorization', b'Bearer test-token')],
+        )
+        self.assertEqual(self._status(messages), 400)
+
+    async def test_malformed_request_ids_are_rejected(self) -> None:
+        invalid_values = (
+            b'',
+            b' ',
+            b' request-123',
+            b'request-123 ',
+            b'request/123',
+            b'request\x00123',
+            b'request\n123',
+            b'\xff',
+            b'a' * (request_context.MAX_REQUEST_ID_HEADER_BYTES + 1),
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(value=invalid_value[:32]):
+                middleware = request_context.RequestContextMiddleware(
+                    self._success_application,
+                )
+                messages = await self._invoke(
+                    middleware,
+                    self._headers(request_id=invalid_value),
+                )
+                self.assertEqual(self._status(messages), 400)
+
+    async def test_header_length_boundaries_are_accepted(self) -> None:
+        authorization = b'Bearer ' + b'a' * (
+            request_context.MAX_AUTHORIZATION_HEADER_BYTES - len(b'Bearer ')
+        )
+        user_name = b'a' * request_context.MAX_USER_HEADER_BYTES
+        request_id = b'a' * request_context.MAX_REQUEST_ID_HEADER_BYTES
+        middleware = request_context.RequestContextMiddleware(
+            self._success_application,
+        )
+
+        messages = await self._invoke(
+            middleware,
+            self._headers(
+                authorization=authorization,
+                user_name=user_name,
+                request_id=request_id,
+            ),
+        )
+
+        self.assertEqual(self._status(messages), 200)
+
+    async def test_non_mcp_requests_bypass_context_validation(self) -> None:
+        observations: list[tuple[str, list[tuple[bytes, bytes]]]] = []
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+                request_context.get_request_credentials()
+            observations.append((scope['type'], scope.get('headers', [])))
+            if scope['type'] == 'http':
+                await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        invalid_headers = [
+            (b'authorization', b'not-a-bearer'),
+            (b'x-osmo-user', b''),
+        ]
+
+        for path in ('/health', '/health/ready', '/mcp/neighbor'):
+            messages = await self._invoke(
+                middleware,
+                invalid_headers,
+                path=path,
+            )
+            self.assertEqual(self._status(messages), 200)
+
+        await self._invoke(
+            middleware,
+            invalid_headers,
+            scope_type='websocket',
+        )
+        self.assertEqual(len(observations), 4)
+        self.assertTrue(all(headers == invalid_headers for _, headers in observations))
+
+        messages = await self._invoke(
+            middleware,
+            invalid_headers,
+            query_string=b'client=test',
+        )
+        self.assertEqual(self._status(messages), 400)
+
+    async def test_non_mcp_request_masks_inherited_credentials(self) -> None:
+        inner_context_was_empty = False
+
+        async def inner_downstream(
+            scope: Scope,
+            receive: Receive,
+            send: Send,
+        ) -> None:
+            nonlocal inner_context_was_empty
+            with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+                request_context.get_request_credentials()
+            inner_context_was_empty = True
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        inner_middleware = request_context.RequestContextMiddleware(
+            inner_downstream,
+        )
+
+        async def outer_downstream(
+            scope: Scope,
+            receive: Receive,
+            send: Send,
+        ) -> None:
+            self.assertEqual(
+                request_context.get_request_credentials().user_name,
+                'alice@example.com',
+            )
+            await self._invoke(inner_middleware, [], path='/health')
+            self.assertEqual(
+                request_context.get_request_credentials().user_name,
+                'alice@example.com',
+            )
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        outer_middleware = request_context.RequestContextMiddleware(
+            outer_downstream,
+        )
+        messages = await self._invoke(outer_middleware, self._headers())
+
+        self.assertEqual(self._status(messages), 200)
+        self.assertTrue(inner_context_was_empty)
+
+    async def test_context_resets_after_exception(self) -> None:
+        sentinel = RuntimeError('downstream failure')
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            del scope, receive, send
+            self.assertEqual(
+                request_context.get_request_credentials().user_name,
+                'alice@example.com',
+            )
+            raise sentinel
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        with self.assertRaises(RuntimeError) as raised:
+            await self._invoke(middleware, self._headers())
+        self.assertIs(raised.exception, sentinel)
+        with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+            request_context.get_request_credentials()
+
+    async def test_context_resets_after_cancellation(self) -> None:
+        entered = asyncio.Event()
+        reset_after_cancellation = False
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            del scope, receive, send
+            request_context.get_request_credentials()
+            entered.set()
+            await asyncio.Future()
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+
+        async def invoke_and_check_reset() -> None:
+            nonlocal reset_after_cancellation
+            try:
+                await self._invoke(middleware, self._headers())
+            finally:
+                try:
+                    request_context.get_request_credentials()
+                except RuntimeError:
+                    reset_after_cancellation = True
+
+        request_task = asyncio.create_task(invoke_and_check_reset())
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        request_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await request_task
+        self.assertTrue(reset_after_cancellation)
+
+    async def test_request_completion_invalidates_copied_task_context(self) -> None:
+        release_background = asyncio.Event()
+        background_context_was_invalidated = False
+        background_task: asyncio.Task[None] | None = None
+
+        async def inspect_context_after_request() -> None:
+            nonlocal background_context_was_invalidated
+            await release_background.wait()
+            try:
+                request_context.get_request_credentials()
+            except RuntimeError:
+                background_context_was_invalidated = True
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            nonlocal background_task
+            request_context.get_request_credentials()
+            background_task = asyncio.create_task(inspect_context_after_request())
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        messages = await self._invoke(middleware, self._headers())
+        self.assertEqual(self._status(messages), 200)
+
+        release_background.set()
+        if background_task is None:
+            self.fail('Downstream did not create the background task.')
+        await background_task
+        self.assertTrue(background_context_was_invalidated)
+
+    async def test_concurrent_requests_keep_credentials_isolated(self) -> None:
+        entered = {
+            'alice@example.com': asyncio.Event(),
+            'bob@example.com': asyncio.Event(),
+        }
+        release = asyncio.Event()
+        observations: dict[
+            str,
+            tuple[request_context.RequestCredentials, request_context.RequestCredentials],
+        ] = {}
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            before = request_context.get_request_credentials()
+            entered[before.user_name].set()
+            await release.wait()
+            after = request_context.get_request_credentials()
+            observations[before.user_name] = (before, after)
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        alice_request = asyncio.create_task(self._invoke(
+            middleware,
+            self._headers(
+                authorization=b'Bearer alice-token',
+                user_name=b'alice@example.com',
+                request_id=b'alice-request',
+            ),
+        ))
+        bob_request = asyncio.create_task(self._invoke(
+            middleware,
+            self._headers(
+                authorization=b'Bearer bob-token',
+                user_name=b'bob@example.com',
+                request_id=b'bob-request',
+            ),
+        ))
+        await asyncio.wait_for(asyncio.gather(
+            entered['alice@example.com'].wait(),
+            entered['bob@example.com'].wait(),
+        ), timeout=5)
+        release.set()
+        await asyncio.gather(alice_request, bob_request)
+
+        alice_before, alice_after = observations['alice@example.com']
+        bob_before, bob_after = observations['bob@example.com']
+        self.assertEqual(alice_before, alice_after)
+        self.assertEqual(bob_before, bob_after)
+        self.assertEqual(alice_before.authorization_header, 'Bearer alice-token')
+        self.assertEqual(bob_before.authorization_header, 'Bearer bob-token')
+        self.assertNotEqual(alice_before, bob_before)
+        with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+            request_context.get_request_credentials()
+
+    def test_credentials_repr_does_not_expose_authorization(self) -> None:
+        credentials = request_context.RequestCredentials(
+            authorization_header='Bearer highly-sensitive-token',
+            user_name='alice@example.com',
+            request_id='request-123',
+        )
+
+        self.assertNotIn('highly-sensitive-token', repr(credentials))
+        self.assertNotIn('highly-sensitive-token', str(credentials))
+        self.assertIn('alice@example.com', repr(credentials))
+        self.assertIn('request-123', repr(credentials))
+
+    @staticmethod
+    async def _success_application(
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        request_context.get_request_credentials()
+        await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -26,6 +26,7 @@ import unittest
 from unittest import mock
 
 import httpx
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import LATEST_PROTOCOL_VERSION
 import pydantic
 from starlette.applications import Starlette
@@ -170,6 +171,46 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn('tool-request-123', response_text)
         self.assertNotIn('tool-test-secret', response_text)
         self.assertFalse(response.json()['result']['isError'])
+
+    async def test_tool_error_cannot_reflect_request_credentials(self) -> None:
+        mcp_server = server.create_mcp_server()
+
+        @mcp_server.tool()
+        async def reflect_tool_error() -> None:
+            credentials = request_context.get_request_credentials()
+            raise ToolError(
+                f'unsafe reflected error: {credentials.authorization_header}')
+
+        application = server.create_application(mcp_server)
+        bearer_secret = 'tool-error-bearer-secret'
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                response = await client.post(
+                    '/mcp',
+                    headers={
+                        'Accept': 'application/json, text/event-stream',
+                        'Content-Type': 'application/json',
+                        login.OSMO_AUTH_HEADER: f'Bearer {bearer_secret}',
+                        login.OSMO_USER_HEADER: 'tool-user@example.com',
+                    },
+                    json={
+                        'jsonrpc': '2.0',
+                        'id': 1,
+                        'method': 'tools/call',
+                        'params': {
+                            'name': 'reflect_tool_error',
+                            'arguments': {},
+                        },
+                    },
+                )
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertIn('MCP tool failed', response.text)
+        self.assertNotIn(bearer_secret, response.text)
 
     def test_runtime_config_requires_https_gateway_origin(self) -> None:
         config = server.MCPServiceConfig(

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -23,18 +23,23 @@ from unittest import mock
 import httpx
 from mcp.types import LATEST_PROTOCOL_VERSION
 
-from src.service.mcp import server
+from src.lib.utils import login
+from src.service.mcp import request_context, server
 
 
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
     def test_create_application_uses_protocol_server(self) -> None:
-        application = object()
+        application = mock.Mock()
         protocol_server = mock.Mock()
         protocol_server.streamable_http_app.return_value = application
 
         self.assertIs(server.create_application(protocol_server), application)
         protocol_server.streamable_http_app.assert_called_once_with()
+        application.add_middleware.assert_called_once_with(
+            request_context.RequestContextMiddleware,
+            path='/mcp',
+        )
 
     async def test_health_endpoints(self) -> None:
         application = server.create_application(server.create_mcp_server())
@@ -63,6 +68,8 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         headers = {
             'Accept': 'application/json, text/event-stream',
             'Content-Type': 'application/json',
+            login.OSMO_AUTH_HEADER: 'Bearer test-token',
+            login.OSMO_USER_HEADER: 'test-user',
         }
         initialize_request = {
             'jsonrpc': '2.0',
@@ -108,6 +115,51 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(initialized_response.status_code, 202)
         self.assertEqual(list_tools_response.status_code, 200)
         self.assertEqual(list_tools_response.json()['result']['tools'], [])
+
+    async def test_request_context_reaches_fastmcp_tool(self) -> None:
+        mcp_server = server.create_mcp_server()
+
+        @mcp_server.tool()
+        async def inspect_request_context() -> dict[str, str | bool | None]:
+            credentials = request_context.get_request_credentials()
+            return {
+                'user_name': credentials.user_name,
+                'request_id': credentials.request_id,
+                'has_bearer': credentials.authorization_header.lower().startswith(
+                    'bearer '
+                ),
+            }
+
+        application = server.create_application(mcp_server)
+        headers = {
+            'Accept': 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            login.OSMO_AUTH_HEADER: 'Bearer tool-test-secret',
+            login.OSMO_USER_HEADER: 'tool-user@example.com',
+            'x-request-id': 'tool-request-123',
+        }
+        request = {
+            'jsonrpc': '2.0',
+            'id': 1,
+            'method': 'tools/call',
+            'params': {
+                'name': 'inspect_request_context',
+                'arguments': {},
+            },
+        }
+
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                    transport=httpx.ASGITransport(app=application),
+                    base_url='http://mcp.test') as client:
+                response = await client.post('/mcp', headers=headers, json=request)
+
+        self.assertEqual(response.status_code, 200)
+        response_text = response.text
+        self.assertIn('tool-user@example.com', response_text)
+        self.assertIn('tool-request-123', response_text)
+        self.assertNotIn('tool-test-secret', response_text)
+        self.assertFalse(response.json()['result']['isError'])
 
 
 class MCPMainTest(unittest.TestCase):

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -65,7 +65,7 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ready_response.status_code, 200)
         self.assertEqual(ready_response.json(), {'status': 'ok'})
 
-    async def test_initialize_and_empty_tool_catalog(self) -> None:
+    async def test_initialize_and_tool_catalog(self) -> None:
         mcp_server = server.create_mcp_server()
         self.assertTrue(mcp_server.settings.stateless_http)
         self.assertTrue(mcp_server.settings.json_response)
@@ -121,7 +121,10 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn('mcp-session-id', initialize_response.headers)
         self.assertEqual(initialized_response.status_code, 202)
         self.assertEqual(list_tools_response.status_code, 200)
-        self.assertEqual(list_tools_response.json()['result']['tools'], [])
+        self.assertEqual(
+            [tool['name'] for tool in list_tools_response.json()['result']['tools']],
+            ['osmo_get_profile'],
+        )
 
     async def test_request_context_reaches_fastmcp_tool(self) -> None:
         mcp_server = server.create_mcp_server()

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -28,8 +28,16 @@ from src.service.mcp import server
 
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
+    def test_create_application_uses_protocol_server(self) -> None:
+        application = object()
+        protocol_server = mock.Mock()
+        protocol_server.streamable_http_app.return_value = application
+
+        self.assertIs(server.create_application(protocol_server), application)
+        protocol_server.streamable_http_app.assert_called_once_with()
+
     async def test_health_endpoints(self) -> None:
-        application = server.create_mcp_server().streamable_http_app()
+        application = server.create_application(server.create_mcp_server())
         async with application.router.lifespan_context(application):
             async with httpx.AsyncClient(
                     transport=httpx.ASGITransport(app=application),
@@ -51,7 +59,7 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(mcp_server.settings.json_response)
         self.assertEqual(mcp_server.settings.streamable_http_path, '/mcp')
 
-        application = mcp_server.streamable_http_app()
+        application = server.create_application(mcp_server)
         headers = {
             'Accept': 'application/json, text/event-stream',
             'Content-Type': 'application/json',

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -16,15 +16,22 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from collections.abc import AsyncIterator
+import contextlib
+import io
+import os
+import sys
 import types
 import unittest
 from unittest import mock
 
 import httpx
 from mcp.types import LATEST_PROTOCOL_VERSION
+import pydantic
+from starlette.applications import Starlette
 
 from src.lib.utils import login
-from src.service.mcp import request_context, server
+from src.service.mcp import gateway, request_context, server
 
 
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
@@ -161,6 +168,143 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn('tool-test-secret', response_text)
         self.assertFalse(response.json()['result']['isError'])
 
+    def test_runtime_config_requires_https_gateway_origin(self) -> None:
+        config = server.MCPServiceConfig(
+            gateway_url='https://gateway.test:8443',
+        )
+        self.assertEqual(str(config.gateway_url), 'https://gateway.test:8443/')
+
+        invalid_urls = (
+            'http://gateway.test',
+            'gateway.test',
+            'https://user:password@gateway.test',
+            'https://gateway.test/api',
+            'https://gateway.test?query=value',
+            'https://gateway.test#fragment',
+        )
+        for invalid_url in invalid_urls:
+            with self.subTest(url=invalid_url):
+                with self.assertRaises(pydantic.ValidationError):
+                    server.MCPServiceConfig(gateway_url=invalid_url)
+
+        for invalid_timeout in (0, -1, 61):
+            with self.subTest(timeout=invalid_timeout):
+                with self.assertRaises(pydantic.ValidationError):
+                    server.MCPServiceConfig(
+                        gateway_url='https://gateway.test',
+                        request_timeout_seconds=invalid_timeout,
+                    )
+
+    def test_runtime_config_load_does_not_echo_invalid_url_credentials(self) -> None:
+        secret = 'startup-url-password-secret'
+        output = io.StringIO()
+        try:
+            server.MCPServiceConfig._instance = None  # pylint: disable=protected-access
+            with (
+                mock.patch.object(sys, 'argv', ['mcp']),
+                mock.patch.dict(
+                    os.environ,
+                    {'OSMO_GATEWAY_URL': f'https://user:{secret}@gateway.test'},
+                    clear=True,
+                ),
+                contextlib.redirect_stdout(output),
+                self.assertRaises(SystemExit),
+            ):
+                server.MCPServiceConfig.load()
+        finally:
+            server.MCPServiceConfig._instance = None  # pylint: disable=protected-access
+
+        self.assertNotIn(secret, output.getvalue())
+        self.assertNotIn('user:', output.getvalue())
+
+    async def test_runtime_application_owns_gateway_context(self) -> None:
+        config = server.MCPServiceConfig(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=7,
+        )
+        app_context = gateway.AppContext(gateway=mock.Mock())
+        lifecycle_events: list[str] = []
+
+        @contextlib.asynccontextmanager
+        async def create_app_context(
+            **kwargs: object,
+        ) -> AsyncIterator[gateway.AppContext]:
+            self.assertEqual(kwargs, {
+                'gateway_url': 'https://gateway.test/',
+                'request_timeout_seconds': 7,
+                'transport': None,
+            })
+            lifecycle_events.append('entered')
+            try:
+                yield app_context
+            finally:
+                lifecycle_events.append('exited')
+
+        with mock.patch.object(
+                gateway, 'create_app_context', new=create_app_context):
+            application = server.create_runtime_application(config)
+            async with application.router.lifespan_context(application):
+                self.assertIs(application.state.mcp_app_context, app_context)
+                self.assertEqual(lifecycle_events, ['entered'])
+
+        self.assertFalse(hasattr(application.state, 'mcp_app_context'))
+        self.assertEqual(lifecycle_events, ['entered', 'exited'])
+
+    async def test_runtime_application_cleans_up_in_dependency_order(self) -> None:
+        config = server.MCPServiceConfig(gateway_url='https://gateway.test')
+        app_context = gateway.AppContext(gateway=mock.Mock())
+        lifecycle_events: list[str] = []
+
+        @contextlib.asynccontextmanager
+        async def protocol_lifespan(
+            application: Starlette,
+        ) -> AsyncIterator[None]:
+            self.assertIs(application.state.mcp_app_context, app_context)
+            lifecycle_events.append('protocol-entered')
+            try:
+                yield
+            finally:
+                self.assertIs(application.state.mcp_app_context, app_context)
+                lifecycle_events.append('protocol-exited')
+
+        @contextlib.asynccontextmanager
+        async def create_app_context(
+            **kwargs: object,
+        ) -> AsyncIterator[gateway.AppContext]:
+            del kwargs
+            lifecycle_events.append('gateway-entered')
+            try:
+                yield app_context
+            finally:
+                lifecycle_events.append('gateway-exited')
+
+        protocol_application = Starlette(lifespan=protocol_lifespan)
+        with (
+            mock.patch.object(server, 'create_mcp_server'),
+            mock.patch.object(
+                server,
+                'create_application',
+                return_value=protocol_application,
+            ),
+            mock.patch.object(
+                gateway,
+                'create_app_context',
+                new=create_app_context,
+            ),
+        ):
+            application = server.create_runtime_application(config)
+            with self.assertRaisesRegex(RuntimeError, 'lifespan failure'):
+                async with application.router.lifespan_context(application):
+                    raise RuntimeError('lifespan failure')
+
+        self.assertFalse(hasattr(application.state, 'mcp_app_context'))
+        self.assertEqual(lifecycle_events, [
+            'gateway-entered',
+            'protocol-entered',
+            'protocol-exited',
+            'gateway-exited',
+        ])
+
 
 class MCPMainTest(unittest.TestCase):
 
@@ -174,10 +318,16 @@ class MCPMainTest(unittest.TestCase):
         uvicorn_config = object()
         uvicorn_server = mock.Mock()
         uvicorn_server.serve = mock.AsyncMock()
+        application = object()
 
         with (
             mock.patch.object(
                 server.MCPServiceConfig, 'load', return_value=config),
+            mock.patch.object(
+                server,
+                'create_runtime_application',
+                return_value=application,
+            ) as application_factory,
             mock.patch.object(
                 server.uvicorn,
                 'Config',
@@ -192,7 +342,7 @@ class MCPMainTest(unittest.TestCase):
             server.main()
 
         config_factory.assert_called_once_with(
-            server.app,
+            application,
             host='127.0.0.1',
             port=9000,
             log_config=None,
@@ -200,6 +350,7 @@ class MCPMainTest(unittest.TestCase):
         )
         server_factory.assert_called_once_with(config=uvicorn_config)
         uvicorn_server.serve.assert_awaited_once_with()
+        application_factory.assert_called_once_with(config)
         config.uvicorn_ssl_kwargs.assert_called_once_with()
 
     def test_main_handles_keyboard_interrupt(self) -> None:
@@ -210,10 +361,16 @@ class MCPMainTest(unittest.TestCase):
         )
         uvicorn_server = mock.Mock()
         uvicorn_server.serve = mock.AsyncMock(side_effect=KeyboardInterrupt)
+        application = object()
 
         with (
             mock.patch.object(
                 server.MCPServiceConfig, 'load', return_value=config),
+            mock.patch.object(
+                server,
+                'create_runtime_application',
+                return_value=application,
+            ) as application_factory,
             mock.patch.object(server.uvicorn, 'Config', return_value=object()),
             mock.patch.object(
                 server.uvicorn,
@@ -224,6 +381,7 @@ class MCPMainTest(unittest.TestCase):
             server.main()
 
         uvicorn_server.serve.assert_awaited_once_with()
+        application_factory.assert_called_once_with(config)
 
 
 if __name__ == '__main__':

--- a/src/utils/static_config.py
+++ b/src/utils/static_config.py
@@ -109,7 +109,8 @@ class StaticConfig(pydantic.BaseModel):
             cls._instance = cls(**config)
         except pydantic.ValidationError as error:
             # Parse through errors and print them in a more user friendly manner
-            for type_error in error.errors():
+            include_input = not cls.model_config.get('hide_input_in_errors', False)
+            for type_error in error.errors(include_input=include_input):
                 if type_error['type'] not in ('type_error.none.not_allowed', 'value_error.missing',
                                                  'missing', 'none_required'):
                     print(type_error)

--- a/test/oetf/main.py
+++ b/test/oetf/main.py
@@ -568,6 +568,7 @@ def _target_from_xml_path(xml_path: str, testlogs_dir: str) -> str:
 
 def render_summary(
     env: Dict[str, str], args: argparse.Namespace, results: List[Dict],
+    bazel_exit: int,
 ) -> str:
     by_status: Dict[str, int] = {"pass": 0, "fail": 0, "error": 0, "skip": 0}
     lines: List[str] = []
@@ -578,6 +579,8 @@ def render_summary(
     if args.name:
         lines.append(f"Name:     {args.name}")
     lines.append(f"Time:     {_now_iso()}")
+    if bazel_exit != 0:
+        lines.append(f"Bazel exit code: {bazel_exit}")
     lines.append("")
     if not results:
         lines.append("(no test results reported by Bazel)")
@@ -604,10 +607,22 @@ def render_summary(
     )
     lines.append("")
     lines.append(
-        "RESULT: PASS" if (by_status["fail"] == 0 and by_status["error"] == 0)
+        "RESULT: PASS" if _run_succeeded(bazel_exit, results)
         else "RESULT: FAIL"
     )
     return "\n".join(lines)
+
+
+def _run_succeeded(bazel_exit: int, results: List[Dict]) -> bool:
+    """Return whether Bazel ran at least one test without a failure."""
+    return (
+        bazel_exit == 0
+        and bool(results)
+        and not any(
+            result["status"] in {"fail", "error"}
+            for result in results
+        )
+    )
 
 
 def _short_label(result: Dict) -> str:
@@ -818,7 +833,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     bazel_exit = proc.returncode
 
     results = parse_bep_test_results(bep_path)
-    print(render_summary(env, args, results))
+    print(render_summary(env, args, results, bazel_exit))
 
     targets = [r["target"] for r in results if r.get("target")]
     maybe_publish_report(args, env, targets)
@@ -827,8 +842,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         write_json(args.output_json, env, args, results)
         print(f"Results JSON written to {args.output_json}", file=sys.stderr)
 
-    failed_or_errored = any(r["status"] in {"fail", "error"} for r in results)
-    return 1 if (bazel_exit != 0 or failed_or_errored) else 0
+    return 0 if _run_succeeded(bazel_exit, results) else 1
 
 
 def _bep_path() -> str:

--- a/test/oetf/tests/BUILD
+++ b/test/oetf/tests/BUILD
@@ -147,5 +147,11 @@ osmo_py_test(
     deps = ["//test/oetf:run_lib"],
 )
 
+osmo_py_test(
+    name = "test_main",
+    srcs = ["test_main.py"],
+    deps = ["//test/oetf:run_lib"],
+)
+
 # test_dev_adapter stays internal — dev_adapter.py is not shipped in the public
 # OETF distribution; the internal overlay package owns its tests.

--- a/test/oetf/tests/test_main.py
+++ b/test/oetf/tests/test_main.py
@@ -1,0 +1,109 @@
+"""
+Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+NVIDIA CORPORATION and its licensors retain all intellectual property
+and proprietary rights in and to this software, related documentation
+and any modifications thereto. Any use, reproduction, disclosure or
+distribution of this software and related documentation without an express
+license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""
+
+import argparse
+from contextlib import redirect_stdout
+import io
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from test.oetf import main as oetf_main
+
+
+class MainResultContractTest(unittest.TestCase):
+    """The OETF wrapper fails closed when Bazel does not run its tests."""
+
+    @staticmethod
+    def _run_main(
+        bazel_exit: int,
+        results: list[dict],
+    ) -> tuple[int, str]:
+        args = argparse.Namespace(
+            env="staging",
+            name="profile-round-trip",
+            output_json="",
+            tags="",
+        )
+        env = {
+            "auth_token": "test-token",
+            "url": "https://staging.example",
+        }
+        stdout = io.StringIO()
+        with mock.patch.object(oetf_main, "parse_args", return_value=args), \
+             mock.patch.object(oetf_main, "resolve_env", return_value=env), \
+             mock.patch.object(oetf_main, "seed_data_credential"), \
+             mock.patch.object(oetf_main, "_bep_path", return_value="/tmp/bep.json"), \
+             mock.patch.object(
+                 oetf_main,
+                 "build_bazel_command",
+                 return_value=["bazel", "test", "//test:target"],
+             ), \
+             mock.patch.object(
+                 oetf_main.subprocess,
+                 "run",
+                 return_value=SimpleNamespace(returncode=bazel_exit),
+             ), \
+             mock.patch.object(
+                 oetf_main,
+                 "parse_bep_test_results",
+                 return_value=results,
+             ), \
+             mock.patch.object(oetf_main, "maybe_publish_report"), \
+             redirect_stdout(stdout):
+            exit_code = oetf_main.main([])
+        return exit_code, stdout.getvalue()
+
+    def test_analysis_failure_with_no_results_reports_fail(self):
+        exit_code, output = self._run_main(1, [])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Bazel exit code: 1", output)
+        self.assertIn("(no test results reported by Bazel)", output)
+        self.assertIn("RESULT: FAIL", output)
+        self.assertNotIn("RESULT: PASS", output)
+
+    def test_zero_results_fail_closed_when_bazel_exits_zero(self):
+        exit_code, output = self._run_main(0, [])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("RESULT: FAIL", output)
+
+    def test_nonzero_bazel_exit_overrides_passing_test_result(self):
+        result = {
+            "target": "//test:target",
+            "classname": "",
+            "name": "target",
+            "time": 0.1,
+            "status": "pass",
+            "message": "",
+        }
+        exit_code, output = self._run_main(1, [result])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("RESULT: FAIL", output)
+
+    def test_successful_bazel_run_with_passing_result_reports_pass(self):
+        result = {
+            "target": "//test:target",
+            "classname": "",
+            "name": "target",
+            "time": 0.1,
+            "status": "pass",
+            "message": "",
+        }
+        exit_code, output = self._run_main(0, [result])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("RESULT: PASS", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Implements the redesigned MCP Phase B request relay on top of the completed Phase A OAuth and Gateway boundary.

This change:

- captures the Gateway-authenticated bearer, user, and optional request ID in request-scoped state and cancels detached relay work when the owning request ends;
- adds a fixed-origin Gateway client with fixed API methods and paths, bounded responses, sanitized errors, no redirects, and no automatic retries;
- adds the typed `osmo_get_profile` tool mapped to `GET /api/profile/settings`, reusing a lightweight profile contract shared with Core;
- preserves the caller's bearer unchanged for the second Gateway pass, where `profile:Read` is authorized independently from `mcp:Access`;
- rejects caller-selected origins, routes, methods, authorization values, and outbound headers;
- prevents bearer reflection through successful tool output and tool errors;
- adds MCP deployment validation for OAuth metadata, probes, ingress isolation, managed configuration, and authentication-bypass cases; and
- documents the request flow, trust boundary, deployment settings, troubleshooting, and tool-extension requirements.

The implementation does not add token exchange, delegation, service credentials, token caching, persistence, refresh, redirects, or automatic retries. It was created from `origin/feature/mcp` plus current `origin/main`; no older implementation branch was reused or modified.

This PR remains a draft until live-environment validation covers OAuth/PKCE behavior, Gateway 401/403 enforcement, the real second-pass API authorization path, deployed log and trace secret checks, and pod restart and dependency-failure behavior.

## Validation

- `bazel test --test_output=errors //src/lib/api/... //src/service/core/profile:profile-pylint //src/service/mcp/... //src/utils:static_config-pylint` (17 targets passed)
- `bazel build //src/service/mcp:mcp_binary`
- Linux arm64 and x86_64 MCP OCI image builds
- `bash deployments/charts/service/ci/validate-mcp-chart.sh`
- `helm lint deployments/charts/service`
- YAML syntax validation for the Helm workflow and MCP values fixture
- `git diff --check`
- independent security, documentation, and commit-provenance audits

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
