### PR TITLE
Add external MCP app and credential tools

### DIFF
--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -117,6 +117,16 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "app_models",
+    srcs = ["app_models.py"],
+    deps = [
+        requirement("pydantic"),
+        ":tool_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "pool_models",
     srcs = ["pool_models.py"],
     deps = [
@@ -214,10 +224,37 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "app_tools",
+    srcs = ["apps.py"],
+    deps = [
+        requirement("mcp"),
+        ":app_models",
+        ":tool_errors",
+        ":tool_requests",
+        ":tool_validation",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "credential_tools",
+    srcs = ["credentials.py"],
+    deps = [
+        requirement("mcp"),
+        requirement("pydantic"),
+        ":tool_errors",
+        ":tool_requests",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "tool_registry",
     srcs = ["tool_registry.py"],
     deps = [
         requirement("mcp"),
+        ":app_tools",
+        ":credential_tools",
         ":health_tools",
         ":pool_tools",
         ":profile_tools",

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -45,29 +45,54 @@ The relay boundary has these invariants:
 - The outbound origin is deployment configuration, never tool input. The Helm
   chart derives it from the public `services.mcp.resourceUrl` by removing the
   exact `/mcp` suffix.
-- Tools select a fixed HTTP method and `/api/...` path. Unknown tool arguments,
-  alternate URLs, queries, fragments, redirects, and path traversal fail
-  closed.
+- Tools select a fixed HTTP method and `/api/...` path. Query names are fixed
+  by each tool and values are encoded from bounded typed inputs. Unknown tool
+  arguments, alternate URLs, embedded queries or fragments, redirects, and
+  path traversal fail closed.
 - The unchanged authorization value and optional request ID are the only
   caller-derived headers forwarded on the second Gateway pass. MCP does not
   copy `x-osmo-*`, cookies, proxy headers, or other inbound request headers.
+  Request IDs that reuse a meaningful bearer-token substring are rejected
+  before forwarding or telemetry.
 - MCP does not exchange, refresh, modify, cache, persist, log, or return the
   bearer token. It clears request context and upstream cookies on completion,
   failure, timeout, or cancellation.
+- Tool arguments are rejected before execution if they contain the active
+  authorization value or bearer token, preventing credential reflection into
+  dynamic path or query values.
 - The `/mcp` request body is counted while streaming and rejected above 1 MiB,
   whether its size is declared or sent with chunked transfer encoding. Body
   collection has a 10-second deadline, and each process admits at most 16
   in-flight MCP requests so aggregate request memory remains bounded. This
   stateless JSON deployment accepts `POST /mcp` only; other methods return 405
   rather than opening long-lived streams outside that admission boundary.
+- Resource tools read the active profile and short-circuit an empty pool scope.
+  Lists send a non-empty explicit pool list to `/api/resources`; detail reads
+  only `/api/resources/{node_name}` and filters the returned assignments before
+  projection. They never use Core's unrestricted `all_pools` behavior. This
+  retains the existing CLI/API contract without a Core change, but profile
+  scope and resource data are still two requests rather than one atomic
+  authorization decision; a future Core endpoint should intersect resource
+  assignments with the current allowed-pools header. Workflow detail tools
+  accept canonical workflow IDs, not UUIDs, so Gateway can resolve the owning
+  pool before authorizing the API request.
 - Outbound calls have a total timeout, bounded response size, identity content
-  encoding, no redirects, and no automatic retries.
+  encoding, no redirects, and no automatic retries. JSON responses remain
+  whole-response validated; long text may return a marked bounded prefix.
 - Receiving APIs remain authoritative for API-specific authorization,
   validation, and side effects. MCP reads upstream error bodies under a
   separate small ceiling and preserves only error codes from a static Core
   contract for correctable client errors. Free-form messages, workflow IDs,
   validation locations, and unknown fields are discarded. Other upstream
   failures remain generic.
+- Every upstream call emits tool, method, static route template, status,
+  outcome, duration, and request-ID telemetry without dynamic resource names
+  or bearer values. A separate final tool outcome is emitted only after MCP
+  result validation, so a malformed HTTP 200 is never classified as a
+  successful tool result.
+- Only explicitly classified, bounded public errors can reach a client.
+  Validation failures use fixed messages and unexpected exceptions fail closed
+  to a generic error without reflecting exception text.
 
 The Gateway, MCP process, receiving OSMO APIs, and applicable middleware are
 inside the bearer-token handling boundary. None of them may log or persist the
@@ -75,24 +100,40 @@ authorization value.
 
 ## Available read tools
 
-The external service exposes narrow tools for:
+The first external catalog contains 14 read-only tools for caller-bound health,
+profile, pool, resource, workflow, application, and credential-metadata
+inspection. Each tool maps to a fixed external API, returns a structured
+allowlisted result, and applies a domain-specific response limit. Credential
+inspection returns names and types only. Profile inspection intentionally
+includes non-secret access-token identity metadata (name and expiry), unlike
+the hosted internal MCP projection.
 
-- caller access and identity: `osmo_health`, `osmo_get_profile`
-- inventory: `osmo_search_pools`, `osmo_list_resources`, `osmo_get_resource`
-- workflows: `osmo_list_workflows`, `osmo_get_workflow`,
-  `osmo_get_workflow_logs`, `osmo_get_workflow_events`,
-  `osmo_get_workflow_spec`
+JSON tools require one complete bounded response. Bounded text tools may
+instead return a safe UTF-8 prefix with `truncated=true` and a machine-readable
+reason when the response reaches its size limit or its live stream does not
+complete before the request timeout.
 
-Each tool maps to a fixed OSMO API route and returns an allowlisted structured
-projection. JSON tools require one complete bounded response. Bounded text
-tools may instead return a safe UTF-8 prefix with `truncated=true` and a
-machine-readable reason when the response reaches its size limit or its live
-stream does not complete before the request timeout.
+See [TOOLS.md](TOOLS.md) for the exact catalog, REST mappings, staged mutation
+plan, and intentionally excluded CLI/admin capabilities.
 
 The Kubernetes `/health`, `/health/live`, and `/health/ready` endpoints only
 report MCP process health. They do not relay a token or test Gateway/API
-authorization. A failed `osmo_get_profile` call therefore does not necessarily
-mean the MCP pod is unhealthy.
+authorization. The `osmo_health` tool is deliberately separate: it probes
+caller-bound Gateway authentication and OSMO profile access.
+
+## Code organization
+
+The external MCP remains independent from the hosted internal MCP. Runtime
+security boundaries live in `request_context.py`, `request_body.py`,
+`gateway.py`, `protocol.py`, and `telemetry.py`. Shared, dependency-light tool
+support lives in `tool_errors.py`, `tool_requests.py`, `tool_validation.py`, and
+`access_scope.py`. Each larger domain keeps its public and upstream contracts in
+`*_models.py` and its fixed routes, authorization decisions, projection, and
+handlers in the matching domain module. `tool_registry.py` is the single source
+of registration metadata used by both the server and catalog.
+
+Do not import the CLI runtime or internal MCP implementation. Extract only pure
+public helpers when behavior genuinely needs to match another OSMO surface.
 
 ## Adding a tool
 
@@ -106,8 +147,9 @@ Keep each new tool a narrow adapter:
    database, Kubernetes, or CLI client dependencies into the MCP image.
 4. Obtain `AppContext` from the injected FastMCP `Context`, obtain credentials
    from `request_context`, and pass both explicitly to `GatewayClient`.
-5. Set a tool-specific response ceiling and validate the complete success
-   response before returning it. Never return an upstream error body.
+5. Set a tool-specific response ceiling. Validate complete JSON responses;
+   expose long text only through the shared truncation contract. Preserve only
+   centrally scrubbed, allowlisted details from actionable client errors.
 6. Set accurate MCP annotations. Only operations with no observable side
    effects are read-only. Do not retry a state-changing operation whose result
    is uncertain.

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -1,0 +1,98 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# External MCP tool plan
+
+The external MCP exposes a deliberately smaller surface than the OSMO CLI. A
+tool is included only when it can be implemented as a bounded, fixed mapping to
+an existing external REST API while preserving the caller's OSMO identity and
+RBAC.
+
+## Phase 1: read-only operations (implemented)
+
+| Capability | Tools | Contract | OSMO APIs |
+| --- | --- | --- | --- |
+| Health | `osmo_health` | Caller-bound Gateway authentication and OSMO API access; distinct from Kubernetes probes | `GET /api/profile/settings` |
+| Profile | `osmo_get_profile` | Active identity, settings, roles, accessible pools, and non-secret token name/expiry metadata | `GET /api/profile/settings` |
+| Pools | `osmo_search_pools` | Accessible pools only; local text search and bounded output preserve shared node-set capacity | `GET /api/profile/settings`, `GET /api/pool_quota` |
+| Resources | `osmo_list_resources`, `osmo_get_resource` | Profile-selected accessible pools; normalized CLI-compatible capacity/used/free quantities; local bounded output and uniform node not-found behavior | `GET /api/profile/settings`, `GET /api/resources`, `GET /api/resources/{node_name}` |
+| Workflows | `osmo_list_workflows`, `osmo_get_workflow`, `osmo_get_workflow_logs`, `osmo_get_workflow_events`, `osmo_get_workflow_spec` | Active user's workflows in token-accessible pools; canonical workflow IDs; compact status and marked bounded text | `GET /api/workflow...` |
+| Applications | `osmo_list_apps`, `osmo_get_app`, `osmo_get_app_spec` | Active user's apps by default; app specs resolve a concrete newest READY version from bounded history when omitted, and return marked bounded text | `GET /api/app...` |
+| Credential metadata | `osmo_list_credentials` | Names and types only; never profiles or credential payloads | `GET /api/credentials` |
+
+These tools are read-only, idempotent, closed-world operations. Workflow and
+application list APIs paginate upstream. Pool and resource tools bound their
+MCP output but may read a complete accessible upstream response because the
+existing APIs do not offer agent-facing pagination. Logs apply Core's tail
+control only when the caller explicitly requests it; all long-text tools return
+a marked bounded prefix. JSON remains whole-response validated. Workflow UUID
+lookup remains excluded until Gateway authorization resolves UUIDs to their
+owning pool.
+
+The existing resource APIs do not atomically intersect resource assignments
+with the current allowed-pools header. Under this no-Core-change phase, MCP
+uses the active profile snapshot and fails closed for callers with no pools.
+Resource lists send a non-empty pool filter. Resource detail fetches only the
+encoded node route, then filters its assignments against that same profile
+scope before projecting any result. A future Core contract should perform the
+intersection on the resource request itself. Large accessible-pool sets can
+also reach the shared 16-KiB query ceiling for list requests even when MCP
+output is small; this is bounded output, not end-to-end pagination.
+
+Returning token name/expiry from `osmo_get_profile` is an intentional external
+product choice; the hosted internal MCP currently omits that metadata. Neither
+surface returns bearer values.
+
+Credential profiles are intentionally omitted from the external MCP even
+though the CLI and hosted internal MCP may display them. Legacy profile values
+can contain secret-bearing userinfo, queries, or fragments; the external
+projection therefore returns only `cred_name` and `cred_type`.
+
+## Phase 2: workflow actions
+
+Add `osmo_validate_workflow`, `osmo_submit_workflow`,
+`osmo_restart_workflow`, and `osmo_cancel_workflow` after the read-only request
+path is established. The transport body limit is already in place; this phase
+still requires exact mutation-body schemas, uncertain-write handling, and
+explicit side-effect annotations. Validation belongs in this phase because a
+failed validation can create a `FAILED_SUBMISSION` workflow record.
+
+## Phase 3: user-owned mutations
+
+Add `osmo_set_profile`, `osmo_set_credential`, `osmo_delete_credential`,
+`osmo_create_app`, `osmo_update_app`, `osmo_delete_app`, `osmo_rename_app`, and
+`osmo_submit_app`. Credential writes require dedicated secret-argument and
+error-reflection tests. Application writes must preserve their asynchronous API
+semantics.
+
+## Out of scope
+
+The external MCP does not expose CLI login/logout or access-token management,
+local file and data transfer, workflow exec/port-forward/rsync, or privileged
+user, backend, and service-configuration administration. Kubernetes process
+health remains available through `/health`, `/health/live`, and `/health/ready`;
+`osmo_health` instead checks caller-bound OSMO access.
+
+## Contract for every tool
+
+Each tool must use a fixed HTTP method and route, accept no origin, token,
+identity, method, route, or header input, validate and encode dynamic values,
+relay only request-local credentials through the same Gateway, validate
+complete JSON responses, mark bounded text prefixes, expose only centrally
+scrubbed allowlisted client-error details, declare accurate MCP annotations,
+and have protocol-level mapping and failure tests.

--- a/src/service/mcp/app_models.py
+++ b/src/service/mcp/app_models.py
@@ -1,0 +1,144 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Annotated, TypeAlias
+
+import pydantic
+
+from src.service.mcp.tool_models import (
+    ClosedToolModel,
+    ExtensibleUpstreamModel,
+    PageLimit,
+    PageOffset,
+)
+
+
+APP_NAME_PATTERN = r'^[A-Za-z0-9_-]+$'
+MAX_APP_FILTER_BYTES = 512
+MAX_USER_FILTER_BYTES = 256
+
+AppName: TypeAlias = Annotated[
+    str,
+    pydantic.Field(
+        min_length=1,
+        max_length=MAX_APP_FILTER_BYTES,
+        pattern=APP_NAME_PATTERN,
+        description='OSMO app name.',
+    ),
+]
+AppNameFilter: TypeAlias = Annotated[
+    str,
+    pydantic.Field(
+        min_length=1,
+        max_length=MAX_APP_FILTER_BYTES,
+        description='Substring to match in app names.',
+    ),
+]
+UserFilter: TypeAlias = Annotated[
+    str,
+    pydantic.Field(
+        min_length=1,
+        max_length=MAX_USER_FILTER_BYTES,
+        description='OSMO user name whose owned apps should be listed.',
+    ),
+]
+UserFilters: TypeAlias = Annotated[
+    list[UserFilter],
+    pydantic.Field(min_length=1, max_length=50),
+]
+AppListLimit: TypeAlias = PageLimit
+AppListOffset: TypeAlias = PageOffset
+AppVersionNumber: TypeAlias = Annotated[
+    int,
+    pydantic.Field(strict=True, ge=1),
+]
+
+
+class AppSummary(ClosedToolModel):
+    """Stable, non-secret metadata for one OSMO app."""
+
+    uuid: Annotated[str, pydantic.Field(min_length=1)]
+    name: Annotated[str, pydantic.Field(min_length=1)]
+    description: str
+    created_date: Annotated[str, pydantic.Field(min_length=1)]
+    owner: Annotated[str, pydantic.Field(min_length=1)]
+    latest_version: AppVersionNumber
+
+
+class AppListResult(ClosedToolModel):
+    """One bounded page of OSMO apps."""
+
+    apps: list[AppSummary]
+    more_entries: bool
+
+
+class AppVersion(ClosedToolModel):
+    """Metadata for one version of an OSMO app."""
+
+    version: AppVersionNumber
+    created_by: Annotated[str, pydantic.Field(min_length=1)]
+    created_date: Annotated[str, pydantic.Field(min_length=1)]
+    status: Annotated[str, pydantic.Field(min_length=1)]
+
+
+class AppResult(ClosedToolModel):
+    """Stable metadata and versions for one OSMO app."""
+
+    uuid: Annotated[str, pydantic.Field(min_length=1)]
+    name: Annotated[str, pydantic.Field(min_length=1)]
+    description: str
+    created_date: Annotated[str, pydantic.Field(min_length=1)]
+    owner: Annotated[str, pydantic.Field(min_length=1)]
+    versions: list[AppVersion]
+    more_versions: bool
+
+
+class AppSpecResult(ClosedToolModel):
+    """The requested OSMO app spec and its selection metadata."""
+
+    name: AppName
+    version: AppVersionNumber
+    spec: str
+    truncated: bool
+    truncation_reason: str | None
+
+
+class _UpstreamAppSummary(AppSummary):
+    """Core app summary with additive response fields ignored."""
+
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+
+class _UpstreamAppListResult(ExtensibleUpstreamModel):
+    apps: list[_UpstreamAppSummary]
+    more_entries: bool
+
+
+class _UpstreamAppVersion(AppVersion):
+    """Core app version with additive response fields ignored."""
+
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+
+class _UpstreamAppResult(ExtensibleUpstreamModel):
+    uuid: Annotated[str, pydantic.Field(min_length=1)]
+    name: Annotated[str, pydantic.Field(min_length=1)]
+    description: str
+    created_date: Annotated[str, pydantic.Field(min_length=1)]
+    owner: Annotated[str, pydantic.Field(min_length=1)]
+    versions: list[_UpstreamAppVersion]

--- a/src/service/mcp/apps.py
+++ b/src/service/mcp/apps.py
@@ -1,0 +1,210 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import re
+
+from mcp.server.fastmcp import Context
+
+from src.service.mcp import tool_requests, tool_validation
+from src.service.mcp.app_models import (
+    APP_NAME_PATTERN as _APP_NAME_PATTERN,
+    MAX_APP_FILTER_BYTES as _MAX_APP_FILTER_BYTES,
+    MAX_USER_FILTER_BYTES as _MAX_USER_FILTER_BYTES,
+    AppListLimit,
+    AppListOffset,
+    AppListResult,
+    AppName,
+    AppNameFilter,
+    AppResult,
+    AppSpecResult,
+    AppVersionNumber,
+    UserFilters,
+    _UpstreamAppListResult,
+    _UpstreamAppResult,
+)
+from src.service.mcp.tool_errors import PublicToolError
+
+
+_APP_LIST_PATH = '/api/app'
+_MAX_APP_RESPONSE_BYTES = 1024 * 1024
+_MAX_APP_SPEC_BYTES = 32 * 1024
+_DEFAULT_APP_LIST_LIMIT = 50
+_APP_VERSION_RESOLUTION_LIMIT = 200
+
+
+async def osmo_list_apps(
+    context: Context,
+    name: AppNameFilter | None = None,
+    users: UserFilters | None = None,
+    all_users: bool = False,
+    limit: AppListLimit = _DEFAULT_APP_LIST_LIMIT,
+    offset: AppListOffset = 0,
+) -> AppListResult:
+    """List OSMO apps newest first, scoped to the active user by default."""
+    if users is not None and all_users:
+        raise PublicToolError('Specify either users or all_users, not both.')
+
+    query: dict[str, str | int | bool | list[str]] = {
+        'order': 'DESC',
+        'limit': limit,
+        'offset': offset,
+    }
+    if name is not None:
+        query['name'] = tool_validation.validate_query_text(
+            name,
+            field='app name filter',
+            max_bytes=_MAX_APP_FILTER_BYTES,
+        )
+    if users is not None:
+        query['users'] = list(dict.fromkeys(
+            tool_validation.validate_query_text(
+                user,
+                field='app user filter',
+                max_bytes=_MAX_USER_FILTER_BYTES,
+            )
+            for user in users
+        ))
+    if all_users:
+        query['all_users'] = True
+
+    response = await tool_requests.request_json_object(
+        context,
+        path=_APP_LIST_PATH,
+        operation='list OSMO apps',
+        max_response_bytes=_MAX_APP_RESPONSE_BYTES,
+        query=query,
+    )
+    upstream = tool_validation.validate_response(
+        _UpstreamAppListResult,
+        response,
+        operation='list OSMO apps',
+    )
+    return AppListResult.model_validate(upstream.model_dump(), strict=True)
+
+
+async def osmo_get_app(
+    context: Context,
+    name: AppName,
+    version: AppVersionNumber | None = None,
+    limit: AppListLimit = _DEFAULT_APP_LIST_LIMIT,
+) -> AppResult:
+    """Get OSMO app metadata and versions, newest version first."""
+    encoded_name = _validated_app_name(name)
+    upstream = await _request_app(
+        context,
+        encoded_name=encoded_name,
+        version=version,
+        limit=limit + 1,
+        operation='get an OSMO app',
+    )
+    return AppResult.model_validate({
+        **upstream.model_dump(),
+        'versions': [
+            app_version.model_dump()
+            for app_version in upstream.versions[:limit]
+        ],
+        'more_versions': len(upstream.versions) > limit,
+    }, strict=True)
+
+
+async def osmo_get_app_spec(
+    context: Context,
+    name: AppName,
+    version: AppVersionNumber | None = None,
+) -> AppSpecResult:
+    """Get an app spec, resolving READY metadata from bounded history."""
+    encoded_name = _validated_app_name(name)
+    resolved_version = version
+    if resolved_version is None:
+        upstream = await _request_app(
+            context,
+            encoded_name=encoded_name,
+            version=None,
+            limit=_APP_VERSION_RESOLUTION_LIMIT + 1,
+            operation='resolve the newest READY OSMO app version',
+        )
+        resolved_version = max(
+            (
+                app_version.version
+                for app_version in upstream.versions[
+                    :_APP_VERSION_RESOLUTION_LIMIT
+                ]
+                if app_version.status == 'READY'
+            ),
+            default=None,
+        )
+        if resolved_version is None:
+            if len(upstream.versions) > _APP_VERSION_RESOLUTION_LIMIT:
+                raise PublicToolError(
+                    'Unable to resolve the newest READY OSMO app version '
+                    'within the bounded version history; specify version '
+                    'explicitly.'
+                )
+            raise PublicToolError(
+                'The requested OSMO app has no READY versions.'
+            )
+
+    spec_result = await tool_requests.request_truncated_text(
+        context,
+        path=f'/api/app/user/{encoded_name}/spec',
+        operation='get an OSMO app spec',
+        max_response_bytes=_MAX_APP_SPEC_BYTES,
+        query={'version': resolved_version},
+    )
+    return AppSpecResult(
+        name=name,
+        version=resolved_version,
+        spec=spec_result.text,
+        truncated=spec_result.truncated,
+        truncation_reason=spec_result.truncation_reason,
+    )
+
+
+def _validated_app_name(name: str) -> str:
+    if re.fullmatch(_APP_NAME_PATTERN, name) is None:
+        raise PublicToolError('Invalid app name.')
+    return tool_validation.safe_path_segment(name, field='app name')
+
+
+async def _request_app(
+    context: Context,
+    *,
+    encoded_name: str,
+    version: int | None,
+    limit: int,
+    operation: str,
+) -> _UpstreamAppResult:
+    query: dict[str, str | int] = {
+        'order': 'DESC',
+        'limit': limit,
+    }
+    if version is not None:
+        query['version'] = version
+
+    response = await tool_requests.request_json_object(
+        context,
+        path=f'/api/app/user/{encoded_name}',
+        operation=operation,
+        max_response_bytes=_MAX_APP_RESPONSE_BYTES,
+        query=query,
+    )
+    return tool_validation.validate_response(
+        _UpstreamAppResult,
+        response,
+        operation=operation,
+    )

--- a/src/service/mcp/credentials.py
+++ b/src/service/mcp/credentials.py
@@ -1,0 +1,88 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from collections.abc import Mapping
+from typing import Annotated
+
+from mcp.server.fastmcp import Context
+import pydantic
+
+from src.service.mcp import tool_requests
+from src.service.mcp.tool_errors import PublicToolError
+
+
+_CREDENTIALS_PATH = '/api/credentials'
+_MAX_CREDENTIAL_RESPONSE_BYTES = 1024 * 1024
+_CREDENTIAL_FIELDS = ('cred_name', 'cred_type')
+
+
+class CredentialMetadata(pydantic.BaseModel, extra='forbid'):
+    """Non-secret metadata for one OSMO credential."""
+
+    cred_name: Annotated[str, pydantic.Field(min_length=1)]
+    cred_type: Annotated[str, pydantic.Field(min_length=1)]
+
+
+class CredentialListResult(pydantic.BaseModel, extra='forbid'):
+    """The active user's credential metadata."""
+
+    credentials: list[CredentialMetadata]
+
+
+async def osmo_list_credentials(context: Context) -> CredentialListResult:
+    """List credential names and types without secret-bearing values."""
+    response = await tool_requests.request_json_object(
+        context,
+        path=_CREDENTIALS_PATH,
+        operation='list OSMO credentials',
+        max_response_bytes=_MAX_CREDENTIAL_RESPONSE_BYTES,
+    )
+    return _project_credential_metadata(response)
+
+
+def _project_credential_metadata(
+    response: tool_requests.JsonObject,
+) -> CredentialListResult:
+    raw_credentials = response.get('credentials')
+    if not isinstance(raw_credentials, list):
+        raise _invalid_response()
+
+    projected_credentials: list[dict[str, object]] = []
+    for credential in raw_credentials:
+        if not isinstance(credential, Mapping):
+            raise _invalid_response()
+        if any(field not in credential for field in _CREDENTIAL_FIELDS):
+            raise _invalid_response()
+        projected_credentials.append({
+            field: credential[field]
+            for field in _CREDENTIAL_FIELDS
+        })
+
+    try:
+        return CredentialListResult.model_validate(
+            {'credentials': projected_credentials},
+            strict=True,
+        )
+    except pydantic.ValidationError:
+        raise _invalid_response() from None
+
+
+def _invalid_response() -> PublicToolError:
+    return PublicToolError(
+        'OSMO returned an invalid response while attempting to list OSMO credentials.'
+    )

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -34,9 +34,20 @@ osmo_py_library(
 )
 
 osmo_py_test(
+    name = "test_apps",
+    srcs = ["test_apps.py"],
+    deps = [
+        requirement("httpx"),
+        ":protocol_harness",
+    ],
+)
+
+osmo_py_test(
     name = "test_catalog",
     srcs = ["test_catalog.py"],
     deps = [
+        "//src/service/mcp:app_tools",
+        "//src/service/mcp:credential_tools",
         "//src/service/mcp:health_tools",
         "//src/service/mcp:pool_tools",
         "//src/service/mcp:profile_tools",
@@ -44,6 +55,15 @@ osmo_py_test(
         "//src/service/mcp:resource_tools",
         "//src/service/mcp:tool_registry",
         "//src/service/mcp:workflow_tools",
+    ],
+)
+
+osmo_py_test(
+    name = "test_credentials",
+    srcs = ["test_credentials.py"],
+    deps = [
+        requirement("httpx"),
+        ":protocol_harness",
     ],
 )
 

--- a/src/service/mcp/tests/test_apps.py
+++ b/src/service/mcp/tests/test_apps.py
@@ -1,0 +1,484 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import unittest
+
+import httpx
+
+from src.service.mcp.tests import protocol_harness
+
+
+_BEARER_SECRET = 'apps-tool-bearer-secret'
+_HARNESS = protocol_harness.ProtocolHarness(
+    tool_names=(
+        'osmo_list_apps',
+        'osmo_get_app',
+        'osmo_get_app_spec',
+    ),
+    bearer_secret=_BEARER_SECRET,
+    request_id='apps-request-123',
+)
+_APP_SUMMARY: dict[str, object] = {
+    'uuid': '0123456789abcdef0123456789abcdef',
+    'name': 'training_app',
+    'description': 'Train a model',
+    'created_date': '2026-07-10T12:30:00Z',
+    'owner': 'alice@example.com',
+    'latest_version': 3,
+}
+_APP_LIST_RESULT: dict[str, object] = {
+    'apps': [_APP_SUMMARY],
+    'more_entries': True,
+}
+_APP_VERSION: dict[str, object] = {
+    'version': 3,
+    'created_by': 'alice@example.com',
+    'created_date': '2026-07-11T12:30:00Z',
+    'status': 'READY',
+}
+_APP_RESULT: dict[str, object] = {
+    'uuid': '0123456789abcdef0123456789abcdef',
+    'name': 'training_app',
+    'description': 'Train a model',
+    'created_date': '2026-07-10T12:30:00Z',
+    'owner': 'alice@example.com',
+    'versions': [_APP_VERSION],
+}
+
+
+class AppToolsProtocolTest(unittest.IsolatedAsyncioTestCase):
+    """Exercise app tools through the stateless Streamable HTTP protocol."""
+
+    async def _invoke_tool(
+        self,
+        handler: protocol_harness.UpstreamHandler,
+        tool_name: str,
+        arguments: dict[str, object] | None = None,
+    ) -> httpx.Response:
+        return await _HARNESS.call_tool(
+            handler,
+            tool_name,
+            arguments,
+        )
+
+    async def test_catalog_exposes_closed_world_structured_schemas(self) -> None:
+        response = await _HARNESS.list_tools(request_id=2)
+        tools = _HARNESS.assert_read_only_closed_catalog(self, response)
+
+        list_properties = tools['osmo_list_apps']['inputSchema']['properties']
+        self.assertEqual(list_properties['limit']['default'], 50)
+        self.assertEqual(list_properties['limit']['maximum'], 200)
+        self.assertEqual(list_properties['offset']['default'], 0)
+        self.assertEqual(list_properties['offset']['minimum'], 0)
+        for tool_name in ('osmo_get_app', 'osmo_get_app_spec'):
+            name_schema = json.dumps(
+                tools[tool_name]['inputSchema']['properties']['name']
+            )
+            self.assertIn('^[A-Za-z0-9_-]+$', name_schema)
+        self.assertEqual(
+            tools['osmo_get_app_spec']['inputSchema']['required'],
+            ['name'],
+        )
+
+    async def test_list_apps_defaults_to_current_user_and_newest_first(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        upstream_secret = 'additive-app-field-secret'
+        upstream_result = {
+            **_APP_LIST_RESULT,
+            'apps': [{
+                **_APP_SUMMARY,
+                'internal_field': upstream_secret,
+            }],
+            'internal_field': upstream_secret,
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=upstream_result)
+
+        response = await self._invoke_tool(handler, 'osmo_list_apps')
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], _APP_LIST_RESULT)
+        self.assertNotIn(upstream_secret, response.text)
+        self.assertEqual(len(captured_requests), 1)
+        upstream_request = captured_requests[0]
+        self.assertEqual(upstream_request.url.path, '/api/app')
+        self.assertEqual(upstream_request.url.params.multi_items(), [
+            ('order', 'DESC'),
+            ('limit', '50'),
+            ('offset', '0'),
+        ])
+        self.assertNotIn('users', upstream_request.url.params)
+        self.assertNotIn('all_users', upstream_request.url.params)
+        self.assertEqual(
+            upstream_request.headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+
+    async def test_list_apps_maps_filters_and_pagination_exactly(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=_APP_LIST_RESULT)
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_list_apps',
+            {
+                'name': 'train',
+                'users': ['alice@example.com', 'bob@example.com'],
+                'limit': 200,
+                'offset': 25,
+            },
+        )
+
+        self.assertFalse(response.json()['result']['isError'])
+        self.assertEqual(captured_requests[0].url.params.multi_items(), [
+            ('order', 'DESC'),
+            ('limit', '200'),
+            ('offset', '25'),
+            ('name', 'train'),
+            ('users', 'alice@example.com'),
+            ('users', 'bob@example.com'),
+        ])
+
+    async def test_get_app_maps_name_version_and_limit_exactly(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=_APP_RESULT)
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_get_app',
+            {'name': 'training_app', 'version': 3, 'limit': 7},
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            **_APP_RESULT,
+            'more_versions': False,
+        })
+        self.assertEqual(
+            captured_requests[0].url.path,
+            '/api/app/user/training_app',
+        )
+        self.assertEqual(captured_requests[0].url.params.multi_items(), [
+            ('order', 'DESC'),
+            ('limit', '8'),
+            ('version', '3'),
+        ])
+
+    async def test_get_app_reports_omitted_versions(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        older_version = {
+            **_APP_VERSION,
+            'version': 2,
+            'created_date': '2026-07-10T12:30:00Z',
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                **_APP_RESULT,
+                'versions': [_APP_VERSION, older_version],
+            })
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_get_app',
+            {'name': 'training_app', 'limit': 1},
+        )
+
+        structured_content = response.json()['result']['structuredContent']
+        self.assertEqual(structured_content['versions'], _APP_RESULT['versions'])
+        self.assertTrue(structured_content['more_versions'])
+        self.assertEqual(captured_requests[0].url.params.multi_items(), [
+            ('order', 'DESC'),
+            ('limit', '2'),
+        ])
+
+    async def test_get_app_spec_returns_bounded_text_with_selection(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        app_spec = 'version: 1\nworkflow:\n  tasks: []\n'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, text=app_spec)
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_get_app_spec',
+            {'name': 'training_app', 'version': 2},
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'name': 'training_app',
+            'version': 2,
+            'spec': app_spec,
+            'truncated': False,
+            'truncation_reason': None,
+        })
+        self.assertEqual(
+            captured_requests[0].url.path,
+            '/api/app/user/training_app/spec',
+        )
+        self.assertEqual(
+            captured_requests[0].url.params.multi_items(),
+            [('version', '2')],
+        )
+
+    async def test_get_app_spec_resolves_newest_ready_version(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        app_spec = 'version: 3\nworkflow:\n  tasks: []\n'
+        pending_version = {
+            **_APP_VERSION,
+            'version': 4,
+            'status': 'PENDING',
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.url.path == '/api/app/user/training_app':
+                return httpx.Response(200, json={
+                    **_APP_RESULT,
+                    'versions': [pending_version, _APP_VERSION],
+                })
+            if request.url.path == '/api/app/user/training_app/spec':
+                return httpx.Response(200, text=app_spec)
+            self.fail(f'unexpected Gateway route: {request.url}')
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_get_app_spec',
+            {'name': 'training_app'},
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'name': 'training_app',
+            'version': 3,
+            'spec': app_spec,
+            'truncated': False,
+            'truncation_reason': None,
+        })
+        self.assertEqual(len(captured_requests), 2)
+        self.assertEqual(
+            captured_requests[0].url.params.multi_items(),
+            [('order', 'DESC'), ('limit', '201')],
+        )
+        self.assertEqual(
+            captured_requests[1].url.params.multi_items(),
+            [('version', '3')],
+        )
+
+    async def test_get_app_spec_fails_when_app_has_no_ready_versions(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                **_APP_RESULT,
+                'versions': [{
+                    **_APP_VERSION,
+                    'version': 4,
+                    'status': 'PENDING',
+                }],
+            })
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_get_app_spec',
+            {'name': 'training_app'},
+        )
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertIn('has no READY versions', response.text)
+        self.assertEqual(len(captured_requests), 1)
+
+    async def test_get_app_spec_reports_bounded_resolution_exhaustion(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+        non_ready_versions = [
+            {
+                **_APP_VERSION,
+                'version': version,
+                'status': 'PENDING',
+            }
+            for version in range(201, 0, -1)
+        ]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                **_APP_RESULT,
+                'versions': non_ready_versions,
+            })
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_get_app_spec',
+            {'name': 'training_app'},
+        )
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertIn('bounded version history', response.text)
+        self.assertIn('specify version explicitly', response.text)
+        self.assertEqual(len(captured_requests), 1)
+        self.assertEqual(
+            captured_requests[0].url.params.multi_items(),
+            [('order', 'DESC'), ('limit', '201')],
+        )
+
+    async def test_invalid_names_and_pagination_fail_before_transport(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=_APP_RESULT)
+
+        cases: tuple[tuple[str, dict[str, object]], ...] = (
+            ('osmo_get_app', {'name': 'parent/child'}),
+            ('osmo_get_app_spec', {'name': '..'}),
+            ('osmo_list_apps', {'limit': 201}),
+            ('osmo_list_apps', {'limit': True}),
+            ('osmo_list_apps', {'offset': -1}),
+            ('osmo_list_apps', {'offset': True}),
+            ('osmo_get_app', {'name': 'training_app', 'version': True}),
+            ('osmo_get_app_spec', {'name': 'training_app', 'version': True}),
+            ('osmo_list_apps', {'name': 'bad\nfilter'}),
+            ('osmo_list_apps', {'users': ['é' * 200]}),
+            ('osmo_list_apps', {
+                'users': [
+                    ('é' * 120) + f'{index:02d}'
+                    for index in range(50)
+                ],
+            }),
+            ('osmo_list_apps', {
+                'users': ['alice@example.com'],
+                'all_users': True,
+            }),
+        )
+        for tool_name, arguments in cases:
+            with self.subTest(tool_name=tool_name, arguments=arguments):
+                response = await self._invoke_tool(handler, tool_name, arguments)
+                self.assertTrue(response.json()['result']['isError'])
+
+        self.assertEqual(captured_requests, [])
+
+    async def test_status_and_malformed_responses_are_sanitized(self) -> None:
+        async def not_found(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(404, content=b'upstream-app-body-secret')
+
+        status_response = await self._invoke_tool(
+            not_found,
+            'osmo_get_app',
+            {'name': 'training_app'},
+        )
+        status_result = status_response.json()['result']
+        self.assertTrue(status_result['isError'])
+        self.assertIn('HTTP 404', json.dumps(status_result))
+        self.assertNotIn('upstream-app-body-secret', json.dumps(status_result))
+
+        async def malformed_json(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'upstream-malformed-secret')
+
+        malformed_response = await self._invoke_tool(
+            malformed_json,
+            'osmo_list_apps',
+        )
+        malformed_result = malformed_response.json()['result']
+        self.assertTrue(malformed_result['isError'])
+        self.assertIn('invalid response', json.dumps(malformed_result))
+        self.assertNotIn('upstream-malformed-secret', json.dumps(malformed_result))
+
+        async def wrong_shape(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, json={
+                'apps': 'upstream-shape-secret',
+                'more_entries': False,
+            })
+
+        shape_response = await self._invoke_tool(
+            wrong_shape,
+            'osmo_list_apps',
+        )
+        shape_result = shape_response.json()['result']
+        self.assertTrue(shape_result['isError'])
+        self.assertNotIn('upstream-shape-secret', json.dumps(shape_result))
+
+    async def test_json_strict_and_escape_heavy_spec_truncation_is_bounded(
+        self,
+    ) -> None:
+        oversized_json = b'{"apps":[],"padding":"' + (
+            b'x' * (1024 * 1024)
+        ) + b'","more_entries":false}'
+        oversized_spec = b'\x00\x1b' * (512 * 1024)
+
+        def oversized_handler(
+            body: bytes,
+        ) -> protocol_harness.UpstreamHandler:
+            async def handler(request: httpx.Request) -> httpx.Response:
+                del request
+                return httpx.Response(200, content=body)
+
+            return handler
+
+        response = await self._invoke_tool(
+            oversized_handler(oversized_json),
+            'osmo_get_app',
+            {'name': 'training_app'},
+        )
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertIn('exceeds the size limit', json.dumps(result))
+        self.assertNotIn(_BEARER_SECRET, json.dumps(result))
+
+        response = await self._invoke_tool(
+            oversized_handler(oversized_spec),
+            'osmo_get_app_spec',
+            {'name': 'training_app', 'version': 1},
+        )
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        structured_content = result['structuredContent']
+        self.assertTrue(structured_content['truncated'])
+        self.assertIsNotNone(structured_content['truncation_reason'])
+        self.assertIn('truncated', structured_content['spec'])
+        self.assertLess(len(response.content), 512 * 1024)
+        self.assertNotIn(_BEARER_SECRET, json.dumps(result))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -21,6 +21,8 @@ from unittest import mock
 import unittest
 
 from src.service.mcp import (
+    apps,
+    credentials,
     health,
     pools,
     profile,
@@ -101,6 +103,35 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'Get OSMO workflow spec',
         'Get the bounded, server-redacted resolved or template workflow YAML.',
     ),
+    (
+        apps.osmo_list_apps,
+        'osmo_list_apps',
+        'List OSMO apps',
+        'List a bounded page of OSMO apps newest first. By default, '
+        'results are scoped to apps associated with the active user.',
+    ),
+    (
+        apps.osmo_get_app,
+        'osmo_get_app',
+        'Get OSMO app',
+        'Get stable metadata and newest-first version information for '
+        'one OSMO app.',
+    ),
+    (
+        apps.osmo_get_app_spec,
+        'osmo_get_app_spec',
+        'Get OSMO app spec',
+        'Get the bounded plain-text workflow spec for one OSMO app. '
+        'When version is omitted, resolve the newest READY version from '
+        'bounded version history.',
+    ),
+    (
+        credentials.osmo_list_credentials,
+        'osmo_list_credentials',
+        'List OSMO credentials',
+        'List only the active user\'s credential names and types. '
+        'Profiles and credential payloads are never returned.',
+    ),
 )
 
 _EXPECTED_REQUIRED_FIELDS = {
@@ -114,6 +145,10 @@ _EXPECTED_REQUIRED_FIELDS = {
     'osmo_get_workflow_logs': ['workflow_id'],
     'osmo_get_workflow_events': ['workflow_id'],
     'osmo_get_workflow_spec': ['workflow_id'],
+    'osmo_list_apps': [],
+    'osmo_get_app': ['name'],
+    'osmo_get_app_spec': ['name'],
+    'osmo_list_credentials': [],
 }
 
 _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
@@ -145,6 +180,15 @@ _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
     },
     'osmo_get_workflow_events': {'task_name': None, 'retry_id': None},
     'osmo_get_workflow_spec': {'use_template': False},
+    'osmo_list_apps': {
+        'name': None,
+        'users': None,
+        'all_users': False,
+        'limit': 50,
+        'offset': 0,
+    },
+    'osmo_get_app': {'version': None, 'limit': 50},
+    'osmo_get_app_spec': {'version': None},
 }
 
 
@@ -152,7 +196,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
     """Lock the ordered, agent-facing external MCP tool contract."""
 
     def test_registry_has_exact_metadata_and_direct_unique_functions(self) -> None:
-        self.assertEqual(len(tool_registry.TOOL_SPECS), 10)
+        self.assertEqual(len(tool_registry.TOOL_SPECS), 14)
         self.assertEqual(
             [
                 (spec.name, spec.title, spec.description)
@@ -167,7 +211,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         registered_functions = [
             spec.function for spec in tool_registry.TOOL_SPECS
         ]
-        self.assertEqual(len({id(function) for function in registered_functions}), 10)
+        self.assertEqual(len({id(function) for function in registered_functions}), 14)
         for spec, (function, _, _, _) in zip(
             tool_registry.TOOL_SPECS,
             _EXPECTED_SPECS,
@@ -180,7 +224,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
 
         tool_registry.register_tools(mcp_server)
 
-        self.assertEqual(mcp_server.add_tool.call_count, 10)
+        self.assertEqual(mcp_server.add_tool.call_count, 14)
         for call, (function, name, title, description) in zip(
             mcp_server.add_tool.call_args_list,
             _EXPECTED_SPECS,
@@ -240,6 +284,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             'osmo_search_pools',
             'osmo_list_resources',
             'osmo_list_workflows',
+            'osmo_list_apps',
         ):
             properties = tools_by_name[tool_name].inputSchema['properties']
             self.assertEqual(properties['limit']['minimum'], 1)
@@ -258,6 +303,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_selection_retains_canonical_order(self) -> None:
         selected_names = {
+            'osmo_get_app_spec',
             'osmo_health',
             'osmo_get_resource',
         }
@@ -267,6 +313,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             [
                 'osmo_health',
                 'osmo_get_resource',
+                'osmo_get_app_spec',
             ],
         )
 
@@ -279,6 +326,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             [
                 'osmo_health',
                 'osmo_get_resource',
+                'osmo_get_app_spec',
             ],
         )
 

--- a/src/service/mcp/tests/test_credentials.py
+++ b/src/service/mcp/tests/test_credentials.py
@@ -1,0 +1,213 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import unittest
+
+import httpx
+
+from src.service.mcp.tests import protocol_harness
+
+
+_BEARER_SECRET = 'credentials-tool-bearer-secret'
+_HARNESS = protocol_harness.ProtocolHarness(
+    tool_names=('osmo_list_credentials',),
+    bearer_secret=_BEARER_SECRET,
+    request_id='credentials-request-123',
+)
+
+
+class CredentialToolsProtocolTest(unittest.IsolatedAsyncioTestCase):
+    """Exercise credential tools through the Streamable HTTP protocol."""
+
+    async def _invoke_tool(
+        self,
+        handler: protocol_harness.UpstreamHandler,
+        arguments: dict[str, object] | None = None,
+    ) -> httpx.Response:
+        return await _HARNESS.call_tool(
+            handler,
+            'osmo_list_credentials',
+            arguments,
+        )
+
+    async def test_catalog_exposes_closed_world_structured_schema(self) -> None:
+        response = await _HARNESS.list_tools(request_id=2)
+        tools = _HARNESS.assert_read_only_closed_catalog(self, response)
+        tool = tools['osmo_list_credentials']
+        self.assertEqual(tool['title'], 'List OSMO credentials')
+        self.assertEqual(tool['inputSchema']['properties'], {})
+
+    async def test_list_credentials_projects_only_allowlisted_metadata(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        upstream_secret = 'upstream-credential-payload-secret'
+        upstream_response = {
+            'credentials': [
+                {
+                    'cred_name': 'nvcr',
+                    'cred_type': 'REGISTRY',
+                    'profile': (
+                        's3://user:password@bucket/path?'
+                        'X-Amz-Signature=profile-secret#fragment'
+                    ),
+                    'password': upstream_secret,
+                    'access_key': upstream_secret,
+                },
+                {
+                    'cred_name': 'generic-api',
+                    'cred_type': 'GENERIC',
+                    'profile': None,
+                    'credential': {'token': upstream_secret},
+                },
+            ],
+            'debug_secret': upstream_secret,
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json=upstream_response)
+
+        response = await self._invoke_tool(handler)
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'credentials': [
+                {
+                    'cred_name': 'nvcr',
+                    'cred_type': 'REGISTRY',
+                },
+                {
+                    'cred_name': 'generic-api',
+                    'cred_type': 'GENERIC',
+                },
+            ],
+        })
+        self.assertNotIn(upstream_secret, response.text)
+        self.assertNotIn('profile-secret', response.text)
+        self.assertNotIn('X-Amz-Signature', response.text)
+        self.assertEqual(len(captured_requests), 1)
+        upstream_request = captured_requests[0]
+        self.assertEqual(upstream_request.method, 'GET')
+        self.assertEqual(upstream_request.url.path, '/api/credentials')
+        self.assertEqual(upstream_request.url.query, b'')
+        self.assertEqual(
+            upstream_request.headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+        self.assertEqual(
+            upstream_request.headers['x-request-id'],
+            'credentials-request-123',
+        )
+
+    async def test_invalid_shapes_fail_closed_without_reflecting_values(self) -> None:
+        invalid_responses: tuple[object, ...] = (
+            {},
+            {'credentials': {}},
+            {'credentials': ['upstream-list-item-secret']},
+            {'credentials': [{
+                'cred_name': 'missing-type',
+            }]},
+            {'credentials': [{
+                'cred_name': 123,
+                'cred_type': 'DATA',
+                'profile': 'upstream-type-secret',
+            }]},
+            {'credentials': [{
+                'cred_name': 'name',
+                'cred_type': None,
+                'profile': None,
+            }]},
+        )
+
+        def response_handler(
+            response_body: object,
+        ) -> protocol_harness.UpstreamHandler:
+            async def handler(request: httpx.Request) -> httpx.Response:
+                del request
+                return httpx.Response(200, json=response_body)
+
+            return handler
+
+        for upstream_response in invalid_responses:
+            with self.subTest(upstream_response=upstream_response):
+                response = await self._invoke_tool(
+                    response_handler(upstream_response)
+                )
+                result = response.json()['result']
+                self.assertTrue(result['isError'])
+                self.assertIn('invalid response', json.dumps(result))
+                self.assertNotIn('upstream-', json.dumps(result))
+                self.assertNotIn(_BEARER_SECRET, json.dumps(result))
+
+    async def test_status_malformed_and_oversized_bodies_are_sanitized(self) -> None:
+        async def forbidden(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(403, content=b'upstream-status-secret')
+
+        status_response = await self._invoke_tool(forbidden)
+        status_result = status_response.json()['result']
+        self.assertTrue(status_result['isError'])
+        self.assertIn('HTTP 403', json.dumps(status_result))
+        self.assertNotIn('upstream-status-secret', json.dumps(status_result))
+
+        async def malformed(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=b'upstream-malformed-secret')
+
+        malformed_response = await self._invoke_tool(malformed)
+        malformed_result = malformed_response.json()['result']
+        self.assertTrue(malformed_result['isError'])
+        self.assertIn('invalid response', json.dumps(malformed_result))
+        self.assertNotIn('upstream-malformed-secret', json.dumps(malformed_result))
+
+        oversized_body = b'{"credentials":[],"padding":"' + (
+            b'x' * (1024 * 1024)
+        ) + b'"}'
+
+        async def oversized(request: httpx.Request) -> httpx.Response:
+            del request
+            return httpx.Response(200, content=oversized_body)
+
+        oversized_response = await self._invoke_tool(oversized)
+        oversized_result = oversized_response.json()['result']
+        self.assertTrue(oversized_result['isError'])
+        self.assertIn('exceeds the size limit', json.dumps(oversized_result))
+        self.assertNotIn(_BEARER_SECRET, json.dumps(oversized_result))
+
+    async def test_unmapped_arguments_are_rejected_before_transport(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={'credentials': []})
+
+        response = await self._invoke_tool(handler, {
+            'include_secrets': True,
+            'authorization': 'Bearer tool-input-secret',
+        })
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertEqual(captured_requests, [])
+        self.assertNotIn('tool-input-secret', json.dumps(result))
+        self.assertNotIn(_BEARER_SECRET, json.dumps(result))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -23,6 +23,8 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from src.service.mcp import (
+    apps,
+    credentials,
     health,
     pools,
     profile,
@@ -127,6 +129,43 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         title='Get OSMO workflow spec',
         description=(
             'Get the bounded, server-redacted resolved or template workflow YAML.'
+        ),
+    ),
+    ToolSpec(
+        function=apps.osmo_list_apps,
+        name='osmo_list_apps',
+        title='List OSMO apps',
+        description=(
+            'List a bounded page of OSMO apps newest first. By default, '
+            'results are scoped to apps associated with the active user.'
+        ),
+    ),
+    ToolSpec(
+        function=apps.osmo_get_app,
+        name='osmo_get_app',
+        title='Get OSMO app',
+        description=(
+            'Get stable metadata and newest-first version information for '
+            'one OSMO app.'
+        ),
+    ),
+    ToolSpec(
+        function=apps.osmo_get_app_spec,
+        name='osmo_get_app_spec',
+        title='Get OSMO app spec',
+        description=(
+            'Get the bounded plain-text workflow spec for one OSMO app. '
+            'When version is omitted, resolve the newest READY version from '
+            'bounded version history.'
+        ),
+    ),
+    ToolSpec(
+        function=credentials.osmo_list_credentials,
+        name='osmo_list_credentials',
+        title='List OSMO credentials',
+        description=(
+            'List only the active user\'s credential names and types. '
+            'Profiles and credential payloads are never returned.'
         ),
     ),
 )


### PR DESCRIPTION
## Description

Complete the external MCP read catalog with app and credential metadata tools.

Issue - None

### Stack

1. #1204 (merged): runtime foundation
2. #1205 (merged): pool and resource inventory tools
3. #1206 (merged): workflow read tools
4. **#1207 (this PR):** app and credential metadata tools plus final documentation

### Summary

- Adds app list, app detail, app spec, and credential metadata tools using existing OSMO routes.
- Resolves an omitted app-spec version to the newest READY version from bounded history and returns that concrete version.
- Requires an explicit version when the bounded history cannot prove the newest READY version.
- Applies bounded, marked text handling to app specs.
- Returns credential names and types only; potentially secret-bearing profiles and credential payloads are never exposed.
- Finalizes the canonical 14-tool registry and agent-facing README/tool documentation.
- Keeps BUILD dependencies limited to direct imports and adds no Python requirements or lockfile changes.

### Validation

- Focused app, credential, catalog, lint, and type checks passed.
- Complete MCP package validation passed: 51/51 test, lint, and type targets.
- `//src/service/mcp:mcp_binary` built successfully.
- `git diff --check` passed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
