### PR TITLE
Add external MCP workflow submission

### DIFF
--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -162,6 +162,7 @@ osmo_py_library(
     deps = [
         requirement("pydantic"),
         ":tool_models",
+        ":workflow_models",
     ],
     visibility = ["//visibility:public"],
 )
@@ -243,6 +244,7 @@ osmo_py_library(
         ":tool_requests",
         ":tool_validation",
         ":workflow_action_models",
+        ":workflow_models",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -102,15 +102,22 @@ authorization value.
 
 The external catalog contains 14 read-only tools for caller-bound health,
 profile, pool, resource, workflow, application, and credential-metadata
-inspection, plus `osmo_validate_workflow`. Each tool maps to a fixed external
-API, returns a structured allowlisted result, and applies a domain-specific
-response limit. Credential inspection returns names and types only. Profile
-inspection intentionally includes non-secret access-token identity metadata
-(name and expiry), unlike the hosted internal MCP projection.
+inspection, plus `osmo_validate_workflow` and `osmo_submit_workflow`. Each tool
+maps to a fixed external API, returns a structured allowlisted result, and
+applies a domain-specific response limit. Credential inspection returns names
+and types only. Profile inspection intentionally includes non-secret
+access-token identity metadata (name and expiry), unlike the hosted internal
+MCP projection.
 
 Workflow validation calls Core's submission endpoint with
 `validation_only=true`. It is intentionally annotated as a non-idempotent
 write because a failed validation can create a `FAILED_SUBMISSION` record.
+Workflow submission accepts bounded raw YAML, template overrides, a target
+pool, and scheduling priority. It intentionally does not accept local paths,
+environment injection, dry-run rendering, or source workflow IDs. The latter
+would let Core read a source spec without a source-pool authorization check.
+The result contains only the new workflow ID, pool, priority, and submission
+confirmation; Core-generated URLs are not returned.
 
 JSON tools require one complete bounded response. Bounded text tools may
 instead return a safe UTF-8 prefix with `truncated=true` and a machine-readable

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -65,14 +65,22 @@ projection therefore returns only `cred_name` and `cred_type`.
 
 ## Phase 2: workflow actions (in progress)
 
-`osmo_validate_workflow` is implemented using the exact bounded TemplateSpec
-projection and `validation_only=true`. It is a non-idempotent write because a
-failed validation can create a `FAILED_SUBMISSION` workflow record. The shared
-mutation relay sends bounded JSON, never retries, and reports an unknown
-outcome for ambiguous transport or server failures.
+`osmo_validate_workflow` and `osmo_submit_workflow` are implemented using
+bounded TemplateSpec projections. Validation sets `validation_only=true` and
+is a non-idempotent write because a failed validation can create a
+`FAILED_SUBMISSION` workflow record. Submission accepts raw YAML and preserves
+the original template when it detects the same template markers as the CLI.
+It returns only the new workflow ID, selected pool, and effective priority.
+The shared mutation relay sends bounded JSON, never retries, and reports an
+unknown outcome for ambiguous transport or server failures.
 
-Add `osmo_submit_workflow`, `osmo_restart_workflow`, and
-`osmo_cancel_workflow` as the remaining Phase 2 actions.
+Submit-by-workflow-ID is intentionally omitted. Core authorizes creation in the
+target pool but reads the source workflow internally without a source-pool
+read check. Dry-run rendering, environment injection, local-file expansion,
+and rsync are also omitted from the agent-facing contract.
+
+Add `osmo_restart_workflow` and `osmo_cancel_workflow` as the remaining Phase 2
+actions.
 
 ## Phase 3: user-owned mutations
 

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -105,6 +105,13 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'Get the bounded, server-redacted resolved or template workflow YAML.',
     ),
     (
+        workflow_actions.osmo_submit_workflow,
+        'osmo_submit_workflow',
+        'Submit an OSMO workflow',
+        'Submit raw workflow YAML to run in OSMO. This consumes real '
+        'compute and is not automatically retried.',
+    ),
+    (
         workflow_actions.osmo_validate_workflow,
         'osmo_validate_workflow',
         'Validate an OSMO workflow',
@@ -153,6 +160,7 @@ _EXPECTED_REQUIRED_FIELDS = {
     'osmo_get_workflow_logs': ['workflow_id'],
     'osmo_get_workflow_events': ['workflow_id'],
     'osmo_get_workflow_spec': ['workflow_id'],
+    'osmo_submit_workflow': ['workflow_spec'],
     'osmo_validate_workflow': ['workflow_spec'],
     'osmo_list_apps': [],
     'osmo_get_app': ['name'],
@@ -189,6 +197,12 @@ _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
     },
     'osmo_get_workflow_events': {'task_name': None, 'retry_id': None},
     'osmo_get_workflow_spec': {'use_template': False},
+    'osmo_submit_workflow': {
+        'pool': None,
+        'set_variables': None,
+        'set_string_variables': None,
+        'priority': 'NORMAL',
+    },
     'osmo_validate_workflow': {
         'pool': None,
         'set_variables': None,
@@ -210,7 +224,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
     """Lock the ordered, agent-facing external MCP tool contract."""
 
     def test_registry_has_exact_metadata_and_direct_unique_functions(self) -> None:
-        self.assertEqual(len(tool_registry.TOOL_SPECS), 15)
+        self.assertEqual(len(tool_registry.TOOL_SPECS), 16)
         self.assertEqual(
             [
                 (spec.name, spec.title, spec.description)
@@ -225,7 +239,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         registered_functions = [
             spec.function for spec in tool_registry.TOOL_SPECS
         ]
-        self.assertEqual(len({id(function) for function in registered_functions}), 15)
+        self.assertEqual(len({id(function) for function in registered_functions}), 16)
         for spec, (function, _, _, _) in zip(
             tool_registry.TOOL_SPECS,
             _EXPECTED_SPECS,
@@ -238,7 +252,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
 
         tool_registry.register_tools(mcp_server)
 
-        self.assertEqual(mcp_server.add_tool.call_count, 15)
+        self.assertEqual(mcp_server.add_tool.call_count, 16)
         for call, (function, name, title, description) in zip(
             mcp_server.add_tool.call_args_list,
             _EXPECTED_SPECS,
@@ -250,10 +264,13 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(call.kwargs['description'], description)
             self.assertTrue(call.kwargs['structured_output'])
             annotations = call.kwargs['annotations']
-            is_validation = name == 'osmo_validate_workflow'
-            self.assertIs(annotations.readOnlyHint, not is_validation)
+            is_write = name in {
+                'osmo_submit_workflow',
+                'osmo_validate_workflow',
+            }
+            self.assertIs(annotations.readOnlyHint, not is_write)
             self.assertFalse(annotations.destructiveHint)
-            self.assertIs(annotations.idempotentHint, not is_validation)
+            self.assertIs(annotations.idempotentHint, not is_write)
             self.assertFalse(annotations.openWorldHint)
 
     async def test_all_tools_have_closed_schemas_and_stable_arguments(self) -> None:
@@ -270,10 +287,13 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         for tool in tools:
             self.assertIsNotNone(tool.annotations)
             assert tool.annotations is not None
-            is_validation = tool.name == 'osmo_validate_workflow'
-            self.assertIs(tool.annotations.readOnlyHint, not is_validation)
+            is_write = tool.name in {
+                'osmo_submit_workflow',
+                'osmo_validate_workflow',
+            }
+            self.assertIs(tool.annotations.readOnlyHint, not is_write)
             self.assertFalse(tool.annotations.destructiveHint)
-            self.assertIs(tool.annotations.idempotentHint, not is_validation)
+            self.assertIs(tool.annotations.idempotentHint, not is_write)
             self.assertFalse(tool.annotations.openWorldHint)
             self._assert_recursively_closed(tool.inputSchema, tool.name)
             self.assertIsNotNone(tool.outputSchema)

--- a/src/service/mcp/tests/test_workflow_actions.py
+++ b/src/service/mcp/tests/test_workflow_actions.py
@@ -28,7 +28,10 @@ from src.service.mcp.tests import protocol_harness
 
 _BEARER_SECRET = 'phase-two-opaque-bearer-secret'
 _HARNESS = protocol_harness.ProtocolHarness(
-    tool_names=('osmo_validate_workflow',),
+    tool_names=(
+        'osmo_submit_workflow',
+        'osmo_validate_workflow',
+    ),
     bearer_secret=_BEARER_SECRET,
     request_id='workflow-action-request-123',
 )
@@ -56,31 +59,234 @@ workflow:
 class WorkflowActionProtocolTest(unittest.IsolatedAsyncioTestCase):
     """Exercise mutation mappings through the real Streamable HTTP protocol."""
 
-    async def test_validation_catalog_is_closed_and_not_read_only(self) -> None:
+    async def test_action_catalog_is_closed_and_not_read_only(self) -> None:
         response = await _HARNESS.list_tools()
         tools = _HARNESS.assert_closed_catalog(
             self,
             response,
             expected_annotations={
+                'osmo_submit_workflow':
+                    protocol_harness.WRITE_ANNOTATIONS,
                 'osmo_validate_workflow':
                     protocol_harness.WRITE_ANNOTATIONS,
             },
         )
-        schema = tools['osmo_validate_workflow']['inputSchema']
-        self.assertEqual(schema['required'], ['workflow_spec'])
-        self.assertEqual(schema['properties']['pool']['default'], None)
+        validation_schema = tools[
+            'osmo_validate_workflow'
+        ]['inputSchema']
+        self.assertEqual(validation_schema['required'], ['workflow_spec'])
         self.assertEqual(
-            schema['properties']['set_variables']['default'],
+            validation_schema['properties']['pool']['default'],
             None,
         )
         self.assertEqual(
-            schema['properties']['set_string_variables']['default'],
+            validation_schema['properties']['set_variables']['default'],
             None,
         )
         self.assertEqual(
-            schema['properties']['workflow_spec']['maxLength'],
+            validation_schema[
+                'properties'
+            ]['set_string_variables']['default'],
+            None,
+        )
+        self.assertEqual(
+            validation_schema['properties']['workflow_spec']['maxLength'],
             256 * 1024,
         )
+        submit_schema = tools['osmo_submit_workflow']['inputSchema']
+        self.assertEqual(submit_schema['required'], ['workflow_spec'])
+        self.assertEqual(
+            submit_schema['properties']['workflow_spec']['maxLength'],
+            128 * 1024,
+        )
+        self.assertEqual(
+            submit_schema['properties']['priority']['default'],
+            'NORMAL',
+        )
+        for excluded_argument in (
+            'workflow_id',
+            'dry_run',
+            'env_vars',
+            'uploaded_templated_spec',
+        ):
+            self.assertNotIn(
+                excluded_argument,
+                submit_schema['properties'],
+            )
+
+    async def test_submit_posts_exact_body_and_projects_result(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        upstream_secret = 'submission-upstream-sensitive-value'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                'name': 'mcp-submission-1',
+                'overview': (
+                    'https://user:password@example.test/'
+                    f'?token={upstream_secret}'
+                ),
+                'logs': (
+                    'https://example.test/logs'
+                    f'?signature={upstream_secret}'
+                ),
+                'dashboard_url': (
+                    f'https://example.test/?secret={upstream_secret}'
+                ),
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_submit_workflow',
+            {
+                'workflow_spec': _WORKFLOW_SPEC,
+                'pool': 'pool-a',
+                'set_variables': ['replicas=2'],
+                'set_string_variables': ['image_tag=latest'],
+                'priority': 'HIGH',
+            },
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'workflow_id': 'mcp-submission-1',
+            'pool': 'pool-a',
+            'priority': 'HIGH',
+            'submitted': True,
+        })
+        self.assertNotIn(upstream_secret, response.text)
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.url.path, '/api/pool/pool-a/workflow')
+        self.assertEqual(
+            request.url.params.multi_items(),
+            [('priority', 'HIGH')],
+        )
+        self.assertEqual(json.loads(request.content), {
+            'file': _WORKFLOW_SPEC,
+            'set_variables': ['replicas=2'],
+            'set_string_variables': ['image_tag=latest'],
+        })
+
+    async def test_submit_preserves_template_and_uses_defaults(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        templated_spec = (
+            _WORKFLOW_SPEC
+            + '\ndefault-values:\n  replicas: 1\n'
+            + '# {{ replicas }}\n'
+        )
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.url.path == '/api/profile/settings':
+                return httpx.Response(200, json=_PROFILE_RESULT)
+            return httpx.Response(200, json={
+                'name': 'mcp-template-1',
+                'overview': 'https://example.test/workflow',
+                'logs': 'https://example.test/logs',
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_submit_workflow',
+            {'workflow_spec': templated_spec},
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'workflow_id': 'mcp-template-1',
+            'pool': 'pool-a',
+            'priority': 'NORMAL',
+            'submitted': True,
+        })
+        self.assertEqual(
+            [request.url.path for request in captured_requests],
+            [
+                '/api/profile/settings',
+                '/api/pool/pool-a/workflow',
+            ],
+        )
+        submit_request = captured_requests[1]
+        self.assertEqual(submit_request.url.params.multi_items(), [])
+        self.assertEqual(json.loads(submit_request.content), {
+            'file': templated_spec,
+            'set_variables': [],
+            'set_string_variables': [],
+            'uploaded_templated_spec': templated_spec,
+        })
+
+    async def test_submit_rejects_unsupported_or_invalid_arguments(
+        self,
+    ) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(200, json={})
+
+        invalid_arguments: tuple[dict[str, object], ...] = (
+            {
+                'workflow_spec': _WORKFLOW_SPEC,
+                'workflow_id': 'private-workflow-1',
+            },
+            {'workflow_spec': _WORKFLOW_SPEC, 'dry_run': True},
+            {'workflow_spec': _WORKFLOW_SPEC, 'priority': 'URGENT'},
+            {'workflow_spec': 'x' * (128 * 1024 + 1)},
+        )
+        async with _HARNESS.client(handler) as client:
+            for request_id, arguments in enumerate(
+                invalid_arguments,
+                start=1,
+            ):
+                with self.subTest(arguments=arguments):
+                    response = await _HARNESS.call_tool_with_client(
+                        client,
+                        'osmo_submit_workflow',
+                        arguments,
+                        request_id=request_id,
+                    )
+                    self.assertTrue(response.json()['result']['isError'])
+
+        self.assertEqual(transport_calls, 0)
+
+    async def test_submit_ambiguous_results_are_not_retried(self) -> None:
+        responses = [
+            httpx.Response(503, content=b'private-server-detail'),
+            httpx.Response(200, json={'name': 'mcp-submission-1'}),
+        ]
+        calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal calls
+            calls += 1
+            return responses.pop(0)
+
+        async with _HARNESS.client(handler) as client:
+            for request_id in range(1, 3):
+                response = await _HARNESS.call_tool_with_client(
+                    client,
+                    'osmo_submit_workflow',
+                    {
+                        'workflow_spec': _WORKFLOW_SPEC,
+                        'pool': 'pool-a',
+                    },
+                    request_id=request_id,
+                )
+                self.assertTrue(response.json()['result']['isError'])
+                self.assertIn('write outcome is unknown', response.text)
+                self.assertIn(
+                    'Inspect OSMO state before retrying',
+                    response.text,
+                )
+                self.assertNotIn('private-server-detail', response.text)
+
+        self.assertEqual(calls, 2)
 
     async def test_explicit_pool_posts_exact_template_payload(self) -> None:
         captured_requests: list[httpx.Request] = []

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -154,6 +154,16 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         ),
     ),
     ToolSpec(
+        function=workflow_actions.osmo_submit_workflow,
+        name='osmo_submit_workflow',
+        title='Submit an OSMO workflow',
+        description=(
+            'Submit raw workflow YAML to run in OSMO. This consumes real '
+            'compute and is not automatically retried.'
+        ),
+        annotations=_write_annotations(destructive=False),
+    ),
+    ToolSpec(
         function=workflow_actions.osmo_validate_workflow,
         name='osmo_validate_workflow',
         title='Validate an OSMO workflow',

--- a/src/service/mcp/workflow_action_models.py
+++ b/src/service/mcp/workflow_action_models.py
@@ -21,6 +21,7 @@ from typing import Annotated, Literal
 import pydantic
 
 from src.service.mcp.tool_models import ClosedToolModel
+from src.service.mcp.workflow_models import WorkflowId, WorkflowPriority
 
 
 PoolName = Annotated[
@@ -30,6 +31,10 @@ PoolName = Annotated[
 WorkflowSpecText = Annotated[
     str,
     pydantic.Field(min_length=1, max_length=256 * 1024),
+]
+SubmitWorkflowSpecText = Annotated[
+    str,
+    pydantic.Field(min_length=1, max_length=128 * 1024),
 ]
 VariableOverride = Annotated[
     str,
@@ -47,6 +52,7 @@ class WorkflowTemplatePayload(ClosedToolModel):
     file: str
     set_variables: list[str]
     set_string_variables: list[str]
+    uploaded_templated_spec: str | None = None
 
 
 class UpstreamValidationResult(ClosedToolModel):
@@ -64,3 +70,22 @@ class ValidateWorkflowResult(ClosedToolModel):
     valid: bool
     pool: PoolName
     logs: Literal['Workflow validation succeeded.']
+
+
+class UpstreamSubmitResult(ClosedToolModel):
+    """Allowlisted normal-submission fields from Core's SubmitResponse."""
+
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+    name: WorkflowId
+    overview: Annotated[str, pydantic.Field(min_length=1, max_length=16_384)]
+    logs: Annotated[str, pydantic.Field(min_length=1, max_length=16_384)]
+
+
+class SubmitWorkflowResult(ClosedToolModel):
+    """Compact confirmation that Core accepted a workflow submission."""
+
+    workflow_id: WorkflowId
+    pool: PoolName
+    priority: WorkflowPriority
+    submitted: Literal[True]

--- a/src/service/mcp/workflow_actions.py
+++ b/src/service/mcp/workflow_actions.py
@@ -26,17 +26,91 @@ from src.service.mcp import (
 )
 from src.service.mcp.workflow_action_models import (
     PoolName,
+    SubmitWorkflowSpecText,
+    SubmitWorkflowResult,
+    UpstreamSubmitResult,
     UpstreamValidationResult,
     ValidateWorkflowResult,
     VariableOverrides,
     WorkflowSpecText,
     WorkflowTemplatePayload,
 )
+from src.service.mcp.workflow_models import (
+    WORKFLOW_PRIORITIES,
+    WorkflowPriority,
+)
 
 
 _MAX_JSON_RESPONSE_BYTES = 64 * 1024
-_MAX_WORKFLOW_SPEC_BYTES = 256 * 1024
+_MAX_VALIDATION_SPEC_BYTES = 256 * 1024
+_MAX_SUBMISSION_SPEC_BYTES = 128 * 1024
 _MAX_OVERRIDE_BYTES = 2048
+_CLI_TEMPLATE_MARKERS = ('{%%', '{{', '{#', 'default-values')
+
+
+async def osmo_submit_workflow(
+    context: Context,
+    workflow_spec: SubmitWorkflowSpecText,
+    pool: PoolName | None = None,
+    set_variables: VariableOverrides | None = None,
+    set_string_variables: VariableOverrides | None = None,
+    priority: WorkflowPriority = 'NORMAL',
+) -> SubmitWorkflowResult:
+    """Submit raw workflow YAML to Core using the caller's OSMO identity."""
+    validated_spec = _validate_workflow_spec(
+        workflow_spec,
+        max_bytes=_MAX_SUBMISSION_SPEC_BYTES,
+    )
+    validated_set_variables = _validate_overrides(
+        set_variables,
+        field='set_variables',
+    )
+    validated_set_string_variables = _validate_overrides(
+        set_string_variables,
+        field='set_string_variables',
+    )
+    if priority not in WORKFLOW_PRIORITIES:
+        raise tool_errors.PublicToolError('Invalid workflow priority.')
+
+    pool_name = await _resolve_pool(context, pool)
+    encoded_pool = tool_validation.safe_path_segment(
+        pool_name,
+        field='pool',
+    )
+    payload = WorkflowTemplatePayload(
+        file=validated_spec,
+        set_variables=validated_set_variables,
+        set_string_variables=validated_set_string_variables,
+        uploaded_templated_spec=(
+            validated_spec
+            if _is_templated_workflow(validated_spec)
+            else None
+        ),
+    )
+    query = (
+        {'priority': priority}
+        if priority != 'NORMAL'
+        else None
+    )
+    response = await tool_requests.request_json_mutation(
+        context,
+        path=f'/api/pool/{encoded_pool}/workflow',
+        operation='submit a workflow',
+        max_response_bytes=_MAX_JSON_RESPONSE_BYTES,
+        query=query,
+        payload=payload.model_dump(mode='json', exclude_none=True),
+    )
+    upstream = tool_validation.validate_mutation_response(
+        UpstreamSubmitResult,
+        response,
+        operation='submit a workflow',
+    )
+    return SubmitWorkflowResult(
+        workflow_id=upstream.name,
+        pool=pool_name,
+        priority=priority,
+        submitted=True,
+    )
 
 
 async def osmo_validate_workflow(
@@ -47,7 +121,10 @@ async def osmo_validate_workflow(
     set_string_variables: VariableOverrides | None = None,
 ) -> ValidateWorkflowResult:
     """Validate workflow YAML using Core's authoritative submission checks."""
-    validated_spec = _validate_workflow_spec(workflow_spec)
+    validated_spec = _validate_workflow_spec(
+        workflow_spec,
+        max_bytes=_MAX_VALIDATION_SPEC_BYTES,
+    )
     validated_set_variables = _validate_overrides(
         set_variables,
         field='set_variables',
@@ -72,7 +149,7 @@ async def osmo_validate_workflow(
         operation='validate a workflow',
         max_response_bytes=_MAX_JSON_RESPONSE_BYTES,
         query={'validation_only': True},
-        payload=payload.model_dump(mode='json'),
+        payload=payload.model_dump(mode='json', exclude_none=True),
     )
     upstream = tool_validation.validate_mutation_response(
         UpstreamValidationResult,
@@ -104,7 +181,11 @@ async def _resolve_pool(context: Context, pool: str | None) -> str:
     )
 
 
-def _validate_workflow_spec(workflow_spec: str) -> str:
+def _validate_workflow_spec(
+    workflow_spec: str,
+    *,
+    max_bytes: int,
+) -> str:
     try:
         encoded_spec = workflow_spec.encode('utf-8')
     except (AttributeError, UnicodeEncodeError):
@@ -112,7 +193,7 @@ def _validate_workflow_spec(workflow_spec: str) -> str:
     if (
         not isinstance(workflow_spec, str)
         or not workflow_spec.strip()
-        or len(encoded_spec) > _MAX_WORKFLOW_SPEC_BYTES
+        or len(encoded_spec) > max_bytes
         or any(
             not character.isprintable()
             and character not in '\n\r\t'
@@ -121,6 +202,11 @@ def _validate_workflow_spec(workflow_spec: str) -> str:
     ):
         raise tool_errors.PublicToolError('Invalid workflow_spec.')
     return workflow_spec
+
+
+def _is_templated_workflow(workflow_spec: str) -> bool:
+    """Match the CLI's lightweight template detection without its runtime."""
+    return any(marker in workflow_spec for marker in _CLI_TEMPLATE_MARKERS)
 
 
 def _validate_overrides(

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -33,6 +33,7 @@ _EXPECTED_TOOL_NAMES = frozenset({
     "osmo_list_resources",
     "osmo_list_workflows",
     "osmo_search_pools",
+    "osmo_submit_workflow",
     "osmo_validate_workflow",
 })
 _MCP_ACCEPT_HEADERS = {


### PR DESCRIPTION
## Description

Add the external `osmo_submit_workflow` tool as the second Phase 2 review
slice.

- submit bounded raw workflow YAML through Core's existing
  `POST /api/pool/{pool}/workflow` route
- support the CLI's template overrides, pool resolution, and
  `HIGH | NORMAL | LOW` priority semantics
- preserve the original template for later `use_template=true` retrieval
- return only the new workflow ID, selected pool, effective priority, and
  submission confirmation
- use the shared one-shot mutation path and report ambiguous outcomes as
  unknown

The tool intentionally omits submit-by-workflow-ID. Core authorizes creation in
the target pool, then reads the source workflow internally without a
source-pool read check. It also omits dry-run rendering, query-string
environment values, local-file expansion, rsync, and output-format controls.

Issue - None

## Validation

- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors -- //src/service/mcp:workflow_action_models-pylint //src/service/mcp:workflow_action_tools-pylint //src/service/mcp:tool_registry-pylint //src/service/mcp/tests:test_workflow_actions //src/service/mcp/tests:test_workflow_actions-pylint //src/service/mcp/tests:test_catalog //src/service/mcp/tests:test_catalog-pylint //test/smoke:mcp-checks-pylint`
  (8 targets passed)
- `bazel --output_user_root=/tmp/osmo-bazel build -- //src/service/mcp:mcp_binary //test/smoke:mcp-checks`
- ancestry-only restack verified with one commit per PR, patch-equivalent
  `git range-diff` results, identical old/new trees, and `git diff --check`

## Stack

1. #1234: mutation-safe transport + workflow validation (merged)
2. This PR: workflow submission
3. #1236: workflow restart and cancellation
4. #1237: Phase 2 deployment smoke coverage and final documentation

This PR now targets `feature/mcp` directly. #1236 and #1237 remain draft and
stacked behind it. The completed stack will merge sequentially into
`feature/mcp`; nothing targets `main`.

## Checklist

- [x] One vertical tool capability
- [x] Existing Core API only; no Core changes
- [x] External MCP runtime remains independently implemented
- [x] Protocol-level request, response, error, and annotation coverage
- [x] Only necessary MCP and smoke build targets used
