### PR TITLE
Add Phase 2 MCP deployment validation

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -109,11 +109,12 @@ not mount a service-account token, and the chart creates no MCP credential
 Secret. Gateway-to-MCP TLS continues to use the shared `gateway.tls`
 configuration described below.
 
-The current `osmo_get_profile` tool maps only to
-`GET /api/profile/settings`, accepts no caller-selected route or headers, and
-requires `profile:Read`. MCP health probes do not call this API; a tool-level
-authentication, authorization, timeout, or dependency error does not by
-itself make the pod unhealthy.
+The external MCP exposes an 18-tool catalog with fixed API routes and no
+caller-selected origin, method, route, or headers. See the
+[external MCP tool plan](../../../src/service/mcp/TOOLS.md) for its exact
+contracts and API mappings. MCP health probes do not call these APIs; a
+tool-level authentication, authorization, timeout, or dependency error does
+not by itself make the pod unhealthy.
 
 Run the enabled and disabled rendering checks locally with:
 

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -182,10 +182,46 @@ Keep each new tool a narrow adapter:
 
 ```bash
 bazel test --test_output=errors //src/service/mcp/...
-bazel build //src/service/mcp:mcp_binary
+bazel build \
+  //src/service/mcp:mcp_binary \
+  //test/smoke:mcp-checks
+bazel test //test/smoke:mcp-checks-pylint
 bash deployments/charts/service/ci/validate-mcp-chart.sh
 ```
 
 The chart validation covers MCP-disabled and MCP-enabled renders, the derived
 Gateway origin, OAuth metadata, probes, ingress isolation, absence of MCP
 credential material, and expected configuration failures.
+
+## Deployment validation
+
+The MCP smoke target requires an MCP-enabled deployment with JWT
+authentication. Its token needs `mcp:Access`, `profile:Read`, and
+`workflow:Create` for `OETF_POOL`.
+
+```bash
+bazel run //test/oetf:run -- --env <mcp-enabled-env> --tags mcp
+```
+
+The smoke test rejects unauthenticated access, verifies the exact 18-tool
+catalog, compares the profile projection with Core, checks caller-bound
+health, and validates a small workflow through Gateway → MCP → Gateway → Core.
+A successful validation does not enqueue compute or create a workflow row.
+The smoke suite intentionally sends only this known-good case because a failed
+Core validation can create a `FAILED_SUBMISSION` row.
+
+When the deployment cannot validate the default public `ubuntu:22.04` image,
+pass an approved image into the Bazel test environment:
+
+```bash
+bazel run //test/oetf:run -- \
+  --env <mcp-enabled-env> \
+  --tags mcp \
+  --bazel-arg=--test_env=OETF_DEFAULT_IMAGE=<registry/image:tag>
+```
+
+Submission, restart, and cancellation remain deliberate Inspector checks
+against disposable workflows. They are not automated in the smoke target
+because doing so would consume compute or mutate existing workflow state.
+For each one-shot action, inspect the workflow after an ambiguous error before
+retrying.

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -63,7 +63,7 @@ though the CLI and hosted internal MCP may display them. Legacy profile values
 can contain secret-bearing userinfo, queries, or fragments; the external
 projection therefore returns only `cred_name` and `cred_type`.
 
-## Phase 2: workflow actions (code complete)
+## Phase 2: workflow actions (implemented; deployment verification pending)
 
 `osmo_validate_workflow`, `osmo_submit_workflow`,
 `osmo_restart_workflow`, and `osmo_cancel_workflow` are implemented.
@@ -87,7 +87,12 @@ query-string cancellation message because Gateway and authz access logs record
 it. The shared mutation relay never retries and reports an unknown outcome for
 ambiguous transport, server, database, or malformed-success failures.
 
-Deployment smoke coverage remains before Phase 2 is considered released.
+The `//test/smoke:mcp-checks` target verifies the exact catalog and exercises
+successful validation through a deployed Gateway/MCP/Core path without
+launching compute. It must pass against an MCP-enabled deployment before Phase
+2 is considered released. Submission, restart, and cancellation remain manual
+Inspector checks against disposable workflows so the smoke suite does not
+consume compute or mutate existing workflow state.
 
 ## Phase 3: user-owned mutations
 

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -8,8 +8,10 @@ distribution of this software and related documentation without an express
 license agreement from NVIDIA CORPORATION is strictly prohibited.
 """
 
-# Smoke: the external MCP catalog and caller-bound profile round trip work.
+# Smoke: the deployed external MCP catalog and safe caller-bound tools work.
 
+import json
+import os
 import unittest
 
 import requests
@@ -53,6 +55,26 @@ _TOKEN_FIELDS = (
 )
 
 
+def _validation_workflow_spec():
+    image = os.environ.get("OETF_DEFAULT_IMAGE") or "ubuntu:22.04"
+    return f"""\
+version: 2
+workflow:
+  name: mcp-smoke-validation
+  resources:
+    default:
+      cpu: 1
+      memory: 1Gi
+      storage: 1Gi
+  tasks:
+  - name: check
+    image: {json.dumps(image)}
+    command: [echo]
+    args: [mcp-validation]
+    resource: default
+"""
+
+
 class McpChecks(SmokeFixture):
     """Exercise the deployed external MCP through its public Gateway route."""
 
@@ -69,6 +91,38 @@ class McpChecks(SmokeFixture):
         if not isinstance(result, dict):
             self.fail("MCP returned an invalid JSON-RPC result.")
         return result
+
+    def _mcp_request(self, request_id, method, params):
+        response = self.service_client.request(
+            method=RequestMethod.POST,
+            endpoint="mcp",
+            headers=dict(_MCP_ACCEPT_HEADERS),
+            payload={
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            },
+            version_header=False,
+        )
+        return self._jsonrpc_result(response, request_id)
+
+    def _call_tool(self, request_id, name, arguments):
+        result = self._mcp_request(
+            request_id,
+            "tools/call",
+            {
+                "name": name,
+                "arguments": arguments,
+            },
+        )
+        structured_content = result.get("structuredContent")
+        if (
+            result.get("isError") is not False
+            or not isinstance(structured_content, dict)
+        ):
+            self.fail(f"MCP tool {name} returned an unsuccessful result.")
+        return structured_content
 
     def test_catalog_and_profile_round_trip(self):
         base_url = self.config.url.rstrip("/")
@@ -91,20 +145,7 @@ class McpChecks(SmokeFixture):
             ).startswith("Bearer resource_metadata=")
         )
 
-        catalog_response = self.service_client.request(
-            method=RequestMethod.POST,
-            endpoint="mcp",
-            headers=dict(_MCP_ACCEPT_HEADERS),
-            payload={
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "tools/list",
-                "params": {},
-            },
-            version_header=False,
-        )
-
-        catalog_result = self._jsonrpc_result(catalog_response, 1)
+        catalog_result = self._mcp_request(1, "tools/list", {})
         catalog_tools = catalog_result.get("tools")
         if not isinstance(catalog_tools, list) or not all(
             isinstance(tool, dict) for tool in catalog_tools
@@ -150,54 +191,37 @@ class McpChecks(SmokeFixture):
             "token": expected_token,
         }
 
-        profile_response = self.service_client.request(
-            method=RequestMethod.POST,
-            endpoint="mcp",
-            headers=dict(_MCP_ACCEPT_HEADERS),
-            payload={
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": "tools/call",
-                "params": {
-                    "name": "osmo_get_profile",
-                    "arguments": {},
-                },
-            },
-            version_header=False,
-        )
-
-        profile_result = self._jsonrpc_result(profile_response, 2)
-        if (
-            profile_result.get("isError") is not False
-            or profile_result.get("structuredContent") != expected_profile
-        ):
+        profile = self._call_tool(2, "osmo_get_profile", {})
+        if profile != expected_profile:
             self.fail(
                 "MCP profile projection does not match the direct Core profile."
             )
 
-        health_response = self.service_client.request(
-            method=RequestMethod.POST,
-            endpoint="mcp",
-            headers=dict(_MCP_ACCEPT_HEADERS),
-            payload={
-                "jsonrpc": "2.0",
-                "id": 3,
-                "method": "tools/call",
-                "params": {
-                    "name": "osmo_health",
-                    "arguments": {},
-                },
-            },
-            version_header=False,
-        )
-
-        health_result = self._jsonrpc_result(health_response, 3)
-        if (
-            health_result.get("isError") is not False
-            or health_result.get("structuredContent")
-            != {"status": "healthy"}
-        ):
+        health = self._call_tool(3, "osmo_health", {})
+        if health != {"status": "healthy"}:
             self.fail("MCP health tool returned an invalid response.")
+
+    def test_workflow_validation_round_trip(self):
+        pool = self.config.pool
+        if not pool:
+            self.fail("OETF_POOL must select a workflow validation pool.")
+
+        validation = self._call_tool(
+            1,
+            "osmo_validate_workflow",
+            {
+                "workflow_spec": _validation_workflow_spec(),
+                "pool": pool,
+            },
+        )
+        self.assertEqual(
+            validation,
+            {
+                "valid": True,
+                "pool": pool,
+                "logs": "Workflow validation succeeded.",
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Add the deployment-validation layer that closes the Phase 2 review stack.

- keep one reusable JSON-RPC request/tool helper in the MCP smoke test
- verify the exact 18-tool deployed catalog, authentication, profile, and
  caller-bound health contracts
- call `osmo_validate_workflow` with a small explicitly bounded workflow
  through Gateway → MCP → Gateway → Core
- document the MCP-enabled JWT, RBAC, pool, and image prerequisites
- keep submit, restart, and cancellation as deliberate Inspector checks
  against disposable workflows

The automated workflow call uses `validation_only=true`. On success, Core
returns before queueing compute or creating a workflow row. The smoke suite
does not send an intentionally invalid spec because failed validation can
create a `FAILED_SUBMISSION` record. Private deployments can pass an approved
image explicitly through Bazel's test environment.

Issue - None

## Validation

- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors -- //test/smoke:mcp-checks-pylint`
- `bazel --output_user_root=/tmp/osmo-bazel build -- //test/smoke:mcp-checks`
- verified Bazel discovery, manual/non-KIND tags, one-commit ancestry,
  deployment safety, documentation accuracy, and `git diff --check`

The live `--tags mcp` run remains pending until an MCP-enabled deployment with
JWT authentication is available. Public KIND keeps MCP disabled.

## Stack

1. #1234: mutation-safe transport + workflow validation (merged)
2. #1235: workflow submission (merged)
3. #1236: workflow restart and cancellation (merged)
4. This PR: deployment smoke coverage and final Phase 2 documentation

This PR now targets `feature/mcp` directly. Nothing targets `main`.

## Checklist

- [x] Existing Core APIs only; no Core changes
- [x] OETF test is colocated under `test/smoke` for Bazel discovery
- [x] No compute launched by successful automated validation
- [x] No destructive workflow actions in smoke automation
- [x] Exact deployed catalog assertion
- [x] MCP-enabled deployment prerequisites documented
- [x] Only the affected smoke lint/build targets used
