### PR TITLE
Add external MCP workflow validation

### DIFF
--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -157,6 +157,16 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "workflow_action_models",
+    srcs = ["workflow_action_models.py"],
+    deps = [
+        requirement("pydantic"),
+        ":tool_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "profile_tools",
     srcs = ["profile.py"],
     deps = [
@@ -224,6 +234,20 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "workflow_action_tools",
+    srcs = ["workflow_actions.py"],
+    deps = [
+        requirement("mcp"),
+        ":access_scope",
+        ":tool_errors",
+        ":tool_requests",
+        ":tool_validation",
+        ":workflow_action_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "app_tools",
     srcs = ["apps.py"],
     deps = [
@@ -259,6 +283,7 @@ osmo_py_library(
         ":pool_tools",
         ":profile_tools",
         ":resource_tools",
+        ":workflow_action_tools",
         ":workflow_tools",
     ],
     visibility = ["//visibility:public"],

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -98,15 +98,19 @@ The Gateway, MCP process, receiving OSMO APIs, and applicable middleware are
 inside the bearer-token handling boundary. None of them may log or persist the
 authorization value.
 
-## Available read tools
+## Available tools
 
-The first external catalog contains 14 read-only tools for caller-bound health,
+The external catalog contains 14 read-only tools for caller-bound health,
 profile, pool, resource, workflow, application, and credential-metadata
-inspection. Each tool maps to a fixed external API, returns a structured
-allowlisted result, and applies a domain-specific response limit. Credential
-inspection returns names and types only. Profile inspection intentionally
-includes non-secret access-token identity metadata (name and expiry), unlike
-the hosted internal MCP projection.
+inspection, plus `osmo_validate_workflow`. Each tool maps to a fixed external
+API, returns a structured allowlisted result, and applies a domain-specific
+response limit. Credential inspection returns names and types only. Profile
+inspection intentionally includes non-secret access-token identity metadata
+(name and expiry), unlike the hosted internal MCP projection.
+
+Workflow validation calls Core's submission endpoint with
+`validation_only=true`. It is intentionally annotated as a non-idempotent
+write because a failed validation can create a `FAILED_SUBMISSION` record.
 
 JSON tools require one complete bounded response. Bounded text tools may
 instead return a safe UTF-8 prefix with `truncated=true` and a machine-readable

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -63,14 +63,16 @@ though the CLI and hosted internal MCP may display them. Legacy profile values
 can contain secret-bearing userinfo, queries, or fragments; the external
 projection therefore returns only `cred_name` and `cred_type`.
 
-## Phase 2: workflow actions
+## Phase 2: workflow actions (in progress)
 
-Add `osmo_validate_workflow`, `osmo_submit_workflow`,
-`osmo_restart_workflow`, and `osmo_cancel_workflow` after the read-only request
-path is established. The transport body limit is already in place; this phase
-still requires exact mutation-body schemas, uncertain-write handling, and
-explicit side-effect annotations. Validation belongs in this phase because a
-failed validation can create a `FAILED_SUBMISSION` workflow record.
+`osmo_validate_workflow` is implemented using the exact bounded TemplateSpec
+projection and `validation_only=true`. It is a non-idempotent write because a
+failed validation can create a `FAILED_SUBMISSION` workflow record. The shared
+mutation relay sends bounded JSON, never retries, and reports an unknown
+outcome for ambiguous transport or server failures.
+
+Add `osmo_submit_workflow`, `osmo_restart_workflow`, and
+`osmo_cancel_workflow` as the remaining Phase 2 actions.
 
 ## Phase 3: user-owned mutations
 

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -20,6 +20,7 @@ import asyncio
 from collections.abc import AsyncIterator, Mapping, Sequence
 import contextlib
 import dataclasses
+import json
 import math
 import re
 import time
@@ -37,6 +38,7 @@ _USER_AGENT = 'osmo-mcp'
 _IDENTITY_ENCODING = 'identity'
 _QUERY_KEY = re.compile(r'[A-Za-z][A-Za-z0-9_]*')
 _MAX_QUERY_BYTES = 16 * 1024
+_MAX_JSON_REQUEST_BYTES = 1024 * 1024
 _MAX_ERROR_RESPONSE_BYTES = 16 * 1024
 _HTTP_LIMITS = httpx.Limits(
     max_connections=100,
@@ -52,6 +54,10 @@ QueryParams: TypeAlias = Mapping[str, QueryValue]
 
 class GatewayClientError(RuntimeError):
     """A sanitized failure while calling the configured OSMO Gateway."""
+
+
+class GatewayUncertainWriteError(GatewayClientError):
+    """A write may have reached OSMO, but no authoritative result was received."""
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -88,6 +94,7 @@ class GatewayClient:
         credentials: request_context.RequestCredentials,
         max_response_bytes: int,
         query: QueryParams | None = None,
+        json_body: Mapping[str, object] | None = None,
     ) -> GatewayResponse:
         """Call a fixed API path and require its 2xx response body to fit."""
         return await self._request(
@@ -96,6 +103,7 @@ class GatewayClient:
             credentials=credentials,
             max_response_bytes=max_response_bytes,
             query=query,
+            json_body=json_body,
             truncate_success=False,
         )
 
@@ -115,6 +123,7 @@ class GatewayClient:
             credentials=credentials,
             max_response_bytes=max_response_bytes,
             query=query,
+            json_body=None,
             truncate_success=True,
         )
 
@@ -126,6 +135,7 @@ class GatewayClient:
         credentials: request_context.RequestCredentials,
         max_response_bytes: int,
         query: QueryParams | None,
+        json_body: Mapping[str, object] | None,
         truncate_success: bool,
     ) -> GatewayResponse:
         """Call a fixed API path with credentials from the active MCP request."""
@@ -140,6 +150,12 @@ class GatewayClient:
         ):
             raise ValueError('Gateway request credentials are invalid.')
         encoded_query = _encode_query_params(query)
+        encoded_body = _encode_json_body(method, json_body)
+        if (
+            encoded_body is not None
+            and _contains_relayed_credentials(encoded_body, credentials)
+        ):
+            raise ValueError('Gateway request body is invalid.')
 
         headers = {
             login.OSMO_AUTH_HEADER: credentials.authorization_header,
@@ -148,12 +164,15 @@ class GatewayClient:
         }
         if credentials.request_id is not None:
             headers[request_context.REQUEST_ID_HEADER] = credentials.request_id
+        if encoded_body is not None:
+            headers['Content-Type'] = 'application/json'
 
         request = self._client.build_request(
             method,
             path,
             headers=headers,
             params=encoded_query,
+            content=encoded_body,
         )
         # HTTPX stores response cookies on the process-wide client. Never let
         # that shared state become credentials on a later caller's request.
@@ -223,16 +242,14 @@ class GatewayClient:
                     or not response.is_success
                 ):
                     outcome = 'transport_error'
-                    raise GatewayClientError(
-                        'OSMO Gateway is unavailable.') from None
+                    raise _transport_error(method) from None
                 response_body = bytes(response_body_prefix)
                 body_truncated = True
                 truncation_reason = _RESPONSE_TIMEOUT
                 outcome = 'response_truncated'
             except httpx.RequestError:
                 outcome = 'transport_error'
-                raise GatewayClientError(
-                    'OSMO Gateway is unavailable.') from None
+                raise _transport_error(method) from None
 
             if response is None:
                 raise AssertionError('Gateway response state is unavailable.')
@@ -407,6 +424,37 @@ def _encode_query_params(
     if len(parse.urlencode(encoded).encode('ascii')) > _MAX_QUERY_BYTES:
         raise ValueError('Gateway query parameters exceed the size limit.')
     return httpx.QueryParams(encoded)
+
+
+def _encode_json_body(
+    method: str,
+    json_body: Mapping[str, object] | None,
+) -> bytes | None:
+    """Serialize one bounded JSON object for an explicit write request."""
+    if json_body is None:
+        return None
+    if method == 'GET' or not isinstance(json_body, Mapping):
+        raise ValueError('Gateway request body is not allowed.')
+    try:
+        encoded_body = json.dumps(
+            dict(json_body),
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(',', ':'),
+        ).encode('utf-8')
+    except (TypeError, ValueError, UnicodeEncodeError):
+        raise ValueError('Gateway request body is invalid.') from None
+    if len(encoded_body) > _MAX_JSON_REQUEST_BYTES:
+        raise ValueError('Gateway request body exceeds the size limit.')
+    return encoded_body
+
+
+def _transport_error(method: str) -> GatewayClientError:
+    if method == 'GET':
+        return GatewayClientError('OSMO Gateway is unavailable.')
+    return GatewayUncertainWriteError(
+        'OSMO Gateway write outcome is unknown.'
+    )
 
 
 def _validate_content_length(

--- a/src/service/mcp/telemetry.py
+++ b/src/service/mcp/telemetry.py
@@ -59,6 +59,13 @@ def route_template(path: str) -> str:
     if len(parts) == 4 and parts[:3] == ['', 'api', 'resources']:
         return '/api/resources/{node_name}'
 
+    if (
+        len(parts) == 5
+        and parts[:3] == ['', 'api', 'pool']
+        and parts[4] == 'workflow'
+    ):
+        return '/api/pool/{pool}/workflow'
+
     return '/api/{unclassified}'
 
 

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -54,6 +54,7 @@ osmo_py_test(
         "//src/service/mcp:protocol",
         "//src/service/mcp:resource_tools",
         "//src/service/mcp:tool_registry",
+        "//src/service/mcp:workflow_action_tools",
         "//src/service/mcp:workflow_tools",
     ],
 )
@@ -186,5 +187,16 @@ osmo_py_test(
         ":protocol_harness",
         "//src/service/mcp:request_context",
         "//src/service/mcp:workflow_tools",
+    ],
+)
+
+osmo_py_test(
+    name = "test_workflow_actions",
+    srcs = ["test_workflow_actions.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("mcp"),
+        ":protocol_harness",
+        "//src/service/mcp:workflow_action_tools",
     ],
 )

--- a/src/service/mcp/tests/protocol_harness.py
+++ b/src/service/mcp/tests/protocol_harness.py
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from collections.abc import AsyncIterator, Callable, Collection, Coroutine
+from collections.abc import AsyncIterator, Callable, Collection, Coroutine, Mapping
 import contextlib
 from typing import Any, TypeAlias
 import unittest
@@ -44,6 +44,18 @@ READ_ONLY_ANNOTATIONS = {
     'readOnlyHint': True,
     'destructiveHint': False,
     'idempotentHint': True,
+    'openWorldHint': False,
+}
+WRITE_ANNOTATIONS = {
+    'readOnlyHint': False,
+    'destructiveHint': False,
+    'idempotentHint': False,
+    'openWorldHint': False,
+}
+DESTRUCTIVE_WRITE_ANNOTATIONS = {
+    'readOnlyHint': False,
+    'destructiveHint': True,
+    'idempotentHint': False,
     'openWorldHint': False,
 }
 
@@ -218,16 +230,34 @@ class ProtocolHarness:
         response: httpx.Response,
     ) -> dict[str, dict[str, Any]]:
         """Assert common external read-tool annotations and schema closure."""
+        return self.assert_closed_catalog(
+            test_case,
+            response,
+            expected_annotations={
+                name: READ_ONLY_ANNOTATIONS
+                for name in self.tool_names
+            },
+        )
+
+    def assert_closed_catalog(
+        self,
+        test_case: unittest.TestCase,
+        response: httpx.Response,
+        *,
+        expected_annotations: Mapping[str, dict[str, bool]],
+    ) -> dict[str, dict[str, Any]]:
+        """Assert exact annotations and recursively closed tool schemas."""
         test_case.assertEqual(response.status_code, 200)
         tools = {
             tool['name']: tool
             for tool in response.json()['result']['tools']
         }
         test_case.assertEqual(set(tools), set(self.tool_names))
-        for tool in tools.values():
+        test_case.assertEqual(set(expected_annotations), set(self.tool_names))
+        for name, tool in tools.items():
             test_case.assertEqual(
                 tool['annotations'],
-                READ_ONLY_ANNOTATIONS,
+                expected_annotations[name],
             )
             input_schema = tool['inputSchema']
             test_case.assertFalse(input_schema['additionalProperties'])

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -29,6 +29,7 @@ from src.service.mcp import (
     protocol,
     resources,
     tool_registry,
+    workflow_actions,
     workflows,
 )
 
@@ -104,6 +105,13 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'Get the bounded, server-redacted resolved or template workflow YAML.',
     ),
     (
+        workflow_actions.osmo_validate_workflow,
+        'osmo_validate_workflow',
+        'Validate an OSMO workflow',
+        'Validate workflow YAML with OSMO Core without submitting it. '
+        'A failed validation may create a FAILED_SUBMISSION record.',
+    ),
+    (
         apps.osmo_list_apps,
         'osmo_list_apps',
         'List OSMO apps',
@@ -145,6 +153,7 @@ _EXPECTED_REQUIRED_FIELDS = {
     'osmo_get_workflow_logs': ['workflow_id'],
     'osmo_get_workflow_events': ['workflow_id'],
     'osmo_get_workflow_spec': ['workflow_id'],
+    'osmo_validate_workflow': ['workflow_spec'],
     'osmo_list_apps': [],
     'osmo_get_app': ['name'],
     'osmo_get_app_spec': ['name'],
@@ -180,6 +189,11 @@ _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
     },
     'osmo_get_workflow_events': {'task_name': None, 'retry_id': None},
     'osmo_get_workflow_spec': {'use_template': False},
+    'osmo_validate_workflow': {
+        'pool': None,
+        'set_variables': None,
+        'set_string_variables': None,
+    },
     'osmo_list_apps': {
         'name': None,
         'users': None,
@@ -196,7 +210,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
     """Lock the ordered, agent-facing external MCP tool contract."""
 
     def test_registry_has_exact_metadata_and_direct_unique_functions(self) -> None:
-        self.assertEqual(len(tool_registry.TOOL_SPECS), 14)
+        self.assertEqual(len(tool_registry.TOOL_SPECS), 15)
         self.assertEqual(
             [
                 (spec.name, spec.title, spec.description)
@@ -211,7 +225,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         registered_functions = [
             spec.function for spec in tool_registry.TOOL_SPECS
         ]
-        self.assertEqual(len({id(function) for function in registered_functions}), 14)
+        self.assertEqual(len({id(function) for function in registered_functions}), 15)
         for spec, (function, _, _, _) in zip(
             tool_registry.TOOL_SPECS,
             _EXPECTED_SPECS,
@@ -219,12 +233,12 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         ):
             self.assertIs(spec.function, function)
 
-    def test_registration_preserves_metadata_and_read_only_contract(self) -> None:
+    def test_registration_preserves_metadata_and_annotations(self) -> None:
         mcp_server = mock.Mock()
 
         tool_registry.register_tools(mcp_server)
 
-        self.assertEqual(mcp_server.add_tool.call_count, 14)
+        self.assertEqual(mcp_server.add_tool.call_count, 15)
         for call, (function, name, title, description) in zip(
             mcp_server.add_tool.call_args_list,
             _EXPECTED_SPECS,
@@ -236,9 +250,10 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(call.kwargs['description'], description)
             self.assertTrue(call.kwargs['structured_output'])
             annotations = call.kwargs['annotations']
-            self.assertTrue(annotations.readOnlyHint)
+            is_validation = name == 'osmo_validate_workflow'
+            self.assertIs(annotations.readOnlyHint, not is_validation)
             self.assertFalse(annotations.destructiveHint)
-            self.assertTrue(annotations.idempotentHint)
+            self.assertIs(annotations.idempotentHint, not is_validation)
             self.assertFalse(annotations.openWorldHint)
 
     async def test_all_tools_have_closed_schemas_and_stable_arguments(self) -> None:
@@ -255,9 +270,10 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         for tool in tools:
             self.assertIsNotNone(tool.annotations)
             assert tool.annotations is not None
-            self.assertTrue(tool.annotations.readOnlyHint)
+            is_validation = tool.name == 'osmo_validate_workflow'
+            self.assertIs(tool.annotations.readOnlyHint, not is_validation)
             self.assertFalse(tool.annotations.destructiveHint)
-            self.assertTrue(tool.annotations.idempotentHint)
+            self.assertIs(tool.annotations.idempotentHint, not is_validation)
             self.assertFalse(tool.annotations.openWorldHint)
             self._assert_recursively_closed(tool.inputSchema, tool.name)
             self.assertIsNotNone(tool.outputSchema)

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -278,6 +278,90 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn('alpha%26beta', str(request.url))
         self.assertIn('release+candidate', str(request.url))
 
+    async def test_write_encodes_one_bounded_json_object(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, content=b'{"name":"workflow-1"}')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            response = await app_context.gateway.request(
+                'POST',
+                '/api/pool/pool-a/workflow',
+                credentials=self._credentials(),
+                max_response_bytes=1024,
+                query={'validation_only': True},
+                json_body={
+                    'file': 'version: 2\n',
+                    'set_variables': ['replicas=2'],
+                    'set_string_variables': [],
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(
+            request.url.path,
+            '/api/pool/pool-a/workflow',
+        )
+        self.assertEqual(
+            request.url.params.multi_items(),
+            [('validation_only', 'true')],
+        )
+        self.assertEqual(request.headers['content-type'], 'application/json')
+        self.assertEqual(
+            request.content,
+            (
+                b'{"file":"version: 2\\n","set_variables":["replicas=2"],'
+                b'"set_string_variables":[]}'
+            ),
+        )
+
+    async def test_invalid_json_bodies_are_rejected_before_transport(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(200, content=b'{}')
+
+        credentials = self._credentials(
+            authorization_header='Bearer request-body-bearer-secret'
+        )
+        invalid_requests = (
+            ('GET', {'file': 'version: 2'}),
+            ('POST', {'value': object()}),
+            ('POST', {'value': float('nan')}),
+            ('POST', {'value': '\ud800'}),
+            ('POST', {'file': 'x' * (1024 * 1024)}),
+            ('POST', {'file': 'request-body-bearer-secret'}),
+        )
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for method, json_body in invalid_requests:
+                with self.subTest(method=method):
+                    with self.assertRaises(ValueError):
+                        await app_context.gateway.request(
+                            method,
+                            '/api/pool/pool-a/workflow',
+                            credentials=credentials,
+                            max_response_bytes=1024,
+                            json_body=json_body,
+                        )
+
+        self.assertEqual(transport_calls, 0)
+
     async def test_only_fixed_api_paths_and_methods_are_allowed(self) -> None:
         transport_calls = 0
 
@@ -482,6 +566,43 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(transport_calls, 1)
         self.assertNotIn('connection-upstream-secret', str(raised.exception))
+        self.assertIsNone(raised.exception.__cause__)
+
+    async def test_write_transport_failure_has_uncertain_outcome_and_no_retry(
+        self,
+    ) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal transport_calls
+            transport_calls += 1
+            raise httpx.ConnectError(
+                'write-transport-upstream-secret',
+                request=request,
+            )
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            with self.assertRaisesRegex(
+                gateway.GatewayUncertainWriteError,
+                'write outcome is unknown',
+            ) as raised:
+                await app_context.gateway.request(
+                    'POST',
+                    '/api/pool/pool-a/workflow',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                    json_body={'file': 'version: 2'},
+                )
+
+        self.assertEqual(transport_calls, 1)
+        self.assertNotIn(
+            'write-transport-upstream-secret',
+            str(raised.exception),
+        )
         self.assertIsNone(raised.exception.__cause__)
 
     async def test_error_status_body_is_read_with_an_independent_cap(self) -> None:

--- a/src/service/mcp/tests/test_telemetry.py
+++ b/src/service/mcp/tests/test_telemetry.py
@@ -31,6 +31,9 @@ class TelemetryTest(unittest.TestCase):
             ),
             '/api/app/user/private-app/spec': '/api/app/user/{app_name}/spec',
             '/api/resources/private-node': '/api/resources/{node_name}',
+            '/api/pool/private-pool/workflow': (
+                '/api/pool/{pool}/workflow'
+            ),
             '/api/unrecognized/private-value': '/api/{unclassified}',
             '/api/profile/settings': '/api/profile/settings',
         }
@@ -38,7 +41,12 @@ class TelemetryTest(unittest.TestCase):
             with self.subTest(path=path):
                 template = telemetry.route_template(path)
                 self.assertEqual(template, expected)
-                for secret in ('private-workflow-1', 'private-app', 'private-node'):
+                for secret in (
+                    'private-workflow-1',
+                    'private-app',
+                    'private-node',
+                    'private-pool',
+                ):
                     self.assertNotIn(secret, template)
 
     def test_log_includes_required_static_fields_only(self) -> None:

--- a/src/service/mcp/tests/test_tool_support.py
+++ b/src/service/mcp/tests/test_tool_support.py
@@ -357,5 +357,107 @@ class TruncatedTextRequestTest(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class JsonMutationRequestTest(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _credentials() -> request_context.RequestCredentials:
+        return request_context.RequestCredentials(
+            authorization_header='Bearer write-test-token-value',
+            user_name='test-user',
+            request_id='write-request-1',
+        )
+
+    async def test_mutation_relays_one_fixed_post_and_validates_json(self) -> None:
+        gateway_client = mock.AsyncMock(spec=gateway.GatewayClient)
+        gateway_client.request.return_value = gateway.GatewayResponse(
+            200,
+            b'{"name":"workflow-1"}',
+        )
+        credentials = self._credentials()
+        payload: tool_requests.JsonObject = {
+            'file': 'version: 2',
+            'set_variables': [],
+            'set_string_variables': [],
+        }
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'get_app_context',
+                return_value=gateway.AppContext(gateway=gateway_client),
+            ),
+            mock.patch.object(
+                request_context,
+                'get_request_credentials',
+                return_value=credentials,
+            ),
+        ):
+            result = await tool_requests.request_json_mutation(
+                mock.Mock(),
+                path='/api/pool/pool-a/workflow',
+                operation='validate a workflow',
+                max_response_bytes=1024,
+                query={'validation_only': True},
+                payload=payload,
+            )
+
+        self.assertEqual(result, {'name': 'workflow-1'})
+        gateway_client.request.assert_awaited_once_with(
+            'POST',
+            '/api/pool/pool-a/workflow',
+            credentials=credentials,
+            max_response_bytes=1024,
+            query={'validation_only': True},
+            json_body=payload,
+        )
+
+    async def test_mutation_transport_and_server_failures_are_uncertain(
+        self,
+    ) -> None:
+        gateway_client = mock.AsyncMock(spec=gateway.GatewayClient)
+        credentials = self._credentials()
+        failures = (
+            gateway.GatewayUncertainWriteError(
+                'transport-upstream-secret'
+            ),
+            gateway.GatewayResponse(
+                503,
+                b'{"message":"server-upstream-secret"}',
+            ),
+        )
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'get_app_context',
+                return_value=gateway.AppContext(gateway=gateway_client),
+            ),
+            mock.patch.object(
+                request_context,
+                'get_request_credentials',
+                return_value=credentials,
+            ),
+        ):
+            for failure in failures:
+                with self.subTest(failure=type(failure).__name__):
+                    if isinstance(failure, Exception):
+                        gateway_client.request.side_effect = failure
+                    else:
+                        gateway_client.request.side_effect = None
+                        gateway_client.request.return_value = failure
+                    with self.assertRaisesRegex(
+                        ToolError,
+                        'write outcome is unknown',
+                    ) as raised:
+                        await tool_requests.request_json_mutation(
+                            mock.Mock(),
+                            path='/api/pool/pool-a/workflow',
+                            operation='validate a workflow',
+                            max_response_bytes=1024,
+                        )
+                    message = str(raised.exception)
+                    self.assertIn('Inspect OSMO state before retrying', message)
+                    self.assertNotIn('upstream-secret', message)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/service/mcp/tests/test_workflow_actions.py
+++ b/src/service/mcp/tests/test_workflow_actions.py
@@ -1,0 +1,388 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import unittest
+
+import httpx
+from mcp.server.fastmcp.exceptions import ToolError
+
+from src.service.mcp import workflow_actions
+from src.service.mcp.tests import protocol_harness
+
+
+_BEARER_SECRET = 'phase-two-opaque-bearer-secret'
+_HARNESS = protocol_harness.ProtocolHarness(
+    tool_names=('osmo_validate_workflow',),
+    bearer_secret=_BEARER_SECRET,
+    request_id='workflow-action-request-123',
+)
+_PROFILE_RESULT = {
+    'profile': {
+        'username': 'alice@example.com',
+        'pool': 'pool-a',
+    },
+    'roles': ['osmo-user'],
+    'pools': ['pool-a', 'pool-b'],
+    'token': None,
+}
+_WORKFLOW_SPEC = """\
+version: 2
+workflow:
+  name: mcp-validation
+  tasks:
+  - name: check
+    image: ubuntu:22.04
+    command: [echo]
+    args: [ok]
+"""
+
+
+class WorkflowActionProtocolTest(unittest.IsolatedAsyncioTestCase):
+    """Exercise mutation mappings through the real Streamable HTTP protocol."""
+
+    async def test_validation_catalog_is_closed_and_not_read_only(self) -> None:
+        response = await _HARNESS.list_tools()
+        tools = _HARNESS.assert_closed_catalog(
+            self,
+            response,
+            expected_annotations={
+                'osmo_validate_workflow':
+                    protocol_harness.WRITE_ANNOTATIONS,
+            },
+        )
+        schema = tools['osmo_validate_workflow']['inputSchema']
+        self.assertEqual(schema['required'], ['workflow_spec'])
+        self.assertEqual(schema['properties']['pool']['default'], None)
+        self.assertEqual(
+            schema['properties']['set_variables']['default'],
+            None,
+        )
+        self.assertEqual(
+            schema['properties']['set_string_variables']['default'],
+            None,
+        )
+        self.assertEqual(
+            schema['properties']['workflow_spec']['maxLength'],
+            256 * 1024,
+        )
+
+    async def test_explicit_pool_posts_exact_template_payload(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        override_secret = 'synthetic-override-sensitive-value'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                'name': 'mcp-validation-1',
+                'logs': 'Workflow validation succeeded.',
+                'overview': 'https://user:url-secret@example.test/workflow',
+                'dashboard_url': 'https://example.test/?token=url-secret',
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_validate_workflow',
+            {
+                'workflow_spec': _WORKFLOW_SPEC,
+                'pool': 'pool-a',
+                'set_variables': ['replicas=2'],
+                'set_string_variables': [
+                    f'password={override_secret}',
+                ],
+            },
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'valid': True,
+            'pool': 'pool-a',
+            'logs': 'Workflow validation succeeded.',
+        })
+        for sensitive_value in (
+            _BEARER_SECRET,
+            override_secret,
+            'url-secret',
+        ):
+            self.assertNotIn(sensitive_value, response.text)
+
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.url.path, '/api/pool/pool-a/workflow')
+        self.assertEqual(
+            request.url.params.multi_items(),
+            [('validation_only', 'true')],
+        )
+        self.assertEqual(
+            json.loads(request.content),
+            {
+                'file': _WORKFLOW_SPEC,
+                'set_variables': ['replicas=2'],
+                'set_string_variables': [
+                    f'password={override_secret}',
+                ],
+            },
+        )
+        self.assertEqual(
+            request.headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+        self.assertEqual(
+            request.headers['x-request-id'],
+            'workflow-action-request-123',
+        )
+        self.assertNotIn('x-osmo-user', request.headers)
+
+    async def test_omitted_pool_uses_accessible_profile_default(self) -> None:
+        captured_paths: list[str] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_paths.append(request.url.path)
+            if request.url.path == '/api/profile/settings':
+                return httpx.Response(200, json=_PROFILE_RESULT)
+            return httpx.Response(200, json={
+                'name': 'mcp-validation-1',
+                'logs': 'Workflow validation succeeded.',
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_validate_workflow',
+            {'workflow_spec': _WORKFLOW_SPEC},
+        )
+
+        self.assertFalse(response.json()['result']['isError'])
+        self.assertEqual(captured_paths, [
+            '/api/profile/settings',
+            '/api/pool/pool-a/workflow',
+        ])
+
+    async def test_omitted_pool_uses_only_accessible_pool(self) -> None:
+        captured_paths: list[str] = []
+        profile_result = {
+            'profile': {
+                'username': 'alice@example.com',
+                'pool': None,
+            },
+            'roles': ['osmo-user'],
+            'pools': ['pool-only'],
+            'token': None,
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_paths.append(request.url.path)
+            if request.url.path == '/api/profile/settings':
+                return httpx.Response(200, json=profile_result)
+            return httpx.Response(200, json={
+                'name': 'mcp-validation-1',
+                'logs': 'Workflow validation succeeded.',
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_validate_workflow',
+            {'workflow_spec': _WORKFLOW_SPEC},
+        )
+
+        self.assertFalse(response.json()['result']['isError'])
+        self.assertEqual(captured_paths, [
+            '/api/profile/settings',
+            '/api/pool/pool-only/workflow',
+        ])
+
+    async def test_omitted_pool_rejects_ambiguous_access(self) -> None:
+        captured_paths: list[str] = []
+        profile_result = {
+            'profile': {
+                'username': 'alice@example.com',
+                'pool': None,
+            },
+            'roles': ['osmo-user'],
+            'pools': ['pool-a', 'pool-b'],
+            'token': None,
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_paths.append(request.url.path)
+            return httpx.Response(200, json=profile_result)
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_validate_workflow',
+            {'workflow_spec': _WORKFLOW_SPEC},
+        )
+
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn(
+            'No unambiguous accessible pool is configured.',
+            response.text,
+        )
+        self.assertEqual(captured_paths, ['/api/profile/settings'])
+
+    async def test_invalid_arguments_fail_before_relay(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(200, json={})
+
+        invalid_arguments: tuple[dict[str, object], ...] = (
+            {'workflow_spec': ''},
+            {'workflow_spec': ' \n\t'},
+            {'workflow_spec': 'version: 2\0'},
+            {'workflow_spec': 'x' * (256 * 1024 + 1)},
+            {'workflow_spec': _WORKFLOW_SPEC, 'pool': '../private'},
+            {'workflow_spec': _WORKFLOW_SPEC, 'set_variables': ['missing']},
+            {'workflow_spec': _WORKFLOW_SPEC, 'set_variables': [True]},
+            {
+                'workflow_spec': _WORKFLOW_SPEC,
+                'set_string_variables': ['key=' + 'x' * 2048],
+            },
+        )
+        async with _HARNESS.client(handler) as client:
+            for request_id, arguments in enumerate(
+                invalid_arguments,
+                start=1,
+            ):
+                with self.subTest(arguments=arguments):
+                    response = await _HARNESS.call_tool_with_client(
+                        client,
+                        'osmo_validate_workflow',
+                        arguments,
+                        request_id=request_id,
+                    )
+                    self.assertTrue(response.json()['result']['isError'])
+
+        self.assertEqual(transport_calls, 0)
+
+    async def test_errors_are_bounded_redacted_and_not_retried(self) -> None:
+        calls = 0
+        input_secret = 'synthetic-workflow-input-sensitive-value'
+
+        async def client_error(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal calls
+            calls += 1
+            return httpx.Response(422, json={
+                'message': input_secret,
+                'error_code': 'SUBMISSION',
+                'workflow_id': 'private-workflow-1',
+            })
+
+        response = await _HARNESS.call_tool(
+            client_error,
+            'osmo_validate_workflow',
+            {
+                'workflow_spec': (
+                    _WORKFLOW_SPEC
+                    + f'\n# password={input_secret}\n'
+                ),
+                'pool': 'pool-a',
+            },
+        )
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('HTTP 422', response.text)
+        self.assertNotIn('SUBMISSION', response.text)
+        self.assertNotIn('private-workflow-1', response.text)
+        self.assertNotIn(input_secret, response.text)
+        self.assertEqual(calls, 1)
+
+        async def server_error(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal calls
+            calls += 1
+            return httpx.Response(
+                503,
+                content=b'server-response-sensitive-value',
+            )
+
+        response = await _HARNESS.call_tool(
+            server_error,
+            'osmo_validate_workflow',
+            {
+                'workflow_spec': _WORKFLOW_SPEC,
+                'pool': 'pool-a',
+            },
+        )
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('write outcome is unknown', response.text)
+        self.assertIn('Inspect OSMO state before retrying', response.text)
+        self.assertNotIn('server-response-sensitive-value', response.text)
+        self.assertEqual(calls, 2)
+
+    async def test_malformed_and_oversized_success_responses_fail_closed(
+        self,
+    ) -> None:
+        responses = [
+            httpx.Response(200, content=b'[]'),
+            httpx.Response(200, json={'name': 'workflow-1'}),
+            httpx.Response(200, json={
+                'name': 'workflow-1',
+                'logs': 'password=upstream-success-secret',
+            }),
+            httpx.Response(200, content=b'x' * (64 * 1024 + 1)),
+        ]
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            return responses.pop(0)
+
+        async with _HARNESS.client(handler) as client:
+            for request_id in range(1, 5):
+                response = await _HARNESS.call_tool_with_client(
+                    client,
+                    'osmo_validate_workflow',
+                    {
+                        'workflow_spec': _WORKFLOW_SPEC,
+                        'pool': 'pool-a',
+                    },
+                    request_id=request_id,
+                )
+                self.assertTrue(response.json()['result']['isError'])
+                self.assertIn('write outcome is unknown', response.text)
+                self.assertLess(len(response.content), 16 * 1024)
+                self.assertNotIn(_BEARER_SECRET, response.text)
+                self.assertNotIn(
+                    'upstream-success-secret',
+                    response.text,
+                )
+
+
+class WorkflowActionValidationUnitTest(unittest.IsolatedAsyncioTestCase):
+    async def test_direct_invalid_values_fail_before_context(self) -> None:
+        with self.assertRaises(ToolError):
+            await workflow_actions.osmo_validate_workflow(
+                None,  # type: ignore[arg-type]
+                'version: 2\0',
+                pool='pool-a',
+            )
+        with self.assertRaises(ToolError):
+            await workflow_actions.osmo_validate_workflow(
+                None,  # type: ignore[arg-type]
+                _WORKFLOW_SPEC,
+                pool='pool-a',
+                set_variables=['missing-equals'],
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tool_errors.py
+++ b/src/service/mcp/tool_errors.py
@@ -66,6 +66,14 @@ class PublicToolError(ToolError):
         )
 
 
+def uncertain_write_error(operation: str) -> PublicToolError:
+    """Return the fixed recovery guidance for an ambiguous mutation result."""
+    return PublicToolError(
+        f'The OSMO write outcome is unknown while attempting to {operation}. '
+        'Inspect OSMO state before retrying.'
+    )
+
+
 def from_fastmcp_error(error: ToolError) -> PublicToolError | None:
     """Recover an intentional public error from FastMCP's generic wrapper."""
     cause = error.__cause__

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -29,8 +29,27 @@ from src.service.mcp import (
     pools,
     profile,
     resources,
+    workflow_actions,
     workflows,
 )
+
+
+def _read_only_annotations() -> ToolAnnotations:
+    return ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=False,
+    )
+
+
+def _write_annotations(*, destructive: bool) -> ToolAnnotations:
+    return ToolAnnotations(
+        readOnlyHint=False,
+        destructiveHint=destructive,
+        idempotentHint=False,
+        openWorldHint=False,
+    )
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -41,6 +60,9 @@ class ToolSpec:
     name: str
     title: str
     description: str
+    annotations: ToolAnnotations = dataclasses.field(
+        default_factory=_read_only_annotations
+    )
 
 
 TOOL_SPECS: tuple[ToolSpec, ...] = (
@@ -132,6 +154,16 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         ),
     ),
     ToolSpec(
+        function=workflow_actions.osmo_validate_workflow,
+        name='osmo_validate_workflow',
+        title='Validate an OSMO workflow',
+        description=(
+            'Validate workflow YAML with OSMO Core without submitting it. '
+            'A failed validation may create a FAILED_SUBMISSION record.'
+        ),
+        annotations=_write_annotations(destructive=False),
+    ),
+    ToolSpec(
         function=apps.osmo_list_apps,
         name='osmo_list_apps',
         title='List OSMO apps',
@@ -201,11 +233,6 @@ def register_tools(
             name=spec.name,
             title=spec.title,
             description=spec.description,
-            annotations=ToolAnnotations(
-                readOnlyHint=True,
-                destructiveHint=False,
-                idempotentHint=True,
-                openWorldHint=False,
-            ),
+            annotations=spec.annotations,
             structured_output=True,
         )

--- a/src/service/mcp/tool_requests.py
+++ b/src/service/mcp/tool_requests.py
@@ -76,12 +76,33 @@ async def request_json_object(
         suppress_upstream_details=suppress_upstream_details,
         not_found_message=not_found_message,
     )
+    return _validate_json_object_body(response.body, operation=operation)
+
+
+async def request_json_mutation(
+    context: Context,
+    *,
+    path: str,
+    operation: str,
+    max_response_bytes: int,
+    query: gateway.QueryParams | None = None,
+    payload: JsonObject | None = None,
+) -> JsonObject:
+    """Relay one fixed POST without retries and require a bounded JSON object."""
+    response = await _request(
+        context,
+        method='POST',
+        path=path,
+        operation=operation,
+        max_response_bytes=max_response_bytes,
+        query=query,
+        json_body=payload,
+        suppress_upstream_details=True,
+    )
     try:
-        return _JSON_OBJECT_ADAPTER.validate_json(response.body, strict=True)
-    except pydantic.ValidationError:
-        raise tool_errors.PublicToolError(
-            f'OSMO returned an invalid response while attempting to {operation}.'
-        ) from None
+        return _validate_json_object_body(response.body, operation=operation)
+    except tool_errors.PublicToolError:
+        raise tool_errors.uncertain_write_error(operation) from None
 
 
 async def request_text(
@@ -189,10 +210,12 @@ def get_app_context(context: Context) -> gateway.AppContext:
 async def _request(
     context: Context,
     *,
+    method: str = 'GET',
     path: str,
     operation: str,
     max_response_bytes: int,
     query: gateway.QueryParams | None,
+    json_body: JsonObject | None = None,
     suppress_upstream_details: bool = False,
     truncate_text: bool = False,
     not_found_message: str | None = None,
@@ -212,13 +235,20 @@ async def _request(
             else app_context.gateway.request
         )
         response = await request_method(
-            'GET',
+            method,
             path,
             credentials=credentials,
             max_response_bytes=max_response_bytes,
             query=query,
+            **(
+                {'json_body': json_body}
+                if not truncate_text
+                else {}
+            ),
         )
     except gateway.GatewayClientError as error:
+        if method != 'GET':
+            raise tool_errors.uncertain_write_error(operation) from None
         raise tool_errors.PublicToolError(str(error)) from None
     except ValueError:
         raise tool_errors.PublicToolError(
@@ -229,6 +259,8 @@ async def _request(
         raise tool_errors.PublicToolError(
             tool_errors.bounded_safe_error(not_found_message)
         )
+    if method != 'GET' and response.status_code >= 500:
+        raise tool_errors.uncertain_write_error(operation)
     if response.status_code != 200:
         raise tool_errors.PublicToolError(tool_errors.upstream_error(
             operation,
@@ -240,6 +272,15 @@ async def _request(
             suppress_upstream_details=suppress_upstream_details,
         ))
     return response
+
+
+def _validate_json_object_body(body: bytes, *, operation: str) -> JsonObject:
+    try:
+        return _JSON_OBJECT_ADAPTER.validate_json(body, strict=True)
+    except pydantic.ValidationError:
+        raise tool_errors.PublicToolError(
+            f'OSMO returned an invalid response while attempting to {operation}.'
+        ) from None
 
 
 def _decode_text_prefix(

--- a/src/service/mcp/tool_validation.py
+++ b/src/service/mcp/tool_validation.py
@@ -22,7 +22,7 @@ from urllib import parse
 
 import pydantic
 
-from src.service.mcp.tool_errors import PublicToolError
+from src.service.mcp.tool_errors import PublicToolError, uncertain_write_error
 
 
 _MAX_PATH_SEGMENT_BYTES = 512
@@ -70,6 +70,23 @@ def validate_response(
             f'OSMO returned an invalid response while attempting to {operation}.'
         )
         raise PublicToolError(message) from None
+
+
+def validate_mutation_response(
+    model: type[_Model],
+    response: object,
+    *,
+    operation: str,
+) -> _Model:
+    """Validate a successful write result or classify its outcome as unknown."""
+    try:
+        return validate_response(
+            model,
+            response,
+            operation=operation,
+        )
+    except PublicToolError:
+        raise uncertain_write_error(operation) from None
 
 
 def validate_integer(

--- a/src/service/mcp/workflow_action_models.py
+++ b/src/service/mcp/workflow_action_models.py
@@ -1,0 +1,66 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Annotated, Literal
+
+import pydantic
+
+from src.service.mcp.tool_models import ClosedToolModel
+
+
+PoolName = Annotated[
+    str,
+    pydantic.Field(min_length=1, max_length=512),
+]
+WorkflowSpecText = Annotated[
+    str,
+    pydantic.Field(min_length=1, max_length=256 * 1024),
+]
+VariableOverride = Annotated[
+    str,
+    pydantic.Field(min_length=2, max_length=2048),
+]
+VariableOverrides = Annotated[
+    list[VariableOverride],
+    pydantic.Field(max_length=50),
+]
+
+
+class WorkflowTemplatePayload(ClosedToolModel):
+    """Exact Core TemplateSpec fields accepted from an MCP workflow action."""
+
+    file: str
+    set_variables: list[str]
+    set_string_variables: list[str]
+
+
+class UpstreamValidationResult(ClosedToolModel):
+    """Allowlisted validation-only fields from Core's SubmitResponse."""
+
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+    name: Annotated[str, pydantic.Field(min_length=1, max_length=512)]
+    logs: Literal['Workflow validation succeeded.']
+
+
+class ValidateWorkflowResult(ClosedToolModel):
+    """Compact confirmation of an authoritative Core validation."""
+
+    valid: bool
+    pool: PoolName
+    logs: Literal['Workflow validation succeeded.']

--- a/src/service/mcp/workflow_actions.py
+++ b/src/service/mcp/workflow_actions.py
@@ -1,0 +1,160 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from mcp.server.fastmcp import Context
+
+from src.service.mcp import (
+    access_scope,
+    tool_errors,
+    tool_requests,
+    tool_validation,
+)
+from src.service.mcp.workflow_action_models import (
+    PoolName,
+    UpstreamValidationResult,
+    ValidateWorkflowResult,
+    VariableOverrides,
+    WorkflowSpecText,
+    WorkflowTemplatePayload,
+)
+
+
+_MAX_JSON_RESPONSE_BYTES = 64 * 1024
+_MAX_WORKFLOW_SPEC_BYTES = 256 * 1024
+_MAX_OVERRIDE_BYTES = 2048
+
+
+async def osmo_validate_workflow(
+    context: Context,
+    workflow_spec: WorkflowSpecText,
+    pool: PoolName | None = None,
+    set_variables: VariableOverrides | None = None,
+    set_string_variables: VariableOverrides | None = None,
+) -> ValidateWorkflowResult:
+    """Validate workflow YAML using Core's authoritative submission checks."""
+    validated_spec = _validate_workflow_spec(workflow_spec)
+    validated_set_variables = _validate_overrides(
+        set_variables,
+        field='set_variables',
+    )
+    validated_set_string_variables = _validate_overrides(
+        set_string_variables,
+        field='set_string_variables',
+    )
+    pool_name = await _resolve_pool(context, pool)
+    encoded_pool = tool_validation.safe_path_segment(
+        pool_name,
+        field='pool',
+    )
+    payload = WorkflowTemplatePayload(
+        file=validated_spec,
+        set_variables=validated_set_variables,
+        set_string_variables=validated_set_string_variables,
+    )
+    response = await tool_requests.request_json_mutation(
+        context,
+        path=f'/api/pool/{encoded_pool}/workflow',
+        operation='validate a workflow',
+        max_response_bytes=_MAX_JSON_RESPONSE_BYTES,
+        query={'validation_only': True},
+        payload=payload.model_dump(mode='json'),
+    )
+    upstream = tool_validation.validate_mutation_response(
+        UpstreamValidationResult,
+        response,
+        operation='validate a workflow',
+    )
+    return ValidateWorkflowResult(
+        valid=True,
+        pool=pool_name,
+        logs=upstream.logs,
+    )
+
+
+async def _resolve_pool(context: Context, pool: str | None) -> str:
+    if pool is not None:
+        return tool_validation.validate_query_text(
+            pool,
+            field='pool',
+            max_bytes=512,
+        )
+
+    scope = await access_scope.request_access_scope(context)
+    if scope.default_pool is not None:
+        return scope.default_pool
+    if len(scope.pools) == 1:
+        return scope.pools[0]
+    raise tool_errors.PublicToolError(
+        'No unambiguous accessible pool is configured.'
+    )
+
+
+def _validate_workflow_spec(workflow_spec: str) -> str:
+    try:
+        encoded_spec = workflow_spec.encode('utf-8')
+    except (AttributeError, UnicodeEncodeError):
+        encoded_spec = b''
+    if (
+        not isinstance(workflow_spec, str)
+        or not workflow_spec.strip()
+        or len(encoded_spec) > _MAX_WORKFLOW_SPEC_BYTES
+        or any(
+            not character.isprintable()
+            and character not in '\n\r\t'
+            for character in workflow_spec
+        )
+    ):
+        raise tool_errors.PublicToolError('Invalid workflow_spec.')
+    return workflow_spec
+
+
+def _validate_overrides(
+    values: list[str] | None,
+    *,
+    field: str,
+) -> list[str]:
+    if values is None:
+        return []
+    if (
+        not isinstance(values, list)
+        or len(values) > 50
+    ):
+        raise tool_errors.PublicToolError(f'Invalid {field}.')
+
+    validated: list[str] = []
+    for value in values:
+        try:
+            encoded_value = value.encode('utf-8')
+        except (AttributeError, UnicodeEncodeError):
+            encoded_value = b''
+        key, separator, _ = value.partition('=') if isinstance(
+            value, str
+        ) else ('', '', '')
+        if (
+            not separator
+            or not key
+            or key != key.strip()
+            or len(encoded_value) > _MAX_OVERRIDE_BYTES
+            or any(
+                ord(character) < 0x20 or ord(character) == 0x7F
+                for character in value
+            )
+        ):
+            raise tool_errors.PublicToolError(f'Invalid {field}.')
+        validated.append(value)
+    return validated

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -18,7 +18,7 @@ from src.lib.utils.client import RequestMethod
 from test.oetf.smoke_fixture import SmokeFixture
 
 
-_PHASE_ONE_TOOL_NAMES = frozenset({
+_EXPECTED_TOOL_NAMES = frozenset({
     "osmo_get_app",
     "osmo_get_app_spec",
     "osmo_get_profile",
@@ -33,6 +33,7 @@ _PHASE_ONE_TOOL_NAMES = frozenset({
     "osmo_list_resources",
     "osmo_list_workflows",
     "osmo_search_pools",
+    "osmo_validate_workflow",
 })
 _MCP_ACCEPT_HEADERS = {
     "Accept": "application/json, text/event-stream",
@@ -50,7 +51,7 @@ _TOKEN_FIELDS = (
 
 
 class McpChecks(SmokeFixture):
-    """Exercise the deployed Phase 1 MCP through its public Gateway route."""
+    """Exercise the deployed external MCP through its public Gateway route."""
 
     def _jsonrpc_result(self, response, request_id):
         if (
@@ -66,7 +67,7 @@ class McpChecks(SmokeFixture):
             self.fail("MCP returned an invalid JSON-RPC result.")
         return result
 
-    def test_phase_one_catalog_and_profile_round_trip(self):
+    def test_catalog_and_profile_round_trip(self):
         base_url = self.config.url.rstrip("/")
         unauthenticated_response = requests.post(
             f"{base_url}/mcp",
@@ -108,10 +109,10 @@ class McpChecks(SmokeFixture):
             self.fail("MCP returned an invalid tool catalog.")
         tool_names = [tool.get("name") for tool in catalog_tools]
         if (
-            len(tool_names) != len(_PHASE_ONE_TOOL_NAMES)
-            or set(tool_names) != _PHASE_ONE_TOOL_NAMES
+            len(tool_names) != len(_EXPECTED_TOOL_NAMES)
+            or set(tool_names) != _EXPECTED_TOOL_NAMES
         ):
-            self.fail("MCP tool catalog does not match the Phase 1 contract.")
+            self.fail("MCP tool catalog does not match the expected contract.")
 
         direct_profile = self.service_client.request(
             method=RequestMethod.GET,


### PR DESCRIPTION
## Description

Start Phase 2 with the shared mutation-safe request path and
`osmo_validate_workflow`.

- relay one bounded, exact JSON mutation body with no automatic retries
- classify transport, 5xx, oversized, and malformed-success mutation results
  as an unknown write outcome
- validate workflow YAML through Core's existing
  `POST /api/pool/{pool}/workflow?validation_only=true` route
- return only the compact allowlisted validation result
- mark validation as non-read-only and non-idempotent because failed
  validation may create a `FAILED_SUBMISSION` record
- keep the external MCP runtime independent and make no Core API changes

Issue - None

## Validation

- complete MCP validation passed: 55 targets
- post-merge-restack focused Gateway, telemetry, support, catalog,
  workflow-action, and smoke-pylint tests passed: 6/6
- `bazel --output_user_root=/tmp/osmo-bazel build //src/service/mcp:mcp_binary //test/smoke:mcp-checks`
  — passed
- range-diff confirms the Phase 2 patch is unchanged after rebasing onto
  #1233's merge commit
- `git diff --check` — passed

## Stack

1. #1233 (merged): Phase 1 deployment smoke prerequisite
2. This PR: mutation-safe transport + workflow validation
3. #1235: workflow submission
4. #1236: workflow restart and cancellation
5. #1237: Phase 2 deployment smoke coverage and final documentation

#1233 is merged, so this PR now targets `feature/mcp` directly. The remaining
merge order is #1234 → #1235 → #1236 → #1237. Each later PR remains based on
the preceding stack branch and ultimately lands sequentially in
`feature/mcp`. Nothing targets `main`.

## Checklist

- [x] Limited to the first Phase 2 review slice
- [x] Uses existing CLI/Core behavior without importing other runtimes
- [x] Adds protocol-level security and contract coverage
- [x] Uses only MCP and smoke build targets needed for this change
