### PR TITLE
MCP Phase C: Add the same-Gateway API relay

### DIFF
--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -49,10 +49,7 @@ setting detects this rotation and triggers Envoy to reload.
 {{- if not $envoy.jwt.providers }}
 {{- fail "services.mcp.enabled requires at least one gateway.envoy.jwt.providers entry" }}
 {{- end }}
-{{- $mcpResourceUrl = required "services.mcp.resourceUrl is required when MCP is enabled" $mcp.resourceUrl }}
-{{- if not (regexMatch "^https://[^/?#]+/mcp$" $mcpResourceUrl) }}
-{{- fail "services.mcp.resourceUrl must be an HTTPS origin followed by the exact /mcp path" }}
-{{- end }}
+{{- $mcpResourceUrl = include "osmo.mcp-resource-url" . }}
 {{- if not (kindIs "slice" $mcp.authorizationServers) }}
 {{- fail "services.mcp.authorizationServers must be a list" }}
 {{- end }}

--- a/deployments/charts/service/templates/_helpers.tpl
+++ b/deployments/charts/service/templates/_helpers.tpl
@@ -204,3 +204,21 @@ OSMO_CONFIGMAP_NAME deliberately references services.service.serviceName
 {{- end }}
 {{- end -}}
 
+{{/*
+Validate and return the canonical public MCP resource URL. The Gateway
+origin used for bearer relay is derived from this single source of truth.
+*/}}
+{{- define "osmo.mcp-resource-url" -}}
+{{- $resourceUrl := required "services.mcp.resourceUrl is required when MCP is enabled" .Values.services.mcp.resourceUrl -}}
+{{- if not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?/mcp$" $resourceUrl) -}}
+{{- fail "services.mcp.resourceUrl must be a valid HTTPS origin followed by the exact /mcp path" -}}
+{{- end -}}
+{{- $portSuffix := regexFind ":[0-9]+/mcp$" $resourceUrl -}}
+{{- if $portSuffix -}}
+{{- $port := trimSuffix "/mcp" (trimPrefix ":" $portSuffix) | int -}}
+{{- if or (lt $port 1) (gt $port 65535) -}}
+{{- fail "services.mcp.resourceUrl port must be between 1 and 65535" -}}
+{{- end -}}
+{{- end -}}
+{{- $resourceUrl -}}
+{{- end -}}

--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -17,6 +17,18 @@
 {{- if .Values.services.mcp.enabled }}
 {{- $mcp := .Values.services.mcp }}
 {{- $imageTag := $mcp.imageTag | default .Values.global.osmoImageTag }}
+{{- $mcpResourceUrl := include "osmo.mcp-resource-url" . }}
+{{- $gatewayUrl := trimSuffix "/mcp" $mcpResourceUrl }}
+{{- $requestTimeoutSeconds := toString $mcp.requestTimeoutSeconds }}
+{{- if not (regexMatch "^([1-9]|[1-5][0-9]|60)$" $requestTimeoutSeconds) }}
+{{- fail "services.mcp.requestTimeoutSeconds must be between 1 and 60" }}
+{{- end }}
+{{- $reservedEnvNames := list "OSMO_MCP_HOST" "OSMO_MCP_PORT" "OSMO_GATEWAY_URL" "OSMO_MCP_REQUEST_TIMEOUT_SECONDS" }}
+{{- range $env := $mcp.extraEnv }}
+{{- if has (toString (default "" $env.name)) $reservedEnvNames }}
+{{- fail (printf "services.mcp.extraEnv must not override managed variable %s" $env.name) }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -77,6 +89,10 @@ spec:
           value: "0.0.0.0"
         - name: OSMO_MCP_PORT
           value: {{ $mcp.port | quote }}
+        - name: OSMO_GATEWAY_URL
+          value: {{ $gatewayUrl | quote }}
+        - name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS
+          value: {{ $requestTimeoutSeconds | quote }}
         {{- with $mcp.extraEnv }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -116,7 +132,6 @@ spec:
   selector:
     app: {{ $mcp.serviceName }}
 
-{{- if .Values.gateway.networkPolicies.enabled }}
 ---
 
 apiVersion: networking.k8s.io/v1
@@ -137,5 +152,4 @@ spec:
     ports:
     - port: {{ $mcp.port }}
       protocol: TCP
-{{- end }}
 {{- end }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -115,6 +115,8 @@ services:
   ##
   mcp:
     ## Enable the MCP workload and its gateway routes. Disabled by default.
+    ## When enabled, the chart always renders an ingress NetworkPolicy for
+    ## MCP because only Gateway-authenticated requests may reach the service.
     ##
     enabled: false
 
@@ -136,9 +138,15 @@ services:
 
     ## Canonical RFC 9728 protected resource identifier. This must be the
     ## externally reachable HTTPS MCP URL ending in /mcp, for example:
-    ## https://osmo.example.com/mcp
+    ## https://osmo.example.com/mcp. The MCP service derives its fixed OSMO
+    ## Gateway origin from this value so bearer tokens cannot be relayed to a
+    ## separately configured origin.
     ##
     resourceUrl: ""
+
+    ## Total timeout in seconds for each MCP request to the OSMO Gateway.
+    ##
+    requestTimeoutSeconds: 10
 
     ## OAuth authorization-server issuer identifiers advertised by the public
     ## protected-resource metadata document. Configure the issuer for the

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -47,10 +47,12 @@ osmo_py_library(
     name = "mcp_service_lib",
     srcs = ["server.py"],
     deps = [
+        requirement("httpx"),
         requirement("mcp"),
         requirement("pydantic"),
         requirement("starlette"),
         requirement("uvicorn"),
+        ":gateway",
         ":request_context",
         "//src/utils:ssl_config",
         "//src/utils:static_config",

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -33,6 +33,17 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "gateway",
+    srcs = ["gateway.py"],
+    deps = [
+        requirement("httpx"),
+        ":request_context",
+        "//src/lib/utils:login",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "mcp_service_lib",
     srcs = ["server.py"],
     deps = [

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -1,0 +1,244 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+import contextlib
+import dataclasses
+import math
+from urllib import parse
+
+import httpx
+
+from src.lib.utils import login
+from src.service.mcp import request_context
+
+
+_ALLOWED_METHODS = frozenset(('GET', 'POST', 'PATCH', 'DELETE'))
+_REQUEST_ID_HEADER = 'x-request-id'
+_USER_AGENT = 'osmo-mcp'
+_IDENTITY_ENCODING = 'identity'
+_HTTP_LIMITS = httpx.Limits(
+    max_connections=100,
+    max_keepalive_connections=20,
+    keepalive_expiry=30,
+)
+
+
+class GatewayClientError(RuntimeError):
+    """A sanitized failure while calling the configured OSMO Gateway."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class GatewayResponse:
+    """A bounded Gateway response safe for tool-specific validation."""
+
+    status_code: int
+    body: bytes = dataclasses.field(repr=False)
+
+
+class GatewayClient:
+    """Send caller-bound requests to one configured OSMO Gateway origin."""
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        *,
+        request_timeout_seconds: float,
+    ) -> None:
+        self._client = client
+        self._request_timeout_seconds = request_timeout_seconds
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        credentials: request_context.RequestCredentials,
+        max_response_bytes: int,
+    ) -> GatewayResponse:
+        """Call a fixed API path with credentials from the active MCP request."""
+        if method not in _ALLOWED_METHODS:
+            raise ValueError('Gateway request method is not allowed.')
+        _validate_api_path(path)
+        if max_response_bytes < 1:
+            raise ValueError('max_response_bytes must be positive.')
+
+        headers = {
+            login.OSMO_AUTH_HEADER: credentials.authorization_header,
+            'Accept-Encoding': _IDENTITY_ENCODING,
+            'User-Agent': _USER_AGENT,
+        }
+        if credentials.request_id is not None:
+            headers[_REQUEST_ID_HEADER] = credentials.request_id
+
+        request = self._client.build_request(method, path, headers=headers)
+        # HTTPX stores response cookies on the process-wide client. Never let
+        # that shared state become credentials on a later caller's request.
+        request.headers.pop('cookie', None)
+
+        try:
+            async with asyncio.timeout(self._request_timeout_seconds):
+                response = await self._client.send(request, stream=True)
+                try:
+                    if 300 <= response.status_code < 400:
+                        raise GatewayClientError(
+                            'OSMO Gateway returned an unsafe redirect.')
+                    if not response.is_success:
+                        return GatewayResponse(response.status_code, b'')
+
+                    if response.headers.get(
+                        'content-encoding', _IDENTITY_ENCODING
+                    ).lower() != _IDENTITY_ENCODING:
+                        raise GatewayClientError(
+                            'OSMO Gateway returned an invalid response.')
+                    _validate_content_length(response, max_response_bytes)
+                    response_body = bytearray()
+                    async for chunk in response.aiter_bytes():
+                        if len(response_body) + len(chunk) > max_response_bytes:
+                            raise GatewayClientError(
+                                'OSMO Gateway response exceeds the size limit.')
+                        response_body.extend(chunk)
+                finally:
+                    await response.aclose()
+        except (TimeoutError, httpx.RequestError):
+            raise GatewayClientError('OSMO Gateway is unavailable.') from None
+        finally:
+            # Set-Cookie is upstream response data, never caller-independent
+            # client state. Clear it even when streaming or decoding fails.
+            self._client.cookies.clear()
+
+        return GatewayResponse(response.status_code, bytes(response_body))
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AppContext:
+    """Process-lifetime dependencies shared by MCP tool calls."""
+
+    gateway: GatewayClient
+
+
+@contextlib.asynccontextmanager
+async def create_app_context(
+    *,
+    gateway_url: str,
+    request_timeout_seconds: float,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> AsyncIterator[AppContext]:
+    """Create one credential-free HTTP connection pool for the MCP process."""
+    validate_gateway_origin(gateway_url)
+    if (
+        not math.isfinite(request_timeout_seconds)
+        or request_timeout_seconds <= 0
+        or request_timeout_seconds > 60
+    ):
+        raise ValueError(
+            'Gateway request timeout must be greater than 0 and at most 60 seconds.')
+    async with httpx.AsyncClient(
+        base_url=gateway_url,
+        follow_redirects=False,
+        limits=_HTTP_LIMITS,
+        timeout=httpx.Timeout(request_timeout_seconds),
+        transport=transport,
+        trust_env=False,
+        verify=True,
+    ) as client:
+        yield AppContext(
+            gateway=GatewayClient(
+                client,
+                request_timeout_seconds=request_timeout_seconds,
+            ),
+        )
+
+
+def validate_gateway_origin(gateway_url: str) -> None:
+    """Reject any Gateway base URL that is not one fixed HTTPS origin."""
+    try:
+        parsed_url = parse.urlsplit(gateway_url)
+        _ = parsed_url.port
+    except ValueError:
+        raise ValueError(
+            'gateway_url must be a valid HTTPS origin.') from None
+
+    if (
+        any(ord(character) <= 0x20 or ord(character) == 0x7F
+            for character in gateway_url)
+        or '\\' in gateway_url
+        or '%' in parsed_url.netloc
+        or parsed_url.scheme != 'https'
+        or not parsed_url.hostname
+        or parsed_url.username is not None
+        or parsed_url.password is not None
+        or parsed_url.path not in ('', '/')
+        or parsed_url.query
+        or parsed_url.fragment
+    ):
+        raise ValueError(
+            'gateway_url must be an HTTPS origin without credentials, '
+            'path, query, or fragment.')
+
+
+def _validate_api_path(path: str) -> None:
+    parsed_path = parse.urlsplit(path)
+    if (
+        any(ord(character) < 0x20 or ord(character) == 0x7F for character in path)
+        or parsed_path.scheme
+        or parsed_path.netloc
+        or parsed_path.query
+        or parsed_path.fragment
+        or not parsed_path.path.startswith('/api/')
+        or '//' in parsed_path.path
+    ):
+        raise ValueError('Gateway requests require a relative OSMO API path.')
+
+    decoded_path = parsed_path.path
+    while True:
+        next_decoded_path = parse.unquote(decoded_path)
+        if next_decoded_path == decoded_path:
+            break
+        decoded_path = next_decoded_path
+    if (
+        not decoded_path.startswith('/api/')
+        or '//' in decoded_path
+        or '\\' in decoded_path
+        or any(
+            ord(character) < 0x20 or ord(character) == 0x7F
+            for character in decoded_path
+        )
+        or any(segment in ('.', '..') for segment in decoded_path.split('/'))
+    ):
+        raise ValueError('Gateway requests require a relative OSMO API path.')
+
+
+def _validate_content_length(
+    response: httpx.Response,
+    max_response_bytes: int,
+) -> None:
+    content_length_header = response.headers.get('content-length')
+    if content_length_header is None:
+        return
+    try:
+        content_length = int(content_length_header)
+    except ValueError:
+        raise GatewayClientError(
+            'OSMO Gateway returned an invalid response.') from None
+    if content_length < 0:
+        raise GatewayClientError('OSMO Gateway returned an invalid response.')
+    if content_length > max_response_bytes:
+        raise GatewayClientError(
+            'OSMO Gateway response exceeds the size limit.')

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -123,7 +123,11 @@ class GatewayClient:
             # client state. Clear it even when streaming or decoding fails.
             self._client.cookies.clear()
 
-        return GatewayResponse(response.status_code, bytes(response_body))
+        response_body_bytes = bytes(response_body)
+        if _contains_relayed_credentials(response_body_bytes, credentials):
+            raise GatewayClientError(
+                'OSMO Gateway returned an invalid response.')
+        return GatewayResponse(response.status_code, response_body_bytes)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -242,3 +246,15 @@ def _validate_content_length(
     if content_length > max_response_bytes:
         raise GatewayClientError(
             'OSMO Gateway response exceeds the size limit.')
+
+
+def _contains_relayed_credentials(
+    response_body: bytes,
+    credentials: request_context.RequestCredentials,
+) -> bool:
+    authorization_header = credentials.authorization_header.encode('ascii')
+    _, _, bearer_token = authorization_header.partition(b' ')
+    return (
+        authorization_header in response_body
+        or (len(bearer_token) >= 16 and bearer_token in response_body)
+    )

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -30,7 +30,6 @@ from src.service.mcp import request_context
 
 
 _ALLOWED_METHODS = frozenset(('GET', 'POST', 'PATCH', 'DELETE'))
-_REQUEST_ID_HEADER = 'x-request-id'
 _USER_AGENT = 'osmo-mcp'
 _IDENTITY_ENCODING = 'identity'
 _HTTP_LIMITS = httpx.Limits(
@@ -85,7 +84,7 @@ class GatewayClient:
             'User-Agent': _USER_AGENT,
         }
         if credentials.request_id is not None:
-            headers[_REQUEST_ID_HEADER] = credentials.request_id
+            headers[request_context.REQUEST_ID_HEADER] = credentials.request_id
 
         request = self._client.build_request(method, path, headers=headers)
         # HTTPX stores response cookies on the process-wide client. Never let

--- a/src/service/mcp/request_context.py
+++ b/src/service/mcp/request_context.py
@@ -27,9 +27,11 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from src.lib.utils import login
 
 
+REQUEST_ID_HEADER = 'x-request-id'
+
 _AUTHORIZATION_HEADER = login.OSMO_AUTH_HEADER.lower().encode('ascii')
 _USER_HEADER = login.OSMO_USER_HEADER.lower().encode('ascii')
-_REQUEST_ID_HEADER = b'x-request-id'
+_REQUEST_ID_HEADER = REQUEST_ID_HEADER.encode('ascii')
 _CONTEXT_HEADERS = frozenset((
     _AUTHORIZATION_HEADER,
     _USER_HEADER,

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -17,7 +17,10 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import asyncio
+from collections.abc import AsyncIterator
+import contextlib
 
+import httpx
 from mcp.server.fastmcp import FastMCP
 import pydantic
 from starlette.applications import Starlette
@@ -25,12 +28,14 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 import uvicorn  # type: ignore
 
-from src.service.mcp import request_context
+from src.service.mcp import gateway, request_context
 from src.utils import ssl_config, static_config
 
 
 class MCPServiceConfig(static_config.StaticConfig, ssl_config.SSLConfig):
     """Runtime configuration for the MCP service."""
+
+    model_config = pydantic.ConfigDict(hide_input_in_errors=True)
 
     host: str = pydantic.Field(
         default='0.0.0.0',
@@ -42,6 +47,20 @@ class MCPServiceConfig(static_config.StaticConfig, ssl_config.SSLConfig):
         le=65535,
         description='The TCP port to bind to when serving the MCP service.',
         json_schema_extra={'command_line': 'port', 'env': 'OSMO_MCP_PORT'})
+    gateway_url: pydantic.AnyHttpUrl = pydantic.Field(
+        description='HTTPS origin of the same-deployment OSMO Gateway.',
+        json_schema_extra={'env': 'OSMO_GATEWAY_URL'})
+    request_timeout_seconds: int = pydantic.Field(
+        default=10,
+        ge=1,
+        le=60,
+        description='Total timeout for each OSMO Gateway request.',
+        json_schema_extra={'env': 'OSMO_MCP_REQUEST_TIMEOUT_SECONDS'})
+
+    @pydantic.model_validator(mode='after')
+    def _validate_gateway_url(self) -> 'MCPServiceConfig':
+        gateway.validate_gateway_origin(str(self.gateway_url))
+        return self
 
 
 def create_mcp_server() -> FastMCP:
@@ -80,17 +99,44 @@ def create_application(protocol_server: FastMCP) -> Starlette:
     return application
 
 
-mcp_server = create_mcp_server()
-app: Starlette = create_application(mcp_server)
+def create_runtime_application(
+    config: MCPServiceConfig,
+    *,
+    http_transport: httpx.AsyncBaseTransport | None = None,
+) -> Starlette:
+    """Create the production application and process-lifetime Gateway client."""
+    protocol_server = create_mcp_server()
+    application = create_application(protocol_server)
+    protocol_lifespan = application.router.lifespan_context
+
+    @contextlib.asynccontextmanager
+    async def application_lifespan(
+        lifespan_application: Starlette,
+    ) -> AsyncIterator[None]:
+        async with gateway.create_app_context(
+            gateway_url=str(config.gateway_url),
+            request_timeout_seconds=config.request_timeout_seconds,
+            transport=http_transport,
+        ) as app_context:
+            lifespan_application.state.mcp_app_context = app_context
+            try:
+                async with protocol_lifespan(lifespan_application):
+                    yield
+            finally:
+                del lifespan_application.state.mcp_app_context
+
+    application.router.lifespan_context = application_lifespan
+    return application
 
 
 def main() -> None:
     """Run the MCP ASGI application with the repository's Uvicorn/TLS pattern."""
     config = MCPServiceConfig.load()
+    application = create_runtime_application(config)
 
     async def run_server() -> None:
         uvicorn_config = uvicorn.Config(
-            app,
+            application,
             host=config.host,
             port=config.port,
             log_config=None,

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -20,6 +20,16 @@ load("//bzl:py.bzl", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_test(
+    name = "test_gateway",
+    srcs = ["test_gateway.py"],
+    deps = [
+        requirement("httpx"),
+        "//src/service/mcp:gateway",
+        "//src/service/mcp:request_context",
+    ],
+)
+
+osmo_py_test(
     name = "test_request_context",
     srcs = ["test_request_context.py"],
     deps = [

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -44,7 +44,10 @@ osmo_py_test(
     deps = [
         requirement("httpx"),
         requirement("mcp"),
+        requirement("pydantic"),
+        requirement("starlette"),
         "//src/lib/utils:login",
+        "//src/service/mcp:gateway",
         "//src/service/mcp:request_context",
         "//src/service/mcp:mcp_service_lib",
     ],

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -1,0 +1,553 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from collections.abc import AsyncIterator, Callable, Coroutine
+import unittest
+
+import httpx
+
+from src.service.mcp import gateway, request_context
+
+
+_Handler = Callable[[httpx.Request], Coroutine[None, None, httpx.Response]]
+
+
+class _TrackingStream(httpx.AsyncByteStream):
+    """Track streaming iteration and cleanup for response-bound tests."""
+
+    def __init__(
+        self,
+        chunks: list[bytes],
+        *,
+        block_after_chunks: bool = False,
+    ) -> None:
+        self._chunks = chunks
+        self._block_after_chunks = block_after_chunks
+        self.iterated_chunks = 0
+        self.close_count = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            self.iterated_chunks += 1
+            yield chunk
+        if self._block_after_chunks:
+            await asyncio.Future()
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+
+class _TrackingTransport(httpx.MockTransport):
+    """Track connection-pool cleanup through the HTTPX transport seam."""
+
+    def __init__(self, handler: _Handler) -> None:
+        super().__init__(handler)
+        self.close_count = 0
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+        await super().aclose()
+
+
+class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
+    """Validate fixed-origin Gateway request and response boundaries."""
+
+    @staticmethod
+    def _credentials(
+        *,
+        authorization_header: str = 'Bearer original.token+/_==',
+        request_id: str | None = 'request-123',
+    ) -> request_context.RequestCredentials:
+        return request_context.RequestCredentials(
+            authorization_header=authorization_header,
+            user_name='alice@example.com',
+            request_id=request_id,
+        )
+
+    async def test_request_uses_fixed_origin_and_approved_headers(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, content=b'{"status":"ok"}')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            response = await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(
+                    authorization_header='bEaReR original.token+/_=='
+                ),
+                max_response_bytes=1024,
+            )
+            response_without_request_id = await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(request_id=None),
+                max_response_bytes=1024,
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b'{"status":"ok"}')
+        self.assertEqual(response_without_request_id.status_code, 200)
+        self.assertEqual(len(captured_requests), 2)
+        self.assertEqual(
+            str(captured_requests[0].url),
+            'https://gateway.test/api/profile/settings',
+        )
+        self.assertEqual(
+            captured_requests[0].headers['authorization'],
+            'bEaReR original.token+/_==',
+        )
+        self.assertEqual(
+            captured_requests[0].headers['x-request-id'],
+            'request-123',
+        )
+        self.assertEqual(captured_requests[0].headers['accept-encoding'], 'identity')
+        self.assertEqual(captured_requests[0].headers['user-agent'], 'osmo-mcp')
+        self.assertNotIn('x-osmo-user', captured_requests[0].headers)
+        self.assertNotIn('cookie', captured_requests[0].headers)
+        self.assertNotIn('proxy-authorization', captured_requests[0].headers)
+        self.assertNotIn('x-request-id', captured_requests[1].headers)
+
+    async def test_only_fixed_api_paths_and_methods_are_allowed(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(200, content=b'{}')
+
+        invalid_paths = (
+            '',
+            'api/profile/settings',
+            '/profile/settings',
+            'https://evil.test/api/profile/settings',
+            '//evil.test/api/profile/settings',
+            '/api/../profile/settings',
+            '/api/%2e%2e/profile/settings',
+            '/api/%252e%252e/profile/settings',
+            '/api\\profile',
+            '/api//profile',
+            '/api/profile?user=alice',
+            '/api/profile#fragment',
+            '/api/profile%00suffix',
+        )
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for invalid_path in invalid_paths:
+                with self.subTest(path=invalid_path):
+                    with self.assertRaises(ValueError):
+                        await app_context.gateway.request(
+                            'GET',
+                            invalid_path,
+                            credentials=self._credentials(),
+                            max_response_bytes=1024,
+                        )
+
+            for invalid_method in ('get', 'PUT', 'OPTIONS'):
+                with self.subTest(method=invalid_method):
+                    with self.assertRaises(ValueError):
+                        await app_context.gateway.request(
+                            invalid_method,
+                            '/api/profile/settings',
+                            credentials=self._credentials(),
+                            max_response_bytes=1024,
+                        )
+
+            with self.assertRaises(ValueError):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=0,
+                )
+
+        self.assertEqual(transport_calls, 0)
+
+    async def test_response_cookies_are_never_replayed(self) -> None:
+        captured_cookies: list[str | None] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_cookies.append(request.headers.get('cookie'))
+            if len(captured_cookies) == 1:
+                return httpx.Response(
+                    200,
+                    headers={'set-cookie': 'session=upstream-secret; Secure'},
+                    content=b'{}',
+                )
+            return httpx.Response(200, content=b'{}')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for _ in range(2):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                )
+                self.assertEqual(
+                    len(app_context.gateway._client.cookies),  # pylint: disable=protected-access
+                    0,
+                )
+
+        self.assertEqual(captured_cookies, [None, None])
+
+    async def test_concurrent_callers_keep_authorization_headers_isolated(self) -> None:
+        captured_authorization_headers: list[str] = []
+        both_requests_arrived = asyncio.Event()
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_authorization_headers.append(request.headers['authorization'])
+            if len(captured_authorization_headers) == 2:
+                both_requests_arrived.set()
+            await asyncio.wait_for(both_requests_arrived.wait(), timeout=1)
+            return httpx.Response(200, content=b'{}')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            await asyncio.gather(*(
+                app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(
+                        authorization_header=f'Bearer caller-{caller}'
+                    ),
+                    max_response_bytes=1024,
+                )
+                for caller in ('alice', 'bob')
+            ))
+
+        self.assertCountEqual(
+            captured_authorization_headers,
+            ['Bearer caller-alice', 'Bearer caller-bob'],
+        )
+
+    async def test_redirect_is_rejected_without_following(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(
+                307,
+                headers={'location': 'https://evil.test/upstream-secret'},
+            )
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'unsafe redirect',
+            ) as raised:
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                )
+
+        self.assertEqual(transport_calls, 1)
+        self.assertNotIn('evil.test', str(raised.exception))
+        self.assertNotIn('upstream-secret', repr(raised.exception))
+
+    async def test_transport_failure_is_sanitized_and_not_retried(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal transport_calls
+            transport_calls += 1
+            raise httpx.ConnectError('connection-upstream-secret', request=request)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'Gateway is unavailable',
+            ) as raised:
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                )
+
+        self.assertEqual(transport_calls, 1)
+        self.assertNotIn('connection-upstream-secret', str(raised.exception))
+        self.assertIsNone(raised.exception.__cause__)
+
+    async def test_error_status_body_is_not_read_or_exposed(self) -> None:
+        stream = _TrackingStream([b'upstream-body-secret'])
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(403, stream=stream)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            response = await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(),
+                max_response_bytes=1024,
+            )
+
+        self.assertEqual(response, gateway.GatewayResponse(403, b''))
+        self.assertEqual(stream.iterated_chunks, 0)
+        self.assertEqual(stream.close_count, 1)
+        self.assertNotIn('upstream-body-secret', repr(response))
+
+    async def test_streaming_response_is_cumulatively_bounded(self) -> None:
+        exact_stream = _TrackingStream([b'ab', b'cd'])
+        oversized_stream = _TrackingStream([
+            b'ab',
+            b'cde',
+            b'later-upstream-secret',
+        ])
+        streams = [exact_stream, oversized_stream]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, stream=streams.pop(0))
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            response = await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(),
+                max_response_bytes=4,
+            )
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'exceeds the size limit',
+            ) as raised:
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=4,
+                )
+
+        self.assertEqual(response.body, b'abcd')
+        self.assertEqual(exact_stream.close_count, 1)
+        self.assertEqual(oversized_stream.iterated_chunks, 2)
+        self.assertEqual(oversized_stream.close_count, 1)
+        self.assertNotIn('later-upstream-secret', str(raised.exception))
+
+    async def test_content_length_is_validated_before_streaming(self) -> None:
+        oversized_stream = _TrackingStream([b'upstream-secret'])
+        invalid_stream = _TrackingStream([b'upstream-secret'])
+        streams_and_headers = [
+            (oversized_stream, {'content-length': '5'}),
+            (invalid_stream, {'content-length': '-1'}),
+        ]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            stream, headers = streams_and_headers.pop(0)
+            return httpx.Response(200, headers=headers, stream=stream)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for expected_error in ('exceeds the size limit', 'invalid response'):
+                with self.subTest(error=expected_error):
+                    with self.assertRaisesRegex(
+                        gateway.GatewayClientError,
+                        expected_error,
+                    ):
+                        await app_context.gateway.request(
+                            'GET',
+                            '/api/profile/settings',
+                            credentials=self._credentials(),
+                            max_response_bytes=4,
+                        )
+
+        self.assertEqual(oversized_stream.iterated_chunks, 0)
+        self.assertEqual(invalid_stream.iterated_chunks, 0)
+        self.assertEqual(oversized_stream.close_count, 1)
+        self.assertEqual(invalid_stream.close_count, 1)
+
+    async def test_compressed_response_is_rejected_before_decoding(self) -> None:
+        stream = _TrackingStream([b'compressed-upstream-secret'])
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(
+                200,
+                headers={'content-encoding': 'gzip'},
+                stream=stream,
+            )
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'invalid response',
+            ):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=100,
+                )
+
+        self.assertEqual(stream.iterated_chunks, 0)
+        self.assertEqual(stream.close_count, 1)
+
+    async def test_app_context_rejects_unsafe_origins_and_timeouts(self) -> None:
+        invalid_origins = (
+            'http://gateway.test',
+            'https://user:secret@gateway.test',
+            'https://gateway.test/api',
+            'https://gateway.test?query=value',
+            'https://gateway.test#fragment',
+            'https://gateway.test\\@evil.test',
+            'https://gateway.test%40evil.test',
+        )
+        for invalid_origin in invalid_origins:
+            with self.subTest(origin=invalid_origin):
+                with self.assertRaises(ValueError):
+                    async with gateway.create_app_context(
+                        gateway_url=invalid_origin,
+                        request_timeout_seconds=5,
+                    ):
+                        self.fail('unsafe Gateway origin was accepted')
+
+        for invalid_timeout in (0, -1, 61, float('inf'), float('nan')):
+            with self.subTest(timeout=invalid_timeout):
+                with self.assertRaises(ValueError):
+                    async with gateway.create_app_context(
+                        gateway_url='https://gateway.test',
+                        request_timeout_seconds=invalid_timeout,
+                    ):
+                        self.fail('unsafe Gateway timeout was accepted')
+
+    async def test_total_timeout_bounds_headers_and_streaming(self) -> None:
+        streaming_response = False
+        blocked_stream = _TrackingStream(
+            [b'a'],
+            block_after_chunks=True,
+        )
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            if streaming_response:
+                return httpx.Response(200, stream=blocked_stream)
+            await asyncio.Future()
+            raise AssertionError('unreachable')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=0.01,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'Gateway is unavailable',
+            ):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=4,
+                )
+
+            streaming_response = True
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'Gateway is unavailable',
+            ):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=4,
+                )
+
+        self.assertEqual(blocked_stream.iterated_chunks, 1)
+        self.assertEqual(blocked_stream.close_count, 1)
+
+    async def test_app_context_owns_and_closes_transport(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'{}')
+
+        transport = _TrackingTransport(handler)
+        self.assertEqual(transport.close_count, 0)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=transport,
+        ) as app_context:
+            self.assertIsInstance(app_context.gateway, gateway.GatewayClient)
+            await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(),
+                max_response_bytes=4,
+            )
+            self.assertEqual(transport.close_count, 0)
+
+        self.assertEqual(transport.close_count, 1)
+
+    def test_gateway_response_repr_hides_body(self) -> None:
+        response = gateway.GatewayResponse(200, b'upstream-body-secret')
+        self.assertNotIn('upstream-body-secret', repr(response))
+        self.assertNotIn('upstream-body-secret', str(response))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -339,6 +339,37 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(stream.close_count, 1)
         self.assertNotIn('upstream-body-secret', repr(response))
 
+    async def test_success_response_cannot_reflect_relayed_credentials(self) -> None:
+        bearer_token = 'reflected-bearer-token-secret'
+        reflected_bodies = [
+            f'{{"authorization":"Bearer {bearer_token}"}}'.encode(),
+            f'{{"token":"{bearer_token}"}}'.encode(),
+        ]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=reflected_bodies.pop(0))
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for _ in range(2):
+                with self.assertRaisesRegex(
+                    gateway.GatewayClientError,
+                    'invalid response',
+                ) as raised:
+                    await app_context.gateway.request(
+                        'GET',
+                        '/api/profile/settings',
+                        credentials=self._credentials(
+                            authorization_header=f'Bearer {bearer_token}'
+                        ),
+                        max_response_bytes=1024,
+                    )
+                self.assertNotIn(bearer_token, str(raised.exception))
+
     async def test_streaming_response_is_cumulatively_bounded(self) -> None:
         exact_stream = _TrackingStream([b'ab', b'cd'])
         oversized_stream = _TrackingStream([

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -414,9 +414,11 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
     async def test_content_length_is_validated_before_streaming(self) -> None:
         oversized_stream = _TrackingStream([b'upstream-secret'])
         invalid_stream = _TrackingStream([b'upstream-secret'])
+        malformed_stream = _TrackingStream([b'upstream-secret'])
         streams_and_headers = [
             (oversized_stream, {'content-length': '5'}),
             (invalid_stream, {'content-length': '-1'}),
+            (malformed_stream, {'content-length': 'not-an-integer'}),
         ]
 
         async def handler(request: httpx.Request) -> httpx.Response:
@@ -429,7 +431,11 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
             request_timeout_seconds=5,
             transport=httpx.MockTransport(handler),
         ) as app_context:
-            for expected_error in ('exceeds the size limit', 'invalid response'):
+            for expected_error in (
+                'exceeds the size limit',
+                'invalid response',
+                'invalid response',
+            ):
                 with self.subTest(error=expected_error):
                     with self.assertRaisesRegex(
                         gateway.GatewayClientError,
@@ -444,8 +450,10 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(oversized_stream.iterated_chunks, 0)
         self.assertEqual(invalid_stream.iterated_chunks, 0)
+        self.assertEqual(malformed_stream.iterated_chunks, 0)
         self.assertEqual(oversized_stream.close_count, 1)
         self.assertEqual(invalid_stream.close_count, 1)
+        self.assertEqual(malformed_stream.close_count, 1)
 
     async def test_compressed_response_is_rejected_before_decoding(self) -> None:
         stream = _TrackingStream([b'compressed-upstream-secret'])
@@ -486,6 +494,7 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
             'https://gateway.test#fragment',
             'https://gateway.test\\@evil.test',
             'https://gateway.test%40evil.test',
+            'https://gateway.test:not-a-port',
         )
         for invalid_origin in invalid_origins:
             with self.subTest(origin=invalid_origin):

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -16,15 +16,22 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from collections.abc import AsyncIterator
+import contextlib
+import io
+import os
+import sys
 import types
 import unittest
 from unittest import mock
 
 import httpx
 from mcp.types import LATEST_PROTOCOL_VERSION
+import pydantic
+from starlette.applications import Starlette
 
 from src.lib.utils import login
-from src.service.mcp import request_context, server
+from src.service.mcp import gateway, request_context, server
 
 
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
@@ -161,6 +168,143 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn('tool-test-secret', response_text)
         self.assertFalse(response.json()['result']['isError'])
 
+    def test_runtime_config_requires_https_gateway_origin(self) -> None:
+        config = server.MCPServiceConfig(
+            gateway_url='https://gateway.test:8443',
+        )
+        self.assertEqual(str(config.gateway_url), 'https://gateway.test:8443/')
+
+        invalid_urls = (
+            'http://gateway.test',
+            'gateway.test',
+            'https://user:password@gateway.test',
+            'https://gateway.test/api',
+            'https://gateway.test?query=value',
+            'https://gateway.test#fragment',
+        )
+        for invalid_url in invalid_urls:
+            with self.subTest(url=invalid_url):
+                with self.assertRaises(pydantic.ValidationError):
+                    server.MCPServiceConfig(gateway_url=invalid_url)
+
+        for invalid_timeout in (0, -1, 61):
+            with self.subTest(timeout=invalid_timeout):
+                with self.assertRaises(pydantic.ValidationError):
+                    server.MCPServiceConfig(
+                        gateway_url='https://gateway.test',
+                        request_timeout_seconds=invalid_timeout,
+                    )
+
+    def test_runtime_config_load_does_not_echo_invalid_url_credentials(self) -> None:
+        secret = 'startup-url-password-secret'
+        output = io.StringIO()
+        try:
+            server.MCPServiceConfig._instance = None  # pylint: disable=protected-access
+            with (
+                mock.patch.object(sys, 'argv', ['mcp']),
+                mock.patch.dict(
+                    os.environ,
+                    {'OSMO_GATEWAY_URL': f'https://user:{secret}@gateway.test'},
+                    clear=True,
+                ),
+                contextlib.redirect_stdout(output),
+                self.assertRaises(SystemExit),
+            ):
+                server.MCPServiceConfig.load()
+        finally:
+            server.MCPServiceConfig._instance = None  # pylint: disable=protected-access
+
+        self.assertNotIn(secret, output.getvalue())
+        self.assertNotIn('user:', output.getvalue())
+
+    async def test_runtime_application_owns_gateway_context(self) -> None:
+        config = server.MCPServiceConfig(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=7,
+        )
+        app_context = gateway.AppContext(gateway=mock.Mock())
+        lifecycle_events: list[str] = []
+
+        @contextlib.asynccontextmanager
+        async def create_app_context(
+            **kwargs: object,
+        ) -> AsyncIterator[gateway.AppContext]:
+            self.assertEqual(kwargs, {
+                'gateway_url': 'https://gateway.test/',
+                'request_timeout_seconds': 7,
+                'transport': None,
+            })
+            lifecycle_events.append('entered')
+            try:
+                yield app_context
+            finally:
+                lifecycle_events.append('exited')
+
+        with mock.patch.object(
+                gateway, 'create_app_context', new=create_app_context):
+            application = server.create_runtime_application(config)
+            async with application.router.lifespan_context(application):
+                self.assertIs(application.state.mcp_app_context, app_context)
+                self.assertEqual(lifecycle_events, ['entered'])
+
+        self.assertFalse(hasattr(application.state, 'mcp_app_context'))
+        self.assertEqual(lifecycle_events, ['entered', 'exited'])
+
+    async def test_runtime_application_cleans_up_in_dependency_order(self) -> None:
+        config = server.MCPServiceConfig(gateway_url='https://gateway.test')
+        app_context = gateway.AppContext(gateway=mock.Mock())
+        lifecycle_events: list[str] = []
+
+        @contextlib.asynccontextmanager
+        async def protocol_lifespan(
+            application: Starlette,
+        ) -> AsyncIterator[None]:
+            self.assertIs(application.state.mcp_app_context, app_context)
+            lifecycle_events.append('protocol-entered')
+            try:
+                yield
+            finally:
+                self.assertIs(application.state.mcp_app_context, app_context)
+                lifecycle_events.append('protocol-exited')
+
+        @contextlib.asynccontextmanager
+        async def create_app_context(
+            **kwargs: object,
+        ) -> AsyncIterator[gateway.AppContext]:
+            del kwargs
+            lifecycle_events.append('gateway-entered')
+            try:
+                yield app_context
+            finally:
+                lifecycle_events.append('gateway-exited')
+
+        protocol_application = Starlette(lifespan=protocol_lifespan)
+        with (
+            mock.patch.object(server, 'create_mcp_server'),
+            mock.patch.object(
+                server,
+                'create_application',
+                return_value=protocol_application,
+            ),
+            mock.patch.object(
+                gateway,
+                'create_app_context',
+                new=create_app_context,
+            ),
+        ):
+            application = server.create_runtime_application(config)
+            with self.assertRaisesRegex(RuntimeError, 'lifespan failure'):
+                async with application.router.lifespan_context(application):
+                    raise RuntimeError('lifespan failure')
+
+        self.assertFalse(hasattr(application.state, 'mcp_app_context'))
+        self.assertEqual(lifecycle_events, [
+            'gateway-entered',
+            'protocol-entered',
+            'protocol-exited',
+            'gateway-exited',
+        ])
+
 
 class MCPMainTest(unittest.TestCase):
 
@@ -174,10 +318,16 @@ class MCPMainTest(unittest.TestCase):
         uvicorn_config = object()
         uvicorn_server = mock.Mock()
         uvicorn_server.serve = mock.AsyncMock()
+        application = object()
 
         with (
             mock.patch.object(
                 server.MCPServiceConfig, 'load', return_value=config),
+            mock.patch.object(
+                server,
+                'create_runtime_application',
+                return_value=application,
+            ) as application_factory,
             mock.patch.object(
                 server.uvicorn,
                 'Config',
@@ -192,7 +342,7 @@ class MCPMainTest(unittest.TestCase):
             server.main()
 
         config_factory.assert_called_once_with(
-            server.app,
+            application,
             host='127.0.0.1',
             port=9000,
             log_config=None,
@@ -200,6 +350,7 @@ class MCPMainTest(unittest.TestCase):
         )
         server_factory.assert_called_once_with(config=uvicorn_config)
         uvicorn_server.serve.assert_awaited_once_with()
+        application_factory.assert_called_once_with(config)
         config.uvicorn_ssl_kwargs.assert_called_once_with()
 
     def test_main_handles_keyboard_interrupt(self) -> None:
@@ -210,10 +361,16 @@ class MCPMainTest(unittest.TestCase):
         )
         uvicorn_server = mock.Mock()
         uvicorn_server.serve = mock.AsyncMock(side_effect=KeyboardInterrupt)
+        application = object()
 
         with (
             mock.patch.object(
                 server.MCPServiceConfig, 'load', return_value=config),
+            mock.patch.object(
+                server,
+                'create_runtime_application',
+                return_value=application,
+            ) as application_factory,
             mock.patch.object(server.uvicorn, 'Config', return_value=object()),
             mock.patch.object(
                 server.uvicorn,
@@ -224,6 +381,7 @@ class MCPMainTest(unittest.TestCase):
             server.main()
 
         uvicorn_server.serve.assert_awaited_once_with()
+        application_factory.assert_called_once_with(config)
 
 
 if __name__ == '__main__':

--- a/src/utils/static_config.py
+++ b/src/utils/static_config.py
@@ -109,7 +109,8 @@ class StaticConfig(pydantic.BaseModel):
             cls._instance = cls(**config)
         except pydantic.ValidationError as error:
             # Parse through errors and print them in a more user friendly manner
-            for type_error in error.errors():
+            include_input = not cls.model_config.get('hide_input_in_errors', False)
+            for type_error in error.errors(include_input=include_input):
                 if type_error['type'] not in ('type_error.none.not_allowed', 'value_error.missing',
                                                  'missing', 'none_required'):
                     print(type_error)


### PR DESCRIPTION
## Description

PR 2 of 4 for the MCP Phases B-D profile round-trip stack. It targets `feature/mcp` after Phase B PR #1187 was merged.

Adds the fixed-origin transport used for MCP-initiated OSMO API requests:

- introduces a shared asynchronous Gateway client with no stored caller credentials;
- derives the outbound Gateway origin from the deployment's canonical MCP resource URL;
- requires tools to select predefined API methods and paths;
- forwards only the unchanged bearer and optional request ID;
- rejects alternate origins, routes, queries, fragments, caller-selected headers, redirects, and path traversal;
- bounds timeouts and response sizes;
- discards upstream error bodies and prevents bearer reflection; and
- wires client startup and shutdown into the MCP application lifecycle.

This PR establishes the relay transport but does not yet register the profile tool. The next PR adds the first typed tool using this transport.

## Validation

- Focused Bazel validation (7 owning test/lint targets passed):
  `bazel test --test_output=errors //src/service/mcp:gateway-pylint //src/service/mcp:mcp_service_lib-pylint //src/service/mcp/tests:test_gateway //src/service/mcp/tests:test_gateway-pylint //src/service/mcp/tests:test_server //src/service/mcp/tests:test_server-pylint //src/utils:static_config-pylint`
- `bazel build //src/service/mcp:mcp_binary`
- Rendered only the MCP-enabled service chart path with `helm template`
- `git diff --check origin/feature/mcp...HEAD`

The binary build verifies the changed production dependency graph; no OCI image is rebuilt.

## Review stack

Please review and merge in order:

1. #1186 — prerequisite `main` sync (merged)
2. #1187 — Phase B request-scoped credentials (merged)
3. #1188 — Phase C same-Gateway API relay (this PR)
4. #1189 — Phases C-D profile tool round trip
5. #1190 — Phases B-D deployment validation and security hardening

The independent OETF reporting fix is #1191 and targets `main`.

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
