### PR TITLE
fix(config): replace ordinary lists during merge

### DIFF
--- a/deployments/upgrades/6_2_to_6_3_upgrade.md
+++ b/deployments/upgrades/6_2_to_6_3_upgrade.md
@@ -34,6 +34,14 @@ SPDX-License-Identifier: Apache-2.0
 | New deployment | [Enable ConfigMap mode](#enable-configmap-mode) (chart defaults provide sensible starting configs) |
 | **Any deployment** | [Router chart merge](#router-chart-merged-into-service-chart) — required for all upgrades to 6.3 |
 
+### Config PATCH semantics for plain lists
+
+In 6.3 the shared config PATCH endpoints treat a list of objects without
+`$index` directives as a complete replacement value instead of appending to
+the stored list. Strategic merges continue to work when patch items carry
+`$index`. Legacy-mode API clients that relied on append behavior must send
+the full desired list.
+
 ## Export existing configs
 
 Use the export script to dump your current configs from the running OSMO instance into Helm values format:

--- a/deployments/upgrades/6_2_to_6_3_upgrade.md
+++ b/deployments/upgrades/6_2_to_6_3_upgrade.md
@@ -30,7 +30,7 @@ SPDX-License-Identifier: Apache-2.0
 | Deployment type | Sections to follow |
 |----------------|-------------------|
 | Migrating to ConfigMap config | [Export existing configs](#export-existing-configs) → [Enable ConfigMap mode](#enable-configmap-mode) → [Create K8s Secrets](#create-kubernetes-secrets) |
-| Staying with DB config | No action required — DB mode is the default and works unchanged |
+| Staying with DB config | No chart action required — DB mode is the default. Review [Config PATCH semantics for plain lists](#config-patch-semantics-for-plain-lists) if API clients patch list configs |
 | New deployment | [Enable ConfigMap mode](#enable-configmap-mode) (chart defaults provide sensible starting configs) |
 | **Any deployment** | [Router chart merge](#router-chart-merged-into-service-chart) — required for all upgrades to 6.3 |
 
@@ -39,8 +39,8 @@ SPDX-License-Identifier: Apache-2.0
 In 6.3 the shared config PATCH endpoints treat a list of objects without
 `$index` directives as a complete replacement value instead of appending to
 the stored list. Strategic merges continue to work when patch items carry
-`$index`. Legacy-mode API clients that relied on append behavior must send
-the full desired list.
+`$index`; in a mixed list, directive-less items are still appended. Legacy-mode
+API clients that relied on append behavior must send the full desired list.
 
 ## Export existing configs
 

--- a/src/lib/utils/common.py
+++ b/src/lib/utils/common.py
@@ -830,6 +830,18 @@ def verify_dict_keys(data: Dict):
 
 
 
+def _has_index_directives(patch_list: List[Any]) -> bool:
+    """
+    Whether a patch list uses $index directives for strategic list edits.
+
+    A list whose items are all dictionaries and where at least one carries an
+    $index directive is edited item by item; directive-less items in such a
+    list are appended. Any other list is a complete replacement value.
+    """
+    return (all(isinstance(item, dict) for item in patch_list)
+            and any('$index' in item for item in patch_list))
+
+
 def strategic_merge_patch(original: Dict[str, Any], patch: Dict[str, Any]) -> Dict[str, Any]:
     """
     Applies a Strategic Merge Patch to Dynamic Configs.
@@ -853,44 +865,34 @@ def strategic_merge_patch(original: Dict[str, Any], patch: Dict[str, Any]) -> Di
                 updated.pop(key, None)
             else:
                 updated[key] = strategic_merge_patch(updated[key], value)
-        elif isinstance(value, list):
-            # Use index directives for strategic list edits. An ordinary list is a
-            # complete value, matching the full-list diff produced by config update.
-            has_index_directive = (
-                value
-                and all(isinstance(item, dict) for item in value)
-                and any('$index' in item for item in value)
-            )
-            if has_index_directive:
-                updated_list = []
-                for i, item in enumerate(updated[key]):
-                    for patch_item in value:
-                        if i == patch_item.get('$index'):
-                            # Apply merge or replace to the matched item.
-                            if patch_item.get('$action', '') == 'replace':
-                                item = patch_item
-                            elif patch_item.get('$action', '') == 'delete':
-                                item = None
-                            else:
-                                item = strategic_merge_patch(item, patch_item)
-                            break
-                    if item:
-                        updated_list.append(item)
-                # Add any items in the patch list that were not matched.
+        elif isinstance(value, list) and _has_index_directives(value):
+            updated_list = []
+            for i, item in enumerate(updated[key]):
                 for patch_item in value:
-                    if not any(i == patch_item.get('$index') for i in range(len(updated[key]))) \
-                            and not patch_item.get('$action', '') == 'delete':
-                        updated_list.append(patch_item)
-                for item in updated_list:
-                    item.pop('$action', None)
-                    item.pop('$index', None)
+                    if i == patch_item.get('$index'):
+                        # Apply merge or replace to the matched item.
+                        if patch_item.get('$action', '') == 'replace':
+                            item = patch_item
+                        elif patch_item.get('$action', '') == 'delete':
+                            item = None
+                        else:
+                            item = strategic_merge_patch(item, patch_item)
+                        break
+                if item:
+                    updated_list.append(item)
+            # Add any items in the patch list that were not matched.
+            for patch_item in value:
+                if not any(i == patch_item.get('$index') for i in range(len(updated[key]))) \
+                        and not patch_item.get('$action', '') == 'delete':
+                    updated_list.append(patch_item)
+            for item in updated_list:
+                item.pop('$action', None)
+                item.pop('$index', None)
 
-                updated[key] = updated_list
-            else:
-                # Apply the list value as a replacement.
-                updated[key] = value
+            updated[key] = updated_list
         else:
-            # Apply the scalar value as a replacement.
+            # Apply the ordinary list or scalar value as a replacement,
+            # matching the full-value diff produced by config update.
             updated[key] = value
 
         updated.pop('$action', None)

--- a/src/lib/utils/common.py
+++ b/src/lib/utils/common.py
@@ -854,8 +854,14 @@ def strategic_merge_patch(original: Dict[str, Any], patch: Dict[str, Any]) -> Di
             else:
                 updated[key] = strategic_merge_patch(updated[key], value)
         elif isinstance(value, list):
-            # Handle the case where the value is a list of dictionaries.
-            if value and all(isinstance(item, dict) for item in value):
+            # Use index directives for strategic list edits. An ordinary list is a
+            # complete value, matching the full-list diff produced by config update.
+            has_index_directive = (
+                value
+                and all(isinstance(item, dict) for item in value)
+                and any('$index' in item for item in value)
+            )
+            if has_index_directive:
                 updated_list = []
                 for i, item in enumerate(updated[key]):
                     for patch_item in value:

--- a/src/lib/utils/tests/test_common.py
+++ b/src/lib/utils/tests/test_common.py
@@ -756,6 +756,12 @@ class TestStrategicMergePatch(unittest.TestCase):
             {'items': [1, 2]}, {'items': [9]})
         self.assertEqual(result['items'], [9])
 
+    def test_replaces_list_of_dicts_without_index_directives(self):
+        result = common.strategic_merge_patch(
+            {'items': [{'x': 1}, {'x': 2}]},
+            {'items': [{'x': 3}]})
+        self.assertEqual(result['items'], [{'x': 3}])
+
     def test_non_dict_original(self):
         # When the original is not a dict but the patch is, return the patch.
         result = common.strategic_merge_patch('scalar', {'a': 1})  # type: ignore[arg-type]

--- a/src/lib/utils/tests/test_common.py
+++ b/src/lib/utils/tests/test_common.py
@@ -762,6 +762,12 @@ class TestStrategicMergePatch(unittest.TestCase):
             {'items': [{'x': 3}]})
         self.assertEqual(result['items'], [{'x': 3}])
 
+    def test_mixed_list_merges_indexed_and_appends_directive_less_items(self):
+        result = common.strategic_merge_patch(
+            {'items': [{'x': 1}]},
+            {'items': [{'$index': 0, 'y': 2}, {'z': 3}]})
+        self.assertEqual(result['items'], [{'x': 1, 'y': 2}, {'z': 3}])
+
     def test_non_dict_original(self):
         # When the original is not a dict but the patch is, return the patch.
         result = common.strategic_merge_patch('scalar', {'a': 1})  # type: ignore[arg-type]


### PR DESCRIPTION
## Description

Issue - None

### Summary

- Replace ordinary lists instead of appending them during recursive config merges.
- Retain strategic merge behavior for lists whose entries carry an `$index` selector.
- Add regression coverage and upgrade guidance for replacement and indexed merge behavior.

### Design context

This is prerequisite A1 for the OSMO-6501 workflow-label Track B stack. It is intentionally independent of label-policy code so the shared config semantic can be reviewed on its own. The full prototype remains in #1194.

### Verification

- `bazel test //src/lib/utils/tests:test_common`
- `bazel test //src/lib/utils:common-pylint //src/lib/utils/tests:test_common-pylint`
- `git diff --check`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
