### PR TITLE
Add external MCP workflow read tools

### DIFF
--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -137,6 +137,16 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "workflow_models",
+    srcs = ["workflow_models.py"],
+    deps = [
+        requirement("pydantic"),
+        ":tool_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "profile_tools",
     srcs = ["profile.py"],
     deps = [
@@ -189,6 +199,21 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "workflow_tools",
+    srcs = ["workflows.py"],
+    deps = [
+        requirement("mcp"),
+        ":access_scope",
+        ":gateway",
+        ":tool_errors",
+        ":tool_requests",
+        ":tool_validation",
+        ":workflow_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "tool_registry",
     srcs = ["tool_registry.py"],
     deps = [
@@ -197,6 +222,7 @@ osmo_py_library(
         ":pool_tools",
         ":profile_tools",
         ":resource_tools",
+        ":workflow_tools",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -73,12 +73,21 @@ The Gateway, MCP process, receiving OSMO APIs, and applicable middleware are
 inside the bearer-token handling boundary. None of them may log or persist the
 authorization value.
 
-## Current tool
+## Available read tools
 
-`osmo_get_profile` maps to `GET /api/profile/settings`, requires the existing
-`profile:Read` action on the second Gateway pass, accepts no tool arguments,
-and limits the response to 64 KiB. Its structured result uses the same
-lightweight profile API contract as Core.
+The external service exposes narrow tools for:
+
+- caller access and identity: `osmo_health`, `osmo_get_profile`
+- inventory: `osmo_search_pools`, `osmo_list_resources`, `osmo_get_resource`
+- workflows: `osmo_list_workflows`, `osmo_get_workflow`,
+  `osmo_get_workflow_logs`, `osmo_get_workflow_events`,
+  `osmo_get_workflow_spec`
+
+Each tool maps to a fixed OSMO API route and returns an allowlisted structured
+projection. JSON tools require one complete bounded response. Bounded text
+tools may instead return a safe UTF-8 prefix with `truncated=true` and a
+machine-readable reason when the response reaches its size limit or its live
+stream does not complete before the request timeout.
 
 The Kubernetes `/health`, `/health/live`, and `/health/ready` endpoints only
 report MCP process health. They do not relay a token or test Gateway/API

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -65,6 +65,7 @@ class GatewayResponse:
 
 
 _RESPONSE_SIZE_LIMIT = 'response_size_limit'
+_RESPONSE_TIMEOUT = 'response_timeout'
 
 
 class GatewayClient:
@@ -161,6 +162,11 @@ class GatewayClient:
         start_time = time.monotonic()
         status_code: int | None = None
         outcome = 'transport_error'
+        response: httpx.Response | None = None
+        response_body = b''
+        response_body_prefix = bytearray()
+        body_truncated = False
+        truncation_reason: str | None = None
         try:
             try:
                 async with asyncio.timeout(self._request_timeout_seconds):
@@ -178,20 +184,24 @@ class GatewayClient:
                                 'OSMO Gateway returned an invalid response.')
 
                         if not response.is_success:
-                            response_body, body_truncated = (
-                                await _read_bounded_prefix(
-                                    response,
-                                    _MAX_ERROR_RESPONSE_BYTES,
-                                )
+                            body_truncated = await _read_bounded_prefix(
+                                response,
+                                _MAX_ERROR_RESPONSE_BYTES,
+                                response_body_prefix,
                             )
+                            response_body = bytes(response_body_prefix)
+                            if body_truncated:
+                                truncation_reason = _RESPONSE_SIZE_LIMIT
                             outcome = 'upstream_error'
                         elif truncate_success:
-                            response_body, body_truncated = (
-                                await _read_bounded_prefix(
-                                    response,
-                                    max_response_bytes,
-                                )
+                            body_truncated = await _read_bounded_prefix(
+                                response,
+                                max_response_bytes,
+                                response_body_prefix,
                             )
+                            response_body = bytes(response_body_prefix)
+                            if body_truncated:
+                                truncation_reason = _RESPONSE_SIZE_LIMIT
                             outcome = (
                                 'response_truncated'
                                 if body_truncated
@@ -206,11 +216,26 @@ class GatewayClient:
                             outcome = 'response_received'
                     finally:
                         await response.aclose()
-            except (TimeoutError, httpx.RequestError):
+            except (TimeoutError, httpx.TimeoutException):
+                if (
+                    not truncate_success
+                    or response is None
+                    or not response.is_success
+                ):
+                    outcome = 'transport_error'
+                    raise GatewayClientError(
+                        'OSMO Gateway is unavailable.') from None
+                response_body = bytes(response_body_prefix)
+                body_truncated = True
+                truncation_reason = _RESPONSE_TIMEOUT
+                outcome = 'response_truncated'
+            except httpx.RequestError:
                 outcome = 'transport_error'
                 raise GatewayClientError(
                     'OSMO Gateway is unavailable.') from None
 
+            if response is None:
+                raise AssertionError('Gateway response state is unavailable.')
             if _contains_relayed_credentials(
                 response_body,
                 credentials,
@@ -223,9 +248,7 @@ class GatewayClient:
                 response.status_code,
                 response_body,
                 body_truncated=body_truncated,
-                truncation_reason=(
-                    _RESPONSE_SIZE_LIMIT if body_truncated else None
-                ),
+                truncation_reason=truncation_reason,
             )
         finally:
             # Set-Cookie is upstream response data, never caller-independent
@@ -429,13 +452,13 @@ async def _read_strict_body(
 async def _read_bounded_prefix(
     response: httpx.Response,
     max_response_bytes: int,
-) -> tuple[bytes, bool]:
+    response_body: bytearray,
+) -> bool:
     """Read at most one prefix and report whether more response bytes exist."""
     content_length = _content_length(response)
     body_truncated = (
         content_length is not None and content_length > max_response_bytes
     )
-    response_body = bytearray()
     async for chunk in response.aiter_bytes():
         remaining = max_response_bytes - len(response_body)
         if len(chunk) > remaining:
@@ -445,7 +468,7 @@ async def _read_bounded_prefix(
         response_body.extend(chunk)
         if len(response_body) == max_response_bytes and body_truncated:
             break
-    return bytes(response_body), body_truncated
+    return body_truncated
 
 
 def _contains_relayed_credentials(

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -43,6 +43,7 @@ osmo_py_test(
         "//src/service/mcp:protocol",
         "//src/service/mcp:resource_tools",
         "//src/service/mcp:tool_registry",
+        "//src/service/mcp:workflow_tools",
     ],
 )
 
@@ -153,5 +154,17 @@ osmo_py_test(
     deps = [
         "//src/service/mcp:request_context",
         "//src/service/mcp:telemetry",
+    ],
+)
+
+osmo_py_test(
+    name = "test_workflows",
+    srcs = ["test_workflows.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("mcp"),
+        ":protocol_harness",
+        "//src/service/mcp:request_context",
+        "//src/service/mcp:workflow_tools",
     ],
 )

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -27,6 +27,7 @@ from src.service.mcp import (
     protocol,
     resources,
     tool_registry,
+    workflows,
 )
 
 
@@ -68,14 +69,51 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'Get one node\'s resource quantities and task configuration for a '
         'selected pool/platform assignment.',
     ),
+    (
+        workflows.osmo_list_workflows,
+        'osmo_list_workflows',
+        'List OSMO workflows',
+        'List the active user\'s workflows across accessible pools, newest first.',
+    ),
+    (
+        workflows.osmo_get_workflow,
+        'osmo_get_workflow',
+        'Get OSMO workflow',
+        'Get one workflow\'s status and optional task-group metadata; '
+        'set skip_groups=true for a compact result.',
+    ),
+    (
+        workflows.osmo_get_workflow_logs,
+        'osmo_get_workflow_logs',
+        'Get OSMO workflow logs',
+        'Get bounded workflow or task logs; set last_n_lines for an explicit '
+        'tail and select error logs explicitly.',
+    ),
+    (
+        workflows.osmo_get_workflow_events,
+        'osmo_get_workflow_events',
+        'Get OSMO workflow events',
+        'Get bounded scheduling and lifecycle events; use the logs tool for output.',
+    ),
+    (
+        workflows.osmo_get_workflow_spec,
+        'osmo_get_workflow_spec',
+        'Get OSMO workflow spec',
+        'Get the bounded, server-redacted resolved or template workflow YAML.',
+    ),
 )
 
-_EXPECTED_REQUIRED_FIELDS: dict[str, list[str]] = {
+_EXPECTED_REQUIRED_FIELDS = {
     'osmo_health': [],
     'osmo_get_profile': [],
     'osmo_search_pools': [],
     'osmo_list_resources': [],
     'osmo_get_resource': ['node_name'],
+    'osmo_list_workflows': [],
+    'osmo_get_workflow': ['workflow_id'],
+    'osmo_get_workflow_logs': ['workflow_id'],
+    'osmo_get_workflow_events': ['workflow_id'],
+    'osmo_get_workflow_spec': ['workflow_id'],
 }
 
 _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
@@ -88,6 +126,25 @@ _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
         'offset': 0,
     },
     'osmo_get_resource': {'pool': None, 'platform': None},
+    'osmo_list_workflows': {
+        'status': None,
+        'name': None,
+        'pool': None,
+        'tags': None,
+        'app': None,
+        'priority': None,
+        'limit': 50,
+        'offset': 0,
+    },
+    'osmo_get_workflow': {'verbose': False, 'skip_groups': False},
+    'osmo_get_workflow_logs': {
+        'task_name': None,
+        'retry_id': None,
+        'last_n_lines': None,
+        'error_logs': False,
+    },
+    'osmo_get_workflow_events': {'task_name': None, 'retry_id': None},
+    'osmo_get_workflow_spec': {'use_template': False},
 }
 
 
@@ -95,7 +152,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
     """Lock the ordered, agent-facing external MCP tool contract."""
 
     def test_registry_has_exact_metadata_and_direct_unique_functions(self) -> None:
-        self.assertEqual(len(tool_registry.TOOL_SPECS), 5)
+        self.assertEqual(len(tool_registry.TOOL_SPECS), 10)
         self.assertEqual(
             [
                 (spec.name, spec.title, spec.description)
@@ -110,7 +167,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         registered_functions = [
             spec.function for spec in tool_registry.TOOL_SPECS
         ]
-        self.assertEqual(len({id(function) for function in registered_functions}), 5)
+        self.assertEqual(len({id(function) for function in registered_functions}), 10)
         for spec, (function, _, _, _) in zip(
             tool_registry.TOOL_SPECS,
             _EXPECTED_SPECS,
@@ -123,7 +180,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
 
         tool_registry.register_tools(mcp_server)
 
-        self.assertEqual(mcp_server.add_tool.call_count, 5)
+        self.assertEqual(mcp_server.add_tool.call_count, 10)
         for call, (function, name, title, description) in zip(
             mcp_server.add_tool.call_args_list,
             _EXPECTED_SPECS,
@@ -182,11 +239,22 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         for tool_name in (
             'osmo_search_pools',
             'osmo_list_resources',
+            'osmo_list_workflows',
         ):
             properties = tools_by_name[tool_name].inputSchema['properties']
             self.assertEqual(properties['limit']['minimum'], 1)
             self.assertEqual(properties['limit']['maximum'], 200)
             self.assertEqual(properties['offset']['minimum'], 0)
+
+        log_properties = tools_by_name[
+            'osmo_get_workflow_logs'
+        ].inputSchema['properties']
+        self.assertEqual(log_properties['last_n_lines']['anyOf'][0]['minimum'], 1)
+        self.assertEqual(
+            log_properties['last_n_lines']['anyOf'][0]['maximum'],
+            10_000,
+        )
+        self.assertEqual(log_properties['retry_id']['anyOf'][0]['minimum'], 0)
 
     async def test_selection_retains_canonical_order(self) -> None:
         selected_names = {

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -913,6 +913,66 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(blocked_stream.iterated_chunks, 1)
         self.assertEqual(blocked_stream.close_count, 1)
 
+    async def test_text_prefix_preserves_safe_partial_body_on_timeout(
+        self,
+    ) -> None:
+        bearer_token = 'stream-timeout-bearer-secret'
+        partial_stream = _TrackingStream(
+            [b'partial log\n'],
+            block_after_chunks=True,
+        )
+        empty_stream = _TrackingStream([], block_after_chunks=True)
+        reflected_stream = _TrackingStream(
+            [bearer_token.encode()],
+            block_after_chunks=True,
+        )
+        streams = [partial_stream, empty_stream, reflected_stream]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, stream=streams.pop(0))
+
+        credentials = self._credentials(
+            authorization_header=f'Bearer {bearer_token}'
+        )
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=0.01,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            partial = await app_context.gateway.request_text_prefix(
+                'GET',
+                '/api/workflow/test-1/logs',
+                credentials=credentials,
+                max_response_bytes=1024,
+            )
+            empty = await app_context.gateway.request_text_prefix(
+                'GET',
+                '/api/workflow/test-1/events',
+                credentials=credentials,
+                max_response_bytes=1024,
+            )
+            with self.assertRaisesRegex(
+                gateway.GatewayClientError,
+                'invalid response',
+            ) as raised:
+                await app_context.gateway.request_text_prefix(
+                    'GET',
+                    '/api/workflow/test-1/logs',
+                    credentials=credentials,
+                    max_response_bytes=1024,
+                )
+
+        self.assertEqual(partial.body, b'partial log\n')
+        self.assertTrue(partial.body_truncated)
+        self.assertEqual(partial.truncation_reason, 'response_timeout')
+        self.assertEqual(empty.body, b'')
+        self.assertTrue(empty.body_truncated)
+        self.assertEqual(empty.truncation_reason, 'response_timeout')
+        self.assertNotIn(bearer_token, str(raised.exception))
+        for stream in (partial_stream, empty_stream, reflected_stream):
+            self.assertEqual(stream.close_count, 1)
+
     async def test_app_context_owns_and_closes_transport(self) -> None:
         async def handler(request: httpx.Request) -> httpx.Response:
             del request

--- a/src/service/mcp/tests/test_tool_support.py
+++ b/src/service/mcp/tests/test_tool_support.py
@@ -343,7 +343,7 @@ class TruncatedTextRequestTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.truncated)
         self.assertEqual(result.truncation_reason, 'response_size_limit')
         self.assertTrue(result.text.startswith('partial text'))
-        self.assertTrue(result.text.endswith('configured byte limit.'))
+        self.assertTrue(result.text.endswith('configured output boundary.'))
         self.assertLessEqual(len(result.text.encode('utf-8')), maximum_bytes)
         gateway_client.request_text_prefix.assert_awaited_once_with(
             'GET',

--- a/src/service/mcp/tests/test_workflows.py
+++ b/src/service/mcp/tests/test_workflows.py
@@ -1,0 +1,675 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from collections.abc import AsyncIterator
+import contextlib
+import json
+import unittest
+
+import httpx
+from mcp.server.fastmcp.exceptions import ToolError
+
+from src.service.mcp import request_context, workflows
+from src.service.mcp.tests import protocol_harness
+
+
+_BEARER_SECRET = 'workflow-tool-bearer-secret'
+_HARNESS = protocol_harness.ProtocolHarness(
+    tool_names=(
+        'osmo_list_workflows',
+        'osmo_get_workflow',
+        'osmo_get_workflow_logs',
+        'osmo_get_workflow_events',
+        'osmo_get_workflow_spec',
+    ),
+    bearer_secret=_BEARER_SECRET,
+    request_id='workflow-request-123',
+    request_timeout_seconds=5,
+)
+_PROFILE_RESULT = {
+    'profile': {
+        'username': 'alice@example.com',
+        'pool': 'pool-a',
+    },
+    'roles': ['osmo-user'],
+    'pools': ['pool-a', 'pool-b'],
+    'token': None,
+}
+_SUMMARY = {
+    'user': 'alice@example.com',
+    'name': 'wf-1',
+    'workflow_uuid': '11111111-1111-1111-1111-111111111111',
+    'submit_time': '2026-07-15T12:00:00Z',
+    'start_time': None,
+    'end_time': None,
+    'queued_time': 2.0,
+    'duration': None,
+    'status': 'RUNNING',
+    'overview': 'https://osmo.test/workflows/wf-1',
+    'logs': 'https://osmo.test/api/workflow/wf-1/logs',
+    'error_logs': None,
+    'grafana_url': None,
+    'dashboard_url': None,
+    'pool': 'pool-a',
+    'app_owner': None,
+    'app_name': None,
+    'app_version': None,
+    'priority': 'NORMAL',
+}
+_DETAIL: dict[str, object] = {
+    'name': 'wf-1',
+    'uuid': '11111111-1111-1111-1111-111111111111',
+    'submitted_by': 'alice@example.com',
+    'cancelled_by': None,
+    'spec': 'must-not-be-returned-by-query-tool',
+    'template_spec': 'must-not-be-returned-by-query-tool',
+    'logs': 'https://osmo.test/api/workflow/wf-1/logs',
+    'events': 'https://osmo.test/api/workflow/wf-1/events',
+    'overview': 'https://osmo.test/workflows/wf-1',
+    'parent_name': None,
+    'parent_job_id': None,
+    'dashboard_url': 'https://user:dashboard-secret@example.test/workflow',
+    'grafana_url': 'https://grafana.test/view?token=grafana-secret#private',
+    'tags': ['nightly'],
+    'submit_time': '2026-07-15T12:00:00Z',
+    'start_time': '2026-07-15T12:01:00Z',
+    'end_time': None,
+    'exec_timeout': None,
+    'queue_timeout': None,
+    'duration': None,
+    'queued_time': 60.0,
+    'status': 'RUNNING',
+    'outputs': '',
+    'groups': [{
+        'name': 'train',
+        'status': 'RUNNING',
+        'start_time': '2026-07-15T12:01:00Z',
+        'end_time': None,
+        'failure_message': None,
+        'tasks': [{
+            'name': 'train-0',
+            'retry_id': 0,
+            'status': 'RUNNING',
+            'failure_message': None,
+            'exit_code': None,
+            'start_time': '2026-07-15T12:01:00Z',
+            'end_time': None,
+            'node_name': 'node-1',
+            'lead': True,
+            'pod_name': 'pod-1',
+            'task_uuid': '22222222-2222-2222-2222-222222222222',
+        }],
+    }],
+    'pool': 'pool-a',
+    'backend': 'backend-a',
+    'app_owner': None,
+    'app_name': None,
+    'app_version': None,
+    'plugins': {},
+    'priority': 'NORMAL',
+}
+
+
+class _StalledTextStream(httpx.AsyncByteStream):
+    """Yield one text prefix and remain open like a running workflow stream."""
+
+    def __init__(self, prefix: bytes) -> None:
+        self._prefix = prefix
+        self.close_count = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield self._prefix
+        await asyncio.Future()
+
+    async def aclose(self) -> None:
+        self.close_count += 1
+
+
+@contextlib.asynccontextmanager
+async def _mcp_client(
+    handler: protocol_harness.AsyncUpstreamHandler,
+    *,
+    accessible_pools: list[str] | None = None,
+) -> AsyncIterator[httpx.AsyncClient]:
+    async def scoped_handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == '/api/profile/settings':
+            profile_result = dict(_PROFILE_RESULT)
+            if accessible_pools is not None:
+                profile_result['pools'] = accessible_pools
+            return httpx.Response(200, json=profile_result)
+        return await handler(request)
+
+    async with _HARNESS.client(scoped_handler) as client:
+        yield client
+
+
+async def _call_tool(
+    client: httpx.AsyncClient,
+    name: str,
+    arguments: dict[str, object] | None = None,
+    *,
+    request_id: int = 1,
+) -> httpx.Response:
+    return await _HARNESS.call_tool_with_client(
+        client,
+        name,
+        arguments,
+        request_id=request_id,
+    )
+
+
+class WorkflowToolProtocolTest(unittest.IsolatedAsyncioTestCase):
+    """Exercise workflow tools through the real Streamable HTTP protocol."""
+
+    async def test_catalog_has_closed_schemas_and_read_annotations(self) -> None:
+        response = await _HARNESS.list_tools()
+        tools = _HARNESS.assert_read_only_closed_catalog(self, response)
+
+        list_properties = tools['osmo_list_workflows']['inputSchema']['properties']
+        self.assertEqual(list_properties['limit']['default'], 50)
+        self.assertEqual(list_properties['limit']['minimum'], 1)
+        self.assertEqual(list_properties['limit']['maximum'], 200)
+        self.assertEqual(list_properties['offset']['minimum'], 0)
+        list_schema = json.dumps(list_properties)
+        for value in ('RUNNING', 'FAILED_PREEMPTED', 'HIGH', 'NORMAL', 'LOW'):
+            self.assertIn(value, list_schema)
+        workflow_id_schema = json.dumps(
+            tools['osmo_get_workflow']['inputSchema']['properties']['workflow_id']
+        )
+        self.assertIn('Canonical OSMO workflow ID', workflow_id_schema)
+        self.assertIn(
+            'skip_groups',
+            tools['osmo_get_workflow']['inputSchema']['properties'],
+        )
+
+        log_properties = tools['osmo_get_workflow_logs']['inputSchema']['properties']
+        self.assertEqual(log_properties['last_n_lines']['anyOf'][0]['minimum'], 1)
+        self.assertEqual(log_properties['last_n_lines']['anyOf'][0]['maximum'], 10_000)
+        self.assertEqual(log_properties['retry_id']['anyOf'][0]['minimum'], 0)
+
+    async def test_default_list_is_current_user_accessible_pools_newest_first(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                'workflows': [_SUMMARY],
+                'more_entries': True,
+            })
+
+        async with _mcp_client(handler) as client:
+            response = await _call_tool(client, 'osmo_list_workflows')
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        structured = result['structuredContent']
+        self.assertEqual(structured['count'], 1)
+        self.assertEqual(structured['limit'], 50)
+        self.assertEqual(structured['offset'], 0)
+        self.assertTrue(structured['more_entries'])
+        self.assertEqual(structured['workflows'][0]['name'], 'wf-1')
+        self.assertNotIn('logs', structured['workflows'][0])
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'GET')
+        self.assertEqual(request.url.path, '/api/workflow')
+        self.assertEqual(request.url.params.multi_items(), [
+            ('limit', '50'),
+            ('offset', '0'),
+            ('order', 'DESC'),
+            ('pools', 'pool-a'),
+            ('pools', 'pool-b'),
+        ])
+        self.assertNotIn('users', request.url.params)
+        self.assertNotIn('all_users', request.url.params)
+        self.assertEqual(
+            request.headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+        self.assertEqual(
+            request.headers[request_context.REQUEST_ID_HEADER],
+            'workflow-request-123',
+        )
+
+    async def test_filtered_list_maps_only_approved_queries(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                'workflows': [],
+                'more_entries': False,
+            })
+
+        async with _mcp_client(handler) as client:
+            response = await _call_tool(client, 'osmo_list_workflows', {
+                'status': ['FAILED', 'RUNNING'],
+                'name': 'training',
+                'pool': ['pool-a', 'pool-b'],
+                'tags': ['nightly', 'gpu'],
+                'app': 'trainer:2',
+                'priority': ['HIGH', 'LOW'],
+                'limit': 7,
+                'offset': 3,
+            })
+
+        self.assertFalse(response.json()['result']['isError'])
+        request = captured_requests[0]
+        self.assertEqual(request.url.params.multi_items(), [
+            ('limit', '7'),
+            ('offset', '3'),
+            ('order', 'DESC'),
+            ('statuses', 'FAILED'),
+            ('statuses', 'RUNNING'),
+            ('name', 'training'),
+            ('tags', 'nightly'),
+            ('tags', 'gpu'),
+            ('app', 'trainer:2'),
+            ('priority', 'HIGH'),
+            ('priority', 'LOW'),
+            ('pools', 'pool-a'),
+            ('pools', 'pool-b'),
+        ])
+        self.assertNotIn('all_pools', request.url.params)
+
+    async def test_list_rejects_inaccessible_pool_before_workflow_relay(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                'workflows': [],
+                'more_entries': False,
+            })
+
+        async with _mcp_client(handler) as client:
+            response = await _call_tool(client, 'osmo_list_workflows', {
+                'pool': ['private-pool'],
+            })
+
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertEqual(captured_requests, [])
+
+    async def test_list_with_no_accessible_pools_returns_empty_page(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                'workflows': [],
+                'more_entries': False,
+            })
+
+        async with _mcp_client(handler, accessible_pools=[]) as client:
+            response = await _call_tool(client, 'osmo_list_workflows')
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'workflows': [],
+            'count': 0,
+            'more_entries': False,
+            'offset': 0,
+            'limit': 50,
+        })
+        self.assertEqual(captured_requests, [])
+
+    async def test_get_and_text_tools_use_exact_routes_and_queries(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.url.path == '/api/workflow/wf-1':
+                return httpx.Response(200, json=_DETAIL)
+            if request.url.path == '/api/workflow/wf-1/error_logs':
+                return httpx.Response(200, content=b'error line\n')
+            if request.url.path == '/api/workflow/wf-1/logs':
+                return httpx.Response(200, content=b'normal line\n')
+            if request.url.path == '/api/workflow/wf-1/events':
+                return httpx.Response(200, content=b'scheduled\n')
+            if request.url.path == '/api/workflow/wf-1/spec':
+                return httpx.Response(200, content=b'name: workflow\n')
+            raise AssertionError(f'unexpected path: {request.url.path}')
+
+        async with _mcp_client(handler) as client:
+            get_response = await _call_tool(
+                client,
+                'osmo_get_workflow',
+                {
+                    'workflow_id': 'wf-1',
+                    'verbose': True,
+                    'skip_groups': True,
+                },
+                request_id=1,
+            )
+            logs_response = await _call_tool(
+                client,
+                'osmo_get_workflow_logs',
+                {
+                    'workflow_id': 'wf-1',
+                    'task_name': 'train-0',
+                    'error_logs': True,
+                    'last_n_lines': 25,
+                    'retry_id': 2,
+                },
+                request_id=2,
+            )
+            normal_logs_response = await _call_tool(
+                client,
+                'osmo_get_workflow_logs',
+                {'workflow_id': 'wf-1'},
+                request_id=3,
+            )
+            events_response = await _call_tool(
+                client,
+                'osmo_get_workflow_events',
+                {
+                    'workflow_id': 'wf-1',
+                    'task_name': 'train-0',
+                    'retry_id': 2,
+                },
+                request_id=4,
+            )
+            spec_response = await _call_tool(
+                client,
+                'osmo_get_workflow_spec',
+                {'workflow_id': 'wf-1', 'use_template': True},
+                request_id=5,
+            )
+
+        get_result = get_response.json()['result']['structuredContent']['workflow']
+        self.assertEqual(get_result['groups'][0]['tasks'][0]['node_name'], 'node-1')
+        self.assertNotIn('spec', get_result)
+        self.assertNotIn('template_spec', get_result)
+        self.assertNotIn('dashboard_url', get_result)
+        self.assertNotIn('grafana_url', get_result)
+        self.assertEqual(
+            logs_response.json()['result']['structuredContent']['logs'],
+            'error line\n',
+        )
+        self.assertEqual(
+            normal_logs_response.json()['result']['structuredContent']['logs'],
+            'normal line\n',
+        )
+        self.assertEqual(
+            events_response.json()['result']['structuredContent']['events'],
+            'scheduled\n',
+        )
+        self.assertEqual(
+            spec_response.json()['result']['structuredContent']['spec'],
+            'name: workflow\n',
+        )
+        for text_response in (
+            logs_response,
+            normal_logs_response,
+            events_response,
+            spec_response,
+        ):
+            structured_content = text_response.json()['result']['structuredContent']
+            self.assertFalse(structured_content['truncated'])
+            self.assertIsNone(structured_content['truncation_reason'])
+        self.assertNotIn('dashboard-secret', get_response.text)
+        self.assertNotIn('grafana-secret', get_response.text)
+
+        self.assertEqual(
+            [request.url.path for request in captured_requests],
+            [
+                '/api/workflow/wf-1',
+                '/api/workflow/wf-1/error_logs',
+                '/api/workflow/wf-1/logs',
+                '/api/workflow/wf-1/events',
+                '/api/workflow/wf-1/spec',
+            ],
+        )
+        self.assertEqual(captured_requests[0].url.params.multi_items(), [
+            ('verbose', 'true'),
+            ('skip_groups', 'true'),
+        ])
+        self.assertEqual(captured_requests[1].url.params.multi_items(), [
+            ('task_name', 'train-0'),
+            ('last_n_lines', '25'),
+            ('retry_id', '2'),
+        ])
+        self.assertEqual(captured_requests[2].url.params.multi_items(), [])
+        self.assertEqual(captured_requests[3].url.params.multi_items(), [
+            ('task_name', 'train-0'),
+            ('retry_id', '2'),
+        ])
+        self.assertEqual(captured_requests[4].url.params.multi_items(), [
+            ('use_template', 'true'),
+        ])
+
+    async def test_running_log_stream_returns_marked_partial_text(
+        self,
+    ) -> None:
+        stream = _StalledTextStream(b'partial running log\n')
+        timeout_harness = protocol_harness.ProtocolHarness(
+            tool_names=('osmo_get_workflow_logs',),
+            bearer_secret=_BEARER_SECRET,
+            request_id='workflow-timeout-request-123',
+            request_timeout_seconds=0.01,
+        )
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            self.assertEqual(request.url.path, '/api/workflow/wf-1/logs')
+            return httpx.Response(200, stream=stream)
+
+        async with timeout_harness.client(handler) as client:
+            response = await timeout_harness.call_tool_with_client(
+                client,
+                'osmo_get_workflow_logs',
+                {'workflow_id': 'wf-1'},
+            )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        structured = result['structuredContent']
+        self.assertTrue(structured['truncated'])
+        self.assertEqual(
+            structured['truncation_reason'],
+            'response_timeout',
+        )
+        self.assertTrue(
+            structured['logs'].startswith('partial running log\n')
+        )
+        self.assertIn('truncated', structured['logs'])
+        self.assertNotIn(_BEARER_SECRET, response.text)
+        self.assertEqual(stream.close_count, 1)
+
+    async def test_invalid_paths_queries_and_cross_fields_fail_before_relay(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={})
+
+        invalid_calls: tuple[tuple[str, dict[str, object]], ...] = (
+            ('osmo_get_workflow', {'workflow_id': '../escape'}),
+            ('osmo_get_workflow', {'workflow_id': '..'}),
+            ('osmo_get_workflow', {
+                'workflow_id': '11111111-1111-1111-1111-111111111111',
+            }),
+            ('osmo_get_workflow', {'workflow_id': 'workflow-name'}),
+            ('osmo_list_workflows', {'limit': 0}),
+            ('osmo_list_workflows', {'limit': True}),
+            ('osmo_list_workflows', {'limit': 201}),
+            ('osmo_list_workflows', {'offset': -1}),
+            ('osmo_list_workflows', {'offset': True}),
+            ('osmo_list_workflows', {'status': []}),
+            ('osmo_list_workflows', {'status': ['NOT_A_STATUS']}),
+            ('osmo_list_workflows', {'priority': []}),
+            ('osmo_list_workflows', {'priority': 'HIGH'}),
+            ('osmo_list_workflows', {'name': 'bad\nquery'}),
+            ('osmo_list_workflows', {'pool': ['p' * 500] * 40}),
+            (
+                'osmo_get_workflow_logs',
+                {'workflow_id': 'wf-1', 'error_logs': True},
+            ),
+            (
+                'osmo_get_workflow_logs',
+                {'workflow_id': 'wf-1', 'retry_id': 1},
+            ),
+            (
+                'osmo_get_workflow_events',
+                {'workflow_id': 'wf-1', 'retry_id': 1},
+            ),
+            (
+                'osmo_get_workflow_logs',
+                {'workflow_id': 'wf-1', 'last_n_lines': 0},
+            ),
+            (
+                'osmo_get_workflow_logs',
+                {'workflow_id': 'wf-1', 'last_n_lines': True},
+            ),
+            (
+                'osmo_get_workflow_events',
+                {'workflow_id': 'wf-1', 'task_name': 'task', 'retry_id': True},
+            ),
+            (
+                'osmo_get_workflow_events',
+                {'workflow_id': 'wf-1', 'task_name': 'bad\ntask'},
+            ),
+        )
+
+        async with _mcp_client(handler) as client:
+            for request_id, (tool_name, arguments) in enumerate(
+                invalid_calls,
+                start=1,
+            ):
+                with self.subTest(tool_name=tool_name, arguments=arguments):
+                    response = await _call_tool(
+                        client,
+                        tool_name,
+                        arguments,
+                        request_id=request_id,
+                    )
+                    self.assertTrue(response.json()['result']['isError'])
+
+        self.assertEqual(captured_requests, [])
+
+    async def test_status_malformed_and_oversized_responses_are_sanitized(self) -> None:
+        async def invoke(
+            handler: protocol_harness.AsyncUpstreamHandler,
+            tool_name: str,
+            arguments: dict[str, object],
+        ) -> httpx.Response:
+            async with _mcp_client(handler) as client:
+                return await _call_tool(client, tool_name, arguments)
+
+        async def not_found_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(404, content=b'upstream-body-secret')
+
+        response = await invoke(
+            not_found_handler,
+            'osmo_get_workflow',
+            {'workflow_id': 'missing-1'},
+        )
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('HTTP 404', response.text)
+        self.assertNotIn('upstream-body-secret', response.text)
+
+        async def malformed_json_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'[]')
+
+        response = await invoke(
+            malformed_json_handler,
+            'osmo_list_workflows',
+            {},
+        )
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('invalid response', response.text)
+
+        async def malformed_page_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, json={'workflows': []})
+
+        response = await invoke(
+            malformed_page_handler,
+            'osmo_list_workflows',
+            {},
+        )
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('invalid response', response.text)
+
+        async def oversized_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'x' * (1024 * 1024 + 1))
+
+        response = await invoke(
+            oversized_handler,
+            'osmo_get_workflow_logs',
+            {'workflow_id': 'wf-1'},
+        )
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertTrue(result['structuredContent']['truncated'])
+        self.assertIsNotNone(
+            result['structuredContent']['truncation_reason'],
+        )
+        self.assertIn('truncated', result['structuredContent']['logs'])
+        self.assertLess(len(response.content), 256 * 1024)
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+        async def invalid_text_handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'\xff')
+
+        response = await invoke(
+            invalid_text_handler,
+            'osmo_get_workflow_events',
+            {'workflow_id': 'wf-1'},
+        )
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('invalid response', response.text)
+
+
+class WorkflowValidationUnitTest(unittest.IsolatedAsyncioTestCase):
+    """Pin validation that must run before a request context is needed."""
+
+    async def test_cross_field_and_direct_argument_validation(self) -> None:
+        with self.assertRaises(ToolError):
+            await workflows.osmo_get_workflow_logs(
+                None,  # type: ignore[arg-type]
+                'wf-1',
+                error_logs=True,
+            )
+        with self.assertRaises(ToolError):
+            await workflows.osmo_get_workflow_events(
+                None,  # type: ignore[arg-type]
+                'wf-1',
+                retry_id=1,
+            )
+        with self.assertRaises(ToolError):
+            await workflows.osmo_list_workflows(
+                None,  # type: ignore[arg-type]
+                status=['INVALID'],  # type: ignore[list-item]
+            )
+        with self.assertRaises(ToolError):
+            await workflows.osmo_list_workflows(
+                None,  # type: ignore[arg-type]
+                limit=True,  # type: ignore[arg-type]
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -27,6 +27,7 @@ from src.service.mcp import (
     pools,
     profile,
     resources,
+    workflows,
 )
 
 
@@ -84,6 +85,48 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         description=(
             'Get one node\'s resource quantities and task configuration for a '
             'selected pool/platform assignment.'
+        ),
+    ),
+    ToolSpec(
+        function=workflows.osmo_list_workflows,
+        name='osmo_list_workflows',
+        title='List OSMO workflows',
+        description=(
+            'List the active user\'s workflows across accessible pools, newest first.'
+        ),
+    ),
+    ToolSpec(
+        function=workflows.osmo_get_workflow,
+        name='osmo_get_workflow',
+        title='Get OSMO workflow',
+        description=(
+            'Get one workflow\'s status and optional task-group metadata; '
+            'set skip_groups=true for a compact result.'
+        ),
+    ),
+    ToolSpec(
+        function=workflows.osmo_get_workflow_logs,
+        name='osmo_get_workflow_logs',
+        title='Get OSMO workflow logs',
+        description=(
+            'Get bounded workflow or task logs; set last_n_lines for an explicit '
+            'tail and select error logs explicitly.'
+        ),
+    ),
+    ToolSpec(
+        function=workflows.osmo_get_workflow_events,
+        name='osmo_get_workflow_events',
+        title='Get OSMO workflow events',
+        description=(
+            'Get bounded scheduling and lifecycle events; use the logs tool for output.'
+        ),
+    ),
+    ToolSpec(
+        function=workflows.osmo_get_workflow_spec,
+        name='osmo_get_workflow_spec',
+        title='Get OSMO workflow spec',
+        description=(
+            'Get the bounded, server-redacted resolved or template workflow YAML.'
         ),
     ),
 )

--- a/src/service/mcp/tool_requests.py
+++ b/src/service/mcp/tool_requests.py
@@ -35,7 +35,8 @@ _JSON_OBJECT_ADAPTER = pydantic.TypeAdapter(JsonObject)
 _PROFILE_PATH = '/api/profile/settings'
 _MAX_PROFILE_RESPONSE_BYTES = 64 * 1024
 _TEXT_TRUNCATION_SENTINEL = (
-    '\n... truncated: OSMO response exceeded the configured byte limit.'
+    '\n... truncated: OSMO response did not complete within the configured '
+    'output boundary.'
 )
 _TEXT_TRUNCATION_SENTINEL_BYTES = len(
     _TEXT_TRUNCATION_SENTINEL.encode('utf-8')
@@ -118,7 +119,7 @@ async def request_truncated_text(
     query: gateway.QueryParams | None = None,
     suppress_upstream_details: bool = False,
 ) -> TruncatedTextResult:
-    """Relay one fixed GET and truncate oversized UTF-8 text with a sentinel."""
+    """Relay one fixed GET and mark an incomplete UTF-8 response prefix."""
     if max_response_bytes <= _TEXT_TRUNCATION_SENTINEL_BYTES:
         raise tool_errors.PublicToolError(
             f'Invalid MCP request while attempting to {operation}.'

--- a/src/service/mcp/workflow_models.py
+++ b/src/service/mcp/workflow_models.py
@@ -1,0 +1,231 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Sequence
+from typing import Annotated, Literal
+
+import pydantic
+
+from src.service.mcp.tool_models import ClosedToolModel, PageLimit, PageOffset
+
+
+__all__ = (
+    'GetWorkflowResult',
+    'LastNLines',
+    'ListWorkflowsResult',
+    'PageLimit',
+    'PageOffset',
+    'QueryText',
+    'QueryTextList',
+    'RetryId',
+    'WorkflowDetail',
+    'WorkflowEventsResult',
+    'WorkflowGroup',
+    'WorkflowId',
+    'WorkflowLogsResult',
+    'WorkflowPriorities',
+    'WorkflowPriority',
+    'WorkflowSpecResult',
+    'WorkflowStatus',
+    'WorkflowStatuses',
+    'WorkflowSummary',
+    'WorkflowTask',
+)
+
+
+MAX_QUERY_TEXT_BYTES = 512
+MAX_QUERY_VALUES = 50
+WORKFLOW_ID_PATTERN = r'[A-Za-z](?:[A-Za-z0-9_-]*[A-Za-z0-9])?-[0-9]+'
+
+LastNLines = Annotated[pydantic.StrictInt, pydantic.Field(ge=1, le=10_000)]
+RetryId = Annotated[pydantic.StrictInt, pydantic.Field(ge=0, le=1_000_000)]
+QueryText = Annotated[str, pydantic.Field(min_length=1, max_length=512)]
+WorkflowId = Annotated[
+    str,
+    pydantic.Field(
+        min_length=3,
+        max_length=512,
+        pattern=f'^{WORKFLOW_ID_PATTERN}$',
+        description='Canonical OSMO workflow ID; UUID lookup is not supported.',
+    ),
+]
+QueryTextList = Annotated[
+    list[QueryText],
+    pydantic.Field(min_length=1, max_length=MAX_QUERY_VALUES),
+]
+WorkflowStatus = Literal[
+    'RUNNING',
+    'PENDING',
+    'WAITING',
+    'COMPLETED',
+    'FAILED',
+    'FAILED_EXEC_TIMEOUT',
+    'FAILED_SERVER_ERROR',
+    'FAILED_QUEUE_TIMEOUT',
+    'FAILED_SUBMISSION',
+    'FAILED_CANCELED',
+    'FAILED_BACKEND_ERROR',
+    'FAILED_IMAGE_PULL',
+    'FAILED_EVICTED',
+    'FAILED_START_ERROR',
+    'FAILED_START_TIMEOUT',
+    'FAILED_PREEMPTED',
+]
+WorkflowStatuses = Annotated[
+    list[WorkflowStatus],
+    pydantic.Field(min_length=1, max_length=MAX_QUERY_VALUES),
+]
+WorkflowPriority = Literal['HIGH', 'NORMAL', 'LOW']
+WorkflowPriorities = Annotated[
+    list[WorkflowPriority],
+    pydantic.Field(min_length=1, max_length=3),
+]
+
+WORKFLOW_STATUSES = frozenset(
+    pydantic.TypeAdapter(WorkflowStatus).json_schema()['enum']
+)
+WORKFLOW_PRIORITIES = frozenset(('HIGH', 'NORMAL', 'LOW'))
+
+
+class WorkflowSummary(ClosedToolModel):
+    """Stable, non-secret fields from one workflow-list entry."""
+
+    user: str
+    name: str
+    workflow_uuid: str
+    submit_time: str
+    status: str
+    priority: str
+    pool: str | None = None
+    overview: str | None = None
+    app_owner: str | None = None
+    app_name: str | None = None
+    app_version: int | None = None
+
+
+class WorkflowTask(ClosedToolModel):
+    """Task state returned as part of a workflow query."""
+
+    name: str
+    retry_id: int
+    status: str
+    failure_message: str | None = None
+    exit_code: int | None = None
+    start_time: str | None = None
+    end_time: str | None = None
+    node_name: str | None = None
+    lead: bool = False
+
+
+class WorkflowGroup(ClosedToolModel):
+    """Task-group state returned as part of a workflow query."""
+
+    name: str
+    status: str
+    failure_message: str | None = None
+    start_time: str | None = None
+    end_time: str | None = None
+    tasks: Sequence[WorkflowTask]
+
+
+class WorkflowDetail(ClosedToolModel):
+    """Bounded workflow status and task metadata, excluding embedded specs."""
+
+    name: str
+    uuid: str
+    submitted_by: str
+    submit_time: str
+    status: str
+    priority: str
+    cancelled_by: str | None = None
+    parent_name: str | None = None
+    parent_job_id: int | None = None
+    tags: list[str]
+    start_time: str | None = None
+    end_time: str | None = None
+    pool: str | None = None
+    backend: str | None = None
+    app_owner: str | None = None
+    app_name: str | None = None
+    app_version: int | None = None
+    overview: str | None = None
+    groups: Sequence[WorkflowGroup]
+
+
+class _UpstreamWorkflowSummary(WorkflowSummary):
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+
+class _UpstreamWorkflowTask(WorkflowTask):
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+
+class _UpstreamWorkflowGroup(WorkflowGroup):
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+    tasks: list[_UpstreamWorkflowTask]
+
+
+class _UpstreamWorkflowDetail(WorkflowDetail):
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+    groups: list[_UpstreamWorkflowGroup]
+
+
+class _UpstreamWorkflowPage(ClosedToolModel):
+    workflows: list[_UpstreamWorkflowSummary]
+    more_entries: bool
+
+
+class ListWorkflowsResult(ClosedToolModel):
+    workflows: list[WorkflowSummary]
+    count: int
+    more_entries: bool
+    offset: int
+    limit: int
+
+
+class GetWorkflowResult(ClosedToolModel):
+    workflow: WorkflowDetail
+
+
+class WorkflowLogsResult(ClosedToolModel):
+    workflow_id: str
+    task_name: str | None
+    retry_id: int | None
+    error_logs: bool
+    logs: str
+    truncated: bool
+    truncation_reason: str | None
+
+
+class WorkflowEventsResult(ClosedToolModel):
+    workflow_id: str
+    task_name: str | None
+    retry_id: int | None
+    events: str
+    truncated: bool
+    truncation_reason: str | None
+
+
+class WorkflowSpecResult(ClosedToolModel):
+    workflow_id: str
+    use_template: bool
+    spec: str
+    truncated: bool
+    truncation_reason: str | None

--- a/src/service/mcp/workflows.py
+++ b/src/service/mcp/workflows.py
@@ -1,0 +1,394 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import re
+
+from mcp.server.fastmcp import Context
+
+from src.service.mcp import (
+    access_scope,
+    gateway,
+    tool_errors,
+    tool_requests,
+    tool_validation,
+)
+from src.service.mcp.workflow_models import (
+    MAX_QUERY_TEXT_BYTES as _MAX_QUERY_TEXT_BYTES,
+    MAX_QUERY_VALUES as _MAX_QUERY_VALUES,
+    WORKFLOW_ID_PATTERN as _WORKFLOW_ID_PATTERN,
+    WORKFLOW_PRIORITIES as _WORKFLOW_PRIORITIES,
+    WORKFLOW_STATUSES as _WORKFLOW_STATUSES,
+    GetWorkflowResult,
+    LastNLines,
+    ListWorkflowsResult,
+    PageLimit,
+    PageOffset,
+    QueryText,
+    QueryTextList,
+    RetryId,
+    WorkflowDetail,
+    WorkflowEventsResult,
+    WorkflowGroup,
+    WorkflowId,
+    WorkflowLogsResult,
+    WorkflowPriority,
+    WorkflowPriorities,
+    WorkflowSpecResult,
+    WorkflowStatus,
+    WorkflowStatuses,
+    WorkflowSummary,
+    WorkflowTask,
+    _UpstreamWorkflowDetail,
+    _UpstreamWorkflowPage,
+)
+
+
+__all__ = (
+    'GetWorkflowResult',
+    'LastNLines',
+    'ListWorkflowsResult',
+    'PageLimit',
+    'PageOffset',
+    'QueryText',
+    'QueryTextList',
+    'RetryId',
+    'WorkflowDetail',
+    'WorkflowEventsResult',
+    'WorkflowGroup',
+    'WorkflowId',
+    'WorkflowLogsResult',
+    'WorkflowPriorities',
+    'WorkflowPriority',
+    'WorkflowSpecResult',
+    'WorkflowStatus',
+    'WorkflowStatuses',
+    'WorkflowSummary',
+    'WorkflowTask',
+    'osmo_get_workflow',
+    'osmo_get_workflow_events',
+    'osmo_get_workflow_logs',
+    'osmo_get_workflow_spec',
+    'osmo_list_workflows',
+)
+
+
+_WORKFLOWS_PATH = '/api/workflow'
+_MAX_JSON_RESPONSE_BYTES = 1024 * 1024
+_MAX_TEXT_RESPONSE_BYTES = 32 * 1024
+_MAX_QUERY_BYTES = 16 * 1024
+
+
+async def osmo_list_workflows(
+    context: Context,
+    status: WorkflowStatuses | None = None,
+    name: QueryText | None = None,
+    pool: QueryTextList | None = None,
+    tags: QueryTextList | None = None,
+    app: QueryText | None = None,
+    priority: WorkflowPriorities | None = None,
+    limit: PageLimit = 50,
+    offset: PageOffset = 0,
+) -> ListWorkflowsResult:
+    """List the active user's workflows across accessible pools, newest first."""
+    tool_validation.validate_page(
+        limit,
+        offset,
+        maximum_limit=200,
+    )
+    query: dict[str, gateway.QueryValue] = {
+        'limit': limit,
+        'offset': offset,
+        'order': 'DESC',
+    }
+    requested_pools = (
+        tool_validation.validate_query_values(
+            pool,
+            field='pool',
+            max_count=_MAX_QUERY_VALUES,
+            max_value_bytes=_MAX_QUERY_TEXT_BYTES,
+        )
+        if pool is not None
+        else None
+    )
+    if status is not None:
+        statuses = tool_validation.validate_query_values(
+            status,
+            field='status',
+            max_count=_MAX_QUERY_VALUES,
+            max_value_bytes=_MAX_QUERY_TEXT_BYTES,
+        )
+        if any(value not in _WORKFLOW_STATUSES for value in statuses):
+            raise tool_errors.PublicToolError('Invalid workflow status.')
+        query['statuses'] = statuses
+    if name is not None:
+        query['name'] = tool_validation.validate_query_text(
+            name,
+            field='name',
+            max_bytes=_MAX_QUERY_TEXT_BYTES,
+        )
+    if tags is not None:
+        query['tags'] = tool_validation.validate_query_values(
+            tags,
+            field='tags',
+            max_count=_MAX_QUERY_VALUES,
+            max_value_bytes=_MAX_QUERY_TEXT_BYTES,
+        )
+    if app is not None:
+        query['app'] = tool_validation.validate_query_text(
+            app,
+            field='app',
+            max_bytes=_MAX_QUERY_TEXT_BYTES,
+        )
+    if priority is not None:
+        priorities = tool_validation.validate_query_values(
+            priority,
+            field='priority',
+            max_count=_MAX_QUERY_VALUES,
+            max_value_bytes=_MAX_QUERY_TEXT_BYTES,
+        )
+        if any(value not in _WORKFLOW_PRIORITIES for value in priorities):
+            raise tool_errors.PublicToolError('Invalid workflow priority.')
+        query['priority'] = priorities
+
+    scope = await access_scope.request_access_scope(context)
+    if requested_pools is not None:
+        if any(
+            pool_name not in scope.pool_names
+            for pool_name in requested_pools
+        ):
+            raise tool_errors.PublicToolError(
+                'One or more requested pools are not accessible.'
+            )
+        selected_pools = requested_pools
+    else:
+        selected_pools = list(scope.pools)
+    if not selected_pools:
+        return ListWorkflowsResult(
+            workflows=[],
+            count=0,
+            more_entries=False,
+            offset=offset,
+            limit=limit,
+        )
+    query['pools'] = selected_pools
+    tool_validation.validate_query_size(
+        query,
+        operation='Workflow query',
+        max_bytes=_MAX_QUERY_BYTES,
+    )
+
+    response = await tool_requests.request_json_object(
+        context,
+        path=_WORKFLOWS_PATH,
+        operation='list workflows',
+        max_response_bytes=_MAX_JSON_RESPONSE_BYTES,
+        query=query,
+    )
+    page = tool_validation.validate_response(
+        _UpstreamWorkflowPage,
+        response,
+        operation='list workflows',
+    )
+    summaries = [
+        WorkflowSummary.model_validate(item.model_dump(), strict=True)
+        for item in page.workflows
+    ]
+    return ListWorkflowsResult(
+        workflows=summaries,
+        count=len(summaries),
+        more_entries=page.more_entries,
+        offset=offset,
+        limit=limit,
+    )
+
+
+async def osmo_get_workflow(
+    context: Context,
+    workflow_id: WorkflowId,
+    verbose: bool = False,
+    skip_groups: bool = False,
+) -> GetWorkflowResult:
+    """Get one workflow's status, task groups, and task metadata."""
+    path = _workflow_path(workflow_id)
+    query: dict[str, bool] = {}
+    if verbose:
+        query['verbose'] = True
+    if skip_groups:
+        query['skip_groups'] = True
+    response = await tool_requests.request_json_object(
+        context,
+        path=path,
+        operation='get a workflow',
+        max_response_bytes=_MAX_JSON_RESPONSE_BYTES,
+        query=query or None,
+    )
+    upstream = tool_validation.validate_response(
+        _UpstreamWorkflowDetail,
+        response,
+        operation='get a workflow',
+    )
+    workflow = WorkflowDetail.model_validate(upstream.model_dump(), strict=True)
+    return GetWorkflowResult(workflow=workflow)
+
+
+async def osmo_get_workflow_logs(
+    context: Context,
+    workflow_id: WorkflowId,
+    task_name: QueryText | None = None,
+    error_logs: bool = False,
+    last_n_lines: LastNLines | None = None,
+    retry_id: RetryId | None = None,
+) -> WorkflowLogsResult:
+    """Get bounded workflow or task logs; error/retry logs require a task."""
+    path = _workflow_path(
+        workflow_id,
+        suffix='error_logs' if error_logs else 'logs',
+    )
+    validated_task_name = _validate_task_controls(
+        task_name=task_name,
+        retry_id=retry_id,
+        error_logs=error_logs,
+    )
+    tool_validation.validate_optional_integer(
+        last_n_lines,
+        field='last_n_lines',
+        minimum=1,
+        maximum=10_000,
+    )
+    query: dict[str, gateway.QueryValue] = {}
+    if validated_task_name is not None:
+        query['task_name'] = validated_task_name
+    if last_n_lines is not None:
+        query['last_n_lines'] = last_n_lines
+    if retry_id is not None:
+        query['retry_id'] = retry_id
+    logs_result = await tool_requests.request_truncated_text(
+        context,
+        path=path,
+        operation='get workflow logs',
+        max_response_bytes=_MAX_TEXT_RESPONSE_BYTES,
+        query=query or None,
+    )
+    return WorkflowLogsResult(
+        workflow_id=workflow_id,
+        task_name=validated_task_name,
+        retry_id=retry_id,
+        error_logs=error_logs,
+        logs=logs_result.text,
+        truncated=logs_result.truncated,
+        truncation_reason=logs_result.truncation_reason,
+    )
+
+
+async def osmo_get_workflow_events(
+    context: Context,
+    workflow_id: WorkflowId,
+    task_name: QueryText | None = None,
+    retry_id: RetryId | None = None,
+) -> WorkflowEventsResult:
+    """Get bounded workflow scheduling and lifecycle events."""
+    path = _workflow_path(workflow_id, suffix='events')
+    validated_task_name = _validate_task_controls(
+        task_name=task_name,
+        retry_id=retry_id,
+        error_logs=False,
+    )
+    query: dict[str, gateway.QueryValue] = {}
+    if validated_task_name is not None:
+        query['task_name'] = validated_task_name
+    if retry_id is not None:
+        query['retry_id'] = retry_id
+    events_result = await tool_requests.request_truncated_text(
+        context,
+        path=path,
+        operation='get workflow events',
+        max_response_bytes=_MAX_TEXT_RESPONSE_BYTES,
+        query=query or None,
+    )
+    return WorkflowEventsResult(
+        workflow_id=workflow_id,
+        task_name=validated_task_name,
+        retry_id=retry_id,
+        events=events_result.text,
+        truncated=events_result.truncated,
+        truncation_reason=events_result.truncation_reason,
+    )
+
+
+async def osmo_get_workflow_spec(
+    context: Context,
+    workflow_id: WorkflowId,
+    use_template: bool = False,
+) -> WorkflowSpecResult:
+    """Get a bounded, redacted workflow YAML spec."""
+    path = _workflow_path(workflow_id, suffix='spec')
+    spec_result = await tool_requests.request_truncated_text(
+        context,
+        path=path,
+        operation='get a workflow spec',
+        max_response_bytes=_MAX_TEXT_RESPONSE_BYTES,
+        query={'use_template': use_template},
+    )
+    return WorkflowSpecResult(
+        workflow_id=workflow_id,
+        use_template=use_template,
+        spec=spec_result.text,
+        truncated=spec_result.truncated,
+        truncation_reason=spec_result.truncation_reason,
+    )
+
+
+def _workflow_path(workflow_id: str, *, suffix: str | None = None) -> str:
+    if re.fullmatch(_WORKFLOW_ID_PATTERN, workflow_id) is None:
+        raise tool_errors.PublicToolError('Invalid workflow_id.')
+    encoded_workflow_id = tool_validation.safe_path_segment(
+        workflow_id,
+        field='workflow_id',
+    )
+    path = f'{_WORKFLOWS_PATH}/{encoded_workflow_id}'
+    return f'{path}/{suffix}' if suffix is not None else path
+
+
+def _validate_task_controls(
+    *,
+    task_name: str | None,
+    retry_id: int | None,
+    error_logs: bool,
+) -> str | None:
+    validated_task_name = None
+    if task_name is not None:
+        validated_task_name = tool_validation.validate_query_text(
+            task_name,
+            field='task_name',
+            max_bytes=_MAX_QUERY_TEXT_BYTES,
+        )
+    tool_validation.validate_optional_integer(
+        retry_id,
+        field='retry_id',
+        minimum=0,
+        maximum=1_000_000,
+    )
+    if error_logs and validated_task_name is None:
+        raise tool_errors.PublicToolError(
+            'task_name is required when error_logs is true.'
+        )
+    if retry_id is not None and validated_task_name is None:
+        raise tool_errors.PublicToolError(
+            'task_name is required when retry_id is set.'
+        )
+    return validated_task_name


### PR DESCRIPTION
## Description

Add caller-bound external MCP workflow read tools.

Issue - None

### Stack

1. #1204 (merged): runtime foundation
2. #1205 (merged): pool and resource inventory tools
3. **#1206 (this PR):** workflow read tools
4. #1207: app and credential metadata tools plus final catalog documentation

### Summary

- Adds workflow list, detail, logs, events, and spec tools using existing OSMO routes and CLI-compatible query semantics.
- Uses canonical workflow IDs and caller-accessible pool scope, with authorization enforced by the second Gateway pass.
- Exposes `skip_groups` so large workflows can still return compact status.
- Leaves the optional log tail unset by default, matching established CLI/internal behavior.
- Returns bounded, marked text prefixes for logs, events, and specs when the byte limit is reached or a live stream times out.
- Keeps strict JSON responses fail-closed, rechecks partial text for relayed credentials, and omits untrusted dashboard/Grafana URLs.
- Keeps workflow output models recursively closed and model-sized.

### Validation

- Focused Gateway, workflow, shared tool-support, lint, and type checks passed.
- Complete MCP package validation passed: 44/44 test, lint, and type targets.
- `//src/service/mcp:mcp_binary` built successfully.
- `git diff --check` passed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] Documentation for this slice is updated; the final catalog is completed in #1207.
