### PR TITLE
Add bounded workflow label metrics dimensions

### DIFF
--- a/docs/deployment_guide/dashboards/BUILD
+++ b/docs/deployment_guide/dashboards/BUILD
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load("//bzl:py.bzl", "osmo_py_test")
+
+osmo_py_test(
+    name = "test_dashboards",
+    srcs = ["test_dashboards.py"],
+    data = ["workflow_resources_usage.json"],
+)

--- a/docs/deployment_guide/dashboards/test_dashboards.py
+++ b/docs/deployment_guide/dashboards/test_dashboards.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structural checks for the Grafana dashboard JSON definitions."""
+
+import json
+import pathlib
+import unittest
+from typing import Any
+
+
+DASHBOARD_DIRECTORY = pathlib.Path(__file__).parent
+
+
+def _load_dashboard(filename: str) -> dict[str, Any]:
+    with (DASHBOARD_DIRECTORY / filename).open(encoding='utf-8') as dashboard_file:
+        return json.load(dashboard_file)
+
+
+def _variables(dashboard: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        variable['name']: variable
+        for variable in dashboard.get('templating', {}).get('list', [])
+    }
+
+
+def _query(variable: dict[str, Any]) -> str:
+    query = variable.get('query', '')
+    return query.get('query', '') if isinstance(query, dict) else query
+
+
+class WorkflowResourcesDashboardTest(unittest.TestCase):
+    """The OSS workflow dashboard remains deployment-neutral."""
+
+    dashboard: dict[str, Any]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.dashboard = _load_dashboard('workflow_resources_usage.json')
+
+    def test_preserves_workflow_resource_panels(self):
+        panel_titles = {panel['title'] for panel in self.dashboard['panels']}
+        self.assertTrue({
+            'CPU Usage',
+            'Memory Usage',
+            'Disk Usage',
+            'GPU Utilization',
+            'GPU Memory Usage',
+            'GPU Node Conditions',
+            'GPU Usage',
+            'GPU Throttle',
+        }.issubset(panel_titles))
+
+    def test_workflow_selector_is_not_bound_to_ppp(self):
+        variables = _variables(self.dashboard)
+        self.assertNotIn('PPP', variables)
+        uuid_query = _query(variables['uuid'])
+        self.assertIn('kube_pod_info', uuid_query)
+        self.assertNotIn('label_PPP', uuid_query)
+
+    def test_panel_ids_are_unique(self):
+        panel_ids = [panel['id'] for panel in self.dashboard['panels']]
+        self.assertEqual(len(panel_ids), len(set(panel_ids)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/deployment_guide/dashboards/test_dashboards.py
+++ b/docs/deployment_guide/dashboards/test_dashboards.py
@@ -51,25 +51,15 @@ class WorkflowResourcesDashboardTest(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.dashboard = _load_dashboard('workflow_resources_usage.json')
 
-    def test_preserves_workflow_resource_panels(self):
-        panel_titles = {panel['title'] for panel in self.dashboard['panels']}
-        self.assertTrue({
-            'CPU Usage',
-            'Memory Usage',
-            'Disk Usage',
-            'GPU Utilization',
-            'GPU Memory Usage',
-            'GPU Node Conditions',
-            'GPU Usage',
-            'GPU Throttle',
-        }.issubset(panel_titles))
+    def test_has_workflow_resource_panels(self):
+        self.assertGreaterEqual(len(self.dashboard['panels']), 8)
 
-    def test_workflow_selector_is_not_bound_to_ppp(self):
+    def test_dashboard_is_deployment_neutral(self):
         variables = _variables(self.dashboard)
         self.assertNotIn('PPP', variables)
         uuid_query = _query(variables['uuid'])
         self.assertIn('kube_pod_info', uuid_query)
-        self.assertNotIn('label_PPP', uuid_query)
+        self.assertNotIn('label_PPP', json.dumps(self.dashboard))
 
     def test_panel_ids_are_unique(self):
         panel_ids = [panel['id'] for panel in self.dashboard['panels']]

--- a/docs/deployment_guide/dashboards/test_dashboards.py
+++ b/docs/deployment_guide/dashboards/test_dashboards.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,12 +38,14 @@ def _variables(dashboard: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
 
 def _query(variable: dict[str, Any]) -> str:
+    # Grafana stores template-variable queries as either a raw string or a
+    # {query: ...} object depending on the dashboard schema version.
     query = variable.get('query', '')
     return query.get('query', '') if isinstance(query, dict) else query
 
 
 class WorkflowResourcesDashboardTest(unittest.TestCase):
-    """The OSS workflow dashboard remains deployment-neutral."""
+    """Structural and deployment-neutrality checks for the OSS dashboard."""
 
     dashboard: dict[str, Any]
 
@@ -52,6 +54,7 @@ class WorkflowResourcesDashboardTest(unittest.TestCase):
         cls.dashboard = _load_dashboard('workflow_resources_usage.json')
 
     def test_has_workflow_resource_panels(self):
+        # Floor, not an exact count: panels may be added freely.
         self.assertGreaterEqual(len(self.dashboard['panels']), 8)
 
     def test_dashboard_is_deployment_neutral(self):

--- a/docs/deployment_guide/dashboards/test_dashboards.py
+++ b/docs/deployment_guide/dashboards/test_dashboards.py
@@ -59,10 +59,10 @@ class WorkflowResourcesDashboardTest(unittest.TestCase):
 
     def test_dashboard_is_deployment_neutral(self):
         variables = _variables(self.dashboard)
-        self.assertNotIn('PPP', variables)
+        self.assertNotIn('project', variables)
         uuid_query = _query(variables['uuid'])
         self.assertIn('kube_pod_info', uuid_query)
-        self.assertNotIn('label_PPP', json.dumps(self.dashboard))
+        self.assertNotIn('label_project', json.dumps(self.dashboard))
 
     def test_panel_ids_are_unique(self):
         panel_ids = [panel['id'] for panel in self.dashboard['panels']]

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -310,7 +310,17 @@ Existing and in-flight workflows are not modified, although their detail-page
 warnings always reflect the current warn policy. In ConfigMap mode, an invalid
 edit is rejected and the previous valid snapshot remains active.
 
-Admission emits
+Only configured policy keys become workflow-label dimensions on
+``osmo_tasks_count``. Attribute names start with ``workflow_label_``. Letters
+and numbers are unchanged; ``_``, ``-``, ``.``, and ``/`` are encoded as
+``__``, ``_dash_``, ``_dot_``, and ``_slash_`` respectively. For example,
+``PPP`` is exported as ``workflow_label_PPP``. Values in the configured
+allow-list are exported verbatim; a present value outside that list is clamped
+to ``<other>``, and a missing key is reported as ``<missing>``. An empty
+allow-list therefore exports every present value as ``<other>``. This keeps
+the number of series bounded to the allow-list plus two sentinels per key.
+
+Admission also emits
 ``osmo_label_validation_total{key, outcome}``, where ``outcome`` is ``ok``,
 ``missing``, ``invalid``, or ``rejected``. The counter covers rejected
 submissions that do not create a workflow row. Keep the policy list small to

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -314,7 +314,7 @@ Only configured policy keys become workflow-label dimensions on
 ``osmo_tasks_count``. Attribute names start with ``workflow_label_``. Letters
 and numbers are unchanged; ``_``, ``-``, ``.``, and ``/`` are encoded as
 ``__``, ``_dash_``, ``_dot_``, and ``_slash_`` respectively. For example,
-``PPP`` is exported as ``workflow_label_PPP``. Values in the configured
+``project`` is exported as ``workflow_label_project``. Values in the configured
 allow-list are exported verbatim; a present value outside that list is clamped
 to ``<other>``, and a missing key is reported as ``<missing>``. Angle
 brackets are not valid in label values, so the sentinels never collide with

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -316,9 +316,11 @@ and numbers are unchanged; ``_``, ``-``, ``.``, and ``/`` are encoded as
 ``__``, ``_dash_``, ``_dot_``, and ``_slash_`` respectively. For example,
 ``PPP`` is exported as ``workflow_label_PPP``. Values in the configured
 allow-list are exported verbatim; a present value outside that list is clamped
-to ``<other>``, and a missing key is reported as ``<missing>``. An empty
-allow-list therefore exports every present value as ``<other>``. This keeps
-the number of series bounded to the allow-list plus two sentinels per key.
+to ``<other>``, and a missing key is reported as ``<missing>``. Angle
+brackets are not valid in label values, so the sentinels never collide with
+real values. An empty allow-list exports every present value as ``<other>``.
+This keeps the number of series bounded to the allow-list plus two sentinels
+per key.
 
 Admission also emits
 ``osmo_label_validation_total{key, outcome}``, where ``outcome`` is ``ok``,

--- a/src/service/core/workflow/helpers.py
+++ b/src/service/core/workflow/helpers.py
@@ -531,7 +531,8 @@ def get_recent_tasks(database: connectors.PostgresConnector,
         minutes_ago: How many minutes back to look for completed tasks
 
     Returns:
-        List of task records with task and workflow information
+        Aggregated task-count rows grouped by pool, user, workflow, task
+        status, and the workflow's labels
     """
     now = datetime.datetime.now(datetime.timezone.utc)
     cutoff_time = now - datetime.timedelta(minutes=minutes_ago)

--- a/src/service/core/workflow/helpers.py
+++ b/src/service/core/workflow/helpers.py
@@ -542,7 +542,9 @@ def get_recent_tasks(database: connectors.PostgresConnector,
         w.pool AS pool,
         w.submitted_by AS user,
         w.workflow_uuid AS workflow_uuid,
-        t.status AS status
+        t.status AS status,
+        w.labels AS labels,
+        COUNT(*) AS count
     FROM
         tasks t
     JOIN
@@ -551,7 +553,7 @@ def get_recent_tasks(database: connectors.PostgresConnector,
         (t.end_time is NULL
             AND w.status IN ('WAITING', 'PENDING', 'RUNNING'))
         OR t.end_time > %s
-    GROUP BY w.pool, w.submitted_by, t.status, w.workflow_uuid
+    GROUP BY w.pool, w.submitted_by, w.workflow_uuid, t.status, w.labels
     """
 
     return database.execute_fetch_command(query, (cutoff_time,), True)

--- a/src/service/core/workflow/tests/BUILD
+++ b/src/service/core/workflow/tests/BUILD
@@ -104,3 +104,13 @@ osmo_py_test(
     ],
     tags = ["requires-network"],
 )
+
+py_test(
+    name = "test_workflow_metrics",
+    srcs = ["test_workflow_metrics.py"],
+    deps = [
+        "//src/service/core/workflow",
+        "//src/utils/connectors",
+        "//src/utils/metrics",
+    ],
+)

--- a/src/service/core/workflow/tests/test_helpers.py
+++ b/src/service/core/workflow/tests/test_helpers.py
@@ -595,6 +595,19 @@ class TestGetRouterCookieSuccess(unittest.TestCase):
 
 class TestGetRecentTasks(unittest.TestCase):
 
+    def test_get_recent_tasks_selects_labels_and_count(self):
+        database = mock.Mock()
+        database.execute_fetch_command.return_value = []
+
+        helpers.get_recent_tasks(database, minutes_ago=5)
+
+        query = database.execute_fetch_command.call_args.args[0]
+        self.assertIn('w.labels AS labels', query)
+        self.assertIn('COUNT(*) AS count', query)
+        self.assertIn(
+            'GROUP BY w.pool, w.submitted_by, w.workflow_uuid, t.status, w.labels',
+            query)
+
     def test_get_recent_tasks_passes_cutoff_time_to_database(self):
         database = mock.Mock()
         database.execute_fetch_command.return_value = []

--- a/src/service/core/workflow/tests/test_helpers.py
+++ b/src/service/core/workflow/tests/test_helpers.py
@@ -604,9 +604,8 @@ class TestGetRecentTasks(unittest.TestCase):
         query = database.execute_fetch_command.call_args.args[0]
         self.assertIn('w.labels AS labels', query)
         self.assertIn('COUNT(*) AS count', query)
-        self.assertIn(
-            'GROUP BY w.pool, w.submitted_by, w.workflow_uuid, t.status, w.labels',
-            query)
+        group_by_clause = query[query.index('GROUP BY'):]
+        self.assertIn('w.labels', group_by_clause)
 
     def test_get_recent_tasks_passes_cutoff_time_to_database(self):
         database = mock.Mock()

--- a/src/service/core/workflow/tests/test_workflow_metrics.py
+++ b/src/service/core/workflow/tests/test_workflow_metrics.py
@@ -70,7 +70,7 @@ class GetTaskMetricsTest(unittest.TestCase):
                 'workflow_uuid': 'workflow-1',
                 'status': 'RUNNING',
                 'labels': {
-                    'PPP': 'project-a',
+                    'project': 'project-a',
                     'cost-center': 'center-1',
                     'experiment': 'first',
                 },
@@ -82,7 +82,7 @@ class GetTaskMetricsTest(unittest.TestCase):
                 'workflow_uuid': 'workflow-1',
                 'status': 'RUNNING',
                 'labels': {
-                    'PPP': 'project-a',
+                    'project': 'project-a',
                     'cost-center': 'center-1',
                     'experiment': 'second',
                 },
@@ -93,7 +93,7 @@ class GetTaskMetricsTest(unittest.TestCase):
                 'user': 'alice',
                 'workflow_uuid': 'workflow-1',
                 'status': 'RUNNING',
-                'labels': {'PPP': 'project-a'},
+                'labels': {'project': 'project-a'},
                 'count': 4,
             },
             {
@@ -117,13 +117,13 @@ class GetTaskMetricsTest(unittest.TestCase):
                 'user': 'alice',
                 'workflow_uuid': 'workflow-1',
                 'status': 'RUNNING',
-                'labels': {'PPP': 'unattributed'},
+                'labels': {'project': 'unattributed'},
                 'count': 6,
             },
         ]
         database = mock.Mock()
         database.get_workflow_configs.return_value = _workflow_config({
-            'PPP': ['project-a'],
+            'project': ['project-a'],
             'cost-center': ['center-1'],
         })
 
@@ -138,7 +138,7 @@ class GetTaskMetricsTest(unittest.TestCase):
             if attributes is None:
                 self.fail('Task metric observation is missing attributes.')
             counts[(
-                attributes['workflow_label_PPP'],
+                attributes['workflow_label_project'],
                 attributes['workflow_label_cost_dash_center'],
             )] = observation.value
             self.assertEqual(attributes['pool'], 'pool-a')
@@ -153,11 +153,11 @@ class GetTaskMetricsTest(unittest.TestCase):
         })
 
     def test_empty_allow_list_clamps_all_present_values_to_other(self):
-        label_policy = connectors.LabelPolicy(key='PPP')
+        label_policy = connectors.LabelPolicy(key='project')
 
         metric_value = workflow_metrics._workflow_label_metric_value  # pylint: disable=protected-access
         self.assertEqual(
-            metric_value({'PPP': 'arbitrary'}, label_policy), '<other>')
+            metric_value({'project': 'arbitrary'}, label_policy), '<other>')
         self.assertEqual(metric_value({}, label_policy), '<missing>')
 
     def test_policy_label_attributes_cannot_overwrite_or_sanitize_to_same_name(self):
@@ -229,13 +229,13 @@ class GetTaskMetricsTest(unittest.TestCase):
 
     def test_cache_is_reused_until_30_second_ttl_expires(self):
         database = mock.Mock()
-        database.get_workflow_configs.return_value = _workflow_config({'PPP': ['project-a']})
+        database.get_workflow_configs.return_value = _workflow_config({'project': ['project-a']})
         first_rows = [{
             'pool': 'pool-a',
             'user': 'alice',
             'workflow_uuid': 'workflow-1',
             'status': 'RUNNING',
-            'labels': {'PPP': 'project-a'},
+            'labels': {'project': 'project-a'},
             'count': 2,
         }]
         refreshed_rows = [{

--- a/src/service/core/workflow/tests/test_workflow_metrics.py
+++ b/src/service/core/workflow/tests/test_workflow_metrics.py
@@ -155,16 +155,10 @@ class GetTaskMetricsTest(unittest.TestCase):
     def test_empty_allow_list_clamps_all_present_values_to_other(self):
         label_policy = connectors.LabelPolicy(key='PPP')
 
+        metric_value = workflow_metrics._workflow_label_metric_value  # pylint: disable=protected-access
         self.assertEqual(
-            workflow_metrics._workflow_label_metric_value(
-                {'PPP': 'arbitrary'}, label_policy,
-            ),
-            '<other>',
-        )
-        self.assertEqual(
-            workflow_metrics._workflow_label_metric_value({}, label_policy),
-            '<missing>',
-        )
+            metric_value({'PPP': 'arbitrary'}, label_policy), '<other>')
+        self.assertEqual(metric_value({}, label_policy), '<missing>')
 
     def test_policy_label_attributes_cannot_overwrite_or_sanitize_to_same_name(self):
         database = mock.Mock()

--- a/src/service/core/workflow/tests/test_workflow_metrics.py
+++ b/src/service/core/workflow/tests/test_workflow_metrics.py
@@ -1,0 +1,309 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import os
+import types
+import unittest
+from unittest import mock
+
+from src.service.core.workflow import workflow_metrics
+from src.utils import connectors
+
+
+def _workflow_config(
+        policy_allow_lists: dict[str, list[str]] | None = None,
+) -> types.SimpleNamespace:
+    policy_allow_lists = policy_allow_lists if policy_allow_lists is not None else {}
+    policy = [
+        connectors.LabelPolicy(key=key, allow_list=allow_list)
+        for key, allow_list in policy_allow_lists.items()
+    ]
+    return types.SimpleNamespace(
+        labels_config=types.SimpleNamespace(policy=policy)
+    )
+
+
+class GetTaskMetricsTest(unittest.TestCase):
+    """Task counts are projected onto configured attribution dimensions."""
+
+    def setUp(self):
+        self._disable_metrics = os.environ.pop('OSMO_DISABLE_TASK_METRICS', None)
+        workflow_metrics._metric_cache.clear()  # pylint: disable=protected-access
+        workflow_metrics._last_refresh_time = 0  # pylint: disable=protected-access
+
+    def tearDown(self):
+        if self._disable_metrics is None:
+            os.environ.pop('OSMO_DISABLE_TASK_METRICS', None)
+        else:
+            os.environ['OSMO_DISABLE_TASK_METRICS'] = self._disable_metrics
+        workflow_metrics._metric_cache.clear()  # pylint: disable=protected-access
+        workflow_metrics._last_refresh_time = 0  # pylint: disable=protected-access
+
+    def test_sums_database_counts_and_collapses_non_policy_labels(self):
+        rows = [
+            {
+                'pool': 'pool-a',
+                'user': 'alice',
+                'workflow_uuid': 'workflow-1',
+                'status': 'RUNNING',
+                'labels': {
+                    'PPP': 'project-a',
+                    'cost-center': 'center-1',
+                    'experiment': 'first',
+                },
+                'count': 2,
+            },
+            {
+                'pool': 'pool-a',
+                'user': 'alice',
+                'workflow_uuid': 'workflow-1',
+                'status': 'RUNNING',
+                'labels': (
+                    '{"PPP":"project-a","cost-center":"center-1",'
+                    '"experiment":"second"}'
+                ),
+                'count': 3,
+            },
+            {
+                'pool': 'pool-a',
+                'user': 'alice',
+                'workflow_uuid': 'workflow-1',
+                'status': 'RUNNING',
+                'labels': '{"PPP":"project-a"}',
+                'count': 4,
+            },
+            {
+                'pool': 'pool-a',
+                'user': 'alice',
+                'workflow_uuid': 'workflow-1',
+                'status': 'RUNNING',
+                'labels': None,
+                'count': 1,
+            },
+            {
+                'pool': 'pool-a',
+                'user': 'alice',
+                'workflow_uuid': 'workflow-1',
+                'status': 'RUNNING',
+                'labels': 'not-json',
+                'count': 2,
+            },
+            {
+                'pool': 'pool-a',
+                'user': 'alice',
+                'workflow_uuid': 'workflow-1',
+                'status': 'RUNNING',
+                'labels': {'PPP': 'unattributed'},
+                'count': 6,
+            },
+        ]
+        database = mock.Mock()
+        database.get_workflow_configs.return_value = _workflow_config({
+            'PPP': ['project-a'],
+            'cost-center': ['center-1'],
+        })
+
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance', return_value=database
+        ), mock.patch.object(
+            workflow_metrics.helpers, 'get_recent_tasks', return_value=rows
+        ), mock.patch.object(
+            workflow_metrics.time, 'time', return_value=100
+        ):
+            observations = list(workflow_metrics.get_task_metrics())
+
+        counts = {}
+        for observation in observations:
+            attributes = observation.attributes
+            if attributes is None:
+                self.fail('Task metric observation is missing attributes.')
+            counts[(
+                attributes['workflow_label_PPP'],
+                attributes['workflow_label_cost_dash_center'],
+            )] = observation.value
+            self.assertEqual(attributes['pool'], 'pool-a')
+            self.assertEqual(attributes['user'], 'alice')
+            self.assertEqual(attributes['workflow_uuid'], 'workflow-1')
+            self.assertEqual(attributes['status'], 'RUNNING')
+        self.assertEqual(counts, {
+            ('project-a', 'center-1'): 5,
+            ('project-a', '<missing>'): 4,
+            ('<missing>', '<missing>'): 3,
+            ('<other>', '<missing>'): 6,
+        })
+
+    def test_empty_allow_list_clamps_all_present_values_to_other(self):
+        label_policy = connectors.LabelPolicy(key='PPP')
+
+        self.assertEqual(
+            workflow_metrics._workflow_label_metric_value(
+                {'PPP': 'arbitrary'}, label_policy,
+            ),
+            '<other>',
+        )
+        self.assertEqual(
+            workflow_metrics._workflow_label_metric_value({}, label_policy),
+            '<missing>',
+        )
+
+    def test_policy_label_attributes_cannot_overwrite_or_sanitize_to_same_name(self):
+        database = mock.Mock()
+        database.get_workflow_configs.return_value = _workflow_config({
+            'pool': ['label-pool'],
+            'a.b': ['dot'],
+            'a/b': ['slash'],
+            'a_dot_b': ['literal-token'],
+        })
+        rows = [{
+            'pool': 'pool-a',
+            'user': 'alice',
+            'workflow_uuid': 'workflow-1',
+            'status': 'RUNNING',
+            'labels': {
+                'pool': 'label-pool',
+                'a.b': 'dot',
+                'a/b': 'slash',
+                'a_dot_b': 'literal-token',
+            },
+            'count': 1,
+        }]
+
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance', return_value=database
+        ), mock.patch.object(
+            workflow_metrics.helpers, 'get_recent_tasks', return_value=rows
+        ), mock.patch.object(
+            workflow_metrics.time, 'time', return_value=100
+        ):
+            observations = list(workflow_metrics.get_task_metrics())
+
+        attributes = observations[0].attributes
+        if attributes is None:
+            self.fail('Task metric observation is missing attributes.')
+        self.assertEqual(attributes['pool'], 'pool-a')
+        self.assertEqual(attributes['workflow_label_pool'], 'label-pool')
+        self.assertEqual(attributes['workflow_label_a_dot_b'], 'dot')
+        self.assertEqual(attributes['workflow_label_a_slash_b'], 'slash')
+        self.assertEqual(
+            attributes['workflow_label_a__dot__b'], 'literal-token'
+        )
+
+    def test_no_label_policies_keeps_base_dimensions_and_database_count(self):
+        database = mock.Mock()
+        database.get_workflow_configs.return_value = _workflow_config()
+        rows = [{
+            'pool': None,
+            'user': 'alice',
+            'workflow_uuid': 'workflow-1',
+            'status': 'COMPLETED',
+            'labels': {'experiment': 'ignored'},
+            'count': 7,
+        }]
+
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance', return_value=database
+        ), mock.patch.object(
+            workflow_metrics.helpers, 'get_recent_tasks', return_value=rows
+        ), mock.patch.object(
+            workflow_metrics.time, 'time', return_value=100
+        ):
+            observations = list(workflow_metrics.get_task_metrics())
+
+        self.assertEqual(len(observations), 1)
+        self.assertEqual(observations[0].value, 7)
+        attributes = observations[0].attributes
+        if attributes is None:
+            self.fail('Task metric observation is missing attributes.')
+        self.assertEqual(dict(attributes), {
+            'pool': 'unknown',
+            'user': 'alice',
+            'workflow_uuid': 'workflow-1',
+            'status': 'COMPLETED',
+        })
+
+    def test_cache_is_reused_until_30_second_ttl_expires(self):
+        database = mock.Mock()
+        database.get_workflow_configs.return_value = _workflow_config({'PPP': ['project-a']})
+        first_rows = [{
+            'pool': 'pool-a',
+            'user': 'alice',
+            'workflow_uuid': 'workflow-1',
+            'status': 'RUNNING',
+            'labels': {'PPP': 'project-a'},
+            'count': 2,
+        }]
+        refreshed_rows = [{
+            **first_rows[0],
+            'count': 9,
+        }]
+
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance', return_value=database
+        ), mock.patch.object(
+            workflow_metrics.helpers,
+            'get_recent_tasks',
+            side_effect=[first_rows, refreshed_rows],
+        ) as get_recent_tasks, mock.patch.object(
+            workflow_metrics.time, 'time', side_effect=[100, 129, 131]
+        ):
+            first = list(workflow_metrics.get_task_metrics())
+            cached = list(workflow_metrics.get_task_metrics())
+            refreshed = list(workflow_metrics.get_task_metrics())
+
+        self.assertEqual(first[0].value, 2)
+        self.assertEqual(cached[0].value, 2)
+        self.assertEqual(refreshed[0].value, 9)
+        self.assertEqual(get_recent_tasks.call_count, 2)
+        self.assertEqual(database.get_workflow_configs.call_count, 2)
+
+    def test_disabled_metrics_do_not_query_database(self):
+        os.environ['OSMO_DISABLE_TASK_METRICS'] = 'true'
+
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance'
+        ) as get_database:
+            observations = list(workflow_metrics.get_task_metrics())
+
+        self.assertEqual(observations, [])
+        get_database.assert_not_called()
+
+
+class RegisterTaskMetricsTest(unittest.TestCase):
+    def test_description_mentions_curated_workflow_labels(self):
+        metric_creator = mock.Mock()
+
+        with mock.patch.object(
+            workflow_metrics.metrics.MetricCreator,
+            'get_meter_instance',
+            return_value=metric_creator,
+        ):
+            workflow_metrics.register_task_metrics()
+
+        metric_creator.send_observable_gauge.assert_called_once_with(
+            name='osmo_tasks_count',
+            callbacks=workflow_metrics.get_task_metrics,
+            description=(
+                'Count of OSMO tasks by status, pool, workflow, '
+                'and prefixed curated workflow labels'
+            ),
+            unit='count',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/core/workflow/tests/test_workflow_metrics.py
+++ b/src/service/core/workflow/tests/test_workflow_metrics.py
@@ -54,6 +54,14 @@ class GetTaskMetricsTest(unittest.TestCase):
         workflow_metrics._metric_cache.clear()  # pylint: disable=protected-access
         workflow_metrics._last_refresh_time = 0  # pylint: disable=protected-access
 
+    def _observe(self, database):
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance', return_value=database
+        ), mock.patch.object(
+            workflow_metrics.time, 'time', return_value=100
+        ):
+            return list(workflow_metrics.get_task_metrics())
+
     def test_sums_database_counts_and_collapses_non_policy_labels(self):
         rows = [
             {
@@ -73,10 +81,11 @@ class GetTaskMetricsTest(unittest.TestCase):
                 'user': 'alice',
                 'workflow_uuid': 'workflow-1',
                 'status': 'RUNNING',
-                'labels': (
-                    '{"PPP":"project-a","cost-center":"center-1",'
-                    '"experiment":"second"}'
-                ),
+                'labels': {
+                    'PPP': 'project-a',
+                    'cost-center': 'center-1',
+                    'experiment': 'second',
+                },
                 'count': 3,
             },
             {
@@ -84,7 +93,7 @@ class GetTaskMetricsTest(unittest.TestCase):
                 'user': 'alice',
                 'workflow_uuid': 'workflow-1',
                 'status': 'RUNNING',
-                'labels': '{"PPP":"project-a"}',
+                'labels': {'PPP': 'project-a'},
                 'count': 4,
             },
             {
@@ -100,7 +109,7 @@ class GetTaskMetricsTest(unittest.TestCase):
                 'user': 'alice',
                 'workflow_uuid': 'workflow-1',
                 'status': 'RUNNING',
-                'labels': 'not-json',
+                'labels': ['unexpected-type'],
                 'count': 2,
             },
             {
@@ -119,13 +128,9 @@ class GetTaskMetricsTest(unittest.TestCase):
         })
 
         with mock.patch.object(
-            connectors.PostgresConnector, 'get_instance', return_value=database
-        ), mock.patch.object(
-            workflow_metrics.helpers, 'get_recent_tasks', return_value=rows
-        ), mock.patch.object(
-            workflow_metrics.time, 'time', return_value=100
-        ):
-            observations = list(workflow_metrics.get_task_metrics())
+                workflow_metrics.helpers, 'get_recent_tasks',
+                return_value=rows):
+            observations = self._observe(database)
 
         counts = {}
         for observation in observations:
@@ -184,13 +189,9 @@ class GetTaskMetricsTest(unittest.TestCase):
         }]
 
         with mock.patch.object(
-            connectors.PostgresConnector, 'get_instance', return_value=database
-        ), mock.patch.object(
-            workflow_metrics.helpers, 'get_recent_tasks', return_value=rows
-        ), mock.patch.object(
-            workflow_metrics.time, 'time', return_value=100
-        ):
-            observations = list(workflow_metrics.get_task_metrics())
+                workflow_metrics.helpers, 'get_recent_tasks',
+                return_value=rows):
+            observations = self._observe(database)
 
         attributes = observations[0].attributes
         if attributes is None:
@@ -216,13 +217,9 @@ class GetTaskMetricsTest(unittest.TestCase):
         }]
 
         with mock.patch.object(
-            connectors.PostgresConnector, 'get_instance', return_value=database
-        ), mock.patch.object(
-            workflow_metrics.helpers, 'get_recent_tasks', return_value=rows
-        ), mock.patch.object(
-            workflow_metrics.time, 'time', return_value=100
-        ):
-            observations = list(workflow_metrics.get_task_metrics())
+                workflow_metrics.helpers, 'get_recent_tasks',
+                return_value=rows):
+            observations = self._observe(database)
 
         self.assertEqual(len(observations), 1)
         self.assertEqual(observations[0].value, 7)
@@ -294,15 +291,11 @@ class RegisterTaskMetricsTest(unittest.TestCase):
         ):
             workflow_metrics.register_task_metrics()
 
-        metric_creator.send_observable_gauge.assert_called_once_with(
-            name='osmo_tasks_count',
-            callbacks=workflow_metrics.get_task_metrics,
-            description=(
-                'Count of OSMO tasks by status, pool, workflow, '
-                'and prefixed curated workflow labels'
-            ),
-            unit='count',
-        )
+        metric_creator.send_observable_gauge.assert_called_once()
+        kwargs = metric_creator.send_observable_gauge.call_args.kwargs
+        self.assertEqual(kwargs['name'], 'osmo_tasks_count')
+        self.assertEqual(kwargs['callbacks'], workflow_metrics.get_task_metrics)
+        self.assertIn('workflow labels', kwargs['description'])
 
 
 if __name__ == '__main__':

--- a/src/service/core/workflow/workflow_metrics.py
+++ b/src/service/core/workflow/workflow_metrics.py
@@ -1,5 +1,5 @@
 """
-SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from collections.abc import Mapping
+import json
 import logging
 import os
 import time
-from typing import Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 # Import with type: ignore to avoid import errors in linting
 import opentelemetry.metrics as otelmetrics  # type: ignore
@@ -34,6 +36,15 @@ from src.utils import connectors
 _metric_cache: List[otelmetrics.Observation] = []
 _last_refresh_time: float = 0
 _CACHE_TTL_SECONDS: int = 30  # Refresh cache every 30 seconds
+_MISSING_WORKFLOW_LABEL_VALUE = '<missing>'
+_OTHER_WORKFLOW_LABEL_VALUE = '<other>'
+_WORKFLOW_LABEL_ATTRIBUTE_PREFIX = 'workflow_label_'
+_WORKFLOW_LABEL_ATTRIBUTE_ESCAPES = {
+    '_': '__',
+    '-': '_dash_',
+    '.': '_dot_',
+    '/': '_slash_',
+}
 
 
 def _is_task_metrics_disabled() -> bool:
@@ -41,6 +52,43 @@ def _is_task_metrics_disabled() -> bool:
     return os.getenv('OSMO_DISABLE_TASK_METRICS', '').lower() in (
         'true', '1', 'yes'
     )
+
+
+def _parse_workflow_labels(raw_labels: Any) -> Dict[str, str]:
+    """Return string workflow labels from a decoded JSONB value or JSON text."""
+    if isinstance(raw_labels, str):
+        try:
+            raw_labels = json.loads(raw_labels)
+        except json.JSONDecodeError:
+            return {}
+    if not isinstance(raw_labels, Mapping):
+        return {}
+    return {
+        key: value
+        for key, value in raw_labels.items()
+        if isinstance(key, str) and isinstance(value, str)
+    }
+
+
+def _workflow_label_attribute_name(label_key: str) -> str:
+    """Build a readable, collision-free Prometheus-safe attribute name."""
+    encoded_key = ''.join(
+        _WORKFLOW_LABEL_ATTRIBUTE_ESCAPES.get(character, character)
+        for character in label_key
+    )
+    return f'{_WORKFLOW_LABEL_ATTRIBUTE_PREFIX}{encoded_key}'
+
+
+def _workflow_label_metric_value(
+        workflow_labels: Dict[str, str],
+        label_policy: connectors.LabelPolicy) -> str:
+    """Clamp a policy label to its bounded metric vocabulary."""
+    value = workflow_labels.get(label_policy.key)
+    if value is None:
+        return _MISSING_WORKFLOW_LABEL_VALUE
+    if not label_policy.allow_list or value not in label_policy.allow_list:
+        return _OTHER_WORKFLOW_LABEL_VALUE
+    return value
 
 
 def get_task_metrics(
@@ -94,8 +142,11 @@ def get_task_metrics(
         prev_age
     )
 
+    label_policies: List[connectors.LabelPolicy] = []
     try:
         database = connectors.PostgresConnector.get_instance()
+        workflow_config = database.get_workflow_configs()
+        label_policies = workflow_config.labels_config.policy
         rows = helpers.get_recent_tasks(database, minutes_ago)
     except osmo_errors.OSMODatabaseError as err:
         logging.debug(
@@ -104,17 +155,25 @@ def get_task_metrics(
         )
         rows = []
 
-    # Count tasks by unique label combinations
+    # Rows arrive pre-aggregated by (pool, user, workflow_uuid, status, labels);
+    # workflow_uuid is a metric dimension, so keys are unique per row today. The
+    # dict guards against duplicate series if the SQL grouping ever loosens.
     task_counts: Dict[Tuple[Tuple[str, str], ...], int] = {}
     for row in rows:
+        workflow_labels = _parse_workflow_labels(row['labels'])
         labels = {
             'pool': row['pool'] or 'unknown',
             'user': row['user'],
             'workflow_uuid': row['workflow_uuid'],
             'status': row['status']
         }
+        labels.update({
+            _workflow_label_attribute_name(label_policy.key):
+                _workflow_label_metric_value(workflow_labels, label_policy)
+            for label_policy in label_policies
+        })
         key = tuple(sorted(labels.items()))
-        task_counts[key] = task_counts.get(key, 0) + 1
+        task_counts[key] = task_counts.get(key, 0) + int(row['count'])
 
     # Generate observations
     _metric_cache.clear()
@@ -140,7 +199,10 @@ def register_task_metrics():
         metric_creator.send_observable_gauge(
             name='osmo_tasks_count',
             callbacks=get_task_metrics,
-            description='Count of OSMO tasks by status, pool, workflow',
+            description=(
+                'Count of OSMO tasks by status, pool, workflow, '
+                'and prefixed curated workflow labels'
+            ),
             unit='count'
         )
     except (ValueError, AttributeError, TypeError) as err:

--- a/src/service/core/workflow/workflow_metrics.py
+++ b/src/service/core/workflow/workflow_metrics.py
@@ -17,7 +17,6 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 from collections.abc import Mapping
-import json
 import logging
 import os
 import time
@@ -55,18 +54,13 @@ def _is_task_metrics_disabled() -> bool:
 
 
 def _parse_workflow_labels(raw_labels: Any) -> Dict[str, str]:
-    """Return string workflow labels from a decoded JSONB value or JSON text."""
-    if isinstance(raw_labels, str):
-        try:
-            raw_labels = json.loads(raw_labels)
-        except json.JSONDecodeError:
-            return {}
+    """Return string workflow labels from a decoded JSONB row value."""
     if not isinstance(raw_labels, Mapping):
         return {}
     return {
         key: value
         for key, value in raw_labels.items()
-        if isinstance(key, str) and isinstance(value, str)
+        if isinstance(value, str)
     }
 
 
@@ -158,6 +152,10 @@ def get_task_metrics(
     # Rows arrive pre-aggregated by (pool, user, workflow_uuid, status, labels);
     # workflow_uuid is a metric dimension, so keys are unique per row today. The
     # dict guards against duplicate series if the SQL grouping ever loosens.
+    policy_attributes = [
+        (_workflow_label_attribute_name(label_policy.key), label_policy)
+        for label_policy in label_policies
+    ]
     task_counts: Dict[Tuple[Tuple[str, str], ...], int] = {}
     for row in rows:
         workflow_labels = _parse_workflow_labels(row['labels'])
@@ -167,11 +165,9 @@ def get_task_metrics(
             'workflow_uuid': row['workflow_uuid'],
             'status': row['status']
         }
-        labels.update({
-            _workflow_label_attribute_name(label_policy.key):
-                _workflow_label_metric_value(workflow_labels, label_policy)
-            for label_policy in label_policies
-        })
+        for attribute_name, label_policy in policy_attributes:
+            labels[attribute_name] = _workflow_label_metric_value(
+                workflow_labels, label_policy)
         key = tuple(sorted(labels.items()))
         task_counts[key] = task_counts.get(key, 0) + int(row['count'])
 

--- a/src/service/core/workflow/workflow_metrics.py
+++ b/src/service/core/workflow/workflow_metrics.py
@@ -35,6 +35,8 @@ from src.utils import connectors
 _metric_cache: List[otelmetrics.Observation] = []
 _last_refresh_time: float = 0
 _CACHE_TTL_SECONDS: int = 30  # Refresh cache every 30 seconds
+# Angle brackets are not valid label characters, so these sentinels can
+# never collide with real label values.
 _MISSING_WORKFLOW_LABEL_VALUE = '<missing>'
 _OTHER_WORKFLOW_LABEL_VALUE = '<other>'
 _WORKFLOW_LABEL_ATTRIBUTE_PREFIX = 'workflow_label_'
@@ -76,7 +78,11 @@ def _workflow_label_attribute_name(label_key: str) -> str:
 def _workflow_label_metric_value(
         workflow_labels: Dict[str, str],
         label_policy: connectors.LabelPolicy) -> str:
-    """Clamp a policy label to its bounded metric vocabulary."""
+    """Clamp a policy label to its bounded metric vocabulary.
+
+    With an empty allow-list every present value clamps to the other
+    sentinel, so series stay bounded in every enforcement mode.
+    """
     value = workflow_labels.get(label_policy.key)
     if value is None:
         return _MISSING_WORKFLOW_LABEL_VALUE
@@ -149,13 +155,13 @@ def get_task_metrics(
         )
         rows = []
 
-    # Rows arrive pre-aggregated by (pool, user, workflow_uuid, status, labels);
-    # workflow_uuid is a metric dimension, so keys are unique per row today. The
-    # dict guards against duplicate series if the SQL grouping ever loosens.
     policy_attributes = [
         (_workflow_label_attribute_name(label_policy.key), label_policy)
         for label_policy in label_policies
     ]
+    # SQL groups by the raw labels JSONB; clamping to the bounded policy
+    # vocabulary can collapse distinct rows onto the same attribute set, so
+    # counts are summed per projected key.
     task_counts: Dict[Tuple[Tuple[str, str], ...], int] = {}
     for row in rows:
         workflow_labels = _parse_workflow_labels(row['labels'])


### PR DESCRIPTION
## Summary

Issue - None

[OSMO-6501] Track B8 of the workflow-labels PR split.

- `osmo_tasks_count` gains one `workflow_label_<key>` attribute per curated policy key (any enforcement mode), value-clamped to the allow-list plus `<missing>` / `<other>` sentinels so cardinality stays bounded at |allow_list|+2 per key.
- Fixes the pre-existing counting defect: the query grouped by every column without `COUNT(*)`, so each series read 1; it now selects and sums real counts.
- Label keys are escaped into Prometheus-safe attribute names (`-`, `.`, `/`, `_` collision-free).
- The OSS `workflow_resources_usage.json` dashboard stays free of any deployment-specific label dimension, pinned by a new structural test; label-specific dashboards are provisioned per deployment.
- The `osmo_label_validation_total{key,outcome}` submit-gate counter landed with #1223 (it is emitted inside the admission gate).

Stacked on #1225 for chain simplicity; functionally depends only on the schema (#1219) and policy config (#1220).
Extracted from prototype #1194.

## Testing

- `bazel test //src/service/core/workflow/tests:test_workflow_metrics` (clamping matrix, sentinel values, attribute-name escaping, count aggregation, config-failure fallback)
- `bazel test //src/service/core/workflow/tests:test_helpers`
- `bazel test //docs/deployment_guide/dashboards:test_dashboards`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow-label dimensions to task metrics, including handling for missing, unexpected, and unsupported values.
  * Documented workflow metric labels, validation outcomes, and cardinality safeguards.
  * Added Grafana dashboard validation coverage for panel structure and deployment-neutral configuration.

* **Bug Fixes**
  * Improved recent-task aggregation to report grouped task counts with workflow labels.

* **Tests**
  * Added comprehensive coverage for workflow metrics, label policies, caching, disabled metrics, and dashboard configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->