### PR TITLE
Add workflow label CLI support

### DIFF
--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -248,7 +248,7 @@ Workflow Labels
 ===============
 
 Workflow labels are optional and format-checked even when no label is required.
-The default configuration is inert:
+The default configuration applies no label policies:
 
 .. code-block:: yaml
 
@@ -273,80 +273,39 @@ key from ``policy`` to disable both warnings and enforcement for that key:
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 22 58
+   :widths: 25 12 43 20
 
-   * - Field
-     - Default
-     - Behavior
+   * - **Field**
+     - **Type**
+     - **Description**
+     - **Default Values**
    * - ``key``
-     - Required
+     - String
      - Kubernetes label key to check. Duplicate policy keys are rejected,
        and at most 16 keys can be configured.
+     - Required
    * - ``allow_list``
-     - ``[]``
+     - List of Strings
      - Exact accepted values. An empty list accepts any well-formed value.
+     - ``[]``
    * - ``enforcement``
-     - ``off``
+     - String (``"off"``, ``warn``, ``enforce``)
      - ``off`` accepts without policy warnings. ``warn`` accepts but warns
        when the key is missing or its value is outside a non-empty allow-list.
        ``enforce`` rejects those violations.
+     - ``"off"``
 
 The same policy applies to new submissions, resubmission by ID, restart, and
 validation-only requests. An ``enforcement: enforce`` rejection creates
 neither a workflow row nor a stored specification. Submit responses carry
-warnings from that admission check. Workflow detail responses recompute
-warn-mode violations from the stored labels and current configuration, so the
-displayed status follows policy changes for every workflow status, including
-completed workflows; warnings are not stored with the workflow.
+warnings from that admission check. Warnings are not stored with the
+workflow: detail responses recompute warn-mode violations from the stored
+labels and the current configuration, so displayed warnings track policy
+changes even for completed workflows.
 
-Staged rollout
---------------
-
-#. Assign a named owner for the key. That owner approves and maintains its
-   allow-list.
-#. Add the key with its final allow-list and ``enforcement: warn``; verify that
-   the configuration loads.
-#. Keep the key at ``enforcement: warn`` for two to four weeks. Monitor warnings
-   and the ``no_label=<key>`` workflow filter as supporting signals.
-#. Measure compliance from the canonical PostgreSQL ``workflows.labels``
-   column. Change the example key and allowed values below to match the policy:
-
-   .. code-block:: sql
-
-      WITH weekly_compliance AS (
-          SELECT
-              date_trunc('week', submit_time) AS week_start,
-              COUNT(*) AS total,
-              COUNT(*) FILTER (
-                  WHERE labels IS NULL
-                     OR NOT (labels ? 'team')
-                     OR labels->>'team' NOT IN ('robotics', 'simulation')
-              ) AS missing_or_invalid
-          FROM workflows
-          WHERE submit_time >= date_trunc('week', CURRENT_TIMESTAMP)
-                                   - INTERVAL '4 weeks'
-            AND submit_time < date_trunc('week', CURRENT_TIMESTAMP)
-          GROUP BY 1
-      )
-      SELECT
-          week_start,
-          total,
-          missing_or_invalid,
-          ROUND(
-              100.0 * missing_or_invalid / NULLIF(total, 0),
-              2
-          ) AS missing_or_invalid_percent
-      FROM weekly_compliance
-      ORDER BY week_start DESC;
-
-#. Change the key to ``enforcement: enforce`` only after the
-   missing-or-invalid rate is below 5% for each of two consecutive complete
-   weeks and the allow-list owner approves enforcement.
-
-PostgreSQL is the authoritative source for rollout compliance measurement;
-warning counts and Prometheus metrics are operational diagnostics. To roll
-back enforcement immediately, use ``enforcement: warn``. To disable both
-warnings and enforcement, use ``enforcement: off`` or remove the policy entry.
+To roll back enforcement immediately, use ``enforcement: warn``. To disable both
+warnings and enforcement, use ``enforcement: "off"`` (quoted: unquoted YAML
+``off`` parses as boolean false) or remove the policy entry.
 Existing and in-flight workflows are not modified, although their detail-page
 warnings always reflect the current warn policy. In ConfigMap mode, an invalid
 edit is rejected and the previous valid snapshot remains active.
@@ -354,9 +313,8 @@ edit is rejected and the previous valid snapshot remains active.
 Admission emits
 ``osmo_label_validation_total{key, outcome}``, where ``outcome`` is ``ok``,
 ``missing``, ``invalid``, or ``rejected``. The counter covers rejected
-submissions that do not create a workflow row; PostgreSQL remains the
-historical compliance source of truth. Keep the policy list small to control
-metric cardinality. Exporting a Pod label through ``kube_pod_labels`` is a
+submissions that do not create a workflow row. Keep the policy list small to
+control metric cardinality. Exporting a Pod label through ``kube_pod_labels`` is a
 separate kube-state-metrics allow-list decision; see
 :ref:`adding_observability`.
 

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -306,9 +306,8 @@ Staged rollout
    allow-list.
 #. Add the key with its final allow-list and ``enforcement: warn``; verify that
    the configuration loads.
-#. Keep the key at ``enforcement: warn`` for two to four weeks. Monitor warnings,
-   the ``no_label=<key>`` workflow filter, and ``osmo_tasks_count`` as
-   supporting signals.
+#. Keep the key at ``enforcement: warn`` for two to four weeks. Monitor warnings
+   and the ``no_label=<key>`` workflow filter as supporting signals.
 #. Measure compliance from the canonical PostgreSQL ``workflows.labels``
    column. Change the example key and allowed values below to match the policy:
 
@@ -352,17 +351,7 @@ Existing and in-flight workflows are not modified, although their detail-page
 warnings always reflect the current warn policy. In ConfigMap mode, an invalid
 edit is rejected and the previous valid snapshot remains active.
 
-Only configured policy keys become workflow-label dimensions on
-``osmo_tasks_count``. Attribute names start with ``workflow_label_``. Letters
-and numbers are unchanged; ``_``, ``-``, ``.``, and ``/`` are encoded as
-``__``, ``_dash_``, ``_dot_``, and ``_slash_`` respectively. For example,
-``PPP`` is exported as ``workflow_label_PPP``. Values in the configured
-allow-list are exported verbatim; a present value outside that list is clamped
-to ``<other>``, and a missing key is reported as ``<missing>``. An empty
-allow-list therefore exports every present value as ``<other>``. This keeps
-the number of series bounded to the allow-list plus two sentinels per key.
-
-Admission also emits
+Admission emits
 ``osmo_label_validation_total{key, outcome}``, where ``outcome`` is ``ok``,
 ``missing``, ``invalid``, or ``rejected``. The counter covers rejected
 submissions that do not create a workflow row; PostgreSQL remains the

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -70,6 +70,10 @@ Top-Level Configuration
      - `Plugins`_
      - Configuration for workflow plugins.
      - See Plugins section
+   * - ``labels_config``
+     - `Workflow Labels`_
+     - Workflow-label policies, accepted values, and staged enforcement.
+     - ``policy: []``
    * - ``max_num_tasks``
      - Integer
      - Maximum number of tasks allowed in a workflow.
@@ -239,6 +243,133 @@ Workflow Information
      - Integer
      - Maximum allowed length for workflow names.
      - ``64``
+
+Workflow Labels
+===============
+
+Workflow labels are optional and format-checked even when no label is required.
+The default configuration is inert:
+
+.. code-block:: yaml
+
+   labels_config:
+     policy: []
+
+Each entry in ``policy`` controls one key independently. Use ``off`` or omit a
+key from ``policy`` to disable both warnings and enforcement for that key:
+
+.. code-block:: yaml
+
+   labels_config:
+     policy:
+     - key: team
+       allow_list:
+       - robotics
+       - simulation
+       enforcement: warn
+     - key: cost-center
+       allow_list: []
+       enforcement: enforce
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 22 58
+
+   * - Field
+     - Default
+     - Behavior
+   * - ``key``
+     - Required
+     - Kubernetes label key to check. Duplicate policy keys are rejected,
+       and at most 16 keys can be configured.
+   * - ``allow_list``
+     - ``[]``
+     - Exact accepted values. An empty list accepts any well-formed value.
+   * - ``enforcement``
+     - ``off``
+     - ``off`` accepts without policy warnings. ``warn`` accepts but warns
+       when the key is missing or its value is outside a non-empty allow-list.
+       ``enforce`` rejects those violations.
+
+The same policy applies to new submissions, resubmission by ID, restart, and
+validation-only requests. An ``enforcement: enforce`` rejection creates
+neither a workflow row nor a stored specification. Submit responses carry
+warnings from that admission check. Workflow detail responses recompute
+warn-mode violations from the stored labels and current configuration, so the
+displayed status follows policy changes for every workflow status, including
+completed workflows; warnings are not stored with the workflow.
+
+Staged rollout
+--------------
+
+#. Assign a named owner for the key. That owner approves and maintains its
+   allow-list.
+#. Add the key with its final allow-list and ``enforcement: warn``; verify that
+   the configuration loads.
+#. Keep the key at ``enforcement: warn`` for two to four weeks. Monitor warnings,
+   the ``no_label=<key>`` workflow filter, and ``osmo_tasks_count`` as
+   supporting signals.
+#. Measure compliance from the canonical PostgreSQL ``workflows.labels``
+   column. Change the example key and allowed values below to match the policy:
+
+   .. code-block:: sql
+
+      WITH weekly_compliance AS (
+          SELECT
+              date_trunc('week', submit_time) AS week_start,
+              COUNT(*) AS total,
+              COUNT(*) FILTER (
+                  WHERE labels IS NULL
+                     OR NOT (labels ? 'team')
+                     OR labels->>'team' NOT IN ('robotics', 'simulation')
+              ) AS missing_or_invalid
+          FROM workflows
+          WHERE submit_time >= date_trunc('week', CURRENT_TIMESTAMP)
+                                   - INTERVAL '4 weeks'
+            AND submit_time < date_trunc('week', CURRENT_TIMESTAMP)
+          GROUP BY 1
+      )
+      SELECT
+          week_start,
+          total,
+          missing_or_invalid,
+          ROUND(
+              100.0 * missing_or_invalid / NULLIF(total, 0),
+              2
+          ) AS missing_or_invalid_percent
+      FROM weekly_compliance
+      ORDER BY week_start DESC;
+
+#. Change the key to ``enforcement: enforce`` only after the
+   missing-or-invalid rate is below 5% for each of two consecutive complete
+   weeks and the allow-list owner approves enforcement.
+
+PostgreSQL is the authoritative source for rollout compliance measurement;
+warning counts and Prometheus metrics are operational diagnostics. To roll
+back enforcement immediately, use ``enforcement: warn``. To disable both
+warnings and enforcement, use ``enforcement: off`` or remove the policy entry.
+Existing and in-flight workflows are not modified, although their detail-page
+warnings always reflect the current warn policy. In ConfigMap mode, an invalid
+edit is rejected and the previous valid snapshot remains active.
+
+Only configured policy keys become workflow-label dimensions on
+``osmo_tasks_count``. Attribute names start with ``workflow_label_``. Letters
+and numbers are unchanged; ``_``, ``-``, ``.``, and ``/`` are encoded as
+``__``, ``_dash_``, ``_dot_``, and ``_slash_`` respectively. For example,
+``PPP`` is exported as ``workflow_label_PPP``. Values in the configured
+allow-list are exported verbatim; a present value outside that list is clamped
+to ``<other>``, and a missing key is reported as ``<missing>``. An empty
+allow-list therefore exports every present value as ``<other>``. This keeps
+the number of series bounded to the allow-list plus two sentinels per key.
+
+Admission also emits
+``osmo_label_validation_total{key, outcome}``, where ``outcome`` is ``ok``,
+``missing``, ``invalid``, or ``rejected``. The counter covers rejected
+submissions that do not create a workflow row; PostgreSQL remains the
+historical compliance source of truth. Keep the policy list small to control
+metric cardinality. Exporting a Pod label through ``kube_pod_labels`` is a
+separate kube-state-metrics allow-list decision; see
+:ref:`adding_observability`.
 
 Backend Images
 ==============

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -37,6 +37,7 @@ Bitnami
 boto
 botocore
 Ceph
+chargeback
 checkpointing
 Checkpointing
 cli
@@ -266,6 +267,7 @@ resrcs
 restitutions
 retryable
 reusability
+rollout
 ros
 routable
 rpc

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -37,7 +37,6 @@ Bitnami
 boto
 botocore
 Ceph
-chargeback
 checkpointing
 Checkpointing
 cli

--- a/docs/user_guide/workflows/specification/index.rst
+++ b/docs/user_guide/workflows/specification/index.rst
@@ -42,6 +42,16 @@ Workflow
      - ``string``
      - No
      - The pool to submit the workflow to.
+   * - :kbd:`labels`
+     - ``dict[string, string]``
+     - No
+     - Immutable workflow metadata copied to every task Pod. Keys and values use
+       Kubernetes label syntax, values must be non-empty, and a workflow can
+       define at most 16 labels. Reserved and rejected: keys with the
+       ``osmo.`` prefix, all keys in the scheduler-owned ``kai.scheduler/``
+       and ``runai/`` domains, and keys whose DNS prefix is or ends in
+       ``kubernetes.io`` or ``k8s.io`` (for example
+       ``app.kubernetes.io/name``).
    * - :kbd:`timeout`
      - ``dict``
      - No
@@ -58,6 +68,31 @@ Workflow
      - ``list``
      - **Yes** (or :kbd:`tasks`)
      - List of :ref:`group definitions <workflow_spec_group>`.
+
+Workflow labels
+---------------
+
+Labels identify a workflow independently of mutable tags. They are stored with
+the submitted specification and copied only to task Pods, not to Services,
+Secrets, scheduler groups, or other objects.
+
+.. code-block:: yaml
+
+   workflow:
+     name: training
+     labels:
+       team: robotics
+       experiment: run42
+     tasks:
+     - name: train
+       image: ubuntu:24.04
+       command: [bash]
+       args: [-lc, "echo training"]
+
+Your administrator may configure particular keys in ``off``, ``warn``, or
+``enforce`` mode. An accepted workflow can still return a warning while an
+administrator is rolling out a requirement. Use :ref:`workflow_submission` to
+validate and override labels without editing a shared specification.
 
 .. _workflow_spec_task:
 

--- a/docs/user_guide/workflows/specification/index.rst
+++ b/docs/user_guide/workflows/specification/index.rst
@@ -43,14 +43,10 @@ Workflow
      - No
      - The pool to submit the workflow to.
    * - :kbd:`labels`
-     - ``dict[string, string]``
+     - ``dict``
      - No
-     - Immutable workflow metadata copied to every task Pod. Keys and values use
-       Kubernetes label syntax, values must be non-empty, and a workflow can
-       define at most 16 labels. Any syntactically valid key is accepted;
-       where a workflow label collides with a system-owned Pod label (the
-       ``osmo.`` selectors or scheduler queue labels), the system value wins
-       on the Pod.
+     - Immutable workflow metadata copied to every task pod. See
+       :ref:`workflow_spec_labels`.
    * - :kbd:`timeout`
      - ``dict``
      - No
@@ -68,12 +64,18 @@ Workflow
      - **Yes** (or :kbd:`tasks`)
      - List of :ref:`group definitions <workflow_spec_group>`.
 
-Workflow labels
+.. _workflow_spec_labels:
+
+Workflow Labels
 ---------------
 
-Labels identify a workflow independently of mutable tags. They are stored with
-the submitted specification and copied only to task Pods, not to Services,
-Secrets, scheduler groups, or other objects.
+Labels identify a workflow independently of mutable tags. Keys and values use
+Kubernetes label syntax, values must be non-empty, and a workflow can define
+at most 16 labels. Labels are stored with the submitted specification and
+copied only to task pods, not to Services, Secrets, scheduler groups, or
+other objects. Any syntactically valid key is accepted; where a workflow
+label collides with a system-owned pod label (the ``osmo.`` selectors or
+scheduler queue labels), the system value wins on the pod.
 
 .. code-block:: yaml
 
@@ -89,7 +91,7 @@ Secrets, scheduler groups, or other objects.
        args: [-lc, "echo training"]
 
 Your administrator may configure particular keys in ``off``, ``warn``, or
-``enforce`` mode. An accepted workflow can still return a warning while an
+``enforce`` mode. A submission can succeed and still print a warning while an
 administrator is rolling out a requirement. Use :ref:`workflow_submission` to
 validate and override labels without editing a shared specification.
 

--- a/docs/user_guide/workflows/specification/index.rst
+++ b/docs/user_guide/workflows/specification/index.rst
@@ -47,11 +47,10 @@ Workflow
      - No
      - Immutable workflow metadata copied to every task Pod. Keys and values use
        Kubernetes label syntax, values must be non-empty, and a workflow can
-       define at most 16 labels. Reserved and rejected: keys with the
-       ``osmo.`` prefix, all keys in the scheduler-owned ``kai.scheduler/``
-       and ``runai/`` domains, and keys whose DNS prefix is or ends in
-       ``kubernetes.io`` or ``k8s.io`` (for example
-       ``app.kubernetes.io/name``).
+       define at most 16 labels. Any syntactically valid key is accepted;
+       where a workflow label collides with a system-owned Pod label (the
+       ``osmo.`` selectors or scheduler queue labels), the system value wins
+       on the Pod.
    * - :kbd:`timeout`
      - ``dict``
      - No

--- a/docs/user_guide/workflows/submission.rst
+++ b/docs/user_guide/workflows/submission.rst
@@ -179,6 +179,58 @@ Override workflow values at submission time:
        --set-string model_name="bert-base" \
        --set-env WANDB_PROJECT=my-experiment
 
+Set Workflow Labels
+~~~~~~~~~~~~~~~~~~~
+
+Add or override immutable workflow labels with repeatable ``--label key=value``
+flags. A command-line value wins over the same key in the workflow YAML.
+
+.. code-block:: bash
+
+   $ osmo workflow submit training.yaml \
+       --label team=robotics \
+       --label experiment=run42
+
+The same flag works for app submission and resubmission by workflow ID. Restart
+does not accept label overrides because it reuses the stored specification; use
+resubmit when a stored label must change.
+
+Validate labels and any administrator policy without creating a workflow:
+
+.. code-block:: bash
+
+   $ osmo workflow validate training.yaml --label team=robotics
+
+When an ``enforcement: warn`` policy is violated, the accepted submission
+prints a warning that explains the gap, the fix, and the consequence once the
+policy is enforced. An ``enforcement: enforce`` rejection identifies the
+missing key or invalid value. Warning and error messages do not reveal the
+configured allow-list.
+
+Find workflows with an exact label, a glob selector, an alternative selector,
+or a missing key:
+
+.. code-block:: bash
+
+   $ osmo workflow list --label team=robotics --label experiment=run42
+   $ osmo workflow list --label 'PPP=robotics_*'
+   $ osmo workflow list --label 'PPP=(team_*|osmo_*)'
+   $ osmo workflow list --label 'PPP=team_(a|b)'
+   $ osmo workflow list --no-label team
+
+Label selectors are case-sensitive. In a glob selector, ``*`` matches zero or
+more characters; every other character, including ``_``, is literal. A
+parenthesized ``|`` group can appear within a selector and matches any one of
+its alternatives. Alternatives can contain ``*`` wildcards. Groups are flat
+(not nested), each group must contain at least two non-empty alternatives,
+and a selector may expand to at most 32 complete patterns. Quote pattern
+selectors so the shell does not interpret them.
+
+Repeated ``--label`` filters are combined, so every supplied selector must
+match. Alternatives within one selector are combined with OR. Pattern syntax
+applies only to workflow list filters; submission and validation labels must
+still contain exact Kubernetes label values.
+
 Dry Run Validation
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/user_guide/workflows/submission.rst
+++ b/docs/user_guide/workflows/submission.rst
@@ -191,9 +191,10 @@ flags. A command-line value wins over the same key in the workflow YAML.
        --label team=robotics \
        --label experiment=run42
 
-The same flag works for app submission and resubmission by workflow ID. Restart
-does not accept label overrides because it reuses the stored specification; use
-resubmit when a stored label must change.
+The same flag works for app submission and resubmission by workflow ID
+(``osmo workflow submit <workflow-id>``). Restart does not accept label
+overrides because it reuses the stored specification; resubmit the workflow
+when a stored label must change.
 
 Validate labels and any administrator policy without creating a workflow:
 
@@ -201,11 +202,15 @@ Validate labels and any administrator policy without creating a workflow:
 
    $ osmo workflow validate training.yaml --label team=robotics
 
-When an ``enforcement: warn`` policy is violated, the accepted submission
-prints a warning that explains the gap, the fix, and the consequence once the
-policy is enforced. An ``enforcement: enforce`` rejection identifies the
-missing key or invalid value. Warning and error messages do not reveal the
-configured allow-list.
+If a label policy is in warn mode, the submission succeeds but prints a
+``WARNING:`` line explaining what to change before the policy is enforced,
+for example::
+
+   WARNING: Workflow is missing label 'team'; add it now to avoid rejected
+   submissions once it is required.
+
+In enforce mode the submission is rejected and the error identifies the
+missing key or disallowed value.
 
 Find workflows with an exact label, a glob selector, an alternative selector,
 or a missing key:
@@ -213,9 +218,9 @@ or a missing key:
 .. code-block:: bash
 
    $ osmo workflow list --label team=robotics --label experiment=run42
-   $ osmo workflow list --label 'PPP=robotics_*'
-   $ osmo workflow list --label 'PPP=(team_*|osmo_*)'
-   $ osmo workflow list --label 'PPP=team_(a|b)'
+   $ osmo workflow list --label 'project=robotics_*'
+   $ osmo workflow list --label 'project=(sim_*|hil_*)'
+   $ osmo workflow list --label 'team=robotics_(a|b)'
    $ osmo workflow list --no-label team
 
 Label selectors are case-sensitive. In a glob selector, ``*`` matches zero or
@@ -223,11 +228,11 @@ more characters; every other character, including ``_``, is literal. A
 parenthesized ``|`` group can appear within a selector and matches any one of
 its alternatives. Alternatives can contain ``*`` wildcards. Groups are flat
 (not nested), each group must contain at least two non-empty alternatives,
-and a selector may expand to at most 32 complete patterns. Quote pattern
-selectors so the shell does not interpret them.
+and the alternatives in a selector may multiply out to at most 32
+combinations. Quote pattern selectors so the shell does not interpret them.
 
-Repeated ``--label`` filters are combined, so every supplied selector must
-match. Alternatives within one selector are combined with OR. Pattern syntax
+Repeated ``--label`` filters are combined with AND, so every supplied
+selector must match. Alternatives within one selector are combined with OR. Pattern syntax
 applies only to workflow list filters; submission and validation labels must
 still contain exact Kubernetes label values.
 

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -219,6 +219,14 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     'LOW. LOW workflows may be preempted to allow a '
                                     'higher priority workflow to run.',
                                choices=[p.value for p in wf_priority.WorkflowPriority])
+    submit_parser.add_argument(
+        '--label',
+        action='append',
+        dest='labels',
+        default=[],
+        metavar='KEY=VALUE',
+        help='Set a workflow label. Repeat to set multiple labels. Values override labels '
+             'declared by the app.')
     submit_parser.set_defaults(func=_submit_app)
 
 
@@ -511,6 +519,8 @@ def _submit_app(service_client: client.ServiceClient, args: argparse.Namespace):
 
     if args.priority:
         params['priority'] = args.priority
+    if args.labels:
+        params['label'] = args.labels
 
     template_data = workflow.parse_file_for_template(app_spec_result,
                                                      args.set,

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -219,14 +219,13 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     'LOW. LOW workflows may be preempted to allow a '
                                     'higher priority workflow to run.',
                                choices=[p.value for p in wf_priority.WorkflowPriority])
-    submit_parser.add_argument(
-        '--label',
-        action='append',
-        dest='labels',
-        default=[],
-        metavar='KEY=VALUE',
-        help='Set a workflow label. Repeat to set multiple labels. Values override labels '
-             'declared by the app.')
+    submit_parser.add_argument('--label',
+                               action='append',
+                               dest='labels',
+                               default=[],
+                               metavar='KEY=VALUE',
+                               help='Set a workflow label. Repeat to set multiple labels. '
+                                    'Values override labels declared by the app.')
     submit_parser.set_defaults(func=_submit_app)
 
 

--- a/src/cli/tests/BUILD
+++ b/src/cli/tests/BUILD
@@ -29,6 +29,16 @@ py_test(
 )
 
 py_test(
+    name = "test_workflow",
+    srcs = [
+        "test_workflow.py"
+    ],
+    deps = [
+        "//src/cli:cli_lib",
+    ]
+)
+
+py_test(
     name = "test_config_update",
     srcs = [
         "test_config_update.py"

--- a/src/cli/tests/BUILD
+++ b/src/cli/tests/BUILD
@@ -97,13 +97,3 @@ py_test(
         "//src/cli:cli_lib",
     ]
 )
-
-py_test(
-    name = "test_workflow",
-    srcs = [
-        "test_workflow.py"
-    ],
-    deps = [
-        "//src/cli:cli_lib",
-    ]
-)

--- a/src/cli/tests/test_app.py
+++ b/src/cli/tests/test_app.py
@@ -158,6 +158,15 @@ class TestSetupParser(unittest.TestCase):
         self.assertEqual(args.set_string, ['s=foo'])
         self.assertEqual(args.set_env, ['K=V'])
 
+    def test_submit_command_labels(self):
+        parser = self._build_parser()
+        args = parser.parse_args([
+            'app', 'submit', 'my-app',
+            '--label', 'team=alpha', '--label', 'run=42',
+        ])
+
+        self.assertEqual(args.labels, ['team=alpha', 'run=42'])
+
 
 class TestCreateApp(unittest.TestCase):
     """Test cases for _create_app."""
@@ -649,6 +658,7 @@ class TestSubmitApp(unittest.TestCase):
             'local_path': '/some/path',
             'rsync': None,
             'format_type': 'text',
+            'labels': [],
         }
         defaults.update(overrides)
         return argparse.Namespace(**defaults)
@@ -673,6 +683,22 @@ class TestSubmitApp(unittest.TestCase):
         self.assertEqual(params['app_uuid'], 'uuid-1')
         self.assertEqual(params['app_version'], 3)
         self.assertEqual(params['priority'], 'HIGH')
+
+    def test_submit_app_forwards_label_overrides(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        service_client.request.side_effect = [
+            {'uuid': 'uuid-1', 'versions': [{'version': 3}]},
+            'spec-text',
+        ]
+        args = self._make_args(labels=['team=alpha', 'run=42'])
+
+        with mock.patch('src.cli.app.workflow.parse_file_for_template',
+                        return_value='template-data'), \
+             mock.patch('src.cli.app.workflow.submit_workflow_helper') as submit_mock:
+            app._submit_app(service_client, args)
+
+        params = submit_mock.call_args.args[4]
+        self.assertEqual(params['label'], ['team=alpha', 'run=42'])
 
     def test_submit_app_no_pool_fetches_default(self):
         service_client = mock.Mock(spec=client.ServiceClient)

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -66,33 +66,6 @@ class TestWorkflowLabelParser(unittest.TestCase):
         self.assertEqual(args.labels, ['team=alpha', 'run=42'])
         self.assertEqual(args.no_labels, ['project', 'owner'])
 
-    def test_list_accepts_wildcard_and_inline_alternation_label_selectors(self):
-        args = self._build_parser().parse_args([
-            'workflow', 'list',
-            '--label', 'PPP=(team_*|osmo_*)',
-            '--label', 'PPP=team_(a|b)',
-        ])
-
-        self.assertEqual(
-            args.labels,
-            ['PPP=(team_*|osmo_*)', 'PPP=team_(a|b)'],
-        )
-
-    def test_list_help_describes_label_selector_forms(self):
-        output = io.StringIO()
-        with contextlib.redirect_stdout(output), self.assertRaises(
-                SystemExit) as raised:
-            self._build_parser().parse_args(['workflow', 'list', '--help'])
-
-        self.assertEqual(raised.exception.code, 0)
-        normalized_help = ' '.join(output.getvalue().split())
-        self.assertIn('exact value, * wildcards', normalized_help)
-        self.assertIn('PPP=(team_*|osmo_*)', normalized_help)
-        self.assertIn('PPP=team_(a|b)', normalized_help)
-
-
-class TestWorkflowLabelRequests(unittest.TestCase):
-
     def test_fresh_submit_forwards_label_overrides(self):
         service_client = mock.Mock(spec=client.ServiceClient)
         args = argparse.Namespace(

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -16,9 +16,251 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import argparse
+import contextlib
+import io
 import unittest
+from unittest import mock
 
 from src.cli import workflow
+from src.lib.utils import client
+
+
+WARN_MISSING_PROJECT_MESSAGE = (
+    "Workflow is missing label 'project'; add it now to avoid rejected "
+    "submissions once it is required."
+)
+
+
+class TestWorkflowLabelParser(unittest.TestCase):
+
+    def _build_parser(self) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        workflow.setup_parser(subparsers)
+        return parser
+
+    def test_submit_accepts_repeatable_labels(self):
+        args = self._build_parser().parse_args([
+            'workflow', 'submit', 'workflow.yaml',
+            '--label', 'team=alpha', '--label', 'run=42',
+        ])
+
+        self.assertEqual(args.labels, ['team=alpha', 'run=42'])
+
+    def test_validate_accepts_repeatable_labels(self):
+        args = self._build_parser().parse_args([
+            'workflow', 'validate', 'workflow.yaml',
+            '--label', 'team=alpha', '--label', 'run=42',
+        ])
+
+        self.assertEqual(args.labels, ['team=alpha', 'run=42'])
+
+    def test_list_accepts_present_and_missing_label_filters(self):
+        args = self._build_parser().parse_args([
+            'workflow', 'list',
+            '--label', 'team=alpha', '--label', 'run=42',
+            '--no-label', 'project', '--no-label', 'owner',
+        ])
+
+        self.assertEqual(args.labels, ['team=alpha', 'run=42'])
+        self.assertEqual(args.no_labels, ['project', 'owner'])
+
+    def test_list_accepts_wildcard_and_inline_alternation_label_selectors(self):
+        args = self._build_parser().parse_args([
+            'workflow', 'list',
+            '--label', 'PPP=(team_*|osmo_*)',
+            '--label', 'PPP=team_(a|b)',
+        ])
+
+        self.assertEqual(
+            args.labels,
+            ['PPP=(team_*|osmo_*)', 'PPP=team_(a|b)'],
+        )
+
+    def test_list_help_describes_label_selector_forms(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), self.assertRaises(
+                SystemExit) as raised:
+            self._build_parser().parse_args(['workflow', 'list', '--help'])
+
+        self.assertEqual(raised.exception.code, 0)
+        normalized_help = ' '.join(output.getvalue().split())
+        self.assertIn('exact value, * wildcards', normalized_help)
+        self.assertIn('PPP=(team_*|osmo_*)', normalized_help)
+        self.assertIn('PPP=team_(a|b)', normalized_help)
+
+
+class TestWorkflowLabelRequests(unittest.TestCase):
+
+    def test_fresh_submit_forwards_label_overrides(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        args = argparse.Namespace(
+            pool='pool-1',
+            priority=None,
+            workflow_file='workflow.yaml',
+            set=[],
+            set_string=[],
+            labels=['team=alpha', 'run=42'],
+        )
+        template_data = mock.Mock()
+
+        with mock.patch.object(workflow, '_load_wf_file', return_value=template_data), \
+             mock.patch.object(workflow, 'submit_workflow_helper') as submit_helper:
+            workflow._submit_workflow(service_client, args)
+
+        params = submit_helper.call_args.args[4]
+        self.assertEqual(params['label'], ['team=alpha', 'run=42'])
+
+    def test_resubmit_by_id_forwards_label_overrides(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        service_client.request.return_value = {
+            'name': 'new-workflow',
+            'overview': 'https://example/workflows/new-workflow',
+        }
+        args = argparse.Namespace(
+            pool='pool-1',
+            priority=None,
+            workflow_file='parent-12345',
+            set=[],
+            set_string=[],
+            labels=['team=alpha'],
+            dry=False,
+            format_type='json',
+            rsync=None,
+        )
+
+        with mock.patch.object(
+                workflow, '_load_wf_file', side_effect=FileNotFoundError), \
+             mock.patch.object(workflow, 'is_workflow_id', return_value=True), \
+             mock.patch('builtins.print'):
+            workflow._submit_workflow(service_client, args)
+
+        request = service_client.request.call_args
+        self.assertEqual(request.kwargs['params']['workflow_id'], 'parent-12345')
+        self.assertEqual(request.kwargs['params']['label'], ['team=alpha'])
+
+    def test_validate_forwards_label_overrides_and_prints_warnings(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        service_client.request.return_value = {
+            'name': 'workflow',
+            'logs': 'Workflow validation succeeded.',
+            'warnings': [WARN_MISSING_PROJECT_MESSAGE],
+        }
+        template_data = workflow.TemplateData(
+            file='version: 2\nworkflow:\n  name: workflow\n',
+            set_variables=[],
+            set_string_variables=[],
+            is_templated=False,
+        )
+        args = argparse.Namespace(
+            pool='pool-1',
+            workflow_file='workflow.yaml',
+            set=[],
+            set_string=[],
+            labels=['team=alpha'],
+        )
+
+        output = io.StringIO()
+        with mock.patch.object(workflow, '_load_wf_file', return_value=template_data), \
+             mock.patch.object(
+                 workflow, '_load_workflow_text', return_value=template_data.file), \
+             mock.patch.object(workflow, 'load_local_files'), \
+             contextlib.redirect_stdout(output):
+            workflow._validate_workflow(service_client, args)
+
+        request = service_client.request.call_args
+        self.assertEqual(request.kwargs['params']['label'], ['team=alpha'])
+        self.assertIn(
+            f'WARNING: {WARN_MISSING_PROJECT_MESSAGE}',
+            output.getvalue(),
+        )
+
+    def test_list_forwards_label_filters(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        service_client.request.return_value = {'workflows': [], 'more_entries': False}
+        args = argparse.Namespace(
+            user=[],
+            status=None,
+            name=None,
+            order='asc',
+            all_users=False,
+            tags=None,
+            pool=[],
+            app=None,
+            priority=None,
+            labels=[
+                'team=alpha',
+                'PPP=(team_*|osmo_*)',
+                'PPP=team_(a|b)',
+            ],
+            no_labels=['project'],
+            submitted_after=None,
+            submitted_before=None,
+            count=20,
+            offset=0,
+            format_type='json',
+        )
+
+        with mock.patch('builtins.print'):
+            workflow._list_workflows(service_client, args)
+
+        params = service_client.request.call_args.kwargs['params']
+        self.assertEqual(
+            params['label'],
+            [
+                'team=alpha',
+                'PPP=(team_*|osmo_*)',
+                'PPP=team_(a|b)',
+            ])
+        self.assertEqual(params['no_label'], ['project'])
+
+
+class TestWorkflowLabelOutput(unittest.TestCase):
+
+    def test_submission_text_prints_server_warnings(self):
+        result = {
+            'name': 'workflow-1',
+            'overview': 'https://example/workflows/workflow-1',
+            'warnings': [WARN_MISSING_PROJECT_MESSAGE],
+        }
+        args = argparse.Namespace(format_type='text', priority=None)
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            workflow.print_submission_results(result, args)
+
+        self.assertIn(
+            f'WARNING: {WARN_MISSING_PROJECT_MESSAGE}',
+            output.getvalue(),
+        )
+
+    def test_workflow_table_displays_sorted_generic_labels(self):
+        table = workflow._workflow_table_generator({
+            'user': 'user',
+            'name': 'workflow-1',
+            'submit_time': '2026-01-01T00:00:00',
+            'status': 'RUNNING',
+            'priority': 'NORMAL',
+            'labels': {'zeta': 'last', 'alpha': 'first'},
+            'overview': 'https://example/workflows/workflow-1',
+        })
+
+        rendered = table.draw()
+        self.assertIn('Labels', rendered)
+        self.assertIn('alpha=first, zeta=last', rendered)
+
+    def test_workflow_table_tolerates_older_response_without_labels(self):
+        table = workflow._workflow_table_generator({
+            'user': 'user',
+            'name': 'workflow-1',
+            'submit_time': '2026-01-01T00:00:00',
+            'status': 'RUNNING',
+            'priority': 'NORMAL',
+            'overview': 'https://example/workflows/workflow-1',
+        })
+
+        self.assertIn('Labels', table.draw())
 
 
 class WorkflowTemplateDetectionTest(unittest.TestCase):

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -33,6 +33,7 @@ WARN_MISSING_PROJECT_MESSAGE = (
 
 
 class TestWorkflowLabelParser(unittest.TestCase):
+    """Label flag parsing and forwarding for submit, validate, and list."""
 
     def _build_parser(self) -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser()
@@ -164,8 +165,8 @@ class TestWorkflowLabelParser(unittest.TestCase):
             priority=None,
             labels=[
                 'team=alpha',
-                'PPP=(team_*|osmo_*)',
-                'PPP=team_(a|b)',
+                'project=(sim_*|hil_*)',
+                'team=robotics_(a|b)',
             ],
             no_labels=['project'],
             submitted_after=None,
@@ -183,13 +184,14 @@ class TestWorkflowLabelParser(unittest.TestCase):
             params['label'],
             [
                 'team=alpha',
-                'PPP=(team_*|osmo_*)',
-                'PPP=team_(a|b)',
+                'project=(sim_*|hil_*)',
+                'team=robotics_(a|b)',
             ])
         self.assertEqual(params['no_label'], ['project'])
 
 
 class TestWorkflowLabelOutput(unittest.TestCase):
+    """Label rendering in list tables, query output, and warning lines."""
 
     def test_submission_text_prints_server_warnings(self):
         result = {

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -1034,13 +1034,13 @@ def _workflow_table_generator(workflow: Any, table: texttable.Texttable | None =
         table.set_cols_dtype(['t' for _ in range(len(keys))])
     row = []
     for key in keys:
-        value = workflow.get(key_mapping[key], {} if key == 'Labels' else '-')
+        value = workflow.get(key_mapping[key], '-')
         if key == 'Submit Time':
             value = common.convert_utc_datetime_to_user_zone(value)
         elif key == 'Overview':
             value = f'{value}' if value else '-'
         elif key == 'Labels':
-            value = _format_labels(value)
+            value = _format_labels(workflow.get('labels'))
         row.append(value)
     table.add_row(row)
     return table

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -147,14 +147,13 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     'LOW. LOW workflows may be preempted to allow a '
                                     'higher priority workflow to run.',
                                choices=[p.value for p in wf_priority.WorkflowPriority])
-    submit_parser.add_argument(
-        '--label',
-        action='append',
-        dest='labels',
-        default=[],
-        metavar='KEY=VALUE',
-        help='Set a workflow label. Repeat to set multiple labels. Values override labels '
-             'declared in the workflow file.')
+    submit_parser.add_argument('--label',
+                               action='append',
+                               dest='labels',
+                               default=[],
+                               metavar='KEY=VALUE',
+                               help='Set a workflow label. Repeat to set multiple labels. '
+                                    'Values override labels declared in the workflow file.')
     submit_parser.set_defaults(func=_submit_workflow)
 
     # Handle 'restart' command
@@ -201,13 +200,14 @@ def setup_parser(parser: argparse._SubParsersAction):
                                  help='The target pool to run the workflow with. If no pool is '
                                       'specified, the default pool assigned in the profile will '
                                       'be used.')
-    validate_parser.add_argument(
-        '--label',
-        action='append',
-        dest='labels',
-        default=[],
-        metavar='KEY=VALUE',
-        help='Set a workflow label for validation. Repeat to set multiple labels.')
+    validate_parser.add_argument('--label',
+                                 action='append',
+                                 dest='labels',
+                                 default=[],
+                                 metavar='KEY=VALUE',
+                                 help='Set a workflow label for validation. Repeat to set '
+                                      'multiple labels. Values override labels declared in '
+                                      'the workflow file.')
     validate_parser.set_defaults(func=_validate_workflow)
 
     # Handle 'logs' command
@@ -339,23 +339,22 @@ def setup_parser(parser: argparse._SubParsersAction):
                              nargs='+',
                              choices=[p.value for p in wf_priority.WorkflowPriority],
                              help='Filter workflows by priority levels.')
-    list_parser.add_argument(
-        '--label',
-        action='append',
-        dest='labels',
-        default=[],
-        metavar='KEY=SELECTOR',
-        help=(
-            'Filter by an exact value, * wildcards, or (VALUE|VALUE) alternatives within a '
-            'selector, such as PPP=(team_*|osmo_*) or PPP=team_(a|b). '
-            'Repeat to require all selectors.'))
-    list_parser.add_argument(
-        '--no-label',
-        action='append',
-        dest='no_labels',
-        default=[],
-        metavar='KEY',
-        help='Filter for workflows without this label key. Repeat to require all keys missing.')
+    list_parser.add_argument('--label',
+                             action='append',
+                             dest='labels',
+                             default=[],
+                             metavar='KEY=SELECTOR',
+                             help='Filter for workflows whose label matches KEY=SELECTOR: '
+                                  'an exact value, * wildcards, or (VALUE|VALUE) '
+                                  'alternatives, such as project=(sim_*|hil_*) or '
+                                  'team=robotics_(a|b). Repeat to require all selectors.')
+    list_parser.add_argument('--no-label',
+                             action='append',
+                             dest='no_labels',
+                             default=[],
+                             metavar='KEY',
+                             help='Filter for workflows without this label key. Repeat to '
+                                  'require every listed key to be absent.')
     group = list_parser.add_mutually_exclusive_group()
     group.add_argument('--user', '-u',
                        nargs='+',

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -147,6 +147,14 @@ def setup_parser(parser: argparse._SubParsersAction):
                                     'LOW. LOW workflows may be preempted to allow a '
                                     'higher priority workflow to run.',
                                choices=[p.value for p in wf_priority.WorkflowPriority])
+    submit_parser.add_argument(
+        '--label',
+        action='append',
+        dest='labels',
+        default=[],
+        metavar='KEY=VALUE',
+        help='Set a workflow label. Repeat to set multiple labels. Values override labels '
+             'declared in the workflow file.')
     submit_parser.set_defaults(func=_submit_workflow)
 
     # Handle 'restart' command
@@ -193,6 +201,13 @@ def setup_parser(parser: argparse._SubParsersAction):
                                  help='The target pool to run the workflow with. If no pool is '
                                       'specified, the default pool assigned in the profile will '
                                       'be used.')
+    validate_parser.add_argument(
+        '--label',
+        action='append',
+        dest='labels',
+        default=[],
+        metavar='KEY=VALUE',
+        help='Set a workflow label for validation. Repeat to set multiple labels.')
     validate_parser.set_defaults(func=_validate_workflow)
 
     # Handle 'logs' command
@@ -324,6 +339,23 @@ def setup_parser(parser: argparse._SubParsersAction):
                              nargs='+',
                              choices=[p.value for p in wf_priority.WorkflowPriority],
                              help='Filter workflows by priority levels.')
+    list_parser.add_argument(
+        '--label',
+        action='append',
+        dest='labels',
+        default=[],
+        metavar='KEY=SELECTOR',
+        help=(
+            'Filter by an exact value, * wildcards, or (VALUE|VALUE) alternatives within a '
+            'selector, such as PPP=(team_*|osmo_*) or PPP=team_(a|b). '
+            'Repeat to require all selectors.'))
+    list_parser.add_argument(
+        '--no-label',
+        action='append',
+        dest='no_labels',
+        default=[],
+        metavar='KEY',
+        help='Filter for workflows without this label key. Repeat to require all keys missing.')
     group = list_parser.add_mutually_exclusive_group()
     group.add_argument('--user', '-u',
                        nargs='+',
@@ -679,6 +711,8 @@ def print_submission_results(result, args: argparse.Namespace, parent_workflow_i
         dashboard_url = result.get('dashboard_url')
         if dashboard_url is not None:
             print(f'Workflow Dashboard - {result['dashboard_url']}')
+        for warning in result.get('warnings', []):
+            print(f'WARNING: {warning}')
         priority = wf_priority.WorkflowPriority(args.priority) \
             if hasattr(args, 'priority') and args.priority else wf_priority.WorkflowPriority.NORMAL
         if priority.preemptible:
@@ -693,6 +727,8 @@ def _submit_workflow(service_client: client.ServiceClient, args: argparse.Namesp
     params = {}
     if args.priority:
         params['priority'] = args.priority
+    if args.labels:
+        params['label'] = args.labels
     try:
         workflow_path = os.path.abspath(args.workflow_file)
         template_dict = _load_wf_file(workflow_path, args.set, args.set_string)
@@ -843,6 +879,8 @@ def _validate_workflow(service_client: client.ServiceClient, args: argparse.Name
 
     template_dict = template_data.to_dict()
     params = {'validation_only': True}
+    if args.labels:
+        params['label'] = args.labels
     if template_data.is_templated:
         params['dry_run'] = True
         result = service_client.request(
@@ -864,6 +902,8 @@ def _validate_workflow(service_client: client.ServiceClient, args: argparse.Name
         payload=template_dict,
         params=params)
     print(f'{result['logs']}')
+    for warning in result.get('warnings', []):
+        print(f'WARNING: {warning}')
 
 
 def _workflow_logs(service_client: client.ServiceClient, args: argparse.Namespace):
@@ -966,6 +1006,13 @@ def _get_tasks_from_workflow(workflow: Any) -> list:
     return tasks_result
 
 
+def _format_labels(labels: Dict[str, str] | None) -> str:
+    """Format a workflow labels map as sorted key=value pairs, or '-' if empty."""
+    return ', '.join(
+        f'{label_key}={label_value}'
+        for label_key, label_value in sorted((labels or {}).items())) or '-'
+
+
 def _workflow_table_generator(workflow: Any, table: texttable.Texttable | None = None)\
                               -> texttable.Texttable:
     """Generates a table row for a given workflow.
@@ -979,6 +1026,7 @@ def _workflow_table_generator(workflow: Any, table: texttable.Texttable | None =
                   'Submit Time': 'submit_time',
                   'Status': 'status',
                   'Priority': 'priority',
+                  'Labels': 'labels',
                   'Overview': 'overview'}
     keys = list(key_mapping.keys())
     if not table:
@@ -986,11 +1034,13 @@ def _workflow_table_generator(workflow: Any, table: texttable.Texttable | None =
         table.set_cols_dtype(['t' for _ in range(len(keys))])
     row = []
     for key in keys:
-        value = workflow.get(key_mapping[key], '-')
+        value = workflow.get(key_mapping[key], {} if key == 'Labels' else '-')
         if key == 'Submit Time':
             value = common.convert_utc_datetime_to_user_zone(value)
         elif key == 'Overview':
             value = f'{value}' if value else '-'
+        elif key == 'Labels':
+            value = _format_labels(value)
         row.append(value)
     table.add_row(row)
     return table
@@ -1010,11 +1060,13 @@ def _query_workflow(service_client: client.ServiceClient, args: argparse.Namespa
                                                                                     '-'))
         status, user = workflow_result['status'], workflow_result['submitted_by']
         overview = workflow_result['overview']
+        labels = _format_labels(workflow_result.get('labels'))
         print('--------------------------------------------------------------------\n'
               f'\nWorkflow ID : {args.workflow_id}'
               f'\nStatus      : {status}'
               f'\nUser        : {user}'
               f'\nSubmit Time : {submit_time}'
+              f'\nLabels      : {labels}'
               f'\nOverview    : {overview}\n')
         keys = ['Task Name', 'Start Time', 'Status']
         if args.verbose:
@@ -1056,6 +1108,10 @@ def _list_workflows(service_client: client.ServiceClient, args: argparse.Namespa
         params['app'] = args.app
     if args.priority:
         params['priority'] = args.priority
+    if args.labels:
+        params['label'] = args.labels
+    if args.no_labels:
+        params['no_label'] = args.no_labels
 
     if args.submitted_after:
         params['submitted_after'] = common.convert_timezone(f'{args.submitted_after}T00:00:00')


### PR DESCRIPTION
## Summary

Issue - None

[OSMO-6501] Track B7 of the workflow-labels PR split.

- `osmo workflow submit --label KEY=VALUE` (repeatable; overrides the YAML per run), same flag on `osmo app submit` and `osmo workflow validate` for pre-flight checks.
- `osmo workflow list --label KEY=SELECTOR` (exact, `*` wildcard, `(a|b)` alternation) and `--no-label KEY` filters; a Labels column in list output; a Labels line on `workflow query`.
- Warn-mode policy messages print as `WARNING:` lines after submit and validate.
- User docs: labels in the workflow spec reference, submit flags and enforcement behavior in the submission guide, and the `labels_config` admin reference in the deployment guide.

Depends on #1223 and #1224. Extracted from prototype #1194.

## Testing

- `bazel test //src/cli/tests:test_workflow //src/cli/tests:test_app` (flag parsing, param forwarding, warning output, label column formatting)
- Docs build runs in CI (docs-build job).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow labels with configurable validation and enforcement policies.
  * Added repeatable `--label` options for submitting and validating workflows and apps.
  * Added label-based workflow filtering with `--label` and `--no-label`.
  * Workflow listings and submission results now display labels and validation warnings.

* **Documentation**
  * Added guidance for label syntax, limits, propagation, selectors, enforcement modes, and resubmission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->