### PR TITLE
Add external MCP profile settings mutation

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -109,7 +109,7 @@ not mount a service-account token, and the chart creates no MCP credential
 Secret. Gateway-to-MCP TLS continues to use the shared `gateway.tls`
 configuration described below.
 
-The external MCP exposes an 18-tool catalog with fixed API routes and no
+The external MCP exposes a 19-tool catalog with fixed API routes and no
 caller-selected origin, method, route, or headers. See the
 [external MCP tool plan](../../../src/service/mcp/TOOLS.md) for its exact
 contracts and API mappings. MCP health probes do not call these APIs; a

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -174,6 +174,9 @@ osmo_py_library(
         requirement("mcp"),
         requirement("pydantic"),
         ":access_scope",
+        ":tool_errors",
+        ":tool_requests",
+        ":tool_validation",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -102,12 +102,18 @@ authorization value.
 
 The external catalog contains 14 read-only tools for caller-bound health,
 profile, pool, resource, workflow, application, and credential-metadata
-inspection, plus four workflow actions: validation, submission, restart, and
-cancellation. Each tool maps to a fixed external API, returns a structured
-allowlisted result, and applies a domain-specific response limit. Credential
-inspection returns names and types only. Profile inspection intentionally
-includes non-secret access-token identity metadata (name and expiry), unlike
-the hosted internal MCP projection.
+inspection, four workflow actions, and one profile-setting action. Each tool
+maps to a fixed external API, returns a structured allowlisted result, and
+applies a domain-specific response limit. Credential inspection returns names
+and types only. Profile inspection intentionally includes non-secret
+access-token identity metadata (name and expiry). Bearer values are never
+returned.
+
+`osmo_set_profile` updates only the default pool or email/Slack notification
+state supported by the external CLI and Core contract. Other profile settings
+are outside this tool's public contract. Core returns no updated profile
+object, so the tool reports only the validated setting that was accepted.
+Profile writes are one-shot and are not automatically retried.
 
 Workflow validation calls Core's submission endpoint with
 `validation_only=true`. It is intentionally annotated as a non-idempotent
@@ -143,17 +149,17 @@ caller-bound Gateway authentication and OSMO profile access.
 
 ## Code organization
 
-The external MCP remains independent from the hosted internal MCP. Runtime
-security boundaries live in `request_context.py`, `request_body.py`,
+Runtime security boundaries live in `request_context.py`, `request_body.py`,
 `gateway.py`, `protocol.py`, and `telemetry.py`. Shared, dependency-light tool
-support lives in `tool_errors.py`, `tool_requests.py`, `tool_validation.py`, and
-`access_scope.py`. Each larger domain keeps its public and upstream contracts in
-`*_models.py` and its fixed routes, authorization decisions, projection, and
-handlers in the matching domain module. `tool_registry.py` is the single source
-of registration metadata used by both the server and catalog.
+support lives in `tool_errors.py`, `tool_requests.py`, `tool_validation.py`,
+and `access_scope.py`. Each larger domain keeps its public and upstream
+contracts in `*_models.py` and its fixed routes, authorization decisions,
+projection, and handlers in the matching domain module. `tool_registry.py` is
+the single source of registration metadata used by both the server and
+catalog.
 
-Do not import the CLI runtime or internal MCP implementation. Extract only pure
-public helpers when behavior genuinely needs to match another OSMO surface.
+Do not import the CLI runtime. Extract only pure public helpers when behavior
+genuinely needs to match another OSMO surface.
 
 ## Adding a tool
 
@@ -203,7 +209,7 @@ authentication. Its token needs `mcp:Access`, `profile:Read`, and
 bazel run //test/oetf:run -- --env <mcp-enabled-env> --tags mcp
 ```
 
-The smoke test rejects unauthenticated access, verifies the exact 18-tool
+The smoke test rejects unauthenticated access, verifies the exact 19-tool
 catalog, compares the profile projection with Core, checks caller-bound
 health, and validates a small workflow through Gateway → MCP → Gateway → Core.
 A successful validation does not enqueue compute or create a workflow row.
@@ -220,8 +226,7 @@ bazel run //test/oetf:run -- \
   --bazel-arg=--test_env=OETF_DEFAULT_IMAGE=<registry/image:tag>
 ```
 
-Submission, restart, and cancellation remain deliberate Inspector checks
-against disposable workflows. They are not automated in the smoke target
-because doing so would consume compute or mutate existing workflow state.
-For each one-shot action, inspect the workflow after an ambiguous error before
-retrying.
+Profile updates, submission, restart, and cancellation remain deliberate
+Inspector checks. They are not automated in the smoke target because doing so
+would mutate saved user or workflow state or consume compute. For each
+one-shot action, inspect OSMO state after an ambiguous error before retrying.

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -54,14 +54,13 @@ intersection on the resource request itself. Large accessible-pool sets can
 also reach the shared 16-KiB query ceiling for list requests even when MCP
 output is small; this is bounded output, not end-to-end pagination.
 
-Returning token name/expiry from `osmo_get_profile` is an intentional external
-product choice; the hosted internal MCP currently omits that metadata. Neither
-surface returns bearer values.
+Returning token name/expiry from `osmo_get_profile` is intentional. The tool
+never returns bearer values.
 
-Credential profiles are intentionally omitted from the external MCP even
-though the CLI and hosted internal MCP may display them. Legacy profile values
-can contain secret-bearing userinfo, queries, or fragments; the external
-projection therefore returns only `cred_name` and `cred_type`.
+Credential profiles are intentionally omitted even though the CLI may display
+them. Legacy profile values can contain secret-bearing userinfo, queries, or
+fragments; the external projection therefore returns only `cred_name` and
+`cred_type`.
 
 ## Phase 2: workflow actions (implemented; deployment verification pending)
 
@@ -75,9 +74,9 @@ pool, and effective priority. Restart and cancel are destructive one-shot
 operations.
 
 Submit-by-workflow-ID is intentionally omitted. Core authorizes creation in the
-target pool but reads the source workflow internally without a source-pool
-read check. Dry-run rendering, environment injection, local-file expansion,
-and rsync are also omitted from the agent-facing contract.
+target pool but does not enforce source-pool read access when retrieving the
+source workflow. Dry-run rendering, environment injection, local-file
+expansion, and rsync are also omitted from the agent-facing contract.
 
 Restart accepts only a failed source workflow and always performs a compact
 source-workflow GET before its POST. This requires `workflow:Read` on the
@@ -94,13 +93,19 @@ launching compute. It must pass against an MCP-enabled deployment before Phase
 Inspector checks against disposable workflows so the smoke suite does not
 consume compute or mutate existing workflow state.
 
-## Phase 3: user-owned mutations
+## Phase 3: user-owned mutations (in progress)
 
-Add `osmo_set_profile`, `osmo_set_credential`, `osmo_delete_credential`,
-`osmo_create_app`, `osmo_update_app`, `osmo_delete_app`, `osmo_rename_app`, and
-`osmo_submit_app`. Credential writes require dedicated secret-argument and
-error-reflection tests. Application writes must preserve their asynchronous API
-semantics.
+`osmo_set_profile` is implemented. It updates exactly one external
+CLI-supported setting per call: the default pool, email notifications, or
+Slack notifications. Other profile settings are outside this tool's public
+contract. Core returns JSON `null` after accepting the write, so MCP returns a
+compact confirmation rather than implying it read back authoritative state.
+
+Remaining work adds `osmo_set_credential`, `osmo_delete_credential`,
+`osmo_create_app`, `osmo_update_app`, `osmo_delete_app`, `osmo_rename_app`,
+and `osmo_submit_app`. Credential writes require dedicated secret-argument and
+error-reflection tests. Application writes must preserve their asynchronous
+API semantics.
 
 ## Out of scope
 

--- a/src/service/mcp/gateway.py
+++ b/src/service/mcp/gateway.py
@@ -50,6 +50,7 @@ _HTTP_LIMITS = httpx.Limits(
 QueryScalar: TypeAlias = str | int | bool
 QueryValue: TypeAlias = QueryScalar | Sequence[QueryScalar]
 QueryParams: TypeAlias = Mapping[str, QueryValue]
+JsonRequestBody: TypeAlias = Mapping[str, object] | str
 
 
 class GatewayClientError(RuntimeError):
@@ -94,7 +95,7 @@ class GatewayClient:
         credentials: request_context.RequestCredentials,
         max_response_bytes: int,
         query: QueryParams | None = None,
-        json_body: Mapping[str, object] | None = None,
+        json_body: JsonRequestBody | None = None,
     ) -> GatewayResponse:
         """Call a fixed API path and require its 2xx response body to fit."""
         return await self._request(
@@ -135,7 +136,7 @@ class GatewayClient:
         credentials: request_context.RequestCredentials,
         max_response_bytes: int,
         query: QueryParams | None,
-        json_body: Mapping[str, object] | None,
+        json_body: JsonRequestBody | None,
         truncate_success: bool,
     ) -> GatewayResponse:
         """Call a fixed API path with credentials from the active MCP request."""
@@ -428,16 +429,24 @@ def _encode_query_params(
 
 def _encode_json_body(
     method: str,
-    json_body: Mapping[str, object] | None,
+    json_body: JsonRequestBody | None,
 ) -> bytes | None:
-    """Serialize one bounded JSON object for an explicit write request."""
+    """Serialize one bounded JSON object or string for a write request."""
     if json_body is None:
         return None
-    if method == 'GET' or not isinstance(json_body, Mapping):
+    if (
+        method == 'GET'
+        or not isinstance(json_body, (Mapping, str))
+    ):
         raise ValueError('Gateway request body is not allowed.')
+    json_value = (
+        dict(json_body)
+        if isinstance(json_body, Mapping)
+        else json_body
+    )
     try:
         encoded_body = json.dumps(
-            dict(json_body),
+            json_value,
             ensure_ascii=False,
             allow_nan=False,
             separators=(',', ':'),

--- a/src/service/mcp/profile.py
+++ b/src/service/mcp/profile.py
@@ -17,11 +17,31 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import datetime
+from typing import Annotated, Literal
 
 from mcp.server.fastmcp import Context
 import pydantic
 
-from src.service.mcp import access_scope
+from src.service.mcp import (
+    access_scope,
+    tool_errors,
+    tool_requests,
+    tool_validation,
+)
+
+
+ProfileSetting = Literal['pool', 'notifications']
+ProfileValue = Annotated[
+    str,
+    pydantic.Field(min_length=1, max_length=512),
+]
+ProfileEnabled = Annotated[
+    pydantic.StrictBool,
+    pydantic.Field(),
+]
+
+_MAX_PROFILE_UPDATE_RESPONSE_BYTES = 1024
+_MAX_PROFILE_VALUE_BYTES = 512
 
 
 class ProfileSettings(pydantic.BaseModel):
@@ -55,6 +75,17 @@ class ProfileResult(pydantic.BaseModel):
     token: TokenIdentity | None = None
 
 
+class ProfileUpdateResult(pydantic.BaseModel):
+    """Closed confirmation of one applied active-user profile setting."""
+
+    model_config = pydantic.ConfigDict(extra='forbid')
+
+    setting: ProfileSetting
+    value: str
+    enabled: bool | None
+    updated: Literal[True]
+
+
 async def osmo_get_profile(context: Context) -> ProfileResult:
     """Get the active user's OSMO profile, roles, and accessible pools."""
     active_profile = (
@@ -63,4 +94,65 @@ async def osmo_get_profile(context: Context) -> ProfileResult:
     return ProfileResult.model_validate(
         active_profile.model_dump(),
         strict=True,
+    )
+
+
+async def osmo_set_profile(
+    context: Context,
+    setting: ProfileSetting,
+    value: ProfileValue,
+    enabled: ProfileEnabled | None = None,
+) -> ProfileUpdateResult:
+    """Update one allowlisted setting for the active OSMO user."""
+    if setting not in ('pool', 'notifications'):
+        raise tool_errors.PublicToolError('Invalid profile setting.')
+    if enabled is not None and not isinstance(enabled, bool):
+        raise tool_errors.PublicToolError('Invalid enabled.')
+
+    payload: tool_requests.JsonObject
+    applied_enabled: bool | None
+    if setting == 'pool':
+        if enabled is not None:
+            raise tool_errors.PublicToolError(
+                'Do not specify enabled when updating the default pool.'
+            )
+        validated_value = tool_validation.validate_query_text(
+            value,
+            field='profile value',
+            max_bytes=_MAX_PROFILE_VALUE_BYTES,
+        )
+        payload = {'pool': validated_value}
+        applied_enabled = None
+    else:
+        if value not in ('email', 'slack'):
+            raise tool_errors.PublicToolError(
+                'Notification value must be email or slack.'
+            )
+        validated_value = value
+        applied_enabled = True if enabled is None else enabled
+        payload = {
+            (
+                'email_notification'
+                if value == 'email'
+                else 'slack_notification'
+            ): applied_enabled,
+        }
+
+    response = await tool_requests.request_json_mutation(
+        context,
+        method='POST',
+        path='/api/profile/settings',
+        operation='update the active user profile',
+        max_response_bytes=_MAX_PROFILE_UPDATE_RESPONSE_BYTES,
+        payload=payload,
+    )
+    if response is not None:
+        raise tool_errors.uncertain_write_error(
+            'update the active user profile'
+        )
+    return ProfileUpdateResult(
+        setting=setting,
+        value=validated_value,
+        enabled=applied_enabled,
+        updated=True,
     )

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -52,6 +52,13 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'pools, and non-secret token identity metadata.',
     ),
     (
+        profile.osmo_set_profile,
+        'osmo_set_profile',
+        'Update OSMO profile',
+        'Update the active user\'s default pool or notification settings. '
+        'This overwrites saved profile state and is not automatically retried.',
+    ),
+    (
         pools.osmo_search_pools,
         'osmo_search_pools',
         'Search OSMO pools',
@@ -166,6 +173,7 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
 _EXPECTED_REQUIRED_FIELDS = {
     'osmo_health': [],
     'osmo_get_profile': [],
+    'osmo_set_profile': ['setting', 'value'],
     'osmo_search_pools': [],
     'osmo_list_resources': [],
     'osmo_get_resource': ['node_name'],
@@ -185,6 +193,7 @@ _EXPECTED_REQUIRED_FIELDS = {
 }
 
 _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
+    'osmo_set_profile': {'enabled': None},
     'osmo_search_pools': {'query': None, 'limit': 50, 'offset': 0},
     'osmo_list_resources': {
         'pool': None,
@@ -242,7 +251,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
     """Lock the ordered, agent-facing external MCP tool contract."""
 
     def test_registry_has_exact_metadata_and_direct_unique_functions(self) -> None:
-        self.assertEqual(len(tool_registry.TOOL_SPECS), 18)
+        self.assertEqual(len(tool_registry.TOOL_SPECS), 19)
         self.assertEqual(
             [
                 (spec.name, spec.title, spec.description)
@@ -257,7 +266,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         registered_functions = [
             spec.function for spec in tool_registry.TOOL_SPECS
         ]
-        self.assertEqual(len({id(function) for function in registered_functions}), 18)
+        self.assertEqual(len({id(function) for function in registered_functions}), 19)
         for spec, (function, _, _, _) in zip(
             tool_registry.TOOL_SPECS,
             _EXPECTED_SPECS,
@@ -270,7 +279,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
 
         tool_registry.register_tools(mcp_server)
 
-        self.assertEqual(mcp_server.add_tool.call_count, 18)
+        self.assertEqual(mcp_server.add_tool.call_count, 19)
         for call, (function, name, title, description) in zip(
             mcp_server.add_tool.call_args_list,
             _EXPECTED_SPECS,
@@ -285,16 +294,21 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             is_write = name in {
                 'osmo_cancel_workflow',
                 'osmo_restart_workflow',
+                'osmo_set_profile',
                 'osmo_submit_workflow',
                 'osmo_validate_workflow',
             }
             is_destructive = name in {
                 'osmo_cancel_workflow',
                 'osmo_restart_workflow',
+                'osmo_set_profile',
             }
             self.assertIs(annotations.readOnlyHint, not is_write)
             self.assertIs(annotations.destructiveHint, is_destructive)
-            self.assertIs(annotations.idempotentHint, not is_write)
+            self.assertIs(
+                annotations.idempotentHint,
+                name == 'osmo_set_profile' or not is_write,
+            )
             self.assertFalse(annotations.openWorldHint)
 
     async def test_all_tools_have_closed_schemas_and_stable_arguments(self) -> None:
@@ -314,19 +328,24 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             is_write = tool.name in {
                 'osmo_cancel_workflow',
                 'osmo_restart_workflow',
+                'osmo_set_profile',
                 'osmo_submit_workflow',
                 'osmo_validate_workflow',
             }
             is_destructive = tool.name in {
                 'osmo_cancel_workflow',
                 'osmo_restart_workflow',
+                'osmo_set_profile',
             }
             self.assertIs(tool.annotations.readOnlyHint, not is_write)
             self.assertIs(
                 tool.annotations.destructiveHint,
                 is_destructive,
             )
-            self.assertIs(tool.annotations.idempotentHint, not is_write)
+            self.assertIs(
+                tool.annotations.idempotentHint,
+                tool.name == 'osmo_set_profile' or not is_write,
+            )
             self.assertFalse(tool.annotations.openWorldHint)
             self._assert_recursively_closed(tool.inputSchema, tool.name)
             self.assertIsNotNone(tool.outputSchema)

--- a/src/service/mcp/tests/test_gateway.py
+++ b/src/service/mcp/tests/test_gateway.py
@@ -324,6 +324,41 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
             ),
         )
 
+    async def test_writes_json_encode_string_bodies(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, content=b'null')
+
+        async with gateway.create_app_context(
+            gateway_url='https://gateway.test',
+            request_timeout_seconds=5,
+            transport=httpx.MockTransport(handler),
+        ) as app_context:
+            for method in ('POST', 'PATCH', 'DELETE'):
+                await app_context.gateway.request(
+                    method,
+                    '/api/app/user/training-app',
+                    credentials=self._credentials(),
+                    max_response_bytes=1024,
+                    json_body='version: 2\nname: "training"',
+                )
+
+        self.assertEqual(
+            [request.method for request in captured_requests],
+            ['POST', 'PATCH', 'DELETE'],
+        )
+        for request in captured_requests:
+            self.assertEqual(
+                request.content,
+                b'"version: 2\\nname: \\"training\\""',
+            )
+            self.assertEqual(
+                request.headers['content-type'],
+                'application/json',
+            )
+
     async def test_invalid_json_bodies_are_rejected_before_transport(self) -> None:
         transport_calls = 0
 
@@ -343,6 +378,8 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
             ('POST', {'value': '\ud800'}),
             ('POST', {'file': 'x' * (1024 * 1024)}),
             ('POST', {'file': 'request-body-bearer-secret'}),
+            ('POST', ['json', 'arrays']),
+            ('PATCH', 1),
         )
         async with gateway.create_app_context(
             gateway_url='https://gateway.test',
@@ -357,7 +394,7 @@ class GatewayClientTest(unittest.IsolatedAsyncioTestCase):
                             '/api/pool/pool-a/workflow',
                             credentials=credentials,
                             max_response_bytes=1024,
-                            json_body=json_body,
+                            json_body=json_body,  # type: ignore[arg-type]
                         )
 
         self.assertEqual(transport_calls, 0)

--- a/src/service/mcp/tests/test_profile.py
+++ b/src/service/mcp/tests/test_profile.py
@@ -186,6 +186,258 @@ class ProfileToolProtocolTest(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn(login.OSMO_USER_HEADER, upstream_request.headers)
         self.assertNotIn('cookie', upstream_request.headers)
 
+    async def test_set_profile_pool_relays_one_closed_mutation(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, content=b'null')
+
+        response, catalog_response = await self._invoke_tool(
+            handler,
+            arguments={
+                'setting': 'pool',
+                'value': 'training-pool',
+            },
+            include_catalog=True,
+            tool_name='osmo_set_profile',
+        )
+
+        self.assertIsNotNone(catalog_response)
+        assert catalog_response is not None
+        tools = {
+            item['name']: item
+            for item in catalog_response.json()['result']['tools']
+        }
+        tool = tools['osmo_set_profile']
+        self.assertEqual(tool['name'], 'osmo_set_profile')
+        self.assertFalse(tool['inputSchema']['additionalProperties'])
+        self.assertEqual(
+            tool['inputSchema']['properties']['setting']['enum'],
+            ['pool', 'notifications'],
+        )
+        enabled_schema = tool['inputSchema']['properties']['enabled']
+        self.assertIn(
+            {'type': 'boolean'},
+            enabled_schema['anyOf'],
+        )
+        self.assertFalse(tool['outputSchema']['additionalProperties'])
+        self.assertEqual(tool['annotations'], {
+            'readOnlyHint': False,
+            'destructiveHint': True,
+            'idempotentHint': True,
+            'openWorldHint': False,
+        })
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'], result)
+        self.assertEqual(result['structuredContent'], {
+            'setting': 'pool',
+            'value': 'training-pool',
+            'enabled': None,
+            'updated': True,
+        })
+        self.assertEqual(len(captured_requests), 1)
+        upstream_request = captured_requests[0]
+        self.assertEqual(upstream_request.method, 'POST')
+        self.assertEqual(
+            str(upstream_request.url),
+            'https://gateway.test/api/profile/settings',
+        )
+        self.assertEqual(
+            upstream_request.content,
+            b'{"pool":"training-pool"}',
+        )
+        self.assertEqual(
+            upstream_request.headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+        self.assertEqual(
+            upstream_request.headers['x-request-id'],
+            'profile-request-123',
+        )
+        self.assertNotIn(_BEARER_SECRET, response.text)
+
+    async def test_set_profile_notifications_default_and_explicit_enabled(
+        self,
+    ) -> None:
+        cases: tuple[
+            tuple[dict[str, object], dict[str, object], bool],
+            ...,
+        ] = (
+            (
+                {'setting': 'notifications', 'value': 'email'},
+                {'email_notification': True},
+                True,
+            ),
+            (
+                {
+                    'setting': 'notifications',
+                    'value': 'slack',
+                    'enabled': False,
+                },
+                {'slack_notification': False},
+                False,
+            ),
+        )
+
+        def success_handler(
+            captured_requests: list[httpx.Request],
+        ) -> _Handler:
+            async def handler(request: httpx.Request) -> httpx.Response:
+                captured_requests.append(request)
+                return httpx.Response(200, content=b'null')
+
+            return handler
+
+        for arguments, expected_payload, expected_enabled in cases:
+            with self.subTest(arguments=arguments):
+                captured_requests: list[httpx.Request] = []
+
+                response, _ = await self._invoke_tool(
+                    success_handler(captured_requests),
+                    arguments=arguments,
+                    tool_name='osmo_set_profile',
+                )
+                result = response.json()['result']
+                self.assertFalse(result['isError'], result)
+                self.assertEqual(
+                    result['structuredContent']['enabled'],
+                    expected_enabled,
+                )
+                self.assertEqual(len(captured_requests), 1)
+                self.assertEqual(
+                    json.loads(captured_requests[0].content),
+                    expected_payload,
+                )
+
+    async def test_set_profile_rejects_invalid_combinations_before_transport(
+        self,
+    ) -> None:
+        input_secret = 'profile-invalid-input-secret'
+        cases: tuple[dict[str, object], ...] = (
+            {
+                'setting': 'pool',
+                'value': 'training-pool',
+                'enabled': True,
+            },
+            {
+                'setting': 'notifications',
+                'value': 'sms',
+            },
+            {
+                'setting': 'notifications',
+                'value': 'email',
+                'enabled': 1,
+            },
+            {
+                'setting': 'bucket',
+                'value': input_secret,
+            },
+            {
+                'setting': 'notifications',
+                'value': 'email',
+                'enabled': input_secret,
+            },
+        )
+
+        async def unexpected_handler(
+            request: httpx.Request,
+        ) -> httpx.Response:
+            raise AssertionError(f'unexpected request: {request.url}')
+
+        for arguments in cases:
+            with self.subTest(arguments=arguments):
+                response, _ = await self._invoke_tool(
+                    unexpected_handler,
+                    arguments=arguments,
+                    tool_name='osmo_set_profile',
+                )
+                result = response.json()['result']
+                self.assertTrue(result['isError'])
+                self.assertNotIn(input_secret, json.dumps(result))
+                self.assertNotIn(_BEARER_SECRET, json.dumps(result))
+
+    async def test_set_profile_write_failures_do_not_reflect_or_retry(
+        self,
+    ) -> None:
+        upstream_secret = 'profile-write-upstream-secret'
+        cases = (
+            httpx.Response(
+                422,
+                json={
+                    'error_code': 'USER',
+                    'message': upstream_secret,
+                },
+            ),
+            httpx.Response(
+                200,
+                json={
+                    'unexpected': upstream_secret,
+                },
+            ),
+        )
+
+        def fixed_response_handler(
+            upstream_response: httpx.Response,
+        ) -> tuple[_Handler, list[httpx.Request]]:
+            captured_requests: list[httpx.Request] = []
+
+            async def handler(request: httpx.Request) -> httpx.Response:
+                captured_requests.append(request)
+                return upstream_response
+
+            return handler, captured_requests
+
+        for upstream_response in cases:
+            with self.subTest(status=upstream_response.status_code):
+                handler, captured_requests = fixed_response_handler(
+                    upstream_response
+                )
+
+                response, _ = await self._invoke_tool(
+                    handler,
+                    arguments={
+                        'setting': 'pool',
+                        'value': 'training-pool',
+                    },
+                    tool_name='osmo_set_profile',
+                )
+                result = response.json()['result']
+                self.assertTrue(result['isError'])
+                self.assertEqual(len(captured_requests), 1)
+                self.assertNotIn(upstream_secret, json.dumps(result))
+                self.assertNotIn(_BEARER_SECRET, json.dumps(result))
+                if upstream_response.status_code == 200:
+                    self.assertIn(
+                        'write outcome is unknown',
+                        json.dumps(result),
+                    )
+
+        transport_calls = 0
+
+        async def transport_failure(
+            request: httpx.Request,
+        ) -> httpx.Response:
+            nonlocal transport_calls
+            transport_calls += 1
+            raise httpx.ConnectError(upstream_secret, request=request)
+
+        response, _ = await self._invoke_tool(
+            transport_failure,
+            arguments={
+                'setting': 'pool',
+                'value': 'training-pool',
+            },
+            tool_name='osmo_set_profile',
+        )
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertEqual(transport_calls, 1)
+        self.assertIn('write outcome is unknown', json.dumps(result))
+        self.assertNotIn(upstream_secret, json.dumps(result))
+        self.assertNotIn(_BEARER_SECRET, json.dumps(result))
+
     async def test_health_is_a_minimal_caller_bound_profile_probe(self) -> None:
         captured_requests: list[httpx.Request] = []
 

--- a/src/service/mcp/tests/test_tool_support.py
+++ b/src/service/mcp/tests/test_tool_support.py
@@ -410,6 +410,155 @@ class JsonMutationRequestTest(unittest.IsolatedAsyncioTestCase):
             json_body=payload,
         )
 
+    async def test_general_mutation_supports_methods_bodies_and_result_values(
+        self,
+    ) -> None:
+        gateway_client = mock.AsyncMock(spec=gateway.GatewayClient)
+        credentials = self._credentials()
+        cases = (
+            (
+                'POST',
+                {'pool': 'pool-a'},
+                b'null',
+                None,
+            ),
+            (
+                'PATCH',
+                'version: 2',
+                b'{"name":"app-a","version":2}',
+                {'name': 'app-a', 'version': 2},
+            ),
+            (
+                'DELETE',
+                None,
+                b'"app-a"',
+                'app-a',
+            ),
+        )
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'get_app_context',
+                return_value=gateway.AppContext(gateway=gateway_client),
+            ),
+            mock.patch.object(
+                request_context,
+                'get_request_credentials',
+                return_value=credentials,
+            ),
+        ):
+            for method, payload, body, expected in cases:
+                with self.subTest(method=method):
+                    gateway_client.reset_mock()
+                    gateway_client.request.return_value = (
+                        gateway.GatewayResponse(200, body)
+                    )
+                    result = await tool_requests.request_json_mutation(
+                        mock.Mock(),
+                        method=method,  # type: ignore[arg-type]
+                        path='/api/profile/settings',
+                        operation='update a setting',
+                        max_response_bytes=1024,
+                        payload=payload,
+                    )
+
+                    self.assertEqual(result, expected)
+                    gateway_client.request.assert_awaited_once_with(
+                        method,
+                        '/api/profile/settings',
+                        credentials=credentials,
+                        max_response_bytes=1024,
+                        query=None,
+                        json_body=payload,
+                    )
+
+    async def test_mutation_rejects_unsupported_json_without_reflection_or_retry(
+        self,
+    ) -> None:
+        gateway_client = mock.AsyncMock(spec=gateway.GatewayClient)
+        credentials = self._credentials()
+        invalid_bodies = (
+            b'["malformed-success-upstream-secret"',
+            b'{"value":"malformed-success-upstream-secret"',
+            b'[]',
+            b'true',
+            b'1',
+        )
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'get_app_context',
+                return_value=gateway.AppContext(gateway=gateway_client),
+            ),
+            mock.patch.object(
+                request_context,
+                'get_request_credentials',
+                return_value=credentials,
+            ),
+        ):
+            for body in invalid_bodies:
+                with self.subTest(body=body):
+                    gateway_client.reset_mock()
+                    gateway_client.request.return_value = (
+                        gateway.GatewayResponse(200, body)
+                    )
+                    with self.assertRaisesRegex(
+                        ToolError,
+                        'write outcome is unknown',
+                    ) as raised:
+                        await tool_requests.request_json_mutation(
+                            mock.Mock(),
+                            method='PATCH',
+                            path='/api/app/user/app-a',
+                            operation='update an app',
+                            max_response_bytes=1024,
+                            payload='version: 2',
+                        )
+
+                    self.assertNotIn('upstream-secret', str(raised.exception))
+                    gateway_client.request.assert_awaited_once()
+
+    async def test_mutation_suppresses_upstream_error_body_without_retry(
+        self,
+    ) -> None:
+        gateway_client = mock.AsyncMock(spec=gateway.GatewayClient)
+        gateway_client.request.return_value = gateway.GatewayResponse(
+            422,
+            (
+                b'{"error_code":"USER",'
+                b'"message":"profile-write-upstream-secret"}'
+            ),
+        )
+        credentials = self._credentials()
+
+        with (
+            mock.patch.object(
+                tool_requests,
+                'get_app_context',
+                return_value=gateway.AppContext(gateway=gateway_client),
+            ),
+            mock.patch.object(
+                request_context,
+                'get_request_credentials',
+                return_value=credentials,
+            ),
+        ):
+            with self.assertRaisesRegex(ToolError, 'HTTP 422') as raised:
+                await tool_requests.request_json_mutation(
+                    mock.Mock(),
+                    method='POST',
+                    path='/api/profile/settings',
+                    operation='update the active user profile',
+                    max_response_bytes=1024,
+                    payload={'pool': 'pool-a'},
+                )
+
+        self.assertNotIn('profile-write-upstream-secret', str(raised.exception))
+        self.assertNotIn('error_code=USER', str(raised.exception))
+        gateway_client.request.assert_awaited_once()
+
     async def test_mutation_transport_and_server_failures_are_uncertain(
         self,
     ) -> None:
@@ -446,6 +595,7 @@ class JsonMutationRequestTest(unittest.IsolatedAsyncioTestCase):
         ):
             for failure in failures:
                 with self.subTest(failure=type(failure).__name__):
+                    gateway_client.reset_mock()
                     if isinstance(failure, Exception):
                         gateway_client.request.side_effect = failure
                     else:
@@ -464,6 +614,7 @@ class JsonMutationRequestTest(unittest.IsolatedAsyncioTestCase):
                     message = str(raised.exception)
                     self.assertIn('Inspect OSMO state before retrying', message)
                     self.assertNotIn('upstream-secret', message)
+                    gateway_client.request.assert_awaited_once()
 
 
 if __name__ == '__main__':

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -43,11 +43,15 @@ def _read_only_annotations() -> ToolAnnotations:
     )
 
 
-def _write_annotations(*, destructive: bool) -> ToolAnnotations:
+def _write_annotations(
+    *,
+    destructive: bool,
+    idempotent: bool = False,
+) -> ToolAnnotations:
     return ToolAnnotations(
         readOnlyHint=False,
         destructiveHint=destructive,
-        idempotentHint=False,
+        idempotentHint=idempotent,
         openWorldHint=False,
     )
 
@@ -82,6 +86,19 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         description=(
             'Get the active user\'s OSMO profile settings, roles, accessible '
             'pools, and non-secret token identity metadata.'
+        ),
+    ),
+    ToolSpec(
+        function=profile.osmo_set_profile,
+        name='osmo_set_profile',
+        title='Update OSMO profile',
+        description=(
+            'Update the active user\'s default pool or notification settings. '
+            'This overwrites saved profile state and is not automatically retried.'
+        ),
+        annotations=_write_annotations(
+            destructive=True,
+            idempotent=True,
         ),
     ),
     ToolSpec(

--- a/src/service/mcp/tool_requests.py
+++ b/src/service/mcp/tool_requests.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
 import json
-from typing import TypeAlias
+from typing import Literal, TypeAlias
 
 from mcp.server.fastmcp import Context
 import pydantic
@@ -29,9 +29,13 @@ from src.service.mcp import gateway, request_context, tool_errors
 
 
 JsonObject: TypeAlias = dict[str, pydantic.JsonValue]
+JsonMutationResult: TypeAlias = JsonObject | str | None
 ActiveProfile: TypeAlias = profile_contract.ProfileResponse
 
 _JSON_OBJECT_ADAPTER = pydantic.TypeAdapter(JsonObject)
+_JSON_MUTATION_RESULT_ADAPTER: pydantic.TypeAdapter[JsonMutationResult] = (
+    pydantic.TypeAdapter(JsonMutationResult)
+)
 _PROFILE_PATH = '/api/profile/settings'
 _MAX_PROFILE_RESPONSE_BYTES = 64 * 1024
 _TEXT_TRUNCATION_SENTINEL = (
@@ -82,16 +86,17 @@ async def request_json_object(
 async def request_json_mutation(
     context: Context,
     *,
+    method: Literal['POST', 'PATCH', 'DELETE'] = 'POST',
     path: str,
     operation: str,
     max_response_bytes: int,
     query: gateway.QueryParams | None = None,
-    payload: JsonObject | None = None,
-) -> JsonObject:
-    """Relay one fixed POST without retries and require a bounded JSON object."""
+    payload: gateway.JsonRequestBody | None = None,
+) -> JsonMutationResult:
+    """Relay one fixed write and require a bounded object, string, or null."""
     response = await _request(
         context,
-        method='POST',
+        method=method,
         path=path,
         operation=operation,
         max_response_bytes=max_response_bytes,
@@ -100,8 +105,11 @@ async def request_json_mutation(
         suppress_upstream_details=True,
     )
     try:
-        return _validate_json_object_body(response.body, operation=operation)
-    except tool_errors.PublicToolError:
+        return _JSON_MUTATION_RESULT_ADAPTER.validate_json(
+            response.body,
+            strict=True,
+        )
+    except pydantic.ValidationError:
         raise tool_errors.uncertain_write_error(operation) from None
 
 
@@ -215,7 +223,7 @@ async def _request(
     operation: str,
     max_response_bytes: int,
     query: gateway.QueryParams | None,
-    json_body: JsonObject | None = None,
+    json_body: gateway.JsonRequestBody | None = None,
     suppress_upstream_details: bool = False,
     truncate_text: bool = False,
     not_found_message: str | None = None,

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -37,6 +37,7 @@ _EXPECTED_TOOL_NAMES = frozenset({
     "osmo_list_workflows",
     "osmo_search_pools",
     "osmo_restart_workflow",
+    "osmo_set_profile",
     "osmo_submit_workflow",
     "osmo_validate_workflow",
 })


### PR DESCRIPTION
## Description

Issue #None

Starts the Phase 3 external MCP mutation stack with the shared write foundation
and `osmo_set_profile`.

- Generalizes the existing bounded, one-shot mutation relay for fixed
  POST/PATCH/DELETE routes, JSON object or string request bodies, and
  null/object/string JSON success values.
- Adds `osmo_set_profile` for the external CLI/Core-supported default-pool and
  email/Slack notification settings.
- Requires strict arguments, an exact JSON-null Core response, compact closed
  output, suppressed free-form write errors, and unknown-outcome guidance
  without retries.
- Updates the catalog and deployment documentation from 18 to 19 tools.

Profile setting support is limited to the default-pool and email/Slack
notification settings exposed by the CLI/Core contract.

### Stack

- Phase 3 stack PR 1/4.
- Targets `feature/mcp` after #1237 merged.
- #1239 is stacked on this PR.
- Nothing in this stack targets `main`.

### Validation

- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors //src/service/mcp/tests:test_gateway //src/service/mcp/tests:test_tool_support //src/service/mcp/tests:test_profile //src/service/mcp/tests:test_catalog`
- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors //test/smoke:mcp-checks-pylint`
- `bazel --output_user_root=/tmp/osmo-bazel build //src/service/mcp:mcp_binary //test/smoke:mcp-checks`
- `git diff --check`

The deployed smoke suite verifies discovery only for this new write tool; it
intentionally does not mutate a user's saved profile.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
