### PR TITLE
Fix duplicate resource name lookups

### DIFF
--- a/src/cli/resources.py
+++ b/src/cli/resources.py
@@ -236,7 +236,15 @@ def _info_resource(service_client: client.ServiceClient, args: argparse.Namespac
     if 'resources' not in response or len(response['resources']) == 0:
         print(f'{args.node_name} is not a resource.')
         return
+    if not args.pool and len(response['resources']) > 1:
+        print(f'Multiple resources named {args.node_name} exist. Specify both --pool and '
+              '--platform to select one.')
+        return
     resource = response['resources'][0]
+    if args.pool:
+        resource = next((candidate for candidate in response['resources']
+                         if args.platform in candidate.get(
+                             'pool_platform_labels', {}).get(args.pool, [])), resource)
     keys = resource['exposed_fields'].keys()
     allocatable_labels_lookup = \
         {resource_label.name: (resource_label.name, resource_label.unit) \

--- a/src/cli/tests/test_resources.py
+++ b/src/cli/tests/test_resources.py
@@ -383,6 +383,25 @@ class TestInfoResource(unittest.TestCase):
         self.assertIn('platform-1', output)
         self.assertIn('Resource Capacity', output)
 
+    def test_duplicate_resources_without_pool_platform_prints_ambiguity(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        service_client.request.return_value = {
+            'resources': [
+                _make_resource(pool_name='pool-a', platform_name='platform-a'),
+                _make_resource(pool_name='pool-b', platform_name='platform-b'),
+            ]
+        }
+        args = self._make_args()
+
+        with mock.patch('builtins.print') as mock_print:
+            resources._info_resource(service_client, args)
+
+        output = _capture(mock_print)
+        self.assertIn('Multiple resources named node-1 exist', output)
+        self.assertIn('--pool', output)
+        self.assertIn('--platform', output)
+        self.assertNotIn('Resource Capacity', output)
+
     def test_invalid_pool_prints_keyerror_message(self):
         service_client = mock.Mock(spec=client.ServiceClient)
         service_client.request.return_value = {'resources': [_make_resource()]}
@@ -406,6 +425,29 @@ class TestInfoResource(unittest.TestCase):
         self.assertIn('cpu: 8', output)
         self.assertIn('Default Mounts', output)
         self.assertIn('/data', output)
+
+    def test_specified_pool_platform_selects_matching_duplicate_resource(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        first_resource = _make_resource(
+            pool_name='pool-a', platform_name='platform-a', node='node-1')
+        selected_resource = _make_resource(
+            pool_name='pool-b', platform_name='platform-b', node='node-1')
+        selected_resource['platform_allocatable_fields']['pool-b']['platform-b']['cpu'] = '32'
+        selected_resource['config_fields']['pool-b']['platform-b']['default_mounts'] = [
+            '/pool-b-data'
+        ]
+        service_client.request.return_value = {
+            'resources': [first_resource, selected_resource]
+        }
+        args = self._make_args(pool='pool-b', platform='platform-b')
+
+        with mock.patch('builtins.print') as mock_print:
+            resources._info_resource(service_client, args)
+
+        output = _capture(mock_print)
+        self.assertIn('cpu: 32', output)
+        self.assertIn('/pool-b-data', output)
+        self.assertNotIn('pool-a', output)
 
 
 if __name__ == '__main__':

--- a/src/ui/src/features/resources/components/resources-page-content.tsx
+++ b/src/ui/src/features/resources/components/resources-page-content.tsx
@@ -47,6 +47,11 @@ import { ResourcePanelHeader } from "@/features/resources/components/panel/panel
 import { ResourcePanelContent } from "@/features/resources/components/panel/panel-content";
 import { ResourcesDataTable } from "@/features/resources/components/table/resources-data-table";
 import { ResourcesToolbar } from "@/features/resources/components/resources-toolbar";
+import {
+  findResourceForSelection,
+  getResourceRowId,
+  getResourceSelectionState,
+} from "@/features/resources/lib/resource-selection";
 import { useResourcesTableStore } from "@/features/resources/stores/resources-table-store";
 import { AdaptiveSummary } from "@/features/resources/components/resource-summary-card";
 import { useResourcesData } from "@/features/resources/hooks/use-resources-data";
@@ -77,13 +82,6 @@ export function ResourcesPageContent({ initialAggregates }: { initialAggregates?
     setConfig: setSelectedPoolConfig,
     clear: clearSelectedResource,
   } = usePanelState();
-
-  const handleResourceSelect = useCallback(
-    (resourceName: string | null) => {
-      startTransition(() => setSelectedResourceName(resourceName));
-    },
-    [setSelectedResourceName, startTransition],
-  );
 
   const handlePoolSelect = useCallback(
     (poolName: string | null) => {
@@ -146,8 +144,8 @@ export function ResourcesPageContent({ initialAggregates }: { initialAggregates?
 
   // Find selected resource from URL
   const selectedResource = useMemo(
-    () => (selectedResourceName ? resources.find((r) => r.name === selectedResourceName) : undefined),
-    [resources, selectedResourceName],
+    () => findResourceForSelection(resources, selectedResourceName, selectedPoolConfig),
+    [resources, selectedResourceName, selectedPoolConfig],
   );
 
   // Panel lifecycle - handles open/close/closing animation state machine
@@ -163,9 +161,13 @@ export function ResourcesPageContent({ initialAggregates }: { initialAggregates?
   // Handle resource click
   const handleResourceClick = useCallback(
     (resource: Resource) => {
-      handleResourceSelect(resource.name);
+      const selection = getResourceSelectionState(resource, selectedPoolConfig);
+      startTransition(() => {
+        setSelectedResourceName(selection.resourceName);
+        setSelectedPoolConfig(selection.poolName);
+      });
     },
-    [handleResourceSelect],
+    [selectedPoolConfig, setSelectedPoolConfig, setSelectedResourceName, startTransition],
   );
 
   // Panel width management
@@ -224,7 +226,7 @@ export function ResourcesPageContent({ initialAggregates }: { initialAggregates?
             onRetry={refetch}
             showPoolsColumn
             onResourceClick={handleResourceClick}
-            selectedResourceId={selectedResourceName ?? undefined}
+            selectedResourceId={selectedResource ? getResourceRowId(selectedResource) : undefined}
             hasNextPage={hasNextPage}
             onLoadMore={fetchNextPage}
             isFetchingNextPage={isFetchingNextPage}
@@ -256,6 +258,7 @@ export function ResourcesPageContent({ initialAggregates }: { initialAggregates?
             onClose={handleClosePanel}
           />
           <ResourcePanelContent
+            key={getResourceRowId(selectedResource)}
             resource={selectedResource}
             selectedPool={selectedPoolConfig}
             onPoolSelect={handlePoolSelect}

--- a/src/ui/src/features/resources/components/table/resources-data-table.tsx
+++ b/src/ui/src/features/resources/components/table/resources-data-table.tsx
@@ -38,6 +38,7 @@ import {
   RESOURCE_COLUMN_SIZE_CONFIG,
 } from "@/features/resources/lib/resource-columns";
 import { createResourceColumns } from "@/features/resources/lib/resource-column-defs";
+import { getResourceRowId } from "@/features/resources/lib/resource-selection";
 import { useResourcesTableStore } from "@/features/resources/stores/resources-table-store";
 import { TABLE_ROW_HEIGHTS } from "@/lib/config";
 import { naturalCompare } from "@/lib/utils";
@@ -45,9 +46,6 @@ import { naturalCompare } from "@/lib/utils";
 // =============================================================================
 // Helpers
 // =============================================================================
-
-/** Stable row ID extractor - defined outside component to avoid recreating */
-const getRowId = (resource: Resource) => resource.name;
 
 // Module-level constant — stable reference, no useMemo needed
 const FIXED_COLUMNS = Array.from(MANDATORY_COLUMN_IDS);
@@ -225,7 +223,7 @@ export const ResourcesDataTable = memo(function ResourcesDataTable({
       <DataTable<Resource>
         data={sortedResources}
         columns={columns}
-        getRowId={getRowId}
+        getRowId={getResourceRowId}
         // Column management
         columnOrder={columnOrder}
         onColumnOrderChange={setColumnOrder}

--- a/src/ui/src/features/resources/lib/resource-selection.test.ts
+++ b/src/ui/src/features/resources/lib/resource-selection.test.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+  findResourceForSelection,
+  getResourceRowId,
+  getResourceSelectionState,
+} from "@/features/resources/lib/resource-selection";
+import { createMockResource } from "@/testing/factories";
+
+describe("resource selection", () => {
+  const backendAResource = createMockResource({
+    name: "ovx001",
+    backend: "backend-a",
+    poolMemberships: [{ pool: "pool-a", platform: "platform-a" }],
+  });
+  const backendBResource = createMockResource({
+    name: "ovx001",
+    backend: "backend-b",
+    poolMemberships: [{ pool: "pool-b", platform: "platform-b" }],
+  });
+  const resources = [backendAResource, backendBResource];
+
+  it("uses configured pool membership to disambiguate duplicate names", () => {
+    expect(findResourceForSelection(resources, "ovx001", "pool-b")).toBe(backendBResource);
+  });
+
+  it("derives click state that resolves back to the clicked duplicate", () => {
+    const selection = getResourceSelectionState(backendBResource, "pool-a");
+
+    expect(selection).toEqual({ resourceName: "ovx001", poolName: "pool-b" });
+    expect(findResourceForSelection(resources, selection.resourceName, selection.poolName)).toBe(backendBResource);
+  });
+
+  it("uses backend-aware row IDs for duplicate names", () => {
+    expect(getResourceRowId(backendAResource)).toBe("backend-a/ovx001");
+    expect(getResourceRowId(backendBResource)).toBe("backend-b/ovx001");
+  });
+
+  it("provides a stable panel key for each resource identity", () => {
+    const sameResourceWithDifferentMembership = {
+      ...backendBResource,
+      poolMemberships: [{ pool: "pool-c", platform: "platform-c" }],
+    };
+
+    expect(getResourceRowId(backendBResource)).not.toBe(getResourceRowId(backendAResource));
+    expect(getResourceRowId(sameResourceWithDifferentMembership)).toBe(getResourceRowId(backendBResource));
+  });
+});

--- a/src/ui/src/features/resources/lib/resource-selection.ts
+++ b/src/ui/src/features/resources/lib/resource-selection.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Resource } from "@/lib/api/adapter/types";
+
+export interface ResourceSelectionState {
+  resourceName: string;
+  poolName: string | null;
+}
+
+export function getResourceRowId(resource: Resource): string {
+  return `${resource.backend}/${resource.name}`;
+}
+
+export function findResourceForSelection(
+  resources: Resource[],
+  resourceName: string | null,
+  configuredPool: string | null,
+): Resource | undefined {
+  if (!resourceName) return undefined;
+
+  const matchingResources = resources.filter((resource) => resource.name === resourceName);
+  if (configuredPool) {
+    const poolMatch = matchingResources.find((resource) =>
+      resource.poolMemberships.some((membership) => membership.pool === configuredPool),
+    );
+    if (poolMatch) return poolMatch;
+  }
+
+  return matchingResources[0];
+}
+
+export function getResourceSelectionState(resource: Resource, configuredPool: string | null): ResourceSelectionState {
+  const poolName = resource.poolMemberships.some((membership) => membership.pool === configuredPool)
+    ? configuredPool
+    : (resource.poolMemberships[0]?.pool ?? null);
+
+  return { resourceName: resource.name, poolName };
+}

--- a/src/ui/src/lib/api/adapter/hooks.test.ts
+++ b/src/ui/src/lib/api/adapter/hooks.test.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { extractPoolMemberships } from "@/lib/api/adapter/hooks";
+import type { ResourcesResponse } from "@/lib/api/generated";
+
+describe("extractPoolMemberships", () => {
+  it("selects the matching backend when resource names are duplicated", () => {
+    const response = {
+      resources: [
+        {
+          hostname: "ovx001",
+          backend: "backend-a",
+          exposed_fields: { node: "ovx001" },
+          pool_platform_labels: { "pool-a": ["platform-a"] },
+        },
+        {
+          hostname: "ovx001",
+          backend: "backend-b",
+          exposed_fields: { node: "ovx001" },
+          pool_platform_labels: { "pool-b": ["platform-b"] },
+        },
+      ],
+    } as unknown as ResourcesResponse;
+
+    expect(extractPoolMemberships(response, "ovx001", "backend-b")).toEqual([
+      { pool: "pool-b", platform: "platform-b" },
+    ]);
+  });
+});

--- a/src/ui/src/lib/api/adapter/hooks.ts
+++ b/src/ui/src/lib/api/adapter/hooks.ts
@@ -262,15 +262,16 @@ export { invalidateResourcesCache };
 export { getResourceFilterOptions };
 
 // WORKAROUND: Must query all_pools=true to get full memberships (Issue: BACKEND_TODOS.md#7)
-function extractPoolMemberships(
+export function extractPoolMemberships(
   data: ResourcesResponse | GeneratedPoolResourcesResponse,
   resourceName: string,
+  backend: string,
 ): PoolMembership[] {
   const backendResources: ResourcesResponse["resources"] = ("resources" in data ? data.resources : undefined) ?? [];
 
   const backendResource = backendResources.find((r) => {
     const nameField = (r.exposed_fields as Record<string, unknown>)?.node;
-    return r.hostname === resourceName || nameField === resourceName;
+    return r.backend === backend && (r.hostname === resourceName || nameField === resourceName);
   });
 
   if (!backendResource) return [];
@@ -327,7 +328,7 @@ export function useResourceDetail(
     // Get pool memberships - prefer fetched data over resource's initial data
     let memberships = resource.poolMemberships;
     if (resourcesQuery.data) {
-      const fetched = extractPoolMemberships(resourcesQuery.data, resource.name);
+      const fetched = extractPoolMemberships(resourcesQuery.data, resource.name, resource.backend);
       if (fetched.length > 0) {
         memberships = fetched;
       }

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -2327,12 +2327,16 @@ class BackendResource(pydantic.BaseModel):
         if len(resources) == 0:
             return all_resources
 
-        pool_config = fetch_verbose_pool_config(postgres, resources[0]['backend']).pools
+        pool_configs: Dict[str, Dict[str, 'Pool']] = {}
 
         for resource in resources:
             taints = resource.get('taints', [])
             label_fields = PostgresConnector.decode_hstore(resource.get('label_fields') or '')
             if resource['available']:
+                backend = resource['backend']
+                if backend not in pool_configs:
+                    pool_configs[backend] = fetch_verbose_pool_config(postgres, backend).pools
+                pool_config = pool_configs[backend]
                 label_fields = PostgresConnector.decode_hstore(resource.get('label_fields') or '')
                 allocatable_fields = PostgresConnector.decode_hstore(
                     resource.get('allocatable_fields') or '')

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -58,3 +58,17 @@ py_test(
     ],
     size = "small"
 )
+
+py_test(
+    name = "test_backend_resource",
+    srcs = [
+        "test_backend_resource.py"
+        ],
+    deps = [
+        "//src/utils/connectors:connectors",
+    ],
+    tags = [
+        "exclusive"
+    ],
+    size = "small"
+)

--- a/src/utils/connectors/tests/test_backend_resource.py
+++ b/src/utils/connectors/tests/test_backend_resource.py
@@ -1,0 +1,85 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+from unittest import mock
+
+from src.utils import connectors
+
+
+def _resource_row(backend: str) -> dict:
+    return {
+        'name': 'ovx001',
+        'backend': backend,
+        'available': True,
+        'taints': [],
+        'label_fields': '',
+        'allocatable_fields': '"cpu"=>"8"',
+        'usage_fields': '"cpu"=>"1"',
+        'non_workflow_usage_fields': '"cpu"=>"0"',
+        'pool_platform_labels': ['shared-pool/dgx'],
+        'resource_type': 'RESERVED',
+    }
+
+
+def _pool_config(backend: str) -> connectors.VerbosePoolConfig:
+    platform = connectors.Platform(
+        host_network_allowed=backend == 'backend-b',
+        default_mounts=[f'/{backend}'],
+    )
+    pool = connectors.Pool(
+        name='shared-pool',
+        backend=backend,
+        platforms={'dgx': platform},
+    )
+    return connectors.VerbosePoolConfig(pools={'shared-pool': pool})
+
+
+class TestBackendResource(unittest.TestCase):
+    def test_list_from_db_hydrates_pool_config_per_backend(self):
+        postgres = mock.Mock(spec=connectors.PostgresConnector)
+        postgres.execute_fetch_command.return_value = [
+            _resource_row('backend-a'),
+            _resource_row('backend-b'),
+        ]
+
+        with mock.patch.object(
+                connectors.PostgresConnector, 'get_instance', return_value=postgres), \
+             mock.patch(
+                'src.utils.connectors.postgres.fetch_verbose_pool_config',
+                side_effect=lambda _postgres, backend: _pool_config(backend)) as fetch_config:
+            resources = connectors.BackendResource.list_from_db()
+
+        self.assertEqual(len(resources), 2)
+        backend_a, backend_b = resources
+        assert backend_a.config_fields is not None
+        assert backend_b.config_fields is not None
+        config_a = backend_a.config_fields['shared-pool']['dgx']
+        config_b = backend_b.config_fields['shared-pool']['dgx']
+        self.assertEqual(config_a.default_mounts, ['/backend-a'])
+        self.assertFalse(config_a.host_network)
+        self.assertEqual(config_b.default_mounts, ['/backend-b'])
+        self.assertTrue(config_b.host_network)
+        self.assertEqual(fetch_config.call_args_list, [
+            mock.call(postgres, 'backend-a'),
+            mock.call(postgres, 'backend-b'),
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Issue #None

Resource names are unique only within a backend, but resource detail paths assumed hostnames were globally unique. With the same hostname in separate backend pools, the CLI and UI selected the first API record and later backend records were hydrated with the first backend pool configuration.

This change:
- caches and applies pool configuration per backend when hydrating resources;
- disambiguates CLI resource info by pool/platform and reports ambiguous unqualified lookups;
- uses backend-aware UI identities while preserving name/pool deep links; and
- adds regression coverage for backend hydration, CLI selection, UI detail membership, and duplicate row selection.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource details now support multiple resources with the same name by selecting the correct pool and platform.
  * The resources interface now keeps resource and pool selections aligned, including resources with duplicate names across backends.
  * Resource details display backend-specific pool memberships and configuration more accurately.

* **Bug Fixes**
  * Corrected resource capacity and configuration details when multiple backends or duplicate resources are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->