### PR TITLE
fix(migrations): reconcile sparse pgroll history

### DIFF
--- a/deployments/charts/service/migrations/005_v6_3_0_schema.json
+++ b/deployments/charts/service/migrations/005_v6_3_0_schema.json
@@ -1,0 +1,24 @@
+{
+  "operations": [
+    {
+      "add_column": {
+        "table": "resources",
+        "column": {
+          "name": "last_updated",
+          "type": "TIMESTAMP",
+          "nullable": true
+        }
+      }
+    },
+    {
+      "add_column": {
+        "table": "resources",
+        "column": {
+          "name": "last_usage_updated",
+          "type": "TIMESTAMP",
+          "nullable": true
+        }
+      }
+    }
+  ]
+}

--- a/deployments/charts/service/migrations/BUILD
+++ b/deployments/charts/service/migrations/BUILD
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bzl:py.bzl", "osmo_py_test")
+
+osmo_py_test(
+    name = "test_run_migrations",
+    srcs = ["test_run_migrations.py"],
+    data = [
+        "run_migrations.sh",
+    ] + glob(["0*.json"]),
+)

--- a/deployments/charts/service/migrations/run_migrations.sh
+++ b/deployments/charts/service/migrations/run_migrations.sh
@@ -73,52 +73,62 @@ run_psql() {
     PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -tAc "$1" 2>&1
 }
 
+# Runs a query and prints its result. On failure prints an ERROR line to
+# stderr and returns nonzero so assignments can abort with `|| exit 1`.
+query() {
+    local description="$1" sql="$2" output
+    if ! output=$(run_psql "$sql"); then
+        echo "ERROR: ${description}: $(echo "$output" | head -1)" >&2
+        return 1
+    fi
+    printf '%s\n' "$output"
+}
+
 create_baseline() {
     local baseline_name="$1"
-    local baseline_directory output
+    local baseline_directory output status
 
     if ! baseline_directory=$(mktemp -d "${TMPDIR:-/tmp}/osmo-pgroll-baseline.XXXXXX"); then
         echo "ERROR: Failed to create a temporary baseline directory."
         return 1
     fi
-    if output=$(pgroll baseline "$baseline_name" "$baseline_directory" --yes --json --postgres-url "$PGROLL_URL" 2>&1); then
-        rm -rf "$baseline_directory"
-        return 0
-    fi
-
+    output=$(pgroll baseline "$baseline_name" "$baseline_directory" --yes --json --postgres-url "$PGROLL_URL" 2>&1)
+    status=$?
     rm -rf "$baseline_directory"
-    echo "ERROR: Failed to create pgroll baseline $baseline_name: $(echo "$output" | head -1)"
-    return 1
+    if [ "$status" -ne 0 ]; then
+        echo "ERROR: Failed to create pgroll baseline $baseline_name: $(echo "$output" | head -1)"
+        return 1
+    fi
+}
+
+# Known migration boundaries in apply order. Baselines and migrations share
+# one table; an unknown name has no rank and never covers anything.
+migration_rank() {
+    case "$1" in
+        000_baseline) echo 0 ;;
+        "$V6_0_DATA_MIGRATION") echo 1 ;;
+        "$V6_0_SCHEMA_MIGRATION") echo 2 ;;
+        "$V6_2_SCHEMA_MIGRATION") echo 3 ;;
+        "$V6_2_DATA_MIGRATION") echo 4 ;;
+        "$V6_3_SCHEMA_MIGRATION") echo 5 ;;
+        *) return 1 ;;
+    esac
 }
 
 baseline_covers_migration() {
-    local migration_name="$1"
     local baseline_rank migration_rank
-
-    case "$BASELINE_MIGRATION" in
-        000_baseline) baseline_rank=0 ;;
-        "$V6_0_DATA_MIGRATION") baseline_rank=1 ;;
-        "$V6_0_SCHEMA_MIGRATION") baseline_rank=2 ;;
-        "$V6_2_SCHEMA_MIGRATION") baseline_rank=3 ;;
-        "$V6_2_DATA_MIGRATION") baseline_rank=4 ;;
-        "$V6_3_SCHEMA_MIGRATION") baseline_rank=5 ;;
-        *)
-            return 1
-            ;;
-    esac
-
-    # Schema fingerprints never infer data migrations. Only an exact completed
-    # history row or an explicit trusted baseline can cover migrations 001/004.
-    case "$migration_name" in
-        "$V6_0_DATA_MIGRATION") migration_rank=1 ;;
-        "$V6_0_SCHEMA_MIGRATION") migration_rank=2 ;;
-        "$V6_2_SCHEMA_MIGRATION") migration_rank=3 ;;
-        "$V6_2_DATA_MIGRATION") migration_rank=4 ;;
-        "$V6_3_SCHEMA_MIGRATION") migration_rank=5 ;;
-        *) return 1 ;;
-    esac
-
+    baseline_rank=$(migration_rank "$BASELINE_MIGRATION") || return 1
+    migration_rank=$(migration_rank "$1") || return 1
     (( baseline_rank >= migration_rank ))
+}
+
+# Whether pgroll history promises a migration's schema: an exact completed
+# row, or a trusted baseline at or past the migration's boundary.
+migration_covered() {
+    local migration_name="$1" recorded
+    recorded=$(query "Failed to check migration history for ${migration_name}" \
+        "SELECT EXISTS (SELECT 1 FROM pgroll.migrations WHERE schema = 'public' AND name = '${migration_name}' AND done = true);") || exit 1
+    [ "$recorded" = "t" ] || baseline_covers_migration "$migration_name"
 }
 
 echo "pgroll migration runner"
@@ -136,22 +146,18 @@ fi
 # --- Step 2: Read migration history ---
 echo ""
 echo "Step 2: Checking migration history..."
-if ! STATUS=$(pgroll status --postgres-url "$PGROLL_URL" 2>&1); then
-    echo "ERROR: Failed to read pgroll status: $(echo "$STATUS" | head -1)"
-    exit 1
-fi
+HISTORY_EXISTS=$(query "Failed to read pgroll migration history" \
+    "SELECT EXISTS (SELECT 1 FROM pgroll.migrations WHERE schema = 'public');") || exit 1
 NO_MIGRATION_HISTORY=false
-if echo "$STATUS" | grep -q '"status": "No migrations"'; then
+if [ "$HISTORY_EXISTS" != "t" ]; then
     NO_MIGRATION_HISTORY=true
 fi
 
 # --- Step 3: Complete any in-progress migration ---
 echo ""
 echo "Step 3: Completing any in-progress migration..."
-if ! ACTIVE_MIGRATION=$(run_psql "SELECT EXISTS (SELECT 1 FROM pgroll.migrations WHERE schema = 'public' AND done = false);"); then
-    echo "ERROR: Failed to check for an active migration: $(echo "$ACTIVE_MIGRATION" | head -1)"
-    exit 1
-fi
+ACTIVE_MIGRATION=$(query "Failed to check for an active migration" \
+    "SELECT EXISTS (SELECT 1 FROM pgroll.migrations WHERE schema = 'public' AND done = false);") || exit 1
 if [ "$ACTIVE_MIGRATION" = "t" ]; then
     if OUTPUT=$(pgroll complete --postgres-url "$PGROLL_URL" 2>&1); then
         echo "  Completed"
@@ -166,11 +172,9 @@ fi
 # --- Step 4: Baseline schemas created before migration tracking ---
 echo ""
 echo "Step 4: Checking bootstrap state..."
-if ! BASELINE_MIGRATION=$(run_psql "SELECT COALESCE((SELECT name FROM pgroll.migrations WHERE schema = 'public' AND migration_type = 'baseline' ORDER BY created_at DESC LIMIT 1), '');"); then
-    echo "ERROR: Failed to read pgroll baseline: $(echo "$BASELINE_MIGRATION" | head -1)"
-    exit 1
-fi
-if ! V6_0_SCHEMA_CURRENT=$(run_psql "
+BASELINE_MIGRATION=$(query "Failed to read pgroll baseline" \
+    "SELECT COALESCE((SELECT name FROM pgroll.migrations WHERE schema = 'public' AND migration_type = 'baseline' ORDER BY created_at DESC LIMIT 1), '');") || exit 1
+V6_0_SCHEMA_CURRENT=$(query "Failed to inspect the existing OSMO v6.0 schema" "
     SELECT
         to_regclass('public.backends') IS NOT NULL
         AND to_regclass('public.pools') IS NOT NULL
@@ -187,15 +191,12 @@ if ! V6_0_SCHEMA_CURRENT=$(run_psql "
                   ('backends', 'cache_config'),
                   ('pools', 'enable_nccl_test')))
         AS v6_0_schema_current;
-"); then
-    echo "ERROR: Failed to inspect the existing OSMO v6.0 schema: $(echo "$V6_0_SCHEMA_CURRENT" | head -1)"
-    exit 1
-fi
+") || exit 1
 # Older deployments created the v6.2 schema through release SQL and application
 # initialization before pgroll tracked every structural migration. Verify the
 # application-compatible structure represented by migrations 002 and 003. The
 # data-bearing migrations 001 and 004 are covered only by history or execution.
-if ! V6_2_SCHEMA_CURRENT=$(run_psql "
+V6_2_SCHEMA_CURRENT=$(query "Failed to inspect the existing OSMO v6.2 schema" "
     WITH expected_columns(
         table_name,
         column_name,
@@ -382,11 +383,11 @@ if ! V6_2_SCHEMA_CURRENT=$(run_psql "
                        AND attribute_info.attnum = key_info.attribute_number
                       ORDER BY key_info.key_order) = expected_index.column_names))
         AS v6_2_schema_current;
-"); then
-    echo "ERROR: Failed to inspect the existing OSMO v6.2 schema: $(echo "$V6_2_SCHEMA_CURRENT" | head -1)"
-    exit 1
-fi
-if ! RELEASED_SCHEMA_CURRENT=$(run_psql "
+") || exit 1
+# Migration 005 formalizes the resources timestamp columns that prerelease
+# deployments already carry; no released code reads them yet (the operator
+# redesign will).
+RELEASED_SCHEMA_CURRENT=$(query "Failed to inspect the migration 005 schema" "
     SELECT COUNT(*) = 2
     FROM information_schema.columns
     WHERE table_schema = 'public'
@@ -395,33 +396,18 @@ if ! RELEASED_SCHEMA_CURRENT=$(run_psql "
       AND data_type = 'timestamp without time zone'
       AND is_nullable = 'YES'
       AND column_default IS NULL;
-"); then
-    echo "ERROR: Failed to inspect the released migration 005 schema: $(echo "$RELEASED_SCHEMA_CURRENT" | head -1)"
-    exit 1
-fi
+") || exit 1
 # A recorded or explicitly baselined migration boundary is a promise that its
-# schema exists. Fail closed instead of silently skipping a missing release
-# migration.
-if ! V6_3_SCHEMA_RECORDED=$(run_psql "SELECT EXISTS (SELECT 1 FROM pgroll.migrations WHERE schema = 'public' AND name = '${V6_3_SCHEMA_MIGRATION}' AND done = true);"); then
-    echo "ERROR: Failed to check migration history for ${V6_3_SCHEMA_MIGRATION}: $(echo "$V6_3_SCHEMA_RECORDED" | head -1)"
-    exit 1
-fi
-V6_3_SCHEMA_COVERED=false
-if [ "$V6_3_SCHEMA_RECORDED" = "t" ] \
-        || baseline_covers_migration "$V6_3_SCHEMA_MIGRATION"; then
-    V6_3_SCHEMA_COVERED=true
-fi
-if [ "$V6_3_SCHEMA_COVERED" = "true" ] && [ "$RELEASED_SCHEMA_CURRENT" != "t" ]; then
+# schema exists. Fail closed instead of silently skipping a missing migration.
+if migration_covered "$V6_3_SCHEMA_MIGRATION" && [ "$RELEASED_SCHEMA_CURRENT" != "t" ]; then
     echo "ERROR: Migration ${V6_3_SCHEMA_MIGRATION} is covered by pgroll history, but its resources columns are missing."
     echo "NEXT: Restore resources.last_updated and resources.last_usage_updated before rerunning migrations."
     exit 1
 fi
 
 if [ "$NO_MIGRATION_HISTORY" = "true" ]; then
-    if ! HAS_OSMO_SCHEMA=$(run_psql "SELECT to_regclass('public.workflows') IS NOT NULL;"); then
-        echo "ERROR: Failed to inspect the public schema: $(echo "$HAS_OSMO_SCHEMA" | head -1)"
-        exit 1
-    fi
+    HAS_OSMO_SCHEMA=$(query "Failed to inspect the public schema" \
+        "SELECT to_regclass('public.workflows') IS NOT NULL;") || exit 1
     if [ "$HAS_OSMO_SCHEMA" = "t" ]; then
         echo "  Existing OSMO schema has no history; creating initial baseline..."
         if ! create_baseline "000_baseline"; then
@@ -444,15 +430,13 @@ for migration_file in "$SCRIPT_DIR"/0*.json; do
         continue
     fi
 
-    if ! MIGRATION_APPLIED=$(run_psql "SELECT EXISTS (SELECT 1 FROM pgroll.migrations WHERE schema = 'public' AND name = '${migration_name}' AND done = true);"); then
-        echo "ERROR: Failed to check migration history: $(echo "$MIGRATION_APPLIED" | head -1)"
-        exit 1
-    fi
-    if [ "$MIGRATION_APPLIED" = "t" ]; then
+    if migration_covered "$migration_name"; then
         echo "    Already applied"
         continue
     fi
 
+    # Schema fingerprints cover only structural migrations; the data-bearing
+    # migrations 001/004 are covered only by history or execution.
     SCHEMA_MIGRATION_CURRENT=false
     case "$migration_name" in
         "$V6_0_SCHEMA_MIGRATION")
@@ -484,14 +468,10 @@ done
 if [ "$TARGET_SCHEMA" != "public" ]; then
     echo ""
     echo "Step 6: Refreshing versioned schema ${TARGET_SCHEMA}..."
-    if ! OUTPUT=$(run_psql "CREATE SCHEMA IF NOT EXISTS ${TARGET_SCHEMA};"); then
-        echo "ERROR: Failed to create versioned schema: $(echo "$OUTPUT" | head -1)"
-        exit 1
-    fi
-    if ! OUTPUT=$(run_psql "DO \$\$ DECLARE tbl RECORD; BEGIN FOR tbl IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP EXECUTE format('CREATE OR REPLACE VIEW ${TARGET_SCHEMA}.%I AS SELECT * FROM public.%I', tbl.tablename, tbl.tablename); END LOOP; END \$\$;"); then
-        echo "ERROR: Failed to refresh versioned-schema views: $(echo "$OUTPUT" | head -1)"
-        exit 1
-    fi
+    query "Failed to create versioned schema" \
+        "CREATE SCHEMA IF NOT EXISTS ${TARGET_SCHEMA};" >/dev/null || exit 1
+    query "Failed to refresh versioned-schema views" \
+        "DO \$\$ DECLARE tbl RECORD; BEGIN FOR tbl IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP EXECUTE format('CREATE OR REPLACE VIEW ${TARGET_SCHEMA}.%I AS SELECT * FROM public.%I', tbl.tablename, tbl.tablename); END LOOP; END \$\$;" >/dev/null || exit 1
     echo "  Refreshed"
 fi
 

--- a/deployments/charts/service/migrations/run_migrations.sh
+++ b/deployments/charts/service/migrations/run_migrations.sh
@@ -24,8 +24,8 @@
 #                Defaults to "public" (no versioned schema, migrations apply to public directly).
 #
 # The script is idempotent: safe to run multiple times against any database state.
-# If the target versioned schema already exists, the script exits immediately (no-op).
-# Migrations that have already been applied or aren't applicable are skipped.
+# Migrations recorded as complete in pgroll's history are skipped. Versioned-schema
+# views are refreshed after every run so they include columns from new migrations.
 
 set -uo pipefail
 
@@ -63,49 +63,372 @@ ENCODED_PASSWORD=$(urlencode "$DB_PASSWORD")
 export PGROLL_URL="postgres://${ENCODED_USER}:${ENCODED_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=require"
 
 TARGET_SCHEMA="${1:-public}"
+V6_0_DATA_MIGRATION="001_v6_0_0_data_prep"
+V6_0_SCHEMA_MIGRATION="002_v6_0_0_schema"
+V6_2_SCHEMA_MIGRATION="003_v6_2_0_schema"
+V6_2_DATA_MIGRATION="004_v6_2_0_data"
+V6_3_SCHEMA_MIGRATION="005_v6_3_0_schema"
 
 run_psql() {
     PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -tAc "$1" 2>&1
+}
+
+create_baseline() {
+    local baseline_name="$1"
+    local baseline_directory output
+
+    if ! baseline_directory=$(mktemp -d "${TMPDIR:-/tmp}/osmo-pgroll-baseline.XXXXXX"); then
+        echo "ERROR: Failed to create a temporary baseline directory."
+        return 1
+    fi
+    if output=$(pgroll baseline "$baseline_name" "$baseline_directory" --yes --json --postgres-url "$PGROLL_URL" 2>&1); then
+        rm -rf "$baseline_directory"
+        return 0
+    fi
+
+    rm -rf "$baseline_directory"
+    echo "ERROR: Failed to create pgroll baseline $baseline_name: $(echo "$output" | head -1)"
+    return 1
+}
+
+baseline_covers_migration() {
+    local migration_name="$1"
+    local baseline_rank migration_rank
+
+    case "$BASELINE_MIGRATION" in
+        000_baseline) baseline_rank=0 ;;
+        "$V6_0_DATA_MIGRATION") baseline_rank=1 ;;
+        "$V6_0_SCHEMA_MIGRATION") baseline_rank=2 ;;
+        "$V6_2_SCHEMA_MIGRATION") baseline_rank=3 ;;
+        "$V6_2_DATA_MIGRATION") baseline_rank=4 ;;
+        "$V6_3_SCHEMA_MIGRATION") baseline_rank=5 ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    # Schema fingerprints never infer data migrations. Only an exact completed
+    # history row or an explicit trusted baseline can cover migrations 001/004.
+    case "$migration_name" in
+        "$V6_0_DATA_MIGRATION") migration_rank=1 ;;
+        "$V6_0_SCHEMA_MIGRATION") migration_rank=2 ;;
+        "$V6_2_SCHEMA_MIGRATION") migration_rank=3 ;;
+        "$V6_2_DATA_MIGRATION") migration_rank=4 ;;
+        "$V6_3_SCHEMA_MIGRATION") migration_rank=5 ;;
+        *) return 1 ;;
+    esac
+
+    (( baseline_rank >= migration_rank ))
 }
 
 echo "pgroll migration runner"
 echo "Target DB: ${DB_HOST}:${DB_PORT}/${DB_NAME}"
 echo "Target schema: ${TARGET_SCHEMA}"
 
-# --- Step 1: Early exit if versioned schema already exists ---
-# If the target is a versioned schema (not "public") and it already exists,
-# all migrations have been applied and views are in place. Nothing to do.
-if [ "$TARGET_SCHEMA" != "public" ]; then
-    SCHEMA_EXISTS=$(run_psql "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '${TARGET_SCHEMA}');" 2>/dev/null)
-    if [ "$SCHEMA_EXISTS" = "t" ]; then
-        echo ""
-        echo "Schema ${TARGET_SCHEMA} already exists. Nothing to do."
-        exit 0
-    fi
+# --- Step 1: Initialize pgroll ---
+echo ""
+echo "Step 1: Initializing pgroll..."
+if ! OUTPUT=$(pgroll init --postgres-url "$PGROLL_URL" 2>&1); then
+    echo "ERROR: Failed to initialize pgroll: $(echo "$OUTPUT" | head -1)"
+    exit 1
 fi
 
-# --- Step 2: Initialize pgroll ---
+# --- Step 2: Read migration history ---
 echo ""
-echo "Step 2: Initializing pgroll..."
-pgroll init --postgres-url "$PGROLL_URL" 2>&1 || true
-
-# --- Step 3: Create baseline if needed ---
-echo ""
-echo "Step 3: Checking migration history..."
-STATUS=$(pgroll status --postgres-url "$PGROLL_URL" 2>&1)
+echo "Step 2: Checking migration history..."
+if ! STATUS=$(pgroll status --postgres-url "$PGROLL_URL" 2>&1); then
+    echo "ERROR: Failed to read pgroll status: $(echo "$STATUS" | head -1)"
+    exit 1
+fi
+NO_MIGRATION_HISTORY=false
 if echo "$STATUS" | grep -q '"status": "No migrations"'; then
-    echo "  Creating baseline..."
-    run_psql "INSERT INTO pgroll.migrations (schema, name, migration, resulting_schema, done, parent) VALUES ('public', '000_baseline', '{}', '\"public_000_baseline\"', true, NULL) ON CONFLICT DO NOTHING;"
+    NO_MIGRATION_HISTORY=true
 fi
 
-# --- Step 4: Complete any in-progress migration ---
+# --- Step 3: Complete any in-progress migration ---
 echo ""
-echo "Step 4: Completing any in-progress migration..."
-OUTPUT=$(pgroll complete --postgres-url "$PGROLL_URL" 2>&1)
-if [ $? -eq 0 ]; then
-    echo "  Completed"
+echo "Step 3: Completing any in-progress migration..."
+if ! ACTIVE_MIGRATION=$(run_psql "SELECT EXISTS (SELECT 1 FROM pgroll.migrations WHERE schema = 'public' AND done = false);"); then
+    echo "ERROR: Failed to check for an active migration: $(echo "$ACTIVE_MIGRATION" | head -1)"
+    exit 1
+fi
+if [ "$ACTIVE_MIGRATION" = "t" ]; then
+    if OUTPUT=$(pgroll complete --postgres-url "$PGROLL_URL" 2>&1); then
+        echo "  Completed"
+    else
+        echo "ERROR: Failed to complete the active migration: $(echo "$OUTPUT" | head -1)"
+        exit 1
+    fi
 else
     echo "  Nothing to complete"
+fi
+
+# --- Step 4: Baseline schemas created before migration tracking ---
+echo ""
+echo "Step 4: Checking bootstrap state..."
+if ! BASELINE_MIGRATION=$(run_psql "SELECT COALESCE((SELECT name FROM pgroll.migrations WHERE schema = 'public' AND migration_type = 'baseline' ORDER BY created_at DESC LIMIT 1), '');"); then
+    echo "ERROR: Failed to read pgroll baseline: $(echo "$BASELINE_MIGRATION" | head -1)"
+    exit 1
+fi
+if ! V6_0_SCHEMA_CURRENT=$(run_psql "
+    SELECT
+        to_regclass('public.backends') IS NOT NULL
+        AND to_regclass('public.pools') IS NOT NULL
+        AND NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND (table_name, column_name) IN (
+                  ('backends', 'gpu_product_label'),
+                  ('backends', 'affinity'),
+                  ('backends', 'node_condition_prefix'),
+                  ('backends', 'config_nccl_test'),
+                  ('backends', 'support_nccl_test'),
+                  ('backends', 'cache_config'),
+                  ('pools', 'enable_nccl_test')))
+        AS v6_0_schema_current;
+"); then
+    echo "ERROR: Failed to inspect the existing OSMO v6.0 schema: $(echo "$V6_0_SCHEMA_CURRENT" | head -1)"
+    exit 1
+fi
+# Older deployments created the v6.2 schema through release SQL and application
+# initialization before pgroll tracked every structural migration. Verify the
+# application-compatible structure represented by migrations 002 and 003. The
+# data-bearing migrations 001 and 004 are covered only by history or execution.
+if ! V6_2_SCHEMA_CURRENT=$(run_psql "
+    WITH expected_columns(
+        table_name,
+        column_name,
+        udt_name,
+        nullable_state,
+        default_kind
+    ) AS (
+        VALUES
+            ('group_templates', 'name', 'text', 'NO', 'none'),
+            ('group_templates', 'group_template', 'jsonb', 'ANY', 'none'),
+            ('users', 'id', 'text', 'NO', 'none'),
+            ('users', 'created_at', 'timestamptz', 'NO', 'now'),
+            ('users', 'created_by', 'text', 'YES', 'none'),
+            ('user_roles', 'id', 'uuid', 'NO', 'uuid'),
+            ('user_roles', 'user_id', 'text', 'NO', 'none'),
+            ('user_roles', 'role_name', 'text', 'NO', 'none'),
+            ('user_roles', 'assigned_by', 'text', 'NO', 'none'),
+            ('user_roles', 'assigned_at', 'timestamptz', 'NO', 'now'),
+            ('access_token_roles', 'user_name', 'text', 'NO', 'none'),
+            ('access_token_roles', 'token_name', 'text', 'NO', 'none'),
+            ('access_token_roles', 'user_role_id', 'uuid', 'NO', 'none'),
+            ('access_token_roles', 'assigned_by', 'text', 'NO', 'none'),
+            ('access_token_roles', 'assigned_at', 'timestamptz', 'NO', 'now'),
+            ('role_external_mappings', 'role_name', 'text', 'NO', 'none'),
+            ('role_external_mappings', 'external_role', 'text', 'NO', 'none'),
+            ('access_token', 'last_seen_at', 'timestamptz', 'YES', 'none'),
+            ('roles', 'sync_mode', 'text', 'NO', 'import'),
+            ('pools', 'common_group_templates', '_text', 'YES', 'optional_text_array'),
+            ('pools', 'parsed_group_templates', 'jsonb', 'YES', 'optional_json_array'),
+            ('pools', 'topology_keys', 'jsonb', 'YES', 'optional_json_array'),
+            ('groups', 'group_template_resource_types', 'jsonb',
+             'YES', 'optional_json_array')
+    ),
+    expected_primary_keys(table_name, column_names) AS (
+        VALUES
+            ('group_templates', ARRAY['name']::TEXT[]),
+            ('users', ARRAY['id']::TEXT[]),
+            ('user_roles', ARRAY['id']::TEXT[])
+    ),
+    expected_foreign_keys(
+        table_name,
+        column_names,
+        referenced_table_name,
+        referenced_column_names
+    ) AS (
+        VALUES
+            ('user_roles', ARRAY['user_id']::TEXT[], 'users', ARRAY['id']::TEXT[]),
+            ('user_roles', ARRAY['role_name']::TEXT[], 'roles', ARRAY['name']::TEXT[]),
+            ('access_token_roles', ARRAY['user_role_id']::TEXT[],
+             'user_roles', ARRAY['id']::TEXT[]),
+            ('role_external_mappings', ARRAY['role_name']::TEXT[],
+             'roles', ARRAY['name']::TEXT[])
+    ),
+    expected_indexes(table_name, index_name, column_names) AS (
+        VALUES
+            ('user_roles', 'idx_user_roles_user', ARRAY['user_id']::TEXT[]),
+            ('user_roles', 'idx_user_roles_role', ARRAY['role_name']::TEXT[]),
+            ('access_token_roles', 'idx_access_token_roles_token',
+             ARRAY['user_name', 'token_name']::TEXT[]),
+            ('access_token_roles', 'idx_access_token_roles_user_role',
+             ARRAY['user_role_id']::TEXT[]),
+            ('role_external_mappings', 'idx_role_external_mappings_external_role',
+             ARRAY['external_role']::TEXT[])
+    )
+    SELECT
+        to_regclass('public.workflows') IS NOT NULL
+        AND to_regclass('public.backends') IS NOT NULL
+        AND to_regclass('public.pools') IS NOT NULL
+        AND to_regclass('public.groups') IS NOT NULL
+        AND to_regclass('public.access_token') IS NOT NULL
+        AND to_regclass('public.roles') IS NOT NULL
+        AND to_regclass('public.dataset_version') IS NOT NULL
+        AND NOT EXISTS (
+            SELECT 1
+            FROM expected_columns expected_column
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM information_schema.columns column_info
+                WHERE column_info.table_schema = 'public'
+                  AND column_info.table_name = expected_column.table_name
+                  AND column_info.column_name = expected_column.column_name
+                  AND column_info.udt_name = expected_column.udt_name
+                  AND (expected_column.nullable_state = 'ANY'
+                       OR column_info.is_nullable = expected_column.nullable_state)
+                  AND CASE expected_column.default_kind
+                      WHEN 'none' THEN column_info.column_default IS NULL
+                      WHEN 'now' THEN column_info.column_default = 'now()'
+                      WHEN 'uuid' THEN column_info.column_default = 'gen_random_uuid()'
+                      WHEN 'import' THEN column_info.column_default = '''import''::text'
+                      WHEN 'optional_text_array' THEN
+                          column_info.column_default IS NULL
+                          OR column_info.column_default = '''{}''::text[]'
+                      WHEN 'optional_json_array' THEN
+                          column_info.column_default IS NULL
+                          OR column_info.column_default = '''[]''::jsonb'
+                      ELSE false
+                  END))
+        AND NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND (table_name, column_name) IN (
+                  ('pools', 'action_permissions'),
+                  ('access_token', 'access_type'),
+                  ('access_token', 'roles'),
+                  ('dataset_version', 'retention_policy')))
+        AND NOT EXISTS (
+            SELECT 1
+            FROM expected_primary_keys expected_primary_key
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint constraint_info
+                WHERE constraint_info.contype = 'p'
+                  AND constraint_info.convalidated
+                  AND constraint_info.conrelid = to_regclass(
+                      'public.' || expected_primary_key.table_name)
+                  AND ARRAY(
+                      SELECT attribute_info.attname::TEXT
+                      FROM unnest(constraint_info.conkey) WITH ORDINALITY
+                           AS key_info(attribute_number, key_order)
+                      JOIN pg_attribute attribute_info
+                        ON attribute_info.attrelid = constraint_info.conrelid
+                       AND attribute_info.attnum = key_info.attribute_number
+                      ORDER BY key_info.key_order) = expected_primary_key.column_names))
+        AND NOT EXISTS (
+            SELECT 1
+            FROM expected_foreign_keys expected_foreign_key
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM pg_constraint constraint_info
+                WHERE constraint_info.contype = 'f'
+                  AND constraint_info.convalidated
+                  AND constraint_info.confdeltype = 'c'
+                  AND constraint_info.conrelid = to_regclass(
+                      'public.' || expected_foreign_key.table_name)
+                  AND constraint_info.confrelid = to_regclass(
+                      'public.' || expected_foreign_key.referenced_table_name)
+                  AND ARRAY(
+                      SELECT attribute_info.attname::TEXT
+                      FROM unnest(constraint_info.conkey) WITH ORDINALITY
+                           AS key_info(attribute_number, key_order)
+                      JOIN pg_attribute attribute_info
+                        ON attribute_info.attrelid = constraint_info.conrelid
+                       AND attribute_info.attnum = key_info.attribute_number
+                      ORDER BY key_info.key_order) = expected_foreign_key.column_names
+                  AND ARRAY(
+                      SELECT attribute_info.attname::TEXT
+                      FROM unnest(constraint_info.confkey) WITH ORDINALITY
+                           AS key_info(attribute_number, key_order)
+                      JOIN pg_attribute attribute_info
+                        ON attribute_info.attrelid = constraint_info.confrelid
+                       AND attribute_info.attnum = key_info.attribute_number
+                      ORDER BY key_info.key_order
+                  ) = expected_foreign_key.referenced_column_names))
+        AND NOT EXISTS (
+            SELECT 1
+            FROM expected_indexes expected_index
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM pg_index index_definition
+                JOIN pg_class index_info
+                  ON index_info.oid = index_definition.indexrelid
+                JOIN pg_class table_info
+                  ON table_info.oid = index_definition.indrelid
+                JOIN pg_namespace namespace_info
+                  ON namespace_info.oid = table_info.relnamespace
+                JOIN pg_am access_method
+                  ON access_method.oid = index_info.relam
+                WHERE namespace_info.nspname = 'public'
+                  AND table_info.relname = expected_index.table_name
+                  AND index_info.relname = expected_index.index_name
+                  AND access_method.amname = 'btree'
+                  AND index_definition.indisvalid
+                  AND index_definition.indisready
+                  AND NOT index_definition.indisunique
+                  AND index_definition.indpred IS NULL
+                  AND index_definition.indexprs IS NULL
+                  AND ARRAY(
+                      SELECT attribute_info.attname::TEXT
+                      FROM unnest(index_definition.indkey) WITH ORDINALITY
+                           AS key_info(attribute_number, key_order)
+                      JOIN pg_attribute attribute_info
+                        ON attribute_info.attrelid = index_definition.indrelid
+                       AND attribute_info.attnum = key_info.attribute_number
+                      ORDER BY key_info.key_order) = expected_index.column_names))
+        AS v6_2_schema_current;
+"); then
+    echo "ERROR: Failed to inspect the existing OSMO v6.2 schema: $(echo "$V6_2_SCHEMA_CURRENT" | head -1)"
+    exit 1
+fi
+if ! RELEASED_SCHEMA_CURRENT=$(run_psql "
+    SELECT COUNT(*) = 2
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'resources'
+      AND column_name IN ('last_updated', 'last_usage_updated')
+      AND data_type = 'timestamp without time zone'
+      AND is_nullable = 'YES'
+      AND column_default IS NULL;
+"); then
+    echo "ERROR: Failed to inspect the released migration 005 schema: $(echo "$RELEASED_SCHEMA_CURRENT" | head -1)"
+    exit 1
+fi
+# A recorded or explicitly baselined migration boundary is a promise that its
+# schema exists. Fail closed instead of silently skipping a missing release
+# migration.
+if ! V6_3_SCHEMA_RECORDED=$(run_psql "SELECT EXISTS (SELECT 1 FROM pgroll.migrations WHERE schema = 'public' AND name = '${V6_3_SCHEMA_MIGRATION}' AND done = true);"); then
+    echo "ERROR: Failed to check migration history for ${V6_3_SCHEMA_MIGRATION}: $(echo "$V6_3_SCHEMA_RECORDED" | head -1)"
+    exit 1
+fi
+V6_3_SCHEMA_COVERED=false
+if [ "$V6_3_SCHEMA_RECORDED" = "t" ] \
+        || baseline_covers_migration "$V6_3_SCHEMA_MIGRATION"; then
+    V6_3_SCHEMA_COVERED=true
+fi
+if [ "$V6_3_SCHEMA_COVERED" = "true" ] && [ "$RELEASED_SCHEMA_CURRENT" != "t" ]; then
+    echo "ERROR: Migration ${V6_3_SCHEMA_MIGRATION} is covered by pgroll history, but its resources columns are missing."
+    echo "NEXT: Restore resources.last_updated and resources.last_usage_updated before rerunning migrations."
+    exit 1
+fi
+
+if [ "$NO_MIGRATION_HISTORY" = "true" ]; then
+    if ! HAS_OSMO_SCHEMA=$(run_psql "SELECT to_regclass('public.workflows') IS NOT NULL;"); then
+        echo "ERROR: Failed to inspect the public schema: $(echo "$HAS_OSMO_SCHEMA" | head -1)"
+        exit 1
+    fi
+    if [ "$HAS_OSMO_SCHEMA" = "t" ]; then
+        echo "  Existing OSMO schema has no history; creating initial baseline..."
+        if ! create_baseline "000_baseline"; then
+            exit 1
+        fi
+        BASELINE_MIGRATION="000_baseline"
+    fi
 fi
 
 # --- Step 5: Apply all migrations ---
@@ -113,26 +436,70 @@ echo ""
 echo "Step 5: Applying migrations..."
 for migration_file in "$SCRIPT_DIR"/0*.json; do
     name="$(basename "$migration_file")"
+    migration_name="${name%.*}"
     echo "  [$name]"
-    OUTPUT=$(pgroll start "$migration_file" --postgres-url "$PGROLL_URL" --complete 2>&1)
-    if [ $? -eq 0 ]; then
+
+    if baseline_covers_migration "$migration_name"; then
+        echo "    Covered by migration boundary $BASELINE_MIGRATION"
+        continue
+    fi
+
+    if ! MIGRATION_APPLIED=$(run_psql "SELECT EXISTS (SELECT 1 FROM pgroll.migrations WHERE schema = 'public' AND name = '${migration_name}' AND done = true);"); then
+        echo "ERROR: Failed to check migration history: $(echo "$MIGRATION_APPLIED" | head -1)"
+        exit 1
+    fi
+    if [ "$MIGRATION_APPLIED" = "t" ]; then
+        echo "    Already applied"
+        continue
+    fi
+
+    SCHEMA_MIGRATION_CURRENT=false
+    case "$migration_name" in
+        "$V6_0_SCHEMA_MIGRATION")
+            [ "$V6_0_SCHEMA_CURRENT" = "t" ] && SCHEMA_MIGRATION_CURRENT=true
+            ;;
+        "$V6_2_SCHEMA_MIGRATION")
+            [ "$V6_0_SCHEMA_CURRENT" = "t" ] \
+                && [ "$V6_2_SCHEMA_CURRENT" = "t" ] \
+                && SCHEMA_MIGRATION_CURRENT=true
+            ;;
+        "$V6_3_SCHEMA_MIGRATION")
+            [ "$RELEASED_SCHEMA_CURRENT" = "t" ] && SCHEMA_MIGRATION_CURRENT=true
+            ;;
+    esac
+    if [ "$SCHEMA_MIGRATION_CURRENT" = "true" ]; then
+        echo "    Already present in schema"
+        continue
+    fi
+
+    if OUTPUT=$(pgroll start "$migration_file" --postgres-url "$PGROLL_URL" --complete 2>&1); then
         echo "    Applied"
     else
-        echo "    Skipped: $(echo "$OUTPUT" | head -1)"
+        echo "ERROR: Failed to apply $name: $(echo "$OUTPUT" | head -1)"
+        exit 1
     fi
 done
 
-# --- Step 6: Create versioned schema with views ---
+# --- Step 6: Create or refresh versioned-schema views ---
 if [ "$TARGET_SCHEMA" != "public" ]; then
     echo ""
-    echo "Step 6: Creating versioned schema ${TARGET_SCHEMA}..."
-    run_psql "CREATE SCHEMA IF NOT EXISTS ${TARGET_SCHEMA};"
-    run_psql "DO \$\$ DECLARE tbl RECORD; BEGIN FOR tbl IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP EXECUTE format('CREATE OR REPLACE VIEW ${TARGET_SCHEMA}.%I AS SELECT * FROM public.%I', tbl.tablename, tbl.tablename); END LOOP; END \$\$;"
-    echo "  Created"
+    echo "Step 6: Refreshing versioned schema ${TARGET_SCHEMA}..."
+    if ! OUTPUT=$(run_psql "CREATE SCHEMA IF NOT EXISTS ${TARGET_SCHEMA};"); then
+        echo "ERROR: Failed to create versioned schema: $(echo "$OUTPUT" | head -1)"
+        exit 1
+    fi
+    if ! OUTPUT=$(run_psql "DO \$\$ DECLARE tbl RECORD; BEGIN FOR tbl IN SELECT tablename FROM pg_tables WHERE schemaname = 'public' LOOP EXECUTE format('CREATE OR REPLACE VIEW ${TARGET_SCHEMA}.%I AS SELECT * FROM public.%I', tbl.tablename, tbl.tablename); END LOOP; END \$\$;"); then
+        echo "ERROR: Failed to refresh versioned-schema views: $(echo "$OUTPUT" | head -1)"
+        exit 1
+    fi
+    echo "  Refreshed"
 fi
 
 echo ""
 echo "Final status:"
-pgroll status --postgres-url "$PGROLL_URL"
+if ! pgroll status --postgres-url "$PGROLL_URL"; then
+    echo "ERROR: Failed to read final pgroll status."
+    exit 1
+fi
 echo ""
 echo "Done."

--- a/deployments/charts/service/migrations/test_run_migrations.py
+++ b/deployments/charts/service/migrations/test_run_migrations.py
@@ -44,40 +44,32 @@ class RunMigrationsTest(unittest.TestCase):
         self.binary_directory.mkdir()
         self.pgroll_log = temporary_path / 'pgroll.log'
         self.psql_log = temporary_path / 'psql.log'
-        self.status_count = temporary_path / 'status-count'
         self._write_executable('psql', r"""#!/usr/bin/env bash
 printf '%s\n' "$*" >> "$MIGRATION_TEST_PSQL_LOG"
+flag() {
+    if [[ "$1" == 'true' ]]; then
+        printf 't\n'
+    else
+        printf 'f\n'
+    fi
+}
 if [[ "$*" == *"AS v6_2_schema_current"* ]]; then
-    if [[ "$MIGRATION_TEST_V6_2_SCHEMA" == 'true' ]]; then
-        printf 't\n'
-    else
-        printf 'f\n'
-    fi
+    flag "$MIGRATION_TEST_V6_2_SCHEMA"
 elif [[ "$*" == *"AS v6_0_schema_current"* ]]; then
-    if [[ "$MIGRATION_TEST_V6_0_SCHEMA" == 'true' ]]; then
-        printf 't\n'
-    else
-        printf 'f\n'
-    fi
+    flag "$MIGRATION_TEST_V6_0_SCHEMA"
 elif [[ "$*" == *"last_usage_updated"* ]]; then
-    if [[ "$MIGRATION_TEST_RELEASED_SCHEMA" == 'true' ]]; then
-        printf 't\n'
-    else
-        printf 'f\n'
-    fi
+    flag "$MIGRATION_TEST_RELEASED_SCHEMA"
 elif [[ "$*" == *"migration_type = 'baseline'"* ]]; then
     printf '%s\n' "$MIGRATION_TEST_BASELINE"
 elif [[ "$*" == *"to_regclass('public.workflows')"* ]]; then
-    if [[ "$MIGRATION_TEST_HAS_OSMO_SCHEMA" == 'true' ]]; then
-        printf 't\n'
-    else
-        printf 'f\n'
-    fi
+    flag "$MIGRATION_TEST_HAS_OSMO_SCHEMA"
 elif [[ "$*" == *"done = false"* ]]; then
-    if [[ "$MIGRATION_TEST_ACTIVE_MIGRATION" == 'true' ]]; then
-        printf 't\n'
-    else
+    flag "$MIGRATION_TEST_ACTIVE_MIGRATION"
+elif [[ "$*" == *"FROM pgroll.migrations WHERE schema = 'public')"* ]]; then
+    if [[ "$MIGRATION_TEST_NO_HISTORY" == 'true' ]]; then
         printf 'f\n'
+    else
+        printf 't\n'
     fi
 elif [[ "$*" == *"FROM pgroll.migrations"* ]]; then
     if [[ -n "$MIGRATION_TEST_BASELINE" \
@@ -107,27 +99,11 @@ case "$1" in
         exit 0
         ;;
     status)
-        status_count=0
-        if [[ -f "$MIGRATION_TEST_STATUS_COUNT" ]]; then
-            read -r status_count < "$MIGRATION_TEST_STATUS_COUNT"
-        fi
-        status_count=$((status_count + 1))
-        printf '%s\n' "$status_count" > "$MIGRATION_TEST_STATUS_COUNT"
-        if [[ "$MIGRATION_TEST_FAIL_COMMAND" == 'status_initial' \
-              && "$status_count" -eq 1 ]]; then
-            printf 'simulated initial status failure\n' >&2
+        if [[ "$MIGRATION_TEST_FAIL_COMMAND" == 'status' ]]; then
+            printf 'simulated status failure\n' >&2
             exit 42
         fi
-        if [[ "$MIGRATION_TEST_FAIL_COMMAND" == 'status_final' \
-              && "$status_count" -eq 2 ]]; then
-            printf 'simulated final status failure\n' >&2
-            exit 43
-        fi
-        if [[ "$MIGRATION_TEST_NO_HISTORY" == 'true' ]]; then
-            printf '{"status": "No migrations"}\n'
-        else
-            printf '{"status": "Complete"}\n'
-        fi
+        printf '{"status": "Complete"}\n'
         exit 0
         ;;
     baseline)
@@ -177,13 +153,12 @@ exit 48
         has_osmo_schema: bool = False,
         no_history: bool = False,
         released_schema: bool = False,
-        target_schema: str = 'public_v6_3_0',
+        target_schema: str = 'public',
         v6_0_schema: bool = False,
         v6_2_schema: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         self.pgroll_log.unlink(missing_ok=True)
         self.psql_log.unlink(missing_ok=True)
-        self.status_count.unlink(missing_ok=True)
 
         environment = os.environ.copy()
         existing_path = environment['PATH']
@@ -203,7 +178,6 @@ exit 48
             'MIGRATION_TEST_PSQL_LOG': str(self.psql_log),
             'MIGRATION_TEST_RELEASED_SCHEMA':
                 str(released_schema).lower(),
-            'MIGRATION_TEST_STATUS_COUNT': str(self.status_count),
             'MIGRATION_TEST_V6_0_SCHEMA': str(v6_0_schema).lower(),
             'MIGRATION_TEST_V6_2_SCHEMA': str(v6_2_schema).lower(),
             'OSMO_POSTGRES_PASSWORD': 'test-password',
@@ -229,7 +203,7 @@ exit 48
         ]
 
     def test_runs_all_migrations_and_refreshes_versioned_views(self) -> None:
-        result = self._run()
+        result = self._run(target_schema='public_v6_3_0')
 
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
         self.assertEqual(list(MIGRATION_FILES), self._start_migrations())
@@ -239,14 +213,10 @@ exit 48
     def test_pgroll_status_and_init_failures_exit_nonzero(self) -> None:
         for failing_command, expected_message in (
             ('init', 'Failed to initialize pgroll'),
-            ('status_initial', 'Failed to read pgroll status'),
-            ('status_final', 'Failed to read final pgroll status'),
+            ('status', 'Failed to read final pgroll status'),
         ):
             with self.subTest(failing_command=failing_command):
-                result = self._run(
-                    failing_command=failing_command,
-                    target_schema='public',
-                )
+                result = self._run(failing_command=failing_command)
 
                 self.assertNotEqual(
                     0, result.returncode, result.stdout + result.stderr)
@@ -257,7 +227,6 @@ exit 48
         result = self._run(
             active_migration=True,
             failing_command='complete',
-            target_schema='public',
         )
 
         self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
@@ -271,7 +240,6 @@ exit 48
         result = self._run(
             active_migration=True,
             complete_succeeds=True,
-            target_schema='public',
         )
 
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
@@ -292,7 +260,6 @@ exit 48
             failing_command='baseline',
             has_osmo_schema=True,
             no_history=True,
-            target_schema='public',
         )
 
         self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
@@ -305,7 +272,6 @@ exit 48
     def test_pgroll_start_failure_exits_nonzero(self) -> None:
         result = self._run(
             failing_migration='005_v6_3_0_schema.json',
-            target_schema='public',
         )
 
         self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
@@ -316,7 +282,6 @@ exit 48
         result = self._run(
             has_osmo_schema=True,
             no_history=True,
-            target_schema='public',
             v6_0_schema=True,
             v6_2_schema=True,
         )
@@ -342,7 +307,6 @@ exit 48
                 for migration_file in MIGRATION_FILES
             ),
             released_schema=True,
-            target_schema='public',
             v6_0_schema=True,
             v6_2_schema=True,
         )
@@ -350,41 +314,34 @@ exit 48
         self.assertEqual(0, result.returncode, result.stdout + result.stderr)
         self.assertFalse(self._start_migrations())
 
-    def test_recorded_005_requires_its_resources_columns(self) -> None:
-        result = self._run(
-            applied_migrations='005_v6_3_0_schema',
-            target_schema='public',
-            v6_0_schema=True,
-            v6_2_schema=True,
-        )
+    def test_covered_005_requires_its_resources_columns(self) -> None:
+        for applied_migrations, baseline_migration in (
+            ('005_v6_3_0_schema', ''),
+            ('', '005_v6_3_0_schema'),
+        ):
+            with self.subTest(applied=applied_migrations,
+                              baseline=baseline_migration):
+                result = self._run(
+                    applied_migrations=applied_migrations,
+                    baseline_migration=baseline_migration,
+                    v6_0_schema=True,
+                    v6_2_schema=True,
+                )
 
-        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
-        self.assertIn(
-            'covered by pgroll history', result.stdout + result.stderr)
-        self.assertIn(
-            'resources columns are missing', result.stdout + result.stderr)
-        self.assertFalse(self._start_migrations())
-
-    def test_005_baseline_requires_its_resources_columns(self) -> None:
-        result = self._run(
-            baseline_migration='005_v6_3_0_schema',
-            target_schema='public',
-            v6_0_schema=True,
-            v6_2_schema=True,
-        )
-
-        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
-        self.assertIn(
-            'covered by pgroll history', result.stdout + result.stderr)
-        self.assertIn(
-            'resources columns are missing', result.stdout + result.stderr)
-        self.assertFalse(self._start_migrations())
+                self.assertNotEqual(
+                    0, result.returncode, result.stdout + result.stderr)
+                self.assertIn(
+                    'covered by pgroll history', result.stdout + result.stderr)
+                self.assertIn(
+                    'resources columns are missing',
+                    result.stdout + result.stderr,
+                )
+                self.assertFalse(self._start_migrations())
 
     def test_valid_005_baseline_covers_released_migrations(self) -> None:
         result = self._run(
             baseline_migration='005_v6_3_0_schema',
             released_schema=True,
-            target_schema='public',
             v6_0_schema=True,
             v6_2_schema=True,
         )
@@ -395,7 +352,6 @@ exit 48
     def test_004_baseline_does_not_cover_005(self) -> None:
         result = self._run(
             baseline_migration='004_v6_2_0_data',
-            target_schema='public',
             v6_0_schema=True,
             v6_2_schema=True,
         )
@@ -411,7 +367,6 @@ exit 48
                 '004_v6_2_0_data',
             ]),
             baseline_migration='000_baseline',
-            target_schema='public',
             v6_0_schema=True,
             v6_2_schema=True,
         )
@@ -441,8 +396,7 @@ exit 48
                 result = self._run(
                     applied_migrations=applied_migrations,
                     baseline_migration='000_baseline',
-                    target_schema='public',
-                    v6_0_schema=True,
+                            v6_0_schema=True,
                     v6_2_schema=True,
                 )
 
@@ -454,7 +408,6 @@ exit 48
         result = self._run(
             applied_migrations='001_v6_0_0_data_prep',
             baseline_migration='000_baseline',
-            target_schema='public',
             v6_0_schema=True,
         )
 
@@ -476,7 +429,6 @@ exit 48
             ]),
             baseline_migration='000_baseline',
             failing_migration='002_v6_0_0_schema.json',
-            target_schema='public',
             v6_2_schema=True,
         )
 
@@ -495,7 +447,6 @@ exit 48
                 '004_v6_2_0_data',
             ]),
             baseline_migration='006_future_migration',
-            target_schema='public',
             v6_0_schema=True,
             v6_2_schema=True,
         )

--- a/deployments/charts/service/migrations/test_run_migrations.py
+++ b/deployments/charts/service/migrations/test_run_migrations.py
@@ -1,0 +1,509 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+RUNNER = pathlib.Path(__file__).with_name('run_migrations.sh')
+MIGRATION_FILES = (
+    '001_v6_0_0_data_prep.json',
+    '002_v6_0_0_schema.json',
+    '003_v6_2_0_schema.json',
+    '004_v6_2_0_data.json',
+    '005_v6_3_0_schema.json',
+)
+
+
+class RunMigrationsTest(unittest.TestCase):
+    """Behavior tests for the pgroll migration runner."""
+
+    def setUp(self) -> None:
+        temporary_path = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temporary_path)
+        self.binary_directory = temporary_path / 'bin'
+        self.binary_directory.mkdir()
+        self.pgroll_log = temporary_path / 'pgroll.log'
+        self.psql_log = temporary_path / 'psql.log'
+        self.status_count = temporary_path / 'status-count'
+        self._write_executable('psql', r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MIGRATION_TEST_PSQL_LOG"
+if [[ "$*" == *"AS v6_2_schema_current"* ]]; then
+    if [[ "$MIGRATION_TEST_V6_2_SCHEMA" == 'true' ]]; then
+        printf 't\n'
+    else
+        printf 'f\n'
+    fi
+elif [[ "$*" == *"AS v6_0_schema_current"* ]]; then
+    if [[ "$MIGRATION_TEST_V6_0_SCHEMA" == 'true' ]]; then
+        printf 't\n'
+    else
+        printf 'f\n'
+    fi
+elif [[ "$*" == *"last_usage_updated"* ]]; then
+    if [[ "$MIGRATION_TEST_RELEASED_SCHEMA" == 'true' ]]; then
+        printf 't\n'
+    else
+        printf 'f\n'
+    fi
+elif [[ "$*" == *"migration_type = 'baseline'"* ]]; then
+    printf '%s\n' "$MIGRATION_TEST_BASELINE"
+elif [[ "$*" == *"to_regclass('public.workflows')"* ]]; then
+    if [[ "$MIGRATION_TEST_HAS_OSMO_SCHEMA" == 'true' ]]; then
+        printf 't\n'
+    else
+        printf 'f\n'
+    fi
+elif [[ "$*" == *"done = false"* ]]; then
+    if [[ "$MIGRATION_TEST_ACTIVE_MIGRATION" == 'true' ]]; then
+        printf 't\n'
+    else
+        printf 'f\n'
+    fi
+elif [[ "$*" == *"FROM pgroll.migrations"* ]]; then
+    if [[ -n "$MIGRATION_TEST_BASELINE" \
+          && "$*" == *"name = '$MIGRATION_TEST_BASELINE'"* ]]; then
+        printf 't\n'
+        exit 0
+    fi
+    IFS=',' read -ra applied_migrations <<< "$MIGRATION_TEST_APPLIED"
+    for applied_migration in "${applied_migrations[@]}"; do
+        if [[ -n "$applied_migration" \
+              && "$*" == *"name = '$applied_migration'"* ]]; then
+            printf 't\n'
+            exit 0
+        fi
+    done
+    printf 'f\n'
+fi
+""")
+        self._write_executable('pgroll', r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MIGRATION_TEST_PGROLL_LOG"
+case "$1" in
+    init)
+        if [[ "$MIGRATION_TEST_FAIL_COMMAND" == 'init' ]]; then
+            printf 'simulated init failure\n' >&2
+            exit 41
+        fi
+        exit 0
+        ;;
+    status)
+        status_count=0
+        if [[ -f "$MIGRATION_TEST_STATUS_COUNT" ]]; then
+            read -r status_count < "$MIGRATION_TEST_STATUS_COUNT"
+        fi
+        status_count=$((status_count + 1))
+        printf '%s\n' "$status_count" > "$MIGRATION_TEST_STATUS_COUNT"
+        if [[ "$MIGRATION_TEST_FAIL_COMMAND" == 'status_initial' \
+              && "$status_count" -eq 1 ]]; then
+            printf 'simulated initial status failure\n' >&2
+            exit 42
+        fi
+        if [[ "$MIGRATION_TEST_FAIL_COMMAND" == 'status_final' \
+              && "$status_count" -eq 2 ]]; then
+            printf 'simulated final status failure\n' >&2
+            exit 43
+        fi
+        if [[ "$MIGRATION_TEST_NO_HISTORY" == 'true' ]]; then
+            printf '{"status": "No migrations"}\n'
+        else
+            printf '{"status": "Complete"}\n'
+        fi
+        exit 0
+        ;;
+    baseline)
+        if [[ "$MIGRATION_TEST_FAIL_COMMAND" == 'baseline' ]]; then
+            printf 'simulated baseline failure\n' >&2
+            exit 44
+        fi
+        exit 0
+        ;;
+    complete)
+        if [[ "$MIGRATION_TEST_FAIL_COMMAND" == 'complete' ]]; then
+            printf 'simulated complete failure\n' >&2
+            exit 45
+        fi
+        if [[ "$MIGRATION_TEST_COMPLETE_SUCCEEDS" == 'true' ]]; then
+            exit 0
+        fi
+        printf 'no migration in progress\n' >&2
+        exit 46
+        ;;
+    start)
+        migration_name="$(basename "$2")"
+        if [[ "$migration_name" == "$MIGRATION_TEST_FAIL_MIGRATION" ]]; then
+            printf 'simulated pgroll failure for %s\n' "$migration_name" >&2
+            exit 47
+        fi
+        exit 0
+        ;;
+esac
+exit 48
+""")
+
+    def _write_executable(self, name: str, contents: str) -> None:
+        path = self.binary_directory / name
+        path.write_text(contents, encoding='utf-8')
+        path.chmod(0o755)
+
+    def _run(
+        self,
+        *,
+        active_migration: bool = False,
+        applied_migrations: str = '',
+        baseline_migration: str = '',
+        complete_succeeds: bool = False,
+        failing_command: str = '',
+        failing_migration: str = '',
+        has_osmo_schema: bool = False,
+        no_history: bool = False,
+        released_schema: bool = False,
+        target_schema: str = 'public_v6_3_0',
+        v6_0_schema: bool = False,
+        v6_2_schema: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        self.pgroll_log.unlink(missing_ok=True)
+        self.psql_log.unlink(missing_ok=True)
+        self.status_count.unlink(missing_ok=True)
+
+        environment = os.environ.copy()
+        existing_path = environment['PATH']
+        environment.update({
+            'MIGRATION_TEST_ACTIVE_MIGRATION':
+                str(active_migration).lower(),
+            'MIGRATION_TEST_APPLIED': applied_migrations,
+            'MIGRATION_TEST_BASELINE': baseline_migration,
+            'MIGRATION_TEST_COMPLETE_SUCCEEDS':
+                str(complete_succeeds).lower(),
+            'MIGRATION_TEST_FAIL_COMMAND': failing_command,
+            'MIGRATION_TEST_FAIL_MIGRATION': failing_migration,
+            'MIGRATION_TEST_HAS_OSMO_SCHEMA':
+                str(has_osmo_schema).lower(),
+            'MIGRATION_TEST_NO_HISTORY': str(no_history).lower(),
+            'MIGRATION_TEST_PGROLL_LOG': str(self.pgroll_log),
+            'MIGRATION_TEST_PSQL_LOG': str(self.psql_log),
+            'MIGRATION_TEST_RELEASED_SCHEMA':
+                str(released_schema).lower(),
+            'MIGRATION_TEST_STATUS_COUNT': str(self.status_count),
+            'MIGRATION_TEST_V6_0_SCHEMA': str(v6_0_schema).lower(),
+            'MIGRATION_TEST_V6_2_SCHEMA': str(v6_2_schema).lower(),
+            'OSMO_POSTGRES_PASSWORD': 'test-password',
+            'PATH': f'{self.binary_directory}:{existing_path}',
+        })
+        return subprocess.run(
+            ['bash', str(RUNNER), target_schema],
+            check=False,
+            capture_output=True,
+            env=environment,
+            text=True,
+            timeout=10,
+        )
+
+    def _pgroll_calls(self) -> list[str]:
+        return self.pgroll_log.read_text(encoding='utf-8').splitlines()
+
+    def _start_migrations(self) -> list[str]:
+        return [
+            pathlib.Path(call.split()[1]).name
+            for call in self._pgroll_calls()
+            if call.startswith('start ')
+        ]
+
+    def test_runs_all_migrations_and_refreshes_versioned_views(self) -> None:
+        result = self._run()
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(list(MIGRATION_FILES), self._start_migrations())
+        psql_calls = self.psql_log.read_text(encoding='utf-8')
+        self.assertIn('CREATE OR REPLACE VIEW public_v6_3_0.', psql_calls)
+
+    def test_pgroll_status_and_init_failures_exit_nonzero(self) -> None:
+        for failing_command, expected_message in (
+            ('init', 'Failed to initialize pgroll'),
+            ('status_initial', 'Failed to read pgroll status'),
+            ('status_final', 'Failed to read final pgroll status'),
+        ):
+            with self.subTest(failing_command=failing_command):
+                result = self._run(
+                    failing_command=failing_command,
+                    target_schema='public',
+                )
+
+                self.assertNotEqual(
+                    0, result.returncode, result.stdout + result.stderr)
+                self.assertIn(
+                    expected_message, result.stdout + result.stderr)
+
+    def test_active_migration_completion_failure_exits_nonzero(self) -> None:
+        result = self._run(
+            active_migration=True,
+            failing_command='complete',
+            target_schema='public',
+        )
+
+        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn(
+            'Failed to complete the active migration',
+            result.stdout + result.stderr,
+        )
+        self.assertFalse(self._start_migrations())
+
+    def test_active_migration_is_completed_before_new_migrations(self) -> None:
+        result = self._run(
+            active_migration=True,
+            complete_succeeds=True,
+            target_schema='public',
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        pgroll_calls = self._pgroll_calls()
+        complete_index = pgroll_calls.index('complete --postgres-url '
+                                            'postgres://postgres:'
+                                            'test-password@localhost:5432/'
+                                            'osmo_db?sslmode=require')
+        first_start_index = next(
+            index
+            for index, call in enumerate(pgroll_calls)
+            if call.startswith('start ')
+        )
+        self.assertLess(complete_index, first_start_index)
+
+    def test_baseline_creation_failure_exits_nonzero(self) -> None:
+        result = self._run(
+            failing_command='baseline',
+            has_osmo_schema=True,
+            no_history=True,
+            target_schema='public',
+        )
+
+        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn(
+            'Failed to create pgroll baseline',
+            result.stdout + result.stderr,
+        )
+        self.assertFalse(self._start_migrations())
+
+    def test_pgroll_start_failure_exits_nonzero(self) -> None:
+        result = self._run(
+            failing_migration='005_v6_3_0_schema.json',
+            target_schema='public',
+        )
+
+        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn(
+            'simulated pgroll failure', result.stdout + result.stderr)
+
+    def test_existing_schema_without_history_replays_untracked_data(self) -> None:
+        result = self._run(
+            has_osmo_schema=True,
+            no_history=True,
+            target_schema='public',
+            v6_0_schema=True,
+            v6_2_schema=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertTrue(any(
+            call.startswith('baseline 000_baseline ')
+            for call in self._pgroll_calls()
+        ))
+        self.assertEqual(
+            [
+                '001_v6_0_0_data_prep.json',
+                '004_v6_2_0_data.json',
+                '005_v6_3_0_schema.json',
+            ],
+            self._start_migrations(),
+        )
+
+    def test_completed_migrations_are_not_started_again(self) -> None:
+        result = self._run(
+            applied_migrations=','.join(
+                migration_file.removesuffix('.json')
+                for migration_file in MIGRATION_FILES
+            ),
+            released_schema=True,
+            target_schema='public',
+            v6_0_schema=True,
+            v6_2_schema=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertFalse(self._start_migrations())
+
+    def test_recorded_005_requires_its_resources_columns(self) -> None:
+        result = self._run(
+            applied_migrations='005_v6_3_0_schema',
+            target_schema='public',
+            v6_0_schema=True,
+            v6_2_schema=True,
+        )
+
+        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn(
+            'covered by pgroll history', result.stdout + result.stderr)
+        self.assertIn(
+            'resources columns are missing', result.stdout + result.stderr)
+        self.assertFalse(self._start_migrations())
+
+    def test_005_baseline_requires_its_resources_columns(self) -> None:
+        result = self._run(
+            baseline_migration='005_v6_3_0_schema',
+            target_schema='public',
+            v6_0_schema=True,
+            v6_2_schema=True,
+        )
+
+        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn(
+            'covered by pgroll history', result.stdout + result.stderr)
+        self.assertIn(
+            'resources columns are missing', result.stdout + result.stderr)
+        self.assertFalse(self._start_migrations())
+
+    def test_valid_005_baseline_covers_released_migrations(self) -> None:
+        result = self._run(
+            baseline_migration='005_v6_3_0_schema',
+            released_schema=True,
+            target_schema='public',
+            v6_0_schema=True,
+            v6_2_schema=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertFalse(self._start_migrations())
+
+    def test_004_baseline_does_not_cover_005(self) -> None:
+        result = self._run(
+            baseline_migration='004_v6_2_0_data',
+            target_schema='public',
+            v6_0_schema=True,
+            v6_2_schema=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(
+            ['005_v6_3_0_schema.json'], self._start_migrations())
+
+    def test_sparse_history_with_data_records_runs_only_005(self) -> None:
+        result = self._run(
+            applied_migrations=','.join([
+                '001_v6_0_0_data_prep',
+                '004_v6_2_0_data',
+            ]),
+            baseline_migration='000_baseline',
+            target_schema='public',
+            v6_0_schema=True,
+            v6_2_schema=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(
+            ['005_v6_3_0_schema.json'], self._start_migrations())
+
+    def test_sparse_history_replays_each_missing_data_migration(self) -> None:
+        for applied_migrations, expected_starts in (
+            (
+                '001_v6_0_0_data_prep',
+                [
+                    '004_v6_2_0_data.json',
+                    '005_v6_3_0_schema.json',
+                ],
+            ),
+            (
+                '004_v6_2_0_data',
+                [
+                    '001_v6_0_0_data_prep.json',
+                    '005_v6_3_0_schema.json',
+                ],
+            ),
+        ):
+            with self.subTest(applied_migrations=applied_migrations):
+                result = self._run(
+                    applied_migrations=applied_migrations,
+                    baseline_migration='000_baseline',
+                    target_schema='public',
+                    v6_0_schema=True,
+                    v6_2_schema=True,
+                )
+
+                self.assertEqual(
+                    0, result.returncode, result.stdout + result.stderr)
+                self.assertEqual(expected_starts, self._start_migrations())
+
+    def test_sparse_v6_0_schema_skips_only_present_structure(self) -> None:
+        result = self._run(
+            applied_migrations='001_v6_0_0_data_prep',
+            baseline_migration='000_baseline',
+            target_schema='public',
+            v6_0_schema=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(
+            [
+                '003_v6_2_0_schema.json',
+                '004_v6_2_0_data.json',
+                '005_v6_3_0_schema.json',
+            ],
+            self._start_migrations(),
+        )
+
+    def test_inconsistent_structural_fingerprint_is_not_skipped(self) -> None:
+        result = self._run(
+            applied_migrations=','.join([
+                '001_v6_0_0_data_prep',
+                '004_v6_2_0_data',
+            ]),
+            baseline_migration='000_baseline',
+            failing_migration='002_v6_0_0_schema.json',
+            target_schema='public',
+            v6_2_schema=True,
+        )
+
+        self.assertNotEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertIn(
+            'Failed to apply 002_v6_0_0_schema.json',
+            result.stdout + result.stderr,
+        )
+
+    def test_unknown_baseline_does_not_cover_005(self) -> None:
+        result = self._run(
+            applied_migrations=','.join([
+                '001_v6_0_0_data_prep',
+                '002_v6_0_0_schema',
+                '003_v6_2_0_schema',
+                '004_v6_2_0_data',
+            ]),
+            baseline_migration='006_future_migration',
+            target_schema='public',
+            v6_0_schema=True,
+            v6_2_schema=True,
+        )
+
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(
+            ['005_v6_3_0_schema.json'], self._start_migrations())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deployments/charts/service/templates/migration-job.yaml
+++ b/deployments/charts/service/templates/migration-job.yaml
@@ -33,10 +33,13 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 data:
-  {{- range $path, $content := .Files.Glob "migrations/*" }}
+  {{- /* Only the runner and migration JSONs; excludes BUILD and test files. */}}
+  {{- range $path, $content := .Files.Glob "migrations/0*.json" }}
   {{ base $path }}: |
     {{- $.Files.Get $path | nindent 4 }}
   {{- end }}
+  run_migrations.sh: |
+    {{- .Files.Get "migrations/run_migrations.sh" | nindent 4 }}
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
## Description

Issue - None

### Summary

- Add the released 005 v6.3 schema migration to the chart.
- Make pgroll initialization, status, completion, baseline, migration, and view-refresh failures fatal.
- Reconcile existing and sparse-history databases without re-running completed migrations.
- Fail closed when migration 005 is recorded or baselined but its resource columns are missing.
- Refresh versioned-schema views on every successful run.
- Package only migration JSON files and the runner in the Helm hook ConfigMap.

### Design context

This is prerequisite A3 for the OSMO-6501 workflow-label Track B stack. It deliberately contains no workflow-label schema or index behavior; B2 builds on it. The full v6.2 structural fingerprint is retained for safe reconciliation and remains an explicit review point while this PR is draft. The full prototype remains in #1194.

### Verification

- `bazel test //deployments/charts/service/migrations:test_run_migrations //deployments/charts/service/migrations:test_run_migrations-pylint --test_output=errors`
- `helm lint deployments/charts/service`
- `helm template test-release deployments/charts/service`
- Enabled-hook render contains exactly migrations 001 through 005 plus `run_migrations.sh`.
- `bash -n deployments/charts/service/migrations/run_migrations.sh`
- `git diff --check`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
