### PR TITLE
Add workflow label validation library

### DIFF
--- a/src/lib/utils/tests/test_validation.py
+++ b/src/lib/utils/tests/test_validation.py
@@ -245,30 +245,17 @@ class TestWorkflowLabelValidation(unittest.TestCase):
             'run_42.alpha',
         )
 
-    def test_rejects_reserved_keys(self):
+    def test_accepts_any_syntactically_valid_key(self):
+        # No deny-list: system-owned pod labels are protected by merge order
+        # at stamping time, so even system-domain keys validate here.
         for key in (
-            'kubernetes.io/name',
-            'k8s.io/name',
+            'app.kubernetes.io/name',
             'topology.kubernetes.io/zone',
-            'example.k8s.io/name',
             'osmo.workflow_uuid',
-        ):
-            with self.subTest(key=key), self.assertRaisesRegex(ValueError, 'reserved'):
-                validation.validate_workflow_label_key(key)
-
-    def test_rejects_scheduler_owned_keys(self):
-        for key in (
             'kai.scheduler/queue',
-            'kai.scheduler/workload-kind',
             'runai/queue',
-            'runai/project',
-            'kai.scheduler/subgroup-name',
+            'example-kubernetes.io/name',
         ):
-            with self.subTest(key=key), self.assertRaisesRegex(ValueError, 'reserved'):
-                validation.validate_workflow_label_key(key)
-
-    def test_accepts_similar_unreserved_dns_prefixes(self):
-        for key in ('example-kubernetes.io/name', 'runai.example/project'):
             with self.subTest(key=key):
                 self.assertEqual(validation.validate_workflow_label_key(key), key)
 

--- a/src/lib/utils/tests/test_validation.py
+++ b/src/lib/utils/tests/test_validation.py
@@ -232,7 +232,7 @@ class TestSanitizedPath(unittest.TestCase):
 
 
 class TestWorkflowLabelValidation(unittest.TestCase):
-    """Tests for workflow label syntax shared by specs, config, and CLI."""
+    """Tests for the workflow label validation helpers."""
 
     def test_accepts_kubernetes_label_key_and_nonempty_value(self):
         self.assertEqual(validation.validate_workflow_label_key('PPP'), 'PPP')
@@ -274,7 +274,7 @@ class TestWorkflowLabelValidation(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'at most 16'):
             validation.validate_workflow_labels(labels)
 
-    def test_rejects_nested_label_values(self):
+    def test_rejects_non_string_label_values(self):
         labels = cast(
             dict[str, str],
             {'PPP': {'team': 'robotics'}},
@@ -296,7 +296,7 @@ class TestWorkflowLabelValidation(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'key=value'):
             validation.parse_workflow_label_assignment('experiment')
 
-    def test_assignment_validation_remains_strict_for_selector_syntax(self):
+    def test_parse_assignment_rejects_selector_syntax(self):
         for assignment in (
             'PPP=*',
             'PPP=robotics_*',
@@ -315,7 +315,7 @@ class TestWorkflowLabelValidation(unittest.TestCase):
             ),
         )
 
-    def test_parse_glob_label_selector(self):
+    def test_parse_glob_selector_collapses_wildcard_runs(self):
         self.assertEqual(
             validation.parse_workflow_label_selector('PPP=robotics_**'),
             validation.WorkflowLabelSelector(

--- a/src/lib/utils/tests/test_validation.py
+++ b/src/lib/utils/tests/test_validation.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 import argparse
 import os
 import tempfile
+from typing import cast
 import unittest
 
 from src.lib.utils import osmo_errors, validation
@@ -228,6 +229,226 @@ class TestSanitizedPath(unittest.TestCase):
 
     def test_sanitized_path_rejects_unresolvable_parent_traversal(self):
         self.assertIsNone(validation.sanitized_path('../etc/passwd'))
+
+
+class TestWorkflowLabelValidation(unittest.TestCase):
+    """Tests for workflow label syntax shared by specs, config, and CLI."""
+
+    def test_accepts_kubernetes_label_key_and_nonempty_value(self):
+        self.assertEqual(validation.validate_workflow_label_key('PPP'), 'PPP')
+        self.assertEqual(
+            validation.validate_workflow_label_key('example.com/experiment'),
+            'example.com/experiment',
+        )
+        self.assertEqual(
+            validation.validate_workflow_label_value('run_42.alpha'),
+            'run_42.alpha',
+        )
+
+    def test_rejects_reserved_keys(self):
+        for key in (
+            'kubernetes.io/name',
+            'k8s.io/name',
+            'topology.kubernetes.io/zone',
+            'example.k8s.io/name',
+            'osmo.workflow_uuid',
+        ):
+            with self.subTest(key=key), self.assertRaisesRegex(ValueError, 'reserved'):
+                validation.validate_workflow_label_key(key)
+
+    def test_rejects_scheduler_owned_keys(self):
+        for key in (
+            'kai.scheduler/queue',
+            'kai.scheduler/workload-kind',
+            'runai/queue',
+            'runai/project',
+            'kai.scheduler/subgroup-name',
+        ):
+            with self.subTest(key=key), self.assertRaisesRegex(ValueError, 'reserved'):
+                validation.validate_workflow_label_key(key)
+
+    def test_accepts_similar_unreserved_dns_prefixes(self):
+        for key in ('example-kubernetes.io/name', 'runai.example/project'):
+            with self.subTest(key=key):
+                self.assertEqual(validation.validate_workflow_label_key(key), key)
+
+    def test_rejects_invalid_key_syntax(self):
+        for key in ('', '/name', 'UPPER.example.com/name', 'example.com/', '-name'):
+            with self.subTest(key=key), self.assertRaises(ValueError):
+                validation.validate_workflow_label_key(key)
+
+    def test_rejects_empty_or_invalid_value(self):
+        for value in ('', '-value', 'value/', 'x' * 64):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                validation.validate_workflow_label_value(value)
+
+    def test_rejects_more_than_sixteen_labels(self):
+        labels = {f'label-{index}': 'value' for index in range(17)}
+        with self.assertRaisesRegex(ValueError, 'at most 16'):
+            validation.validate_workflow_labels(labels)
+
+    def test_rejects_nested_label_values(self):
+        labels = cast(
+            dict[str, str],
+            {'PPP': {'team': 'robotics'}},
+        )
+        with self.assertRaisesRegex(ValueError, 'values must be strings'):
+            validation.validate_workflow_labels(labels)
+
+    def test_parse_assignment_returns_validated_key_and_value(self):
+        self.assertEqual(
+            validation.parse_workflow_label_assignment('experiment=run42'),
+            ('experiment', 'run42'),
+        )
+
+    def test_parse_assignment_rejects_invalid_value(self):
+        with self.assertRaises(ValueError):
+            validation.parse_workflow_label_assignment('experiment=run=42')
+
+    def test_parse_assignment_rejects_missing_equals(self):
+        with self.assertRaisesRegex(ValueError, 'key=value'):
+            validation.parse_workflow_label_assignment('experiment')
+
+    def test_assignment_validation_remains_strict_for_selector_syntax(self):
+        for assignment in (
+            'PPP=*',
+            'PPP=robotics_*',
+            'PPP=(team_a|team_b)',
+            'PPP=team_(a|b)',
+        ):
+            with self.subTest(assignment=assignment), self.assertRaises(ValueError):
+                validation.parse_workflow_label_assignment(assignment)
+
+    def test_parse_exact_label_selector(self):
+        self.assertEqual(
+            validation.parse_workflow_label_selector('PPP=robotics'),
+            validation.WorkflowLabelSelector(
+                key='PPP',
+                values=('robotics',),
+            ),
+        )
+
+    def test_parse_glob_label_selector(self):
+        self.assertEqual(
+            validation.parse_workflow_label_selector('PPP=robotics_**'),
+            validation.WorkflowLabelSelector(
+                key='PPP',
+                values=('robotics_*',),
+            ),
+        )
+
+    def test_parse_match_all_label_selector(self):
+        self.assertEqual(
+            validation.parse_workflow_label_selector('PPP=*'),
+            validation.WorkflowLabelSelector(
+                key='PPP',
+                values=('*',),
+            ),
+        )
+
+    def test_parse_alternation_label_selector(self):
+        self.assertEqual(
+            validation.parse_workflow_label_selector('PPP=(team_a|team_b)'),
+            validation.WorkflowLabelSelector(
+                key='PPP',
+                values=('team_a', 'team_b'),
+            ),
+        )
+
+    def test_parse_wildcard_alternatives(self):
+        self.assertEqual(
+            validation.parse_workflow_label_selector('PPP=(team_*|osmo_*)'),
+            validation.WorkflowLabelSelector(
+                key='PPP',
+                values=('team_*', 'osmo_*'),
+            ),
+        )
+
+    def test_parse_inline_alternatives(self):
+        self.assertEqual(
+            validation.parse_workflow_label_selector('PPP=team_(a|b)'),
+            validation.WorkflowLabelSelector(
+                key='PPP',
+                values=('team_a', 'team_b'),
+            ),
+        )
+
+    def test_parse_multiple_flat_groups(self):
+        self.assertEqual(
+            validation.parse_workflow_label_selector(
+                'PPP=(team|osmo)_(a|b*)'),
+            validation.WorkflowLabelSelector(
+                key='PPP',
+                values=('team_a', 'team_b*', 'osmo_a', 'osmo_b*'),
+            ),
+        )
+
+    def test_selector_rejects_missing_separator(self):
+        with self.assertRaisesRegex(ValueError, 'selectors must use key=value'):
+            validation.parse_workflow_label_selector('PPP')
+
+    def test_selector_rejects_unwrapped_or_unbalanced_alternation(self):
+        for selector in (
+            'PPP=team_a|team_b',
+            'PPP=(team_a|team_b',
+            'PPP=team_a|team_b)',
+        ):
+            with self.subTest(selector=selector), self.assertRaisesRegex(
+                    ValueError, r'alternatives must use \(value\|value\)'):
+                validation.parse_workflow_label_selector(selector)
+
+    def test_selector_rejects_empty_or_single_alternation(self):
+        for selector in (
+            'PPP=()',
+            'PPP=(team_a)',
+            'PPP=(team_a|)',
+            'PPP=(|team_b)',
+        ):
+            with self.subTest(selector=selector), self.assertRaisesRegex(
+                    ValueError, 'at least two non-empty values'):
+                validation.parse_workflow_label_selector(selector)
+
+    def test_selector_rejects_nested_alternation(self):
+        for selector in (
+            'PPP=((team_a|team_b))',
+            'PPP=(team_a|(team_b|team_c))',
+        ):
+            with self.subTest(selector=selector), self.assertRaisesRegex(
+                    ValueError, 'cannot be nested'):
+                validation.parse_workflow_label_selector(selector)
+
+    def test_selector_rejects_invalid_literal_pattern_characters(self):
+        for selector in (
+            'PPP=team[ab]',
+            'PPP=team?',
+            'PPP=team=value',
+        ):
+            with self.subTest(selector=selector), self.assertRaises(ValueError):
+                validation.parse_workflow_label_selector(selector)
+
+    def test_selector_accepts_max_expanded_patterns(self):
+        selector = ''.join('(a|b)' for _ in range(5))
+        parsed_selector = validation.parse_workflow_label_selector(
+            f'PPP={selector}')
+        self.assertEqual(len(parsed_selector.values), 32)
+
+    def test_selector_rejects_too_many_expanded_patterns(self):
+        alternatives = '|'.join(
+            f'team_{index}'
+            for index in range(
+                validation.MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS + 1)
+        )
+        for selector in (
+            f'PPP=({alternatives})',
+            f"PPP={''.join('(a|b)' for _ in range(6))}",
+        ):
+            with self.subTest(selector=selector), self.assertRaisesRegex(
+                    ValueError, 'at most 32 patterns'):
+                validation.parse_workflow_label_selector(selector)
+
+    def test_selector_rejects_glob_longer_than_label_limit(self):
+        with self.assertRaises(ValueError):
+            validation.parse_workflow_label_selector('PPP=' + 'x' * 63 + '*')
 
 
 if __name__ == '__main__':

--- a/src/lib/utils/tests/test_validation.py
+++ b/src/lib/utils/tests/test_validation.py
@@ -427,9 +427,8 @@ class TestWorkflowLabelValidation(unittest.TestCase):
                 validation.parse_workflow_label_selector(selector)
 
     def test_selector_accepts_max_expanded_patterns(self):
-        selector = ''.join('(a|b)' for _ in range(5))
         parsed_selector = validation.parse_workflow_label_selector(
-            f'PPP={selector}')
+            f"PPP={'(a|b)' * 5}")
         self.assertEqual(len(parsed_selector.values), 32)
 
     def test_selector_rejects_too_many_expanded_patterns(self):
@@ -440,7 +439,7 @@ class TestWorkflowLabelValidation(unittest.TestCase):
         )
         for selector in (
             f'PPP=({alternatives})',
-            f"PPP={''.join('(a|b)' for _ in range(6))}",
+            f"PPP={'(a|b)' * 6}",
         ):
             with self.subTest(selector=selector), self.assertRaisesRegex(
                     ValueError, 'at most 32 patterns'):

--- a/src/lib/utils/validation.py
+++ b/src/lib/utils/validation.py
@@ -19,10 +19,11 @@ SPDX-License-Identifier: Apache-2.0
 import argparse
 from collections.abc import Mapping
 import dataclasses
+import itertools
+import math
 import os
 import pathlib
 import re
-from typing import Dict
 
 from . import common, osmo_errors
 from ..data.storage import constants
@@ -35,6 +36,7 @@ WORKFLOW_LABEL_RESERVED_DNS_SUFFIXES = ('kubernetes.io', 'k8s.io')
 
 _LABEL_NAME_PATTERN = re.compile(
     r'^[A-Za-z0-9](?:[-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$')
+_WILDCARD_RUN_PATTERN = re.compile(r'\*+')
 _DNS_LABEL_PATTERN = r'[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?'
 _DNS_PREFIX_PATTERN = re.compile(
     rf'^(?=.{{1,253}}$){_DNS_LABEL_PATTERN}(?:\.{_DNS_LABEL_PATTERN})*$')
@@ -56,7 +58,7 @@ def validate_workflow_label_key(key: str) -> str:
     """Validate a workflow label key against Kubernetes qualified-name syntax."""
     if not isinstance(key, str):
         raise ValueError('Workflow label keys must be strings.')
-    if any(key.startswith(prefix) for prefix in WORKFLOW_LABEL_RESERVED_PREFIXES):
+    if key.startswith(WORKFLOW_LABEL_RESERVED_PREFIXES):
         raise ValueError(f'Workflow label key "{key}" is reserved.')
 
     parts = key.split('/')
@@ -92,7 +94,7 @@ def validate_workflow_label_value(value: str) -> str:
     return value
 
 
-def validate_workflow_labels(labels: Mapping[str, str]) -> Dict[str, str]:
+def validate_workflow_labels(labels: Mapping[str, str]) -> dict[str, str]:
     """Validate and copy a complete workflow labels map."""
     if not isinstance(labels, Mapping):
         raise ValueError('Workflow labels must be a map of string keys to string values.')
@@ -100,16 +102,15 @@ def validate_workflow_labels(labels: Mapping[str, str]) -> Dict[str, str]:
         raise ValueError(
             f'Workflows can have at most {MAX_WORKFLOW_LABELS} labels.')
 
-    validated_labels: Dict[str, str] = {}
     for key, value in labels.items():
-        validated_key = validate_workflow_label_key(key)
-        validated_labels[validated_key] = validate_workflow_label_value(value)
-    return validated_labels
+        validate_workflow_label_key(key)
+        validate_workflow_label_value(value)
+    return dict(labels)
 
 
 def parse_workflow_label_assignment(assignment: str) -> tuple[str, str]:
     """Parse and validate a workflow label assignment in key=value form."""
-    if not isinstance(assignment, str) or '=' not in assignment:
+    if '=' not in assignment:
         raise ValueError('Workflow labels must use key=value format.')
     key, value = assignment.split('=', 1)
     return validate_workflow_label_key(key), validate_workflow_label_value(value)
@@ -158,31 +159,23 @@ def _expand_workflow_label_selector_pattern(value: str) -> tuple[str, ...]:
     if literal_characters:
         segments.append((''.join(literal_characters),))
 
-    expanded_patterns: tuple[str, ...] = ('',)
-    for alternatives in segments:
-        if (len(expanded_patterns) * len(alternatives) >
-                MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS):
-            raise ValueError(
-                'Workflow label selectors can expand to at most '
-                f'{MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS} patterns.')
-        expanded_patterns = tuple(
-            prefix + alternative
-            for prefix in expanded_patterns
-            for alternative in alternatives
-        )
+    if (math.prod(len(alternatives) for alternatives in segments) >
+            MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS):
+        raise ValueError(
+            'Workflow label selectors can expand to at most '
+            f'{MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS} patterns.')
 
-    normalized_patterns: list[str] = []
-    for pattern in expanded_patterns:
-        normalized_pattern = re.sub(r'\*+', '*', pattern)
+    normalized_patterns = dict.fromkeys(
+        _WILDCARD_RUN_PATTERN.sub('*', ''.join(parts))
+        for parts in itertools.product(*segments))
+    for normalized_pattern in normalized_patterns:
         validate_workflow_label_value(normalized_pattern.replace('*', 'a'))
-        if normalized_pattern not in normalized_patterns:
-            normalized_patterns.append(normalized_pattern)
     return tuple(normalized_patterns)
 
 
 def parse_workflow_label_selector(selector: str) -> WorkflowLabelSelector:
     """Parse an exact or anchored glob-alternation selector."""
-    if not isinstance(selector, str) or '=' not in selector:
+    if '=' not in selector:
         raise ValueError('Workflow label selectors must use key=value format.')
 
     key, value = selector.split('=', 1)

--- a/src/lib/utils/validation.py
+++ b/src/lib/utils/validation.py
@@ -17,12 +17,179 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import argparse
+from collections.abc import Mapping
+import dataclasses
 import os
 import pathlib
 import re
+from typing import Dict
 
 from . import common, osmo_errors
 from ..data.storage import constants
+
+
+MAX_WORKFLOW_LABELS = 16
+MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS = 32
+WORKFLOW_LABEL_RESERVED_PREFIXES = ('osmo.', 'kai.scheduler/', 'runai/')
+WORKFLOW_LABEL_RESERVED_DNS_SUFFIXES = ('kubernetes.io', 'k8s.io')
+
+_LABEL_NAME_PATTERN = re.compile(
+    r'^[A-Za-z0-9](?:[-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$')
+_DNS_LABEL_PATTERN = r'[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?'
+_DNS_PREFIX_PATTERN = re.compile(
+    rf'^(?=.{{1,253}}$){_DNS_LABEL_PATTERN}(?:\.{_DNS_LABEL_PATTERN})*$')
+
+
+@dataclasses.dataclass(frozen=True)
+class WorkflowLabelSelector:
+    """A validated workflow label selector.
+
+    Each value is either a literal (exact match) or an anchored glob pattern
+    containing ``*`` wildcards; a workflow matches when any value matches.
+    """
+
+    key: str
+    values: tuple[str, ...]
+
+
+def validate_workflow_label_key(key: str) -> str:
+    """Validate a workflow label key against Kubernetes qualified-name syntax."""
+    if not isinstance(key, str):
+        raise ValueError('Workflow label keys must be strings.')
+    if any(key.startswith(prefix) for prefix in WORKFLOW_LABEL_RESERVED_PREFIXES):
+        raise ValueError(f'Workflow label key "{key}" is reserved.')
+
+    parts = key.split('/')
+    if len(parts) == 1:
+        prefix = None
+        name = parts[0]
+    elif len(parts) == 2:
+        prefix, name = parts
+    else:
+        raise ValueError(f'Workflow label key "{key}" is not a valid Kubernetes label key.')
+
+    if prefix is not None:
+        if (prefix in WORKFLOW_LABEL_RESERVED_DNS_SUFFIXES or any(
+                prefix.endswith(f'.{suffix}')
+                for suffix in WORKFLOW_LABEL_RESERVED_DNS_SUFFIXES)):
+            raise ValueError(f'Workflow label key "{key}" is reserved.')
+        if not _DNS_PREFIX_PATTERN.fullmatch(prefix):
+            raise ValueError(
+                f'Workflow label key "{key}" has an invalid DNS prefix.')
+    if not _LABEL_NAME_PATTERN.fullmatch(name):
+        raise ValueError(
+            f'Workflow label key "{key}" has an invalid name segment.')
+    return key
+
+
+def validate_workflow_label_value(value: str) -> str:
+    """Validate a non-empty workflow label value against Kubernetes syntax."""
+    if not isinstance(value, str):
+        raise ValueError('Workflow label values must be strings.')
+    if not _LABEL_NAME_PATTERN.fullmatch(value):
+        raise ValueError(
+            f'Workflow label value "{value}" must be a non-empty valid Kubernetes label value.')
+    return value
+
+
+def validate_workflow_labels(labels: Mapping[str, str]) -> Dict[str, str]:
+    """Validate and copy a complete workflow labels map."""
+    if not isinstance(labels, Mapping):
+        raise ValueError('Workflow labels must be a map of string keys to string values.')
+    if len(labels) > MAX_WORKFLOW_LABELS:
+        raise ValueError(
+            f'Workflows can have at most {MAX_WORKFLOW_LABELS} labels.')
+
+    validated_labels: Dict[str, str] = {}
+    for key, value in labels.items():
+        validated_key = validate_workflow_label_key(key)
+        validated_labels[validated_key] = validate_workflow_label_value(value)
+    return validated_labels
+
+
+def parse_workflow_label_assignment(assignment: str) -> tuple[str, str]:
+    """Parse and validate a workflow label assignment in key=value form."""
+    if not isinstance(assignment, str) or '=' not in assignment:
+        raise ValueError('Workflow labels must use key=value format.')
+    key, value = assignment.split('=', 1)
+    return validate_workflow_label_key(key), validate_workflow_label_value(value)
+
+
+def _expand_workflow_label_selector_pattern(value: str) -> tuple[str, ...]:
+    """Expand non-nested alternation groups into complete glob patterns."""
+    segments: list[tuple[str, ...]] = []
+    literal_characters: list[str] = []
+    position = 0
+    while position < len(value):
+        character = value[position]
+        if character == '(':
+            if literal_characters:
+                segments.append((''.join(literal_characters),))
+                literal_characters = []
+
+            closing_position = value.find(')', position + 1)
+            if closing_position == -1:
+                raise ValueError(
+                    'Workflow label selector alternatives must use '
+                    '(value|value) format.')
+
+            group_value = value[position + 1:closing_position]
+            if '(' in group_value:
+                raise ValueError(
+                    'Workflow label selector alternatives cannot be nested.')
+
+            alternatives = tuple(group_value.split('|'))
+            if len(alternatives) < 2 or any(not item for item in alternatives):
+                raise ValueError(
+                    'Workflow label selector alternatives must contain at least '
+                    'two non-empty values.')
+            segments.append(alternatives)
+            position = closing_position + 1
+            continue
+
+        if character in ')|':
+            raise ValueError(
+                'Workflow label selector alternatives must use '
+                '(value|value) format.')
+
+        literal_characters.append(character)
+        position += 1
+
+    if literal_characters:
+        segments.append((''.join(literal_characters),))
+
+    expanded_patterns: tuple[str, ...] = ('',)
+    for alternatives in segments:
+        if (len(expanded_patterns) * len(alternatives) >
+                MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS):
+            raise ValueError(
+                'Workflow label selectors can expand to at most '
+                f'{MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS} patterns.')
+        expanded_patterns = tuple(
+            prefix + alternative
+            for prefix in expanded_patterns
+            for alternative in alternatives
+        )
+
+    normalized_patterns: list[str] = []
+    for pattern in expanded_patterns:
+        normalized_pattern = re.sub(r'\*+', '*', pattern)
+        validate_workflow_label_value(normalized_pattern.replace('*', 'a'))
+        if normalized_pattern not in normalized_patterns:
+            normalized_patterns.append(normalized_pattern)
+    return tuple(normalized_patterns)
+
+
+def parse_workflow_label_selector(selector: str) -> WorkflowLabelSelector:
+    """Parse an exact or anchored glob-alternation selector."""
+    if not isinstance(selector, str) or '=' not in selector:
+        raise ValueError('Workflow label selectors must use key=value format.')
+
+    key, value = selector.split('=', 1)
+    return WorkflowLabelSelector(
+        key=validate_workflow_label_key(key),
+        values=_expand_workflow_label_selector_pattern(value),
+    )
 
 
 def positive_integer(x: int):

--- a/src/lib/utils/validation.py
+++ b/src/lib/utils/validation.py
@@ -31,8 +31,6 @@ from ..data.storage import constants
 
 MAX_WORKFLOW_LABELS = 16
 MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS = 32
-WORKFLOW_LABEL_RESERVED_PREFIXES = ('osmo.', 'kai.scheduler/', 'runai/')
-WORKFLOW_LABEL_RESERVED_DNS_SUFFIXES = ('kubernetes.io', 'k8s.io')
 
 _LABEL_NAME_PATTERN = re.compile(
     r'^[A-Za-z0-9](?:[-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$')
@@ -55,11 +53,14 @@ class WorkflowLabelSelector:
 
 
 def validate_workflow_label_key(key: str) -> str:
-    """Validate a workflow label key against Kubernetes qualified-name syntax."""
+    """Validate a workflow label key against Kubernetes qualified-name syntax.
+
+    Any syntactically valid key is accepted. System-owned pod labels (the
+    ``osmo.`` selectors and scheduler queue labels) are protected by merge
+    order at stamping time, not by a deny-list here.
+    """
     if not isinstance(key, str):
         raise ValueError('Workflow label keys must be strings.')
-    if key.startswith(WORKFLOW_LABEL_RESERVED_PREFIXES):
-        raise ValueError(f'Workflow label key "{key}" is reserved.')
 
     parts = key.split('/')
     if len(parts) == 1:
@@ -71,10 +72,6 @@ def validate_workflow_label_key(key: str) -> str:
         raise ValueError(f'Workflow label key "{key}" is not a valid Kubernetes label key.')
 
     if prefix is not None:
-        if (prefix in WORKFLOW_LABEL_RESERVED_DNS_SUFFIXES or any(
-                prefix.endswith(f'.{suffix}')
-                for suffix in WORKFLOW_LABEL_RESERVED_DNS_SUFFIXES)):
-            raise ValueError(f'Workflow label key "{key}" is reserved.')
         if not _DNS_PREFIX_PATTERN.fullmatch(prefix):
             raise ValueError(
                 f'Workflow label key "{key}" has an invalid DNS prefix.')

--- a/src/lib/utils/validation.py
+++ b/src/lib/utils/validation.py
@@ -1,5 +1,5 @@
 """
-SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class WorkflowLabelSelector:
     """A validated workflow label selector.
 
     Each value is either a literal (exact match) or an anchored glob pattern
-    containing ``*`` wildcards; a workflow matches when any value matches.
+    containing '*' wildcards; a workflow matches when any value matches.
     """
 
     key: str
@@ -56,7 +56,7 @@ def validate_workflow_label_key(key: str) -> str:
     """Validate a workflow label key against Kubernetes qualified-name syntax.
 
     Any syntactically valid key is accepted. System-owned pod labels (the
-    ``osmo.`` selectors and scheduler queue labels) are protected by merge
+    'osmo.' selectors and scheduler queue labels) are protected by merge
     order at stamping time, not by a deny-list here.
     """
     if not isinstance(key, str):
@@ -82,12 +82,12 @@ def validate_workflow_label_key(key: str) -> str:
 
 
 def validate_workflow_label_value(value: str) -> str:
-    """Validate a non-empty workflow label value against Kubernetes syntax."""
+    """Validate a workflow label value against Kubernetes label-value syntax."""
     if not isinstance(value, str):
         raise ValueError('Workflow label values must be strings.')
     if not _LABEL_NAME_PATTERN.fullmatch(value):
         raise ValueError(
-            f'Workflow label value "{value}" must be a non-empty valid Kubernetes label value.')
+            f'Workflow label value "{value}" is not a valid non-empty Kubernetes label value.')
     return value
 
 
@@ -113,8 +113,14 @@ def parse_workflow_label_assignment(assignment: str) -> tuple[str, str]:
     return validate_workflow_label_key(key), validate_workflow_label_value(value)
 
 
-def _expand_workflow_label_selector_pattern(value: str) -> tuple[str, ...]:
-    """Expand non-nested alternation groups into complete glob patterns."""
+def _expand_workflow_label_selector_value(value: str) -> tuple[str, ...]:
+    """Expand a selector value's alternation groups into glob patterns.
+
+    Expansion is eager: the full cross product is materialized, capped at
+    MAX_WORKFLOW_LABEL_SELECTOR_PATTERNS before wildcard-run collapsing and
+    deduplication, and every expanded pattern must satisfy label-value
+    syntax.
+    """
     segments: list[tuple[str, ...]] = []
     literal_characters: list[str] = []
     position = 0
@@ -166,6 +172,8 @@ def _expand_workflow_label_selector_pattern(value: str) -> tuple[str, ...]:
         _WILDCARD_RUN_PATTERN.sub('*', ''.join(parts))
         for parts in itertools.product(*segments))
     for normalized_pattern in normalized_patterns:
+        # Wildcards are not valid label characters; validate syntax and
+        # length with a stand-in character per wildcard.
         validate_workflow_label_value(normalized_pattern.replace('*', 'a'))
     return tuple(normalized_patterns)
 
@@ -178,7 +186,7 @@ def parse_workflow_label_selector(selector: str) -> WorkflowLabelSelector:
     key, value = selector.split('=', 1)
     return WorkflowLabelSelector(
         key=validate_workflow_label_key(key),
-        values=_expand_workflow_label_selector_pattern(value),
+        values=_expand_workflow_label_selector_value(value),
     )
 
 


### PR DESCRIPTION
## Description

Issue - None
Tracking: OSMO-6501

Track B1 of the workflow-label split from #1194.

### What changed

- Added reusable Kubernetes-style workflow label key and value validation.
- Added whole-map validation with a 16-label bound. There is no reserved-key deny-list: system-owned pod labels are protected by merge order at stamping time, not by rejection here.
- Added strict `key=value` assignment parsing for submit overrides.
- Added bounded selector parsing for exact values, `*` wildcards, and flat `(a|b)` alternatives.
- Added focused unit coverage for syntax (including acceptance of system-domain keys), assignments, alternation expansion, and failure cases.

### Why

Workflow specs, policy config, CLI overrides, and list filters need one shared validation contract. Keeping parsing in `lib/utils/validation.py` prevents those surfaces from drifting and avoids exposing user-supplied regular expressions.

### Impact

This PR is inert on its own: it adds the shared library only. Later Track B PRs consume it for workflow persistence, admission, filtering, and UI/API surfaces.

### Review notes

- The selector model is deliberately only `key + values`; each value is either exact or an anchored glob. A separate operator enum added no information.
- Selector expansion is capped at 32 patterns.

### Verification

- `bazel test //src/lib/utils/tests:test_validation --test_output=errors`
- `bazel test //src/lib/utils:validation-pylint //src/lib/utils/tests:test_validation-pylint --test_output=errors`
- `git diff --check`

Integration prototype: #1194.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workflow label validation for keys, values, assignments, and label maps.
  - Added workflow label selector parsing with support for exact values, wildcards, alternation, and expanded pattern matching.
  - Added safeguards for malformed selectors and excessive label or pattern expansions.

- **Tests**
  - Added comprehensive coverage for valid and invalid workflow labels, selector syntax, wildcard handling, alternation, and expansion limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->