### PR TITLE
MCP Phase B: Add request-scoped credentials

### DIFF
--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -23,6 +23,16 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@osmo_constants//:constants.bzl", "BASE_IMAGE_URL", "IMAGE_TAG")
 
 osmo_py_library(
+    name = "request_context",
+    srcs = ["request_context.py"],
+    deps = [
+        requirement("starlette"),
+        "//src/lib/utils:login",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "mcp_service_lib",
     srcs = ["server.py"],
     deps = [
@@ -30,6 +40,7 @@ osmo_py_library(
         requirement("pydantic"),
         requirement("starlette"),
         requirement("uvicorn"),
+        ":request_context",
         "//src/utils:ssl_config",
         "//src/utils:static_config",
     ],

--- a/src/service/mcp/request_context.py
+++ b/src/service/mcp/request_context.py
@@ -1,0 +1,184 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Iterable
+import contextvars
+import dataclasses
+import re
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from src.lib.utils import login
+
+
+_AUTHORIZATION_HEADER = login.OSMO_AUTH_HEADER.lower().encode('ascii')
+_USER_HEADER = login.OSMO_USER_HEADER.lower().encode('ascii')
+_REQUEST_ID_HEADER = b'x-request-id'
+_CONTEXT_HEADERS = frozenset((
+    _AUTHORIZATION_HEADER,
+    _USER_HEADER,
+    _REQUEST_ID_HEADER,
+))
+_BEARER_VALUE = re.compile(
+    r'Bearer [A-Za-z0-9._~+/-]+=*',
+    flags=re.IGNORECASE,
+)
+_REQUEST_ID = re.compile(r'[A-Za-z0-9][A-Za-z0-9._:-]*')
+MAX_AUTHORIZATION_HEADER_BYTES = 128 * 1024
+MAX_USER_HEADER_BYTES = 256
+MAX_REQUEST_ID_HEADER_BYTES = 128
+_INVALID_CONTEXT_RESPONSE = {'error': 'Invalid MCP authentication context.'}
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class RequestCredentials:
+    """Gateway-authenticated credentials owned by one MCP request."""
+
+    authorization_header: str = dataclasses.field(repr=False)
+    user_name: str
+    request_id: str | None
+
+
+@dataclasses.dataclass(slots=True)
+class _RequestState:
+    credentials: RequestCredentials | None
+
+
+_request_state: contextvars.ContextVar[_RequestState | None] = (
+    contextvars.ContextVar('mcp_request_state', default=None))
+
+
+class RequestContextMiddleware:
+    """Bind Gateway-owned authentication headers to one MCP request."""
+
+    def __init__(self, application: ASGIApp, path: str = '/mcp') -> None:
+        self._application = application
+        self._path = path
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        mask_token = _request_state.set(None)
+        try:
+            if scope['type'] != 'http' or scope.get('path') != self._path:
+                await self._application(scope, receive, send)
+                return
+
+            credentials = _parse_credentials(scope.get('headers', []))
+            if credentials is None:
+                response = JSONResponse(_INVALID_CONTEXT_RESPONSE, status_code=400)
+                await response(scope, receive, send)
+                return
+
+            downstream_scope = dict(scope)
+            downstream_scope['headers'] = [
+                (name, value)
+                for name, value in scope.get('headers', [])
+                if name.lower() not in _CONTEXT_HEADERS
+            ]
+            request_state = _RequestState(credentials=credentials)
+            context_token = _request_state.set(request_state)
+            try:
+                await self._application(downstream_scope, receive, send)
+            finally:
+                request_state.credentials = None
+                _request_state.reset(context_token)
+        finally:
+            _request_state.reset(mask_token)
+
+
+def get_request_credentials() -> RequestCredentials:
+    """Return credentials for the active MCP request."""
+    request_state = _request_state.get()
+    if request_state is None or request_state.credentials is None:
+        raise RuntimeError('MCP request credentials are unavailable.')
+    return request_state.credentials
+
+
+def _parse_credentials(
+    raw_headers: Iterable[tuple[bytes, bytes]],
+) -> RequestCredentials | None:
+    relevant_headers: dict[bytes, list[bytes]] = {}
+    for name, value in raw_headers:
+        normalized_name = name.lower()
+        if normalized_name in _CONTEXT_HEADERS:
+            relevant_headers.setdefault(normalized_name, []).append(value)
+
+    authorization_values = relevant_headers.get(_AUTHORIZATION_HEADER, [])
+    user_values = relevant_headers.get(_USER_HEADER, [])
+    request_id_values = relevant_headers.get(_REQUEST_ID_HEADER, [])
+    if (
+        len(authorization_values) != 1
+        or len(user_values) != 1
+        or len(request_id_values) > 1
+        or len(authorization_values[0]) > MAX_AUTHORIZATION_HEADER_BYTES
+        or len(user_values[0]) > MAX_USER_HEADER_BYTES
+        or (
+            request_id_values
+            and len(request_id_values[0]) > MAX_REQUEST_ID_HEADER_BYTES
+        )
+    ):
+        return None
+
+    authorization_header = _decode_ascii(authorization_values[0])
+    user_name = _decode_utf8(user_values[0])
+    if (
+        authorization_header is None
+        or _BEARER_VALUE.fullmatch(authorization_header) is None
+        or user_name is None
+        or not _is_valid_user_name(user_name)
+    ):
+        return None
+
+    request_id: str | None = None
+    if request_id_values:
+        request_id = _decode_ascii(request_id_values[0])
+        if request_id is None or _REQUEST_ID.fullmatch(request_id) is None:
+            return None
+
+    return RequestCredentials(
+        authorization_header=authorization_header,
+        user_name=user_name,
+        request_id=request_id,
+    )
+
+
+def _decode_ascii(value: bytes) -> str | None:
+    try:
+        return value.decode('ascii')
+    except UnicodeDecodeError:
+        return None
+
+
+def _decode_utf8(value: bytes) -> str | None:
+    try:
+        return value.decode('utf-8')
+    except UnicodeDecodeError:
+        return None
+
+
+def _is_valid_user_name(user_name: str) -> bool:
+    try:
+        encoded_length = len(user_name.encode('utf-8'))
+    except UnicodeEncodeError:
+        return False
+    return (
+        bool(user_name)
+        and user_name == user_name.strip()
+        and encoded_length <= MAX_USER_HEADER_BYTES
+        and all(character.isprintable() for character in user_name)
+    )

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -69,8 +69,13 @@ def create_mcp_server() -> FastMCP:
     return server
 
 
+def create_application(protocol_server: FastMCP) -> Starlette:
+    """Create the ASGI application for an MCP protocol server."""
+    return protocol_server.streamable_http_app()
+
+
 mcp_server = create_mcp_server()
-app: Starlette = mcp_server.streamable_http_app()
+app: Starlette = create_application(mcp_server)
 
 
 def main() -> None:

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -25,6 +25,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 import uvicorn  # type: ignore
 
+from src.service.mcp import request_context
 from src.utils import ssl_config, static_config
 
 
@@ -71,7 +72,12 @@ def create_mcp_server() -> FastMCP:
 
 def create_application(protocol_server: FastMCP) -> Starlette:
     """Create the ASGI application for an MCP protocol server."""
-    return protocol_server.streamable_http_app()
+    application = protocol_server.streamable_http_app()
+    application.add_middleware(
+        request_context.RequestContextMiddleware,
+        path='/mcp',
+    )
+    return application
 
 
 mcp_server = create_mcp_server()

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -20,11 +20,22 @@ load("//bzl:py.bzl", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_test(
+    name = "test_request_context",
+    srcs = ["test_request_context.py"],
+    deps = [
+        requirement("starlette"),
+        "//src/service/mcp:request_context",
+    ],
+)
+
+osmo_py_test(
     name = "test_server",
     srcs = ["test_server.py"],
     deps = [
         requirement("httpx"),
         requirement("mcp"),
+        "//src/lib/utils:login",
+        "//src/service/mcp:request_context",
         "//src/service/mcp:mcp_service_lib",
     ],
 )

--- a/src/service/mcp/tests/test_request_context.py
+++ b/src/service/mcp/tests/test_request_context.py
@@ -1,0 +1,521 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+import json
+import unittest
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from src.service.mcp import request_context
+
+
+class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):
+
+    @staticmethod
+    def _headers(
+        authorization: bytes = b'Bearer test-token',
+        user_name: bytes = b'alice@example.com',
+        request_id: bytes | None = b'request-123',
+    ) -> list[tuple[bytes, bytes]]:
+        headers = [
+            (b'Authorization', authorization),
+            (b'X-Osmo-User', user_name),
+        ]
+        if request_id is not None:
+            headers.append((b'X-Request-ID', request_id))
+        return headers
+
+    @staticmethod
+    async def _invoke(
+        application: ASGIApp,
+        headers: list[tuple[bytes, bytes]],
+        *,
+        path: str = '/mcp',
+        query_string: bytes = b'',
+        scope_type: str = 'http',
+    ) -> list[Message]:
+        scope: Scope = {
+            'type': scope_type,
+            'asgi': {'version': '3.0', 'spec_version': '2.3'},
+            'http_version': '1.1',
+            'method': 'POST',
+            'scheme': 'http',
+            'path': path,
+            'raw_path': path.encode('ascii'),
+            'query_string': query_string,
+            'root_path': '',
+            'headers': headers,
+            'server': ('mcp.test', 80),
+            'client': ('test-client', 1234),
+            'state': {},
+        }
+        messages: list[Message] = []
+
+        async def receive() -> Message:
+            return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+        async def send(message: Message) -> None:
+            messages.append(message)
+
+        await application(scope, receive, send)
+        return messages
+
+    @staticmethod
+    def _status(messages: list[Message]) -> int:
+        starts = [
+            message for message in messages
+            if message['type'] == 'http.response.start'
+        ]
+        if len(starts) != 1:
+            raise AssertionError(f'Expected one response start, got {starts!r}.')
+        return starts[0]['status']
+
+    @staticmethod
+    def _body(messages: list[Message]) -> bytes:
+        return b''.join(
+            message.get('body', b'')
+            for message in messages
+            if message['type'] == 'http.response.body'
+        )
+
+    async def test_valid_headers_create_context_and_are_consumed(self) -> None:
+        captured: list[request_context.RequestCredentials] = []
+        downstream_headers: list[tuple[bytes, bytes]] = []
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            captured.append(request_context.get_request_credentials())
+            downstream_headers.extend(scope['headers'])
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        headers = self._headers(
+            authorization=b'bEaReR opaque.a-b_c~+/==',
+            user_name=b'alice+tag#EXT#@example.com',
+            request_id=b'req-123_ABC.trace:span',
+        )
+        headers.append((b'x-unrelated', b'kept'))
+
+        messages = await self._invoke(middleware, headers)
+
+        self.assertEqual(self._status(messages), 200)
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(
+            captured[0].authorization_header,
+            'bEaReR opaque.a-b_c~+/==',
+        )
+        self.assertEqual(captured[0].user_name, 'alice+tag#EXT#@example.com')
+        self.assertEqual(captured[0].request_id, 'req-123_ABC.trace:span')
+        self.assertEqual(downstream_headers, [(b'x-unrelated', b'kept')])
+        with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+            request_context.get_request_credentials()
+
+    async def test_optional_request_id_is_absent(self) -> None:
+        captured: list[request_context.RequestCredentials] = []
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            captured.append(request_context.get_request_credentials())
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        messages = await self._invoke(
+            middleware,
+            self._headers(request_id=None),
+        )
+
+        self.assertEqual(self._status(messages), 200)
+        self.assertIsNone(captured[0].request_id)
+
+    async def test_duplicate_context_headers_are_rejected(self) -> None:
+        downstream_calls = 0
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            del scope, receive, send
+            nonlocal downstream_calls
+            downstream_calls += 1
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        duplicate_headers = (
+            (b'authorization', b'Bearer test-token'),
+            (b'x-osmo-user', b'alice@example.com'),
+            (b'x-request-id', b'request-123'),
+        )
+
+        for duplicate_name, duplicate_value in duplicate_headers:
+            with self.subTest(header=duplicate_name):
+                headers = self._headers()
+                headers.append((duplicate_name.upper(), duplicate_value))
+                messages = await self._invoke(middleware, headers)
+                self.assertEqual(self._status(messages), 400)
+                self.assertEqual(
+                    json.loads(self._body(messages)),
+                    {'error': 'Invalid MCP authentication context.'},
+                )
+
+        self.assertEqual(downstream_calls, 0)
+
+    async def test_malformed_authorization_headers_are_rejected(self) -> None:
+        invalid_values = (
+            b'',
+            b'Bearer',
+            b'Bearer ',
+            b'Basic token',
+            b' Bearer token',
+            b'Bearer\ttoken',
+            b'Bearer token extra',
+            b'Bearer token\x00',
+            b'Bearer \xff',
+            b'Bearer token=middle=value',
+            b'a' * (request_context.MAX_AUTHORIZATION_HEADER_BYTES + 1),
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(value=invalid_value[:32]):
+                middleware = request_context.RequestContextMiddleware(
+                    self._success_application,
+                )
+                messages = await self._invoke(
+                    middleware,
+                    self._headers(authorization=invalid_value),
+                )
+                self.assertEqual(self._status(messages), 400)
+                response_body = self._body(messages)
+                if invalid_value:
+                    self.assertNotIn(invalid_value, response_body)
+
+        middleware = request_context.RequestContextMiddleware(
+            self._success_application,
+        )
+        messages = await self._invoke(
+            middleware,
+            [(b'x-osmo-user', b'alice@example.com')],
+        )
+        self.assertEqual(self._status(messages), 400)
+
+    async def test_malformed_user_headers_are_rejected(self) -> None:
+        invalid_values = (
+            b'',
+            b' ',
+            b' alice@example.com',
+            b'alice@example.com ',
+            b'alice\x00@example.com',
+            b'alice\n@example.com',
+            b'\xff',
+            b'a' * (request_context.MAX_USER_HEADER_BYTES + 1),
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(value=invalid_value[:32]):
+                middleware = request_context.RequestContextMiddleware(
+                    self._success_application,
+                )
+                messages = await self._invoke(
+                    middleware,
+                    self._headers(user_name=invalid_value),
+                )
+                self.assertEqual(self._status(messages), 400)
+
+        middleware = request_context.RequestContextMiddleware(
+            self._success_application,
+        )
+        messages = await self._invoke(
+            middleware,
+            [(b'authorization', b'Bearer test-token')],
+        )
+        self.assertEqual(self._status(messages), 400)
+
+    async def test_malformed_request_ids_are_rejected(self) -> None:
+        invalid_values = (
+            b'',
+            b' ',
+            b' request-123',
+            b'request-123 ',
+            b'request/123',
+            b'request\x00123',
+            b'request\n123',
+            b'\xff',
+            b'a' * (request_context.MAX_REQUEST_ID_HEADER_BYTES + 1),
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(value=invalid_value[:32]):
+                middleware = request_context.RequestContextMiddleware(
+                    self._success_application,
+                )
+                messages = await self._invoke(
+                    middleware,
+                    self._headers(request_id=invalid_value),
+                )
+                self.assertEqual(self._status(messages), 400)
+
+    async def test_header_length_boundaries_are_accepted(self) -> None:
+        authorization = b'Bearer ' + b'a' * (
+            request_context.MAX_AUTHORIZATION_HEADER_BYTES - len(b'Bearer ')
+        )
+        user_name = b'a' * request_context.MAX_USER_HEADER_BYTES
+        request_id = b'a' * request_context.MAX_REQUEST_ID_HEADER_BYTES
+        middleware = request_context.RequestContextMiddleware(
+            self._success_application,
+        )
+
+        messages = await self._invoke(
+            middleware,
+            self._headers(
+                authorization=authorization,
+                user_name=user_name,
+                request_id=request_id,
+            ),
+        )
+
+        self.assertEqual(self._status(messages), 200)
+
+    async def test_non_mcp_requests_bypass_context_validation(self) -> None:
+        observations: list[tuple[str, list[tuple[bytes, bytes]]]] = []
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+                request_context.get_request_credentials()
+            observations.append((scope['type'], scope.get('headers', [])))
+            if scope['type'] == 'http':
+                await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        invalid_headers = [
+            (b'authorization', b'not-a-bearer'),
+            (b'x-osmo-user', b''),
+        ]
+
+        for path in ('/health', '/health/ready', '/mcp/neighbor'):
+            messages = await self._invoke(
+                middleware,
+                invalid_headers,
+                path=path,
+            )
+            self.assertEqual(self._status(messages), 200)
+
+        await self._invoke(
+            middleware,
+            invalid_headers,
+            scope_type='websocket',
+        )
+        self.assertEqual(len(observations), 4)
+        self.assertTrue(all(headers == invalid_headers for _, headers in observations))
+
+        messages = await self._invoke(
+            middleware,
+            invalid_headers,
+            query_string=b'client=test',
+        )
+        self.assertEqual(self._status(messages), 400)
+
+    async def test_non_mcp_request_masks_inherited_credentials(self) -> None:
+        inner_context_was_empty = False
+
+        async def inner_downstream(
+            scope: Scope,
+            receive: Receive,
+            send: Send,
+        ) -> None:
+            nonlocal inner_context_was_empty
+            with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+                request_context.get_request_credentials()
+            inner_context_was_empty = True
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        inner_middleware = request_context.RequestContextMiddleware(
+            inner_downstream,
+        )
+
+        async def outer_downstream(
+            scope: Scope,
+            receive: Receive,
+            send: Send,
+        ) -> None:
+            self.assertEqual(
+                request_context.get_request_credentials().user_name,
+                'alice@example.com',
+            )
+            await self._invoke(inner_middleware, [], path='/health')
+            self.assertEqual(
+                request_context.get_request_credentials().user_name,
+                'alice@example.com',
+            )
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        outer_middleware = request_context.RequestContextMiddleware(
+            outer_downstream,
+        )
+        messages = await self._invoke(outer_middleware, self._headers())
+
+        self.assertEqual(self._status(messages), 200)
+        self.assertTrue(inner_context_was_empty)
+
+    async def test_context_resets_after_exception(self) -> None:
+        sentinel = RuntimeError('downstream failure')
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            del scope, receive, send
+            self.assertEqual(
+                request_context.get_request_credentials().user_name,
+                'alice@example.com',
+            )
+            raise sentinel
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        with self.assertRaises(RuntimeError) as raised:
+            await self._invoke(middleware, self._headers())
+        self.assertIs(raised.exception, sentinel)
+        with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+            request_context.get_request_credentials()
+
+    async def test_context_resets_after_cancellation(self) -> None:
+        entered = asyncio.Event()
+        reset_after_cancellation = False
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            del scope, receive, send
+            request_context.get_request_credentials()
+            entered.set()
+            await asyncio.Future()
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+
+        async def invoke_and_check_reset() -> None:
+            nonlocal reset_after_cancellation
+            try:
+                await self._invoke(middleware, self._headers())
+            finally:
+                try:
+                    request_context.get_request_credentials()
+                except RuntimeError:
+                    reset_after_cancellation = True
+
+        request_task = asyncio.create_task(invoke_and_check_reset())
+        await asyncio.wait_for(entered.wait(), timeout=5)
+        request_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await request_task
+        self.assertTrue(reset_after_cancellation)
+
+    async def test_request_completion_invalidates_copied_task_context(self) -> None:
+        release_background = asyncio.Event()
+        background_context_was_invalidated = False
+        background_task: asyncio.Task[None] | None = None
+
+        async def inspect_context_after_request() -> None:
+            nonlocal background_context_was_invalidated
+            await release_background.wait()
+            try:
+                request_context.get_request_credentials()
+            except RuntimeError:
+                background_context_was_invalidated = True
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            nonlocal background_task
+            request_context.get_request_credentials()
+            background_task = asyncio.create_task(inspect_context_after_request())
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        messages = await self._invoke(middleware, self._headers())
+        self.assertEqual(self._status(messages), 200)
+
+        release_background.set()
+        if background_task is None:
+            self.fail('Downstream did not create the background task.')
+        await background_task
+        self.assertTrue(background_context_was_invalidated)
+
+    async def test_concurrent_requests_keep_credentials_isolated(self) -> None:
+        entered = {
+            'alice@example.com': asyncio.Event(),
+            'bob@example.com': asyncio.Event(),
+        }
+        release = asyncio.Event()
+        observations: dict[
+            str,
+            tuple[request_context.RequestCredentials, request_context.RequestCredentials],
+        ] = {}
+
+        async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+            before = request_context.get_request_credentials()
+            entered[before.user_name].set()
+            await release.wait()
+            after = request_context.get_request_credentials()
+            observations[before.user_name] = (before, after)
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        middleware = request_context.RequestContextMiddleware(downstream)
+        alice_request = asyncio.create_task(self._invoke(
+            middleware,
+            self._headers(
+                authorization=b'Bearer alice-token',
+                user_name=b'alice@example.com',
+                request_id=b'alice-request',
+            ),
+        ))
+        bob_request = asyncio.create_task(self._invoke(
+            middleware,
+            self._headers(
+                authorization=b'Bearer bob-token',
+                user_name=b'bob@example.com',
+                request_id=b'bob-request',
+            ),
+        ))
+        await asyncio.wait_for(asyncio.gather(
+            entered['alice@example.com'].wait(),
+            entered['bob@example.com'].wait(),
+        ), timeout=5)
+        release.set()
+        await asyncio.gather(alice_request, bob_request)
+
+        alice_before, alice_after = observations['alice@example.com']
+        bob_before, bob_after = observations['bob@example.com']
+        self.assertEqual(alice_before, alice_after)
+        self.assertEqual(bob_before, bob_after)
+        self.assertEqual(alice_before.authorization_header, 'Bearer alice-token')
+        self.assertEqual(bob_before.authorization_header, 'Bearer bob-token')
+        self.assertNotEqual(alice_before, bob_before)
+        with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
+            request_context.get_request_credentials()
+
+    def test_credentials_repr_does_not_expose_authorization(self) -> None:
+        credentials = request_context.RequestCredentials(
+            authorization_header='Bearer highly-sensitive-token',
+            user_name='alice@example.com',
+            request_id='request-123',
+        )
+
+        self.assertNotIn('highly-sensitive-token', repr(credentials))
+        self.assertNotIn('highly-sensitive-token', str(credentials))
+        self.assertIn('alice@example.com', repr(credentials))
+        self.assertIn('request-123', repr(credentials))
+
+    @staticmethod
+    async def _success_application(
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        request_context.get_request_credentials()
+        await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -23,18 +23,23 @@ from unittest import mock
 import httpx
 from mcp.types import LATEST_PROTOCOL_VERSION
 
-from src.service.mcp import server
+from src.lib.utils import login
+from src.service.mcp import request_context, server
 
 
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
     def test_create_application_uses_protocol_server(self) -> None:
-        application = object()
+        application = mock.Mock()
         protocol_server = mock.Mock()
         protocol_server.streamable_http_app.return_value = application
 
         self.assertIs(server.create_application(protocol_server), application)
         protocol_server.streamable_http_app.assert_called_once_with()
+        application.add_middleware.assert_called_once_with(
+            request_context.RequestContextMiddleware,
+            path='/mcp',
+        )
 
     async def test_health_endpoints(self) -> None:
         application = server.create_application(server.create_mcp_server())
@@ -63,6 +68,8 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         headers = {
             'Accept': 'application/json, text/event-stream',
             'Content-Type': 'application/json',
+            login.OSMO_AUTH_HEADER: 'Bearer test-token',
+            login.OSMO_USER_HEADER: 'test-user',
         }
         initialize_request = {
             'jsonrpc': '2.0',
@@ -108,6 +115,51 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(initialized_response.status_code, 202)
         self.assertEqual(list_tools_response.status_code, 200)
         self.assertEqual(list_tools_response.json()['result']['tools'], [])
+
+    async def test_request_context_reaches_fastmcp_tool(self) -> None:
+        mcp_server = server.create_mcp_server()
+
+        @mcp_server.tool()
+        async def inspect_request_context() -> dict[str, str | bool | None]:
+            credentials = request_context.get_request_credentials()
+            return {
+                'user_name': credentials.user_name,
+                'request_id': credentials.request_id,
+                'has_bearer': credentials.authorization_header.lower().startswith(
+                    'bearer '
+                ),
+            }
+
+        application = server.create_application(mcp_server)
+        headers = {
+            'Accept': 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            login.OSMO_AUTH_HEADER: 'Bearer tool-test-secret',
+            login.OSMO_USER_HEADER: 'tool-user@example.com',
+            'x-request-id': 'tool-request-123',
+        }
+        request = {
+            'jsonrpc': '2.0',
+            'id': 1,
+            'method': 'tools/call',
+            'params': {
+                'name': 'inspect_request_context',
+                'arguments': {},
+            },
+        }
+
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                    transport=httpx.ASGITransport(app=application),
+                    base_url='http://mcp.test') as client:
+                response = await client.post('/mcp', headers=headers, json=request)
+
+        self.assertEqual(response.status_code, 200)
+        response_text = response.text
+        self.assertIn('tool-user@example.com', response_text)
+        self.assertIn('tool-request-123', response_text)
+        self.assertNotIn('tool-test-secret', response_text)
+        self.assertFalse(response.json()['result']['isError'])
 
 
 class MCPMainTest(unittest.TestCase):

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -28,8 +28,16 @@ from src.service.mcp import server
 
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
+    def test_create_application_uses_protocol_server(self) -> None:
+        application = object()
+        protocol_server = mock.Mock()
+        protocol_server.streamable_http_app.return_value = application
+
+        self.assertIs(server.create_application(protocol_server), application)
+        protocol_server.streamable_http_app.assert_called_once_with()
+
     async def test_health_endpoints(self) -> None:
-        application = server.create_mcp_server().streamable_http_app()
+        application = server.create_application(server.create_mcp_server())
         async with application.router.lifespan_context(application):
             async with httpx.AsyncClient(
                     transport=httpx.ASGITransport(app=application),
@@ -51,7 +59,7 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(mcp_server.settings.json_response)
         self.assertEqual(mcp_server.settings.streamable_http_path, '/mcp')
 
-        application = mcp_server.streamable_http_app()
+        application = server.create_application(mcp_server)
         headers = {
             'Accept': 'application/json, text/event-stream',
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Description

PR 1 of 4 for the MCP Phases B-D profile round-trip stack. It targets `feature/mcp` after prerequisite sync PR #1186 was merged.

Adds the request-scoped authentication boundary used by MCP token relay:

- refactors MCP application construction so middleware can be tested independently;
- requires exactly one Gateway-forwarded bearer header and trusted user header on the exact `/mcp` path;
- accepts an optional bounded request ID;
- stores credentials in immutable request-local context;
- removes authentication and identity headers before the MCP SDK handles the ASGI request; and
- clears request-local credentials on success, error, and cancellation.

The bearer is redacted from object representations. This PR does not call OSMO APIs, register production tools, change Helm configuration, cache credentials, or restore any token-exchange behavior.

The next PR adds the fixed-origin outbound Gateway relay.

## Validation

- Focused Bazel validation (6 owning test/lint targets passed):
  `bazel test --test_output=errors //src/service/mcp:request_context-pylint //src/service/mcp:mcp_service_lib-pylint //src/service/mcp/tests:test_request_context //src/service/mcp/tests:test_request_context-pylint //src/service/mcp/tests:test_server //src/service/mcp/tests:test_server-pylint`
- `git diff --check origin/feature/mcp...HEAD`

No image or unrelated MCP package build is needed for this request-middleware-only change.

## Review stack

Please review and merge in order:

1. #1186 — prerequisite `main` sync (merged)
2. #1187 — Phase B request-scoped credentials (this PR)
3. #1188 — Phase C same-Gateway API relay
4. #1189 — Phases C-D profile tool round trip
5. #1190 — Phases B-D deployment validation and security hardening

The independent OETF reporting fix is #1191 and targets `main`.

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
