### PR TITLE
Trim credential payload file line endings

### DIFF
--- a/src/cli/credential.py
+++ b/src/cli/credential.py
@@ -98,7 +98,7 @@ def _run_set_command(service_client: client.ServiceClient, args: argparse.Namesp
             try:
                 with open(value, 'r', encoding='utf-8') as file:
                     contents = file.read()
-                    cred_payload[key] = contents
+                    cred_payload[key] = contents.rstrip('\r\n')
             except FileNotFoundError:
                 print(f'File {value} cannot be found.')
                 sys.exit(1)

--- a/src/cli/tests/test_credential.py
+++ b/src/cli/tests/test_credential.py
@@ -264,8 +264,8 @@ class TestRunSetCommand(unittest.TestCase):
         )
 
     def test_payload_file_strips_trailing_line_ending(self):
-        """Test that payload-file mode strips LF and CRLF line endings."""
-        for line_ending in (b'\n', b'\r\n'):
+        """Test that payload-file mode strips LF, CRLF, and CR line endings."""
+        for line_ending in (b'\n', b'\r\n', b'\r'):
             with self.subTest(line_ending=line_ending):
                 service_client = mock.Mock(spec=client.ServiceClient)
                 service_client.request.return_value = {'status': 'ok'}

--- a/src/cli/tests/test_credential.py
+++ b/src/cli/tests/test_credential.py
@@ -263,6 +263,35 @@ class TestRunSetCommand(unittest.TestCase):
             payload={'registry_credential': {'auth': 'file-contents'}},
         )
 
+    def test_payload_file_strips_trailing_line_ending(self):
+        """Test that payload-file mode strips LF and CRLF line endings."""
+        for line_ending in (b'\n', b'\r\n'):
+            with self.subTest(line_ending=line_ending):
+                service_client = mock.Mock(spec=client.ServiceClient)
+                service_client.request.return_value = {'status': 'ok'}
+
+                with tempfile.NamedTemporaryFile('wb', delete=False) as temp:
+                    temp.write(b' leading\nfile-contents \t' + line_ending)
+                    temp_path = temp.name
+                self.addCleanup(os.unlink, temp_path)
+
+                args = self._args(
+                    type='REGISTRY',
+                    payload=None,
+                    payload_file=[f'auth={temp_path}'],
+                )
+
+                with mock.patch('builtins.print'):
+                    credential._run_set_command(service_client, args)
+
+                service_client.request.assert_called_once_with(
+                    client.RequestMethod.POST,
+                    'api/credentials/mycred',
+                    payload={'registry_credential': {
+                        'auth': ' leading\nfile-contents \t',
+                    }},
+                )
+
     def test_generic_wraps_in_credential_key(self):
         """Test that GENERIC type wraps payload into a nested 'credential' dict."""
         service_client = mock.Mock(spec=client.ServiceClient)


### PR DESCRIPTION
## Description

Secret files commonly end with an LF, CRLF, or CR line ending. `osmo credential set --payload-file` previously included trailing line-ending characters in the credential value, which could cause registry authentication to fail even when the token itself was valid.

Strip trailing line-ending characters from payload-file values while preserving all other content. Add regression coverage for LF, CRLF, and CR inputs.

Issue - None

Validation:

- `bazel test //src/cli:cli_lib-pylint //src/cli/tests:all --nocache_test_results --test_output=errors`
- `ruff check src/cli/credential.py src/cli/tests/test_credential.py`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credential payloads loaded from files no longer include trailing line endings.
  * Embedded newlines and other meaningful whitespace within the payload are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->