### PR TITLE
Add external MCP pool and resource tools

### DIFF
--- a/src/lib/utils/BUILD
+++ b/src/lib/utils/BUILD
@@ -75,7 +75,13 @@ osmo_py_library(
         requirement("requests"),
         requirement("texttable"),
         ":osmo_errors",
+        ":resource_quantities",
     ],
+)
+
+osmo_py_library(
+    name = "resource_quantities",
+    srcs = ["resource_quantities.py"],
 )
 
 osmo_py_library(

--- a/src/lib/utils/common.py
+++ b/src/lib/utils/common.py
@@ -38,7 +38,7 @@ import pytz
 import requests  # type: ignore
 import texttable  # type: ignore
 
-from . import osmo_errors
+from . import osmo_errors, resource_quantities
 
 
 # If no registry hostname is provided, default to dockerhub
@@ -83,7 +83,7 @@ UuidPattern = Annotated[
         pattern=f'^{UUID_REGEX}|{OLD_UUID_REGEX}|{GROUP_UUID_REGEX}$')]
 
 WFID_REGEX = r'[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?-\d+$'
-RESOURCE_REGEX = r'(?P<size>(\d+(?:\.\d+)?))(?P<unit>([a-zA-Z]*))'
+RESOURCE_REGEX = resource_quantities.RESOURCE_REGEX
 
 # What encoding to accept from docker registry http requests
 OCI_IMAGE_INDEX_ENCODING = 'application/vnd.oci.image.index.v1+json'
@@ -99,26 +99,9 @@ USERNAME_REGEX = r'^[a-zA-Z0-9]([a-zA-Z0-9_.@-]*[a-zA-Z0-9])?$'
 DOCKER_AUTH_TOKEN_KEYS = ['token', 'access_token']
 
 # A dict to convert different measurements to TiB, GiB, MiB, KiB or B.
-MEASUREMENTS = {
-    'T': 10,
-    'Ti': 10,
-    'TiB': 10,
-    'G': 0,
-    'Gi': 0,
-    'GiB': 0,
-    'M': -10,
-    'Mi': -10,
-    'MiB': -10,
-    'K': -20,
-    'Ki': -20,
-    'KiB': -20,
-    'B': -30,
-    'm': -40
-}
+MEASUREMENTS = resource_quantities.MEASUREMENTS
 
-MEASUREMENTS_SHORT = {
-    'Ti', 'Gi', 'Mi', 'Ki', 'B', 'm'
-}
+MEASUREMENTS_SHORT = resource_quantities.MEASUREMENTS_SHORT
 
 # Default chunk size for etags
 CHUNK_SIZE = 8 * 1024 * 1024
@@ -680,24 +663,12 @@ def convert_resource_value_str(resource_val: str, target: str = 'GiB') -> float:
     Raises:
         utils.OSMOSchemaError: The given measurement of is not supported.
     """
-    resource_val = str(resource_val)
-    pattern = RESOURCE_REGEX
-    match = re.fullmatch(pattern, resource_val)
-    if not match:
-        raise ValueError(
-            f'Failure in converting resource value {resource_val}'
-        )
-    num = match.group('size')
-    unit = match.group('unit')
-
-    if not unit:
-        unit = 'B'
-    if unit not in MEASUREMENTS:
-        raise osmo_errors.OSMOSchemaError(f'Can not recognize {resource_val}.')
-    if target not in MEASUREMENTS:
-        raise osmo_errors.OSMOSchemaError(f'Can not recognize {target}.')
-    raise_power = MEASUREMENTS[unit] - MEASUREMENTS[target]
-    return float(num) * 2 ** raise_power
+    try:
+        return resource_quantities.convert_resource_value(resource_val, target)
+    except resource_quantities.UnsupportedResourceUnitError as error:
+        raise osmo_errors.OSMOSchemaError(
+            f'Can not recognize {error.value}.'
+        ) from error
 
 
 def collect_file_sizes(files: List[str]) -> Tuple[Dict[str, int], int]:

--- a/src/lib/utils/resource_quantities.py
+++ b/src/lib/utils/resource_quantities.py
@@ -1,0 +1,170 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Mapping
+import math
+import re
+from typing import Any, Final
+
+
+RESOURCE_REGEX: Final = r'(?P<size>(\d+(?:\.\d+)?))(?P<unit>([a-zA-Z]*))'
+
+# Binary shifts relative to Gi. Kubernetes resource payloads use a mix of
+# plain byte counts and binary unit suffixes, while OSMO presents memory and
+# storage in Gi.
+MEASUREMENTS: Final = {
+    'T': 10,
+    'Ti': 10,
+    'TiB': 10,
+    'G': 0,
+    'Gi': 0,
+    'GiB': 0,
+    'M': -10,
+    'Mi': -10,
+    'MiB': -10,
+    'K': -20,
+    'Ki': -20,
+    'KiB': -20,
+    'B': -30,
+    'm': -40,
+}
+MEASUREMENTS_SHORT: Final = {'Ti', 'Gi', 'Mi', 'Ki', 'B', 'm'}
+
+RESOURCE_UNITS: Final = {
+    'storage': 'Gi',
+    'cpu': None,
+    'memory': 'Gi',
+    'gpu': None,
+}
+
+
+class UnsupportedResourceUnitError(ValueError):
+    """A resource value or requested target has an unsupported unit."""
+
+    def __init__(self, value: object) -> None:
+        super().__init__(value)
+        self.value = value
+
+
+def convert_resource_value(value: object, target: str = 'GiB') -> float:
+    """Convert a byte quantity to ``target`` using OSMO's binary units."""
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        raise ValueError(f'Failure in converting resource value {value}')
+
+    match = re.fullmatch(RESOURCE_REGEX, str(value))
+    if not match:
+        raise ValueError(f'Failure in converting resource value {value}')
+
+    unit = match.group('unit') or 'B'
+    if unit not in MEASUREMENTS:
+        raise UnsupportedResourceUnitError(value)
+    if target not in MEASUREMENTS:
+        raise UnsupportedResourceUnitError(target)
+
+    power = MEASUREMENTS[unit] - MEASUREMENTS[target]
+    return float(match.group('size')) * 2 ** power
+
+
+def convert_quantity_value(name: str, value: object) -> float:
+    """Convert one API quantity to the unit exposed by OSMO's CLI."""
+    if name not in RESOURCE_UNITS:
+        raise ValueError(f'Unsupported resource quantity {name}.')
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        raise ValueError(f'Invalid {name} resource quantity.')
+
+    converted = (
+        float(value)
+        if RESOURCE_UNITS[name] is None
+        else convert_resource_value(value)
+    )
+    if not math.isfinite(converted):
+        raise ValueError(f'Invalid {name} resource quantity.')
+    return converted
+
+
+def round_used_capacity(used: float, capacity: float) -> tuple[int, int]:
+    """Ceil usage, floor capacity, and clamp usage into the capacity range."""
+    rounded_capacity = max(0, math.floor(capacity))
+    rounded_used = max(0, min(math.ceil(used), rounded_capacity))
+    return rounded_used, rounded_capacity
+
+
+def normalize_resource_quantities(
+    resource: Mapping[str, Any],
+    pool: str,
+    platform: str,
+) -> dict[str, dict[str, int | str]]:
+    """Project one node assignment into capacity, used, free, and unit.
+
+    Platform-specific capacity takes precedence when present. Availability is
+    deliberately derived from normalized capacity and usage so all callers
+    have the same rounding behavior even when ``platform_available_fields`` is
+    absent or was calculated using unrounded values.
+    """
+    capacity_fields = _selected_capacity_fields(resource, pool, platform)
+    usage_fields = resource.get('usage_fields')
+    if not isinstance(usage_fields, Mapping):
+        return {}
+
+    quantities: dict[str, dict[str, int | str]] = {}
+    for name, unit in RESOURCE_UNITS.items():
+        if name not in capacity_fields:
+            continue
+        if name in ('cpu', 'gpu'):
+            raw_usage = usage_fields.get(name, 0)
+        elif name in usage_fields:
+            raw_usage = usage_fields[name]
+        else:
+            continue
+        try:
+            capacity = convert_quantity_value(name, capacity_fields[name])
+            used = convert_quantity_value(name, raw_usage)
+        except (ValueError, TypeError, OverflowError):
+            # Match the existing CLI/internal MCP projection: one malformed or
+            # unsupported quantity does not discard the other resource kinds.
+            continue
+        if capacity <= 0:
+            continue
+
+        rounded_used, rounded_capacity = round_used_capacity(used, capacity)
+        quantity: dict[str, int | str] = {
+            'capacity': rounded_capacity,
+            'used': rounded_used,
+            'free': rounded_capacity - rounded_used,
+        }
+        if unit is not None:
+            quantity['unit'] = unit
+        quantities[name] = quantity
+    return quantities
+
+
+def _selected_capacity_fields(
+    resource: Mapping[str, Any],
+    pool: str,
+    platform: str,
+) -> Mapping[str, Any]:
+    platform_fields = resource.get('platform_allocatable_fields')
+    if isinstance(platform_fields, Mapping):
+        pool_fields = platform_fields.get(pool)
+        if isinstance(pool_fields, Mapping):
+            selected_fields = pool_fields.get(platform)
+            if isinstance(selected_fields, Mapping):
+                return selected_fields
+
+    allocatable_fields = resource.get('allocatable_fields')
+    return allocatable_fields if isinstance(allocatable_fields, Mapping) else {}

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -72,6 +72,15 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "tool_models",
+    srcs = ["tool_models.py"],
+    deps = [
+        requirement("pydantic"),
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "tool_validation",
     srcs = ["tool_validation.py"],
     deps = [
@@ -108,6 +117,26 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "pool_models",
+    srcs = ["pool_models.py"],
+    deps = [
+        requirement("pydantic"),
+        ":tool_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "resource_models",
+    srcs = ["resource_models.py"],
+    deps = [
+        requirement("pydantic"),
+        ":tool_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "profile_tools",
     srcs = ["profile.py"],
     deps = [
@@ -130,12 +159,44 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "pool_tools",
+    srcs = ["pools.py"],
+    deps = [
+        requirement("mcp"),
+        ":access_scope",
+        ":pool_models",
+        ":tool_errors",
+        ":tool_requests",
+        ":tool_validation",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "resource_tools",
+    srcs = ["resources.py"],
+    deps = [
+        requirement("mcp"),
+        requirement("pydantic"),
+        ":access_scope",
+        ":resource_models",
+        ":tool_errors",
+        ":tool_requests",
+        ":tool_validation",
+        "//src/lib/utils:resource_quantities",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "tool_registry",
     srcs = ["tool_registry.py"],
     deps = [
         requirement("mcp"),
         ":health_tools",
+        ":pool_tools",
         ":profile_tools",
+        ":resource_tools",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/service/mcp/pool_models.py
+++ b/src/service/mcp/pool_models.py
@@ -1,0 +1,107 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Annotated
+
+import pydantic
+
+from src.service.mcp.tool_models import (
+    ClosedToolModel,
+    ExtensibleUpstreamModel,
+    PageLimit,
+    PageOffset,
+)
+
+
+MAX_QUERY_CHARACTERS = 256
+
+SearchQuery = Annotated[
+    str,
+    pydantic.Field(max_length=MAX_QUERY_CHARACTERS),
+]
+
+
+class PoolResourceUsage(ClosedToolModel):
+    """GPU quota and physical-capacity values returned by OSMO."""
+
+    quota_used: str
+    quota_free: str
+    quota_limit: str
+    total_usage: str
+    total_capacity: str
+    total_free: str
+
+
+class PoolSummary(ClosedToolModel):
+    """Agent-facing subset of one accessible pool."""
+
+    name: str
+    description: str
+    status: str | None
+    backend: str
+    default_platform: str | None
+    resource_usage: PoolResourceUsage
+
+
+class SharedCapacity(ClosedToolModel):
+    """Physical capacity counted once for one set of sharing pools."""
+
+    total_capacity: str
+    total_free: str
+
+
+class PoolNodeSet(ClosedToolModel):
+    """Pools sharing the same physical node capacity."""
+
+    index: PageOffset
+    shared_capacity: bool
+    pool_names: list[str]
+    capacity: SharedCapacity
+    pools: list[PoolSummary]
+
+
+class PoolSearchResult(ClosedToolModel):
+    """Bounded pool output with complete accessible capacity kept explicit."""
+
+    node_sets: list[PoolNodeSet]
+    accessible_resource_sum: PoolResourceUsage
+    count: PageOffset
+    total_matches: PageOffset
+    offset: PageOffset
+    limit: PageLimit
+    more_entries: bool
+
+
+class _UpstreamPool(ExtensibleUpstreamModel):
+    """Fields consumed from Core's larger pool response."""
+
+    name: str
+    description: str = ''
+    status: str | None = None
+    backend: str
+    default_platform: str | None = None
+    resource_usage: PoolResourceUsage
+
+
+class _UpstreamNodeSet(ClosedToolModel):
+    pools: list[_UpstreamPool]
+
+
+class _UpstreamPoolResponse(ClosedToolModel):
+    node_sets: list[_UpstreamNodeSet]
+    resource_sum: PoolResourceUsage

--- a/src/service/mcp/pools.py
+++ b/src/service/mcp/pools.py
@@ -1,0 +1,181 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from mcp.server.fastmcp import Context
+
+from src.service.mcp import access_scope, tool_requests, tool_validation
+from src.service.mcp.pool_models import (
+    MAX_QUERY_CHARACTERS as _MAX_QUERY_CHARACTERS,
+    PageLimit,
+    PageOffset,
+    PoolNodeSet,
+    PoolResourceUsage,
+    PoolSearchResult,
+    PoolSummary,
+    SearchQuery,
+    SharedCapacity,
+    _UpstreamPool,
+    _UpstreamPoolResponse,
+)
+from src.service.mcp.tool_errors import PublicToolError
+
+
+_POOL_QUOTA_PATH = '/api/pool_quota'
+_MAX_POOL_RESPONSE_BYTES = 1024 * 1024
+_DEFAULT_LIMIT = 50
+_MAX_LIMIT = 200
+
+
+async def osmo_search_pools(
+    context: Context,
+    query: SearchQuery | None = None,
+    limit: PageLimit = _DEFAULT_LIMIT,
+    offset: PageOffset = 0,
+) -> PoolSearchResult:
+    """Search pools accessible to the active user without double-counting shared capacity."""
+    normalized_query = _normalize_query(query)
+    tool_validation.validate_page(
+        limit,
+        offset,
+        maximum_limit=_MAX_LIMIT,
+        error_message='Invalid pool pagination arguments.',
+    )
+
+    scope = await access_scope.request_access_scope(context)
+    if scope.empty:
+        return PoolSearchResult(
+            node_sets=[],
+            accessible_resource_sum=_zero_resource_usage(),
+            count=0,
+            total_matches=0,
+            offset=offset,
+            limit=limit,
+            more_entries=False,
+        )
+
+    accessible_pools = list(scope.pools)
+    pool_payload = await tool_requests.request_json_object(
+        context,
+        path=_POOL_QUOTA_PATH,
+        operation='search accessible pools',
+        max_response_bytes=_MAX_POOL_RESPONSE_BYTES,
+        query={
+            'all_pools': False,
+            'pools': accessible_pools,
+        },
+    )
+    upstream = tool_validation.validate_response(
+        _UpstreamPoolResponse,
+        pool_payload,
+        error_message='OSMO returned an invalid pool response.',
+    )
+
+    accessible_names = scope.pool_names
+    records: list[tuple[int, _UpstreamPool, list[str], SharedCapacity]] = []
+    for index, node_set in enumerate(upstream.node_sets):
+        node_set_names = [pool.name for pool in node_set.pools]
+        if any(name not in accessible_names for name in node_set_names):
+            raise PublicToolError('OSMO returned an invalid pool response.')
+        if not node_set.pools:
+            continue
+        capacity = SharedCapacity(
+            total_capacity=node_set.pools[0].resource_usage.total_capacity,
+            total_free=node_set.pools[0].resource_usage.total_free,
+        )
+        for pool in node_set.pools:
+            if _matches_query(pool, normalized_query):
+                records.append((index, pool, node_set_names, capacity))
+
+    total_matches = len(records)
+    page = records[offset:offset + limit]
+    grouped_pools: dict[int, list[PoolSummary]] = {}
+    node_set_metadata: dict[int, tuple[list[str], SharedCapacity]] = {}
+    for index, pool, node_set_names, capacity in page:
+        grouped_pools.setdefault(index, []).append(_pool_summary(pool))
+        node_set_metadata[index] = (node_set_names, capacity)
+
+    node_sets = []
+    for index, page_pools in grouped_pools.items():
+        node_set_names, capacity = node_set_metadata[index]
+        node_sets.append(PoolNodeSet(
+            index=index,
+            shared_capacity=len(node_set_names) > 1,
+            pool_names=node_set_names,
+            capacity=capacity,
+            pools=page_pools,
+        ))
+
+    return PoolSearchResult(
+        node_sets=node_sets,
+        # Core computes this over the complete accessible response and counts
+        # each shared node set once. Local search and pagination must not turn
+        # it into a misleading sum of repeated per-pool capacity.
+        accessible_resource_sum=upstream.resource_sum,
+        count=len(page),
+        total_matches=total_matches,
+        offset=offset,
+        limit=limit,
+        more_entries=offset + len(page) < total_matches,
+    )
+
+
+def _normalize_query(query: str | None) -> str:
+    if query is None:
+        return ''
+    if (
+        not isinstance(query, str)
+        or len(query) > _MAX_QUERY_CHARACTERS
+        or any(ord(character) < 0x20 or ord(character) == 0x7F for character in query)
+    ):
+        raise PublicToolError('Invalid pool search query.')
+    return query.strip().casefold()
+
+
+def _zero_resource_usage() -> PoolResourceUsage:
+    return PoolResourceUsage(
+        quota_used='0',
+        quota_free='0',
+        quota_limit='0',
+        total_usage='0',
+        total_capacity='0',
+        total_free='0',
+    )
+
+
+def _matches_query(pool: _UpstreamPool, query: str) -> bool:
+    if not query:
+        return True
+    values = (
+        pool.name,
+        pool.description,
+        pool.status or '',
+        pool.backend,
+        pool.default_platform or '',
+    )
+    return any(query in value.casefold() for value in values)
+
+
+def _pool_summary(pool: _UpstreamPool) -> PoolSummary:
+    return PoolSummary(
+        name=pool.name,
+        description=pool.description,
+        status=pool.status,
+        backend=pool.backend,
+        default_platform=pool.default_platform,
+        resource_usage=pool.resource_usage,
+    )

--- a/src/service/mcp/resource_models.py
+++ b/src/service/mcp/resource_models.py
@@ -1,0 +1,155 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Annotated
+
+import pydantic
+
+from src.service.mcp.tool_models import (
+    ClosedToolModel,
+    ExtensibleUpstreamModel,
+    PageLimit,
+    PageOffset,
+)
+
+
+__all__ = (
+    'PageLimit',
+    'PageOffset',
+    'ResourceConfiguration',
+    'ResourceDetail',
+    'ResourceListResult',
+    'ResourceQuantities',
+    'ResourceQuantity',
+    'ResourceSelection',
+    'ResourceSummary',
+    'Selector',
+    'SelectorList',
+)
+
+
+MAX_SELECTORS = 100
+MAX_SELECTOR_CHARACTERS = 512
+
+Selector = Annotated[
+    str,
+    pydantic.Field(min_length=1, max_length=MAX_SELECTOR_CHARACTERS),
+]
+SelectorList = Annotated[
+    list[Selector],
+    pydantic.Field(min_length=1, max_length=MAX_SELECTORS),
+]
+
+
+class ResourceQuantity(ClosedToolModel):
+    """One normalized OSMO resource quantity."""
+
+    capacity: Annotated[int, pydantic.Field(ge=0)]
+    used: Annotated[int, pydantic.Field(ge=0)]
+    free: Annotated[int, pydantic.Field(ge=0)]
+    unit: str | None = pydantic.Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
+
+
+class ResourceQuantities(ClosedToolModel):
+    """Allowlisted quantities using the same units as the OSMO CLI."""
+
+    storage: ResourceQuantity | None = pydantic.Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
+    cpu: ResourceQuantity | None = pydantic.Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
+    memory: ResourceQuantity | None = pydantic.Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
+    gpu: ResourceQuantity | None = pydantic.Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
+
+
+class ResourceSummary(ClosedToolModel):
+    """One node assignment to a pool and platform."""
+
+    node: str
+    backend: str
+    resource_type: str
+    pool: str
+    platform: str
+    resources: ResourceQuantities
+
+
+class ResourceListResult(ClosedToolModel):
+    """Bounded, flattened node resource results."""
+
+    resources: list[ResourceSummary]
+    count: int
+    total_entries: int
+    offset: int
+    limit: int
+    more_entries: bool
+
+
+class ResourceSelection(ClosedToolModel):
+    pool: str
+    platform: str
+
+
+class ResourceConfiguration(ClosedToolModel):
+    """Task-facing configuration for one node assignment."""
+
+    host_network: bool
+    privileged: bool
+    default_mounts: list[str]
+    allowed_mounts: list[str]
+
+
+class ResourceDetail(ClosedToolModel):
+    """Concise detail for one node and selected pool/platform assignment."""
+
+    node: str
+    backend: str
+    resource_type: str
+    assignments: dict[str, list[str]]
+    selected: ResourceSelection
+    resources: ResourceQuantities
+    configuration: ResourceConfiguration
+
+
+class _UpstreamResource(ExtensibleUpstreamModel):
+    """Fields consumed from Core's larger node resource object."""
+
+    hostname: str
+    backend: str
+    resource_type: str
+    usage_fields: dict[str, pydantic.JsonValue]
+    allocatable_fields: dict[str, pydantic.JsonValue]
+    platform_allocatable_fields: dict[str, pydantic.JsonValue] | None = None
+    platform_available_fields: dict[str, pydantic.JsonValue] | None = None
+    config_fields: dict[str, pydantic.JsonValue] | None = None
+    pool_platform_labels: dict[str, list[str]]
+
+
+class _UpstreamResourcesResponse(ClosedToolModel):
+    resources: list[_UpstreamResource]

--- a/src/service/mcp/resources.py
+++ b/src/service/mcp/resources.py
@@ -1,0 +1,382 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from mcp.server.fastmcp import Context
+import pydantic
+
+from src.lib.utils import resource_quantities
+from src.service.mcp import (
+    access_scope,
+    tool_errors,
+    tool_requests,
+    tool_validation,
+)
+from src.service.mcp.resource_models import (
+    MAX_SELECTORS as _MAX_SELECTORS,
+    MAX_SELECTOR_CHARACTERS as _MAX_SELECTOR_CHARACTERS,
+    PageLimit,
+    PageOffset,
+    ResourceConfiguration,
+    ResourceDetail,
+    ResourceListResult,
+    ResourceQuantity,
+    ResourceQuantities,
+    ResourceSelection,
+    ResourceSummary,
+    Selector,
+    SelectorList,
+    _UpstreamResource,
+    _UpstreamResourcesResponse,
+)
+
+
+__all__ = (
+    'PageLimit',
+    'PageOffset',
+    'ResourceConfiguration',
+    'ResourceDetail',
+    'ResourceListResult',
+    'ResourceQuantities',
+    'ResourceQuantity',
+    'ResourceSelection',
+    'ResourceSummary',
+    'Selector',
+    'SelectorList',
+    'osmo_get_resource',
+    'osmo_list_resources',
+)
+
+
+_RESOURCES_PATH = '/api/resources'
+_MAX_RESOURCES_RESPONSE_BYTES = 2 * 1024 * 1024
+_DEFAULT_LIMIT = 50
+_MAX_LIMIT = 200
+_RESOURCE_NOT_FOUND_MESSAGE = 'The requested node is not available.'
+
+
+async def osmo_list_resources(
+    context: Context,
+    pool: SelectorList | None = None,
+    platform: SelectorList | None = None,
+    all_pools: bool = False,
+    limit: PageLimit = _DEFAULT_LIMIT,
+    offset: PageOffset = 0,
+) -> ResourceListResult:
+    """List node capacity, usage, and availability by pool/platform assignment."""
+    tool_validation.validate_page(
+        limit,
+        offset,
+        maximum_limit=_MAX_LIMIT,
+        error_message='Invalid resource pagination arguments.',
+    )
+    pools = _validated_selectors(pool, field='pool')
+    platforms = _validated_selectors(platform, field='platform')
+    if all_pools and pools:
+        raise tool_errors.PublicToolError(
+            'pool and all_pools=true cannot be used together.'
+        )
+
+    scope = await access_scope.request_access_scope(context)
+    if scope.empty:
+        return ResourceListResult(
+            resources=[],
+            count=0,
+            total_entries=0,
+            offset=offset,
+            limit=limit,
+            more_entries=False,
+        )
+    if all_pools:
+        pools = list(scope.pools)
+    elif pools:
+        if any(pool_name not in scope.pool_names for pool_name in pools):
+            raise tool_errors.PublicToolError(
+                'One or more requested pools are not accessible.'
+            )
+    else:
+        if scope.default_pool is not None:
+            pools = [scope.default_pool]
+        elif len(scope.pools) == 1:
+            pools = [scope.pools[0]]
+        else:
+            raise tool_errors.PublicToolError(
+                'No accessible default pool is configured; provide pool or '
+                'set all_pools=true.'
+            )
+
+    query: dict[str, bool | list[str]] = {
+        'all_pools': False,
+        'pools': pools,
+    }
+    if platforms:
+        query['platforms'] = platforms
+
+    payload = await tool_requests.request_json_object(
+        context,
+        path=_RESOURCES_PATH,
+        operation='list node resources',
+        max_response_bytes=_MAX_RESOURCES_RESPONSE_BYTES,
+        query=query,
+    )
+    upstream = _validate_resources_response(payload)
+
+    requested_pools = set(pools)
+    requested_platforms = set(platforms)
+    entries: list[ResourceSummary] = []
+    for resource in sorted(
+        upstream.resources,
+        key=lambda item: (item.hostname, item.backend, item.resource_type),
+    ):
+        for pool_name in sorted(resource.pool_platform_labels):
+            if requested_pools and pool_name not in requested_pools:
+                continue
+            for platform_name in sorted(set(
+                resource.pool_platform_labels[pool_name]
+            )):
+                if requested_platforms and platform_name not in requested_platforms:
+                    continue
+                entries.append(_resource_summary(resource, pool_name, platform_name))
+
+    total_entries = len(entries)
+    page = entries[offset:offset + limit]
+    return ResourceListResult(
+        resources=page,
+        count=len(page),
+        total_entries=total_entries,
+        offset=offset,
+        limit=limit,
+        more_entries=offset + len(page) < total_entries,
+    )
+
+
+async def osmo_get_resource(
+    context: Context,
+    node_name: Selector,
+    pool: Selector | None = None,
+    platform: Selector | None = None,
+) -> ResourceDetail:
+    """Get one node's resources and task configuration for a pool/platform."""
+    if (pool is None) != (platform is None):
+        raise tool_errors.PublicToolError(
+            'pool and platform must be provided together.'
+        )
+
+    encoded_node_name = tool_validation.safe_path_segment(
+        node_name,
+        field='node_name',
+    )
+    selected_pool = _validated_selector(pool, field='pool') if pool is not None else None
+    selected_platform = (
+        _validated_selector(platform, field='platform')
+        if platform is not None
+        else None
+    )
+
+    scope = await access_scope.request_access_scope(context)
+    if (
+        scope.empty
+        or (
+            selected_pool is not None
+            and selected_pool not in scope.pool_names
+        )
+    ):
+        raise _resource_not_found()
+
+    payload = await tool_requests.request_json_object(
+        context,
+        path=f'{_RESOURCES_PATH}/{encoded_node_name}',
+        operation='get a node resource',
+        max_response_bytes=_MAX_RESOURCES_RESPONSE_BYTES,
+        not_found_message=_RESOURCE_NOT_FOUND_MESSAGE,
+    )
+    upstream = _validate_resources_response(payload)
+    node_resources = [
+        resource
+        for resource in upstream.resources
+        if resource.hostname == node_name
+    ]
+    if not node_resources:
+        raise _resource_not_found()
+
+    if selected_pool is None or selected_platform is None:
+        available_assignments = [
+            (resource, pool_name, platform_name)
+            for resource in node_resources
+            for pool_name in sorted(resource.pool_platform_labels)
+            if pool_name in scope.pool_names
+            for platform_name in sorted(set(
+                resource.pool_platform_labels[pool_name]
+            ))
+        ]
+        if not available_assignments:
+            raise _resource_not_found()
+        if len(available_assignments) != 1:
+            raise tool_errors.PublicToolError(
+                'The node has multiple accessible pool/platform assignments; '
+                'provide pool and platform.'
+            )
+        resource, selected_pool, selected_platform = available_assignments[0]
+    else:
+        candidates = [
+            resource
+            for resource in node_resources
+            if selected_platform in resource.pool_platform_labels.get(
+                selected_pool,
+                [],
+            )
+        ]
+        if not candidates:
+            raise _resource_not_found()
+        if len(candidates) > 1:
+            raise tool_errors.PublicToolError(
+                'OSMO returned an ambiguous node resource response.'
+            )
+        resource = candidates[0]
+
+    assignments = {
+        pool_name: sorted(set(resource.pool_platform_labels[pool_name]))
+        for pool_name in sorted(resource.pool_platform_labels)
+        if (
+            pool_name in scope.pool_names
+            and resource.pool_platform_labels[pool_name]
+        )
+    }
+    if not assignments:
+        raise _resource_not_found()
+    if (
+        selected_pool not in assignments
+        or selected_platform not in assignments[selected_pool]
+    ):
+        raise _resource_not_found()
+
+    config_payload = _nested_object(
+        resource.config_fields,
+        selected_pool,
+        selected_platform,
+    )
+    configuration = tool_validation.validate_response(
+        ResourceConfiguration,
+        {
+            key: config_payload[key]
+            for key in ResourceConfiguration.model_fields
+            if key in config_payload
+        },
+        error_message='OSMO returned an invalid node resource response.',
+    )
+
+    summary = _resource_summary(resource, selected_pool, selected_platform)
+    return ResourceDetail(
+        node=resource.hostname,
+        backend=resource.backend,
+        resource_type=resource.resource_type,
+        assignments=assignments,
+        selected=ResourceSelection(
+            pool=selected_pool,
+            platform=selected_platform,
+        ),
+        resources=summary.resources,
+        configuration=configuration,
+    )
+
+
+def _validate_resources_response(
+    payload: tool_requests.JsonObject,
+) -> _UpstreamResourcesResponse:
+    return tool_validation.validate_response(
+        _UpstreamResourcesResponse,
+        payload,
+        error_message='OSMO returned an invalid resource response.',
+    )
+
+
+def _resource_summary(
+    resource: _UpstreamResource,
+    pool: str,
+    platform: str,
+) -> ResourceSummary:
+    return ResourceSummary(
+        node=resource.hostname,
+        backend=resource.backend,
+        resource_type=resource.resource_type,
+        pool=pool,
+        platform=platform,
+        resources=_normalized_quantities(resource, pool, platform),
+    )
+
+
+def _nested_object(
+    root: dict[str, pydantic.JsonValue] | None,
+    first_key: str,
+    second_key: str,
+) -> dict[str, pydantic.JsonValue]:
+    if root is None:
+        return {}
+    first_value = root.get(first_key)
+    if not isinstance(first_value, dict):
+        return {}
+    second_value = first_value.get(second_key)
+    if not isinstance(second_value, dict):
+        return {}
+    return second_value
+
+
+def _normalized_quantities(
+    resource: _UpstreamResource,
+    pool: str,
+    platform: str,
+) -> ResourceQuantities:
+    try:
+        quantities = resource_quantities.normalize_resource_quantities(
+            resource.model_dump(),
+            pool,
+            platform,
+        )
+        return ResourceQuantities.model_validate(quantities, strict=True)
+    except (ValueError, TypeError, OverflowError, pydantic.ValidationError):
+        raise tool_errors.PublicToolError(
+            'OSMO returned an invalid resource response.'
+        ) from None
+
+
+def _resource_not_found() -> tool_errors.PublicToolError:
+    return tool_errors.PublicToolError(_RESOURCE_NOT_FOUND_MESSAGE)
+
+
+def _validated_selectors(values: list[str] | None, *, field: str) -> list[str]:
+    if values is None:
+        return []
+    if (
+        not isinstance(values, list)
+        or not values
+        or len(values) > _MAX_SELECTORS
+    ):
+        raise tool_errors.PublicToolError(f'Invalid {field} filters.')
+    return list(dict.fromkeys(
+        _validated_selector(value, field=field)
+        for value in values
+    ))
+
+
+def _validated_selector(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or len(value) > _MAX_SELECTOR_CHARACTERS:
+        raise tool_errors.PublicToolError(f'Invalid {field}.')
+    # Query values are encoded by GatewayClient; call the shared segment helper
+    # here for the same empty/control/slash/traversal validation without using
+    # its percent-encoded return value as a query value.
+    tool_validation.safe_path_segment(value, field=field)
+    return value

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -16,16 +16,32 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-load("//bzl:py.bzl", "osmo_py_test")
+load("//bzl:py.bzl", "osmo_py_library", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
+
+osmo_py_library(
+    name = "protocol_harness",
+    srcs = ["protocol_harness.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("starlette"),
+        "//src/lib/utils:login",
+        "//src/service/mcp:gateway",
+        "//src/service/mcp:protocol",
+        "//src/service/mcp:request_context",
+        "//src/service/mcp:tool_registry",
+    ],
+)
 
 osmo_py_test(
     name = "test_catalog",
     srcs = ["test_catalog.py"],
     deps = [
         "//src/service/mcp:health_tools",
+        "//src/service/mcp:pool_tools",
         "//src/service/mcp:profile_tools",
         "//src/service/mcp:protocol",
+        "//src/service/mcp:resource_tools",
         "//src/service/mcp:tool_registry",
     ],
 )
@@ -37,6 +53,19 @@ osmo_py_test(
         requirement("httpx"),
         "//src/service/mcp:gateway",
         "//src/service/mcp:request_context",
+    ],
+)
+
+osmo_py_test(
+    name = "test_pools",
+    srcs = ["test_pools.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("mcp"),
+        ":protocol_harness",
+        "//src/service/mcp:pool_tools",
+        "//src/service/mcp:request_context",
+        "//src/service/mcp:tool_requests",
     ],
 )
 
@@ -61,6 +90,20 @@ osmo_py_test(
         requirement("httpx"),
         "//src/lib/utils:login",
         "//src/service/mcp:mcp_service_lib",
+    ],
+)
+
+osmo_py_test(
+    name = "test_resources",
+    srcs = ["test_resources.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("mcp"),
+        ":protocol_harness",
+        "//src/lib/utils:resource_quantities",
+        "//src/service/mcp:request_context",
+        "//src/service/mcp:resource_tools",
+        "//src/service/mcp:tool_requests",
     ],
 )
 

--- a/src/service/mcp/tests/protocol_harness.py
+++ b/src/service/mcp/tests/protocol_harness.py
@@ -1,0 +1,251 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import AsyncIterator, Callable, Collection, Coroutine
+import contextlib
+from typing import Any, TypeAlias
+import unittest
+
+import httpx
+from starlette.applications import Starlette
+
+from src.lib.utils import login
+from src.service.mcp import (
+    gateway,
+    protocol,
+    request_context,
+    tool_registry,
+)
+
+
+SyncUpstreamHandler: TypeAlias = Callable[[httpx.Request], httpx.Response]
+AsyncUpstreamHandler: TypeAlias = Callable[
+    [httpx.Request], Coroutine[None, None, httpx.Response]
+]
+UpstreamHandler: TypeAlias = SyncUpstreamHandler | AsyncUpstreamHandler
+UpstreamTransport: TypeAlias = httpx.AsyncBaseTransport | UpstreamHandler
+
+READ_ONLY_ANNOTATIONS = {
+    'readOnlyHint': True,
+    'destructiveHint': False,
+    'idempotentHint': True,
+    'openWorldHint': False,
+}
+
+
+class ProtocolHarness:
+    """Run selected external tools through their real Streamable HTTP path."""
+
+    def __init__(
+        self,
+        *,
+        tool_names: Collection[str],
+        bearer_secret: str,
+        request_id: str,
+        user_name: str = 'alice@example.com',
+        request_timeout_seconds: float = 10,
+    ) -> None:
+        self.tool_names = tuple(tool_names)
+        self.bearer_secret = bearer_secret
+        self.request_id = request_id
+        self.user_name = user_name
+        self.request_timeout_seconds = request_timeout_seconds
+
+    def create_application(self) -> Starlette:
+        """Build one isolated selected-tool protocol application."""
+        mcp_server = protocol.OSMOFastMCP(
+            name='OSMO MCP protocol test',
+            host='0.0.0.0',
+            port=8000,
+            streamable_http_path='/mcp',
+            stateless_http=True,
+            json_response=True,
+        )
+        tool_registry.register_tools(mcp_server, names=self.tool_names)
+        application = mcp_server.streamable_http_app()
+        application.add_middleware(
+            request_context.RequestContextMiddleware,
+            path='/mcp',
+        )
+        return application
+
+    def headers(self) -> dict[str, str]:
+        """Return the trusted Gateway headers for one MCP test request."""
+        return {
+            'Accept': 'application/json, text/event-stream',
+            'Content-Type': 'application/json',
+            login.OSMO_AUTH_HEADER: f'Bearer {self.bearer_secret}',
+            login.OSMO_USER_HEADER: self.user_name,
+            request_context.REQUEST_ID_HEADER: self.request_id,
+        }
+
+    @staticmethod
+    def tool_call(
+        name: str,
+        arguments: dict[str, object] | None = None,
+        *,
+        request_id: int = 1,
+    ) -> dict[str, object]:
+        """Build one tools/call JSON-RPC request."""
+        return {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'method': 'tools/call',
+            'params': {
+                'name': name,
+                'arguments': arguments or {},
+            },
+        }
+
+    @staticmethod
+    def tool_list(*, request_id: int = 1) -> dict[str, object]:
+        """Build one tools/list JSON-RPC request."""
+        return {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'method': 'tools/list',
+            'params': {},
+        }
+
+    @contextlib.asynccontextmanager
+    async def client(
+        self,
+        upstream: UpstreamTransport,
+    ) -> AsyncIterator[httpx.AsyncClient]:
+        """Open an MCP client backed by one bounded mock Gateway transport."""
+        application = self.create_application()
+        transport = (
+            upstream
+            if isinstance(upstream, httpx.AsyncBaseTransport)
+            else httpx.MockTransport(upstream)
+        )
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=self.request_timeout_seconds,
+            transport=transport,
+        ) as app_context:
+            application.state.mcp_app_context = app_context
+            async with application.router.lifespan_context(application):
+                async with httpx.AsyncClient(
+                    transport=httpx.ASGITransport(app=application),
+                    base_url='http://mcp.test',
+                ) as client:
+                    yield client
+
+    async def post_with_client(
+        self,
+        client: httpx.AsyncClient,
+        payload: dict[str, object],
+    ) -> httpx.Response:
+        """Post one JSON-RPC payload through an already-open test client."""
+        return await client.post(
+            '/mcp',
+            headers=self.headers(),
+            json=payload,
+        )
+
+    async def post(
+        self,
+        upstream: UpstreamTransport,
+        payload: dict[str, object],
+    ) -> httpx.Response:
+        """Open an isolated client and post one JSON-RPC payload."""
+        async with self.client(upstream) as client:
+            return await self.post_with_client(client, payload)
+
+    async def call_tool_with_client(
+        self,
+        client: httpx.AsyncClient,
+        name: str,
+        arguments: dict[str, object] | None = None,
+        *,
+        request_id: int = 1,
+    ) -> httpx.Response:
+        """Invoke one selected tool through an already-open client."""
+        return await self.post_with_client(
+            client,
+            self.tool_call(name, arguments, request_id=request_id),
+        )
+
+    async def call_tool(
+        self,
+        upstream: UpstreamTransport,
+        name: str,
+        arguments: dict[str, object] | None = None,
+        *,
+        request_id: int = 1,
+    ) -> httpx.Response:
+        """Invoke one selected tool through an isolated client."""
+        return await self.post(
+            upstream,
+            self.tool_call(name, arguments, request_id=request_id),
+        )
+
+    async def list_tools(
+        self,
+        upstream: UpstreamTransport | None = None,
+        *,
+        request_id: int = 1,
+    ) -> httpx.Response:
+        """List the selected registry tools through the protocol."""
+        return await self.post(
+            (
+                upstream
+                if upstream is not None
+                else _unexpected_upstream_request
+            ),
+            self.tool_list(request_id=request_id),
+        )
+
+    def assert_read_only_closed_catalog(
+        self,
+        test_case: unittest.TestCase,
+        response: httpx.Response,
+    ) -> dict[str, dict[str, Any]]:
+        """Assert common external read-tool annotations and schema closure."""
+        test_case.assertEqual(response.status_code, 200)
+        tools = {
+            tool['name']: tool
+            for tool in response.json()['result']['tools']
+        }
+        test_case.assertEqual(set(tools), set(self.tool_names))
+        for tool in tools.values():
+            test_case.assertEqual(
+                tool['annotations'],
+                READ_ONLY_ANNOTATIONS,
+            )
+            input_schema = tool['inputSchema']
+            test_case.assertFalse(input_schema['additionalProperties'])
+            output_schema = tool['outputSchema']
+            test_case.assertEqual(output_schema['type'], 'object')
+            test_case.assertFalse(output_schema['additionalProperties'])
+            for definition in output_schema.get('$defs', {}).values():
+                if (
+                    definition.get('type') == 'object'
+                    and 'properties' in definition
+                ):
+                    test_case.assertFalse(
+                        definition['additionalProperties']
+                    )
+        return tools
+
+
+async def _unexpected_upstream_request(
+    request: httpx.Request,
+) -> httpx.Response:
+    raise AssertionError(f'unexpected Gateway request: {request.url}')

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -20,7 +20,14 @@ from collections.abc import Callable, Mapping
 from unittest import mock
 import unittest
 
-from src.service.mcp import health, profile, protocol, tool_registry
+from src.service.mcp import (
+    health,
+    pools,
+    profile,
+    protocol,
+    resources,
+    tool_registry,
+)
 
 
 _ExpectedSpec = tuple[Callable[..., object], str, str, str]
@@ -40,21 +47,55 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'Get the active user\'s OSMO profile settings, roles, accessible '
         'pools, and non-secret token identity metadata.',
     ),
+    (
+        pools.osmo_search_pools,
+        'osmo_search_pools',
+        'Search OSMO pools',
+        'Search compute pools accessible to the active user. Results retain '
+        'node-set sharing information, GPU quota usage, and bounded output.',
+    ),
+    (
+        resources.osmo_list_resources,
+        'osmo_list_resources',
+        'List OSMO resources',
+        'List node capacity, usage, and available resources for selected '
+        'pools and platforms with bounded output.',
+    ),
+    (
+        resources.osmo_get_resource,
+        'osmo_get_resource',
+        'Get OSMO resource',
+        'Get one node\'s resource quantities and task configuration for a '
+        'selected pool/platform assignment.',
+    ),
 )
 
 _EXPECTED_REQUIRED_FIELDS: dict[str, list[str]] = {
     'osmo_health': [],
     'osmo_get_profile': [],
+    'osmo_search_pools': [],
+    'osmo_list_resources': [],
+    'osmo_get_resource': ['node_name'],
 }
 
-_EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {}
+_EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
+    'osmo_search_pools': {'query': None, 'limit': 50, 'offset': 0},
+    'osmo_list_resources': {
+        'pool': None,
+        'platform': None,
+        'all_pools': False,
+        'limit': 50,
+        'offset': 0,
+    },
+    'osmo_get_resource': {'pool': None, 'platform': None},
+}
 
 
 class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
     """Lock the ordered, agent-facing external MCP tool contract."""
 
     def test_registry_has_exact_metadata_and_direct_unique_functions(self) -> None:
-        self.assertEqual(len(tool_registry.TOOL_SPECS), 2)
+        self.assertEqual(len(tool_registry.TOOL_SPECS), 5)
         self.assertEqual(
             [
                 (spec.name, spec.title, spec.description)
@@ -69,7 +110,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         registered_functions = [
             spec.function for spec in tool_registry.TOOL_SPECS
         ]
-        self.assertEqual(len({id(function) for function in registered_functions}), 2)
+        self.assertEqual(len({id(function) for function in registered_functions}), 5)
         for spec, (function, _, _, _) in zip(
             tool_registry.TOOL_SPECS,
             _EXPECTED_SPECS,
@@ -82,7 +123,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
 
         tool_registry.register_tools(mcp_server)
 
-        self.assertEqual(mcp_server.add_tool.call_count, 2)
+        self.assertEqual(mcp_server.add_tool.call_count, 5)
         for call, (function, name, title, description) in zip(
             mcp_server.add_tool.call_args_list,
             _EXPECTED_SPECS,
@@ -137,17 +178,27 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
                     f'{tool.name}.{field} default changed',
                 )
 
+        tools_by_name = {tool.name: tool for tool in tools}
+        for tool_name in (
+            'osmo_search_pools',
+            'osmo_list_resources',
+        ):
+            properties = tools_by_name[tool_name].inputSchema['properties']
+            self.assertEqual(properties['limit']['minimum'], 1)
+            self.assertEqual(properties['limit']['maximum'], 200)
+            self.assertEqual(properties['offset']['minimum'], 0)
+
     async def test_selection_retains_canonical_order(self) -> None:
         selected_names = {
             'osmo_health',
-            'osmo_get_profile',
+            'osmo_get_resource',
         }
         selected_specs = tool_registry.select_tool_specs(selected_names)
         self.assertEqual(
             [spec.name for spec in selected_specs],
             [
                 'osmo_health',
-                'osmo_get_profile',
+                'osmo_get_resource',
             ],
         )
 
@@ -159,7 +210,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             [tool.name for tool in await mcp_server.list_tools()],
             [
                 'osmo_health',
-                'osmo_get_profile',
+                'osmo_get_resource',
             ],
         )
 

--- a/src/service/mcp/tests/test_pools.py
+++ b/src/service/mcp/tests/test_pools.py
@@ -1,0 +1,377 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+from unittest import mock
+
+import httpx
+from mcp.server.fastmcp.exceptions import ToolError
+
+from src.service.mcp import (
+    pools,
+    request_context,
+    tool_requests,
+)
+from src.service.mcp.tests import protocol_harness
+
+
+_BEARER_SECRET = 'pool-tool-bearer-secret'
+_HARNESS = protocol_harness.ProtocolHarness(
+    tool_names=('osmo_search_pools',),
+    bearer_secret=_BEARER_SECRET,
+    request_id='pool-request-123',
+)
+
+
+def _usage(
+    *,
+    capacity: str = '8',
+    free: str = '6',
+) -> dict[str, str]:
+    return {
+        'quota_used': '2',
+        'quota_free': '6',
+        'quota_limit': '8',
+        'total_usage': '2',
+        'total_capacity': capacity,
+        'total_free': free,
+    }
+
+
+def _pool(
+    name: str,
+    *,
+    description: str,
+    capacity: str = '8',
+) -> dict[str, object]:
+    return {
+        'name': name,
+        'description': description,
+        'status': 'ONLINE',
+        'backend': 'backend-1',
+        'default_platform': 'gpu',
+        'resource_usage': _usage(capacity=capacity),
+        'platforms': {'gpu': {'internal': 'not returned'}},
+        'topology_keys': [{'internal': 'not returned'}],
+    }
+
+
+def _profile(*accessible_pools: str) -> dict[str, object]:
+    return {
+        'profile': {
+            'username': 'alice@example.com',
+            'pool': accessible_pools[0] if accessible_pools else None,
+        },
+        'roles': ['osmo-user'],
+        'pools': list(accessible_pools),
+        'token': None,
+    }
+
+
+class PoolToolTest(unittest.IsolatedAsyncioTestCase):
+    """Validate pool mapping, pagination, and MCP catalog metadata."""
+
+    async def _invoke_tool(
+        self,
+        handler: protocol_harness.UpstreamTransport,
+        arguments: dict[str, object] | None = None,
+    ) -> httpx.Response:
+        return await _HARNESS.call_tool(
+            handler,
+            'osmo_search_pools',
+            arguments,
+        )
+
+    async def test_catalog_has_bounded_schema_and_read_only_annotations(self) -> None:
+        response = await _HARNESS.list_tools()
+        tools = _HARNESS.assert_read_only_closed_catalog(self, response)
+        tool = tools['osmo_search_pools']
+        input_schema = tool['inputSchema']
+        self.assertEqual(input_schema['properties']['limit']['default'], 50)
+        self.assertEqual(input_schema['properties']['limit']['minimum'], 1)
+        self.assertEqual(input_schema['properties']['limit']['maximum'], 200)
+        self.assertEqual(input_schema['properties']['offset']['minimum'], 0)
+
+    async def test_search_uses_accessible_pools_and_preserves_shared_node_set(self) -> None:
+        context = mock.Mock()
+        pool_payload = {
+            'node_sets': [
+                {
+                    'pools': [
+                        _pool('alpha', description='Shared GPU capacity'),
+                        _pool('beta', description='Shared GPU capacity'),
+                    ],
+                },
+                {
+                    'pools': [
+                        _pool(
+                            'gamma',
+                            description='CPU-only pool',
+                            capacity='0',
+                        ),
+                    ],
+                },
+            ],
+            'resource_sum': _usage(capacity='8'),
+        }
+        request_json = mock.AsyncMock(side_effect=[
+            _profile('alpha', 'beta', 'gamma', 'alpha'),
+            pool_payload,
+        ])
+
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            result = await pools.osmo_search_pools(
+                context,
+                query=' shared ',
+                limit=1,
+                offset=1,
+            )
+
+        self.assertEqual(request_json.await_args_list, [
+            mock.call(
+                context,
+                path='/api/profile/settings',
+                operation='read the active user profile',
+                max_response_bytes=64 * 1024,
+            ),
+            mock.call(
+                context,
+                path='/api/pool_quota',
+                operation='search accessible pools',
+                max_response_bytes=1024 * 1024,
+                query={
+                    'all_pools': False,
+                    'pools': ['alpha', 'beta', 'gamma'],
+                },
+            ),
+        ])
+        self.assertEqual(result.count, 1)
+        self.assertEqual(result.total_matches, 2)
+        self.assertFalse(result.more_entries)
+        self.assertEqual(
+            result.accessible_resource_sum.total_capacity,
+            '8',
+        )
+        self.assertEqual(len(result.node_sets), 1)
+        node_set = result.node_sets[0]
+        self.assertEqual(node_set.index, 0)
+        self.assertTrue(node_set.shared_capacity)
+        self.assertEqual(node_set.pool_names, ['alpha', 'beta'])
+        self.assertEqual(node_set.capacity.total_capacity, '8')
+        self.assertEqual([pool.name for pool in node_set.pools], ['beta'])
+        result_json = result.model_dump_json()
+        self.assertNotIn('topology_keys', result_json)
+        self.assertNotIn('internal', result_json)
+
+    async def test_no_accessible_pools_returns_zero_without_pool_query(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock(return_value=_profile())
+
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            result = await pools.osmo_search_pools(
+                context,
+                query='anything',
+                limit=10,
+                offset=7,
+            )
+
+        request_json.assert_awaited_once_with(
+            context,
+            path='/api/profile/settings',
+            operation='read the active user profile',
+            max_response_bytes=64 * 1024,
+        )
+        self.assertEqual(result.node_sets, [])
+        self.assertEqual(result.count, 0)
+        self.assertEqual(result.total_matches, 0)
+        self.assertEqual(result.offset, 7)
+        self.assertEqual(result.limit, 10)
+        self.assertFalse(result.more_entries)
+        self.assertEqual(result.accessible_resource_sum, pools.PoolResourceUsage(
+            quota_used='0',
+            quota_free='0',
+            quota_limit='0',
+            total_usage='0',
+            total_capacity='0',
+            total_free='0',
+        ))
+
+    async def test_protocol_relays_credentials_through_both_fixed_routes(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.url.path == '/api/profile/settings':
+                return httpx.Response(200, json=_profile('alpha'))
+            if request.url.path == '/api/pool_quota':
+                return httpx.Response(200, json={
+                    'node_sets': [{
+                        'pools': [_pool('alpha', description='GPU pool')],
+                    }],
+                    'resource_sum': _usage(),
+                })
+            self.fail(f'unexpected Gateway route: {request.url}')
+
+        response = await self._invoke_tool(handler)
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(
+            result['structuredContent']['node_sets'][0]['pools'][0]['name'],
+            'alpha',
+        )
+        self.assertIn('accessible_resource_sum', result['structuredContent'])
+        self.assertNotIn('resource_sum', result['structuredContent'])
+        self.assertEqual(
+            [request.url.path for request in captured_requests],
+            ['/api/profile/settings', '/api/pool_quota'],
+        )
+        self.assertEqual(captured_requests[1].url.params.multi_items(), [
+            ('all_pools', 'false'),
+            ('pools', 'alpha'),
+        ])
+        for request in captured_requests:
+            self.assertEqual(
+                request.headers['authorization'],
+                f'Bearer {_BEARER_SECRET}',
+            )
+            self.assertEqual(
+                request.headers[request_context.REQUEST_ID_HEADER],
+                'pool-request-123',
+            )
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+    async def test_protocol_sanitizes_gateway_failure(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(403, content=b'upstream-pool-body-secret')
+
+        response = await self._invoke_tool(handler)
+
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('HTTP 403', response.text)
+        self.assertNotIn('upstream-pool-body-secret', response.text)
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+    async def test_inaccessible_or_malformed_upstream_pool_fails_closed(self) -> None:
+        context = mock.Mock()
+        inaccessible_payload = {
+            'node_sets': [{
+                'pools': [_pool('not-allowed', description='private')],
+            }],
+            'resource_sum': _usage(),
+        }
+        request_json = mock.AsyncMock(side_effect=[
+            _profile('alpha'),
+            inaccessible_payload,
+        ])
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                request_json,
+            ),
+            self.assertRaisesRegex(ToolError, 'invalid pool response'),
+        ):
+            await pools.osmo_search_pools(context)
+
+        malformed_request = mock.AsyncMock(side_effect=[
+            _profile('alpha'),
+            {'node_sets': 'not-a-list', 'resource_sum': _usage()},
+        ])
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                malformed_request,
+            ),
+            self.assertRaisesRegex(ToolError, 'invalid pool response'),
+        ):
+            await pools.osmo_search_pools(context)
+
+    async def test_invalid_search_bounds_fail_before_transport(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock()
+        invalid_calls = (
+            {'limit': 0},
+            {'limit': 201},
+            {'limit': True},
+            {'offset': -1},
+            {'offset': True},
+            {'query': 'x' * 257},
+            {'query': 'line\nbreak'},
+        )
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            for arguments in invalid_calls:
+                with self.subTest(arguments=arguments):
+                    with self.assertRaises(ToolError):
+                        await pools.osmo_search_pools(context, **arguments)
+
+        request_json.assert_not_awaited()
+
+    async def test_protocol_rejects_boolean_pagination_before_relay(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=_profile('alpha'))
+
+        cases: tuple[dict[str, object], ...] = (
+            {'limit': True},
+            {'offset': True},
+        )
+        for arguments in cases:
+            with self.subTest(arguments=arguments):
+                response = await self._invoke_tool(
+                    handler,
+                    arguments,
+                )
+                self.assertTrue(response.json()['result']['isError'])
+
+        self.assertEqual(captured_requests, [])
+
+    async def test_profile_and_gateway_failures_are_not_rewritten(self) -> None:
+        context = mock.Mock()
+        upstream_error = ToolError('OSMO Gateway response exceeds the size limit.')
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                mock.AsyncMock(side_effect=upstream_error),
+            ),
+            self.assertRaises(ToolError) as raised,
+        ):
+            await pools.osmo_search_pools(context)
+
+        self.assertIs(raised.exception, upstream_error)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_resources.py
+++ b/src/service/mcp/tests/test_resources.py
@@ -1,0 +1,907 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+from unittest import mock
+
+import httpx
+from mcp.server.fastmcp.exceptions import ToolError
+
+from src.lib.utils import resource_quantities
+from src.service.mcp import (
+    request_context,
+    resources,
+    tool_requests,
+)
+from src.service.mcp.tests import protocol_harness
+
+
+_BEARER_SECRET = 'resource-tool-bearer-secret'
+_HARNESS = protocol_harness.ProtocolHarness(
+    tool_names=(
+        'osmo_list_resources',
+        'osmo_get_resource',
+    ),
+    bearer_secret=_BEARER_SECRET,
+    request_id='resource-request-123',
+)
+
+
+def _profile(
+    *,
+    default_pool: str | None = 'alpha',
+    accessible_pools: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        'profile': {
+            'username': 'alice@example.com',
+            'pool': default_pool,
+        },
+        'roles': ['osmo-user'],
+        'pools': (
+            accessible_pools
+            if accessible_pools is not None
+            else ['alpha', 'beta']
+        ),
+        'token': None,
+    }
+
+
+def _resource(
+    node: str = 'node-1',
+) -> dict[str, object]:
+    return {
+        'hostname': node,
+        'backend': 'backend-1',
+        'resource_type': 'SHARED',
+        'usage_fields': {
+            'storage': '20481Mi',
+            'cpu': '2.1',
+            'memory': 8589934592,
+            'gpu': '1.2',
+            'internal_usage': 'not returned',
+        },
+        'allocatable_fields': {
+            'storage': 107374182400,
+            'cpu': '8.9',
+            'memory': '33554432Ki',
+            'gpu': '4.9',
+            'internal_capacity': 'not returned',
+        },
+        'platform_allocatable_fields': {
+            'alpha': {
+                'gpu': {
+                    'storage': '94371840Ki',
+                    'cpu': '7.9',
+                    'memory': 32212254720,
+                    'gpu': '4.9',
+                },
+                'cpu': {
+                    'storage': '80Gi',
+                    'cpu': '6',
+                    'memory': '28Gi',
+                    'gpu': '0',
+                },
+            },
+            'beta': {
+                'gpu': {
+                    'storage': '94371840Ki',
+                    'cpu': '7.9',
+                    'memory': 32212254720,
+                    'gpu': '4.9',
+                },
+            },
+        },
+        'platform_available_fields': {
+            'alpha': {
+                'gpu': {
+                    'storage': '70Gi',
+                    'cpu': '5',
+                    'memory': '22Gi',
+                    'gpu': '3',
+                },
+                'cpu': {
+                    'storage': '60Gi',
+                    'cpu': '4',
+                    'memory': '20Gi',
+                    'gpu': '0',
+                },
+            },
+            'beta': {
+                'gpu': {
+                    'storage': '70Gi',
+                    'cpu': '5',
+                    'memory': '22Gi',
+                    'gpu': '3',
+                },
+            },
+        },
+        'config_fields': {
+            'alpha': {
+                'gpu': {
+                    'host_network': True,
+                    'privileged': False,
+                    'default_mounts': ['/data'],
+                    'allowed_mounts': ['/data', '/scratch'],
+                    'internal_config': 'not returned',
+                },
+            },
+        },
+        'pool_platform_labels': {
+            'alpha': ['gpu', 'cpu'],
+            'beta': ['gpu'],
+        },
+        'label_fields': {'internal-label': 'not returned'},
+        'taints': [{'internal-taint': 'not returned'}],
+    }
+
+
+class ResourceQuantityHelperTest(unittest.TestCase):
+    """Keep CLI-facing normalization stable for real Core quantity shapes."""
+
+    def test_normalizes_bytes_and_ki_with_null_platform_maps(self) -> None:
+        payload = _resource()
+        payload['platform_allocatable_fields'] = None
+        payload['platform_available_fields'] = None
+
+        result = resource_quantities.normalize_resource_quantities(
+            payload,
+            'alpha',
+            'gpu',
+        )
+
+        self.assertEqual(result, {
+            'storage': {
+                'capacity': 100,
+                'used': 21,
+                'free': 79,
+                'unit': 'Gi',
+            },
+            'cpu': {'capacity': 8, 'used': 3, 'free': 5},
+            'memory': {
+                'capacity': 32,
+                'used': 8,
+                'free': 24,
+                'unit': 'Gi',
+            },
+            'gpu': {'capacity': 4, 'used': 2, 'free': 2},
+        })
+
+    def test_clamps_rounded_usage_to_capacity(self) -> None:
+        result = resource_quantities.normalize_resource_quantities(
+            {
+                'allocatable_fields': {'cpu': '2.9'},
+                'usage_fields': {'cpu': '8.1'},
+            },
+            'alpha',
+            'gpu',
+        )
+
+        self.assertEqual(result, {
+            'cpu': {'capacity': 2, 'used': 2, 'free': 0},
+        })
+
+    def test_skips_one_bad_quantity_and_defaults_missing_count_usage(self) -> None:
+        result = resource_quantities.normalize_resource_quantities(
+            {
+                'allocatable_fields': {
+                    'storage': 'not-a-quantity',
+                    'cpu': '8',
+                    'memory': '32Gi',
+                    'gpu': '4',
+                },
+                'usage_fields': {'memory': '8Gi'},
+            },
+            'alpha',
+            'gpu',
+        )
+
+        self.assertEqual(result, {
+            'cpu': {'capacity': 8, 'used': 0, 'free': 8},
+            'memory': {
+                'capacity': 32,
+                'used': 8,
+                'free': 24,
+                'unit': 'Gi',
+            },
+            'gpu': {'capacity': 4, 'used': 0, 'free': 4},
+        })
+        self.assertEqual(
+            resources.ResourceQuantities.model_validate(
+                result,
+                strict=True,
+            ).model_dump(mode='json'),
+            result,
+        )
+
+
+class ResourceToolTest(unittest.IsolatedAsyncioTestCase):
+    """Validate resource route mapping, projection, and input boundaries."""
+
+    async def _invoke_tool(
+        self,
+        handler: protocol_harness.UpstreamTransport,
+        tool_name: str,
+        arguments: dict[str, object],
+    ) -> httpx.Response:
+        return await _HARNESS.call_tool(
+            handler,
+            tool_name,
+            arguments,
+        )
+
+    async def test_catalog_has_two_bounded_read_only_tools(self) -> None:
+        response = await _HARNESS.list_tools()
+        tools = _HARNESS.assert_read_only_closed_catalog(self, response)
+        list_tool = tools['osmo_list_resources']
+        list_schema = list_tool['inputSchema']
+        self.assertEqual(list_schema['properties']['limit']['default'], 50)
+        self.assertEqual(list_schema['properties']['limit']['maximum'], 200)
+        self.assertEqual(list_schema['properties']['offset']['minimum'], 0)
+        get_tool = tools['osmo_get_resource']
+        self.assertEqual(get_tool['inputSchema']['required'], ['node_name'])
+
+    async def test_list_uses_default_pool_and_projects_allowlisted_fields(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock(side_effect=[
+            _profile(),
+            {'resources': [_resource()]},
+        ])
+
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            result = await resources.osmo_list_resources(
+                context,
+                platform=['gpu'],
+            )
+
+        self.assertEqual(request_json.await_args_list, [
+            mock.call(
+                context,
+                path='/api/profile/settings',
+                operation='read the active user profile',
+                max_response_bytes=64 * 1024,
+            ),
+            mock.call(
+                context,
+                path='/api/resources',
+                operation='list node resources',
+                max_response_bytes=2 * 1024 * 1024,
+                query={
+                    'all_pools': False,
+                    'pools': ['alpha'],
+                    'platforms': ['gpu'],
+                },
+            ),
+        ])
+        self.assertEqual(result.count, 1)
+        self.assertEqual(result.total_entries, 1)
+        entry = result.resources[0]
+        self.assertEqual(entry.node, 'node-1')
+        self.assertEqual(entry.pool, 'alpha')
+        self.assertEqual(entry.platform, 'gpu')
+        self.assertEqual(entry.resources.cpu, resources.ResourceQuantity(
+            capacity=7,
+            used=3,
+            free=4,
+        ))
+        self.assertEqual(entry.resources.storage, resources.ResourceQuantity(
+            capacity=90,
+            used=21,
+            free=69,
+            unit='Gi',
+        ))
+        self.assertEqual(entry.resources.memory, resources.ResourceQuantity(
+            capacity=30,
+            used=8,
+            free=22,
+            unit='Gi',
+        ))
+        self.assertEqual(entry.resources.gpu, resources.ResourceQuantity(
+            capacity=4,
+            used=2,
+            free=2,
+        ))
+        serialized_entry = entry.model_dump(mode='json')
+        self.assertEqual(serialized_entry['resources'], {
+            'storage': {
+                'capacity': 90,
+                'used': 21,
+                'free': 69,
+                'unit': 'Gi',
+            },
+            'cpu': {
+                'capacity': 7,
+                'used': 3,
+                'free': 4,
+            },
+            'memory': {
+                'capacity': 30,
+                'used': 8,
+                'free': 22,
+                'unit': 'Gi',
+            },
+            'gpu': {
+                'capacity': 4,
+                'used': 2,
+                'free': 2,
+            },
+        })
+        result_json = result.model_dump_json()
+        self.assertNotIn('internal', result_json)
+        self.assertNotIn('label_fields', result_json)
+        self.assertNotIn('taints', result_json)
+
+    async def test_list_explicit_pools_deduplicates_and_paginates_locally(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock(side_effect=[
+            _profile(),
+            {'resources': [_resource()]},
+        ])
+
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            result = await resources.osmo_list_resources(
+                context,
+                pool=['alpha', 'alpha', 'beta'],
+                limit=1,
+                offset=1,
+            )
+
+        self.assertEqual(request_json.await_args_list, [
+            mock.call(
+                context,
+                path='/api/profile/settings',
+                operation='read the active user profile',
+                max_response_bytes=64 * 1024,
+            ),
+            mock.call(
+                context,
+                path='/api/resources',
+                operation='list node resources',
+                max_response_bytes=2 * 1024 * 1024,
+                query={
+                    'all_pools': False,
+                    'pools': ['alpha', 'beta'],
+                },
+            ),
+        ])
+        self.assertEqual(result.count, 1)
+        self.assertEqual(result.total_entries, 3)
+        self.assertTrue(result.more_entries)
+        self.assertEqual(result.resources[0].pool, 'alpha')
+        self.assertEqual(result.resources[0].platform, 'gpu')
+
+    async def test_list_with_no_accessible_pools_short_circuits(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock(return_value=_profile(
+            accessible_pools=[],
+        ))
+
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            result = await resources.osmo_list_resources(
+                context,
+                limit=10,
+                offset=7,
+            )
+
+        request_json.assert_awaited_once_with(
+            context,
+            path='/api/profile/settings',
+            operation='read the active user profile',
+            max_response_bytes=64 * 1024,
+        )
+        self.assertEqual(result.resources, [])
+        self.assertEqual(result.count, 0)
+        self.assertEqual(result.total_entries, 0)
+        self.assertEqual(result.offset, 7)
+        self.assertEqual(result.limit, 10)
+        self.assertFalse(result.more_entries)
+
+    async def test_protocol_relays_credentials_to_fixed_resource_route(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.url.path == '/api/profile/settings':
+                return httpx.Response(200, json=_profile())
+            if request.url.path == '/api/resources':
+                return httpx.Response(200, json={'resources': [_resource()]})
+            self.fail(f'unexpected Gateway route: {request.url}')
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_list_resources',
+            {'pool': ['alpha'], 'platform': ['gpu']},
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent']['resources'][0]['node'], 'node-1')
+        self.assertEqual(len(captured_requests), 2)
+        request = captured_requests[1]
+        self.assertEqual(request.url.path, '/api/resources')
+        self.assertEqual(request.url.params.multi_items(), [
+            ('all_pools', 'false'),
+            ('pools', 'alpha'),
+            ('platforms', 'gpu'),
+        ])
+        for captured_request in captured_requests:
+            self.assertEqual(
+                captured_request.headers['authorization'],
+                f'Bearer {_BEARER_SECRET}',
+            )
+            self.assertEqual(
+                captured_request.headers[request_context.REQUEST_ID_HEADER],
+                'resource-request-123',
+            )
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+    async def test_get_protocol_reads_profile_then_fetches_only_the_node(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        node = _resource()
+        node['pool_platform_labels'] = {'alpha': ['gpu']}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.url.path == '/api/profile/settings':
+                return httpx.Response(200, json=_profile())
+            if request.url.path == '/api/resources/node-1':
+                return httpx.Response(200, json={'resources': [node]})
+            self.fail(f'unexpected Gateway route: {request.url}')
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_get_resource',
+            {'node_name': 'node-1'},
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent']['node'], 'node-1')
+        self.assertEqual(len(captured_requests), 2)
+        request = captured_requests[1]
+        self.assertEqual(request.url.path, '/api/resources/node-1')
+        self.assertEqual(request.url.params.multi_items(), [])
+        for captured_request in captured_requests:
+            self.assertEqual(
+                captured_request.headers['authorization'],
+                f'Bearer {_BEARER_SECRET}',
+            )
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+    async def test_get_protocol_has_uniform_missing_and_inaccessible_result(
+        self,
+    ) -> None:
+        inaccessible_node = _resource()
+        inaccessible_node['pool_platform_labels'] = {'beta': ['gpu']}
+        outcomes = (
+            httpx.Response(404, json={'message': 'node does not exist'}),
+            httpx.Response(200, json={'resources': [inaccessible_node]}),
+        )
+        messages: list[str] = []
+
+        for detail_response in outcomes:
+            async def handler(
+                request: httpx.Request,
+                response: httpx.Response = detail_response,
+            ) -> httpx.Response:
+                if request.url.path == '/api/profile/settings':
+                    return httpx.Response(
+                        200,
+                        json=_profile(accessible_pools=['alpha']),
+                )
+                if request.url.path == '/api/resources/node-1':
+                    return response
+                self.fail(f'unexpected Gateway route: {request.url}')
+
+            response = await self._invoke_tool(
+                handler,
+                'osmo_get_resource',
+                {'node_name': 'node-1'},
+            )
+            result = response.json()['result']
+            self.assertTrue(result['isError'])
+            messages.append(result['content'][0]['text'])
+
+        self.assertEqual(messages, [
+            (
+                'Error executing tool osmo_get_resource: '
+                'The requested node is not available.'
+            ),
+            (
+                'Error executing tool osmo_get_resource: '
+                'The requested node is not available.'
+            ),
+        ])
+
+    async def test_protocol_rejects_boolean_pagination_before_transport(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=_profile())
+
+        invalid_calls: tuple[dict[str, object], ...] = (
+            {'limit': True},
+            {'offset': True},
+        )
+        for arguments in invalid_calls:
+            with self.subTest(arguments=arguments):
+                response = await self._invoke_tool(
+                    handler,
+                    'osmo_list_resources',
+                    arguments,
+                )
+                self.assertTrue(response.json()['result']['isError'])
+
+        self.assertEqual(captured_requests, [])
+
+    async def test_protocol_sanitizes_gateway_failure(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(403, content=b'upstream-resource-body-secret')
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_list_resources',
+            {'pool': ['alpha']},
+        )
+
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('HTTP 403', response.text)
+        self.assertNotIn('upstream-resource-body-secret', response.text)
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+    async def test_get_resource_uses_node_route_and_returns_configuration(self) -> None:
+        context = mock.Mock()
+        node_name = 'node name+日本語'
+        node = _resource(node_name)
+        node['pool_platform_labels'] = {'alpha': ['gpu', 'cpu']}
+        request_json = mock.AsyncMock(side_effect=[
+            _profile(accessible_pools=['alpha']),
+            {'resources': [node]},
+        ])
+
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            result = await resources.osmo_get_resource(
+                context,
+                node_name,
+                pool='alpha',
+                platform='gpu',
+            )
+
+        self.assertEqual(request_json.await_args_list, [
+            mock.call(
+                context,
+                path='/api/profile/settings',
+                operation='read the active user profile',
+                max_response_bytes=64 * 1024,
+            ),
+            mock.call(
+                context,
+                path=(
+                    '/api/resources/'
+                    'node%20name%2B%E6%97%A5%E6%9C%AC%E8%AA%9E'
+                ),
+                operation='get a node resource',
+                max_response_bytes=2 * 1024 * 1024,
+                not_found_message='The requested node is not available.',
+            ),
+        ])
+        self.assertEqual(result.node, node_name)
+        self.assertEqual(result.selected.pool, 'alpha')
+        self.assertEqual(result.selected.platform, 'gpu')
+        self.assertEqual(result.assignments, {
+            'alpha': ['cpu', 'gpu'],
+        })
+        self.assertTrue(result.configuration.host_network)
+        self.assertFalse(result.configuration.privileged)
+        self.assertEqual(result.configuration.default_mounts, ['/data'])
+        storage = result.resources.storage
+        self.assertIsNotNone(storage)
+        assert storage is not None
+        self.assertEqual(storage.capacity, 90)
+        self.assertEqual(storage.used, 21)
+        self.assertEqual(storage.free, 69)
+        self.assertNotIn('internal_config', result.model_dump_json())
+
+    async def test_get_resource_disambiguates_duplicate_node_names_by_assignment(self) -> None:
+        context = mock.Mock()
+        alpha_resource = _resource()
+        alpha_resource['pool_platform_labels'] = {'alpha': ['gpu']}
+        beta_resource = _resource()
+        beta_resource['backend'] = 'backend-2'
+        beta_resource['pool_platform_labels'] = {'beta': ['gpu']}
+        request_json = mock.AsyncMock(side_effect=[
+            _profile(),
+            {'resources': [alpha_resource, beta_resource]},
+        ])
+
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            result = await resources.osmo_get_resource(
+                context,
+                'node-1',
+                pool='alpha',
+                platform='gpu',
+            )
+
+        self.assertEqual(result.backend, 'backend-1')
+        self.assertEqual(result.assignments, {'alpha': ['gpu']})
+
+    async def test_get_resource_requires_selection_for_multiple_assignments(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock(side_effect=[
+            _profile(),
+            {'resources': [_resource()]},
+        ])
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                request_json,
+            ),
+            self.assertRaisesRegex(ToolError, 'provide pool and platform'),
+        ):
+            await resources.osmo_get_resource(context, 'node-1')
+
+        self.assertEqual(request_json.await_count, 2)
+
+    async def test_get_resource_auto_selects_exactly_one_assignment(self) -> None:
+        context = mock.Mock()
+        node = _resource()
+        node['pool_platform_labels'] = {
+            'alpha': ['gpu'],
+            'beta': ['gpu'],
+        }
+        request_json = mock.AsyncMock(side_effect=[
+            _profile(accessible_pools=['alpha']),
+            {'resources': [node]},
+        ])
+
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            result = await resources.osmo_get_resource(context, 'node-1')
+
+        self.assertEqual(result.selected, resources.ResourceSelection(
+            pool='alpha',
+            platform='gpu',
+        ))
+        self.assertEqual(result.assignments, {'alpha': ['gpu']})
+        self.assertNotIn('beta', result.model_dump_json())
+
+    async def test_get_resource_has_uniform_not_found_result(self) -> None:
+        context = mock.Mock()
+        messages: list[str] = []
+
+        payloads: tuple[dict[str, object], ...] = (
+            {'resources': []},
+            {'resources': [_resource('another-node')]},
+        )
+        for payload in payloads:
+            with (
+                mock.patch.object(
+                    tool_requests,
+                    'request_json_object',
+                    mock.AsyncMock(side_effect=[_profile(), payload]),
+                ),
+                self.assertRaises(ToolError) as raised,
+            ):
+                await resources.osmo_get_resource(context, 'node-1')
+            messages.append(str(raised.exception))
+
+        self.assertEqual(messages, [
+            'The requested node is not available.',
+            'The requested node is not available.',
+        ])
+
+    async def test_get_resource_with_no_accessible_pools_short_circuits(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock(return_value=_profile(accessible_pools=[]))
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                request_json,
+            ),
+            self.assertRaisesRegex(
+                ToolError,
+                'The requested node is not available',
+            ),
+        ):
+            await resources.osmo_get_resource(context, 'node-1')
+
+        request_json.assert_awaited_once_with(
+            context,
+            path='/api/profile/settings',
+            operation='read the active user profile',
+            max_response_bytes=64 * 1024,
+        )
+
+    async def test_get_resource_in_inaccessible_pool_uses_uniform_not_found(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock(return_value=_profile(
+            accessible_pools=['alpha'],
+        ))
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                request_json,
+            ),
+            self.assertRaises(ToolError) as raised,
+        ):
+            await resources.osmo_get_resource(
+                context,
+                'node-1',
+                pool='beta',
+                platform='gpu',
+            )
+
+        self.assertEqual(
+            str(raised.exception),
+            'The requested node is not available.',
+        )
+        request_json.assert_awaited_once_with(
+            context,
+            path='/api/profile/settings',
+            operation='read the active user profile',
+            max_response_bytes=64 * 1024,
+        )
+
+    async def test_invalid_paths_filters_and_bounds_fail_before_transport(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock()
+        with mock.patch.object(
+            tool_requests,
+            'request_json_object',
+            request_json,
+        ):
+            with self.assertRaisesRegex(ToolError, 'Invalid node_name'):
+                await resources.osmo_get_resource(context, '../node')
+            with self.assertRaisesRegex(ToolError, 'provided together'):
+                await resources.osmo_get_resource(
+                    context,
+                    'node-1',
+                    pool='alpha',
+                )
+            with self.assertRaisesRegex(ToolError, 'Invalid pool'):
+                await resources.osmo_list_resources(
+                    context,
+                    pool=['alpha/other'],
+                )
+            with self.assertRaisesRegex(ToolError, 'Invalid pool'):
+                await resources.osmo_list_resources(context, pool=[])
+            with self.assertRaisesRegex(ToolError, 'Invalid platform'):
+                await resources.osmo_list_resources(context, platform=[])
+            with self.assertRaisesRegex(ToolError, 'cannot be used together'):
+                await resources.osmo_list_resources(
+                    context,
+                    pool=['alpha'],
+                    all_pools=True,
+                )
+            with self.assertRaisesRegex(ToolError, 'pagination'):
+                await resources.osmo_list_resources(context, limit=201)
+            with self.assertRaisesRegex(ToolError, 'pagination'):
+                await resources.osmo_list_resources(context, limit=True)
+            with self.assertRaisesRegex(ToolError, 'pagination'):
+                await resources.osmo_list_resources(context, offset=True)
+
+        request_json.assert_not_awaited()
+
+    async def test_inaccessible_pool_is_rejected_before_resource_request(self) -> None:
+        context = mock.Mock()
+        request_json = mock.AsyncMock(return_value=_profile(
+            accessible_pools=['alpha'],
+        ))
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                request_json,
+            ),
+            self.assertRaisesRegex(ToolError, 'not accessible'),
+        ):
+            await resources.osmo_list_resources(context, pool=['beta'])
+
+        request_json.assert_awaited_once_with(
+            context,
+            path='/api/profile/settings',
+            operation='read the active user profile',
+            max_response_bytes=64 * 1024,
+        )
+
+    async def test_malformed_and_gateway_failures_are_sanitized_or_preserved(self) -> None:
+        context = mock.Mock()
+        malformed = mock.AsyncMock(side_effect=[
+            _profile(),
+            {'resources': [{'hostname': 'node-1'}]},
+        ])
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                malformed,
+            ),
+            self.assertRaisesRegex(ToolError, 'invalid resource response'),
+        ):
+            await resources.osmo_list_resources(
+                context,
+                pool=['alpha'],
+            )
+
+        missing_configuration = _resource()
+        missing_configuration['config_fields'] = {}
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                mock.AsyncMock(side_effect=[
+                    _profile(accessible_pools=['alpha']),
+                    {'resources': [missing_configuration]},
+                ]),
+            ),
+            self.assertRaisesRegex(ToolError, 'invalid node resource response'),
+        ):
+            await resources.osmo_get_resource(
+                context,
+                'node-1',
+                pool='alpha',
+                platform='gpu',
+            )
+
+        upstream_error = ToolError('OSMO Gateway response exceeds the size limit.')
+        with (
+            mock.patch.object(
+                tool_requests,
+                'request_json_object',
+                mock.AsyncMock(side_effect=[_profile(), upstream_error]),
+            ),
+            self.assertRaises(ToolError) as raised,
+        ):
+            await resources.osmo_get_resource(context, 'node-1')
+        self.assertIs(raised.exception, upstream_error)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tool_models.py
+++ b/src/service/mcp/tool_models.py
@@ -1,0 +1,43 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Annotated
+
+import pydantic
+
+
+PageLimit = Annotated[
+    int,
+    pydantic.Field(strict=True, ge=1, le=200),
+]
+PageOffset = Annotated[
+    int,
+    pydantic.Field(strict=True, ge=0),
+]
+
+
+class ClosedToolModel(pydantic.BaseModel):
+    """MCP-facing model whose advertised object schema is closed."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+
+class ExtensibleUpstreamModel(pydantic.BaseModel):
+    """Allowlisted projection that tolerates additive upstream fields."""
+
+    model_config = pydantic.ConfigDict(extra='ignore')

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -22,7 +22,12 @@ import dataclasses
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
-from src.service.mcp import health, profile
+from src.service.mcp import (
+    health,
+    pools,
+    profile,
+    resources,
+)
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -52,6 +57,33 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         description=(
             'Get the active user\'s OSMO profile settings, roles, accessible '
             'pools, and non-secret token identity metadata.'
+        ),
+    ),
+    ToolSpec(
+        function=pools.osmo_search_pools,
+        name='osmo_search_pools',
+        title='Search OSMO pools',
+        description=(
+            'Search compute pools accessible to the active user. Results retain '
+            'node-set sharing information, GPU quota usage, and bounded output.'
+        ),
+    ),
+    ToolSpec(
+        function=resources.osmo_list_resources,
+        name='osmo_list_resources',
+        title='List OSMO resources',
+        description=(
+            'List node capacity, usage, and available resources for selected '
+            'pools and platforms with bounded output.'
+        ),
+    ),
+    ToolSpec(
+        function=resources.osmo_get_resource,
+        name='osmo_get_resource',
+        title='Get OSMO resource',
+        description=(
+            'Get one node\'s resource quantities and task configuration for a '
+            'selected pool/platform assignment.'
         ),
     ),
 )


### PR DESCRIPTION
## Description

Add caller-bound external MCP tools for pool and resource inventory.

Issue - None

### Stack

1. #1204 (merged): runtime foundation
2. **#1205 (this PR):** pool and resource inventory tools
3. #1206: workflow read tools
4. #1207: app and credential metadata tools plus final documentation

### Summary

- Adds `osmo_search_pools`, `osmo_list_resources`, and `osmo_get_resource`.
- Reuses existing OSMO routes and filters results to the caller's accessible pools.
- Uses direct resource-detail lookup instead of downloading the full inventory for one node.
- Extracts a dependency-free resource quantity helper shared with existing CLI formatting semantics.
- Returns normalized capacity, used, free, and unit values, including derived free capacity when needed.
- Short-circuits callers with no accessible pools and keeps model output bounded.
- Adds no Python requirements or lockfile changes.

### Validation

- Focused catalog, pool, resource, and shared conversion tests passed.
- Complete MCP package validation passed: 40/40 test, lint, and type targets.
- `//src/service/mcp:mcp_binary` built successfully.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is completed by the final PR in this stack.
