### PR TITLE
fix(charts): log-rotate permissions fix

### DIFF
--- a/deployments/charts/service/templates/agent-logrotate-config.yaml
+++ b/deployments/charts/service/templates/agent-logrotate-config.yaml
@@ -23,7 +23,7 @@ metadata:
 data:
   logrotate.conf: |
     /logs/*.txt {
-        su 1001 1001
+        su root root
         maxsize 10M
         hourly
         missingok

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -211,11 +211,8 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 1001
-          runAsGroup: 1001
+          runAsUser: 0
+          runAsGroup: 0
         command: ["/bin/sh", "-c"]
         args:
         - |


### PR DESCRIPTION
## Description
Unfortunately logrotate program requires a known user, so this extra fix is needed to #1195

Issue #None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log rotation reliability by running log rotation processes with the required root permissions.
  * Updated the log rotation service configuration to use consistent root user and group settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->