### PR TITLE
Add workflow labels database schema

### DIFF
--- a/deployments/charts/service/migrations/005_v6_4_0_workflow_labels.json
+++ b/deployments/charts/service/migrations/005_v6_4_0_workflow_labels.json
@@ -1,0 +1,14 @@
+{
+  "operations": [
+    {
+      "add_column": {
+        "table": "workflows",
+        "column": {
+          "name": "labels",
+          "type": "JSONB",
+          "nullable": true
+        }
+      }
+    }
+  ]
+}

--- a/deployments/charts/service/migrations/006_v6_4_0_workflow_labels_gin_index.json
+++ b/deployments/charts/service/migrations/006_v6_4_0_workflow_labels_gin_index.json
@@ -1,0 +1,12 @@
+{
+  "operations": [
+    {
+      "create_index": {
+        "name": "workflow_labels_gin_idx",
+        "table": "workflows",
+        "method": "gin",
+        "columns": [{"column": "labels"}]
+      }
+    }
+  ]
+}

--- a/deployments/upgrades/6_3_to_6_4_upgrade.md
+++ b/deployments/upgrades/6_3_to_6_4_upgrade.md
@@ -1,0 +1,76 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Upgrading OSMO from 6.3 to 6.4
+
+## What's new in 6.4
+
+- **Workflow labels** — optional, immutable `key: value` metadata on the
+  workflow spec, stored in PostgreSQL and stamped onto task pods. See the
+  workflow specification and submission guides for usage, and the
+  `labels_config` reference for the admin policy.
+
+## Database migration
+
+OSMO 6.4 reads and writes the nullable `workflows.labels` JSONB column. Every
+upgrade from 6.3 must apply migrations `005_v6_4_0_workflow_labels.json` and
+`006_v6_4_0_workflow_labels_gin_index.json` before the API, worker, or agent
+starts.
+
+Enable the idempotent pgroll pre-upgrade Job in the service chart values:
+
+```yaml
+services:
+  migration:
+    enabled: true
+```
+
+For ArgoCD, run it as a PreSync hook:
+
+```yaml
+services:
+  migration:
+    enabled: true
+    extraAnnotations:
+      argocd.argoproj.io/hook: PreSync
+      argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+```
+
+Before allowing the service rollout to continue, verify the column and generic
+GIN index exist:
+
+```sql
+SELECT column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'workflows'
+  AND column_name = 'labels';
+
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND tablename = 'workflows'
+  AND indexname = 'workflow_labels_gin_idx';
+```
+
+The expected results contain one `jsonb` column row and a `jsonb_ops` GIN
+index on `labels`. New databases receive both from the in-code schema.
+
+The generic GIN index accelerates key existence, exact-value, and alternation
+filters. Deployments with curated keys should also provision per-key indexes
+for prefix and missing-label queries. For example:
+
+```sql
+CREATE INDEX CONCURRENTLY workflow_labels_ppp_pattern_idx
+    ON workflows ((labels ->> 'PPP') text_pattern_ops);
+
+CREATE INDEX CONCURRENTLY workflow_labels_ppp_missing_idx
+    ON workflows (submit_time DESC)
+    WHERE labels IS NULL OR NOT (labels ? 'PPP');
+```
+
+Use deployment-specific index names and replace `PPP` with the configured key.
+Create or drop these indexes outside a transaction because PostgreSQL does not
+allow `CONCURRENTLY` inside a transaction block.

--- a/src/tests/common/database/testdata/schema.sql
+++ b/src/tests/common/database/testdata/schema.sql
@@ -59,6 +59,10 @@ CREATE TABLE IF NOT EXISTS pools (
 
 CREATE TABLE IF NOT EXISTS workflows (
     workflow_id TEXT PRIMARY KEY,
-    pool TEXT NOT NULL DEFAULT ''
+    pool TEXT NOT NULL DEFAULT '',
+    labels JSONB
 );
+
+CREATE INDEX IF NOT EXISTS workflow_labels_gin_idx
+    ON workflows USING gin (labels jsonb_ops);
 

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -875,6 +875,7 @@ class PostgresConnector:
                 app_uuid TEXT,
                 app_version INT,
                 plugins JSONB,
+                labels JSONB,
                 priority TEXT DEFAULT 'NORMAL',
                 PRIMARY KEY (workflow_uuid),
                 CONSTRAINT workflows_name_job UNIQUE(workflow_name, job_id),
@@ -894,6 +895,11 @@ class PostgresConnector:
             CREATE INDEX CONCURRENTLY IF NOT EXISTS workflow_list_index_pool_status
                 ON workflows
                 USING btree (pool, status, submit_time ASC);
+            ''',
+            '''
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS workflow_labels_gin_idx
+                ON workflows
+                USING gin (labels jsonb_ops);
             '''
         ]
         for cmd in index_cmds:

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -87,3 +87,12 @@ py_test(
     ],
     size = "small"
 )
+
+py_test(
+    name = "test_workflow_label_schema",
+    srcs = ["test_workflow_label_schema.py"],
+    deps = [
+        "//src/utils/connectors:connectors",
+    ],
+    size = "small",
+)

--- a/src/utils/connectors/tests/test_workflow_label_schema.py
+++ b/src/utils/connectors/tests/test_workflow_label_schema.py
@@ -1,0 +1,79 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+from unittest import mock
+
+from src.utils import connectors
+
+
+def _normalize_sql(command: str) -> str:
+    return ' '.join(command.split())
+
+
+class TestWorkflowLabelSchema(unittest.TestCase):
+    """The in-code database bootstrap defines the canonical label schema."""
+
+    commit_commands: list[str]
+    autocommit_commands: list[str]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        database = object.__new__(connectors.PostgresConnector)
+        database.execute_commit_command = mock.Mock()
+        database.execute_autocommit_command = mock.Mock()
+        database._init_tables()  # pylint: disable=protected-access
+
+        cls.commit_commands = [
+            _normalize_sql(call.args[0])
+            for call in database.execute_commit_command.call_args_list
+        ]
+        cls.autocommit_commands = [
+            _normalize_sql(call.args[0])
+            for call in database.execute_autocommit_command.call_args_list
+        ]
+
+    def test_in_code_schema_has_nullable_jsonb_labels(self) -> None:
+        workflow_table = next(
+            command
+            for command in self.commit_commands
+            if 'CREATE TABLE IF NOT EXISTS workflows' in command
+        )
+
+        self.assertIn('labels JSONB,', workflow_table)
+        self.assertNotIn('labels JSONB NOT NULL', workflow_table)
+        self.assertNotIn('labels JSONB DEFAULT', workflow_table)
+
+    def test_in_code_schema_has_concurrent_jsonb_ops_gin_index(self) -> None:
+        labels_index = next(
+            command
+            for command in self.autocommit_commands
+            if 'workflow_labels_gin_idx' in command
+        )
+
+        self.assertIn(
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS '
+            'workflow_labels_gin_idx',
+            labels_index,
+        )
+        self.assertIn(
+            'ON workflows USING gin (labels jsonb_ops)', labels_index)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Issue - None

Tracking: OSMO-6501

### Summary

Add the nullable `workflows.labels` JSONB column and its `jsonb_ops` GIN index (`workflow_labels_gin_idx`) through all three schema paths:

- pgroll migrations `005_v6_4_0_workflow_labels` (add column) and `006_v6_4_0_workflow_labels_gin_index` (index), picked up by the existing migration runner's `0*.json` loop — **no runner changes**.
- the in-code bootstrap DDL (`PostgresConnector._init_tables`).
- the test fixture schema (`schema.sql`).

Document the 6.3 → 6.4 database migration in `deployments/upgrades/6_3_to_6_4_upgrade.md`, with the verification queries and the optional per-key `text_pattern_ops` / partial indexes for curated keys.

### Design context

Track B2 of the OSMO-6501 workflow-label stack, based on `main` (B1 validation merged in #1216). The label feature ships in **6.4** — prod is already 6.3.1 — so the migrations are numbered after the last released migration `004` and versioned `v6_4_0`. This slice is schema/index only; admission, filtering, CLI, UI, and metrics are later slices. Full prototype: #1194.

The generic `jsonb_ops` GIN index keeps key-existence (`PPP=*`) and exact/alternation filters index-eligible; deployment-specific expression/partial indexes for curated keys are an operator recipe in the upgrade guide and ship with query behavior in B6 (#1224).

### Verification

- `bazel test //src/utils/connectors/tests:test_workflow_label_schema` — the in-code bootstrap defines the nullable column and the concurrent `jsonb_ops` GIN index.
- `bazel test //src/utils/connectors/tests:test_backend_resource` — unaffected sibling target still builds.
- `helm template` renders the migration ConfigMap with `005_v6_4_0` / `006_v6_4_0` + `run_migrations.sh` (no test/BUILD sources).
- Both migration JSON files parse.

### Benchmark: does the GIN index help the label-filter query?

The dev instance has ~zero labeled rows (labels are new), so a live `EXPLAIN ANALYZE` there proves nothing. Instead this was measured on **Postgres 15.1** (the deployed version) with the **real `workflows` schema and all three production indexes**, seeded with **500k rows** in a realistic distribution (40% unlabeled; a skewed `PPP` key where common values ≈17% of rows and rare values ≈0.5%). Queries are the exact predicate shapes `helpers.get_workflows()` emits — wrapped subselect, `apps` LEFT JOIN, mandatory `status` filter, `ORDER BY submit_time LIMIT 20`. Each shape was run `EXPLAIN (ANALYZE, BUFFERS)` warm, **with** and **without** `workflow_labels_gin_idx`.

| List filter | SQL predicate | Index-eligible | With GIN | Without GIN | Speedup | Plan (with GIN) |
|---|---|:---:|---:|---:|:---:|---|
| `label=PPP=proj_35` (rare, 0.55%) | `labels @> jsonb_build_object(k,v)` | ✅ | **13.5 ms** | 154 ms | **11×** | Bitmap Index Scan `workflow_labels_gin_idx` |
| `label=PPP=(proj_35\|proj_36)` (~1.1%) | OR of `@>` | ✅ | **14.0 ms** | 253 ms | **18×** | BitmapOr of two GIN scans |
| `label=PPP=proj_0` (common, 17.5%) | `labels @> jsonb_build_object(k,v)` | ✅ | **74.9 ms** | 163 ms | **2.2×** | Parallel Bitmap GIN |
| `label=PPP=*` (key exists, 60%) | `labels ? k` | ✅ | 90.0 ms | 90.7 ms | ~1× | Seq Scan — planner declines the index |
| `label=PPP=robotics_*` (glob) | `labels ->> k LIKE … ESCAPE` | ❌ | 53.0 ms | 52.0 ms | 1× | Seq Scan |
| `no_label=PPP` | `labels IS NULL OR NOT (labels ? k)` | ❌ | 73.1 ms | 74.3 ms | 1× | Seq Scan |

**Why the wins are large:** a label-only filter has no btree that provides `submit_time` ordering (both `workflow_list_*` btrees lead with `submitted_by`/`pool`, `status`), so without the GIN index the fallback is a full **Seq Scan + Sort**. The index turns the selective exact/alternation cases into a bitmap scan — **11–18×** faster.

**The planner declines the index where it wouldn't help**, so it never hurts: non-selective key-existence (`?` at 60%) and the non-eligible `->> LIKE` glob and `no_label` negation all Seq Scan with or without it. When a label filter is combined with `pool`/`user`, the existing `workflow_list_index_pool_status` btree already serves both the filter and the ordering, so GIN's clear win is the **pool-agnostic, selective label lookup**.

**Cost:** the GIN index is **2.3 MB** vs 27 MB / 23 MB for the two existing `workflow_list_*` btrees (66 MB table) — negligible storage and write overhead.

<details>
<summary>Representative <code>EXPLAIN (ANALYZE, BUFFERS)</code> — <code>label=PPP=proj_35</code></summary>

```
-- WITH workflow_labels_gin_idx
Limit  (actual time=13.393..13.397 rows=20)
  ->  Sort  (Sort Key: submit_time; top-N heapsort)
        ->  Bitmap Heap Scan on workflows  (actual time=2.139..12.301 rows=2487)
              ->  Bitmap Index Scan on workflow_labels_gin_idx  (actual time=1.874 rows=2736)
Execution Time: 13.479 ms

-- WITHOUT the index (dropped)
Limit  (actual time=... rows=20)
  ->  Parallel Seq Scan on workflows  (actual time=0.118..144.984 rows=829, loops=3)
Execution Time: 154.143 ms
```
</details>

Reproduction script (seeds the dataset and runs all six shapes): shared in the PR thread.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional workflow labels as immutable key-value metadata stored in the workflows database.
  * Introduced a JSONB `labels` field and an indexed GIN lookup to speed up label-based filtering.

* **Documentation**
  * Added 6.3 → 6.4 upgrade guidance, including required migrations, rollout order, and verification steps.

* **Tests**
  * Added automated checks to confirm the updated schema (nullable JSONB column) and the creation of the concurrent GIN index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
