### PR TITLE
fix(chart): bound agent file log retention

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -55,9 +55,13 @@ See [../README.md](../README.md) for the full two-chart flow.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `global.logs.enabled` | Enable logging | `true` |
+| `global.logs.enabled` | Apply global logging configuration to OSMO service containers | `true` |
 | `global.logs.logLevel` | Log level for application | `DEBUG` |
 | `global.logs.k8sLogLevel` | Log level for Kubernetes | `WARNING` |
+
+OSMO services write logs to stdout for collection by the platform log agent. `osmo-agent` also
+retains backend-forwarded logs in a bounded `/logs` volume; its dedicated logrotate sidecar keeps
+five 10 MiB copies by default.
 
 
 ### Configuration File Settings

--- a/deployments/charts/service/templates/agent-logrotate-config.yaml
+++ b/deployments/charts/service/templates/agent-logrotate-config.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.global.logs.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.services.agent.serviceName }}-logrotate
+  labels:
+    {{- include "osmo.labels" . | nindent 4 }}
+data:
+  logrotate.conf: |
+    /logs/*.txt {
+        su 1001 1001
+        maxsize 10M
+        hourly
+        missingok
+        notifempty
+        rotate 5
+        copytruncate
+    }
+{{- end }}

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -203,13 +203,46 @@ spec:
           timeoutSeconds: 20
 
 
+      {{- if .Values.global.logs.enabled }}
+      # TODO: Remove this sidecar when backend-forwarded agent logs can be sent to stdout.
+      # get_backend_logger currently suppresses propagation without a file handler.
+      - name: logrotate
+        image: fluent/fluent-bit:4.0.8-debug
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          runAsUser: 1001
+          runAsGroup: 1001
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          while true; do
+            logrotate --state /tmp/logrotate.status /etc/osmo-logrotate/logrotate.conf
+            sleep 60
+          done
+        volumeMounts:
+        - name: logs
+          mountPath: /logs
+        - name: agent-logrotate-config
+          mountPath: /etc/osmo-logrotate
+          readOnly: true
+      {{- end }}
       {{- include "osmo.extra-sidecars" .Values.services.agent | nindent 6 }}
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.agent | nindent 8 }}
         {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
         {{- if .Values.global.logs.enabled }}
         - name: logs
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 256Mi
+        {{- end}}
+        {{- if .Values.global.logs.enabled }}
+        - name: agent-logrotate-config
+          configMap:
+            name: {{ .Values.services.agent.serviceName }}-logrotate
         {{- end}}
         {{- if .Values.services.configFile.enabled}}
         - configMap:

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -139,10 +139,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - api_service
         {{- end }}
         {{- if .Values.services.defaultAdmin.enabled }}
         - --default_admin_username
@@ -194,7 +190,7 @@ spec:
         ports:
         - name: metrics
           containerPort: 9464
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.configs.enabled .Values.services.service.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.service) }}
+        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.service.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.service) }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
@@ -203,10 +199,6 @@ spec:
           subPath: mek.yaml
         {{- end }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
-        {{- end }}
         {{- include "osmo.extra-volume-mounts" .Values.services.service | nindent 8 }}
         {{- include "osmo.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.service) | nindent 8 }}
         resources:
@@ -241,10 +233,6 @@ spec:
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.service | nindent 8 }}
         {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.service) | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- if .Values.services.configFile.enabled}}
         - configMap:
             defaultMode: 420

--- a/deployments/charts/service/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/service/templates/delayed-job-monitor.yaml
@@ -103,10 +103,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - delayed_job_monitor
         {{- end }}
         - --enable_metrics
         {{- range $arg := .Values.services.delayedJobMonitor.extraArgs }}
@@ -132,17 +128,13 @@ spec:
         resources:
         {{- toYaml .Values.services.service.resources | nindent 10 }}
 
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.delayedJobMonitor.extraVolumeMounts }}
+        {{- if or .Values.services.configFile.enabled .Values.services.delayedJobMonitor.extraVolumeMounts .Values.services.delayedJobMonitor.volumeMounts }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
         - mountPath: {{ .Values.services.configFile.path }}
           name: mek-volume
           subPath: mek.yaml
-        {{- end }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
         {{- end }}
         {{- include "osmo.extra-volume-mounts" .Values.services.delayedJobMonitor | nindent 8 }}
         {{- if .Values.services.delayedJobMonitor.volumeMounts }}
@@ -167,10 +159,6 @@ spec:
 
       {{- include "osmo.extra-sidecars" .Values.services.delayedJobMonitor | nindent 6 }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- include "osmo.extra-volumes" .Values.services.delayedJobMonitor | nindent 8 }}
         {{- if .Values.services.configFile.enabled}}
         - configMap:

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -476,10 +476,6 @@ spec:
           {{- end }}
           - "--cache-ttl={{ $gw.authz.cache.ttl }}"
           - "--cache-max-size={{ $gw.authz.cache.maxSize }}"
-          {{- if .Values.global.logs.enabled }}
-          - "--log-dir=/logs"
-          - "--log-name=authz_sidecar"
-          {{- end }}
           {{- with .Values.global.logs.logFormat }}
           - "--log-format={{ . }}"
           {{- end }}
@@ -499,11 +495,8 @@ spec:
                 name: db-secret
                 key: db-password
           {{- end }}
+        {{- if or .Values.services.configs.enabled $gw.authz.extraVolumeMounts }}
         volumeMounts:
-          {{- if .Values.global.logs.enabled }}
-          - name: logs
-            mountPath: /logs
-          {{- end }}
           {{- if .Values.services.configs.enabled }}
           - name: configs
             mountPath: /etc/osmo/configs
@@ -512,6 +505,7 @@ spec:
           {{- with $gw.authz.extraVolumeMounts }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+        {{- end }}
         {{- with $gw.authz.livenessProbe }}
         livenessProbe:
           {{- toYaml . | nindent 10 }}
@@ -523,10 +517,6 @@ spec:
         resources:
           {{- toYaml $gw.authz.resources | nindent 10 }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end }}
         {{- if .Values.services.configs.enabled }}
         - name: configs
           configMap:

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -116,10 +116,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - logger_service
         {{- end }}
         {{- include "osmo.configmap-args" . | nindent 8 }}
         {{- range $arg := .Values.services.logger.extraArgs }}
@@ -146,7 +142,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.services.logger.imagePullPolicy }}
         ports:
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.configs.enabled .Values.services.logger.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.logger) }}
+        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.logger.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.logger) }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
@@ -155,10 +151,6 @@ spec:
           subPath: mek.yaml
         {{- end }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
-        {{- end }}
         {{- include "osmo.extra-volume-mounts" .Values.services.logger | nindent 8 }}
         {{- include "osmo.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
         resources:
@@ -199,10 +191,6 @@ spec:
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.logger | nindent 8 }}
         {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- if .Values.services.configFile.enabled}}
         - configMap:
             defaultMode: 420

--- a/deployments/charts/service/templates/router-service.yaml
+++ b/deployments/charts/service/templates/router-service.yaml
@@ -110,10 +110,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - router_service
         {{- end }}
         {{- with .Values.services.router.extraArgs }}
         {{- range . }}
@@ -163,16 +159,12 @@ spec:
           protocol: {{ .protocol | default "TCP" }}
         {{- end }}
         {{- end }}
-        {{- if or .Values.global.logs.enabled .Values.services.configFile.enabled .Values.services.router.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.router) }}
+        {{- if or .Values.services.configFile.enabled .Values.services.router.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.router) }}
         volumeMounts:
         {{- if .Values.services.configFile.enabled}}
         - mountPath: {{ .Values.services.configFile.path }}
           name: mek-volume
           subPath: mek.yaml
-        {{- end }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
         {{- end }}
         {{- with .Values.services.router.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
@@ -201,10 +193,6 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- if .Values.services.configFile.enabled}}
         - configMap:
             defaultMode: 420

--- a/deployments/charts/service/templates/ui-service.yaml
+++ b/deployments/charts/service/templates/ui-service.yaml
@@ -116,7 +116,7 @@ spec:
             drop: ["ALL"]
           runAsNonRoot: true
           runAsUser: 1000
-        {{- if or .Values.global.logs.enabled .Values.services.ui.extraVolumeMounts }}
+        {{- if .Values.services.ui.extraVolumeMounts }}
         volumeMounts:
         {{- end }}
         {{- with .Values.services.ui.extraVolumeMounts }}
@@ -242,10 +242,6 @@ spec:
         {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- with .Values.services.ui.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -114,10 +114,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - worker
         {{- end }}
         {{- include "osmo.configmap-args" . | nindent 8 }}
         {{- range $arg := .Values.services.worker.extraArgs }}
@@ -145,7 +141,7 @@ spec:
               name: redis-secret
               key: redis-password
         {{- end }}
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.configs.enabled .Values.services.worker.extraVolumeMounts }}
+        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.worker.extraVolumeMounts }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
@@ -154,10 +150,6 @@ spec:
           subPath: mek.yaml
         {{- end }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
-        {{- end }}
         {{- include "osmo.extra-volume-mounts" .Values.services.worker | nindent 8 }}
         resources:
         {{- toYaml .Values.services.worker.resources | nindent 10 }}
@@ -181,10 +173,6 @@ spec:
 
       {{- include "osmo.extra-sidecars" .Values.services.worker | nindent 6 }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- include "osmo.extra-volumes" .Values.services.worker | nindent 8 }}
         {{- if .Values.services.configFile.enabled}}
         - configMap:

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -56,7 +56,7 @@ global:
   ## Logging configuration for all Osmo services
   ##
   logs:
-    ## Enable centralized logging collection and log volume mounting
+    ## Apply logging configuration to OSMO service containers
     ##
     enabled: true
 


### PR DESCRIPTION
## Summary

Prevent `osmo-agent` from exhausting node ephemeral storage with unbounded `/logs` files.

The agent was writing high-volume DEBUG WebSocket protocol traffic to its `emptyDir`; one production pod accumulated 53 GiB across two files. This became unbounded after the log-collection/rotation sidecar removal.

## Changes

- Keep `osmo-agent` file logging because backend-forwarded logs currently require its file handler.
- Add an agent-only `logrotate` sidecar:
  - checks every minute
  - rotates at 10 MiB
  - retains five rotations
  - uses `copytruncate` so the Python file handlers can remain open
- Cap the agent `/logs` `emptyDir` at 256 MiB.
- Remove unused file-log arguments, `/logs` mounts, and `emptyDir` volumes from the other service deployments; they continue logging to stdout.
- Add a TODO documenting that the agent sidecar can be removed once backend-forwarded logs are emitted to stdout safely.

## Validation

- `helm lint deployments/charts/service`
- `helm lint deployments/charts/service --values deployments/charts/service/quick-start-values.yaml`
- Rendered the chart with default, quick-start, config-file-enabled, and `global.logs.enabled=false` configurations.
- Confirmed logging-disabled renders contain no `/logs`, logrotate, `--log_dir`, or `--log_name` resources.
- `git diff --check`

## Notes

This bounds node-local disk usage without dropping backend-forwarded agent logs. DEBUG protocol traffic remains available through stdout collection.

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Centralized logging now stores forwarded service logs in a bounded shared location.
  - Log rotation runs automatically, retaining up to five 10 MiB copies to help control disk usage.
  - Logging is enabled and configured through the existing global logging settings.

- **Documentation**
  - Expanded logging guidance explains service log destinations, retention behavior, rotation defaults, and available log-level settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->