### PR TITLE
Add external MCP Phase 1 deployment smoke test

### DIFF
--- a/test/smoke/BUILD
+++ b/test/smoke/BUILD
@@ -18,6 +18,14 @@ oetf_smoke_test(
     tags = ["api", "kind"],
 )
 
+# Public KIND has no JWT issuer and keeps MCP disabled. Run this target against
+# an MCP-enabled deployment with token authentication.
+oetf_smoke_test(
+    name = "mcp-checks",
+    src = "mcp_checks.py",
+    tags = ["api", "auth", "mcp"],
+)
+
 # auth-checks stays internal — public quick-start chart ships no JWT issuer
 # (only oauth2Proxy). Re-enable here once the public chart adds one.
 

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -1,0 +1,200 @@
+"""
+Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+NVIDIA CORPORATION and its licensors retain all intellectual property
+and proprietary rights in and to this software, related documentation
+and any modifications thereto. Any use, reproduction, disclosure or
+distribution of this software and related documentation without an express
+license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""
+
+# Smoke: the external MCP catalog and caller-bound profile round trip work.
+
+import unittest
+
+import requests
+
+from src.lib.utils.client import RequestMethod
+from test.oetf.smoke_fixture import SmokeFixture
+
+
+_PHASE_ONE_TOOL_NAMES = frozenset({
+    "osmo_get_app",
+    "osmo_get_app_spec",
+    "osmo_get_profile",
+    "osmo_get_resource",
+    "osmo_get_workflow",
+    "osmo_get_workflow_events",
+    "osmo_get_workflow_logs",
+    "osmo_get_workflow_spec",
+    "osmo_health",
+    "osmo_list_apps",
+    "osmo_list_credentials",
+    "osmo_list_resources",
+    "osmo_list_workflows",
+    "osmo_search_pools",
+})
+_MCP_ACCEPT_HEADERS = {
+    "Accept": "application/json, text/event-stream",
+}
+_PROFILE_FIELDS = (
+    "username",
+    "email_notification",
+    "slack_notification",
+    "pool",
+)
+_TOKEN_FIELDS = (
+    "name",
+    "expires_at",
+)
+
+
+class McpChecks(SmokeFixture):
+    """Exercise the deployed Phase 1 MCP through its public Gateway route."""
+
+    def _jsonrpc_result(self, response, request_id):
+        if (
+            not isinstance(response, dict)
+            or response.get("jsonrpc") != "2.0"
+            or response.get("id") != request_id
+            or "error" in response
+        ):
+            self.fail("MCP returned an unsuccessful JSON-RPC response.")
+
+        result = response.get("result")
+        if not isinstance(result, dict):
+            self.fail("MCP returned an invalid JSON-RPC result.")
+        return result
+
+    def test_phase_one_catalog_and_profile_round_trip(self):
+        base_url = self.config.url.rstrip("/")
+        unauthenticated_response = requests.post(
+            f"{base_url}/mcp",
+            headers=dict(_MCP_ACCEPT_HEADERS),
+            json={
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "tools/list",
+                "params": {},
+            },
+            timeout=10,
+            allow_redirects=False,
+        )
+        self.assertEqual(unauthenticated_response.status_code, 401)
+        self.assertTrue(
+            unauthenticated_response.headers.get(
+                "www-authenticate", ""
+            ).startswith("Bearer resource_metadata=")
+        )
+
+        catalog_response = self.service_client.request(
+            method=RequestMethod.POST,
+            endpoint="mcp",
+            headers=dict(_MCP_ACCEPT_HEADERS),
+            payload={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {},
+            },
+            version_header=False,
+        )
+
+        catalog_result = self._jsonrpc_result(catalog_response, 1)
+        catalog_tools = catalog_result.get("tools")
+        if not isinstance(catalog_tools, list) or not all(
+            isinstance(tool, dict) for tool in catalog_tools
+        ):
+            self.fail("MCP returned an invalid tool catalog.")
+        tool_names = [tool.get("name") for tool in catalog_tools]
+        if (
+            len(tool_names) != len(_PHASE_ONE_TOOL_NAMES)
+            or set(tool_names) != _PHASE_ONE_TOOL_NAMES
+        ):
+            self.fail("MCP tool catalog does not match the Phase 1 contract.")
+
+        direct_profile = self.service_client.request(
+            method=RequestMethod.GET,
+            endpoint="api/profile/settings",
+        )
+        if not isinstance(direct_profile, dict):
+            self.fail("Core returned an invalid profile response.")
+        direct_profile_settings = direct_profile.get("profile")
+        if (
+            not isinstance(direct_profile_settings, dict)
+            or not isinstance(direct_profile.get("roles"), list)
+            or not isinstance(direct_profile.get("pools"), list)
+        ):
+            self.fail("Core returned an invalid profile response.")
+
+        direct_token = direct_profile.get("token")
+        expected_token = None
+        if direct_token is not None:
+            if not isinstance(direct_token, dict):
+                self.fail("Core returned invalid token metadata.")
+            expected_token = {
+                field: direct_token.get(field)
+                for field in _TOKEN_FIELDS
+            }
+        expected_profile = {
+            "profile": {
+                field: direct_profile_settings.get(field)
+                for field in _PROFILE_FIELDS
+            },
+            "roles": direct_profile["roles"],
+            "pools": direct_profile["pools"],
+            "token": expected_token,
+        }
+
+        profile_response = self.service_client.request(
+            method=RequestMethod.POST,
+            endpoint="mcp",
+            headers=dict(_MCP_ACCEPT_HEADERS),
+            payload={
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "osmo_get_profile",
+                    "arguments": {},
+                },
+            },
+            version_header=False,
+        )
+
+        profile_result = self._jsonrpc_result(profile_response, 2)
+        if (
+            profile_result.get("isError") is not False
+            or profile_result.get("structuredContent") != expected_profile
+        ):
+            self.fail(
+                "MCP profile projection does not match the direct Core profile."
+            )
+
+        health_response = self.service_client.request(
+            method=RequestMethod.POST,
+            endpoint="mcp",
+            headers=dict(_MCP_ACCEPT_HEADERS),
+            payload={
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "osmo_health",
+                    "arguments": {},
+                },
+            },
+            version_header=False,
+        )
+
+        health_result = self._jsonrpc_result(health_response, 3)
+        if (
+            health_result.get("isError") is not False
+            or health_result.get("structuredContent")
+            != {"status": "healthy"}
+        ):
+            self.fail("MCP health tool returned an invalid response.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Add the deployment-level OETF smoke test that closes external MCP Phase 1.

The test exercises the public `/mcp` Gateway route and verifies:

- a request without a bearer token receives `401` with the MCP
  resource-metadata challenge;
- the deployed catalog contains exactly the 14 Phase 1 tools;
- `osmo_get_profile` matches the same caller's allowlisted Core profile,
  proving the authenticated Gateway → MCP → Gateway → Core round trip; and
- `osmo_health` returns the expected structured result.

The target is tagged `mcp` and intentionally excluded from public KIND because
that environment has no JWT issuer and keeps MCP disabled. Assertions use
fixed failure messages so unexpected response content or profile metadata is
not written to CI logs.

#1232 has merged. This PR now targets `feature/mcp` directly. It does not
target `main`.

Issue - None

### Validation

- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors -- //test/smoke:mcp-checks-pylint`
  — passed.
- `bazel --output_user_root=/tmp/osmo-bazel build //test/smoke:mcp-checks`
  — passed.
- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors -- //test/oetf/tests/... //src/service/mcp/tests/...`
  — 60/60 tests passed.
- `git diff --check` — passed.

### Deployment validation before approval

- Run `bazel run //test/oetf:run -- --env <mcp-enabled-jwt-env> --tags mcp`
  with a caller that has `mcp:Access` and `profile:Read`.
- Confirm the fail-on-bad case by temporarily routing the MCP profile request
  to a missing Core path: the direct Core profile check remains healthy while
  the MCP round trip fails, then restore the route.
- Separately verify denial for a valid caller without `mcp:Access` and for an
  MCP caller without `profile:Read` once those two negative-role credentials
  are provisioned. These deployment cases are not claimed as automated
  coverage in this PR.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
