### PR TITLE
testbot: use picker metadata for PR targets

### DIFF
--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -14,6 +14,7 @@ on:
       - 'bzl/**'
       - 'MODULE.bazel'
       - 'src/**'
+      - '!src/scripts/testbot/**'
       - '.github/workflows/oetf-kind.yaml'
   workflow_dispatch: {}
 

--- a/src/scripts/testbot/create_pr.py
+++ b/src/scripts/testbot/create_pr.py
@@ -12,6 +12,7 @@ Usage:
 """
 
 import argparse
+from collections import Counter
 import datetime
 import json
 import logging
@@ -140,10 +141,10 @@ _SUSPECTED_BUG_RE = re.compile(
     """
 )
 
-# Map a generated test file back to the source file it covers, so the
-# Stage-2 picker rationale (keyed on source path) can be attached to the
-# right test in the PR body. Mirrors the conventions enforced by
-# TESTBOT_RULES.md and the basename-stripping in the title generator.
+# Best-effort fallback for ad-hoc runs without picker metadata. Normal
+# workflow runs get their source targets directly from targets_meta.json;
+# generated test names are output artifacts and do not reliably encode the
+# source they exercise (for example, test_task_pure.py tests task.py).
 _TEST_TO_SOURCE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"(.*?)/tests/test_([^/]+\.py)$"), r"\1/\2"),
     (re.compile(r"(.+)_test(\.go)$"), r"\1\2"),
@@ -163,8 +164,9 @@ def _test_to_source_paths(test_path: str) -> list[str]:
     #1058 surfaced this — the naive strip didn't match the picker's
     meta key and the rationale section got dropped.
 
-    Callers walk the returned list and pick the first candidate that
-    exists in the picker meta (or on disk).
+    This is used only when picker metadata is unavailable. Callers prefer a
+    candidate that exists on disk before falling back to the conventional
+    first result.
     """
     candidates: list[str] = []
     for pattern, replacement in _TEST_TO_SOURCE_PATTERNS:
@@ -209,11 +211,86 @@ def _load_targets_meta(path: str) -> dict[str, dict]:
     if not isinstance(entries, list):
         logger.warning("targets meta is not a list: %r", entries)
         return {}
-    return {
-        entry["file_path"]: entry
-        for entry in entries
-        if isinstance(entry, dict) and entry.get("file_path")
+    meta: dict[str, dict] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        raw_file_path = entry.get("file_path")
+        if not isinstance(raw_file_path, str) or not raw_file_path.strip():
+            logger.warning(
+                "Skipping target metadata entry with invalid file_path: %r",
+                entry,
+            )
+            continue
+        file_path = raw_file_path.strip()
+        if file_path in meta:
+            logger.warning(
+                "Duplicate target metadata for %s; using the last entry",
+                file_path,
+            )
+        meta[file_path] = entry
+    return meta
+
+
+def _source_paths_for_pr(
+    changed_files: list[str],
+    meta: dict[str, dict],
+) -> list[str]:
+    """Return source targets for the PR, preserving authoritative order.
+
+    Picker metadata records what the workflow selected and is therefore the
+    source of truth. Generated test paths only describe how the generator
+    organized its output; one source can have multiple semantically named test
+    files, and one test can exercise multiple selected sources.
+
+    Filename inference remains as a compatibility fallback for local or ad-hoc
+    runs that do not provide picker metadata.
+    """
+    if meta:
+        return list(meta)
+
+    logger.warning(
+        "No target metadata available; inferring source paths from test names",
+    )
+    source_paths: list[str] = []
+    seen: set[str] = set()
+    for test_path in changed_files:
+        candidates = _test_to_source_paths(test_path)
+        if not candidates:
+            continue
+        source_path = next(
+            (candidate for candidate in candidates if Path(candidate).is_file()),
+            candidates[0],
+        )
+        if source_path not in seen:
+            seen.add(source_path)
+            source_paths.append(source_path)
+    return source_paths
+
+
+def _files_summary_for_pr(
+    source_paths: list[str],
+    changed_files: list[str],
+) -> str:
+    """Summarize source targets for titles and commit subjects.
+
+    Unique source basenames stay compact. When multiple selected sources share
+    a basename, their full paths disambiguate them. Changed-file basenames are
+    used only when no source target can be resolved.
+    """
+    if not source_paths:
+        changed_basenames = {
+            path.rsplit("/", maxsplit=1)[-1] for path in changed_files
+        }
+        return ", ".join(sorted(changed_basenames))
+
+    basenames = [path.rsplit("/", maxsplit=1)[-1] for path in source_paths]
+    basename_counts = Counter(basenames)
+    summary_parts = {
+        path if basename_counts[basename] > 1 else basename
+        for path, basename in zip(source_paths, basenames, strict=True)
     }
+    return ", ".join(sorted(summary_parts))
 
 
 def _build_generator_summary_section(path: str) -> str:
@@ -320,36 +397,17 @@ def _build_coverage_section(path: str) -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _build_rationale_section(
-    changed_files: list[str],
-    meta: dict[str, dict],
-) -> str:
+def _build_rationale_section(meta: dict[str, dict]) -> str:
     """Render the 'Why ... was targeted' section, or '' when no rationale."""
-    seen_sources: list[str] = []
-    seen_set: set[str] = set()
-    for test_path in changed_files:
-        # Walk candidates in specificity order — most-specific (naive
-        # `_test` strip) first, falling back to `_integration_test`
-        # stripping. The first match against the picker meta wins, so
-        # `user_role_sync_integration_test.go` correctly attaches the
-        # rationale meant for `user_role_sync.go` while a hypothetical
-        # `kafka_integration_test.go` testing `kafka_integration.go`
-        # still resolves to the more-specific target.
-        for candidate in _test_to_source_paths(test_path):
-            if candidate in meta and candidate not in seen_set:
-                seen_set.add(candidate)
-                seen_sources.append(candidate)
-                break
-    if not seen_sources:
+    if not meta:
         return ""
     heading = (
         "## Why this file was targeted"
-        if len(seen_sources) == 1
+        if len(meta) == 1
         else "## Why these files were targeted"
     )
     blocks: list[str] = [heading, ""]
-    for source in seen_sources:
-        entry = meta[source]
+    for source, entry in meta.items():
         try:
             coverage = float(entry.get("coverage_pct", 0.0))
         except (TypeError, ValueError):
@@ -552,48 +610,27 @@ def main() -> None:
 
     logger.info("Changed test files: %s", changed_files)
 
-    # Load picker meta early so the title can prefer the picker's
-    # canonical source path over the naive `_test` strip — important
-    # for `_integration_test.go` files where the strip otherwise
-    # yields a non-existent `foo_integration.go` instead of `foo.go`.
+    # Picker metadata is authoritative for the selected source targets.
+    # Generated test filenames describe output organization and may not
+    # mirror source basenames (for example, test_task_pure.py tests task.py).
     targets_meta = _load_targets_meta(args.targets_meta)
-
-    # Walk each changed test file to its source-file equivalent using the
-    # meta-aware mapping (handles _integration_test.go correctly).
-    # Non-test changes (BUILD edits) are recorded separately so we can
-    # render them under "Files tested" without confusing source vs test.
-    source_paths: set[str] = set()
-    non_test_basenames: set[str] = set()
-    for test_path in changed_files:
-        candidates = _test_to_source_paths(test_path)
-        if not candidates:
-            # Non-test file (e.g., the BUILD edit) — keep its basename
-            # for the title fallback.
-            non_test_basenames.add(test_path.rsplit("/", maxsplit=1)[-1])
-            continue
-        # Prefer the candidate the picker actually targeted; fall back
-        # to the most-specific naive strip when no picker meta is
-        # available (local dry-run, ad-hoc dispatch).
-        chosen = next(
-            (c for c in candidates if c in targets_meta),
-            candidates[0],
+    if args.targets_meta and not targets_meta:
+        logger.error(
+            "Target metadata was provided but contained no valid targets: %s",
+            args.targets_meta,
         )
-        source_paths.add(chosen)
+        sys.exit(1)
+    source_paths = _source_paths_for_pr(changed_files, targets_meta)
 
-    # Title uses basenames of the source files (and non-test files like
-    # BUILD), summarized — keeps the historical title shape.
-    source_basenames = {p.rsplit("/", maxsplit=1)[-1] for p in source_paths}
-    files_summary = ", ".join(sorted(source_basenames | non_test_basenames))
+    # Title names selected source files, not generated tests or BUILD wiring.
+    files_summary = _files_summary_for_pr(source_paths, changed_files)
 
-    # "Files tested" body section lists the SOURCE files the picker
-    # targeted — what reviewers actually want to scan. The committed
-    # test file paths still appear in the diff, so we don't lose
-    # information by hiding them here. Fall back to listing all
-    # changed files when we couldn't resolve any source path (entirely
-    # non-test diff — shouldn't happen for a real testbot run but keeps
-    # the section non-empty defensively).
+    # "Targets selected" lists the source files chosen by the picker. It does
+    # not claim a one-to-one mapping to generated files; per-target coverage
+    # below reports how much each selected source was actually exercised.
+    # Fall back to changed files only for ad-hoc runs without metadata.
     if source_paths:
-        files_list = "\n".join(f"- `{p}`" for p in sorted(source_paths))
+        files_list = "\n".join(f"- `{p}`" for p in source_paths)
     else:
         files_list = "\n".join(f"- `{f}`" for f in changed_files)
 
@@ -622,7 +659,7 @@ def main() -> None:
         bugs_section = f"\n## Suspected bugs\n{bugs_list}\n"
 
     # targets_meta already loaded above for the title computation.
-    rationale_section = _build_rationale_section(changed_files, targets_meta)
+    rationale_section = _build_rationale_section(targets_meta)
     if rationale_section:
         rationale_section = "\n" + rationale_section
 
@@ -642,7 +679,7 @@ AI-generated tests targeting file(s) with low coverage.
 
 Issue - None
 
-## Files tested
+## Targets selected
 {files_list}
 {rationale_section}{generator_summary_section}{coverage_section}{bugs_section}
 ## Checklist

--- a/src/scripts/testbot/tests/test_create_pr.py
+++ b/src/scripts/testbot/tests/test_create_pr.py
@@ -19,11 +19,13 @@ from src.scripts.testbot.create_pr import (  # noqa: E501
     _build_slack_review_payload,
     _enable_auto_merge,
     _extract_pr_url,
+    _files_summary_for_pr,
     _get_slack_bot_token,
     _load_targets_meta,
     _post_slack_review_request,
     _resolve_slack_channel,
     _scan_suspected_bugs,
+    _source_paths_for_pr,
     _test_to_source_path,
     _test_to_source_paths,
     has_unapproved_testbot_pr,
@@ -235,6 +237,30 @@ class TestPrCreationHelpers(unittest.TestCase):
         )
         post_slack_mock.assert_not_called()
 
+    def test_main_rejects_missing_explicit_target_metadata(self):
+        with patch("src.scripts.testbot.create_pr.has_unapproved_testbot_pr",
+                   return_value=False), \
+                patch("src.scripts.testbot.create_pr.get_changed_test_files",
+                      return_value=["src/utils/job/tests/test_task_units.py"]), \
+                patch("src.scripts.testbot.create_pr.run") as run_mock, \
+                patch("src.scripts.testbot.create_pr.subprocess.run") \
+                as subprocess_run_mock, \
+                patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "create_pr.py",
+                        "--targets-meta",
+                        "/no/such/targets_meta.json",
+                    ],
+                ):
+            with self.assertRaises(SystemExit) as exit_ctx:
+                main()
+
+        self.assertNotIn(exit_ctx.exception.code, (0, None))
+        run_mock.assert_not_called()
+        subprocess_run_mock.assert_not_called()
+
 
 class TestSlackReviewRequest(unittest.TestCase):
     """Tests for Slack review request helpers."""
@@ -401,14 +427,10 @@ class TestSlackReviewRequest(unittest.TestCase):
         self.assertEqual(post_mock.call_args.kwargs["bot_token"], "token")
         self.assertEqual(post_mock.call_args.kwargs["channel"], "#osmo-slack-test")
 
-    def test_main_pr_body_files_tested_lists_source_paths(self):
-        # "Files tested" should list the source files the picker
-        # targeted, not the test files that were committed (those
-        # appear in the diff already). PR #1065 surfaced this — the
-        # body showed src/utils/job/tests/test_backend_jobs.py
-        # instead of the more reviewer-useful
-        # src/utils/job/backend_jobs.py. Test by capturing the body
-        # passed to gh pr create via subprocess.run's args.
+    def test_main_uses_picker_target_when_test_has_semantic_name(self):
+        # PR #1184 regression: task.py was selected, but the generator
+        # organized its output as test_task_units.py. Source identity comes
+        # from picker metadata, never by reversing the generated test name.
         gh_create_result = subprocess.CompletedProcess(
             [], 0, stdout="https://github.com/NVIDIA/OSMO/pull/123\n",
         )
@@ -417,10 +439,10 @@ class TestSlackReviewRequest(unittest.TestCase):
         ) as meta_fh:
             json.dump([
                 {
-                    "file_path": "src/utils/job/backend_jobs.py",
-                    "coverage_pct": 23.6,
-                    "uncovered_lines": 60,
-                    "uncovered_ranges": [[105, 110]],
+                    "file_path": "src/utils/job/task.py",
+                    "coverage_pct": 63.8,
+                    "uncovered_lines": 393,
+                    "uncovered_ranges": [[100, 110]],
                     "reason": "test rationale",
                 },
             ], meta_fh)
@@ -431,7 +453,7 @@ class TestSlackReviewRequest(unittest.TestCase):
                        return_value=False), \
                     patch("src.scripts.testbot.create_pr.get_changed_test_files",
                           return_value=[
-                              "src/utils/job/tests/test_backend_jobs.py",
+                              "src/utils/job/tests/test_task_units.py",
                               "src/utils/job/tests/BUILD",
                           ]), \
                     patch("src.scripts.testbot.create_pr.run",
@@ -460,17 +482,27 @@ class TestSlackReviewRequest(unittest.TestCase):
         argv = gh_calls[0].args[0]
         body = argv[argv.index("--body") + 1]
 
-        self.assertIn("## Files tested", body)
-        # Source path appears in body, test file path does NOT.
-        self.assertIn("`src/utils/job/backend_jobs.py`", body)
-        self.assertNotIn(
-            "`src/utils/job/tests/test_backend_jobs.py`", body,
-            "test file path leaked into 'Files tested' — should show source",
-        )
-        # Title still uses the source basename as before.
+        self.assertIn("## Targets selected", body)
+        self.assertIn("`src/utils/job/task.py`", body)
+        self.assertIn("## Why this file was targeted", body)
+        self.assertIn("> test rationale", body)
+        targets_selected = body.split("## Targets selected\n", maxsplit=1)[1]
+        targets_selected = targets_selected.split("\n## ", maxsplit=1)[0]
+        self.assertNotIn("test_task_units.py", targets_selected)
+
         title = argv[argv.index("--title") + 1]
-        self.assertIn("backend_jobs.py", title)
-        self.assertNotIn("test_backend_jobs.py", title)
+        self.assertEqual(title, "[testbot] Add tests for task.py")
+        self.assertNotIn("BUILD", title)
+
+        commit_calls = [
+            call for call in run_mock.call_args_list
+            if call.args and call.args[0] and call.args[0][:2] == ["git", "commit"]
+        ]
+        self.assertEqual(len(commit_calls), 1)
+        self.assertIn(
+            "Add AI-generated tests for task.py",
+            commit_calls[0].args[0],
+        )
 
     def test_main_skips_slack_when_skip_slack_env_true(self):
         # workflow_dispatch skip_slack=true sets SKIP_SLACK=true.
@@ -750,111 +782,171 @@ class TestLoadTargetsMeta(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_skips_entries_with_invalid_file_paths(self):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8",
+        ) as fh:
+            json.dump([
+                42,
+                {"file_path": ["not", "hashable"], "reason": "bad"},
+                {"file_path": "", "reason": "empty"},
+                {"file_path": "   ", "reason": "whitespace"},
+                {"reason": "missing"},
+                {"file_path": "  src/lib/padded.py  ", "reason": "trimmed"},
+                {"file_path": "src/lib/valid.py", "reason": "kept"},
+            ], fh)
+            path = fh.name
+        try:
+            self.assertEqual(
+                list(_load_targets_meta(path)),
+                ["src/lib/padded.py", "src/lib/valid.py"],
+            )
+        finally:
+            os.unlink(path)
+
+    def test_duplicate_file_path_uses_last_entry(self):
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".json", delete=False, encoding="utf-8",
+        ) as fh:
+            json.dump([
+                {"file_path": "src/lib/foo.py", "reason": "first"},
+                {"file_path": "src/lib/foo.py", "reason": "second"},
+            ], fh)
+            path = fh.name
+        try:
+            meta = _load_targets_meta(path)
+            self.assertEqual(list(meta), ["src/lib/foo.py"])
+            self.assertEqual(meta["src/lib/foo.py"]["reason"], "second")
+        finally:
+            os.unlink(path)
+
+
+class TestSourcePathsForPr(unittest.TestCase):
+    """Tests for authoritative source-target selection."""
+
+    def test_uses_ordered_metadata_for_semantic_test_filename(self):
+        meta = {
+            "src/utils/job/task.py": {"reason": "first"},
+            "src/utils/job/jobs.py": {"reason": "second"},
+        }
+
+        source_paths = _source_paths_for_pr(
+            [
+                "src/utils/job/tests/BUILD",
+                "src/utils/job/tests/test_task_units.py",
+            ],
+            meta,
+        )
+
+        self.assertEqual(source_paths, [
+            "src/utils/job/task.py",
+            "src/utils/job/jobs.py",
+        ])
+
+    def test_infers_source_from_test_name_without_metadata(self):
+        source_paths = _source_paths_for_pr(
+            [
+                "src/lib/tests/BUILD",
+                "src/lib/tests/test_foo.py",
+            ],
+            {},
+        )
+
+        self.assertEqual(source_paths, ["src/lib/foo.py"])
+
+    @patch(
+        "src.scripts.testbot.create_pr.Path.is_file",
+        side_effect=[False, True],
+    )
+    def test_fallback_prefers_existing_integration_source(self, mock_is_file):
+        source_paths = _source_paths_for_pr(
+            ["src/utils/roles/user_role_sync_integration_test.go"],
+            {},
+        )
+
+        self.assertEqual(mock_is_file.call_count, 2)
+        self.assertEqual(
+            source_paths,
+            ["src/utils/roles/user_role_sync.go"],
+        )
+
+
+class TestFilesSummaryForPr(unittest.TestCase):
+    """Tests for concise, unambiguous target summaries."""
+
+    def test_uses_basenames_for_unique_sources(self):
+        self.assertEqual(
+            _files_summary_for_pr(
+                ["src/a/foo.py", "src/b/bar.py"],
+                ["src/tests/BUILD"],
+            ),
+            "bar.py, foo.py",
+        )
+
+    def test_uses_paths_for_duplicate_basenames(self):
+        self.assertEqual(
+            _files_summary_for_pr(
+                ["src/a/foo.py", "src/b/foo.py"],
+                ["src/tests/test_foo.py"],
+            ),
+            "src/a/foo.py, src/b/foo.py",
+        )
+
+    def test_falls_back_to_changed_basenames_without_sources(self):
+        self.assertEqual(
+            _files_summary_for_pr(
+                [],
+                ["src/tests/BUILD", "src/tests/test_custom.py"],
+            ),
+            "BUILD, test_custom.py",
+        )
+
 
 class TestBuildRationaleSection(unittest.TestCase):
     """Tests for the 'Why this file was targeted' PR-body section."""
 
     def test_empty_when_no_meta(self):
-        self.assertEqual(_build_rationale_section(["src/x/tests/test_y.py"], {}), "")
+        self.assertEqual(_build_rationale_section({}), "")
 
-    def test_go_integration_test_attaches_rationale_to_underscore_source(self):
-        # PR #1058 regression: the rationale silently dropped because
-        # the naive `_test` strip mapped the integration test to
-        # `user_role_sync_integration.go` instead of the picker's
-        # target `user_role_sync.go`. The fallback candidate must
-        # match the picker meta.
+    def test_renders_authoritative_picker_target(self):
         meta = {
-            "src/utils/roles/user_role_sync.go": {
-                "file_path": "src/utils/roles/user_role_sync.go",
-                "coverage_pct": 0.0,
-                "uncovered_lines": 97,
-                "reason": "Owns IDP-to-OSMO role sync — RBAC blast radius.",
+            "src/utils/job/task.py": {
+                "file_path": "src/utils/job/task.py",
+                "coverage_pct": 63.8,
+                "uncovered_lines": 393,
+                "reason": "Owns task lifecycle behavior.",
             },
         }
-        section = _build_rationale_section(
-            ["src/utils/roles/user_role_sync_integration_test.go"],
-            meta,
-        )
-        self.assertIn("`src/utils/roles/user_role_sync.go`", section)
-        self.assertIn("Owns IDP-to-OSMO role sync", section)
 
-    def test_prefers_naive_strip_when_both_candidates_match_meta(self):
-        # Hypothetical: meta has BOTH `kafka_integration.go` (a real
-        # source file) and `kafka.go`. The naive strip wins so we
-        # don't accidentally attach the kafka-integration rationale to
-        # kafka.go.
-        meta = {
-            "src/foo/kafka.go": {
-                "file_path": "src/foo/kafka.go",
-                "coverage_pct": 50.0, "uncovered_lines": 10,
-                "reason": "kafka rationale",
-            },
-            "src/foo/kafka_integration.go": {
-                "file_path": "src/foo/kafka_integration.go",
-                "coverage_pct": 30.0, "uncovered_lines": 20,
-                "reason": "kafka_integration rationale",
-            },
-        }
-        section = _build_rationale_section(
-            ["src/foo/kafka_integration_test.go"], meta,
-        )
-        self.assertIn("kafka_integration rationale", section)
-        self.assertNotIn("kafka rationale", section)
+        section = _build_rationale_section(meta)
 
-    def test_singular_heading_for_one_target(self):
-        meta = {
-            "src/lib/utils/common.py": {
-                "file_path": "src/lib/utils/common.py",
-                "coverage_pct": 45.3,
-                "uncovered_lines": 332,
-                "reason": "Highest fan-in file packed with pure utilities.",
-            },
-        }
-        section = _build_rationale_section(
-            ["src/lib/utils/tests/test_common.py"], meta,
-        )
         self.assertIn("## Why this file was targeted", section)
-        self.assertIn("**`src/lib/utils/common.py`**", section)
-        self.assertIn("45.3% coverage", section)
-        self.assertIn("332 uncovered lines", section)
-        self.assertIn("> Highest fan-in", section)
+        self.assertIn("**`src/utils/job/task.py`**", section)
+        self.assertIn("63.8% coverage", section)
+        self.assertIn("393 uncovered lines", section)
+        self.assertIn("> Owns task lifecycle behavior.", section)
 
-    def test_plural_heading_for_multiple_targets(self):
+    def test_plural_heading_preserves_picker_order(self):
         meta = {
-            "src/a/foo.py": {
-                "file_path": "src/a/foo.py",
+            "src/z/first.py": {
+                "file_path": "src/z/first.py",
                 "coverage_pct": 10.0, "uncovered_lines": 50,
                 "reason": "first",
             },
-            "src/b/bar.py": {
-                "file_path": "src/b/bar.py",
+            "src/a/second.py": {
+                "file_path": "src/a/second.py",
                 "coverage_pct": 20.0, "uncovered_lines": 80,
                 "reason": "second",
             },
         }
-        section = _build_rationale_section(
-            ["src/a/tests/test_foo.py", "src/b/tests/test_bar.py"],
-            meta,
-        )
-        self.assertIn("## Why these files were targeted", section)
-        self.assertIn("**`src/a/foo.py`**", section)
-        self.assertIn("**`src/b/bar.py`**", section)
 
-    def test_skips_test_with_no_meta(self):
-        meta = {
-            "src/lib/foo.py": {
-                "file_path": "src/lib/foo.py",
-                "coverage_pct": 10.0, "uncovered_lines": 5,
-                "reason": "covered",
-            },
-        }
-        section = _build_rationale_section(
-            ["src/lib/tests/test_foo.py", "src/lib/tests/test_unrelated.py"],
-            meta,
+        section = _build_rationale_section(meta)
+
+        self.assertIn("## Why these files were targeted", section)
+        self.assertLess(
+            section.index("src/z/first.py"),
+            section.index("src/a/second.py"),
         )
-        self.assertIn("**`src/lib/foo.py`**", section)
-        self.assertNotIn("test_unrelated", section)
-        self.assertNotIn("unrelated.py", section)
 
     def test_multi_sentence_reason_with_roi_clause_preserved(self):
         # Per the picker prompt's 3-clause contract, the reason names
@@ -875,9 +967,7 @@ class TestBuildRationaleSection(unittest.TestCase):
                 ),
             },
         }
-        section = _build_rationale_section(
-            ["src/utils/job/tests/test_jobs.py"], meta,
-        )
+        section = _build_rationale_section(meta)
         self.assertIn("workflow job state machine", section)
         self.assertIn("would corrupt workflow state", section)
         self.assertIn("Highest ROI on today's shortlist", section)
@@ -899,26 +989,10 @@ class TestBuildRationaleSection(unittest.TestCase):
                 ),
             },
         }
-        section = _build_rationale_section(
-            ["src/lib/tests/test_foo.py"], meta,
-        )
+        section = _build_rationale_section(meta)
         self.assertIn("> Owns the foo contract.", section)
         self.assertIn("> Regression class: silent serializer drift.", section)
         self.assertIn("> ROI: highest fan-in (47) on the list.", section)
-
-    def test_dedupes_when_two_tests_map_to_same_source(self):
-        meta = {
-            "src/lib/foo.py": {
-                "file_path": "src/lib/foo.py",
-                "coverage_pct": 10.0, "uncovered_lines": 5,
-                "reason": "covered",
-            },
-        }
-        section = _build_rationale_section(
-            ["src/lib/tests/test_foo.py", "src/lib/tests/test_foo.py"],
-            meta,
-        )
-        self.assertEqual(section.count("**`src/lib/foo.py`**"), 1)
 
     def test_coerces_unexpected_field_types(self):
         # Defensive: a malformed sidecar (string coverage, list uncovered,
@@ -932,9 +1006,7 @@ class TestBuildRationaleSection(unittest.TestCase):
                 "reason": 42,
             },
         }
-        section = _build_rationale_section(
-            ["src/lib/tests/test_foo.py"], meta,
-        )
+        section = _build_rationale_section(meta)
         self.assertIn("**`src/lib/foo.py`**", section)
         self.assertIn("0.0% coverage", section)
         self.assertIn("0 uncovered lines", section)
@@ -948,9 +1020,7 @@ class TestBuildRationaleSection(unittest.TestCase):
                 "reason": "",
             },
         }
-        section = _build_rationale_section(
-            ["src/lib/tests/test_foo.py"], meta,
-        )
+        section = _build_rationale_section(meta)
         self.assertIn("**`src/lib/foo.py`**", section)
         self.assertNotIn("> ", section)
 


### PR DESCRIPTION
## Summary

- Use Stage 2 picker metadata as the authoritative source for PR targets and rationales.
- Reserve filename inference for ad-hoc runs without metadata, and fail when workflow-supplied metadata is missing or invalid.
- Preserve selected-target order, disambiguate basename collisions, and label the PR section as "Targets selected".
- Exclude testbot-only changes from the Local KIND Deployment workflow.

## Root cause

In [PR #1184](https://github.com/NVIDIA/OSMO/pull/1184), the generator organized tests for `src/utils/job/task.py` into a new `test_task_units.py` suite. `create_pr.py` then tried to reverse that generated filename into a source path, inferred a nonexistent `task_units.py`, and therefore could not match the picker metadata containing the real target and its reason.

Generated test filenames are output artifacts, so they cannot reliably encode source identity: one source may have several suites, a suite may cover multiple sources, and semantic suffixes such as `_units` are legitimate.

Issue - None

## Impact

Testbot PR titles, commit subjects, selected-target lists, and target-picking rationales now remain correct for arbitrary test filenames, multiple targets, BUILD wiring changes, and malformed metadata. Future testbot-only changes no longer consume Local KIND deployment capacity.

## Validation

- `bazel test //src/scripts/testbot/tests:test_create_pr`
- `bazel test //src/scripts/testbot/tests:test_create_pr-pylint`
- `bazel test //src/scripts/testbot:testbot-pylint`
- `bazel test //src/scripts/testbot/tests/...`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request summaries now identify selected source targets more clearly, with concise file summaries and rationale details.
  * Target metadata is validated more reliably, with invalid entries skipped and duplicate entries handled consistently.

* **Bug Fixes**
  * Improved fallback behavior when target metadata is unavailable.
  * Prevented the local deployment workflow from running for testbot-only changes.

* **Tests**
  * Expanded coverage for metadata validation, target selection, summaries, rationale rendering, and missing metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->