### PR TITLE
Add external MCP workflow lifecycle actions

### DIFF
--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -240,11 +240,13 @@ osmo_py_library(
     deps = [
         requirement("mcp"),
         ":access_scope",
+        ":gateway",
         ":tool_errors",
         ":tool_requests",
         ":tool_validation",
         ":workflow_action_models",
         ":workflow_models",
+        ":workflow_tools",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -102,12 +102,12 @@ authorization value.
 
 The external catalog contains 14 read-only tools for caller-bound health,
 profile, pool, resource, workflow, application, and credential-metadata
-inspection, plus `osmo_validate_workflow` and `osmo_submit_workflow`. Each tool
-maps to a fixed external API, returns a structured allowlisted result, and
-applies a domain-specific response limit. Credential inspection returns names
-and types only. Profile inspection intentionally includes non-secret
-access-token identity metadata (name and expiry), unlike the hosted internal
-MCP projection.
+inspection, plus four workflow actions: validation, submission, restart, and
+cancellation. Each tool maps to a fixed external API, returns a structured
+allowlisted result, and applies a domain-specific response limit. Credential
+inspection returns names and types only. Profile inspection intentionally
+includes non-secret access-token identity metadata (name and expiry), unlike
+the hosted internal MCP projection.
 
 Workflow validation calls Core's submission endpoint with
 `validation_only=true`. It is intentionally annotated as a non-idempotent
@@ -118,6 +118,15 @@ environment injection, dry-run rendering, or source workflow IDs. The latter
 would let Core read a source spec without a source-pool authorization check.
 The result contains only the new workflow ID, pool, priority, and submission
 confirmation; Core-generated URLs are not returned.
+
+Restart accepts only a failed source workflow and always performs a compact
+workflow read before its POST, including when the target pool is explicit.
+This requires source-workflow read access in addition to create access on the
+target pool before Core reads the source spec. Cancellation accepts one
+canonical workflow ID per call. It intentionally omits the CLI's cancellation
+message because that value is persisted and appears in Gateway/authz URL logs.
+Both actions are destructive, one-shot operations whose ambiguous outcomes
+must be inspected before retrying.
 
 JSON tools require one complete bounded response. Bounded text tools may
 instead return a safe UTF-8 prefix with `truncated=true` and a machine-readable

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -63,24 +63,31 @@ though the CLI and hosted internal MCP may display them. Legacy profile values
 can contain secret-bearing userinfo, queries, or fragments; the external
 projection therefore returns only `cred_name` and `cred_type`.
 
-## Phase 2: workflow actions (in progress)
+## Phase 2: workflow actions (code complete)
 
-`osmo_validate_workflow` and `osmo_submit_workflow` are implemented using
-bounded TemplateSpec projections. Validation sets `validation_only=true` and
-is a non-idempotent write because a failed validation can create a
-`FAILED_SUBMISSION` workflow record. Submission accepts raw YAML and preserves
-the original template when it detects the same template markers as the CLI.
-It returns only the new workflow ID, selected pool, and effective priority.
-The shared mutation relay sends bounded JSON, never retries, and reports an
-unknown outcome for ambiguous transport or server failures.
+`osmo_validate_workflow`, `osmo_submit_workflow`,
+`osmo_restart_workflow`, and `osmo_cancel_workflow` are implemented.
+Validation sets `validation_only=true` and is a non-idempotent write because a
+failed validation can create a `FAILED_SUBMISSION` workflow record. Submission
+accepts raw YAML and preserves the original template when it detects the same
+template markers as the CLI. It returns only the new workflow ID, selected
+pool, and effective priority. Restart and cancel are destructive one-shot
+operations.
 
 Submit-by-workflow-ID is intentionally omitted. Core authorizes creation in the
 target pool but reads the source workflow internally without a source-pool
 read check. Dry-run rendering, environment injection, local-file expansion,
 and rsync are also omitted from the agent-facing contract.
 
-Add `osmo_restart_workflow` and `osmo_cancel_workflow` as the remaining Phase 2
-actions.
+Restart accepts only a failed source workflow and always performs a compact
+source-workflow GET before its POST. This requires `workflow:Read` on the
+source before Core's restart route enforces `workflow:Create` on the target
+pool. Cancel accepts one canonical ID per call and omits the CLI's persisted,
+query-string cancellation message because Gateway and authz access logs record
+it. The shared mutation relay never retries and reports an unknown outcome for
+ambiguous transport, server, database, or malformed-success failures.
+
+Deployment smoke coverage remains before Phase 2 is considered released.
 
 ## Phase 3: user-owned mutations
 

--- a/src/service/mcp/telemetry.py
+++ b/src/service/mcp/telemetry.py
@@ -30,7 +30,13 @@ _STATIC_ROUTES = frozenset({
     '/api/app',
     '/api/credentials',
 })
-_WORKFLOW_SUFFIXES = frozenset({'logs', 'error_logs', 'events', 'spec'})
+_WORKFLOW_SUFFIXES = frozenset({
+    'logs',
+    'error_logs',
+    'events',
+    'spec',
+    'cancel',
+})
 
 
 def route_template(path: str) -> str:
@@ -65,6 +71,14 @@ def route_template(path: str) -> str:
         and parts[4] == 'workflow'
     ):
         return '/api/pool/{pool}/workflow'
+
+    if (
+        len(parts) == 7
+        and parts[:3] == ['', 'api', 'pool']
+        and parts[4] == 'workflow'
+        and parts[6] == 'restart'
+    ):
+        return '/api/pool/{pool}/workflow/{workflow_id}/restart'
 
     return '/api/{unclassified}'
 

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -119,6 +119,20 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'A failed validation may create a FAILED_SUBMISSION record.',
     ),
     (
+        workflow_actions.osmo_restart_workflow,
+        'osmo_restart_workflow',
+        'Restart an OSMO workflow',
+        'Restart one failed workflow as a new run. This consumes real '
+        'compute and requires source-workflow read access.',
+    ),
+    (
+        workflow_actions.osmo_cancel_workflow,
+        'osmo_cancel_workflow',
+        'Cancel an OSMO workflow',
+        'Request cancellation of one workflow; force cancellation is '
+        'destructive and not reversible.',
+    ),
+    (
         apps.osmo_list_apps,
         'osmo_list_apps',
         'List OSMO apps',
@@ -162,6 +176,8 @@ _EXPECTED_REQUIRED_FIELDS = {
     'osmo_get_workflow_spec': ['workflow_id'],
     'osmo_submit_workflow': ['workflow_spec'],
     'osmo_validate_workflow': ['workflow_spec'],
+    'osmo_restart_workflow': ['workflow_id'],
+    'osmo_cancel_workflow': ['workflow_id'],
     'osmo_list_apps': [],
     'osmo_get_app': ['name'],
     'osmo_get_app_spec': ['name'],
@@ -208,6 +224,8 @@ _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
         'set_variables': None,
         'set_string_variables': None,
     },
+    'osmo_restart_workflow': {'pool': None},
+    'osmo_cancel_workflow': {'force': False},
     'osmo_list_apps': {
         'name': None,
         'users': None,
@@ -224,7 +242,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
     """Lock the ordered, agent-facing external MCP tool contract."""
 
     def test_registry_has_exact_metadata_and_direct_unique_functions(self) -> None:
-        self.assertEqual(len(tool_registry.TOOL_SPECS), 16)
+        self.assertEqual(len(tool_registry.TOOL_SPECS), 18)
         self.assertEqual(
             [
                 (spec.name, spec.title, spec.description)
@@ -239,7 +257,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         registered_functions = [
             spec.function for spec in tool_registry.TOOL_SPECS
         ]
-        self.assertEqual(len({id(function) for function in registered_functions}), 16)
+        self.assertEqual(len({id(function) for function in registered_functions}), 18)
         for spec, (function, _, _, _) in zip(
             tool_registry.TOOL_SPECS,
             _EXPECTED_SPECS,
@@ -252,7 +270,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
 
         tool_registry.register_tools(mcp_server)
 
-        self.assertEqual(mcp_server.add_tool.call_count, 16)
+        self.assertEqual(mcp_server.add_tool.call_count, 18)
         for call, (function, name, title, description) in zip(
             mcp_server.add_tool.call_args_list,
             _EXPECTED_SPECS,
@@ -265,11 +283,17 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             self.assertTrue(call.kwargs['structured_output'])
             annotations = call.kwargs['annotations']
             is_write = name in {
+                'osmo_cancel_workflow',
+                'osmo_restart_workflow',
                 'osmo_submit_workflow',
                 'osmo_validate_workflow',
             }
+            is_destructive = name in {
+                'osmo_cancel_workflow',
+                'osmo_restart_workflow',
+            }
             self.assertIs(annotations.readOnlyHint, not is_write)
-            self.assertFalse(annotations.destructiveHint)
+            self.assertIs(annotations.destructiveHint, is_destructive)
             self.assertIs(annotations.idempotentHint, not is_write)
             self.assertFalse(annotations.openWorldHint)
 
@@ -288,11 +312,20 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             self.assertIsNotNone(tool.annotations)
             assert tool.annotations is not None
             is_write = tool.name in {
+                'osmo_cancel_workflow',
+                'osmo_restart_workflow',
                 'osmo_submit_workflow',
                 'osmo_validate_workflow',
             }
+            is_destructive = tool.name in {
+                'osmo_cancel_workflow',
+                'osmo_restart_workflow',
+            }
             self.assertIs(tool.annotations.readOnlyHint, not is_write)
-            self.assertFalse(tool.annotations.destructiveHint)
+            self.assertIs(
+                tool.annotations.destructiveHint,
+                is_destructive,
+            )
             self.assertIs(tool.annotations.idempotentHint, not is_write)
             self.assertFalse(tool.annotations.openWorldHint)
             self._assert_recursively_closed(tool.inputSchema, tool.name)

--- a/src/service/mcp/tests/test_telemetry.py
+++ b/src/service/mcp/tests/test_telemetry.py
@@ -29,10 +29,16 @@ class TelemetryTest(unittest.TestCase):
             '/api/workflow/private-workflow-1/logs': (
                 '/api/workflow/{workflow_id}/logs'
             ),
+            '/api/workflow/private-workflow-1/cancel': (
+                '/api/workflow/{workflow_id}/cancel'
+            ),
             '/api/app/user/private-app/spec': '/api/app/user/{app_name}/spec',
             '/api/resources/private-node': '/api/resources/{node_name}',
             '/api/pool/private-pool/workflow': (
                 '/api/pool/{pool}/workflow'
+            ),
+            '/api/pool/private-pool/workflow/private-workflow-1/restart': (
+                '/api/pool/{pool}/workflow/{workflow_id}/restart'
             ),
             '/api/unrecognized/private-value': '/api/{unclassified}',
             '/api/profile/settings': '/api/profile/settings',

--- a/src/service/mcp/tests/test_tool_support.py
+++ b/src/service/mcp/tests/test_tool_support.py
@@ -423,6 +423,13 @@ class JsonMutationRequestTest(unittest.IsolatedAsyncioTestCase):
                 503,
                 b'{"message":"server-upstream-secret"}',
             ),
+            gateway.GatewayResponse(
+                400,
+                (
+                    b'{"error_code":"DATABASE",'
+                    b'"message":"database-upstream-secret"}'
+                ),
+            ),
         )
 
         with (

--- a/src/service/mcp/tests/test_workflow_actions.py
+++ b/src/service/mcp/tests/test_workflow_actions.py
@@ -29,6 +29,8 @@ from src.service.mcp.tests import protocol_harness
 _BEARER_SECRET = 'phase-two-opaque-bearer-secret'
 _HARNESS = protocol_harness.ProtocolHarness(
     tool_names=(
+        'osmo_cancel_workflow',
+        'osmo_restart_workflow',
         'osmo_submit_workflow',
         'osmo_validate_workflow',
     ),
@@ -54,6 +56,17 @@ workflow:
     command: [echo]
     args: [ok]
 """
+_FAILED_WORKFLOW = {
+    'name': 'source-workflow-1',
+    'uuid': 'source-workflow-uuid',
+    'submitted_by': 'alice@example.com',
+    'submit_time': '2026-07-23T12:00:00Z',
+    'status': 'FAILED',
+    'priority': 'NORMAL',
+    'tags': [],
+    'pool': 'pool-a',
+    'groups': [],
+}
 
 
 class WorkflowActionProtocolTest(unittest.IsolatedAsyncioTestCase):
@@ -65,6 +78,10 @@ class WorkflowActionProtocolTest(unittest.IsolatedAsyncioTestCase):
             self,
             response,
             expected_annotations={
+                'osmo_cancel_workflow':
+                    protocol_harness.DESTRUCTIVE_WRITE_ANNOTATIONS,
+                'osmo_restart_workflow':
+                    protocol_harness.DESTRUCTIVE_WRITE_ANNOTATIONS,
                 'osmo_submit_workflow':
                     protocol_harness.WRITE_ANNOTATIONS,
                 'osmo_validate_workflow':
@@ -113,6 +130,19 @@ class WorkflowActionProtocolTest(unittest.IsolatedAsyncioTestCase):
                 excluded_argument,
                 submit_schema['properties'],
             )
+        restart_schema = tools['osmo_restart_workflow']['inputSchema']
+        self.assertEqual(restart_schema['required'], ['workflow_id'])
+        self.assertEqual(
+            restart_schema['properties']['pool']['default'],
+            None,
+        )
+        cancel_schema = tools['osmo_cancel_workflow']['inputSchema']
+        self.assertEqual(cancel_schema['required'], ['workflow_id'])
+        self.assertEqual(
+            cancel_schema['properties']['force']['default'],
+            False,
+        )
+        self.assertNotIn('message', cancel_schema['properties'])
 
     async def test_submit_posts_exact_body_and_projects_result(self) -> None:
         captured_requests: list[httpx.Request] = []
@@ -287,6 +317,233 @@ class WorkflowActionProtocolTest(unittest.IsolatedAsyncioTestCase):
                 self.assertNotIn('private-server-detail', response.text)
 
         self.assertEqual(calls, 2)
+
+    async def test_restart_preflights_source_and_uses_its_pool(self) -> None:
+        captured_requests: list[httpx.Request] = []
+        upstream_secret = 'restart-upstream-sensitive-value'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.method == 'GET':
+                return httpx.Response(200, json=_FAILED_WORKFLOW)
+            return httpx.Response(200, json={
+                'name': 'restarted-workflow-2',
+                'overview': (
+                    f'https://example.test/?token={upstream_secret}'
+                ),
+                'logs': (
+                    f'https://example.test/logs?secret={upstream_secret}'
+                ),
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_restart_workflow',
+            {'workflow_id': 'source-workflow-1'},
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'workflow_id': 'restarted-workflow-2',
+            'parent_workflow_id': 'source-workflow-1',
+            'pool': 'pool-a',
+            'restart_submitted': True,
+        })
+        self.assertNotIn(upstream_secret, response.text)
+        self.assertEqual(len(captured_requests), 2)
+        source_request = captured_requests[0]
+        restart_request = captured_requests[1]
+        self.assertEqual(source_request.method, 'GET')
+        self.assertEqual(
+            source_request.url.path,
+            '/api/workflow/source-workflow-1',
+        )
+        self.assertEqual(
+            source_request.url.params.multi_items(),
+            [('skip_groups', 'true')],
+        )
+        self.assertEqual(restart_request.method, 'POST')
+        self.assertEqual(
+            restart_request.url.path,
+            '/api/pool/pool-a/workflow/source-workflow-1/restart',
+        )
+        self.assertEqual(restart_request.content, b'')
+
+    async def test_restart_explicit_pool_still_requires_source_read(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(403, json={
+                'message': 'private authorization detail',
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_restart_workflow',
+            {
+                'workflow_id': 'source-workflow-1',
+                'pool': 'pool-b',
+            },
+        )
+
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('authorization denied', response.text)
+        self.assertNotIn('private authorization detail', response.text)
+        self.assertNotIn('write outcome is unknown', response.text)
+        self.assertEqual(len(captured_requests), 1)
+        self.assertEqual(
+            captured_requests[0].url.path,
+            '/api/workflow/source-workflow-1',
+        )
+
+    async def test_cancel_posts_force_and_projects_result(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+        upstream_secret = 'cancel-upstream-sensitive-value'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                'name': 'source-workflow-1',
+                'detail': upstream_secret,
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_cancel_workflow',
+            {
+                'workflow_id': 'source-workflow-1',
+                'force': True,
+            },
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'workflow_id': 'source-workflow-1',
+            'force': True,
+            'cancellation_submitted': True,
+        })
+        self.assertNotIn(upstream_secret, response.text)
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(
+            request.url.path,
+            '/api/workflow/source-workflow-1/cancel',
+        )
+        self.assertEqual(
+            request.url.params.multi_items(),
+            [('force', 'true')],
+        )
+        self.assertEqual(request.content, b'')
+
+    async def test_lifecycle_rejects_invalid_arguments_before_relay(
+        self,
+    ) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(200, json={})
+
+        calls: tuple[tuple[str, dict[str, object]], ...] = (
+            (
+                'osmo_restart_workflow',
+                {'workflow_id': '../private-workflow-1'},
+            ),
+            (
+                'osmo_cancel_workflow',
+                {'workflow_id': '550e8400-e29b-41d4-a716-446655440000'},
+            ),
+            (
+                'osmo_cancel_workflow',
+                {'workflow_id': 'source-workflow-1', 'force': 1},
+            ),
+            (
+                'osmo_cancel_workflow',
+                {
+                    'workflow_id': 'source-workflow-1',
+                    'message': 'not accepted by the external MCP',
+                },
+            ),
+        )
+        async with _HARNESS.client(handler) as client:
+            for request_id, (tool_name, arguments) in enumerate(
+                calls,
+                start=1,
+            ):
+                with self.subTest(
+                    tool_name=tool_name,
+                    arguments=arguments,
+                ):
+                    response = await _HARNESS.call_tool_with_client(
+                        client,
+                        tool_name,
+                        arguments,
+                        request_id=request_id,
+                    )
+                    self.assertTrue(response.json()['result']['isError'])
+
+        self.assertEqual(transport_calls, 0)
+
+    async def test_lifecycle_ambiguous_results_are_not_retried(
+        self,
+    ) -> None:
+        restart_calls = 0
+
+        async def restart_handler(
+            request: httpx.Request,
+        ) -> httpx.Response:
+            nonlocal restart_calls
+            restart_calls += 1
+            if request.method == 'GET':
+                return httpx.Response(200, json=_FAILED_WORKFLOW)
+            return httpx.Response(503, content=b'private-restart-detail')
+
+        restart_response = await _HARNESS.call_tool(
+            restart_handler,
+            'osmo_restart_workflow',
+            {'workflow_id': 'source-workflow-1'},
+        )
+        self.assertTrue(restart_response.json()['result']['isError'])
+        self.assertIn(
+            'write outcome is unknown',
+            restart_response.text,
+        )
+        self.assertNotIn('private-restart-detail', restart_response.text)
+        self.assertEqual(restart_calls, 2)
+
+        cancel_calls = 0
+
+        async def cancel_handler(
+            request: httpx.Request,
+        ) -> httpx.Response:
+            del request
+            nonlocal cancel_calls
+            cancel_calls += 1
+            return httpx.Response(200, json={
+                'name': 'different-workflow-2',
+            })
+
+        cancel_response = await _HARNESS.call_tool(
+            cancel_handler,
+            'osmo_cancel_workflow',
+            {'workflow_id': 'source-workflow-1'},
+        )
+        self.assertTrue(cancel_response.json()['result']['isError'])
+        self.assertIn(
+            'write outcome is unknown',
+            cancel_response.text,
+        )
+        self.assertEqual(cancel_calls, 1)
 
     async def test_explicit_pool_posts_exact_template_payload(self) -> None:
         captured_requests: list[httpx.Request] = []

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -174,6 +174,26 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         annotations=_write_annotations(destructive=False),
     ),
     ToolSpec(
+        function=workflow_actions.osmo_restart_workflow,
+        name='osmo_restart_workflow',
+        title='Restart an OSMO workflow',
+        description=(
+            'Restart one failed workflow as a new run. This consumes real '
+            'compute and requires source-workflow read access.'
+        ),
+        annotations=_write_annotations(destructive=True),
+    ),
+    ToolSpec(
+        function=workflow_actions.osmo_cancel_workflow,
+        name='osmo_cancel_workflow',
+        title='Cancel an OSMO workflow',
+        description=(
+            'Request cancellation of one workflow; force cancellation is '
+            'destructive and not reversible.'
+        ),
+        annotations=_write_annotations(destructive=True),
+    ),
+    ToolSpec(
         function=apps.osmo_list_apps,
         name='osmo_list_apps',
         title='List OSMO apps',

--- a/src/service/mcp/tool_requests.py
+++ b/src/service/mcp/tool_requests.py
@@ -261,6 +261,11 @@ async def _request(
         )
     if method != 'GET' and response.status_code >= 500:
         raise tool_errors.uncertain_write_error(operation)
+    if (
+        method != 'GET'
+        and _mutation_error_code(response) == 'DATABASE'
+    ):
+        raise tool_errors.uncertain_write_error(operation)
     if response.status_code != 200:
         raise tool_errors.PublicToolError(tool_errors.upstream_error(
             operation,
@@ -272,6 +277,26 @@ async def _request(
             suppress_upstream_details=suppress_upstream_details,
         ))
     return response
+
+
+def _mutation_error_code(
+    response: gateway.GatewayResponse,
+) -> str | None:
+    """Read only the bounded structural error code from a failed mutation."""
+    if (
+        response.status_code == 200
+        or response.body_truncated
+        or not response.body
+    ):
+        return None
+    try:
+        payload = json.loads(response.body)
+    except (UnicodeDecodeError, ValueError, TypeError, RecursionError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error_code = payload.get('error_code')
+    return error_code if isinstance(error_code, str) else None
 
 
 def _validate_json_object_body(body: bytes, *, operation: str) -> JsonObject:

--- a/src/service/mcp/workflow_action_models.py
+++ b/src/service/mcp/workflow_action_models.py
@@ -44,6 +44,10 @@ VariableOverrides = Annotated[
     list[VariableOverride],
     pydantic.Field(max_length=50),
 ]
+ForceCancel = Annotated[
+    pydantic.StrictBool,
+    pydantic.Field(),
+]
 
 
 class WorkflowTemplatePayload(ClosedToolModel):
@@ -89,3 +93,28 @@ class SubmitWorkflowResult(ClosedToolModel):
     pool: PoolName
     priority: WorkflowPriority
     submitted: Literal[True]
+
+
+class UpstreamCancelResult(ClosedToolModel):
+    """Allowlisted fields from Core's CancelResponse."""
+
+    model_config = pydantic.ConfigDict(extra='ignore')
+
+    name: WorkflowId
+
+
+class RestartWorkflowResult(ClosedToolModel):
+    """Compact confirmation that Core accepted a workflow restart."""
+
+    workflow_id: WorkflowId
+    parent_workflow_id: WorkflowId
+    pool: PoolName
+    restart_submitted: Literal[True]
+
+
+class CancelWorkflowResult(ClosedToolModel):
+    """Compact confirmation that Core accepted a cancellation request."""
+
+    workflow_id: WorkflowId
+    force: bool
+    cancellation_submitted: Literal[True]

--- a/src/service/mcp/workflow_actions.py
+++ b/src/service/mcp/workflow_actions.py
@@ -20,14 +20,20 @@ from mcp.server.fastmcp import Context
 
 from src.service.mcp import (
     access_scope,
+    gateway,
     tool_errors,
     tool_requests,
     tool_validation,
+    workflows,
 )
 from src.service.mcp.workflow_action_models import (
+    CancelWorkflowResult,
+    ForceCancel,
     PoolName,
+    RestartWorkflowResult,
     SubmitWorkflowSpecText,
     SubmitWorkflowResult,
+    UpstreamCancelResult,
     UpstreamSubmitResult,
     UpstreamValidationResult,
     ValidateWorkflowResult,
@@ -37,6 +43,7 @@ from src.service.mcp.workflow_action_models import (
 )
 from src.service.mcp.workflow_models import (
     WORKFLOW_PRIORITIES,
+    WorkflowId,
     WorkflowPriority,
 )
 
@@ -160,6 +167,80 @@ async def osmo_validate_workflow(
         valid=True,
         pool=pool_name,
         logs=upstream.logs,
+    )
+
+
+async def osmo_restart_workflow(
+    context: Context,
+    workflow_id: WorkflowId,
+    pool: PoolName | None = None,
+) -> RestartWorkflowResult:
+    """Restart a failed workflow after authorizing read access to its source."""
+    source = await workflows.osmo_get_workflow(
+        context,
+        workflow_id,
+        skip_groups=True,
+    )
+    pool_name = (
+        await _resolve_pool(context, pool)
+        if pool is not None or source.workflow.pool is None
+        else source.workflow.pool
+    )
+    encoded_pool = tool_validation.safe_path_segment(
+        pool_name,
+        field='pool',
+    )
+    encoded_workflow_id = workflows.workflow_path_segment(workflow_id)
+    response = await tool_requests.request_json_mutation(
+        context,
+        path=(
+            f'/api/pool/{encoded_pool}/workflow/'
+            f'{encoded_workflow_id}/restart'
+        ),
+        operation='restart a workflow',
+        max_response_bytes=_MAX_JSON_RESPONSE_BYTES,
+    )
+    upstream = tool_validation.validate_mutation_response(
+        UpstreamSubmitResult,
+        response,
+        operation='restart a workflow',
+    )
+    return RestartWorkflowResult(
+        workflow_id=upstream.name,
+        parent_workflow_id=workflow_id,
+        pool=pool_name,
+        restart_submitted=True,
+    )
+
+
+async def osmo_cancel_workflow(
+    context: Context,
+    workflow_id: WorkflowId,
+    force: ForceCancel = False,
+) -> CancelWorkflowResult:
+    """Request cancellation of one workflow through Core."""
+    if not isinstance(force, bool):
+        raise tool_errors.PublicToolError('Invalid force.')
+    encoded_workflow_id = workflows.workflow_path_segment(workflow_id)
+    query: dict[str, gateway.QueryValue] = {'force': force}
+    response = await tool_requests.request_json_mutation(
+        context,
+        path=f'/api/workflow/{encoded_workflow_id}/cancel',
+        operation='cancel a workflow',
+        max_response_bytes=_MAX_JSON_RESPONSE_BYTES,
+        query=query,
+    )
+    upstream = tool_validation.validate_mutation_response(
+        UpstreamCancelResult,
+        response,
+        operation='cancel a workflow',
+    )
+    if upstream.name != workflow_id:
+        raise tool_errors.uncertain_write_error('cancel a workflow')
+    return CancelWorkflowResult(
+        workflow_id=upstream.name,
+        force=force,
+        cancellation_submitted=True,
     )
 
 

--- a/src/service/mcp/workflows.py
+++ b/src/service/mcp/workflows.py
@@ -79,6 +79,8 @@ __all__ = (
     'WorkflowStatuses',
     'WorkflowSummary',
     'WorkflowTask',
+    'workflow_path',
+    'workflow_path_segment',
     'osmo_get_workflow',
     'osmo_get_workflow_events',
     'osmo_get_workflow_logs',
@@ -224,7 +226,7 @@ async def osmo_get_workflow(
     skip_groups: bool = False,
 ) -> GetWorkflowResult:
     """Get one workflow's status, task groups, and task metadata."""
-    path = _workflow_path(workflow_id)
+    path = workflow_path(workflow_id)
     query: dict[str, bool] = {}
     if verbose:
         query['verbose'] = True
@@ -255,7 +257,7 @@ async def osmo_get_workflow_logs(
     retry_id: RetryId | None = None,
 ) -> WorkflowLogsResult:
     """Get bounded workflow or task logs; error/retry logs require a task."""
-    path = _workflow_path(
+    path = workflow_path(
         workflow_id,
         suffix='error_logs' if error_logs else 'logs',
     )
@@ -302,7 +304,7 @@ async def osmo_get_workflow_events(
     retry_id: RetryId | None = None,
 ) -> WorkflowEventsResult:
     """Get bounded workflow scheduling and lifecycle events."""
-    path = _workflow_path(workflow_id, suffix='events')
+    path = workflow_path(workflow_id, suffix='events')
     validated_task_name = _validate_task_controls(
         task_name=task_name,
         retry_id=retry_id,
@@ -336,7 +338,7 @@ async def osmo_get_workflow_spec(
     use_template: bool = False,
 ) -> WorkflowSpecResult:
     """Get a bounded, redacted workflow YAML spec."""
-    path = _workflow_path(workflow_id, suffix='spec')
+    path = workflow_path(workflow_id, suffix='spec')
     spec_result = await tool_requests.request_truncated_text(
         context,
         path=path,
@@ -353,15 +355,25 @@ async def osmo_get_workflow_spec(
     )
 
 
-def _workflow_path(workflow_id: str, *, suffix: str | None = None) -> str:
+def workflow_path(
+    workflow_id: str,
+    *,
+    suffix: str | None = None,
+) -> str:
+    """Build a fixed Core workflow route from one canonical ID."""
+    encoded_workflow_id = workflow_path_segment(workflow_id)
+    path = f'{_WORKFLOWS_PATH}/{encoded_workflow_id}'
+    return f'{path}/{suffix}' if suffix is not None else path
+
+
+def workflow_path_segment(workflow_id: str) -> str:
+    """Validate and encode one canonical workflow ID for a fixed route."""
     if re.fullmatch(_WORKFLOW_ID_PATTERN, workflow_id) is None:
         raise tool_errors.PublicToolError('Invalid workflow_id.')
-    encoded_workflow_id = tool_validation.safe_path_segment(
+    return tool_validation.safe_path_segment(
         workflow_id,
         field='workflow_id',
     )
-    path = f'{_WORKFLOWS_PATH}/{encoded_workflow_id}'
-    return f'{path}/{suffix}' if suffix is not None else path
 
 
 def _validate_task_controls(

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -19,6 +19,7 @@ from test.oetf.smoke_fixture import SmokeFixture
 
 
 _EXPECTED_TOOL_NAMES = frozenset({
+    "osmo_cancel_workflow",
     "osmo_get_app",
     "osmo_get_app_spec",
     "osmo_get_profile",
@@ -33,6 +34,7 @@ _EXPECTED_TOOL_NAMES = frozenset({
     "osmo_list_resources",
     "osmo_list_workflows",
     "osmo_search_pools",
+    "osmo_restart_workflow",
     "osmo_submit_workflow",
     "osmo_validate_workflow",
 })


### PR DESCRIPTION
## Description

Add the external workflow lifecycle tools as the third Phase 2 review slice.

- `osmo_restart_workflow` accepts only a failed source workflow and always
  preflights it through `GET /api/workflow/{id}?skip_groups=true` before
  calling Core's restart route
- resolve the restart target from the explicit pool, source workflow, or
  caller profile using the CLI's intended precedence
- `osmo_cancel_workflow` cancels one canonical workflow ID through Core's
  existing route and supports strict `force`
- return compact, closed confirmation objects without Core URLs or arbitrary
  upstream fields
- mark both actions destructive and non-idempotent, with no automatic retries

The source preflight closes a Core authorization gap: Core's restart route
checks create access on the target pool but reads the source workflow
internally. Cancellation intentionally omits the CLI's free-form `message`
because Core persists it and Gateway/authz access logs include query strings.

Mutation failures with Core's structural `DATABASE` error code are also treated
as outcome unknown. Restart work can be queued before the related database
write fails, so callers must inspect workflow state before retrying.

Issue - None

## Validation

- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors -- //src/service/mcp:telemetry-pylint //src/service/mcp:tool_requests-pylint //src/service/mcp:workflow_action_models-pylint //src/service/mcp:workflow_action_tools-pylint //src/service/mcp:workflow_tools-pylint //src/service/mcp:tool_registry-pylint //src/service/mcp/tests:test_catalog //src/service/mcp/tests:test_catalog-pylint //src/service/mcp/tests:test_tool_support //src/service/mcp/tests:test_tool_support-pylint //src/service/mcp/tests:test_telemetry //src/service/mcp/tests:test_telemetry-pylint //src/service/mcp/tests:test_workflow_actions //src/service/mcp/tests:test_workflow_actions-pylint //src/service/mcp/tests:test_workflows //test/smoke:mcp-checks-pylint`
  (16 targets passed)
- after clarifying the failed-workflow precondition, reran the four directly
  affected catalog and lint targets (4 passed)
- `bazel --output_user_root=/tmp/osmo-bazel build -- //src/service/mcp:mcp_binary //test/smoke:mcp-checks`
- one commit per PR, verified parentage, focused security and CLI/Core parity
  reviews, and `git diff --check`

## Stack

1. #1234: mutation-safe transport + workflow validation (merged)
2. #1235: workflow submission (merged)
3. This PR: workflow restart and cancellation
4. #1237: Phase 2 deployment smoke coverage and final documentation

This PR now targets `feature/mcp` directly. #1237 remains draft and stacked
behind it. The completed stack will merge sequentially into `feature/mcp`;
nothing targets `main`.

## Checklist

- [x] Existing Core APIs only; no Core changes
- [x] Source authorization enforced before restart
- [x] Failed-workflow precondition documented in the agent-facing contract
- [x] Canonical workflow IDs and strict arguments
- [x] No free-form cancellation text
- [x] Ambiguous writes are never retried
- [x] External MCP runtime remains independently implemented
- [x] Only necessary MCP and smoke build targets used
