### PR TITLE
Harden external MCP runtime foundation

### DIFF
--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -33,12 +33,76 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "request_body",
+    srcs = ["request_body.py"],
+    deps = [
+        requirement("starlette"),
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "gateway",
     srcs = ["gateway.py"],
     deps = [
         requirement("httpx"),
         ":request_context",
+        ":telemetry",
         "//src/lib/utils:login",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "telemetry",
+    srcs = ["telemetry.py"],
+    deps = [
+        ":request_context",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "tool_errors",
+    srcs = ["tool_errors.py"],
+    deps = [
+        requirement("mcp"),
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "tool_validation",
+    srcs = ["tool_validation.py"],
+    deps = [
+        requirement("pydantic"),
+        ":tool_errors",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "tool_requests",
+    srcs = ["tool_requests.py"],
+    deps = [
+        requirement("mcp"),
+        requirement("pydantic"),
+        requirement("starlette"),
+        ":gateway",
+        ":request_context",
+        ":tool_errors",
+        "//src/lib/api:profile",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "access_scope",
+    srcs = ["access_scope.py"],
+    deps = [
+        requirement("mcp"),
+        ":tool_requests",
+        ":tool_validation",
     ],
     visibility = ["//visibility:public"],
 )
@@ -49,10 +113,29 @@ osmo_py_library(
     deps = [
         requirement("mcp"),
         requirement("pydantic"),
-        requirement("starlette"),
-        ":gateway",
-        ":request_context",
-        "//src/lib/api:profile",
+        ":access_scope",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "health_tools",
+    srcs = ["health.py"],
+    deps = [
+        requirement("mcp"),
+        requirement("pydantic"),
+        ":access_scope",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "tool_registry",
+    srcs = ["tool_registry.py"],
+    deps = [
+        requirement("mcp"),
+        ":health_tools",
+        ":profile_tools",
     ],
     visibility = ["//visibility:public"],
 )
@@ -64,6 +147,8 @@ osmo_py_library(
         requirement("mcp"),
         requirement("pydantic"),
         ":request_context",
+        ":telemetry",
+        ":tool_errors",
     ],
     visibility = ["//visibility:public"],
 )
@@ -78,9 +163,11 @@ osmo_py_library(
         requirement("starlette"),
         requirement("uvicorn"),
         ":gateway",
-        ":profile_tools",
         ":protocol",
+        ":request_body",
         ":request_context",
+        ":tool_registry",
+        "//src/lib/utils:logging",
         "//src/utils:ssl_config",
         "//src/utils:static_config",
     ],

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -54,12 +54,20 @@ The relay boundary has these invariants:
 - MCP does not exchange, refresh, modify, cache, persist, log, or return the
   bearer token. It clears request context and upstream cookies on completion,
   failure, timeout, or cancellation.
+- The `/mcp` request body is counted while streaming and rejected above 1 MiB,
+  whether its size is declared or sent with chunked transfer encoding. Body
+  collection has a 10-second deadline, and each process admits at most 16
+  in-flight MCP requests so aggregate request memory remains bounded. This
+  stateless JSON deployment accepts `POST /mcp` only; other methods return 405
+  rather than opening long-lived streams outside that admission boundary.
 - Outbound calls have a total timeout, bounded response size, identity content
-  encoding, no redirects, and no automatic retries. Upstream error bodies are
-  discarded.
+  encoding, no redirects, and no automatic retries.
 - Receiving APIs remain authoritative for API-specific authorization,
-  validation, and side effects. MCP returns bounded tool errors that can
-  identify a safe upstream HTTP status and never include the upstream body.
+  validation, and side effects. MCP reads upstream error bodies under a
+  separate small ceiling and preserves only error codes from a static Core
+  contract for correctable client errors. Free-form messages, workflow IDs,
+  validation locations, and unknown fields are discarded. Other upstream
+  failures remain generic.
 
 The Gateway, MCP process, receiving OSMO APIs, and applicable middleware are
 inside the bearer-token handling boundary. None of them may log or persist the

--- a/src/service/mcp/access_scope.py
+++ b/src/service/mcp/access_scope.py
@@ -1,0 +1,70 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import dataclasses
+
+from mcp.server.fastmcp import Context
+
+from src.service.mcp import tool_requests, tool_validation
+
+
+_MAX_POOL_NAME_BYTES = 512
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AccessScope:
+    """Validated profile plus stable ordered and membership pool views."""
+
+    profile: tool_requests.ActiveProfile
+    pools: tuple[str, ...]
+    pool_names: frozenset[str]
+
+    @property
+    def default_pool(self) -> str | None:
+        """Return the configured default only when it remains accessible."""
+        default_pool = self.profile.profile.pool
+        if default_pool and default_pool in self.pool_names:
+            return default_pool
+        return None
+
+    @property
+    def empty(self) -> bool:
+        """Whether the caller has no accessible pools."""
+        return not self.pools
+
+
+def from_profile(profile: tool_requests.ActiveProfile) -> AccessScope:
+    """Build an ordered, de-duplicated pool scope from a validated profile."""
+    pools = tuple(dict.fromkeys(
+        tool_validation.validate_query_text(
+            pool,
+            field='accessible pool',
+            max_bytes=_MAX_POOL_NAME_BYTES,
+        )
+        for pool in profile.pools
+    ))
+    return AccessScope(
+        profile=profile,
+        pools=pools,
+        pool_names=frozenset(pools),
+    )
+
+
+async def request_access_scope(context: Context) -> AccessScope:
+    """Read the active profile once and derive its ordered pool scope."""
+    return from_profile(await tool_requests.request_active_profile(context))

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -17,26 +17,37 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping, Sequence
 import contextlib
 import dataclasses
 import math
+import re
+import time
+from typing import TypeAlias
 from urllib import parse
 
 import httpx
 
 from src.lib.utils import login
-from src.service.mcp import request_context
+from src.service.mcp import request_context, telemetry
 
 
 _ALLOWED_METHODS = frozenset(('GET', 'POST', 'PATCH', 'DELETE'))
 _USER_AGENT = 'osmo-mcp'
 _IDENTITY_ENCODING = 'identity'
+_QUERY_KEY = re.compile(r'[A-Za-z][A-Za-z0-9_]*')
+_MAX_QUERY_BYTES = 16 * 1024
+_MAX_ERROR_RESPONSE_BYTES = 16 * 1024
 _HTTP_LIMITS = httpx.Limits(
     max_connections=100,
     max_keepalive_connections=20,
     keepalive_expiry=30,
 )
+
+
+QueryScalar: TypeAlias = str | int | bool
+QueryValue: TypeAlias = QueryScalar | Sequence[QueryScalar]
+QueryParams: TypeAlias = Mapping[str, QueryValue]
 
 
 class GatewayClientError(RuntimeError):
@@ -49,6 +60,11 @@ class GatewayResponse:
 
     status_code: int
     body: bytes = dataclasses.field(repr=False)
+    body_truncated: bool = False
+    truncation_reason: str | None = None
+
+
+_RESPONSE_SIZE_LIMIT = 'response_size_limit'
 
 
 class GatewayClient:
@@ -70,6 +86,46 @@ class GatewayClient:
         *,
         credentials: request_context.RequestCredentials,
         max_response_bytes: int,
+        query: QueryParams | None = None,
+    ) -> GatewayResponse:
+        """Call a fixed API path and require its 2xx response body to fit."""
+        return await self._request(
+            method,
+            path,
+            credentials=credentials,
+            max_response_bytes=max_response_bytes,
+            query=query,
+            truncate_success=False,
+        )
+
+    async def request_text_prefix(
+        self,
+        method: str,
+        path: str,
+        *,
+        credentials: request_context.RequestCredentials,
+        max_response_bytes: int,
+        query: QueryParams | None = None,
+    ) -> GatewayResponse:
+        """Return a bounded prefix from one fixed API path's 2xx response."""
+        return await self._request(
+            method,
+            path,
+            credentials=credentials,
+            max_response_bytes=max_response_bytes,
+            query=query,
+            truncate_success=True,
+        )
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        credentials: request_context.RequestCredentials,
+        max_response_bytes: int,
+        query: QueryParams | None,
+        truncate_success: bool,
     ) -> GatewayResponse:
         """Call a fixed API path with credentials from the active MCP request."""
         if method not in _ALLOWED_METHODS:
@@ -77,6 +133,12 @@ class GatewayClient:
         _validate_api_path(path)
         if max_response_bytes < 1:
             raise ValueError('max_response_bytes must be positive.')
+        if request_context.request_id_overlaps_bearer(
+            credentials.authorization_header,
+            credentials.request_id,
+        ):
+            raise ValueError('Gateway request credentials are invalid.')
+        encoded_query = _encode_query_params(query)
 
         headers = {
             login.OSMO_AUTH_HEADER: credentials.authorization_header,
@@ -86,47 +148,97 @@ class GatewayClient:
         if credentials.request_id is not None:
             headers[request_context.REQUEST_ID_HEADER] = credentials.request_id
 
-        request = self._client.build_request(method, path, headers=headers)
+        request = self._client.build_request(
+            method,
+            path,
+            headers=headers,
+            params=encoded_query,
+        )
         # HTTPX stores response cookies on the process-wide client. Never let
         # that shared state become credentials on a later caller's request.
         request.headers.pop('cookie', None)
 
+        start_time = time.monotonic()
+        status_code: int | None = None
+        outcome = 'transport_error'
         try:
-            async with asyncio.timeout(self._request_timeout_seconds):
-                response = await self._client.send(request, stream=True)
-                try:
-                    if 300 <= response.status_code < 400:
-                        raise GatewayClientError(
-                            'OSMO Gateway returned an unsafe redirect.')
-                    if not response.is_success:
-                        return GatewayResponse(response.status_code, b'')
-
-                    if response.headers.get(
-                        'content-encoding', _IDENTITY_ENCODING
-                    ).lower() != _IDENTITY_ENCODING:
-                        raise GatewayClientError(
-                            'OSMO Gateway returned an invalid response.')
-                    _validate_content_length(response, max_response_bytes)
-                    response_body = bytearray()
-                    async for chunk in response.aiter_bytes():
-                        if len(response_body) + len(chunk) > max_response_bytes:
+            try:
+                async with asyncio.timeout(self._request_timeout_seconds):
+                    response = await self._client.send(request, stream=True)
+                    status_code = response.status_code
+                    outcome = 'invalid_response'
+                    try:
+                        if 300 <= response.status_code < 400:
                             raise GatewayClientError(
-                                'OSMO Gateway response exceeds the size limit.')
-                        response_body.extend(chunk)
-                finally:
-                    await response.aclose()
-        except (TimeoutError, httpx.RequestError):
-            raise GatewayClientError('OSMO Gateway is unavailable.') from None
+                                'OSMO Gateway returned an unsafe redirect.')
+                        if response.headers.get(
+                            'content-encoding', _IDENTITY_ENCODING
+                        ).lower() != _IDENTITY_ENCODING:
+                            raise GatewayClientError(
+                                'OSMO Gateway returned an invalid response.')
+
+                        if not response.is_success:
+                            response_body, body_truncated = (
+                                await _read_bounded_prefix(
+                                    response,
+                                    _MAX_ERROR_RESPONSE_BYTES,
+                                )
+                            )
+                            outcome = 'upstream_error'
+                        elif truncate_success:
+                            response_body, body_truncated = (
+                                await _read_bounded_prefix(
+                                    response,
+                                    max_response_bytes,
+                                )
+                            )
+                            outcome = (
+                                'response_truncated'
+                                if body_truncated
+                                else 'response_received'
+                            )
+                        else:
+                            response_body = await _read_strict_body(
+                                response,
+                                max_response_bytes,
+                            )
+                            body_truncated = False
+                            outcome = 'response_received'
+                    finally:
+                        await response.aclose()
+            except (TimeoutError, httpx.RequestError):
+                outcome = 'transport_error'
+                raise GatewayClientError(
+                    'OSMO Gateway is unavailable.') from None
+
+            if _contains_relayed_credentials(
+                response_body,
+                credentials,
+                include_partial_suffix=body_truncated,
+            ):
+                outcome = 'invalid_response'
+                raise GatewayClientError(
+                    'OSMO Gateway returned an invalid response.')
+            return GatewayResponse(
+                response.status_code,
+                response_body,
+                body_truncated=body_truncated,
+                truncation_reason=(
+                    _RESPONSE_SIZE_LIMIT if body_truncated else None
+                ),
+            )
         finally:
             # Set-Cookie is upstream response data, never caller-independent
             # client state. Clear it even when streaming or decoding fails.
             self._client.cookies.clear()
-
-        response_body_bytes = bytes(response_body)
-        if _contains_relayed_credentials(response_body_bytes, credentials):
-            raise GatewayClientError(
-                'OSMO Gateway returned an invalid response.')
-        return GatewayResponse(response.status_code, response_body_bytes)
+            telemetry.log_upstream_call(
+                method=method,
+                path=path,
+                status_code=status_code,
+                duration_ms=(time.monotonic() - start_time) * 1000,
+                outcome=outcome,
+                request_id=credentials.request_id,
+            )
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -218,6 +330,7 @@ def _validate_api_path(path: str) -> None:
     if (
         not decoded_path.startswith('/api/')
         or '//' in decoded_path
+        or decoded_path.count('/') != parsed_path.path.count('/')
         or '\\' in decoded_path
         or any(
             ord(character) < 0x20 or ord(character) == 0x7F
@@ -228,13 +341,66 @@ def _validate_api_path(path: str) -> None:
         raise ValueError('Gateway requests require a relative OSMO API path.')
 
 
+def _encode_query_params(
+    query: QueryParams | None,
+) -> httpx.QueryParams | None:
+    """Validate and encode caller-independent query names and typed values."""
+    if query is None:
+        return None
+    if not isinstance(query, Mapping):
+        raise ValueError('Gateway query parameters must be a mapping.')
+
+    encoded: list[tuple[str, str | int | float | bool | None]] = []
+    for key, raw_value in query.items():
+        if not isinstance(key, str) or _QUERY_KEY.fullmatch(key) is None:
+            raise ValueError('Gateway query parameter name is not allowed.')
+        values: Sequence[QueryScalar]
+        if isinstance(raw_value, (str, int, bool)):
+            values = (raw_value,)
+        elif isinstance(raw_value, Sequence) and not isinstance(
+            raw_value, (bytes, bytearray)
+        ):
+            values = raw_value
+        else:
+            raise ValueError('Gateway query parameter value is not allowed.')
+
+        for value in values:
+            if not isinstance(value, (str, int, bool)):
+                raise ValueError('Gateway query parameter value is not allowed.')
+            normalized = str(value).lower() if isinstance(value, bool) else str(value)
+            try:
+                normalized.encode('utf-8')
+            except UnicodeEncodeError:
+                raise ValueError(
+                    'Gateway query parameter value is not allowed.'
+                ) from None
+            if any(
+                ord(character) < 0x20 or ord(character) == 0x7F
+                for character in normalized
+            ):
+                raise ValueError('Gateway query parameter value is not allowed.')
+            encoded.append((key, normalized))
+
+    if len(parse.urlencode(encoded).encode('ascii')) > _MAX_QUERY_BYTES:
+        raise ValueError('Gateway query parameters exceed the size limit.')
+    return httpx.QueryParams(encoded)
+
+
 def _validate_content_length(
     response: httpx.Response,
     max_response_bytes: int,
 ) -> None:
+    content_length = _content_length(response)
+    if content_length is not None and content_length > max_response_bytes:
+        raise GatewayClientError(
+            'OSMO Gateway response exceeds the size limit.')
+
+
+def _content_length(response: httpx.Response) -> int | None:
+    """Parse a Content-Length header without trusting it as the actual size."""
     content_length_header = response.headers.get('content-length')
     if content_length_header is None:
-        return
+        return None
     try:
         content_length = int(content_length_header)
     except ValueError:
@@ -242,22 +408,75 @@ def _validate_content_length(
             'OSMO Gateway returned an invalid response.') from None
     if content_length < 0:
         raise GatewayClientError('OSMO Gateway returned an invalid response.')
-    if content_length > max_response_bytes:
-        raise GatewayClientError(
-            'OSMO Gateway response exceeds the size limit.')
+    return content_length
+
+
+async def _read_strict_body(
+    response: httpx.Response,
+    max_response_bytes: int,
+) -> bytes:
+    """Read a whole successful body or fail closed when it is oversized."""
+    _validate_content_length(response, max_response_bytes)
+    response_body = bytearray()
+    async for chunk in response.aiter_bytes():
+        if len(response_body) + len(chunk) > max_response_bytes:
+            raise GatewayClientError(
+                'OSMO Gateway response exceeds the size limit.')
+        response_body.extend(chunk)
+    return bytes(response_body)
+
+
+async def _read_bounded_prefix(
+    response: httpx.Response,
+    max_response_bytes: int,
+) -> tuple[bytes, bool]:
+    """Read at most one prefix and report whether more response bytes exist."""
+    content_length = _content_length(response)
+    body_truncated = (
+        content_length is not None and content_length > max_response_bytes
+    )
+    response_body = bytearray()
+    async for chunk in response.aiter_bytes():
+        remaining = max_response_bytes - len(response_body)
+        if len(chunk) > remaining:
+            response_body.extend(chunk[:remaining])
+            body_truncated = True
+            break
+        response_body.extend(chunk)
+        if len(response_body) == max_response_bytes and body_truncated:
+            break
+    return bytes(response_body), body_truncated
 
 
 def _contains_relayed_credentials(
     response_body: bytes,
     credentials: request_context.RequestCredentials,
+    *,
+    include_partial_suffix: bool = False,
 ) -> bool:
     authorization_header = credentials.authorization_header.encode('ascii')
     _, _, bearer_token = authorization_header.partition(b' ')
-    return (
+    if (
         authorization_header in response_body
         or (
             len(bearer_token)
             >= request_context.MIN_BEARER_TOKEN_SUBSTRING_BYTES
             and bearer_token in response_body
         )
-    )
+    ):
+        return True
+
+    if not include_partial_suffix:
+        return False
+    # A size boundary can split a reflected credential. Reject a meaningful
+    # prefix of either relayed secret instead of returning that partial secret to
+    # the MCP caller. Checking one fixed prefix keeps this linear even when the
+    # request contains the maximum-sized bearer token.
+    for secret in (authorization_header, bearer_token):
+        if (
+            len(secret) >= request_context.MIN_BEARER_TOKEN_SUBSTRING_BYTES
+            and secret[:request_context.MIN_BEARER_TOKEN_SUBSTRING_BYTES]
+            in response_body
+        ):
+            return True
+    return False

--- a/src/service/mcp/health.py
+++ b/src/service/mcp/health.py
@@ -1,0 +1,38 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Literal
+
+from mcp.server.fastmcp import Context
+import pydantic
+
+from src.service.mcp import access_scope
+
+
+class HealthResult(pydantic.BaseModel):
+    """Caller-bound OSMO API health result."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    status: Literal['healthy']
+
+
+async def osmo_health(context: Context) -> HealthResult:
+    """Verify that the active caller can reach and authenticate to OSMO."""
+    await access_scope.request_access_scope(context)
+    return HealthResult(status='healthy')

--- a/src/service/mcp/profile.py
+++ b/src/service/mcp/profile.py
@@ -16,97 +16,51 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
+import datetime
+
+from mcp.server.fastmcp import Context
 import pydantic
-from starlette.requests import Request
 
-from src.lib.api import profile as profile_contract
-from src.service.mcp import gateway, request_context
+from src.service.mcp import access_scope
 
 
-_PROFILE_PATH = '/api/profile/settings'
-_MAX_PROFILE_RESPONSE_BYTES = 64 * 1024
+class ProfileSettings(pydantic.BaseModel):
+    """Allowlisted active-user settings."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    username: str | None = None
+    email_notification: bool | None = None
+    slack_notification: bool | None = None
+    pool: str | None = None
 
 
-async def osmo_get_profile(context: Context) -> profile_contract.ProfileResponse:
+class TokenIdentity(pydantic.BaseModel):
+    """Non-secret identity metadata for the active access token."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    name: str
+    expires_at: datetime.datetime | None = None
+
+
+class ProfileResult(pydantic.BaseModel):
+    """Closed, allowlisted projection of the active OSMO profile."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    profile: ProfileSettings
+    roles: list[str]
+    pools: list[str]
+    token: TokenIdentity | None = None
+
+
+async def osmo_get_profile(context: Context) -> ProfileResult:
     """Get the active user's OSMO profile, roles, and accessible pools."""
-    app_context = _get_app_context(context)
-    try:
-        credentials = request_context.get_request_credentials()
-    except RuntimeError:
-        raise ToolError(
-            'MCP request authentication context is unavailable.') from None
-
-    try:
-        response = await app_context.gateway.request(
-            'GET',
-            _PROFILE_PATH,
-            credentials=credentials,
-            max_response_bytes=_MAX_PROFILE_RESPONSE_BYTES,
-        )
-    except gateway.GatewayClientError as error:
-        raise ToolError(str(error)) from None
-
-    if response.status_code != 200:
-        raise ToolError(_profile_error(response.status_code))
-
-    try:
-        return profile_contract.ProfileResponse.model_validate_json(
-            response.body,
-            strict=True,
-        )
-    except pydantic.ValidationError:
-        raise ToolError('OSMO returned an invalid profile response.') from None
-
-
-def register_tools(server: FastMCP) -> None:
-    """Register profile tools on one FastMCP server instance."""
-    server.add_tool(
-        osmo_get_profile,
-        name='osmo_get_profile',
-        title='Get OSMO profile',
-        description=(
-            'Get the active user\'s OSMO profile settings, roles, accessible '
-            'pools, and non-secret token identity metadata.'
-        ),
-        annotations=ToolAnnotations(
-            readOnlyHint=True,
-            destructiveHint=False,
-            idempotentHint=True,
-            openWorldHint=False,
-        ),
-        structured_output=True,
+    active_profile = (
+        await access_scope.request_access_scope(context)
+    ).profile
+    return ProfileResult.model_validate(
+        active_profile.model_dump(),
+        strict=True,
     )
-
-
-def _get_app_context(context: Context) -> gateway.AppContext:
-    try:
-        request = context.request_context.request
-    except ValueError:
-        raise ToolError('MCP runtime context is unavailable.') from None
-    if not isinstance(request, Request):
-        raise ToolError('MCP runtime context is unavailable.')
-
-    try:
-        app_context = request.app.state.mcp_app_context
-    except (AttributeError, KeyError):
-        raise ToolError('MCP runtime context is unavailable.') from None
-    if not isinstance(app_context, gateway.AppContext):
-        raise ToolError('MCP runtime context is unavailable.')
-    return app_context
-
-
-def _profile_error(status_code: int) -> str:
-    if status_code == 401:
-        message = 'OSMO rejected the active authentication'
-    elif status_code == 403:
-        message = 'OSMO authorization denied profile access'
-    elif status_code == 429:
-        message = 'OSMO profile access is rate limited'
-    elif 500 <= status_code < 600:
-        message = 'OSMO profile service is unavailable'
-    else:
-        message = 'OSMO profile request failed'
-    return f'{message} (HTTP {status_code}).'

--- a/src/service/mcp/protocol.py
+++ b/src/service/mcp/protocol.py
@@ -17,6 +17,8 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 from collections.abc import Mapping, Sequence
+import json
+import time
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -25,7 +27,10 @@ from mcp.types import ContentBlock
 from mcp.types import Tool as MCPTool
 import pydantic
 
-from src.service.mcp import request_context
+from src.service.mcp import request_context, telemetry, tool_errors
+
+
+_MAX_SERIALIZED_TOOL_RESULT_BYTES = 512 * 1024
 
 
 class OSMOFastMCP(FastMCP):
@@ -42,35 +47,98 @@ class OSMOFastMCP(FastMCP):
         name: str,
         arguments: dict[str, Any],
     ) -> Sequence[ContentBlock] | dict[str, Any]:
-        tools_by_name = {
-            tool.name: tool
-            for tool in await super().list_tools()
-        }
-        tool = tools_by_name.get(name)
-        if tool is None:
-            raise ToolError('Unknown MCP tool.')
-
-        allowed_arguments = set(tool.inputSchema.get('properties', {}))
-        if not arguments.keys() <= allowed_arguments:
-            raise ToolError('Invalid MCP tool arguments.')
-
+        start_time = time.monotonic()
+        telemetry_tool_name = 'unknown'
+        request_id: str | None = None
+        outcome = 'unexpected_error'
         try:
-            with request_context.track_request_task() as credentials:
+            request_id = (
+                request_context.get_request_credentials().request_id
+            )
+            tools_by_name = {
+                tool.name: tool
+                for tool in await super().list_tools()
+            }
+            tool = tools_by_name.get(name)
+            if tool is None:
+                outcome = 'public_error'
+                raise tool_errors.PublicToolError('Unknown MCP tool.')
+            telemetry_tool_name = tool.name
+
+            allowed_arguments = set(tool.inputSchema.get('properties', {}))
+            if not arguments.keys() <= allowed_arguments:
+                outcome = 'validation_error'
+                raise tool_errors.PublicToolError(
+                    'Invalid MCP tool arguments.'
+                )
+
+            with (
+                request_context.track_request_task() as credentials,
+                request_context.track_tool(telemetry_tool_name),
+            ):
+                if _contains_relayed_credentials(arguments, credentials):
+                    outcome = 'validation_error'
+                    raise tool_errors.PublicToolError(
+                        'MCP tool arguments are invalid.'
+                    )
                 try:
                     result = await super().call_tool(name, arguments)
                 except ToolError as error:
                     if isinstance(error.__cause__, pydantic.ValidationError):
-                        raise ToolError('MCP tool validation failed.') from None
-                    if _contains_relayed_credentials(str(error), credentials):
-                        raise ToolError('MCP tool failed.') from None
-                    raise
+                        outcome = 'validation_error'
+                        raise tool_errors.PublicToolError(
+                            'MCP tool validation failed.'
+                        ) from None
+                    public_error = tool_errors.from_fastmcp_error(error)
+                    if public_error is None:
+                        outcome = 'unexpected_error'
+                        raise tool_errors.PublicToolError(
+                            tool_errors.GENERIC_TOOL_ERROR
+                        ) from None
+                    if _contains_relayed_credentials(
+                        str(public_error),
+                        credentials,
+                    ):
+                        outcome = 'unexpected_error'
+                        raise tool_errors.PublicToolError(
+                            tool_errors.GENERIC_TOOL_ERROR
+                        ) from None
+                    outcome = 'public_error'
+                    raise public_error from None
 
+                outcome = 'invalid_result'
                 if _contains_relayed_credentials(result, credentials):
-                    raise ToolError('MCP tool returned an invalid response.')
+                    raise tool_errors.PublicToolError(
+                        'MCP tool returned an invalid response.'
+                    )
+                if _serialized_size(result) > _MAX_SERIALIZED_TOOL_RESULT_BYTES:
+                    raise tool_errors.PublicToolError(
+                        'MCP tool result exceeds the size limit.'
+                    )
+                outcome = 'success'
                 return result
+        except tool_errors.PublicToolError:
+            raise
         except request_context.RequestContextUnavailable:
-            raise ToolError(
+            outcome = 'context_error'
+            raise tool_errors.PublicToolError(
                 'MCP request authentication context is unavailable.') from None
+        except Exception:
+            outcome = 'unexpected_error'
+            raise tool_errors.PublicToolError(
+                tool_errors.GENERIC_TOOL_ERROR
+            ) from None
+        finally:
+            # Observability must never replace the sanitized MCP result.
+            try:
+                telemetry.log_tool_outcome(
+                    tool_name=telemetry_tool_name,
+                    outcome=outcome,
+                    duration_ms=(time.monotonic() - start_time) * 1000,
+                    request_id=request_id,
+                )
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
 
 
 def _contains_relayed_credentials(
@@ -129,3 +197,35 @@ def _contains_sensitive_value(
             for item in value
         )
     return False
+
+
+def _serialized_size(value: object) -> int:
+    """Measure the JSON form handed to MCP before transport-level duplication."""
+    try:
+        payload = json.dumps(
+            _json_safe(value),
+            ensure_ascii=False,
+            separators=(',', ':'),
+        ).encode('utf-8')
+    except (TypeError, ValueError, UnicodeError):
+        raise tool_errors.PublicToolError(
+            'MCP tool returned an invalid response.'
+        ) from None
+    return len(payload)
+
+
+def _json_safe(value: object) -> object:
+    if isinstance(value, pydantic.BaseModel):
+        return _json_safe(value.model_dump(mode='json', by_alias=True))
+    if isinstance(value, Mapping):
+        return {
+            str(key): _json_safe(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, bytes):
+        return value.decode('utf-8', errors='strict')
+    if isinstance(value, bytearray):
+        return bytes(value).decode('utf-8', errors='strict')
+    return value

--- a/src/service/mcp/request_body.py
+++ b/src/service/mcp/request_body.py
@@ -16,20 +16,37 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import asyncio
+
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 
 MAX_MCP_REQUEST_BODY_BYTES = 1024 * 1024
+MAX_CONCURRENT_MCP_REQUESTS = 16
+MCP_REQUEST_BODY_TIMEOUT_SECONDS = 10
 
 _CONTENT_LENGTH_HEADER = b'content-length'
 _REQUEST_TOO_LARGE = {
     'error': 'MCP request body exceeds the 1 MiB limit.',
 }
+_REQUEST_BODY_TIMEOUT = {
+    'error': 'MCP request body timed out.',
+}
+_REQUEST_CAPACITY_EXCEEDED = {
+    'error': 'MCP service is temporarily at capacity.',
+}
+_METHOD_NOT_ALLOWED = {
+    'error': 'MCP accepts POST requests only.',
+}
+
+
+class _RequestBodyTooLarge(Exception):
+    """Internal fixed signal for a streamed request-body overflow."""
 
 
 class RequestBodyLimitMiddleware:
-    """Enforce a bounded request body for one ASGI HTTP path."""
+    """Bound POST body size, read time, and in-flight work for one path."""
 
     def __init__(
         self,
@@ -37,6 +54,8 @@ class RequestBodyLimitMiddleware:
         *,
         path: str = '/mcp',
         max_body_bytes: int = MAX_MCP_REQUEST_BODY_BYTES,
+        max_concurrent_requests: int = MAX_CONCURRENT_MCP_REQUESTS,
+        body_timeout_seconds: float = MCP_REQUEST_BODY_TIMEOUT_SECONDS,
     ) -> None:
         if (
             isinstance(max_body_bytes, bool)
@@ -44,9 +63,26 @@ class RequestBodyLimitMiddleware:
             or max_body_bytes < 1
         ):
             raise ValueError('max_body_bytes must be a positive integer.')
+        if (
+            isinstance(max_concurrent_requests, bool)
+            or not isinstance(max_concurrent_requests, int)
+            or max_concurrent_requests < 1
+        ):
+            raise ValueError(
+                'max_concurrent_requests must be a positive integer.'
+            )
+        if (
+            isinstance(body_timeout_seconds, bool)
+            or not isinstance(body_timeout_seconds, (int, float))
+            or body_timeout_seconds <= 0
+        ):
+            raise ValueError('body_timeout_seconds must be positive.')
         self._application = application
         self._path = path
         self._max_body_bytes = max_body_bytes
+        self._max_concurrent_requests = max_concurrent_requests
+        self._body_timeout_seconds = float(body_timeout_seconds)
+        self._active_requests = 0
 
     async def __call__(
         self,
@@ -57,53 +93,110 @@ class RequestBodyLimitMiddleware:
         if scope['type'] != 'http' or scope.get('path') != self._path:
             await self._application(scope, receive, send)
             return
+        if scope.get('method') != 'POST':
+            await _send_error(
+                scope,
+                receive,
+                send,
+                _METHOD_NOT_ALLOWED,
+                405,
+                headers={'Allow': 'POST'},
+            )
+            return
 
         content_length = _content_length(scope)
         if (
             content_length is not None
             and content_length > self._max_body_bytes
         ):
-            await _reject_request(scope, receive, send)
+            await _send_error(scope, receive, send, _REQUEST_TOO_LARGE, 413)
             return
 
-        buffered_body = bytearray()
-        saw_request_message = False
-        terminal_message: Message | None = None
-        while True:
-            message = await receive()
-            if message['type'] != 'http.request':
-                terminal_message = message
-                break
-            saw_request_message = True
-            chunk = message.get('body', b'')
-            if len(buffered_body) + len(chunk) > self._max_body_bytes:
-                await _reject_request(scope, receive, send)
+        if self._active_requests >= self._max_concurrent_requests:
+            await _send_error(
+                scope,
+                receive,
+                send,
+                _REQUEST_CAPACITY_EXCEEDED,
+                503,
+                headers={'Retry-After': '1'},
+            )
+            return
+
+        self._active_requests += 1
+        try:
+            try:
+                async with asyncio.timeout(self._body_timeout_seconds):
+                    buffered_request, terminal_message = (
+                        await _read_bounded_request(
+                            receive,
+                            self._max_body_bytes,
+                        )
+                    )
+            except _RequestBodyTooLarge:
+                await _send_error(
+                    scope,
+                    receive,
+                    send,
+                    _REQUEST_TOO_LARGE,
+                    413,
+                )
                 return
-            buffered_body.extend(chunk)
-            if not message.get('more_body', False):
-                break
+            except TimeoutError:
+                await _send_error(
+                    scope,
+                    receive,
+                    send,
+                    _REQUEST_BODY_TIMEOUT,
+                    408,
+                )
+                return
 
-        buffered_messages: list[Message] = []
-        if saw_request_message:
-            buffered_messages.append({
-                'type': 'http.request',
-                'body': bytes(buffered_body),
-                'more_body': terminal_message is not None,
-            })
-        if terminal_message is not None:
-            buffered_messages.append(terminal_message)
+            async def replay_receive() -> Message:
+                nonlocal buffered_request, terminal_message
+                if buffered_request is not None:
+                    message = buffered_request
+                    buffered_request = None
+                    return message
+                if terminal_message is not None:
+                    message = terminal_message
+                    terminal_message = None
+                    return message
+                return await receive()
 
-        next_message = 0
+            await self._application(scope, replay_receive, send)
+        finally:
+            self._active_requests -= 1
 
-        async def replay_receive() -> Message:
-            nonlocal next_message
-            if next_message < len(buffered_messages):
-                message = buffered_messages[next_message]
-                next_message += 1
-                return message
-            return await receive()
 
-        await self._application(scope, replay_receive, send)
+async def _read_bounded_request(
+    receive: Receive,
+    max_body_bytes: int,
+) -> tuple[Message | None, Message | None]:
+    """Consolidate one bounded request without retaining the accumulator."""
+    buffered_body = bytearray()
+    saw_request_message = False
+    terminal_message: Message | None = None
+    while True:
+        message = await receive()
+        if message['type'] != 'http.request':
+            terminal_message = message
+            break
+        saw_request_message = True
+        chunk = message.get('body', b'')
+        if len(buffered_body) + len(chunk) > max_body_bytes:
+            raise _RequestBodyTooLarge()
+        buffered_body.extend(chunk)
+        if not message.get('more_body', False):
+            break
+
+    if not saw_request_message:
+        return None, terminal_message
+    return ({
+        'type': 'http.request',
+        'body': bytes(buffered_body),
+        'more_body': terminal_message is not None,
+    }, terminal_message)
 
 
 def _content_length(scope: Scope) -> int | None:
@@ -124,10 +217,14 @@ def _content_length(scope: Scope) -> int | None:
         return None
 
 
-async def _reject_request(
+async def _send_error(
     scope: Scope,
     receive: Receive,
     send: Send,
+    body: dict[str, str],
+    status_code: int,
+    *,
+    headers: dict[str, str] | None = None,
 ) -> None:
-    response = JSONResponse(_REQUEST_TOO_LARGE, status_code=413)
+    response = JSONResponse(body, status_code=status_code, headers=headers)
     await response(scope, receive, send)

--- a/src/service/mcp/request_body.py
+++ b/src/service/mcp/request_body.py
@@ -1,0 +1,133 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+MAX_MCP_REQUEST_BODY_BYTES = 1024 * 1024
+
+_CONTENT_LENGTH_HEADER = b'content-length'
+_REQUEST_TOO_LARGE = {
+    'error': 'MCP request body exceeds the 1 MiB limit.',
+}
+
+
+class RequestBodyLimitMiddleware:
+    """Enforce a bounded request body for one ASGI HTTP path."""
+
+    def __init__(
+        self,
+        application: ASGIApp,
+        *,
+        path: str = '/mcp',
+        max_body_bytes: int = MAX_MCP_REQUEST_BODY_BYTES,
+    ) -> None:
+        if (
+            isinstance(max_body_bytes, bool)
+            or not isinstance(max_body_bytes, int)
+            or max_body_bytes < 1
+        ):
+            raise ValueError('max_body_bytes must be a positive integer.')
+        self._application = application
+        self._path = path
+        self._max_body_bytes = max_body_bytes
+
+    async def __call__(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        if scope['type'] != 'http' or scope.get('path') != self._path:
+            await self._application(scope, receive, send)
+            return
+
+        content_length = _content_length(scope)
+        if (
+            content_length is not None
+            and content_length > self._max_body_bytes
+        ):
+            await _reject_request(scope, receive, send)
+            return
+
+        buffered_body = bytearray()
+        saw_request_message = False
+        terminal_message: Message | None = None
+        while True:
+            message = await receive()
+            if message['type'] != 'http.request':
+                terminal_message = message
+                break
+            saw_request_message = True
+            chunk = message.get('body', b'')
+            if len(buffered_body) + len(chunk) > self._max_body_bytes:
+                await _reject_request(scope, receive, send)
+                return
+            buffered_body.extend(chunk)
+            if not message.get('more_body', False):
+                break
+
+        buffered_messages: list[Message] = []
+        if saw_request_message:
+            buffered_messages.append({
+                'type': 'http.request',
+                'body': bytes(buffered_body),
+                'more_body': terminal_message is not None,
+            })
+        if terminal_message is not None:
+            buffered_messages.append(terminal_message)
+
+        next_message = 0
+
+        async def replay_receive() -> Message:
+            nonlocal next_message
+            if next_message < len(buffered_messages):
+                message = buffered_messages[next_message]
+                next_message += 1
+                return message
+            return await receive()
+
+        await self._application(scope, replay_receive, send)
+
+
+def _content_length(scope: Scope) -> int | None:
+    """Return one valid declared length; streamed counting remains authoritative."""
+    values = [
+        value
+        for name, value in scope.get('headers', [])
+        if name.lower() == _CONTENT_LENGTH_HEADER
+    ]
+    if len(values) != 1:
+        return None
+    try:
+        value = values[0].decode('ascii')
+        if not value or not value.isdecimal():
+            return None
+        return int(value)
+    except (UnicodeDecodeError, ValueError):
+        return None
+
+
+async def _reject_request(
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+) -> None:
+    response = JSONResponse(_REQUEST_TOO_LARGE, status_code=413)
+    await response(scope, receive, send)

--- a/src/service/mcp/request_context.py
+++ b/src/service/mcp/request_context.py
@@ -49,6 +49,7 @@ MAX_AUTHORIZATION_HEADER_BYTES = 128 * 1024
 MAX_USER_HEADER_BYTES = 256
 MAX_REQUEST_ID_HEADER_BYTES = 128
 MIN_BEARER_TOKEN_SUBSTRING_BYTES = 16
+MIN_BEARER_TOKEN_BYTES = MIN_BEARER_TOKEN_SUBSTRING_BYTES
 _INVALID_CONTEXT_RESPONSE = {'error': 'Invalid MCP authentication context.'}
 
 
@@ -64,6 +65,10 @@ class RequestCredentials:
     user_name: str
     request_id: str | None
 
+    def __post_init__(self) -> None:
+        if not _is_supported_authorization_header(self.authorization_header):
+            raise ValueError('Unsupported MCP authorization header.')
+
 
 @dataclasses.dataclass(slots=True)
 class _RequestState:
@@ -75,6 +80,8 @@ class _RequestState:
 
 _request_state: contextvars.ContextVar[_RequestState | None] = (
     contextvars.ContextVar('mcp_request_state', default=None))
+_active_tool_name: contextvars.ContextVar[str | None] = (
+    contextvars.ContextVar('mcp_active_tool_name', default=None))
 
 
 class RequestContextMiddleware:
@@ -126,6 +133,21 @@ def get_request_credentials() -> RequestCredentials:
     return request_state.credentials
 
 
+def get_active_tool_name() -> str | None:
+    """Return the canonical MCP tool name for the active invocation, if any."""
+    return _active_tool_name.get()
+
+
+@contextlib.contextmanager
+def track_tool(name: str) -> Iterator[None]:
+    """Bind a canonical tool name to downstream Gateway telemetry."""
+    token = _active_tool_name.set(name)
+    try:
+        yield
+    finally:
+        _active_tool_name.reset(token)
+
+
 @contextlib.contextmanager
 def track_request_task() -> Iterator[RequestCredentials]:
     """Cancel the current tool task when its owning MCP request ends."""
@@ -145,6 +167,32 @@ def track_request_task() -> Iterator[RequestCredentials]:
         yield credentials
     finally:
         request_state.active_tasks.discard(current_task)
+
+
+def request_id_overlaps_bearer(
+    authorization_header: str,
+    request_id: str | None,
+) -> bool:
+    """Return whether a request ID discloses meaningful bearer material."""
+    if request_id is None:
+        return False
+    _, separator, bearer_token = authorization_header.partition(' ')
+    if not separator or not bearer_token:
+        return False
+    if request_id == bearer_token:
+        return True
+    if (
+        len(request_id) < MIN_BEARER_TOKEN_SUBSTRING_BYTES
+        or len(bearer_token) < MIN_BEARER_TOKEN_SUBSTRING_BYTES
+    ):
+        return False
+    return any(
+        request_id[start:start + MIN_BEARER_TOKEN_SUBSTRING_BYTES]
+        in bearer_token
+        for start in range(
+            len(request_id) - MIN_BEARER_TOKEN_SUBSTRING_BYTES + 1
+        )
+    )
 
 
 def _parse_credentials(
@@ -176,7 +224,7 @@ def _parse_credentials(
     user_name = _decode_utf8(user_values[0])
     if (
         authorization_header is None
-        or _BEARER_VALUE.fullmatch(authorization_header) is None
+        or not _is_supported_authorization_header(authorization_header)
         or user_name is None
         or not _is_valid_user_name(user_name)
     ):
@@ -185,7 +233,14 @@ def _parse_credentials(
     request_id: str | None = None
     if request_id_values:
         request_id = _decode_ascii(request_id_values[0])
-        if request_id is None or _REQUEST_ID.fullmatch(request_id) is None:
+        if (
+            request_id is None
+            or _REQUEST_ID.fullmatch(request_id) is None
+            or request_id_overlaps_bearer(
+                authorization_header,
+                request_id,
+            )
+        ):
             return None
 
     return RequestCredentials(
@@ -193,6 +248,14 @@ def _parse_credentials(
         user_name=user_name,
         request_id=request_id,
     )
+
+
+def _is_supported_authorization_header(value: str) -> bool:
+    """Require enough bearer entropy for reliable reflection detection."""
+    if _BEARER_VALUE.fullmatch(value) is None:
+        return False
+    _, _, bearer_token = value.partition(' ')
+    return len(bearer_token) >= MIN_BEARER_TOKEN_BYTES
 
 
 def _decode_ascii(value: bytes) -> str | None:

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -28,11 +28,22 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 import uvicorn  # type: ignore
 
-from src.service.mcp import gateway, profile, protocol, request_context
+from src.lib.utils import logging as logging_utils
+from src.service.mcp import (
+    gateway,
+    protocol,
+    request_body,
+    request_context,
+    tool_registry,
+)
 from src.utils import ssl_config, static_config
 
 
-class MCPServiceConfig(static_config.StaticConfig, ssl_config.SSLConfig):
+class MCPServiceConfig(
+    logging_utils.LoggingConfig,
+    static_config.StaticConfig,
+    ssl_config.SSLConfig,
+):
     """Runtime configuration for the MCP service."""
 
     model_config = pydantic.ConfigDict(hide_input_in_errors=True)
@@ -73,7 +84,7 @@ def create_mcp_server() -> FastMCP:
         stateless_http=True,
         json_response=True,
     )
-    profile.register_tools(server)
+    tool_registry.register_tools(server)
 
     @server.custom_route('/health/live', methods=['GET'], include_in_schema=False)
     async def health_live(request: Request) -> JSONResponse:  # pylint: disable=unused-argument
@@ -96,6 +107,11 @@ def create_application(protocol_server: FastMCP) -> Starlette:
     application.add_middleware(
         request_context.RequestContextMiddleware,
         path='/mcp',
+    )
+    application.add_middleware(
+        request_body.RequestBodyLimitMiddleware,
+        path='/mcp',
+        max_body_bytes=request_body.MAX_MCP_REQUEST_BODY_BYTES,
     )
     return application
 
@@ -133,6 +149,7 @@ def create_runtime_application(
 def main() -> None:
     """Run the MCP ASGI application with the repository's Uvicorn/TLS pattern."""
     config = MCPServiceConfig.load()
+    logging_utils.init_logger('mcp', config)
     application = create_runtime_application(config)
 
     async def run_server() -> None:

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -105,13 +105,17 @@ def create_application(protocol_server: FastMCP) -> Starlette:
     """Create the ASGI application for an MCP protocol server."""
     application = protocol_server.streamable_http_app()
     application.add_middleware(
-        request_context.RequestContextMiddleware,
-        path='/mcp',
-    )
-    application.add_middleware(
         request_body.RequestBodyLimitMiddleware,
         path='/mcp',
         max_body_bytes=request_body.MAX_MCP_REQUEST_BODY_BYTES,
+        max_concurrent_requests=request_body.MAX_CONCURRENT_MCP_REQUESTS,
+        body_timeout_seconds=(
+            request_body.MCP_REQUEST_BODY_TIMEOUT_SECONDS
+        ),
+    )
+    application.add_middleware(
+        request_context.RequestContextMiddleware,
+        path='/mcp',
     )
     return application
 

--- a/src/service/mcp/telemetry.py
+++ b/src/service/mcp/telemetry.py
@@ -1,0 +1,102 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import logging
+
+from src.service.mcp import request_context
+
+
+_LOGGER = logging.getLogger(__name__)
+_STATIC_ROUTES = frozenset({
+    '/api/profile/settings',
+    '/api/pool_quota',
+    '/api/resources',
+    '/api/workflow',
+    '/api/app',
+    '/api/credentials',
+})
+_WORKFLOW_SUFFIXES = frozenset({'logs', 'error_logs', 'events', 'spec'})
+
+
+def route_template(path: str) -> str:
+    """Return a static telemetry label without logging resource identifiers."""
+    if path in _STATIC_ROUTES:
+        return path
+
+    parts = path.split('/')
+    if len(parts) in (4, 5) and parts[:3] == ['', 'api', 'workflow']:
+        template = '/api/workflow/{workflow_id}'
+        if len(parts) == 5 and parts[4] in _WORKFLOW_SUFFIXES:
+            return f'{template}/{parts[4]}'
+        if len(parts) == 4:
+            return template
+
+    if (
+        len(parts) in (5, 6)
+        and parts[:4] == ['', 'api', 'app', 'user']
+    ):
+        template = '/api/app/user/{app_name}'
+        if len(parts) == 6 and parts[5] == 'spec':
+            return f'{template}/spec'
+        if len(parts) == 5:
+            return template
+
+    if len(parts) == 4 and parts[:3] == ['', 'api', 'resources']:
+        return '/api/resources/{node_name}'
+
+    return '/api/{unclassified}'
+
+
+def log_upstream_call(
+    *,
+    method: str,
+    path: str,
+    status_code: int | None,
+    duration_ms: float,
+    outcome: str,
+    request_id: str | None,
+) -> None:
+    """Emit one identifier-free structured record for an upstream call."""
+    _LOGGER.info(
+        'OSMO MCP upstream call tool=%s method=%s route=%s status=%s '
+        'outcome=%s duration_ms=%.3f request_id=%s',
+        request_context.get_active_tool_name() or '-',
+        method,
+        route_template(path),
+        status_code if status_code is not None else '-',
+        outcome,
+        duration_ms,
+        request_id or '-',
+    )
+
+
+def log_tool_outcome(
+    *,
+    tool_name: str,
+    outcome: str,
+    duration_ms: float,
+    request_id: str | None,
+) -> None:
+    """Emit the final result classification after MCP result validation."""
+    _LOGGER.info(
+        'OSMO MCP tool call tool=%s outcome=%s duration_ms=%.3f request_id=%s',
+        tool_name,
+        outcome,
+        duration_ms,
+        request_id or '-',
+    )

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -95,6 +95,7 @@ osmo_py_test(
     srcs = ["test_tool_support.py"],
     deps = [
         requirement("mcp"),
+        "//src/lib/utils:osmo_errors",
         "//src/service/mcp:gateway",
         "//src/service/mcp:request_context",
         "//src/service/mcp:tool_errors",

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -20,12 +20,37 @@ load("//bzl:py.bzl", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_test(
+    name = "test_catalog",
+    srcs = ["test_catalog.py"],
+    deps = [
+        "//src/service/mcp:health_tools",
+        "//src/service/mcp:profile_tools",
+        "//src/service/mcp:protocol",
+        "//src/service/mcp:tool_registry",
+    ],
+)
+
+osmo_py_test(
     name = "test_gateway",
     srcs = ["test_gateway.py"],
     deps = [
         requirement("httpx"),
         "//src/service/mcp:gateway",
         "//src/service/mcp:request_context",
+    ],
+)
+
+osmo_py_test(
+    name = "test_protocol",
+    srcs = ["test_protocol.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("mcp"),
+        requirement("pydantic"),
+        "//src/lib/utils:login",
+        "//src/service/mcp:protocol",
+        "//src/service/mcp:request_context",
+        "//src/service/mcp:tool_errors",
     ],
 )
 
@@ -58,7 +83,31 @@ osmo_py_test(
         requirement("starlette"),
         "//src/lib/utils:login",
         "//src/service/mcp:gateway",
+        "//src/service/mcp:request_body",
         "//src/service/mcp:request_context",
         "//src/service/mcp:mcp_service_lib",
+        "//src/service/mcp:tool_registry",
+    ],
+)
+
+osmo_py_test(
+    name = "test_tool_support",
+    srcs = ["test_tool_support.py"],
+    deps = [
+        requirement("mcp"),
+        "//src/service/mcp:gateway",
+        "//src/service/mcp:request_context",
+        "//src/service/mcp:tool_errors",
+        "//src/service/mcp:tool_requests",
+        "//src/service/mcp:tool_validation",
+    ],
+)
+
+osmo_py_test(
+    name = "test_telemetry",
+    srcs = ["test_telemetry.py"],
+    deps = [
+        "//src/service/mcp:request_context",
+        "//src/service/mcp:telemetry",
     ],
 )

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -1,0 +1,208 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Callable, Mapping
+from unittest import mock
+import unittest
+
+from src.service.mcp import health, profile, protocol, tool_registry
+
+
+_ExpectedSpec = tuple[Callable[..., object], str, str, str]
+
+_EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
+    (
+        health.osmo_health,
+        'osmo_health',
+        'Check OSMO health',
+        'Verify caller-bound Gateway authentication and OSMO API access. '
+        'This is separate from the MCP process health endpoints.',
+    ),
+    (
+        profile.osmo_get_profile,
+        'osmo_get_profile',
+        'Get OSMO profile',
+        'Get the active user\'s OSMO profile settings, roles, accessible '
+        'pools, and non-secret token identity metadata.',
+    ),
+)
+
+_EXPECTED_REQUIRED_FIELDS: dict[str, list[str]] = {
+    'osmo_health': [],
+    'osmo_get_profile': [],
+}
+
+_EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {}
+
+
+class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
+    """Lock the ordered, agent-facing external MCP tool contract."""
+
+    def test_registry_has_exact_metadata_and_direct_unique_functions(self) -> None:
+        self.assertEqual(len(tool_registry.TOOL_SPECS), 2)
+        self.assertEqual(
+            [
+                (spec.name, spec.title, spec.description)
+                for spec in tool_registry.TOOL_SPECS
+            ],
+            [
+                (name, title, description)
+                for _, name, title, description in _EXPECTED_SPECS
+            ],
+        )
+
+        registered_functions = [
+            spec.function for spec in tool_registry.TOOL_SPECS
+        ]
+        self.assertEqual(len({id(function) for function in registered_functions}), 2)
+        for spec, (function, _, _, _) in zip(
+            tool_registry.TOOL_SPECS,
+            _EXPECTED_SPECS,
+            strict=True,
+        ):
+            self.assertIs(spec.function, function)
+
+    def test_registration_preserves_metadata_and_read_only_contract(self) -> None:
+        mcp_server = mock.Mock()
+
+        tool_registry.register_tools(mcp_server)
+
+        self.assertEqual(mcp_server.add_tool.call_count, 2)
+        for call, (function, name, title, description) in zip(
+            mcp_server.add_tool.call_args_list,
+            _EXPECTED_SPECS,
+            strict=True,
+        ):
+            self.assertIs(call.args[0], function)
+            self.assertEqual(call.kwargs['name'], name)
+            self.assertEqual(call.kwargs['title'], title)
+            self.assertEqual(call.kwargs['description'], description)
+            self.assertTrue(call.kwargs['structured_output'])
+            annotations = call.kwargs['annotations']
+            self.assertTrue(annotations.readOnlyHint)
+            self.assertFalse(annotations.destructiveHint)
+            self.assertTrue(annotations.idempotentHint)
+            self.assertFalse(annotations.openWorldHint)
+
+    async def test_all_tools_have_closed_schemas_and_stable_arguments(self) -> None:
+        mcp_server = protocol.OSMOFastMCP(
+            name='OSMO MCP catalog contract test'
+        )
+        tool_registry.register_tools(mcp_server)
+
+        tools = await mcp_server.list_tools()
+        self.assertEqual(
+            [tool.name for tool in tools],
+            [name for _, name, _, _ in _EXPECTED_SPECS],
+        )
+        for tool in tools:
+            self.assertIsNotNone(tool.annotations)
+            assert tool.annotations is not None
+            self.assertTrue(tool.annotations.readOnlyHint)
+            self.assertFalse(tool.annotations.destructiveHint)
+            self.assertTrue(tool.annotations.idempotentHint)
+            self.assertFalse(tool.annotations.openWorldHint)
+            self._assert_recursively_closed(tool.inputSchema, tool.name)
+            self.assertIsNotNone(tool.outputSchema)
+            assert tool.outputSchema is not None
+            self._assert_recursively_closed(tool.outputSchema, tool.name)
+
+            self.assertEqual(
+                tool.inputSchema.get('required', []),
+                _EXPECTED_REQUIRED_FIELDS[tool.name],
+            )
+            properties = tool.inputSchema['properties']
+            for field, expected_default in _EXPECTED_DEFAULTS.get(
+                tool.name,
+                {},
+            ).items():
+                self.assertEqual(
+                    properties[field].get('default'),
+                    expected_default,
+                    f'{tool.name}.{field} default changed',
+                )
+
+    async def test_selection_retains_canonical_order(self) -> None:
+        selected_names = {
+            'osmo_health',
+            'osmo_get_profile',
+        }
+        selected_specs = tool_registry.select_tool_specs(selected_names)
+        self.assertEqual(
+            [spec.name for spec in selected_specs],
+            [
+                'osmo_health',
+                'osmo_get_profile',
+            ],
+        )
+
+        mcp_server = protocol.OSMOFastMCP(
+            name='OSMO MCP selected catalog test'
+        )
+        tool_registry.register_tools(mcp_server, names=selected_names)
+        self.assertEqual(
+            [tool.name for tool in await mcp_server.list_tools()],
+            [
+                'osmo_health',
+                'osmo_get_profile',
+            ],
+        )
+
+    def test_unknown_selection_is_rejected_before_registration(self) -> None:
+        mcp_server = mock.Mock()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r'^Unknown OSMO MCP tool name\(s\): osmo_unknown\.$',
+        ):
+            tool_registry.register_tools(
+                mcp_server,
+                names={'osmo_unknown'},
+            )
+
+        mcp_server.add_tool.assert_not_called()
+
+    def _assert_recursively_closed(
+        self,
+        schema: object,
+        path: str,
+    ) -> None:
+        if isinstance(schema, Mapping):
+            if schema.get('type') == 'object':
+                additional_properties = schema.get('additionalProperties')
+                if 'properties' in schema:
+                    self.assertIs(
+                        additional_properties,
+                        False,
+                        f'{path} permits undeclared object properties',
+                    )
+                else:
+                    self.assertIsInstance(
+                        additional_properties,
+                        Mapping,
+                        f'{path} contains an untyped open object',
+                    )
+            for key, value in schema.items():
+                self._assert_recursively_closed(value, f'{path}.{key}')
+        elif isinstance(schema, list):
+            for index, value in enumerate(schema):
+                self._assert_recursively_closed(value, f'{path}[{index}]')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -130,6 +130,154 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn('proxy-authorization', captured_requests[0].headers)
         self.assertNotIn('x-request-id', captured_requests[1].headers)
 
+    async def test_request_rejects_bearer_overlapping_request_id(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(200, content=b'{}')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with (
+                self.assertNoLogs('src.service.mcp.telemetry', level='INFO'),
+                self.assertRaisesRegex(ValueError, 'credentials are invalid'),
+            ):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(
+                        authorization_header=(
+                            'Bearer opaque-token-segment-1234567890'
+                        ),
+                        request_id='opaque-token-segment',
+                    ),
+                    max_response_bytes=1024,
+                )
+
+        self.assertEqual(transport_calls, 0)
+
+    async def test_request_telemetry_uses_sanitized_gateway_context(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'logs')
+
+        credentials = request_context.RequestCredentials(
+            authorization_header='Bearer telemetry-bearer-secret-1234567890',
+            user_name='private-user@example.com',
+            request_id='safe-request-123',
+        )
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with (
+                request_context.track_tool('osmo_get_workflow_logs'),
+                self.assertLogs(
+                    'src.service.mcp.telemetry',
+                    level='INFO',
+                ) as captured,
+            ):
+                await app_context.gateway.request_text_prefix(
+                    'GET',
+                    '/api/workflow/private-workflow-42/logs',
+                    credentials=credentials,
+                    max_response_bytes=1024,
+                    query={'task_name': 'private-task'},
+                )
+
+        self.assertEqual(len(captured.output), 1)
+        record = captured.output[0]
+        for expected in (
+            'tool=osmo_get_workflow_logs',
+            'method=GET',
+            'route=/api/workflow/{workflow_id}/logs',
+            'status=200',
+            'outcome=response_received',
+            'request_id=safe-request-123',
+        ):
+            self.assertIn(expected, record)
+        for secret in (
+            'telemetry-bearer-secret-1234567890',
+            'private-user@example.com',
+            'private-workflow-42',
+            'private-task',
+        ):
+            self.assertNotIn(secret, record)
+
+    async def test_malformed_200_is_not_labeled_semantic_success(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'not-json')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with (
+                request_context.track_tool('osmo_get_profile'),
+                self.assertLogs(
+                    'src.service.mcp.telemetry',
+                    level='INFO',
+                ) as captured,
+            ):
+                response = await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                )
+
+        self.assertEqual(response.body, b'not-json')
+        self.assertEqual(len(captured.output), 1)
+        record = captured.output[0]
+        self.assertIn('status=200', record)
+        self.assertIn('outcome=response_received', record)
+        self.assertNotIn('outcome=success', record)
+
+    async def test_request_encodes_typed_query_parameters(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, content=b'{}')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            await app_context.gateway.request(
+                'GET',
+                '/api/workflow',
+                credentials=self._credentials(),
+                max_response_bytes=1024,
+                query={
+                    'limit': 50,
+                    'all_pools': True,
+                    'tags': ['alpha&beta', 'release candidate'],
+                },
+            )
+
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.url.path, '/api/workflow')
+        self.assertEqual(request.url.params.multi_items(), [
+            ('limit', '50'),
+            ('all_pools', 'true'),
+            ('tags', 'alpha&beta'),
+            ('tags', 'release candidate'),
+        ])
+        self.assertIn('alpha%26beta', str(request.url))
+        self.assertIn('release+candidate', str(request.url))
+
     async def test_only_fixed_api_paths_and_methods_are_allowed(self) -> None:
         transport_calls = 0
 
@@ -148,6 +296,8 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
             '/api/../profile/settings',
             '/api/%2e%2e/profile/settings',
             '/api/%252e%252e/profile/settings',
+            '/api/profile/foo%2fbar',
+            '/api/profile/foo%252fbar',
             '/api\\profile',
             '/api//profile',
             '/api/profile?user=alice',
@@ -187,6 +337,25 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
                     credentials=self._credentials(),
                     max_response_bytes=0,
                 )
+
+            invalid_queries: tuple[object, ...] = (
+                {'bad-name': 'value'},
+                {'limit': object()},
+                {'tags': ['valid', object()]},
+                {'name': 'contains\nnewline'},
+                {'name': '\ud800'},
+                {'name': 'x' * (16 * 1024)},
+            )
+            for invalid_query in invalid_queries:
+                with self.subTest(query=invalid_query):
+                    with self.assertRaises(ValueError):
+                        await app_context.gateway.request(
+                            'GET',
+                            '/api/profile/settings',
+                            credentials=self._credentials(),
+                            max_response_bytes=1024,
+                            query=invalid_query,  # type: ignore[arg-type]
+                        )
 
         self.assertEqual(transport_calls, 0)
 
@@ -243,7 +412,7 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
                     'GET',
                     '/api/profile/settings',
                     credentials=self._credentials(
-                        authorization_header=f'Bearer caller-{caller}'
+                        authorization_header=f'Bearer caller-{caller}-secret'
                     ),
                     max_response_bytes=1024,
                 )
@@ -252,7 +421,7 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertCountEqual(
             captured_authorization_headers,
-            ['Bearer caller-alice', 'Bearer caller-bob'],
+            ['Bearer caller-alice-secret', 'Bearer caller-bob-secret'],
         )
 
     async def test_redirect_is_rejected_without_following(self) -> None:
@@ -315,8 +484,9 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn('connection-upstream-secret', str(raised.exception))
         self.assertIsNone(raised.exception.__cause__)
 
-    async def test_error_status_body_is_not_read_or_exposed(self) -> None:
-        stream = _TrackingStream([b'upstream-body-secret'])
+    async def test_error_status_body_is_read_with_an_independent_cap(self) -> None:
+        error_body = b'{"message":"correct the request"}'
+        stream = _TrackingStream([error_body])
 
         async def handler(request: httpx.Request) -> httpx.Response:
             del request
@@ -334,10 +504,97 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
                 max_response_bytes=1024,
             )
 
-        self.assertEqual(response, gateway.GatewayResponse(403, b''))
-        self.assertEqual(stream.iterated_chunks, 0)
+        self.assertEqual(response, gateway.GatewayResponse(403, error_body))
+        self.assertEqual(stream.iterated_chunks, 1)
         self.assertEqual(stream.close_count, 1)
-        self.assertNotIn('upstream-body-secret', repr(response))
+        self.assertNotIn('correct the request', repr(response))
+
+        oversized_stream = _TrackingStream([
+            b'x' * (gateway._MAX_ERROR_RESPONSE_BYTES + 1),  # pylint: disable=protected-access
+            b'later-upstream-secret',
+        ])
+
+        async def oversized_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(422, stream=oversized_stream)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(oversized_handler),
+        ) as app_context:
+            oversized_response = await app_context.gateway.request(
+                'GET',
+                '/api/profile/settings',
+                credentials=self._credentials(),
+                max_response_bytes=1,
+            )
+
+        self.assertEqual(
+            len(oversized_response.body),
+            gateway._MAX_ERROR_RESPONSE_BYTES,  # pylint: disable=protected-access
+        )
+        self.assertTrue(oversized_response.body_truncated)
+        self.assertEqual(
+            oversized_response.truncation_reason,
+            'response_size_limit',
+        )
+        self.assertEqual(oversized_stream.iterated_chunks, 1)
+        self.assertEqual(oversized_stream.close_count, 1)
+        self.assertNotIn('later-upstream-secret', repr(oversized_response))
+
+    async def test_error_status_rejects_compression_and_credential_reflection(
+        self,
+    ) -> None:
+        compressed_stream = _TrackingStream([b'compressed-upstream-secret'])
+        bearer_token = 'reflected-error-bearer-secret'
+        responses = [
+            httpx.Response(
+                400,
+                headers={'content-encoding': 'gzip'},
+                stream=compressed_stream,
+            ),
+            httpx.Response(
+                400,
+                content=f'{{"message":"Bearer {bearer_token}"}}'.encode(),
+            ),
+        ]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return responses.pop(0)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'invalid response',
+            ):
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                )
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'invalid response',
+            ) as raised:
+                await app_context.gateway.request(
+                    'GET',
+                    '/api/profile/settings',
+                    credentials=self._credentials(
+                        authorization_header=f'Bearer {bearer_token}'
+                    ),
+                    max_response_bytes=1024,
+                )
+
+        self.assertEqual(compressed_stream.iterated_chunks, 0)
+        self.assertEqual(compressed_stream.close_count, 1)
+        self.assertNotIn(bearer_token, str(raised.exception))
 
     async def test_success_response_cannot_reflect_relayed_credentials(self) -> None:
         bearer_token = 'reflected-bearer-token-secret'
@@ -369,6 +626,38 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
                         max_response_bytes=1024,
                     )
                 self.assertNotIn(bearer_token, str(raised.exception))
+
+    async def test_truncated_text_cannot_reflect_a_partial_relayed_credential(
+        self,
+    ) -> None:
+        bearer_token = 'partial-reflection-bearer-secret'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(
+                200,
+                content=f'{bearer_token}-additional-output'.encode(),
+            )
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'invalid response',
+            ) as raised:
+                await app_context.gateway.request_text_prefix(
+                    'GET',
+                    '/api/workflow/test-1/logs',
+                    credentials=self._credentials(
+                        authorization_header=f'Bearer {bearer_token}'
+                    ),
+                    max_response_bytes=20,
+                )
+
+        self.assertNotIn(bearer_token, str(raised.exception))
 
     async def test_streaming_response_is_cumulatively_bounded(self) -> None:
         exact_stream = _TrackingStream([b'ab', b'cd'])
@@ -410,6 +699,71 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(oversized_stream.iterated_chunks, 2)
         self.assertEqual(oversized_stream.close_count, 1)
         self.assertNotIn('later-upstream-secret', str(raised.exception))
+
+    async def test_text_prefix_returns_size_truncation_and_closes_early(
+        self,
+    ) -> None:
+        exact_stream = _TrackingStream([b'ab', b'cd'])
+        oversized_stream = _TrackingStream([
+            b'ab',
+            b'cdef',
+            b'later-upstream-secret',
+        ])
+        content_length_stream = _TrackingStream([
+            b'abcd',
+            b'later-upstream-secret',
+        ])
+        responses = [
+            httpx.Response(200, stream=exact_stream),
+            httpx.Response(200, stream=oversized_stream),
+            httpx.Response(
+                200,
+                headers={'content-length': '100'},
+                stream=content_length_stream,
+            ),
+        ]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return responses.pop(0)
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            exact = await app_context.gateway.request_text_prefix(
+                'GET',
+                '/api/workflow/test-1/logs',
+                credentials=self._credentials(),
+                max_response_bytes=4,
+            )
+            oversized = await app_context.gateway.request_text_prefix(
+                'GET',
+                '/api/workflow/test-1/logs',
+                credentials=self._credentials(),
+                max_response_bytes=4,
+            )
+            advertised_oversized = await app_context.gateway.request_text_prefix(
+                'GET',
+                '/api/workflow/test-1/logs',
+                credentials=self._credentials(),
+                max_response_bytes=4,
+            )
+
+        self.assertEqual(exact.body, b'abcd')
+        self.assertFalse(exact.body_truncated)
+        self.assertIsNone(exact.truncation_reason)
+        self.assertEqual(oversized.body, b'abcd')
+        self.assertTrue(oversized.body_truncated)
+        self.assertEqual(oversized.truncation_reason, 'response_size_limit')
+        self.assertEqual(advertised_oversized.body, b'abcd')
+        self.assertTrue(advertised_oversized.body_truncated)
+        self.assertEqual(exact_stream.close_count, 1)
+        self.assertEqual(oversized_stream.iterated_chunks, 2)
+        self.assertEqual(oversized_stream.close_count, 1)
+        self.assertEqual(content_length_stream.iterated_chunks, 1)
+        self.assertEqual(content_length_stream.close_count, 1)
 
     async def test_content_length_is_validated_before_streaming(self) -> None:
         oversized_stream = _TrackingStream([b'upstream-secret'])

--- a/src/service/mcp/tests/test_profile.py
+++ b/src/service/mcp/tests/test_profile.py
@@ -146,22 +146,25 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         assert catalog_response is not None
         self.assertEqual(catalog_response.status_code, 200)
         tools = catalog_response.json()['result']['tools']
-        self.assertEqual(len(tools), 1)
-        self.assertEqual(tools[0]['name'], 'osmo_get_profile')
-        self.assertEqual(tools[0]['title'], 'Get OSMO profile')
-        self.assertEqual(tools[0]['inputSchema']['properties'], {})
-        self.assertFalse(tools[0]['inputSchema']['additionalProperties'])
-        self.assertEqual(tools[0]['annotations'], {
+        tools_by_name = {tool['name']: tool for tool in tools}
+        profile_tool = tools_by_name['osmo_get_profile']
+        self.assertEqual(profile_tool['title'], 'Get OSMO profile')
+        self.assertEqual(profile_tool['inputSchema']['properties'], {})
+        self.assertFalse(profile_tool['inputSchema']['additionalProperties'])
+        self.assertEqual(profile_tool['annotations'], {
             'readOnlyHint': True,
             'destructiveHint': False,
             'idempotentHint': True,
             'openWorldHint': False,
         })
-        self.assertEqual(tools[0]['outputSchema']['type'], 'object')
+        self.assertEqual(profile_tool['outputSchema']['type'], 'object')
+        for definition in profile_tool['outputSchema'].get('$defs', {}).values():
+            if definition.get('type') == 'object':
+                self.assertFalse(definition['additionalProperties'])
 
         self.assertEqual(response.status_code, 200)
         result = response.json()['result']
-        self.assertFalse(result['isError'])
+        self.assertFalse(result['isError'], result)
         self.assertEqual(result['structuredContent'], _PROFILE_RESULT)
         self.assertNotIn(_BEARER_SECRET, response.text)
 
@@ -182,6 +185,62 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn(login.OSMO_USER_HEADER, upstream_request.headers)
         self.assertNotIn('cookie', upstream_request.headers)
+
+    async def test_health_is_a_minimal_caller_bound_profile_probe(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=_PROFILE_RESULT)
+
+        response, catalog_response = await self._invoke_tool(
+            handler,
+            include_catalog=True,
+            tool_name='osmo_health',
+        )
+
+        self.assertIsNotNone(catalog_response)
+        assert catalog_response is not None
+        tools = {
+            tool['name']: tool
+            for tool in catalog_response.json()['result']['tools']
+        }
+        health_tool = tools['osmo_health']
+        self.assertEqual(health_tool['inputSchema']['properties'], {})
+        self.assertFalse(health_tool['inputSchema']['additionalProperties'])
+        self.assertEqual(health_tool['annotations'], {
+            'readOnlyHint': True,
+            'destructiveHint': False,
+            'idempotentHint': True,
+            'openWorldHint': False,
+        })
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'], result)
+        self.assertEqual(result['structuredContent'], {'status': 'healthy'})
+        self.assertEqual(len(captured_requests), 1)
+        self.assertEqual(
+            str(captured_requests[0].url),
+            'https://gateway.test/api/profile/settings',
+        )
+        self.assertEqual(
+            captured_requests[0].headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+    async def test_health_propagates_sanitized_profile_failures(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        response, _ = await self._invoke_tool(
+            _error_response_handler(503, captured_requests),
+            tool_name='osmo_health',
+        )
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertIn('HTTP 503', json.dumps(result))
+        self.assertNotIn('upstream-profile-body-secret', json.dumps(result))
+        self.assertNotIn(_BEARER_SECRET, json.dumps(result))
 
     async def test_concurrent_profile_calls_keep_requests_and_results_isolated(self) -> None:
         captured_credentials: list[tuple[str, str | None]] = []
@@ -311,13 +370,13 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
             [f'Bearer {_BEARER_SECRET}', f'Bearer {_BEARER_SECRET}'],
         )
 
-    async def test_get_profile_maps_api_statuses_without_exposing_body(self) -> None:
+    async def test_get_profile_uses_central_sanitized_status_mapping(self) -> None:
         cases = (
             (401, 'rejected the active authentication'),
-            (403, 'authorization denied profile access'),
-            (429, 'profile access is rate limited'),
-            (500, 'profile service is unavailable'),
-            (418, 'profile request failed'),
+            (403, 'authorization denied the request'),
+            (429, 'rate limited the request'),
+            (500, 'service is unavailable'),
+            (418, 'request failed'),
         )
         for status_code, expected_error in cases:
             with self.subTest(status_code=status_code):
@@ -334,6 +393,33 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
                 self.assertIn(f'HTTP {status_code}', result_text)
                 self.assertNotIn('upstream-profile-body-secret', result_text)
                 self.assertNotIn(_BEARER_SECRET, result_text)
+
+    async def test_get_profile_preserves_scrubbed_actionable_error(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        upstream_secret = 'profile-error-secret'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(400, json={
+                'message': (
+                    'Invalid profile update: '
+                    f'password={upstream_secret}'
+                ),
+                'error_code': 'INVALID_PROFILE',
+            })
+
+        response, _ = await self._invoke_tool(handler)
+
+        self.assertEqual(len(captured_requests), 1)
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        result_text = json.dumps(result)
+        self.assertIn('HTTP 400', result_text)
+        self.assertIn('Invalid profile update', result_text)
+        self.assertIn('password=[REDACTED]', result_text)
+        self.assertIn('error_code=INVALID_PROFILE', result_text)
+        self.assertNotIn(upstream_secret, result_text)
+        self.assertNotIn(_BEARER_SECRET, result_text)
 
     async def test_get_profile_sanitizes_transport_and_schema_failures(self) -> None:
         async def transport_failure(request: httpx.Request) -> httpx.Response:
@@ -362,7 +448,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn('upstream-schema-secret', json.dumps(schema_result))
         self.assertNotIn(_BEARER_SECRET, json.dumps(schema_result))
 
-    async def test_get_profile_does_not_expose_internal_profile_fields(self) -> None:
+    async def test_get_profile_drops_extra_nested_profile_fields(self) -> None:
         upstream_profile: dict[str, object] = dict(_PROFILE_RESULT)
         upstream_profile['profile'] = {
             'username': 'alice@example.com',
@@ -378,7 +464,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
 
         response, _ = await self._invoke_tool(handler)
         result = response.json()['result']
-        self.assertFalse(result['isError'])
+        self.assertFalse(result['isError'], result)
         self.assertNotIn(
             'upstream-internal-profile-secret',
             json.dumps(result),
@@ -387,7 +473,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
     async def test_get_profile_rejects_semantically_reflected_credentials(
         self,
     ) -> None:
-        short_secret = 'a'
+        short_secret = 'minimum-token-16'
         short_reflection: dict[str, object] = dict(_PROFILE_RESULT)
         short_reflection['token'] = {
             'name': short_secret,
@@ -440,7 +526,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         malformed_response, _ = await self._invoke_tool(malformed_body)
         malformed_result = malformed_response.json()['result']
         self.assertTrue(malformed_result['isError'])
-        self.assertIn('invalid profile response', json.dumps(malformed_result))
+        self.assertIn('invalid response', json.dumps(malformed_result))
         self.assertNotIn(
             'upstream-malformed-body-secret',
             json.dumps(malformed_result),
@@ -492,6 +578,24 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(unknown_result['isError'])
         self.assertEqual(captured_requests, [])
         self.assertNotIn('unknown-tool-input-secret', json.dumps(unknown_result))
+
+    async def test_active_credentials_cannot_be_forwarded_as_tool_inputs(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={'apps': [], 'more_entries': False})
+
+        response, _ = await self._invoke_tool(
+            handler,
+            tool_name='osmo_list_apps',
+            arguments={'name': _BEARER_SECRET},
+        )
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertEqual(captured_requests, [])
+        self.assertNotIn(_BEARER_SECRET, json.dumps(result))
 
     async def test_get_profile_fails_closed_without_runtime_context(self) -> None:
         application = server.create_application(server.create_mcp_server())

--- a/src/service/mcp/tests/test_profile.py
+++ b/src/service/mcp/tests/test_profile.py
@@ -405,7 +405,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
                     'Invalid profile update: '
                     f'password={upstream_secret}'
                 ),
-                'error_code': 'INVALID_PROFILE',
+                'error_code': 'USER',
             })
 
         response, _ = await self._invoke_tool(handler)
@@ -415,7 +415,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result['isError'])
         result_text = json.dumps(result)
         self.assertIn('HTTP 400', result_text)
-        self.assertIn('error_code=INVALID_PROFILE', result_text)
+        self.assertIn('error_code=USER', result_text)
         self.assertNotIn('Invalid profile update', result_text)
         self.assertNotIn(upstream_secret, result_text)
         self.assertNotIn(_BEARER_SECRET, result_text)

--- a/src/service/mcp/tests/test_profile.py
+++ b/src/service/mcp/tests/test_profile.py
@@ -394,7 +394,7 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
                 self.assertNotIn('upstream-profile-body-secret', result_text)
                 self.assertNotIn(_BEARER_SECRET, result_text)
 
-    async def test_get_profile_preserves_scrubbed_actionable_error(self) -> None:
+    async def test_get_profile_preserves_safe_structured_error_metadata(self) -> None:
         captured_requests: list[httpx.Request] = []
         upstream_secret = 'profile-error-secret'
 
@@ -415,9 +415,8 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result['isError'])
         result_text = json.dumps(result)
         self.assertIn('HTTP 400', result_text)
-        self.assertIn('Invalid profile update', result_text)
-        self.assertIn('password=[REDACTED]', result_text)
         self.assertIn('error_code=INVALID_PROFILE', result_text)
+        self.assertNotIn('Invalid profile update', result_text)
         self.assertNotIn(upstream_secret, result_text)
         self.assertNotIn(_BEARER_SECRET, result_text)
 

--- a/src/service/mcp/tests/test_protocol.py
+++ b/src/service/mcp/tests/test_protocol.py
@@ -1,0 +1,295 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Callable
+import json
+from typing import Annotated
+import unittest
+from unittest import mock
+
+import httpx
+from mcp.server.fastmcp.exceptions import ToolError
+import pydantic
+
+from src.lib.utils import login
+from src.service.mcp import protocol, tool_errors, request_context
+
+
+def _failing_tool(message: str) -> Callable[[], object]:
+    async def failure() -> None:
+        raise tool_errors.PublicToolError(message)
+
+    return failure
+
+
+class PublicExceptionBoundaryTest(unittest.IsolatedAsyncioTestCase):
+    """Exercise exception classification through the real MCP transport."""
+
+    async def _call_tool(
+        self,
+        function: Callable[..., object],
+        arguments: dict[str, object] | None = None,
+        *,
+        requested_name: str = 'boundary_test_tool',
+    ) -> httpx.Response:
+        mcp_server = protocol.OSMOFastMCP(
+            name='OSMO public exception boundary test',
+            host='0.0.0.0',
+            port=8000,
+            streamable_http_path='/mcp',
+            stateless_http=True,
+            json_response=True,
+        )
+        mcp_server.add_tool(function, name='boundary_test_tool')
+        application = mcp_server.streamable_http_app()
+        application.add_middleware(
+            request_context.RequestContextMiddleware,
+            path='/mcp',
+        )
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                return await client.post(
+                    '/mcp',
+                    headers={
+                        'Accept': 'application/json, text/event-stream',
+                        'Content-Type': 'application/json',
+                        login.OSMO_AUTH_HEADER: 'Bearer boundary-test-secret',
+                        login.OSMO_USER_HEADER: 'boundary-user@example.com',
+                        request_context.REQUEST_ID_HEADER: 'boundary-request-123',
+                    },
+                    json={
+                        'jsonrpc': '2.0',
+                        'id': 1,
+                        'method': 'tools/call',
+                        'params': {
+                            'name': requested_name,
+                            'arguments': arguments or {},
+                        },
+                    },
+                )
+
+    async def test_plain_tool_error_is_generic(self) -> None:
+        unsafe_detail = 'plain-tool-error-detail-must-not-be-public'
+
+        async def unmarked_failure() -> None:
+            raise ToolError(unsafe_detail)
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured:
+            response = await self._call_tool(unmarked_failure)
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        result_text = json.dumps(result)
+        self.assertIn(tool_errors.GENERIC_TOOL_ERROR, result_text)
+        self.assertNotIn(unsafe_detail, result_text)
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn('outcome=unexpected_error', captured.output[0])
+        self.assertNotIn(unsafe_detail, captured.output[0])
+
+    async def test_explicit_public_tool_error_remains_public(self) -> None:
+        async def expected_failure() -> None:
+            raise tool_errors.PublicToolError(
+                'The requested workflow is not available.'
+            )
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured:
+            response = await self._call_tool(expected_failure)
+
+        result_text = json.dumps(response.json()['result'])
+        self.assertIn('The requested workflow is not available.', result_text)
+        self.assertNotIn(tool_errors.GENERIC_TOOL_ERROR, result_text)
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn('outcome=public_error', captured.output[0])
+
+    async def test_unexpected_exception_is_generic(self) -> None:
+        unexpected_secret = 'unexpected-runtime-detail-secret'
+
+        async def unexpected_failure() -> None:
+            raise RuntimeError(f'database failure: {unexpected_secret}')
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured:
+            response = await self._call_tool(unexpected_failure)
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        result_text = json.dumps(result)
+        self.assertIn(tool_errors.GENERIC_TOOL_ERROR, result_text)
+        self.assertNotIn(unexpected_secret, result_text)
+        self.assertNotIn('RuntimeError', result_text)
+        self.assertLess(len(response.content), 16 * 1024)
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn('outcome=unexpected_error', captured.output[0])
+        self.assertNotIn(unexpected_secret, captured.output[0])
+
+    async def test_nested_tool_error_is_not_treated_as_public(self) -> None:
+        unexpected_secret = 'nested-exception-detail-secret'
+
+        async def nested_failure() -> None:
+            try:
+                raise RuntimeError(unexpected_secret)
+            except RuntimeError as error:
+                raise ToolError('apparently safe outer message') from error
+
+        response = await self._call_tool(nested_failure)
+
+        result_text = json.dumps(response.json()['result'])
+        self.assertIn(tool_errors.GENERIC_TOOL_ERROR, result_text)
+        self.assertNotIn('apparently safe outer message', result_text)
+        self.assertNotIn(unexpected_secret, result_text)
+
+    async def test_invalid_public_messages_fail_closed(self) -> None:
+        invalid_messages = (
+            'line one\nline two',
+            'x' * (tool_errors.MAX_PUBLIC_TOOL_ERROR_BYTES + 1),
+        )
+        for message in invalid_messages:
+            with self.subTest(message_length=len(message)):
+                response = await self._call_tool(_failing_tool(message))
+
+                result_text = json.dumps(response.json()['result'])
+                self.assertIn(tool_errors.GENERIC_TOOL_ERROR, result_text)
+                self.assertLess(len(response.content), 16 * 1024)
+
+    async def test_validation_exception_uses_fixed_public_error(self) -> None:
+        async def typed_tool(
+            value: Annotated[int, pydantic.Field(strict=True)],
+        ) -> int:
+            return value
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured:
+            response = await self._call_tool(typed_tool, {'value': True})
+
+        result_text = json.dumps(response.json()['result'])
+        self.assertIn('MCP tool validation failed.', result_text)
+        self.assertNotIn('validation error', result_text.lower())
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn('outcome=validation_error', captured.output[0])
+
+    async def test_success_is_logged_after_result_validation(self) -> None:
+        async def successful_tool() -> dict[str, str]:
+            return {'status': 'ok'}
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured:
+            response = await self._call_tool(successful_tool)
+
+        self.assertFalse(response.json()['result']['isError'])
+        self.assertEqual(len(captured.output), 1)
+        record = captured.output[0]
+        self.assertIn('tool=boundary_test_tool', record)
+        self.assertIn('outcome=success', record)
+        self.assertIn('request_id=boundary-request-123', record)
+
+    async def test_invalid_result_is_never_logged_as_success(self) -> None:
+        async def credential_result() -> dict[str, str]:
+            credentials = request_context.get_request_credentials()
+            return {'unsafe': credentials.authorization_header}
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured:
+            response = await self._call_tool(credential_result)
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertEqual(len(captured.output), 1)
+        record = captured.output[0]
+        self.assertIn('outcome=invalid_result', record)
+        self.assertNotIn('outcome=success', record)
+        self.assertNotIn('boundary-test-secret', record)
+
+    async def test_unknown_name_is_not_written_to_telemetry(self) -> None:
+        async def unused_tool() -> None:
+            self.fail('unknown tool must not execute')
+
+        client_supplied_name = 'private-client-supplied-tool-name'
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured:
+            response = await self._call_tool(
+                unused_tool,
+                requested_name=client_supplied_name,
+            )
+
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertEqual(len(captured.output), 1)
+        record = captured.output[0]
+        self.assertIn('tool=unknown', record)
+        self.assertIn('outcome=public_error', record)
+        self.assertIn('request_id=boundary-request-123', record)
+        self.assertNotIn(client_supplied_name, record)
+
+    async def test_missing_request_context_has_final_outcome(self) -> None:
+        async def unused_tool() -> None:
+            self.fail('tool must not execute without a request context')
+
+        mcp_server = protocol.OSMOFastMCP(name='context boundary test')
+        mcp_server.add_tool(unused_tool, name='context_test_tool')
+
+        with (
+            self.assertLogs(
+                'src.service.mcp.telemetry',
+                level='INFO',
+            ) as captured,
+            self.assertRaises(tool_errors.PublicToolError),
+        ):
+            await mcp_server.call_tool('context_test_tool', {})
+
+        self.assertEqual(len(captured.output), 1)
+        record = captured.output[0]
+        self.assertIn('tool=context_test_tool', record)
+        self.assertIn('outcome=context_error', record)
+
+    async def test_telemetry_failure_cannot_replace_public_result(self) -> None:
+        async def expected_failure() -> None:
+            raise tool_errors.PublicToolError(
+                'The requested object is not available.'
+            )
+
+        telemetry_secret = 'telemetry-handler-exception-secret'
+        with mock.patch.object(
+            protocol.telemetry,
+            'log_tool_outcome',
+            side_effect=RuntimeError(telemetry_secret),
+        ):
+            response = await self._call_tool(expected_failure)
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        result_text = json.dumps(result)
+        self.assertIn('The requested object is not available.', result_text)
+        self.assertNotIn(telemetry_secret, result_text)

--- a/src/service/mcp/tests/test_request_context.py
+++ b/src/service/mcp/tests/test_request_context.py
@@ -30,7 +30,7 @@ class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):
 
     @staticmethod
     def _headers(
-        authorization: bytes = b'Bearer test-token',
+        authorization: bytes = b'Bearer test-token-value',
         user_name: bytes = b'alice@example.com',
         request_id: bytes | None = b'request-123',
     ) -> list[tuple[bytes, bytes]]:
@@ -199,6 +199,19 @@ class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):
                 if invalid_value:
                     self.assertNotIn(invalid_value, response_body)
 
+    async def test_short_bearer_token_is_rejected(self) -> None:
+        middleware = request_context.RequestContextMiddleware(
+            self._success_application,
+        )
+
+        messages = await self._invoke(
+            middleware,
+            self._headers(authorization=b'Bearer short-token'),
+        )
+
+        self.assertEqual(self._status(messages), 400)
+        self.assertNotIn(b'short-token', self._body(messages))
+
         middleware = request_context.RequestContextMiddleware(
             self._success_application,
         )
@@ -264,12 +277,37 @@ class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):
                 )
                 self.assertEqual(self._status(messages), 400)
 
+    async def test_request_ids_overlapping_bearer_are_rejected(self) -> None:
+        bearer_token = b'opaque-token-segment-1234567890'
+        overlapping_request_ids = (
+            bearer_token,
+            b'opaque-token-segment',
+            b'request-opaque-token-segment-suffix',
+            b'token-segment-1234',
+        )
+
+        for request_id in overlapping_request_ids:
+            with self.subTest(request_id=request_id):
+                middleware = request_context.RequestContextMiddleware(
+                    self._success_application,
+                )
+                messages = await self._invoke(
+                    middleware,
+                    self._headers(
+                        authorization=b'Bearer ' + bearer_token,
+                        request_id=request_id,
+                    ),
+                )
+
+                self.assertEqual(self._status(messages), 400)
+                self.assertNotIn(bearer_token, self._body(messages))
+
     async def test_header_length_boundaries_are_accepted(self) -> None:
         authorization = b'Bearer ' + b'a' * (
             request_context.MAX_AUTHORIZATION_HEADER_BYTES - len(b'Bearer ')
         )
         user_name = b'a' * request_context.MAX_USER_HEADER_BYTES
-        request_id = b'a' * request_context.MAX_REQUEST_ID_HEADER_BYTES
+        request_id = b'b' * request_context.MAX_REQUEST_ID_HEADER_BYTES
         middleware = request_context.RequestContextMiddleware(
             self._success_application,
         )
@@ -465,7 +503,7 @@ class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):
         alice_request = asyncio.create_task(self._invoke(
             middleware,
             self._headers(
-                authorization=b'Bearer alice-token',
+                authorization=b'Bearer alice-token-value',
                 user_name=b'alice@example.com',
                 request_id=b'alice-request',
             ),
@@ -473,7 +511,7 @@ class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):
         bob_request = asyncio.create_task(self._invoke(
             middleware,
             self._headers(
-                authorization=b'Bearer bob-token',
+                authorization=b'Bearer bob-token-value-1',
                 user_name=b'bob@example.com',
                 request_id=b'bob-request',
             ),
@@ -489,8 +527,14 @@ class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):
         bob_before, bob_after = observations['bob@example.com']
         self.assertEqual(alice_before, alice_after)
         self.assertEqual(bob_before, bob_after)
-        self.assertEqual(alice_before.authorization_header, 'Bearer alice-token')
-        self.assertEqual(bob_before.authorization_header, 'Bearer bob-token')
+        self.assertEqual(
+            alice_before.authorization_header,
+            'Bearer alice-token-value',
+        )
+        self.assertEqual(
+            bob_before.authorization_header,
+            'Bearer bob-token-value-1',
+        )
         self.assertNotEqual(alice_before, bob_before)
         with self.assertRaisesRegex(RuntimeError, 'credentials are unavailable'):
             request_context.get_request_credentials()

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -16,6 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import asyncio
 from collections.abc import AsyncIterator
 import contextlib
 import io
@@ -31,6 +32,8 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import LATEST_PROTOCOL_VERSION
 import pydantic
 from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from src.lib.utils import login
 from src.service.mcp import (
@@ -53,13 +56,19 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         protocol_server.streamable_http_app.assert_called_once_with()
         self.assertEqual(application.add_middleware.call_args_list, [
             mock.call(
-                request_context.RequestContextMiddleware,
-                path='/mcp',
-            ),
-            mock.call(
                 request_body.RequestBodyLimitMiddleware,
                 path='/mcp',
                 max_body_bytes=request_body.MAX_MCP_REQUEST_BODY_BYTES,
+                max_concurrent_requests=(
+                    request_body.MAX_CONCURRENT_MCP_REQUESTS
+                ),
+                body_timeout_seconds=(
+                    request_body.MCP_REQUEST_BODY_TIMEOUT_SECONDS
+                ),
+            ),
+            mock.call(
+                request_context.RequestContextMiddleware,
+                path='/mcp',
             ),
         ])
 
@@ -94,6 +103,58 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
             return {'accepted_bytes': len(padding.encode('utf-8'))}
 
         return server.create_application(mcp_server)
+
+    @staticmethod
+    async def _invoke_asgi(
+        application: ASGIApp,
+        receive: Receive,
+        *,
+        method: str = 'POST',
+        headers: list[tuple[bytes, bytes]] | None = None,
+    ) -> list[Message]:
+        scope: Scope = {
+            'type': 'http',
+            'asgi': {'version': '3.0', 'spec_version': '2.3'},
+            'http_version': '1.1',
+            'method': method,
+            'scheme': 'http',
+            'path': '/mcp',
+            'raw_path': b'/mcp',
+            'query_string': b'',
+            'root_path': '',
+            'headers': headers or [],
+            'server': ('mcp.test', 80),
+            'client': ('test-client', 1234),
+            'state': {},
+        }
+        messages: list[Message] = []
+
+        async def send(message: Message) -> None:
+            messages.append(message)
+
+        await application(scope, receive, send)
+        return messages
+
+    @staticmethod
+    def _asgi_status(messages: list[Message]) -> int:
+        response_starts = [
+            message for message in messages
+            if message['type'] == 'http.response.start'
+        ]
+        if len(response_starts) != 1:
+            raise AssertionError(
+                f'Expected one response start, got {response_starts!r}.'
+            )
+        return response_starts[0]['status']
+
+    @staticmethod
+    def _asgi_json(messages: list[Message]) -> object:
+        body = b''.join(
+            message.get('body', b'')
+            for message in messages
+            if message['type'] == 'http.response.body'
+        )
+        return json.loads(body)
 
     async def _post_sized_tool_request(
         self,
@@ -176,6 +237,143 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json(), {
             'error': 'MCP request body exceeds the 1 MiB limit.',
         })
+
+    async def test_stalled_request_body_is_rejected_after_deadline(self) -> None:
+        downstream_called = False
+
+        async def downstream(
+            scope: Scope,
+            receive: Receive,
+            send: Send,
+        ) -> None:
+            del scope, receive, send
+            nonlocal downstream_called
+            downstream_called = True
+
+        never_received = asyncio.Event()
+
+        async def receive() -> Message:
+            await never_received.wait()
+            raise AssertionError('Unreachable receive continuation.')
+
+        application = request_body.RequestBodyLimitMiddleware(
+            downstream,
+            body_timeout_seconds=0.01,
+        )
+        messages = await self._invoke_asgi(application, receive)
+
+        self.assertEqual(self._asgi_status(messages), 408)
+        self.assertEqual(self._asgi_json(messages), {
+            'error': 'MCP request body timed out.',
+        })
+        self.assertFalse(downstream_called)
+
+    async def test_in_flight_request_limit_rejects_excess_work(self) -> None:
+        downstream_entered = asyncio.Event()
+        release_downstream = asyncio.Event()
+
+        async def downstream(
+            scope: Scope,
+            receive: Receive,
+            send: Send,
+        ) -> None:
+            await receive()
+            downstream_entered.set()
+            await release_downstream.wait()
+            await JSONResponse({'status': 'ok'})(scope, receive, send)
+
+        async def receive() -> Message:
+            return {
+                'type': 'http.request',
+                'body': b'{}',
+                'more_body': False,
+            }
+
+        rejected_body_reads = 0
+
+        async def rejected_receive() -> Message:
+            nonlocal rejected_body_reads
+            rejected_body_reads += 1
+            return await receive()
+
+        application = request_body.RequestBodyLimitMiddleware(
+            downstream,
+            max_concurrent_requests=1,
+        )
+        first_request = asyncio.create_task(
+            self._invoke_asgi(application, receive)
+        )
+        await downstream_entered.wait()
+        try:
+            rejected_messages = await self._invoke_asgi(
+                application,
+                rejected_receive,
+            )
+        finally:
+            release_downstream.set()
+        first_messages = await first_request
+        reused_messages = await self._invoke_asgi(application, receive)
+
+        self.assertEqual(self._asgi_status(first_messages), 200)
+        self.assertEqual(self._asgi_status(rejected_messages), 503)
+        self.assertEqual(self._asgi_status(reused_messages), 200)
+        self.assertEqual(rejected_body_reads, 0)
+        self.assertEqual(self._asgi_json(rejected_messages), {
+            'error': 'MCP service is temporarily at capacity.',
+        })
+        response_start = next(
+            message for message in rejected_messages
+            if message['type'] == 'http.response.start'
+        )
+        self.assertIn((b'retry-after', b'1'), response_start['headers'])
+
+    async def test_invalid_context_is_rejected_before_body_is_read(self) -> None:
+        body_reads = 0
+
+        async def receive() -> Message:
+            nonlocal body_reads
+            body_reads += 1
+            return {
+                'type': 'http.request',
+                'body': b'opaque request body',
+                'more_body': False,
+            }
+
+        application = server.create_application(server.create_mcp_server())
+        messages = await self._invoke_asgi(application, receive)
+
+        self.assertEqual(self._asgi_status(messages), 400)
+        self.assertEqual(body_reads, 0)
+
+    async def test_non_post_mcp_requests_do_not_open_streams(self) -> None:
+        body_reads = 0
+
+        async def receive() -> Message:
+            nonlocal body_reads
+            body_reads += 1
+            return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+        application = server.create_application(server.create_mcp_server())
+        messages = await self._invoke_asgi(
+            application,
+            receive,
+            method='GET',
+            headers=[
+                (b'authorization', b'Bearer get-request-secret'),
+                (b'x-osmo-user', b'get-request-user'),
+            ],
+        )
+
+        self.assertEqual(self._asgi_status(messages), 405)
+        self.assertEqual(self._asgi_json(messages), {
+            'error': 'MCP accepts POST requests only.',
+        })
+        self.assertEqual(body_reads, 0)
+        response_start = next(
+            message for message in messages
+            if message['type'] == 'http.response.start'
+        )
+        self.assertIn((b'allow', b'POST'), response_start['headers'])
 
     async def test_health_endpoints(self) -> None:
         application = server.create_application(server.create_mcp_server())

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 from collections.abc import AsyncIterator
 import contextlib
 import io
+import json
 import os
 import sys
 import types
@@ -32,7 +33,13 @@ import pydantic
 from starlette.applications import Starlette
 
 from src.lib.utils import login
-from src.service.mcp import gateway, request_context, server
+from src.service.mcp import (
+    gateway,
+    request_body,
+    request_context,
+    server,
+    tool_registry,
+)
 
 
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
@@ -44,10 +51,131 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertIs(server.create_application(protocol_server), application)
         protocol_server.streamable_http_app.assert_called_once_with()
-        application.add_middleware.assert_called_once_with(
-            request_context.RequestContextMiddleware,
-            path='/mcp',
+        self.assertEqual(application.add_middleware.call_args_list, [
+            mock.call(
+                request_context.RequestContextMiddleware,
+                path='/mcp',
+            ),
+            mock.call(
+                request_body.RequestBodyLimitMiddleware,
+                path='/mcp',
+                max_body_bytes=request_body.MAX_MCP_REQUEST_BODY_BYTES,
+            ),
+        ])
+
+    @staticmethod
+    def _sized_tool_request(size: int) -> bytes:
+        def encode_request(padding: str) -> bytes:
+            return json.dumps({
+                'jsonrpc': '2.0',
+                'id': 1,
+                'method': 'tools/call',
+                'params': {
+                    'name': 'accept_request_body',
+                    'arguments': {'padding': padding},
+                },
+            }, separators=(',', ':')).encode('utf-8')
+
+        empty_body = encode_request('')
+        padding_size = size - len(empty_body)
+        if padding_size < 0:
+            raise ValueError('Requested test body is too small.')
+        body = encode_request('x' * padding_size)
+        if len(body) != size:
+            raise AssertionError('Failed to construct the requested body size.')
+        return body
+
+    @staticmethod
+    def _body_limit_application() -> Starlette:
+        mcp_server = server.create_mcp_server()
+
+        @mcp_server.tool()
+        async def accept_request_body(padding: str) -> dict[str, int]:
+            return {'accepted_bytes': len(padding.encode('utf-8'))}
+
+        return server.create_application(mcp_server)
+
+    async def _post_sized_tool_request(
+        self,
+        size: int,
+        *,
+        chunked: bool,
+        declared_size: int | None = None,
+    ) -> httpx.Response:
+        body = self._sized_tool_request(size)
+        content: bytes | AsyncIterator[bytes]
+        if chunked:
+            async def body_chunks() -> AsyncIterator[bytes]:
+                chunk_size = 64 * 1024
+                for offset in range(0, len(body), chunk_size):
+                    yield body[offset:offset + chunk_size]
+
+            content = body_chunks()
+        else:
+            content = body
+
+        headers = {
+            'Accept': 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            login.OSMO_AUTH_HEADER: 'Bearer body-limit-secret',
+            login.OSMO_USER_HEADER: 'body-limit-user',
+        }
+        if declared_size is not None:
+            headers['Content-Length'] = str(declared_size)
+
+        application = self._body_limit_application()
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                return await client.post(
+                    '/mcp',
+                    headers=headers,
+                    content=content,
+                )
+
+    async def test_content_length_request_at_limit_is_accepted(self) -> None:
+        response = await self._post_sized_tool_request(
+            request_body.MAX_MCP_REQUEST_BODY_BYTES,
+            chunked=False,
+            declared_size=request_body.MAX_MCP_REQUEST_BODY_BYTES,
         )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()['result']['isError'])
+
+    async def test_content_length_request_over_limit_is_rejected(self) -> None:
+        response = await self._post_sized_tool_request(
+            1024,
+            chunked=False,
+            declared_size=request_body.MAX_MCP_REQUEST_BODY_BYTES + 1,
+        )
+
+        self.assertEqual(response.status_code, 413)
+        self.assertEqual(response.json(), {
+            'error': 'MCP request body exceeds the 1 MiB limit.',
+        })
+
+    async def test_chunked_request_at_limit_is_accepted(self) -> None:
+        response = await self._post_sized_tool_request(
+            request_body.MAX_MCP_REQUEST_BODY_BYTES,
+            chunked=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()['result']['isError'])
+
+    async def test_chunked_request_over_limit_is_rejected(self) -> None:
+        response = await self._post_sized_tool_request(
+            request_body.MAX_MCP_REQUEST_BODY_BYTES + 1,
+            chunked=True,
+        )
+
+        self.assertEqual(response.status_code, 413)
+        self.assertEqual(response.json(), {
+            'error': 'MCP request body exceeds the 1 MiB limit.',
+        })
 
     async def test_health_endpoints(self) -> None:
         application = server.create_application(server.create_mcp_server())
@@ -76,7 +204,7 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         headers = {
             'Accept': 'application/json, text/event-stream',
             'Content-Type': 'application/json',
-            login.OSMO_AUTH_HEADER: 'Bearer test-token',
+            login.OSMO_AUTH_HEADER: 'Bearer test-token-value',
             login.OSMO_USER_HEADER: 'test-user',
         }
         initialize_request = {
@@ -124,7 +252,11 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(list_tools_response.status_code, 200)
         self.assertEqual(
             [tool['name'] for tool in list_tools_response.json()['result']['tools']],
-            ['osmo_get_profile'],
+            [spec.name for spec in tool_registry.TOOL_SPECS],
+        )
+        self.assertEqual(
+            len(tool_registry.TOOL_SPECS),
+            len({spec.name for spec in tool_registry.TOOL_SPECS}),
         )
 
     async def test_request_context_reaches_fastmcp_tool(self) -> None:
@@ -212,11 +344,51 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn('MCP tool failed', response.text)
         self.assertNotIn(bearer_secret, response.text)
 
+    async def test_oversized_final_tool_result_is_rejected(self) -> None:
+        mcp_server = server.create_mcp_server()
+
+        @mcp_server.tool()
+        async def oversized_result() -> dict[str, str]:
+            return {'text': 'x' * (513 * 1024)}
+
+        application = server.create_application(mcp_server)
+        async with application.router.lifespan_context(application):
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=application),
+                base_url='http://mcp.test',
+            ) as client:
+                response = await client.post(
+                    '/mcp',
+                    headers={
+                        'Accept': 'application/json, text/event-stream',
+                        'Content-Type': 'application/json',
+                        login.OSMO_AUTH_HEADER: 'Bearer result-size-secret',
+                        login.OSMO_USER_HEADER: 'tool-user@example.com',
+                    },
+                    json={
+                        'jsonrpc': '2.0',
+                        'id': 1,
+                        'method': 'tools/call',
+                        'params': {
+                            'name': 'oversized_result',
+                            'arguments': {},
+                        },
+                    },
+                )
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertIn('result exceeds the size limit', response.text)
+        self.assertLess(len(response.content), 16 * 1024)
+        self.assertNotIn('result-size-secret', response.text)
+
     def test_runtime_config_requires_https_gateway_origin(self) -> None:
         config = server.MCPServiceConfig(
             gateway_url='https://gateway.test:8443',
         )
         self.assertEqual(str(config.gateway_url), 'https://gateway.test:8443/')
+        self.assertEqual(config.log_level.name, 'INFO')
+        self.assertEqual(config.log_format.value, 'text')
 
         invalid_urls = (
             'http://gateway.test',
@@ -368,6 +540,10 @@ class MCPMainTest(unittest.TestCase):
             mock.patch.object(
                 server.MCPServiceConfig, 'load', return_value=config),
             mock.patch.object(
+                server.logging_utils,
+                'init_logger',
+            ) as init_logger,
+            mock.patch.object(
                 server,
                 'create_runtime_application',
                 return_value=application,
@@ -395,6 +571,7 @@ class MCPMainTest(unittest.TestCase):
         server_factory.assert_called_once_with(config=uvicorn_config)
         uvicorn_server.serve.assert_awaited_once_with()
         application_factory.assert_called_once_with(config)
+        init_logger.assert_called_once_with('mcp', config)
         config.uvicorn_ssl_kwargs.assert_called_once_with()
 
     def test_main_handles_keyboard_interrupt(self) -> None:
@@ -410,6 +587,7 @@ class MCPMainTest(unittest.TestCase):
         with (
             mock.patch.object(
                 server.MCPServiceConfig, 'load', return_value=config),
+            mock.patch.object(server.logging_utils, 'init_logger'),
             mock.patch.object(
                 server,
                 'create_runtime_application',

--- a/src/service/mcp/tests/test_telemetry.py
+++ b/src/service/mcp/tests/test_telemetry.py
@@ -1,0 +1,96 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+
+from src.service.mcp import request_context, telemetry
+
+
+class TelemetryTest(unittest.TestCase):
+    """Keep upstream telemetry useful without logging resource identifiers."""
+
+    def test_route_templates_remove_dynamic_identifiers(self) -> None:
+        cases = {
+            '/api/workflow/private-workflow-1/logs': (
+                '/api/workflow/{workflow_id}/logs'
+            ),
+            '/api/app/user/private-app/spec': '/api/app/user/{app_name}/spec',
+            '/api/resources/private-node': '/api/resources/{node_name}',
+            '/api/unrecognized/private-value': '/api/{unclassified}',
+            '/api/profile/settings': '/api/profile/settings',
+        }
+        for path, expected in cases.items():
+            with self.subTest(path=path):
+                template = telemetry.route_template(path)
+                self.assertEqual(template, expected)
+                for secret in ('private-workflow-1', 'private-app', 'private-node'):
+                    self.assertNotIn(secret, template)
+
+    def test_log_includes_required_static_fields_only(self) -> None:
+        with (
+            request_context.track_tool('osmo_get_workflow'),
+            self.assertLogs('src.service.mcp.telemetry', level='INFO') as captured,
+        ):
+            telemetry.log_upstream_call(
+                method='GET',
+                path='/api/workflow/private-workflow-1',
+                status_code=200,
+                duration_ms=12.5,
+                outcome='response_received',
+                request_id='request-123',
+            )
+
+        self.assertEqual(len(captured.output), 1)
+        record = captured.output[0]
+        for expected in (
+            'tool=osmo_get_workflow',
+            'method=GET',
+            'route=/api/workflow/{workflow_id}',
+            'status=200',
+            'outcome=response_received',
+            'duration_ms=12.500',
+            'request_id=request-123',
+        ):
+            self.assertIn(expected, record)
+        self.assertNotIn('private-workflow-1', record)
+
+    def test_log_tool_outcome_uses_only_classified_fields(self) -> None:
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured:
+            telemetry.log_tool_outcome(
+                tool_name='osmo_get_profile',
+                outcome='invalid_result',
+                duration_ms=3.25,
+                request_id='request-456',
+            )
+
+        self.assertEqual(len(captured.output), 1)
+        record = captured.output[0]
+        for expected in (
+            'tool=osmo_get_profile',
+            'outcome=invalid_result',
+            'duration_ms=3.250',
+            'request_id=request-456',
+        ):
+            self.assertIn(expected, record)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_tool_support.py
+++ b/src/service/mcp/tests/test_tool_support.py
@@ -79,13 +79,11 @@ class ToolSupportTest(unittest.TestCase):
             body=body,
         )
 
-        self.assertIn('Invalid request', message)
-        self.assertIn('password=[REDACTED]', message)
-        self.assertIn('https://[REDACTED]@example.test', message)
-        self.assertIn('X-Amz-Signature=[REDACTED]', message)
         self.assertIn('error_code=OSMO_USAGE_ERROR', message)
         self.assertIn('workflow_id=job-42', message)
+        self.assertNotIn('Invalid request', message)
         self.assertNotIn('correct horse battery staple', message)
+        self.assertNotIn('user:pass', message)
         self.assertNotIn('signature-secret', message)
         self.assertNotIn('arbitrary-secret', message)
 
@@ -114,21 +112,26 @@ class ToolSupportTest(unittest.TestCase):
                 for secret in secrets:
                     self.assertNotIn(secret, safe_value)
 
-    def test_actionable_message_is_scrubbed_before_truncation(self) -> None:
-        secret = 's' * 1200
-        body = json.dumps({
-            'message': f'password="{secret}" correctable-field',
-        }).encode('utf-8')
+    def test_arbitrary_upstream_messages_are_never_forwarded(self) -> None:
+        opaque_secret = 'sk-live-opaque-value-without-a-sensitive-label'
+        for status_code, body in (
+            (400, json.dumps({'message': opaque_secret}).encode('utf-8')),
+            (409, json.dumps({'message': opaque_secret}).encode('utf-8')),
+            (422, json.dumps({'detail': [{
+                'loc': ['query', 'name'],
+                'msg': opaque_secret,
+            }]}).encode('utf-8')),
+        ):
+            with self.subTest(status_code=status_code):
+                message = tool_errors.upstream_error(  # pylint: disable=protected-access
+                    'submit a request',
+                    status_code,
+                    body=body,
+                )
 
-        message = tool_errors.upstream_error(  # pylint: disable=protected-access
-            'submit a request',
-            400,
-            body=body,
-        )
-
-        self.assertIn('password=[REDACTED]', message)
-        self.assertIn('correctable-field', message)
-        self.assertNotIn(secret, message)
+                self.assertNotIn(opaque_secret, message)
+                if status_code == 422:
+                    self.assertIn('Validation failed at query.name', message)
 
     def test_fastapi_validation_errors_drop_input_context_and_unknown_fields(
         self,
@@ -148,7 +151,7 @@ class ToolSupportTest(unittest.TestCase):
         )
 
         self.assertIn(
-            'Validation failed at body.credential - token=[REDACTED]',
+            'Validation failed at body.credential',
             message,
         )
         for secret in (

--- a/src/service/mcp/tests/test_tool_support.py
+++ b/src/service/mcp/tests/test_tool_support.py
@@ -22,6 +22,7 @@ from unittest import mock
 
 from mcp.server.fastmcp.exceptions import ToolError
 
+from src.lib.utils import osmo_errors
 from src.service.mcp import (
     gateway,
     request_context,
@@ -69,7 +70,7 @@ class ToolSupportTest(unittest.TestCase):
             b'{"message":"Invalid request; password=\'correct horse battery '
             b'staple\'; endpoint=https://user:pass@example.test/path?'
             b'X-Amz-Signature=signature-secret",'
-            b'"error_code":"OSMO_USAGE_ERROR","workflow_id":"job-42",'
+            b'"error_code":"USAGE","workflow_id":"job-42",'
             b'"credential":{"unusual_key":"arbitrary-secret"}}'
         )
 
@@ -79,13 +80,72 @@ class ToolSupportTest(unittest.TestCase):
             body=body,
         )
 
-        self.assertIn('error_code=OSMO_USAGE_ERROR', message)
-        self.assertIn('workflow_id=job-42', message)
+        self.assertIn('error_code=USAGE', message)
+        self.assertNotIn('workflow_id', message)
+        self.assertNotIn('job-42', message)
         self.assertNotIn('Invalid request', message)
         self.assertNotIn('correct horse battery staple', message)
         self.assertNotIn('user:pass', message)
         self.assertNotIn('signature-secret', message)
         self.assertNotIn('arbitrary-secret', message)
+
+    def test_upstream_error_codes_use_an_exact_static_allowlist(self) -> None:
+        allowed_codes = {
+            error_type.error_code
+            for error_type in (
+                osmo_errors.OSMOError,
+                osmo_errors.OSMOUserError,
+                osmo_errors.OSMOUsageError,
+                osmo_errors.OSMOResourceError,
+                osmo_errors.OSMOCredentialError,
+                osmo_errors.OSMODatabaseError,
+                osmo_errors.OSMOSubmissionError,
+            )
+        }
+        self.assertEqual(
+            set(tool_errors._PUBLIC_UPSTREAM_ERROR_CODES),  # pylint: disable=protected-access
+            allowed_codes,
+        )
+        for error_code in allowed_codes:
+            with self.subTest(error_code=error_code):
+                message = tool_errors.upstream_error(
+                    'submit a request',
+                    400,
+                    body=json.dumps({'error_code': error_code}).encode('utf-8'),
+                )
+                self.assertIn(f'error_code={error_code}', message)
+
+        for error_code in (
+            'INVALID_PROFILE',
+            'OSMO_USAGE_ERROR',
+            'sk-live-opaque-secret',
+            'OTHER',
+        ):
+            with self.subTest(error_code=error_code):
+                message = tool_errors.upstream_error(
+                    'submit a request',
+                    400,
+                    body=json.dumps({'error_code': error_code}).encode('utf-8'),
+                )
+                self.assertNotIn('OSMO detail:', message)
+                self.assertNotIn(error_code, message)
+
+    def test_malformed_upstream_error_metadata_is_ignored(self) -> None:
+        for body in (
+            b'{',
+            b'[]',
+            b'null',
+            b'\xff',
+            b'{"error_code":["USAGE"]}',
+            b'{"error_code":true}',
+        ):
+            with self.subTest(body=body):
+                message = tool_errors.upstream_error(
+                    'submit a request',
+                    400,
+                    body=body,
+                )
+                self.assertNotIn('OSMO detail:', message)
 
     def test_sensitive_assignments_fail_closed_for_ambiguous_values(self) -> None:
         cases = (
@@ -131,7 +191,8 @@ class ToolSupportTest(unittest.TestCase):
 
                 self.assertNotIn(opaque_secret, message)
                 if status_code == 422:
-                    self.assertIn('Validation failed at query.name', message)
+                    self.assertNotIn('query.name', message)
+                    self.assertNotIn('Validation failed', message)
 
     def test_fastapi_validation_errors_drop_input_context_and_unknown_fields(
         self,
@@ -150,10 +211,8 @@ class ToolSupportTest(unittest.TestCase):
             body=body,
         )
 
-        self.assertIn(
-            'Validation failed at body.credential',
-            message,
-        )
+        self.assertNotIn('Validation failed', message)
+        self.assertNotIn('body.credential', message)
         for secret in (
             'validation-secret',
             'input-secret',
@@ -185,10 +244,11 @@ class ToolSupportTest(unittest.TestCase):
                 message = tool_errors.upstream_error(  # pylint: disable=protected-access
                     'write a credential',
                     400,
-                    body=secret_body,
+                    body=b'{"error_code":"USAGE"}',
                     **options,
                 )
-                self.assertNotIn('upstream-detail-secret', message)
+                self.assertNotIn('OSMO detail:', message)
+                self.assertNotIn('error_code=USAGE', message)
 
     def test_error_redaction_and_final_message_bound_are_central(self) -> None:
         message = tool_errors.upstream_error(  # pylint: disable=protected-access

--- a/src/service/mcp/tests/test_tool_support.py
+++ b/src/service/mcp/tests/test_tool_support.py
@@ -1,0 +1,298 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import unittest
+from unittest import mock
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+from src.service.mcp import (
+    gateway,
+    request_context,
+    tool_errors,
+    tool_requests,
+    tool_validation,
+)
+
+
+class ToolSupportTest(unittest.TestCase):
+    """Validate dynamic path segments before they reach the Gateway client."""
+
+    def test_safe_path_segment_encodes_data_without_changing_route_shape(self) -> None:
+        self.assertEqual(
+            tool_validation.safe_path_segment(
+                'workflow name+日本語',
+                field='workflow_id',
+            ),
+            'workflow%20name%2B%E6%97%A5%E6%9C%AC%E8%AA%9E',
+        )
+        self.assertEqual(
+            tool_validation.safe_path_segment('node-01.example', field='node_name'),
+            'node-01.example',
+        )
+
+    def test_safe_path_segment_rejects_ambiguous_or_oversized_values(self) -> None:
+        invalid_values = (
+            '',
+            ' leading',
+            'trailing ',
+            '.',
+            '..',
+            'parent/child',
+            'parent\\child',
+            'line\nbreak',
+            'x' * 513,
+        )
+        for value in invalid_values:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ToolError, 'Invalid workflow_id'):
+                    tool_validation.safe_path_segment(value, field='workflow_id')
+
+    def test_actionable_core_errors_preserve_only_safe_known_fields(self) -> None:
+        body = (
+            b'{"message":"Invalid request; password=\'correct horse battery '
+            b'staple\'; endpoint=https://user:pass@example.test/path?'
+            b'X-Amz-Signature=signature-secret",'
+            b'"error_code":"OSMO_USAGE_ERROR","workflow_id":"job-42",'
+            b'"credential":{"unusual_key":"arbitrary-secret"}}'
+        )
+
+        message = tool_errors.upstream_error(  # pylint: disable=protected-access
+            'submit a request',
+            400,
+            body=body,
+        )
+
+        self.assertIn('Invalid request', message)
+        self.assertIn('password=[REDACTED]', message)
+        self.assertIn('https://[REDACTED]@example.test', message)
+        self.assertIn('X-Amz-Signature=[REDACTED]', message)
+        self.assertIn('error_code=OSMO_USAGE_ERROR', message)
+        self.assertIn('workflow_id=job-42', message)
+        self.assertNotIn('correct horse battery staple', message)
+        self.assertNotIn('signature-secret', message)
+        self.assertNotIn('arbitrary-secret', message)
+
+    def test_sensitive_assignments_fail_closed_for_ambiguous_values(self) -> None:
+        cases = (
+            (
+                'password=correct horse battery staple; retry=true',
+                ('correct', 'horse', 'battery', 'staple'),
+            ),
+            (
+                'token="unterminated; secret, words',
+                ('unterminated', 'secret', 'words'),
+            ),
+            (
+                'validation failed: "password": "json secret words"',
+                ('json', 'secret', 'words'),
+            ),
+        )
+
+        for value, secrets in cases:
+            with self.subTest(value=value):
+                safe_value = tool_errors.safe_error_text(  # pylint: disable=protected-access
+                    value
+                )
+                self.assertIn('[REDACTED]', safe_value)
+                for secret in secrets:
+                    self.assertNotIn(secret, safe_value)
+
+    def test_actionable_message_is_scrubbed_before_truncation(self) -> None:
+        secret = 's' * 1200
+        body = json.dumps({
+            'message': f'password="{secret}" correctable-field',
+        }).encode('utf-8')
+
+        message = tool_errors.upstream_error(  # pylint: disable=protected-access
+            'submit a request',
+            400,
+            body=body,
+        )
+
+        self.assertIn('password=[REDACTED]', message)
+        self.assertIn('correctable-field', message)
+        self.assertNotIn(secret, message)
+
+    def test_fastapi_validation_errors_drop_input_context_and_unknown_fields(
+        self,
+    ) -> None:
+        body = (
+            b'{"detail":[{"loc":["body","credential"],'
+            b'"msg":"token=validation-secret is invalid",'
+            b'"input":{"unknown":"input-secret"},'
+            b'"ctx":{"error":"context-secret"},'
+            b'"type":"value_error"}],"extra":"extra-secret"}'
+        )
+
+        message = tool_errors.upstream_error(  # pylint: disable=protected-access
+            'validate a request',
+            422,
+            body=body,
+        )
+
+        self.assertIn(
+            'Validation failed at body.credential - token=[REDACTED]',
+            message,
+        )
+        for secret in (
+            'validation-secret',
+            'input-secret',
+            'context-secret',
+            'extra-secret',
+        ):
+            self.assertNotIn(secret, message)
+        self.assertNotIn('value_error', message)
+
+    def test_non_actionable_truncated_and_suppressed_errors_are_generic(
+        self,
+    ) -> None:
+        secret_body = b'{"message":"upstream-detail-secret"}'
+        for status_code in (401, 403, 404, 429, 500):
+            with self.subTest(status_code=status_code):
+                message = tool_errors.upstream_error(  # pylint: disable=protected-access
+                    'read data',
+                    status_code,
+                    body=secret_body,
+                )
+                self.assertIn(f'HTTP {status_code}', message)
+                self.assertNotIn('upstream-detail-secret', message)
+
+        for options in (
+            {'body_truncated': True},
+            {'suppress_upstream_details': True},
+        ):
+            with self.subTest(options=options):
+                message = tool_errors.upstream_error(  # pylint: disable=protected-access
+                    'write a credential',
+                    400,
+                    body=secret_body,
+                    **options,
+                )
+                self.assertNotIn('upstream-detail-secret', message)
+
+    def test_error_redaction_and_final_message_bound_are_central(self) -> None:
+        message = tool_errors.upstream_error(  # pylint: disable=protected-access
+            'operation with Bearer operation-secret',
+            409,
+            body=(
+                b'{"message":"token=body-secret '
+                b'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature '
+                + b'x' * 5000
+                + b'"}'
+            ),
+        )
+
+        self.assertLessEqual(
+            len(message),
+            tool_errors._MAX_TOOL_ERROR_CHARS,  # pylint: disable=protected-access
+        )
+        self.assertIn('Bearer [REDACTED]', message)
+        self.assertNotIn('operation-secret', message)
+        self.assertNotIn('body-secret', message)
+        self.assertNotIn('eyJhbGci', message)
+
+    def test_text_prefix_decoder_drops_only_an_incomplete_final_codepoint(
+        self,
+    ) -> None:
+        truncated = gateway.GatewayResponse(
+            200,
+            b'ab\xe2\x82',
+            body_truncated=True,
+            truncation_reason='response_size_limit',
+        )
+        self.assertEqual(
+            tool_requests._decode_text_prefix(  # pylint: disable=protected-access
+                truncated,
+                operation='read text',
+            ),
+            'ab',
+        )
+
+        for response in (
+            gateway.GatewayResponse(200, b'ab\xe2\x82'),
+            gateway.GatewayResponse(
+                200,
+                b'a\xffb',
+                body_truncated=True,
+                truncation_reason='response_size_limit',
+            ),
+        ):
+            with self.subTest(response=response):
+                with self.assertRaisesRegex(ToolError, 'invalid response'):
+                    tool_requests._decode_text_prefix(  # pylint: disable=protected-access
+                        response,
+                        operation='read text',
+                    )
+
+
+class TruncatedTextRequestTest(unittest.IsolatedAsyncioTestCase):
+    async def test_request_reserves_sentinel_and_returns_metadata(self) -> None:
+        gateway_client = mock.AsyncMock(spec=gateway.GatewayClient)
+        gateway_client.request_text_prefix.return_value = gateway.GatewayResponse(
+            200,
+            b'partial text',
+            body_truncated=True,
+            truncation_reason='response_size_limit',
+        )
+        credentials = request_context.RequestCredentials(
+            authorization_header='Bearer test-token-value',
+            user_name='test-user',
+            request_id='request-1',
+        )
+        maximum_bytes = 256
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'get_app_context',
+                return_value=gateway.AppContext(gateway=gateway_client),
+            ),
+            mock.patch.object(
+                request_context,
+                'get_request_credentials',
+                return_value=credentials,
+            ),
+        ):
+            result = await tool_requests.request_truncated_text(
+                mock.Mock(),
+                path='/api/workflow/test-1/logs',
+                operation='get workflow logs',
+                max_response_bytes=maximum_bytes,
+            )
+
+        self.assertTrue(result.truncated)
+        self.assertEqual(result.truncation_reason, 'response_size_limit')
+        self.assertTrue(result.text.startswith('partial text'))
+        self.assertTrue(result.text.endswith('configured byte limit.'))
+        self.assertLessEqual(len(result.text.encode('utf-8')), maximum_bytes)
+        gateway_client.request_text_prefix.assert_awaited_once_with(
+            'GET',
+            '/api/workflow/test-1/logs',
+            credentials=credentials,
+            max_response_bytes=(
+                maximum_bytes
+                - tool_requests._TEXT_TRUNCATION_SENTINEL_BYTES  # pylint: disable=protected-access
+            ),
+            query=None,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tool_errors.py
+++ b/src/service/mcp/tool_errors.py
@@ -27,8 +27,15 @@ GENERIC_TOOL_ERROR = 'MCP tool failed.'
 MAX_PUBLIC_TOOL_ERROR_BYTES = 4096
 
 _MAX_TOOL_ERROR_CHARS = 2048
-_MAX_VALIDATION_ERRORS = 3
-_SAFE_IDENTIFIER = re.compile(r'[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}')
+_PUBLIC_UPSTREAM_ERROR_CODES = {
+    'OSMO_ERROR': 'OSMO_ERROR',
+    'USER': 'USER',
+    'USAGE': 'USAGE',
+    'RESOURCE': 'RESOURCE',
+    'CREDENTIAL': 'CREDENTIAL',
+    'DATABASE': 'DATABASE',
+    'SUBMISSION': 'SUBMISSION',
+}
 _URL_USERINFO = re.compile(
     r'(?P<scheme>\b[A-Za-z][A-Za-z0-9+.-]*://)[^/@\s]+@'
 )
@@ -92,7 +99,6 @@ def upstream_error(
     result = f'{message} while attempting to {operation} (HTTP {status_code}).'
     if status_code in (400, 409, 422) and not suppress_upstream_details:
         detail = _actionable_upstream_detail(
-            status_code,
             body,
             body_truncated=body_truncated,
         )
@@ -132,12 +138,11 @@ def safe_error_text(value: str) -> str:
 
 
 def _actionable_upstream_detail(
-    status_code: int,
     body: bytes,
     *,
     body_truncated: bool,
 ) -> str | None:
-    """Extract only known, non-payload OSMO validation fields."""
+    """Map a finite Core error-code contract to local public literals."""
     if not body or body_truncated:
         return None
     try:
@@ -147,50 +152,13 @@ def _actionable_upstream_detail(
     if not isinstance(payload, dict):
         return None
 
-    if status_code == 422:
-        validation_detail = _fastapi_validation_detail(payload.get('detail'))
-        if validation_detail is not None:
-            return validation_detail
-
-    fields: list[str] = []
-    for name in ('error_code', 'workflow_id'):
-        raw_value = payload.get(name)
-        if (
-            isinstance(raw_value, str)
-            and _SAFE_IDENTIFIER.fullmatch(raw_value) is not None
-        ):
-            fields.append(f'{name}={raw_value}')
-    return '; '.join(fields) or None
-
-
-def _fastapi_validation_detail(value: object) -> str | None:
-    """Project FastAPI validation errors to field locations only."""
-    if not isinstance(value, list):
+    raw_error_code = payload.get('error_code')
+    if not isinstance(raw_error_code, str):
         return None
-    locations: list[str] = []
-    for item in value[:_MAX_VALIDATION_ERRORS]:
-        if not isinstance(item, dict):
-            continue
-        location = _validation_location(item.get('loc'))
-        if location is not None:
-            locations.append(location)
-    if not locations:
+    public_error_code = _PUBLIC_UPSTREAM_ERROR_CODES.get(raw_error_code)
+    if public_error_code is None:
         return None
-    return 'Validation failed at ' + '; '.join(locations)
-
-
-def _validation_location(value: object) -> str | None:
-    if not isinstance(value, list) or not value or len(value) > 8:
-        return None
-    parts: list[str] = []
-    for part in value:
-        if isinstance(part, bool) or not isinstance(part, (str, int)):
-            return None
-        normalized = str(part)
-        if _SAFE_IDENTIFIER.fullmatch(normalized) is None:
-            return None
-        parts.append(normalized)
-    return '.'.join(parts)
+    return f'error_code={public_error_code}'
 
 
 def _is_public_message(message: object) -> bool:

--- a/src/service/mcp/tool_errors.py
+++ b/src/service/mcp/tool_errors.py
@@ -27,7 +27,6 @@ GENERIC_TOOL_ERROR = 'MCP tool failed.'
 MAX_PUBLIC_TOOL_ERROR_BYTES = 4096
 
 _MAX_TOOL_ERROR_CHARS = 2048
-_MAX_UPSTREAM_MESSAGE_CHARS = 1024
 _MAX_VALIDATION_ERRORS = 3
 _SAFE_IDENTIFIER = re.compile(r'[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}')
 _URL_USERINFO = re.compile(
@@ -154,12 +153,6 @@ def _actionable_upstream_detail(
             return validation_detail
 
     fields: list[str] = []
-    raw_message = payload.get('message')
-    if isinstance(raw_message, str):
-        safe_message = safe_error_text(raw_message)
-        safe_message = safe_message[:_MAX_UPSTREAM_MESSAGE_CHARS]
-        if safe_message:
-            fields.append(safe_message)
     for name in ('error_code', 'workflow_id'):
         raw_value = payload.get(name)
         if (
@@ -171,24 +164,19 @@ def _actionable_upstream_detail(
 
 
 def _fastapi_validation_detail(value: object) -> str | None:
-    """Project FastAPI validation errors to locations and messages only."""
+    """Project FastAPI validation errors to field locations only."""
     if not isinstance(value, list):
         return None
-    errors: list[str] = []
+    locations: list[str] = []
     for item in value[:_MAX_VALIDATION_ERRORS]:
         if not isinstance(item, dict):
             continue
         location = _validation_location(item.get('loc'))
-        raw_message = item.get('msg')
-        if location is None or not isinstance(raw_message, str):
-            continue
-        message = safe_error_text(raw_message)
-        message = message[:_MAX_UPSTREAM_MESSAGE_CHARS]
-        if message:
-            errors.append(f'{location} - {message}')
-    if not errors:
+        if location is not None:
+            locations.append(location)
+    if not locations:
         return None
-    return 'Validation failed at ' + '; '.join(errors)
+    return 'Validation failed at ' + '; '.join(locations)
 
 
 def _validation_location(value: object) -> str | None:

--- a/src/service/mcp/tool_errors.py
+++ b/src/service/mcp/tool_errors.py
@@ -1,0 +1,218 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import re
+import unicodedata
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+
+GENERIC_TOOL_ERROR = 'MCP tool failed.'
+MAX_PUBLIC_TOOL_ERROR_BYTES = 4096
+
+_MAX_TOOL_ERROR_CHARS = 2048
+_MAX_UPSTREAM_MESSAGE_CHARS = 1024
+_MAX_VALIDATION_ERRORS = 3
+_SAFE_IDENTIFIER = re.compile(r'[A-Za-z0-9][A-Za-z0-9_.:/-]{0,255}')
+_URL_USERINFO = re.compile(
+    r'(?P<scheme>\b[A-Za-z][A-Za-z0-9+.-]*://)[^/@\s]+@'
+)
+_BEARER_VALUE = re.compile(
+    r'\bBearer\s+[A-Za-z0-9._~+/-]+=*',
+    flags=re.IGNORECASE,
+)
+_JWT_VALUE = re.compile(
+    r'\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b'
+)
+_SENSITIVE_ASSIGNMENT = re.compile(
+    r'(?P<prefix>\b(?:authorization|password|secret|token|api[_-]?key|'
+    r'access[_-]?key|private[_-]?key|client[_-]?secret|assertion|credential|'
+    r'signature|x-amz-signature|x-amz-credential)\b["\']?\s*[:=]\s*)'
+    r'(?P<value>\[REDACTED\]|"(?:\\.|[^"\\])*"|'
+    r'\'(?:\\.|[^\'\\])*\'|"(?:\\.|[^"\\])*\Z|'
+    r'\'(?:\\.|[^\'\\])*\Z|[^,;&}\]]+)',
+    flags=re.IGNORECASE,
+)
+
+
+class PublicToolError(ToolError):
+    """A bounded error whose message is explicitly approved for MCP clients."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message if _is_public_message(message) else GENERIC_TOOL_ERROR
+        )
+
+
+def from_fastmcp_error(error: ToolError) -> PublicToolError | None:
+    """Recover an intentional public error from FastMCP's generic wrapper."""
+    cause = error.__cause__
+    # Subclasses are not implicitly trusted to preserve the bounded message.
+    if type(cause) is PublicToolError:  # pylint: disable=unidiomatic-typecheck
+        return PublicToolError(str(error))
+    return None
+
+
+def upstream_error(
+    operation: str,
+    status_code: int,
+    *,
+    body: bytes = b'',
+    body_truncated: bool = False,
+    suppress_upstream_details: bool = False,
+) -> str:
+    """Map one upstream failure to a bounded, allowlisted public message."""
+    if status_code == 401:
+        message = 'OSMO rejected the active authentication'
+    elif status_code == 403:
+        message = 'OSMO authorization denied the request'
+    elif status_code == 404:
+        message = 'OSMO could not find the requested resource'
+    elif status_code == 429:
+        message = 'OSMO rate limited the request'
+    elif 500 <= status_code < 600:
+        message = 'OSMO service is unavailable'
+    else:
+        message = 'OSMO request failed'
+    result = f'{message} while attempting to {operation} (HTTP {status_code}).'
+    if status_code in (400, 409, 422) and not suppress_upstream_details:
+        detail = _actionable_upstream_detail(
+            status_code,
+            body,
+            body_truncated=body_truncated,
+        )
+        if detail is not None:
+            result = f'{result} OSMO detail: {detail}'
+    return bounded_safe_error(result)
+
+
+def bounded_safe_error(message: str) -> str:
+    """Scrub and bound text before intentionally exposing it to a client."""
+    safe_message = safe_error_text(message)
+    if len(safe_message) <= _MAX_TOOL_ERROR_CHARS:
+        return safe_message
+    return safe_message[:_MAX_TOOL_ERROR_CHARS - 1].rstrip() + '\u2026'
+
+
+def safe_error_text(value: str) -> str:
+    """Redact common credentials and collapse log/control injection."""
+    value = _URL_USERINFO.sub(r'\g<scheme>[REDACTED]@', value)
+    value = _BEARER_VALUE.sub('Bearer [REDACTED]', value)
+    value = _JWT_VALUE.sub('[REDACTED]', value)
+    value = _SENSITIVE_ASSIGNMENT.sub(
+        lambda match: (
+            match.group(0)
+            if match.group('value') == '[REDACTED]'
+            else match.group('prefix') + '[REDACTED]'
+        ),
+        value,
+    )
+    without_controls = ''.join(
+        character
+        for character in value
+        if unicodedata.category(character) not in ('Cc', 'Cf')
+        or character.isspace()
+    )
+    return ' '.join(without_controls.split())
+
+
+def _actionable_upstream_detail(
+    status_code: int,
+    body: bytes,
+    *,
+    body_truncated: bool,
+) -> str | None:
+    """Extract only known, non-payload OSMO validation fields."""
+    if not body or body_truncated:
+        return None
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, ValueError, TypeError, RecursionError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    if status_code == 422:
+        validation_detail = _fastapi_validation_detail(payload.get('detail'))
+        if validation_detail is not None:
+            return validation_detail
+
+    fields: list[str] = []
+    raw_message = payload.get('message')
+    if isinstance(raw_message, str):
+        safe_message = safe_error_text(raw_message)
+        safe_message = safe_message[:_MAX_UPSTREAM_MESSAGE_CHARS]
+        if safe_message:
+            fields.append(safe_message)
+    for name in ('error_code', 'workflow_id'):
+        raw_value = payload.get(name)
+        if (
+            isinstance(raw_value, str)
+            and _SAFE_IDENTIFIER.fullmatch(raw_value) is not None
+        ):
+            fields.append(f'{name}={raw_value}')
+    return '; '.join(fields) or None
+
+
+def _fastapi_validation_detail(value: object) -> str | None:
+    """Project FastAPI validation errors to locations and messages only."""
+    if not isinstance(value, list):
+        return None
+    errors: list[str] = []
+    for item in value[:_MAX_VALIDATION_ERRORS]:
+        if not isinstance(item, dict):
+            continue
+        location = _validation_location(item.get('loc'))
+        raw_message = item.get('msg')
+        if location is None or not isinstance(raw_message, str):
+            continue
+        message = safe_error_text(raw_message)
+        message = message[:_MAX_UPSTREAM_MESSAGE_CHARS]
+        if message:
+            errors.append(f'{location} - {message}')
+    if not errors:
+        return None
+    return 'Validation failed at ' + '; '.join(errors)
+
+
+def _validation_location(value: object) -> str | None:
+    if not isinstance(value, list) or not value or len(value) > 8:
+        return None
+    parts: list[str] = []
+    for part in value:
+        if isinstance(part, bool) or not isinstance(part, (str, int)):
+            return None
+        normalized = str(part)
+        if _SAFE_IDENTIFIER.fullmatch(normalized) is None:
+            return None
+        parts.append(normalized)
+    return '.'.join(parts)
+
+
+def _is_public_message(message: object) -> bool:
+    if not isinstance(message, str) or not message or message != message.strip():
+        return False
+    try:
+        encoded_message = message.encode('utf-8')
+    except UnicodeEncodeError:
+        return False
+    return (
+        len(encoded_message) <= MAX_PUBLIC_TOOL_ERROR_BYTES
+        and all(character.isprintable() for character in message)
+    )

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -1,0 +1,97 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Callable, Collection
+import dataclasses
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from src.service.mcp import health, profile
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ToolSpec:
+    """Registration metadata for one external OSMO MCP tool."""
+
+    function: Callable[..., object]
+    name: str
+    title: str
+    description: str
+
+
+TOOL_SPECS: tuple[ToolSpec, ...] = (
+    ToolSpec(
+        function=health.osmo_health,
+        name='osmo_health',
+        title='Check OSMO health',
+        description=(
+            'Verify caller-bound Gateway authentication and OSMO API access. '
+            'This is separate from the MCP process health endpoints.'
+        ),
+    ),
+    ToolSpec(
+        function=profile.osmo_get_profile,
+        name='osmo_get_profile',
+        title='Get OSMO profile',
+        description=(
+            'Get the active user\'s OSMO profile settings, roles, accessible '
+            'pools, and non-secret token identity metadata.'
+        ),
+    ),
+)
+
+
+def select_tool_specs(
+    names: Collection[str] | None = None,
+) -> tuple[ToolSpec, ...]:
+    """Select tools by name while retaining the canonical registration order."""
+    if names is None:
+        return TOOL_SPECS
+
+    requested_names = frozenset(names)
+    known_names = frozenset(spec.name for spec in TOOL_SPECS)
+    unknown_names = requested_names - known_names
+    if unknown_names:
+        formatted_names = ', '.join(sorted(unknown_names))
+        raise ValueError(f'Unknown OSMO MCP tool name(s): {formatted_names}.')
+    return tuple(
+        spec for spec in TOOL_SPECS if spec.name in requested_names
+    )
+
+
+def register_tools(
+    server: FastMCP,
+    *,
+    names: Collection[str] | None = None,
+) -> None:
+    """Register the selected external tools without wrapping their functions."""
+    for spec in select_tool_specs(names):
+        server.add_tool(
+            spec.function,
+            name=spec.name,
+            title=spec.title,
+            description=spec.description,
+            annotations=ToolAnnotations(
+                readOnlyHint=True,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=False,
+            ),
+            structured_output=True,
+        )

--- a/src/service/mcp/tool_requests.py
+++ b/src/service/mcp/tool_requests.py
@@ -1,0 +1,265 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import dataclasses
+import json
+from typing import TypeAlias
+
+from mcp.server.fastmcp import Context
+import pydantic
+from starlette.requests import Request
+
+from src.lib.api import profile as profile_contract
+from src.service.mcp import gateway, request_context, tool_errors
+
+
+JsonObject: TypeAlias = dict[str, pydantic.JsonValue]
+ActiveProfile: TypeAlias = profile_contract.ProfileResponse
+
+_JSON_OBJECT_ADAPTER = pydantic.TypeAdapter(JsonObject)
+_PROFILE_PATH = '/api/profile/settings'
+_MAX_PROFILE_RESPONSE_BYTES = 64 * 1024
+_TEXT_TRUNCATION_SENTINEL = (
+    '\n... truncated: OSMO response exceeded the configured byte limit.'
+)
+_TEXT_TRUNCATION_SENTINEL_BYTES = len(
+    _TEXT_TRUNCATION_SENTINEL.encode('utf-8')
+)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class TruncatedTextResult:
+    """One bounded UTF-8 text response and explicit completeness metadata."""
+
+    text: str
+    truncated: bool
+    truncation_reason: str | None
+
+
+async def request_json_object(
+    context: Context,
+    *,
+    path: str,
+    operation: str,
+    max_response_bytes: int,
+    query: gateway.QueryParams | None = None,
+    suppress_upstream_details: bool = False,
+    not_found_message: str | None = None,
+) -> JsonObject:
+    """Relay one fixed GET and require a bounded JSON object response.
+
+    A caller may replace an upstream 404 with one fixed, scrubbed message when
+    its tool contract intentionally makes missing and inaccessible equivalent.
+    """
+    response = await _request(
+        context,
+        path=path,
+        operation=operation,
+        max_response_bytes=max_response_bytes,
+        query=query,
+        suppress_upstream_details=suppress_upstream_details,
+        not_found_message=not_found_message,
+    )
+    try:
+        return _JSON_OBJECT_ADAPTER.validate_json(response.body, strict=True)
+    except pydantic.ValidationError:
+        raise tool_errors.PublicToolError(
+            f'OSMO returned an invalid response while attempting to {operation}.'
+        ) from None
+
+
+async def request_text(
+    context: Context,
+    *,
+    path: str,
+    operation: str,
+    max_response_bytes: int,
+    query: gateway.QueryParams | None = None,
+    suppress_upstream_details: bool = False,
+) -> str:
+    """Relay one fixed GET and require a bounded UTF-8 text response."""
+    response = await _request(
+        context,
+        path=path,
+        operation=operation,
+        max_response_bytes=max_response_bytes,
+        query=query,
+        suppress_upstream_details=suppress_upstream_details,
+    )
+    try:
+        return response.body.decode('utf-8', errors='strict')
+    except UnicodeDecodeError:
+        raise tool_errors.PublicToolError(
+            f'OSMO returned an invalid response while attempting to {operation}.'
+        ) from None
+
+
+async def request_truncated_text(
+    context: Context,
+    *,
+    path: str,
+    operation: str,
+    max_response_bytes: int,
+    query: gateway.QueryParams | None = None,
+    suppress_upstream_details: bool = False,
+) -> TruncatedTextResult:
+    """Relay one fixed GET and truncate oversized UTF-8 text with a sentinel."""
+    if max_response_bytes <= _TEXT_TRUNCATION_SENTINEL_BYTES:
+        raise tool_errors.PublicToolError(
+            f'Invalid MCP request while attempting to {operation}.'
+        )
+    response = await _request(
+        context,
+        path=path,
+        operation=operation,
+        max_response_bytes=(
+            max_response_bytes - _TEXT_TRUNCATION_SENTINEL_BYTES
+        ),
+        query=query,
+        suppress_upstream_details=suppress_upstream_details,
+        truncate_text=True,
+    )
+    text = _decode_text_prefix(response, operation=operation)
+    if response.body_truncated:
+        text += _TEXT_TRUNCATION_SENTINEL
+    return TruncatedTextResult(
+        text=text,
+        truncated=response.body_truncated,
+        truncation_reason=response.truncation_reason,
+    )
+
+
+async def request_active_profile(context: Context) -> ActiveProfile:
+    """Read and validate the active caller's profile and token pool scope."""
+    response = await request_json_object(
+        context,
+        path=_PROFILE_PATH,
+        operation='read the active user profile',
+        max_response_bytes=_MAX_PROFILE_RESPONSE_BYTES,
+    )
+    try:
+        return profile_contract.ProfileResponse.model_validate_json(
+            json.dumps(response, ensure_ascii=False),
+            strict=True,
+        )
+    except pydantic.ValidationError:
+        raise tool_errors.PublicToolError(
+            'OSMO returned an invalid profile response.'
+        ) from None
+
+
+def get_app_context(context: Context) -> gateway.AppContext:
+    """Resolve process-lifetime dependencies from a real MCP HTTP request."""
+    try:
+        request = context.request_context.request
+    except ValueError:
+        raise tool_errors.PublicToolError(
+            'MCP runtime context is unavailable.'
+        ) from None
+    if not isinstance(request, Request):
+        raise tool_errors.PublicToolError('MCP runtime context is unavailable.')
+
+    try:
+        app_context = request.app.state.mcp_app_context
+    except (AttributeError, KeyError):
+        raise tool_errors.PublicToolError(
+            'MCP runtime context is unavailable.'
+        ) from None
+    if not isinstance(app_context, gateway.AppContext):
+        raise tool_errors.PublicToolError('MCP runtime context is unavailable.')
+    return app_context
+
+
+async def _request(
+    context: Context,
+    *,
+    path: str,
+    operation: str,
+    max_response_bytes: int,
+    query: gateway.QueryParams | None,
+    suppress_upstream_details: bool = False,
+    truncate_text: bool = False,
+    not_found_message: str | None = None,
+) -> gateway.GatewayResponse:
+    app_context = get_app_context(context)
+    try:
+        credentials = request_context.get_request_credentials()
+    except RuntimeError:
+        raise tool_errors.PublicToolError(
+            'MCP request authentication context is unavailable.'
+        ) from None
+
+    try:
+        request_method = (
+            app_context.gateway.request_text_prefix
+            if truncate_text
+            else app_context.gateway.request
+        )
+        response = await request_method(
+            'GET',
+            path,
+            credentials=credentials,
+            max_response_bytes=max_response_bytes,
+            query=query,
+        )
+    except gateway.GatewayClientError as error:
+        raise tool_errors.PublicToolError(str(error)) from None
+    except ValueError:
+        raise tool_errors.PublicToolError(
+            f'Invalid MCP request while attempting to {operation}.'
+        ) from None
+
+    if response.status_code == 404 and not_found_message is not None:
+        raise tool_errors.PublicToolError(
+            tool_errors.bounded_safe_error(not_found_message)
+        )
+    if response.status_code != 200:
+        raise tool_errors.PublicToolError(tool_errors.upstream_error(
+            operation,
+            response.status_code,
+            body=response.body,
+            body_truncated=response.body_truncated,
+            suppress_upstream_details=suppress_upstream_details,
+        ))
+    return response
+
+
+def _decode_text_prefix(
+    response: gateway.GatewayResponse,
+    *,
+    operation: str,
+) -> str:
+    """Decode a complete UTF-8 body or a valid prefix ending mid-codepoint."""
+    try:
+        return response.body.decode('utf-8', errors='strict')
+    except UnicodeDecodeError as error:
+        if (
+            response.body_truncated
+            and error.reason == 'unexpected end of data'
+            and error.end == len(response.body)
+            and len(response.body) - error.start <= 3
+        ):
+            try:
+                return response.body[:error.start].decode(
+                    'utf-8', errors='strict'
+                )
+            except UnicodeDecodeError:
+                pass
+        raise tool_errors.PublicToolError(
+            f'OSMO returned an invalid response while attempting to {operation}.'
+        ) from None

--- a/src/service/mcp/tool_requests.py
+++ b/src/service/mcp/tool_requests.py
@@ -232,6 +232,8 @@ async def _request(
         raise tool_errors.PublicToolError(tool_errors.upstream_error(
             operation,
             response.status_code,
+            # The bounded body stays internal to the strict projector. Only
+            # allowlisted structural metadata can reach the MCP client.
             body=response.body,
             body_truncated=response.body_truncated,
             suppress_upstream_details=suppress_upstream_details,

--- a/src/service/mcp/tool_validation.py
+++ b/src/service/mcp/tool_validation.py
@@ -1,0 +1,205 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import TypeVar
+from urllib import parse
+
+import pydantic
+
+from src.service.mcp.tool_errors import PublicToolError
+
+
+_MAX_PATH_SEGMENT_BYTES = 512
+
+_Model = TypeVar('_Model', bound=pydantic.BaseModel)
+
+
+def safe_path_segment(value: str, *, field: str) -> str:
+    """Validate and percent-encode one user-selected OSMO path segment."""
+    try:
+        encoded_length = len(value.encode('utf-8'))
+    except (AttributeError, UnicodeEncodeError):
+        encoded_length = _MAX_PATH_SEGMENT_BYTES + 1
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or encoded_length > _MAX_PATH_SEGMENT_BYTES
+        or value in ('.', '..')
+        or '/' in value
+        or '\\' in value
+        or any(
+            ord(character) < 0x20 or ord(character) == 0x7F
+            for character in value
+        )
+    ):
+        raise PublicToolError(f'Invalid {field}.')
+    return parse.quote(value, safe='-._~')
+
+
+def validate_response(
+    model: type[_Model],
+    response: object,
+    *,
+    operation: str | None = None,
+    error_message: str | None = None,
+) -> _Model:
+    """Strictly validate an upstream DTO behind one fixed public error."""
+    if (operation is None) == (error_message is None):
+        raise ValueError('Specify exactly one response validation error.')
+    try:
+        return model.model_validate(response, strict=True)
+    except pydantic.ValidationError:
+        message = error_message or (
+            f'OSMO returned an invalid response while attempting to {operation}.'
+        )
+        raise PublicToolError(message) from None
+
+
+def validate_integer(
+    value: int,
+    *,
+    field: str,
+    minimum: int,
+    maximum: int | None = None,
+) -> int:
+    """Require a strict JSON integer within inclusive bounds."""
+    if not _is_valid_integer(
+        value,
+        minimum=minimum,
+        maximum=maximum,
+    ):
+        raise PublicToolError(f'Invalid {field}.')
+    return value
+
+
+def validate_optional_integer(
+    value: int | None,
+    *,
+    field: str,
+    minimum: int,
+    maximum: int | None = None,
+) -> int | None:
+    """Validate an optional strict integer without coercion."""
+    if value is None:
+        return None
+    return validate_integer(
+        value,
+        field=field,
+        minimum=minimum,
+        maximum=maximum,
+    )
+
+
+def validate_page(
+    limit: int,
+    offset: int,
+    *,
+    maximum_limit: int,
+    error_message: str | None = None,
+) -> tuple[int, int]:
+    """Validate strict non-boolean pagination arguments."""
+    valid = (
+        _is_valid_integer(limit, minimum=1, maximum=maximum_limit)
+        and _is_valid_integer(offset, minimum=0)
+    )
+    if not valid:
+        if error_message is not None:
+            raise PublicToolError(error_message)
+        if not _is_valid_integer(limit, minimum=1, maximum=maximum_limit):
+            raise PublicToolError('Invalid limit.')
+        raise PublicToolError('Invalid offset.')
+    return limit, offset
+
+
+def validate_query_size(
+    query: Mapping[str, object],
+    *,
+    operation: str,
+    max_bytes: int,
+) -> None:
+    """Bound a query by the exact ASCII byte length sent upstream."""
+    encoded_query = parse.urlencode(query, doseq=True).encode('ascii')
+    if len(encoded_query) > max_bytes:
+        raise PublicToolError(f'{operation} is too large.')
+
+
+def validate_query_text(
+    value: str,
+    *,
+    field: str,
+    max_bytes: int,
+) -> str:
+    """Validate one bounded, trimmed, control-free query value."""
+    try:
+        encoded_length = len(value.encode('utf-8'))
+    except (AttributeError, UnicodeEncodeError):
+        encoded_length = max_bytes + 1
+    if (
+        not isinstance(value, str)
+        or not value
+        or value != value.strip()
+        or encoded_length > max_bytes
+        or any(
+            ord(character) < 0x20 or ord(character) == 0x7F
+            for character in value
+        )
+    ):
+        raise PublicToolError(f'Invalid {field}.')
+    return value
+
+
+def validate_query_values(
+    values: Sequence[str],
+    *,
+    field: str,
+    max_count: int,
+    max_value_bytes: int,
+    deduplicate: bool = False,
+) -> list[str]:
+    """Validate one bounded list of query values without coercion."""
+    if (
+        not isinstance(values, list)
+        or not values
+        or len(values) > max_count
+    ):
+        raise PublicToolError(f'Invalid {field}.')
+    validated = [
+        validate_query_text(
+            value,
+            field=field,
+            max_bytes=max_value_bytes,
+        )
+        for value in values
+    ]
+    return list(dict.fromkeys(validated)) if deduplicate else validated
+
+
+def _is_valid_integer(
+    value: object,
+    *,
+    minimum: int,
+    maximum: int | None = None,
+) -> bool:
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value >= minimum
+        and (maximum is None or value <= maximum)
+    )


### PR DESCRIPTION
## Description

Harden the external MCP runtime and establish the shared read-tool foundation.

Issue - None

### Stack

1. **#1204 (this PR):** runtime foundation, shared support, profile, and caller-bound health
2. #1205: pool and resource inventory tools
3. #1206: workflow read tools
4. #1207: app and credential metadata tools plus final catalog documentation

### Summary

- Enforces a streaming 1 MiB `POST /mcp` body limit for both declared and chunked bodies, a 10-second body-read deadline, and a 16-request in-flight cap. Non-POST `/mcp` requests return 405 instead of opening unbounded streams.
- Adds bounded Gateway reads, bearer-reflection protection, final serialized-result limits, and request/tool telemetry.
- Projects upstream errors through an exact allowlist of Core error-code literals. Free-form messages, workflow IDs, validation locations, and unknown fields never reach MCP clients.
- Centralizes request validation, accessible-pool scope, tool registration, and read-only annotations.
- Keeps the caller-bound `osmo_get_profile` tool and adds profile-backed `osmo_health`.
- Configures application logging so required production telemetry is emitted.

### Validation

- Focused #1204 MCP dependency closure and changed-file linters — 10/10 passed.
- Full restacked MCP suite: `bazel --output_user_root=/tmp/bazel-osmo-external test --test_output=errors //src/service/mcp:request_body-pylint //src/service/mcp:tool_errors-pylint //src/service/mcp/tests:all` — 29/29 tests passed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is completed by the final PR in this stack.
