### PR TITLE
#1067 - Normalize empty S3 validation endpoints

### DIFF
--- a/src/lib/data/storage/backends/backends.py
+++ b/src/lib/data/storage/backends/backends.py
@@ -174,7 +174,7 @@ class Boto3Backend(common.StorageBackend):
             data_cred: The data credential to use for validation.
         """
         # Use credential's override_url if set, otherwise fallback to backend's parsed endpoint
-        endpoint_url = data_cred.override_url or self.endpoint
+        endpoint_url = data_cred.override_url or self.endpoint or None
 
         s3_client = s3.create_client(
             data_cred=data_cred,

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -340,6 +340,35 @@ class CredentialOverrideUrlTest(unittest.TestCase):
         # Assert - S3Backend.endpoint is empty string, so endpoint_url should be None
         self.assertIsNone(s3_client_factory.endpoint_url)
 
+    @mock.patch('src.lib.data.storage.backends.backends._skip_data_auth', return_value=False)
+    @mock.patch('src.lib.data.storage.backends.s3.create_client')
+    def test_s3_data_auth_with_default_credential_uses_default_endpoint(
+        self,
+        mock_create_client,
+        mock_skip_data_auth,
+    ):
+        """Test that ambient credentials use the default AWS S3 endpoint."""
+        # pylint: disable=unused-argument
+        mock_s3_client = mock.Mock()
+        mock_create_client.return_value = mock_s3_client
+        s3_backend = cast(backends.S3Backend, backends.construct_storage_backend(
+            uri='s3://test-bucket/test-key',
+        ))
+        data_cred = credentials.DefaultDataCredential(
+            endpoint='s3://test-bucket',
+            region='us-east-1',
+        )
+
+        s3_backend.data_auth(data_cred=data_cred)
+
+        mock_create_client.assert_called_once_with(
+            data_cred=data_cred,
+            scheme='s3',
+            endpoint_url=None,
+            region='us-east-1',
+        )
+        mock_s3_client.head_bucket.assert_called_once_with(Bucket='test-bucket')
+
     def test_swift_client_factory_override_url_takes_precedence(self):
         """Test that credential's override_url overrides Swift's endpoint."""
         # Arrange


### PR DESCRIPTION
## Description

Normalize the native S3 backend's empty endpoint to `None` when validating bucket access. This allows boto3 to use its default or environment-configured AWS endpoint for `DefaultDataCredential`, including IRSA, while preserving explicit credential overrides and the non-empty endpoints used by other backends.

The regression test covers bucket validation with ambient credentials and verifies both the default endpoint and the `HeadBucket` request.

Issue #1067

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I, the PR author, have personally reviewed every line of this PR.

## Validation

- `bazel test --test_output=errors //src/lib/data/storage/backends/tests:test_backends`
- `bazel test --test_output=errors //src/lib/data/storage/backends:backends-pylint //src/lib/data/storage/backends/tests:test_backends-pylint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 bucket access checks when using default credentials and endpoints.
  * Ensured bucket validation connects to the correct default endpoint and region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->