### PR TITLE
Allow set flags to be extended in CLI

### DIFF
--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -162,6 +162,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                                choices=('json', 'text'), default='text',
                                help='Specify the output format type (Default text).')
     submit_parser.add_argument('--set',
+                               action='extend',
+                               dest='set',
                                nargs='+',
                                default=[],
                                help='Assign fields in the workflow file with desired elements '
@@ -170,6 +172,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     ' in the yaml file should be in the form {{ field }}. '
                                     'Values will be cast as int or float if applicable')
     submit_parser.add_argument('--set-string',
+                               action='extend',
                                dest='set_string',
                                nargs='+',
                                default=[],
@@ -179,6 +182,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     ' in the yaml file should be in the form {{ field }}. '
                                     'All values will be cast as string')
     submit_parser.add_argument('--set-env',
+                               action='extend',
                                dest='set_env',
                                nargs='+',
                                default=[],

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -94,6 +94,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                                choices=('json', 'text'), default='text',
                                help='Specify the output format type (Default text).')
     submit_parser.add_argument('--set',
+                               action='extend',
+                               dest='set',
                                nargs='+',
                                default=[],
                                help='Assign fields in the workflow file with desired elements '
@@ -102,6 +104,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     ' in the yaml file should be in the form {{ field }}. '
                                     'Values will be cast as int or float if applicable')
     submit_parser.add_argument('--set-string',
+                               action='extend',
                                dest='set_string',
                                nargs='+',
                                default=[],
@@ -111,6 +114,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     ' in the yaml file should be in the form {{ field }}. '
                                     'All values will be cast as string')
     submit_parser.add_argument('--set-env',
+                               action='extend',
                                dest='set_env',
                                nargs='+',
                                default=[],
@@ -166,6 +170,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                                  type=lambda p: os.path.abspath(p),
                                  help='The workflow file to submit.').complete = shtab.FILE
     validate_parser.add_argument('--set',
+                                 action='extend',
+                                 dest='set',
                                  nargs='+',
                                  default=[],
                                  help='Assign fields in the workflow file with desired elements '
@@ -174,6 +180,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                       'fields in the yaml file should be in the form {{ field }}. '
                                       'Values will be cast as int or float if applicable')
     validate_parser.add_argument('--set-string',
+                                 action='extend',
                                  dest='set_string',
                                  nargs='+',
                                  default=[],


### PR DESCRIPTION
## Description
Allows our `--set` flags to be extended so we support `--set field=value field=value` as well as `--set field=value --set field=value`

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated `--set`, `--set-string`, and `--set-env` options are now all preserved when submitting applications or workflows.
  * Workflow validation and submission correctly accumulate repeated templating options instead of replacing earlier values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->