### PR TITLE
Sync feature/mcp with main before E2E validation

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -55,9 +55,13 @@ See [../README.md](../README.md) for the full two-chart flow.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `global.logs.enabled` | Enable logging | `true` |
+| `global.logs.enabled` | Apply global logging configuration to OSMO service containers | `true` |
 | `global.logs.logLevel` | Log level for application | `DEBUG` |
 | `global.logs.k8sLogLevel` | Log level for Kubernetes | `WARNING` |
+
+OSMO services write logs to stdout for collection by the platform log agent. `osmo-agent` also
+retains backend-forwarded logs in a bounded `/logs` volume; its dedicated logrotate sidecar keeps
+five 10 MiB copies by default.
 
 
 ### Configuration File Settings

--- a/deployments/charts/service/templates/agent-logrotate-config.yaml
+++ b/deployments/charts/service/templates/agent-logrotate-config.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.global.logs.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.services.agent.serviceName }}-logrotate
+  labels:
+    {{- include "osmo.labels" . | nindent 4 }}
+data:
+  logrotate.conf: |
+    /logs/*.txt {
+        su 1001 1001
+        maxsize 10M
+        hourly
+        missingok
+        notifempty
+        rotate 5
+        copytruncate
+    }
+{{- end }}

--- a/deployments/charts/service/templates/agent-logrotate-config.yaml
+++ b/deployments/charts/service/templates/agent-logrotate-config.yaml
@@ -23,7 +23,7 @@ metadata:
 data:
   logrotate.conf: |
     /logs/*.txt {
-        su 1001 1001
+        su root root
         maxsize 10M
         hourly
         missingok

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -211,11 +211,8 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 1001
-          runAsGroup: 1001
+          runAsUser: 0
+          runAsGroup: 0
         command: ["/bin/sh", "-c"]
         args:
         - |

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -203,13 +203,46 @@ spec:
           timeoutSeconds: 20
 
 
+      {{- if .Values.global.logs.enabled }}
+      # TODO: Remove this sidecar when backend-forwarded agent logs can be sent to stdout.
+      # get_backend_logger currently suppresses propagation without a file handler.
+      - name: logrotate
+        image: fluent/fluent-bit:4.0.8-debug
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          runAsNonRoot: true
+          runAsUser: 1001
+          runAsGroup: 1001
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          while true; do
+            logrotate --state /tmp/logrotate.status /etc/osmo-logrotate/logrotate.conf
+            sleep 60
+          done
+        volumeMounts:
+        - name: logs
+          mountPath: /logs
+        - name: agent-logrotate-config
+          mountPath: /etc/osmo-logrotate
+          readOnly: true
+      {{- end }}
       {{- include "osmo.extra-sidecars" .Values.services.agent | nindent 6 }}
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.agent | nindent 8 }}
         {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
         {{- if .Values.global.logs.enabled }}
         - name: logs
-          emptyDir: {}
+          emptyDir:
+            sizeLimit: 256Mi
+        {{- end}}
+        {{- if .Values.global.logs.enabled }}
+        - name: agent-logrotate-config
+          configMap:
+            name: {{ .Values.services.agent.serviceName }}-logrotate
         {{- end}}
         {{- if .Values.services.configFile.enabled}}
         - configMap:

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -139,10 +139,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - api_service
         {{- end }}
         {{- if .Values.services.defaultAdmin.enabled }}
         - --default_admin_username
@@ -194,7 +190,7 @@ spec:
         ports:
         - name: metrics
           containerPort: 9464
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.configs.enabled .Values.services.service.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.service) }}
+        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.service.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.service) }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
@@ -203,10 +199,6 @@ spec:
           subPath: mek.yaml
         {{- end }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
-        {{- end }}
         {{- include "osmo.extra-volume-mounts" .Values.services.service | nindent 8 }}
         {{- include "osmo.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.service) | nindent 8 }}
         resources:
@@ -241,10 +233,6 @@ spec:
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.service | nindent 8 }}
         {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.service) | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- if .Values.services.configFile.enabled}}
         - configMap:
             defaultMode: 420

--- a/deployments/charts/service/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/service/templates/delayed-job-monitor.yaml
@@ -103,10 +103,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - delayed_job_monitor
         {{- end }}
         - --enable_metrics
         {{- range $arg := .Values.services.delayedJobMonitor.extraArgs }}
@@ -132,17 +128,13 @@ spec:
         resources:
         {{- toYaml .Values.services.service.resources | nindent 10 }}
 
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.delayedJobMonitor.extraVolumeMounts }}
+        {{- if or .Values.services.configFile.enabled .Values.services.delayedJobMonitor.extraVolumeMounts .Values.services.delayedJobMonitor.volumeMounts }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
         - mountPath: {{ .Values.services.configFile.path }}
           name: mek-volume
           subPath: mek.yaml
-        {{- end }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
         {{- end }}
         {{- include "osmo.extra-volume-mounts" .Values.services.delayedJobMonitor | nindent 8 }}
         {{- if .Values.services.delayedJobMonitor.volumeMounts }}
@@ -167,10 +159,6 @@ spec:
 
       {{- include "osmo.extra-sidecars" .Values.services.delayedJobMonitor | nindent 6 }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- include "osmo.extra-volumes" .Values.services.delayedJobMonitor | nindent 8 }}
         {{- if .Values.services.configFile.enabled}}
         - configMap:

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -476,10 +476,6 @@ spec:
           {{- end }}
           - "--cache-ttl={{ $gw.authz.cache.ttl }}"
           - "--cache-max-size={{ $gw.authz.cache.maxSize }}"
-          {{- if .Values.global.logs.enabled }}
-          - "--log-dir=/logs"
-          - "--log-name=authz_sidecar"
-          {{- end }}
           {{- with .Values.global.logs.logFormat }}
           - "--log-format={{ . }}"
           {{- end }}
@@ -499,11 +495,8 @@ spec:
                 name: db-secret
                 key: db-password
           {{- end }}
+        {{- if or .Values.services.configs.enabled $gw.authz.extraVolumeMounts }}
         volumeMounts:
-          {{- if .Values.global.logs.enabled }}
-          - name: logs
-            mountPath: /logs
-          {{- end }}
           {{- if .Values.services.configs.enabled }}
           - name: configs
             mountPath: /etc/osmo/configs
@@ -512,6 +505,7 @@ spec:
           {{- with $gw.authz.extraVolumeMounts }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
+        {{- end }}
         {{- with $gw.authz.livenessProbe }}
         livenessProbe:
           {{- toYaml . | nindent 10 }}
@@ -523,10 +517,6 @@ spec:
         resources:
           {{- toYaml $gw.authz.resources | nindent 10 }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end }}
         {{- if .Values.services.configs.enabled }}
         - name: configs
           configMap:

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -116,10 +116,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - logger_service
         {{- end }}
         {{- include "osmo.configmap-args" . | nindent 8 }}
         {{- range $arg := .Values.services.logger.extraArgs }}
@@ -146,7 +142,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.services.logger.imagePullPolicy }}
         ports:
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.configs.enabled .Values.services.logger.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.logger) }}
+        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.logger.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.logger) }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
@@ -155,10 +151,6 @@ spec:
           subPath: mek.yaml
         {{- end }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
-        {{- end }}
         {{- include "osmo.extra-volume-mounts" .Values.services.logger | nindent 8 }}
         {{- include "osmo.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
         resources:
@@ -199,10 +191,6 @@ spec:
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.logger | nindent 8 }}
         {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- if .Values.services.configFile.enabled}}
         - configMap:
             defaultMode: 420

--- a/deployments/charts/service/templates/router-service.yaml
+++ b/deployments/charts/service/templates/router-service.yaml
@@ -110,10 +110,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - router_service
         {{- end }}
         {{- with .Values.services.router.extraArgs }}
         {{- range . }}
@@ -163,16 +159,12 @@ spec:
           protocol: {{ .protocol | default "TCP" }}
         {{- end }}
         {{- end }}
-        {{- if or .Values.global.logs.enabled .Values.services.configFile.enabled .Values.services.router.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.router) }}
+        {{- if or .Values.services.configFile.enabled .Values.services.router.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.router) }}
         volumeMounts:
         {{- if .Values.services.configFile.enabled}}
         - mountPath: {{ .Values.services.configFile.path }}
           name: mek-volume
           subPath: mek.yaml
-        {{- end }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
         {{- end }}
         {{- with .Values.services.router.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
@@ -201,10 +193,6 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- if .Values.services.configFile.enabled}}
         - configMap:
             defaultMode: 420

--- a/deployments/charts/service/templates/ui-service.yaml
+++ b/deployments/charts/service/templates/ui-service.yaml
@@ -116,7 +116,7 @@ spec:
             drop: ["ALL"]
           runAsNonRoot: true
           runAsUser: 1000
-        {{- if or .Values.global.logs.enabled .Values.services.ui.extraVolumeMounts }}
+        {{- if .Values.services.ui.extraVolumeMounts }}
         volumeMounts:
         {{- end }}
         {{- with .Values.services.ui.extraVolumeMounts }}
@@ -242,10 +242,6 @@ spec:
         {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- with .Values.services.ui.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -114,10 +114,6 @@ spec:
         - {{ .Values.global.logs.k8sLogLevel }}
         - --log_format
         - {{ .Values.global.logs.logFormat | default "text" }}
-        - --log_dir
-        - /logs
-        - --log_name
-        - worker
         {{- end }}
         {{- include "osmo.configmap-args" . | nindent 8 }}
         {{- range $arg := .Values.services.worker.extraArgs }}
@@ -145,7 +141,7 @@ spec:
               name: redis-secret
               key: redis-password
         {{- end }}
-        {{- if or .Values.services.configFile.enabled .Values.global.logs.enabled .Values.services.configs.enabled .Values.services.worker.extraVolumeMounts }}
+        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.worker.extraVolumeMounts }}
         volumeMounts:
         {{- end }}
         {{- if .Values.services.configFile.enabled}}
@@ -154,10 +150,6 @@ spec:
           subPath: mek.yaml
         {{- end }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          mountPath: /logs
-        {{- end }}
         {{- include "osmo.extra-volume-mounts" .Values.services.worker | nindent 8 }}
         resources:
         {{- toYaml .Values.services.worker.resources | nindent 10 }}
@@ -181,10 +173,6 @@ spec:
 
       {{- include "osmo.extra-sidecars" .Values.services.worker | nindent 6 }}
       volumes:
-        {{- if .Values.global.logs.enabled }}
-        - name: logs
-          emptyDir: {}
-        {{- end}}
         {{- include "osmo.extra-volumes" .Values.services.worker | nindent 8 }}
         {{- if .Values.services.configFile.enabled}}
         - configMap:

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -56,7 +56,7 @@ global:
   ## Logging configuration for all Osmo services
   ##
   logs:
-    ## Enable centralized logging collection and log volume mounting
+    ## Apply logging configuration to OSMO service containers
     ##
     enabled: true
 

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -162,6 +162,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                                choices=('json', 'text'), default='text',
                                help='Specify the output format type (Default text).')
     submit_parser.add_argument('--set',
+                               action='extend',
+                               dest='set',
                                nargs='+',
                                default=[],
                                help='Assign fields in the workflow file with desired elements '
@@ -170,6 +172,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     ' in the yaml file should be in the form {{ field }}. '
                                     'Values will be cast as int or float if applicable')
     submit_parser.add_argument('--set-string',
+                               action='extend',
                                dest='set_string',
                                nargs='+',
                                default=[],
@@ -179,6 +182,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     ' in the yaml file should be in the form {{ field }}. '
                                     'All values will be cast as string')
     submit_parser.add_argument('--set-env',
+                               action='extend',
                                dest='set_env',
                                nargs='+',
                                default=[],

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -94,6 +94,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                                choices=('json', 'text'), default='text',
                                help='Specify the output format type (Default text).')
     submit_parser.add_argument('--set',
+                               action='extend',
+                               dest='set',
                                nargs='+',
                                default=[],
                                help='Assign fields in the workflow file with desired elements '
@@ -102,6 +104,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     ' in the yaml file should be in the form {{ field }}. '
                                     'Values will be cast as int or float if applicable')
     submit_parser.add_argument('--set-string',
+                               action='extend',
                                dest='set_string',
                                nargs='+',
                                default=[],
@@ -111,6 +114,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     ' in the yaml file should be in the form {{ field }}. '
                                     'All values will be cast as string')
     submit_parser.add_argument('--set-env',
+                               action='extend',
                                dest='set_env',
                                nargs='+',
                                default=[],
@@ -166,6 +170,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                                  type=lambda p: os.path.abspath(p),
                                  help='The workflow file to submit.').complete = shtab.FILE
     validate_parser.add_argument('--set',
+                                 action='extend',
+                                 dest='set',
                                  nargs='+',
                                  default=[],
                                  help='Assign fields in the workflow file with desired elements '
@@ -174,6 +180,7 @@ def setup_parser(parser: argparse._SubParsersAction):
                                       'fields in the yaml file should be in the form {{ field }}. '
                                       'Values will be cast as int or float if applicable')
     validate_parser.add_argument('--set-string',
+                                 action='extend',
                                  dest='set_string',
                                  nargs='+',
                                  default=[],

--- a/test/oetf/main.py
+++ b/test/oetf/main.py
@@ -568,6 +568,7 @@ def _target_from_xml_path(xml_path: str, testlogs_dir: str) -> str:
 
 def render_summary(
     env: Dict[str, str], args: argparse.Namespace, results: List[Dict],
+    bazel_exit: int,
 ) -> str:
     by_status: Dict[str, int] = {"pass": 0, "fail": 0, "error": 0, "skip": 0}
     lines: List[str] = []
@@ -578,6 +579,8 @@ def render_summary(
     if args.name:
         lines.append(f"Name:     {args.name}")
     lines.append(f"Time:     {_now_iso()}")
+    if bazel_exit != 0:
+        lines.append(f"Bazel exit code: {bazel_exit}")
     lines.append("")
     if not results:
         lines.append("(no test results reported by Bazel)")
@@ -604,10 +607,22 @@ def render_summary(
     )
     lines.append("")
     lines.append(
-        "RESULT: PASS" if (by_status["fail"] == 0 and by_status["error"] == 0)
+        "RESULT: PASS" if _run_succeeded(bazel_exit, results)
         else "RESULT: FAIL"
     )
     return "\n".join(lines)
+
+
+def _run_succeeded(bazel_exit: int, results: List[Dict]) -> bool:
+    """Return whether Bazel ran at least one test without a failure."""
+    return (
+        bazel_exit == 0
+        and bool(results)
+        and not any(
+            result["status"] in {"fail", "error"}
+            for result in results
+        )
+    )
 
 
 def _short_label(result: Dict) -> str:
@@ -818,7 +833,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     bazel_exit = proc.returncode
 
     results = parse_bep_test_results(bep_path)
-    print(render_summary(env, args, results))
+    print(render_summary(env, args, results, bazel_exit))
 
     targets = [r["target"] for r in results if r.get("target")]
     maybe_publish_report(args, env, targets)
@@ -827,8 +842,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         write_json(args.output_json, env, args, results)
         print(f"Results JSON written to {args.output_json}", file=sys.stderr)
 
-    failed_or_errored = any(r["status"] in {"fail", "error"} for r in results)
-    return 1 if (bazel_exit != 0 or failed_or_errored) else 0
+    return 0 if _run_succeeded(bazel_exit, results) else 1
 
 
 def _bep_path() -> str:

--- a/test/oetf/tests/BUILD
+++ b/test/oetf/tests/BUILD
@@ -147,5 +147,12 @@ osmo_py_test(
     deps = ["//test/oetf:run_lib"],
 )
 
+osmo_py_test(
+    name = "test_main",
+    srcs = ["test_main.py"],
+    deps = ["//test/oetf:run_lib"],
+    tags = ["manual"],
+)
+
 # test_dev_adapter stays internal — dev_adapter.py is not shipped in the public
 # OETF distribution; the internal overlay package owns its tests.

--- a/test/oetf/tests/test_main.py
+++ b/test/oetf/tests/test_main.py
@@ -1,0 +1,117 @@
+"""
+Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+NVIDIA CORPORATION and its licensors retain all intellectual property
+and proprietary rights in and to this software, related documentation
+and any modifications thereto. Any use, reproduction, disclosure or
+distribution of this software and related documentation without an express
+license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""
+
+import argparse
+from contextlib import redirect_stdout
+import io
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from test.oetf import main as oetf_main
+
+
+class MainResultContractTest(unittest.TestCase):
+    """The OETF wrapper fails closed when Bazel does not run its tests."""
+
+    @staticmethod
+    def _result(status: str = "pass") -> dict:
+        return {
+            "target": "//test:target",
+            "classname": "",
+            "name": "target",
+            "time": 0.1,
+            "status": status,
+            "message": "",
+        }
+
+    @staticmethod
+    def _run_main(
+        bazel_exit: int,
+        results: list[dict],
+    ) -> tuple[int, str]:
+        args = argparse.Namespace(
+            env="staging",
+            name="profile-round-trip",
+            output_json="",
+            tags="",
+        )
+        env = {
+            "auth_token": "test-token",
+            "url": "https://staging.example",
+        }
+        stdout = io.StringIO()
+        with mock.patch.object(oetf_main, "parse_args", return_value=args), \
+             mock.patch.object(oetf_main, "resolve_env", return_value=env), \
+             mock.patch.object(oetf_main, "seed_data_credential"), \
+             mock.patch.object(oetf_main, "_bep_path", return_value="/tmp/bep.json"), \
+             mock.patch.object(
+                 oetf_main,
+                 "build_bazel_command",
+                 return_value=["bazel", "test", "//test:target"],
+             ), \
+             mock.patch.object(
+                 oetf_main.subprocess,
+                 "run",
+                 return_value=SimpleNamespace(returncode=bazel_exit),
+             ), \
+             mock.patch.object(
+                 oetf_main,
+                 "parse_bep_test_results",
+                 return_value=results,
+             ), \
+             mock.patch.object(oetf_main, "maybe_publish_report"), \
+             redirect_stdout(stdout):
+            exit_code = oetf_main.main([])
+        return exit_code, stdout.getvalue()
+
+    def test_analysis_failure_with_no_results_reports_fail(self):
+        exit_code, output = self._run_main(1, [])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Bazel exit code: 1", output)
+        self.assertIn("(no test results reported by Bazel)", output)
+        self.assertIn("RESULT: FAIL", output)
+        self.assertNotIn("RESULT: PASS", output)
+
+    def test_zero_results_fail_closed_when_bazel_exits_zero(self):
+        exit_code, output = self._run_main(0, [])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("RESULT: FAIL", output)
+
+    def test_nonzero_bazel_exit_overrides_passing_test_result(self):
+        exit_code, output = self._run_main(1, [self._result()])
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Bazel exit code: 1", output)
+        self.assertIn("RESULT: FAIL", output)
+
+    def test_failed_or_errored_result_reports_fail(self):
+        for status in ("fail", "error"):
+            with self.subTest(status=status):
+                exit_code, output = self._run_main(
+                    0,
+                    [self._result(status)],
+                )
+
+                self.assertEqual(exit_code, 1)
+                self.assertIn("RESULT: FAIL", output)
+                self.assertNotIn("RESULT: PASS", output)
+
+    def test_successful_bazel_run_with_passing_result_reports_pass(self):
+        exit_code, output = self._run_main(0, [self._result()])
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("RESULT: PASS", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Synchronizes the current `main` branch into `feature/mcp` after the MCP Phases B-D stack was completed.

This brings the feature branch forward with the four changes that landed on `main` after the previous sync:

- extensible CLI set flags (#1192);
- bounded agent file-log retention (#1195);
- log-rotation permission fixes (#1197); and
- fail-closed OETF result reporting (#1191).

This PR adds no new MCP product behavior. It preserves the completed profile-tool implementation while incorporating newer `main` fixes and the corrected OETF pass/fail contract.

After this sync, `feature/mcp` can be validated through the focused OETF round trip before additional tools are added.

## Validation

- MCP production dependency graph:
  `bazel build //src/service/mcp:mcp_binary`
- Focused OETF runner validation (3 targets passed):
  `bazel test --test_output=errors //test/oetf:run_lib-pylint //test/oetf/tests:test_main //test/oetf/tests:test_main-pylint`
- MCP-disabled/enabled Helm lint and positive/negative render validation:
  `bash deployments/charts/service/ci/validate-mcp-chart.sh`
- `git diff --check origin/feature/mcp...HEAD`

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
