### PR TITLE
Add external MCP credential mutations

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -109,7 +109,7 @@ not mount a service-account token, and the chart creates no MCP credential
 Secret. Gateway-to-MCP TLS continues to use the shared `gateway.tls`
 configuration described below.
 
-The external MCP exposes a 19-tool catalog with fixed API routes and no
+The external MCP exposes a 21-tool catalog with fixed API routes and no
 caller-selected origin, method, route, or headers. See the
 [external MCP tool plan](../../../src/service/mcp/TOOLS.md) for its exact
 contracts and API mappings. MCP health probes do not call these APIs; a

--- a/src/lib/api/BUILD
+++ b/src/lib/api/BUILD
@@ -28,3 +28,12 @@ osmo_py_library(
     deps = [requirement("pydantic")],
     visibility = ["//visibility:public"],
 )
+
+osmo_py_library(
+    name = "storage",
+    srcs = [
+        "__init__.py",
+        "storage.py",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/src/lib/api/storage.py
+++ b/src/lib/api/storage.py
@@ -1,0 +1,46 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import re
+
+
+URI_COMPONENT = r'[^/,;*]+'
+SWIFT_REGEX = fr'^swift://{URI_COMPONENT}(/{URI_COMPONENT}){{2,}}/*$'
+S3_REGEX = fr'^s3://{URI_COMPONENT}(/{URI_COMPONENT})*/*$'
+GS_REGEX = fr'^gs://{URI_COMPONENT}(/{URI_COMPONENT})*/*$'
+TOS_REGEX = fr'^tos://{URI_COMPONENT}(/{URI_COMPONENT})+/*$'
+AZURE_REGEX = fr'^azure://{URI_COMPONENT}(/{URI_COMPONENT})+/*$'
+STORAGE_BACKEND_REGEX = (
+    fr'({SWIFT_REGEX}|{S3_REGEX}|{GS_REGEX}|{TOS_REGEX}|{AZURE_REGEX})'
+)
+STORAGE_BACKEND_SCHEMES: tuple[str, ...] = tuple(
+    re.findall(r'\^(\w+)://', STORAGE_BACKEND_REGEX)
+)
+
+SWIFT_PROFILE_REGEX = fr'^swift://{URI_COMPONENT}(/{URI_COMPONENT})/*'
+S3_PROFILE_REGEX = fr'^s3://{URI_COMPONENT}/*'
+GS_PROFILE_REGEX = fr'^gs://{URI_COMPONENT}/*'
+TOS_PROFILE_REGEX = fr'^tos://{URI_COMPONENT}(/{URI_COMPONENT})/*'
+AZURE_PROFILE_REGEX = fr'^azure://{URI_COMPONENT}/*'
+STORAGE_PROFILE_REGEX = (
+    fr'({SWIFT_PROFILE_REGEX}|{S3_PROFILE_REGEX}|{GS_PROFILE_REGEX}|'
+    fr'{TOS_PROFILE_REGEX}|{AZURE_PROFILE_REGEX})'
+)
+STORAGE_CREDENTIAL_REGEX = (
+    fr'({STORAGE_PROFILE_REGEX}|{STORAGE_BACKEND_REGEX})'
+)

--- a/src/lib/data/storage/constants/BUILD
+++ b/src/lib/data/storage/constants/BUILD
@@ -24,5 +24,6 @@ osmo_py_library(
     srcs = glob(["*.py"]),
     deps = [
         requirement("pydantic"),
+        "//src/lib/api:storage",
     ],
 )

--- a/src/lib/data/storage/constants/constants.py
+++ b/src/lib/data/storage/constants/constants.py
@@ -18,10 +18,54 @@
 Constants for the data module.
 """
 
-import re
 from typing import Annotated
 
 import pydantic
+
+from src.lib.api.storage import (
+    AZURE_PROFILE_REGEX,
+    AZURE_REGEX,
+    GS_PROFILE_REGEX,
+    GS_REGEX,
+    S3_PROFILE_REGEX,
+    S3_REGEX,
+    STORAGE_BACKEND_REGEX,
+    STORAGE_BACKEND_SCHEMES,
+    STORAGE_CREDENTIAL_REGEX,
+    STORAGE_PROFILE_REGEX,
+    SWIFT_PROFILE_REGEX,
+    SWIFT_REGEX,
+    TOS_PROFILE_REGEX,
+    TOS_REGEX,
+    URI_COMPONENT,
+)
+
+__all__ = [
+    'AZURE_PROFILE_REGEX',
+    'AZURE_REGEX',
+    'DEFAULT_AZURE_HOST',
+    'DEFAULT_AZURE_REGION',
+    'DEFAULT_BOTO3_REGION',
+    'DEFAULT_GS_HOST',
+    'DEFAULT_GS_REGION',
+    'DEFAULT_TOS_REGION',
+    'GS_PROFILE_REGEX',
+    'GS_REGEX',
+    'S3_PROFILE_REGEX',
+    'S3_REGEX',
+    'STORAGE_BACKEND_REGEX',
+    'STORAGE_BACKEND_SCHEMES',
+    'STORAGE_CREDENTIAL_REGEX',
+    'STORAGE_PROFILE_REGEX',
+    'SWIFT_PROFILE_REGEX',
+    'SWIFT_REGEX',
+    'StorageBackendPattern',
+    'StorageCredentialPattern',
+    'StorageProfilePattern',
+    'TOS_PROFILE_REGEX',
+    'TOS_REGEX',
+    'URI_COMPONENT',
+]
 
 DEFAULT_BOTO3_REGION = 'us-east-1'
 DEFAULT_GS_REGION = 'us-east1'
@@ -31,34 +75,8 @@ DEFAULT_GS_HOST = 'storage.googleapis.com'
 DEFAULT_AZURE_HOST = 'blob.core.windows.net'
 
 
-# Regex rules for uris
-URI_COMPONENT = r'[^/,;*]+'
-SWIFT_REGEX = fr'^swift://{URI_COMPONENT}(/{URI_COMPONENT}){{2,}}/*$'
-S3_REGEX = fr'^s3://{URI_COMPONENT}(/{URI_COMPONENT})*/*$'
-GS_REGEX = fr'^gs://{URI_COMPONENT}(/{URI_COMPONENT})*/*$'
-TOS_REGEX = fr'^tos://{URI_COMPONENT}(/{URI_COMPONENT})+/*$'
-AZURE_REGEX = fr'^azure://{URI_COMPONENT}(/{URI_COMPONENT})+/*$'
-STORAGE_BACKEND_REGEX = fr'({SWIFT_REGEX}|{S3_REGEX}|{GS_REGEX}|{TOS_REGEX}|{AZURE_REGEX})'
 StorageBackendPattern = Annotated[str, pydantic.Field(pattern=STORAGE_BACKEND_REGEX)]
 
-# Schemes are derived from STORAGE_BACKEND_REGEX so adding a new backend
-# (e.g., a new *_REGEX included in the union above) auto-propagates here
-# and to any consumer that lists supported schemes (e.g., error messages).
-STORAGE_BACKEND_SCHEMES: tuple[str, ...] = tuple(
-    re.findall(r'\^(\w+)://', STORAGE_BACKEND_REGEX)
-)
-
-
-# Regex rules for storage profiles
-SWIFT_PROFILE_REGEX = fr'^swift://{URI_COMPONENT}(/{URI_COMPONENT})/*'
-S3_PROFILE_REGEX = fr'^s3://{URI_COMPONENT}/*'
-GS_PROFILE_REGEX = fr'^gs://{URI_COMPONENT}/*'
-TOS_PROFILE_REGEX = fr'^tos://{URI_COMPONENT}(/{URI_COMPONENT})/*'
-AZURE_PROFILE_REGEX = fr'^azure://{URI_COMPONENT}/*'
-STORAGE_PROFILE_REGEX = fr'({SWIFT_PROFILE_REGEX}|{S3_PROFILE_REGEX}|' \
-    fr'{GS_PROFILE_REGEX}|{TOS_PROFILE_REGEX}|' \
-    fr'{AZURE_PROFILE_REGEX})'
 StorageProfilePattern = Annotated[str, pydantic.Field(pattern=STORAGE_PROFILE_REGEX)]
 
-STORAGE_CREDENTIAL_REGEX = fr'({STORAGE_PROFILE_REGEX}|{STORAGE_BACKEND_REGEX})'
 StorageCredentialPattern = Annotated[str, pydantic.Field(pattern=STORAGE_CREDENTIAL_REGEX)]

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -168,6 +168,16 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "credential_action_models",
+    srcs = ["credential_action_models.py"],
+    deps = [
+        requirement("pydantic"),
+        ":tool_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "profile_tools",
     srcs = ["profile.py"],
     deps = [
@@ -280,11 +290,26 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "credential_action_tools",
+    srcs = ["credential_actions.py"],
+    deps = [
+        requirement("mcp"),
+        ":credential_action_models",
+        ":tool_errors",
+        ":tool_requests",
+        ":tool_validation",
+        "//src/lib/api:storage",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "tool_registry",
     srcs = ["tool_registry.py"],
     deps = [
         requirement("mcp"),
         ":app_tools",
+        ":credential_action_tools",
         ":credential_tools",
         ":health_tools",
         ":pool_tools",

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -102,18 +102,35 @@ authorization value.
 
 The external catalog contains 14 read-only tools for caller-bound health,
 profile, pool, resource, workflow, application, and credential-metadata
-inspection, four workflow actions, and one profile-setting action. Each tool
-maps to a fixed external API, returns a structured allowlisted result, and
-applies a domain-specific response limit. Credential inspection returns names
-and types only. Profile inspection intentionally includes non-secret
-access-token identity metadata (name and expiry). Bearer values are never
-returned.
+inspection, plus four workflow actions, one profile-setting action, and two
+credential actions. Each tool maps to a fixed external API, returns a
+structured allowlisted result, and applies a domain-specific response limit.
+Credential inspection returns names and types only. Profile inspection
+intentionally includes non-secret access-token identity metadata (name and
+expiry). Bearer values are never returned.
 
 `osmo_set_profile` updates only the default pool or email/Slack notification
 state supported by the external CLI and Core contract. Other profile settings
 are outside this tool's public contract. Core returns no updated profile
 object, so the tool reports only the validated setting that was accepted.
 Profile writes are one-shot and are not automatically retried.
+
+`osmo_set_credential` accepts the canonical documented REGISTRY, DATA, and
+GENERIC payload shapes used by the CLI and Core, with bounded string-only
+values. The MCP sends the validated payload to Core but never returns or logs
+it. Registry and data profile fields reject URL userinfo, query, and fragment
+components before the write, and `osmo_delete_credential` omits Core's legacy
+profile value from its result.
+Credential mutations are destructive, one-shot operations. The calling MCP
+client still owns the tool arguments it submitted and may retain them in its
+own transcript or logs; callers must use a client appropriate for secret
+entry.
+
+Core currently authorizes credential POST requests as `credentials:Create`
+even though it is the CLI's set route. Core also conflicts records by profile,
+so a same-name update with a different or null profile can be rejected instead
+of replaced. The external MCP preserves those API/RBAC semantics and reports
+the Core failure rather than emulating a replacement.
 
 Workflow validation calls Core's submission endpoint with
 `validation_only=true`. It is intentionally annotated as a non-idempotent
@@ -209,12 +226,14 @@ authentication. Its token needs `mcp:Access`, `profile:Read`, and
 bazel run //test/oetf:run -- --env <mcp-enabled-env> --tags mcp
 ```
 
-The smoke test rejects unauthenticated access, verifies the exact 19-tool
+The smoke test rejects unauthenticated access, verifies the exact 21-tool
 catalog, compares the profile projection with Core, checks caller-bound
 health, and validates a small workflow through Gateway → MCP → Gateway → Core.
 A successful validation does not enqueue compute or create a workflow row.
 The smoke suite intentionally sends only this known-good case because a failed
 Core validation can create a `FAILED_SUBMISSION` row.
+Profile and credential mutations remain manual Inspector checks against
+disposable user-owned state.
 
 When the deployment cannot validate the default public `ubuntu:22.04` image,
 pass an approved image into the Bazel test environment:

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -95,17 +95,29 @@ consume compute or mutate existing workflow state.
 
 ## Phase 3: user-owned mutations (in progress)
 
-`osmo_set_profile` is implemented. It updates exactly one external
-CLI-supported setting per call: the default pool, email notifications, or
-Slack notifications. Other profile settings are outside this tool's public
-contract. Core returns JSON `null` after accepting the write, so MCP returns a
-compact confirmation rather than implying it read back authoritative state.
+`osmo_set_profile`, `osmo_set_credential`, and `osmo_delete_credential` are
+implemented. Profile updates change exactly one external CLI-supported
+setting per call: the default pool, email notifications, or Slack
+notifications. Other profile settings are outside this tool's public contract.
+Core returns JSON `null` after accepting the write, so MCP returns a compact
+confirmation rather than implying it read back authoritative state.
 
-Remaining work adds `osmo_set_credential`, `osmo_delete_credential`,
-`osmo_create_app`, `osmo_update_app`, `osmo_delete_app`, `osmo_rename_app`,
-and `osmo_submit_app`. Credential writes require dedicated secret-argument and
-error-reflection tests. Application writes must preserve their asynchronous
-API semantics.
+Credential writes accept the canonical documented REGISTRY, DATA, and GENERIC
+payload shapes used by the CLI and Core. Values are bounded strings and are
+sent only in the fixed Core request body; they are never returned or logged by
+MCP. Registry and data profile fields reject URL userinfo, query, and fragment
+components. Delete results project only the matching credential name and type,
+omitting Core's legacy profile field. The MCP cannot control whether the
+calling client retains the original secret-bearing tool arguments, so callers
+must use an appropriate client.
+Core currently maps the CLI's credential set POST route to
+`credentials:Create` and conflicts records by profile. A same-name update with
+a different or null profile can therefore be rejected instead of replaced;
+MCP preserves that existing API/RBAC behavior.
+
+Remaining work adds `osmo_create_app`, `osmo_update_app`, `osmo_delete_app`,
+`osmo_rename_app`, and `osmo_submit_app`. Application writes must preserve
+their asynchronous API semantics.
 
 ## Out of scope
 

--- a/src/service/mcp/credential_action_models.py
+++ b/src/service/mcp/credential_action_models.py
@@ -1,0 +1,109 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Annotated, Any, Literal
+
+import pydantic
+
+from src.service.mcp.tool_models import ClosedToolModel, ExtensibleUpstreamModel
+
+
+CREDENTIAL_NAME_PATTERN = (
+    r'^[a-zA-Z]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$'
+)
+MAX_CREDENTIAL_NAME_LENGTH = 512
+MAX_CREDENTIAL_PAYLOAD_ENTRIES = 64
+MAX_CREDENTIAL_PAYLOAD_KEY_LENGTH = 256
+MAX_CREDENTIAL_PAYLOAD_VALUE_LENGTH = 64 * 1024
+
+CredentialType = Literal['REGISTRY', 'DATA', 'GENERIC']
+CredentialName = Annotated[
+    str,
+    pydantic.Field(
+        min_length=1,
+        max_length=MAX_CREDENTIAL_NAME_LENGTH,
+        pattern=CREDENTIAL_NAME_PATTERN,
+    ),
+]
+CredentialNameInput = Annotated[
+    Any,
+    pydantic.WithJsonSchema({
+        'type': 'string',
+        'minLength': 1,
+        'maxLength': MAX_CREDENTIAL_NAME_LENGTH,
+        'pattern': CREDENTIAL_NAME_PATTERN,
+    }),
+]
+CredentialTypeInput = Annotated[
+    Any,
+    pydantic.WithJsonSchema({
+        'type': 'string',
+        'enum': ['REGISTRY', 'DATA', 'GENERIC'],
+    }),
+]
+CredentialPayloadInput = Annotated[
+    Any,
+    pydantic.WithJsonSchema({
+        'type': 'object',
+        'minProperties': 1,
+        'maxProperties': MAX_CREDENTIAL_PAYLOAD_ENTRIES,
+        'propertyNames': {
+            'type': 'string',
+            'minLength': 1,
+            'maxLength': MAX_CREDENTIAL_PAYLOAD_KEY_LENGTH,
+        },
+        'additionalProperties': {
+            'type': 'string',
+            'minLength': 1,
+            'maxLength': MAX_CREDENTIAL_PAYLOAD_VALUE_LENGTH,
+            'writeOnly': True,
+        },
+    }),
+]
+
+
+class SetCredentialResult(ClosedToolModel):
+    """Compact confirmation that Core accepted a credential write."""
+
+    cred_name: CredentialName
+    cred_type: CredentialType
+    saved: Literal[True]
+
+
+class UpstreamDeletedCredential(ExtensibleUpstreamModel):
+    """Allowlisted metadata for one credential returned by Core."""
+
+    cred_name: CredentialName
+    cred_type: CredentialType
+
+
+class UpstreamDeleteCredentialResult(ExtensibleUpstreamModel):
+    """Allowlisted Core response for one credential deletion."""
+
+    credentials: Annotated[
+        list[UpstreamDeletedCredential],
+        pydantic.Field(min_length=1, max_length=1),
+    ]
+
+
+class DeleteCredentialResult(ClosedToolModel):
+    """Compact confirmation that Core deleted one credential."""
+
+    cred_name: CredentialName
+    cred_type: CredentialType
+    deleted: Literal[True]

--- a/src/service/mcp/credential_actions.py
+++ b/src/service/mcp/credential_actions.py
@@ -1,0 +1,291 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import re
+from typing import cast
+from urllib import parse
+
+from mcp.server.fastmcp import Context
+
+from src.lib.api import storage as storage_contract
+from src.service.mcp import tool_errors, tool_requests, tool_validation
+from src.service.mcp.credential_action_models import (
+    CREDENTIAL_NAME_PATTERN,
+    MAX_CREDENTIAL_NAME_LENGTH,
+    MAX_CREDENTIAL_PAYLOAD_ENTRIES,
+    MAX_CREDENTIAL_PAYLOAD_KEY_LENGTH,
+    MAX_CREDENTIAL_PAYLOAD_VALUE_LENGTH,
+    CredentialNameInput,
+    CredentialPayloadInput,
+    CredentialType,
+    CredentialTypeInput,
+    DeleteCredentialResult,
+    SetCredentialResult,
+    UpstreamDeleteCredentialResult,
+)
+
+
+_CREDENTIALS_PATH = '/api/credentials'
+_MAX_SET_CREDENTIAL_RESPONSE_BYTES = 1024
+_MAX_DELETE_CREDENTIAL_RESPONSE_BYTES = 64 * 1024
+_MAX_ENCODED_PAYLOAD_BYTES = 128 * 1024
+_CREDENTIAL_NAME = re.compile(CREDENTIAL_NAME_PATTERN)
+_CREDENTIAL_TYPES = frozenset(('REGISTRY', 'DATA', 'GENERIC'))
+_REGISTRY_FIELDS = frozenset(('auth', 'registry', 'username'))
+_REGISTRY_REQUIRED_FIELDS = frozenset(('auth',))
+_DATA_FIELDS = frozenset((
+    'access_key_id',
+    'access_key',
+    'endpoint',
+    'region',
+    'override_url',
+    'addressing_style',
+))
+_DATA_REQUIRED_FIELDS = frozenset((
+    'access_key_id',
+    'access_key',
+    'endpoint',
+))
+_DATA_ADDRESSING_STYLES = frozenset(('auto', 'path', 'virtual'))
+
+
+async def osmo_set_credential(
+    context: Context,
+    name: CredentialNameInput,
+    cred_type: CredentialTypeInput,
+    payload: CredentialPayloadInput,
+) -> SetCredentialResult:
+    """Set one OSMO credential without returning its payload."""
+    validated_name, encoded_name = _validate_credential_name(name)
+    validated_type = _validate_credential_type(cred_type)
+    request_payload = _credential_request_payload(
+        validated_type,
+        payload,
+    )
+    response = await tool_requests.request_json_mutation(
+        context,
+        method='POST',
+        path=f'{_CREDENTIALS_PATH}/{encoded_name}',
+        operation='set an OSMO credential',
+        max_response_bytes=_MAX_SET_CREDENTIAL_RESPONSE_BYTES,
+        payload=request_payload,
+    )
+    if response is not None:
+        raise tool_errors.uncertain_write_error('set an OSMO credential')
+    return SetCredentialResult(
+        cred_name=validated_name,
+        cred_type=validated_type,
+        saved=True,
+    )
+
+
+async def osmo_delete_credential(
+    context: Context,
+    name: CredentialNameInput,
+) -> DeleteCredentialResult:
+    """Delete one OSMO credential and return only non-secret metadata."""
+    validated_name, encoded_name = _validate_credential_name(name)
+    response = await tool_requests.request_json_mutation(
+        context,
+        method='DELETE',
+        path=f'{_CREDENTIALS_PATH}/{encoded_name}',
+        operation='delete an OSMO credential',
+        max_response_bytes=_MAX_DELETE_CREDENTIAL_RESPONSE_BYTES,
+        payload=None,
+    )
+    upstream = tool_validation.validate_mutation_response(
+        UpstreamDeleteCredentialResult,
+        response,
+        operation='delete an OSMO credential',
+    )
+    deleted_credential = upstream.credentials[0]
+    if deleted_credential.cred_name != validated_name:
+        raise tool_errors.uncertain_write_error(
+            'delete an OSMO credential'
+        )
+    return DeleteCredentialResult(
+        cred_name=deleted_credential.cred_name,
+        cred_type=deleted_credential.cred_type,
+        deleted=True,
+    )
+
+
+def _validate_credential_name(name: object) -> tuple[str, str]:
+    if not isinstance(name, str):
+        raise tool_errors.PublicToolError('Invalid credential name.')
+    try:
+        encoded_length = len(name.encode('utf-8'))
+    except UnicodeEncodeError:
+        encoded_length = MAX_CREDENTIAL_NAME_LENGTH + 1
+    if (
+        encoded_length > MAX_CREDENTIAL_NAME_LENGTH
+        or _CREDENTIAL_NAME.fullmatch(name) is None
+    ):
+        raise tool_errors.PublicToolError('Invalid credential name.')
+    return (
+        name,
+        tool_validation.safe_path_segment(
+            name,
+            field='credential name',
+        ),
+    )
+
+
+def _validate_credential_type(
+    credential_type: object,
+) -> CredentialType:
+    if (
+        not isinstance(credential_type, str)
+        or credential_type not in _CREDENTIAL_TYPES
+    ):
+        raise tool_errors.PublicToolError('Invalid cred_type.')
+    return cast(CredentialType, credential_type)
+
+
+def _credential_request_payload(
+    credential_type: CredentialType,
+    payload: object,
+) -> dict[str, object]:
+    validated_payload = _validate_payload_values(payload)
+    payload_fields = frozenset(validated_payload)
+
+    if credential_type == 'REGISTRY':
+        if (
+            not _REGISTRY_REQUIRED_FIELDS.issubset(payload_fields)
+            or not payload_fields.issubset(_REGISTRY_FIELDS)
+            or (
+                'registry' in validated_payload
+                and _has_unsafe_url_components(
+                    validated_payload['registry']
+                )
+            )
+        ):
+            raise _invalid_payload()
+        request_payload: dict[str, object] = {
+            'registry_credential': validated_payload,
+        }
+    elif credential_type == 'DATA':
+        if (
+            not _DATA_REQUIRED_FIELDS.issubset(payload_fields)
+            or not payload_fields.issubset(_DATA_FIELDS)
+            or (
+                'addressing_style' in validated_payload
+                and validated_payload['addressing_style']
+                not in _DATA_ADDRESSING_STYLES
+            )
+            or _has_unsafe_url_components(
+                validated_payload['endpoint']
+            )
+            or re.fullmatch(
+                storage_contract.STORAGE_CREDENTIAL_REGEX,
+                validated_payload['endpoint'],
+            ) is None
+            or (
+                'override_url' in validated_payload
+                and _has_unsafe_url_components(
+                    validated_payload['override_url']
+                )
+            )
+        ):
+            raise _invalid_payload()
+        validated_payload['endpoint'] = (
+            validated_payload['endpoint'].rstrip('/')
+        )
+        request_payload = {
+            'data_credential': validated_payload,
+        }
+    else:
+        request_payload = {
+            'generic_credential': {
+                'credential': validated_payload,
+            },
+        }
+
+    try:
+        encoded_payload = json.dumps(
+            request_payload,
+            ensure_ascii=False,
+            separators=(',', ':'),
+        ).encode('utf-8')
+    except (TypeError, ValueError, UnicodeEncodeError, RecursionError):
+        raise _invalid_payload() from None
+    if len(encoded_payload) > _MAX_ENCODED_PAYLOAD_BYTES:
+        raise _invalid_payload()
+    return request_payload
+
+
+def _validate_payload_values(payload: object) -> dict[str, str]:
+    if (
+        not isinstance(payload, dict)
+        or not payload
+        or len(payload) > MAX_CREDENTIAL_PAYLOAD_ENTRIES
+    ):
+        raise _invalid_payload()
+
+    validated: dict[str, str] = {}
+    for key, raw_value in payload.items():
+        if not _valid_payload_key(key):
+            raise _invalid_payload()
+        if not _valid_payload_value(raw_value):
+            raise _invalid_payload()
+        validated[key] = raw_value
+    return validated
+
+
+def _valid_payload_key(value: object) -> bool:
+    if not isinstance(value, str) or not value or value != value.strip():
+        return False
+    try:
+        encoded_length = len(value.encode('utf-8'))
+    except UnicodeEncodeError:
+        return False
+    return (
+        encoded_length <= MAX_CREDENTIAL_PAYLOAD_KEY_LENGTH
+        and all(character.isprintable() for character in value)
+    )
+
+
+def _valid_payload_value(value: object) -> bool:
+    if not isinstance(value, str) or not value or '\x00' in value:
+        return False
+    try:
+        encoded_length = len(value.encode('utf-8'))
+    except UnicodeEncodeError:
+        return False
+    return encoded_length <= MAX_CREDENTIAL_PAYLOAD_VALUE_LENGTH
+
+
+def _has_unsafe_url_components(value: str) -> bool:
+    """Reject secret-bearing URL components instead of storing them."""
+    if '?' in value or '#' in value:
+        return True
+    candidate = (
+        value
+        if '://' in value or value.startswith('//')
+        else f'//{value}'
+    )
+    try:
+        parsed = parse.urlsplit(candidate)
+        return parsed.username is not None or parsed.password is not None
+    except ValueError:
+        return True
+
+
+def _invalid_payload() -> tool_errors.PublicToolError:
+    return tool_errors.PublicToolError('Invalid credential payload.')

--- a/src/service/mcp/telemetry.py
+++ b/src/service/mcp/telemetry.py
@@ -65,6 +65,9 @@ def route_template(path: str) -> str:
     if len(parts) == 4 and parts[:3] == ['', 'api', 'resources']:
         return '/api/resources/{node_name}'
 
+    if len(parts) == 4 and parts[:3] == ['', 'api', 'credentials']:
+        return '/api/credentials/{credential_name}'
+
     if (
         len(parts) == 5
         and parts[:3] == ['', 'api', 'pool']

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -47,6 +47,7 @@ osmo_py_test(
     srcs = ["test_catalog.py"],
     deps = [
         "//src/service/mcp:app_tools",
+        "//src/service/mcp:credential_action_tools",
         "//src/service/mcp:credential_tools",
         "//src/service/mcp:health_tools",
         "//src/service/mcp:pool_tools",
@@ -65,6 +66,18 @@ osmo_py_test(
     deps = [
         requirement("httpx"),
         ":protocol_harness",
+    ],
+)
+
+osmo_py_test(
+    name = "test_credential_actions",
+    srcs = ["test_credential_actions.py"],
+    deps = [
+        requirement("httpx"),
+        requirement("mcp"),
+        ":protocol_harness",
+        "//src/service/mcp:credential_action_models",
+        "//src/service/mcp:credential_action_tools",
     ],
 )
 

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -287,6 +287,9 @@ _IDEMPOTENT_WRITE_TOOL_NAMES = frozenset({
     'osmo_set_credential',
     'osmo_set_profile',
 })
+_OPEN_WORLD_TOOL_NAMES = frozenset({
+    'osmo_set_credential',
+})
 
 
 class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
@@ -350,7 +353,10 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
                 annotations.idempotentHint,
                 name in _IDEMPOTENT_WRITE_TOOL_NAMES or not is_write,
             )
-            self.assertFalse(annotations.openWorldHint)
+            self.assertIs(
+                annotations.openWorldHint,
+                name in _OPEN_WORLD_TOOL_NAMES,
+            )
 
     async def test_all_tools_have_closed_schemas_and_stable_arguments(self) -> None:
         mcp_server = protocol.OSMOFastMCP(
@@ -380,7 +386,10 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
                     or not is_write
                 ),
             )
-            self.assertFalse(tool.annotations.openWorldHint)
+            self.assertIs(
+                tool.annotations.openWorldHint,
+                tool.name in _OPEN_WORLD_TOOL_NAMES,
+            )
             self._assert_recursively_closed(tool.inputSchema, tool.name)
             self.assertIsNotNone(tool.outputSchema)
             assert tool.outputSchema is not None

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -22,6 +22,7 @@ import unittest
 
 from src.service.mcp import (
     apps,
+    credential_actions,
     credentials,
     health,
     pools,
@@ -168,6 +169,23 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'List only the active user\'s credential names and types. '
         'Profiles and credential payloads are never returned.',
     ),
+    (
+        credential_actions.osmo_set_credential,
+        'osmo_set_credential',
+        'Set OSMO credential',
+        'Set one credential. REGISTRY requires auth and optionally '
+        'registry/username; DATA requires access_key_id, access_key, and '
+        'endpoint and optionally region/override_url/addressing_style; '
+        'GENERIC accepts string key/value pairs. MCP does not return or log '
+        'payload values; the calling client may retain its arguments.',
+    ),
+    (
+        credential_actions.osmo_delete_credential,
+        'osmo_delete_credential',
+        'Delete OSMO credential',
+        'Delete one active-user credential without returning its payload '
+        'or legacy profile value.',
+    ),
 )
 
 _EXPECTED_REQUIRED_FIELDS = {
@@ -190,6 +208,8 @@ _EXPECTED_REQUIRED_FIELDS = {
     'osmo_get_app': ['name'],
     'osmo_get_app_spec': ['name'],
     'osmo_list_credentials': [],
+    'osmo_set_credential': ['name', 'cred_type', 'payload'],
+    'osmo_delete_credential': ['name'],
 }
 
 _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
@@ -246,12 +266,37 @@ _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
     'osmo_get_app_spec': {'version': None},
 }
 
+_WRITE_TOOL_NAMES = frozenset({
+    'osmo_cancel_workflow',
+    'osmo_delete_credential',
+    'osmo_restart_workflow',
+    'osmo_set_credential',
+    'osmo_set_profile',
+    'osmo_submit_workflow',
+    'osmo_validate_workflow',
+})
+_DESTRUCTIVE_TOOL_NAMES = frozenset({
+    'osmo_cancel_workflow',
+    'osmo_delete_credential',
+    'osmo_restart_workflow',
+    'osmo_set_credential',
+    'osmo_set_profile',
+})
+_IDEMPOTENT_WRITE_TOOL_NAMES = frozenset({
+    'osmo_delete_credential',
+    'osmo_set_credential',
+    'osmo_set_profile',
+})
+
 
 class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
     """Lock the ordered, agent-facing external MCP tool contract."""
 
     def test_registry_has_exact_metadata_and_direct_unique_functions(self) -> None:
-        self.assertEqual(len(tool_registry.TOOL_SPECS), 19)
+        self.assertEqual(
+            len(tool_registry.TOOL_SPECS),
+            len(_EXPECTED_SPECS),
+        )
         self.assertEqual(
             [
                 (spec.name, spec.title, spec.description)
@@ -266,7 +311,10 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         registered_functions = [
             spec.function for spec in tool_registry.TOOL_SPECS
         ]
-        self.assertEqual(len({id(function) for function in registered_functions}), 19)
+        self.assertEqual(
+            len({id(function) for function in registered_functions}),
+            len(_EXPECTED_SPECS),
+        )
         for spec, (function, _, _, _) in zip(
             tool_registry.TOOL_SPECS,
             _EXPECTED_SPECS,
@@ -279,7 +327,10 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
 
         tool_registry.register_tools(mcp_server)
 
-        self.assertEqual(mcp_server.add_tool.call_count, 19)
+        self.assertEqual(
+            mcp_server.add_tool.call_count,
+            len(_EXPECTED_SPECS),
+        )
         for call, (function, name, title, description) in zip(
             mcp_server.add_tool.call_args_list,
             _EXPECTED_SPECS,
@@ -291,23 +342,13 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(call.kwargs['description'], description)
             self.assertTrue(call.kwargs['structured_output'])
             annotations = call.kwargs['annotations']
-            is_write = name in {
-                'osmo_cancel_workflow',
-                'osmo_restart_workflow',
-                'osmo_set_profile',
-                'osmo_submit_workflow',
-                'osmo_validate_workflow',
-            }
-            is_destructive = name in {
-                'osmo_cancel_workflow',
-                'osmo_restart_workflow',
-                'osmo_set_profile',
-            }
+            is_write = name in _WRITE_TOOL_NAMES
+            is_destructive = name in _DESTRUCTIVE_TOOL_NAMES
             self.assertIs(annotations.readOnlyHint, not is_write)
             self.assertIs(annotations.destructiveHint, is_destructive)
             self.assertIs(
                 annotations.idempotentHint,
-                name == 'osmo_set_profile' or not is_write,
+                name in _IDEMPOTENT_WRITE_TOOL_NAMES or not is_write,
             )
             self.assertFalse(annotations.openWorldHint)
 
@@ -325,18 +366,8 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         for tool in tools:
             self.assertIsNotNone(tool.annotations)
             assert tool.annotations is not None
-            is_write = tool.name in {
-                'osmo_cancel_workflow',
-                'osmo_restart_workflow',
-                'osmo_set_profile',
-                'osmo_submit_workflow',
-                'osmo_validate_workflow',
-            }
-            is_destructive = tool.name in {
-                'osmo_cancel_workflow',
-                'osmo_restart_workflow',
-                'osmo_set_profile',
-            }
+            is_write = tool.name in _WRITE_TOOL_NAMES
+            is_destructive = tool.name in _DESTRUCTIVE_TOOL_NAMES
             self.assertIs(tool.annotations.readOnlyHint, not is_write)
             self.assertIs(
                 tool.annotations.destructiveHint,
@@ -344,7 +375,10 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             )
             self.assertIs(
                 tool.annotations.idempotentHint,
-                tool.name == 'osmo_set_profile' or not is_write,
+                (
+                    tool.name in _IDEMPOTENT_WRITE_TOOL_NAMES
+                    or not is_write
+                ),
             )
             self.assertFalse(tool.annotations.openWorldHint)
             self._assert_recursively_closed(tool.inputSchema, tool.name)

--- a/src/service/mcp/tests/test_credential_actions.py
+++ b/src/service/mcp/tests/test_credential_actions.py
@@ -1,0 +1,855 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import unittest
+from unittest import mock
+
+import httpx
+from mcp.server.fastmcp.exceptions import ToolError
+
+from src.service.mcp import credential_actions
+from src.service.mcp.credential_action_models import (
+    MAX_CREDENTIAL_PAYLOAD_VALUE_LENGTH,
+)
+from src.service.mcp.tests import protocol_harness
+
+
+_BEARER_SECRET = 'credential-action-bearer-secret'
+_REQUEST_ID = 'phase-three-request-123'
+_HARNESS = protocol_harness.ProtocolHarness(
+    tool_names=(
+        'osmo_set_credential',
+        'osmo_delete_credential',
+    ),
+    bearer_secret=_BEARER_SECRET,
+    request_id=_REQUEST_ID,
+)
+_DESTRUCTIVE_IDEMPOTENT_ANNOTATIONS = {
+    **protocol_harness.DESTRUCTIVE_WRITE_ANNOTATIONS,
+    'idempotentHint': True,
+}
+
+
+class CredentialActionProtocolTest(unittest.IsolatedAsyncioTestCase):
+    """Exercise credential mutations through real Streamable HTTP handling."""
+
+    async def test_catalog_has_non_reflective_closed_action_schemas(
+        self,
+    ) -> None:
+        response = await _HARNESS.list_tools()
+        tools = _HARNESS.assert_closed_catalog(
+            self,
+            response,
+            expected_annotations={
+                'osmo_set_credential':
+                    _DESTRUCTIVE_IDEMPOTENT_ANNOTATIONS,
+                'osmo_delete_credential':
+                    _DESTRUCTIVE_IDEMPOTENT_ANNOTATIONS,
+            },
+        )
+
+        set_schema = tools['osmo_set_credential']['inputSchema']
+        self.assertEqual(
+            set_schema['required'],
+            ['name', 'cred_type', 'payload'],
+        )
+        self.assertEqual(
+            set_schema['properties']['name']['maxLength'],
+            512,
+        )
+        self.assertEqual(
+            set_schema['properties']['cred_type']['enum'],
+            ['REGISTRY', 'DATA', 'GENERIC'],
+        )
+        payload_schema = set_schema['properties']['payload']
+        self.assertEqual(payload_schema['type'], 'object')
+        self.assertEqual(payload_schema['maxProperties'], 64)
+        self.assertEqual(
+            payload_schema['additionalProperties']['type'],
+            'string',
+        )
+        self.assertEqual(
+            payload_schema['additionalProperties']['maxLength'],
+            64 * 1024,
+        )
+        self.assertTrue(
+            payload_schema['additionalProperties']['writeOnly']
+        )
+        self.assertEqual(
+            tools['osmo_delete_credential']['inputSchema']['required'],
+            ['name'],
+        )
+        for tool_name in _HARNESS.tool_names:
+            output_properties = tools[tool_name][
+                'outputSchema'
+            ]['properties']
+            for excluded_field in (
+                'payload',
+                'profile',
+                'credential',
+                'auth',
+            ):
+                self.assertNotIn(excluded_field, output_properties)
+
+    async def test_set_relays_exact_envelope_and_request_identity(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+        payload_secret = 'registry-protocol-payload-secret'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(
+                200,
+                content=b'null',
+                headers={'content-type': 'application/json'},
+            )
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured_logs:
+            response = await _HARNESS.call_tool(
+                handler,
+                'osmo_set_credential',
+                {
+                    'name': 'registry-cred',
+                    'cred_type': 'REGISTRY',
+                    'payload': {
+                        'auth': payload_secret,
+                        'registry': 'nvcr.io/example',
+                        'username': 'registry-user',
+                    },
+                },
+            )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'], response.text)
+        self.assertEqual(result['structuredContent'], {
+            'cred_name': 'registry-cred',
+            'cred_type': 'REGISTRY',
+            'saved': True,
+        })
+        self.assertNotIn(payload_secret, response.text)
+        self.assertNotIn(_BEARER_SECRET, response.text)
+        telemetry_text = '\n'.join(captured_logs.output)
+        self.assertIn('tool=osmo_set_credential', telemetry_text)
+        self.assertIn(
+            'route=/api/credentials/{credential_name}',
+            telemetry_text,
+        )
+        for excluded in (
+            _BEARER_SECRET,
+            'registry-cred',
+            'registry-protocol-payload-secret',
+            'nvcr.io/example',
+            'registry-user',
+        ):
+            self.assertNotIn(excluded, telemetry_text)
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.url.path, '/api/credentials/registry-cred')
+        self.assertEqual(request.url.query, b'')
+        self.assertEqual(json.loads(request.content), {
+            'registry_credential': {
+                'auth': payload_secret,
+                'registry': 'nvcr.io/example',
+                'username': 'registry-user',
+            },
+        })
+        self.assertEqual(
+            request.headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+        self.assertEqual(
+            request.headers['x-request-id'],
+            _REQUEST_ID,
+        )
+
+    async def test_delete_projects_exact_matching_metadata(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+        profile_secret = (
+            's3://user:password@example-bucket?'
+            'X-Amz-Signature=delete-profile-secret'
+        )
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                'credentials': [{
+                    'cred_name': 'data_cred',
+                    'cred_type': 'DATA',
+                    'profile': profile_secret,
+                    'payload': 'delete-upstream-payload-secret',
+                }],
+            })
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured_logs:
+            response = await _HARNESS.call_tool(
+                handler,
+                'osmo_delete_credential',
+                {'name': 'data_cred'},
+            )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'cred_name': 'data_cred',
+            'cred_type': 'DATA',
+            'deleted': True,
+        })
+        self.assertNotIn(profile_secret, response.text)
+        self.assertNotIn('delete-upstream-payload-secret', response.text)
+        self.assertNotIn(_BEARER_SECRET, response.text)
+        telemetry_text = '\n'.join(captured_logs.output)
+        self.assertIn('tool=osmo_delete_credential', telemetry_text)
+        self.assertIn(
+            'route=/api/credentials/{credential_name}',
+            telemetry_text,
+        )
+        for excluded in (
+            _BEARER_SECRET,
+            'data_cred',
+            profile_secret,
+            'delete-upstream-payload-secret',
+        ):
+            self.assertNotIn(excluded, telemetry_text)
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'DELETE')
+        self.assertEqual(request.url.path, '/api/credentials/data_cred')
+        self.assertEqual(request.content, b'')
+        self.assertEqual(
+            request.headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+        self.assertEqual(
+            request.headers['x-request-id'],
+            _REQUEST_ID,
+        )
+
+    async def test_reflected_validation_error_is_not_returned(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+        reflected_secret = 'reflected-core-validation-secret'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(422, json={
+                'detail': [{
+                    'loc': ['body', 'generic_credential', 'credential'],
+                    'msg': reflected_secret,
+                    'input': {
+                        'token': reflected_secret,
+                    },
+                }],
+                'error_code': 'CREDENTIAL',
+            })
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured_logs:
+            response = await _HARNESS.call_tool(
+                handler,
+                'osmo_set_credential',
+                {
+                    'name': 'generic-cred',
+                    'cred_type': 'GENERIC',
+                    'payload': {'token': reflected_secret},
+                },
+            )
+
+        result = response.json()['result']
+        self.assertTrue(result['isError'])
+        self.assertIn('HTTP 422', str(result))
+        self.assertNotIn(reflected_secret, response.text)
+        self.assertNotIn('generic_credential', response.text)
+        self.assertNotIn('error_code', response.text)
+        self.assertEqual(len(captured_requests), 1)
+        telemetry_text = '\n'.join(captured_logs.output)
+        for excluded in (
+            _BEARER_SECRET,
+            'generic-cred',
+            reflected_secret,
+            'generic_credential',
+            'error_code',
+        ):
+            self.assertNotIn(excluded, telemetry_text)
+
+    async def test_ambiguous_failures_are_unknown_and_one_shot(
+        self,
+    ) -> None:
+        upstream_secret = 'ambiguous-upstream-secret'
+        captured_requests: list[httpx.Request] = []
+
+        async def malformed(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(
+                200,
+                content=f'not-json-{upstream_secret}'.encode('utf-8'),
+            )
+
+        async def unavailable(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(
+                503,
+                json={'message': upstream_secret},
+            )
+
+        async def transport_failure(
+            request: httpx.Request,
+        ) -> httpx.Response:
+            captured_requests.append(request)
+            raise httpx.ReadError(upstream_secret, request=request)
+
+        for name, handler in (
+            ('malformed', malformed),
+            ('unavailable', unavailable),
+            ('transport', transport_failure),
+        ):
+            with self.subTest(failure=name):
+                captured_requests.clear()
+                response = await _HARNESS.call_tool(
+                    handler,
+                    'osmo_set_credential',
+                    {
+                        'name': 'generic-cred',
+                        'cred_type': 'GENERIC',
+                        'payload': {'token': 'write-input-secret'},
+                    },
+                )
+                result = response.json()['result']
+                self.assertTrue(result['isError'])
+                self.assertIn('write outcome is unknown', str(result))
+                self.assertIn(
+                    'Inspect OSMO state before retrying',
+                    str(result),
+                )
+                self.assertNotIn(upstream_secret, response.text)
+                self.assertEqual(len(captured_requests), 1)
+
+    async def test_invalid_protocol_inputs_never_reach_transport(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+        input_secret = 'invalid-protocol-input-secret'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(
+                200,
+                content=b'null',
+                headers={'content-type': 'application/json'},
+            )
+
+        invalid_arguments: tuple[dict[str, object], ...] = (
+            {
+                'name': f'bad/{input_secret}',
+                'cred_type': 'GENERIC',
+                'payload': {'token': input_secret},
+            },
+            {
+                'name': 'generic-cred',
+                'cred_type': input_secret,
+                'payload': {'token': input_secret},
+            },
+            {
+                'name': 'generic-cred',
+                'cred_type': 'GENERIC',
+                'payload': {'token': 123, 'opaque': input_secret},
+            },
+            {
+                'name': 'generic-cred',
+                'cred_type': 'GENERIC',
+                'payload': [input_secret],
+            },
+            {
+                'name': 'generic-cred',
+                'cred_type': 'GENERIC',
+                'payload': {
+                    'token': input_secret + ('x' * (64 * 1024)),
+                },
+            },
+            {
+                'name': 'registry-cred',
+                'cred_type': 'REGISTRY',
+                'payload': {
+                    'auth': 'registry-auth-secret',
+                    'registry': (
+                        'https://user:password@registry.example/'
+                        f'?token={input_secret}'
+                    ),
+                },
+            },
+            {
+                'name': 'data-cred',
+                'cred_type': 'DATA',
+                'payload': {
+                    'access_key_id': 'access-key-id',
+                    'access_key': 'access-key-secret',
+                    'endpoint': (
+                        f's3://bucket?X-Amz-Signature={input_secret}'
+                    ),
+                },
+            },
+        )
+
+        for arguments in invalid_arguments:
+            with self.subTest(
+                cred_type=arguments.get('cred_type'),
+                payload_type=type(arguments.get('payload')).__name__,
+            ):
+                captured_requests.clear()
+                response = await _HARNESS.call_tool(
+                    handler,
+                    'osmo_set_credential',
+                    arguments,
+                )
+                result = response.json()['result']
+                self.assertTrue(result['isError'])
+                self.assertNotIn(input_secret, response.text)
+                self.assertNotIn('registry-auth-secret', response.text)
+                self.assertNotIn('access-key-secret', response.text)
+                self.assertEqual(captured_requests, [])
+
+
+class CredentialActionTest(unittest.IsolatedAsyncioTestCase):
+    """Validate secret-safe mappings for external credential mutations."""
+
+    def setUp(self) -> None:
+        self.context = mock.Mock()
+        self.request_mutation = mock.AsyncMock()
+        self.request_patch = mock.patch.object(
+            credential_actions.tool_requests,
+            'request_json_mutation',
+            self.request_mutation,
+        )
+        self.request_patch.start()
+        self.addCleanup(self.request_patch.stop)
+
+    async def test_set_credential_sends_exact_type_envelopes(self) -> None:
+        cases = (
+            (
+                'registry-cred',
+                'REGISTRY',
+                {
+                    'auth': 'registry-secret-value',
+                    'registry': 'nvcr.io/example',
+                    'username': 'registry-user',
+                },
+                {
+                    'registry_credential': {
+                        'auth': 'registry-secret-value',
+                        'registry': 'nvcr.io/example',
+                        'username': 'registry-user',
+                    },
+                },
+            ),
+            (
+                'data_cred',
+                'DATA',
+                {
+                    'access_key_id': 'data-access-key-id',
+                    'access_key': 'data-access-key-secret',
+                    'endpoint': 's3://example-bucket',
+                    'region': 'us-west-2',
+                    'override_url': 'https://storage.example.test',
+                    'addressing_style': 'virtual',
+                },
+                {
+                    'data_credential': {
+                        'access_key_id': 'data-access-key-id',
+                        'access_key': 'data-access-key-secret',
+                        'endpoint': 's3://example-bucket',
+                        'region': 'us-west-2',
+                        'override_url': 'https://storage.example.test',
+                        'addressing_style': 'virtual',
+                    },
+                },
+            ),
+            (
+                'generic-cred',
+                'GENERIC',
+                {
+                    'api_token': 'generic-api-secret',
+                    'ssh_key': 'line one\nline two\n',
+                },
+                {
+                    'generic_credential': {
+                        'credential': {
+                            'api_token': 'generic-api-secret',
+                            'ssh_key': 'line one\nline two\n',
+                        },
+                    },
+                },
+            ),
+        )
+        for name, cred_type, payload, expected_payload in cases:
+            with self.subTest(cred_type=cred_type):
+                self.request_mutation.reset_mock()
+                self.request_mutation.return_value = None
+
+                result = await credential_actions.osmo_set_credential(
+                    self.context,
+                    name,
+                    cred_type,
+                    payload,
+                )
+
+                self.assertEqual(result.model_dump(mode='json'), {
+                    'cred_name': name,
+                    'cred_type': cred_type,
+                    'saved': True,
+                })
+                result_text = result.model_dump_json()
+                for value in payload.values():
+                    self.assertNotIn(value, result_text)
+                self.request_mutation.assert_awaited_once_with(
+                    self.context,
+                    method='POST',
+                    path=f'/api/credentials/{name}',
+                    operation='set an OSMO credential',
+                    max_response_bytes=1024,
+                    payload=expected_payload,
+                )
+
+    async def test_invalid_payloads_are_fixed_and_never_reach_transport(
+        self,
+    ) -> None:
+        input_secret = 'local-validation-secret-value'
+        invalid_cases: tuple[tuple[object, object], ...] = (
+            ('REGISTRY', {'username': input_secret}),
+            (
+                'REGISTRY',
+                {'auth': input_secret, 'unexpected': input_secret},
+            ),
+            (
+                'DATA',
+                {
+                    'access_key_id': input_secret,
+                    'access_key': input_secret,
+                },
+            ),
+            (
+                'DATA',
+                {
+                    'access_key_id': input_secret,
+                    'access_key': input_secret,
+                    'endpoint': 's3://bucket',
+                    'addressing_style': input_secret,
+                },
+            ),
+            ('GENERIC', {}),
+            ('GENERIC', {'token': 123}),
+            ('GENERIC', {' token ': input_secret}),
+            ('GENERIC', {'token': ''}),
+            ('GENERIC', ['token', input_secret]),
+        )
+
+        for cred_type, payload in invalid_cases:
+            with self.subTest(
+                cred_type=cred_type,
+                payload_type=type(payload).__name__,
+            ):
+                self.request_mutation.reset_mock()
+                with self.assertRaisesRegex(
+                    ToolError,
+                    '^Invalid credential payload\\.$',
+                ) as raised:
+                    await credential_actions.osmo_set_credential(
+                        self.context,
+                        'generic-cred',
+                        cred_type,
+                        payload,
+                    )
+                self.assertNotIn(input_secret, str(raised.exception))
+                self.request_mutation.assert_not_awaited()
+
+    async def test_secret_bearing_url_components_are_rejected(
+        self,
+    ) -> None:
+        cases = (
+            (
+                'REGISTRY',
+                {
+                    'auth': 'registry-auth-secret',
+                    'registry': (
+                        'https://user:url-userinfo-secret@'
+                        'registry.example/repository'
+                    ),
+                },
+                'url-userinfo-secret',
+            ),
+            (
+                'REGISTRY',
+                {
+                    'auth': 'registry-auth-secret',
+                    'registry': (
+                        'registry.example/repository?'
+                        'token=url-query-secret'
+                    ),
+                },
+                'url-query-secret',
+            ),
+            (
+                'REGISTRY',
+                {
+                    'auth': 'registry-auth-secret',
+                    'registry': (
+                        'registry.example/repository#'
+                        'url-fragment-secret'
+                    ),
+                },
+                'url-fragment-secret',
+            ),
+            (
+                'DATA',
+                {
+                    'access_key_id': 'access-key-id',
+                    'access_key': 'access-key-secret',
+                    'endpoint': 's3://user:url-endpoint-secret@bucket',
+                },
+                'url-endpoint-secret',
+            ),
+            (
+                'DATA',
+                {
+                    'access_key_id': 'access-key-id',
+                    'access_key': 'access-key-secret',
+                    'endpoint': 's3://bucket',
+                    'override_url': (
+                        'https://storage.example/'
+                        '?signature=url-override-secret'
+                    ),
+                },
+                'url-override-secret',
+            ),
+        )
+
+        for cred_type, payload, reflected_secret in cases:
+            with self.subTest(
+                cred_type=cred_type,
+                reflected_secret=reflected_secret,
+            ):
+                self.request_mutation.reset_mock()
+                with self.assertRaisesRegex(
+                    ToolError,
+                    '^Invalid credential payload\\.$',
+                ) as raised:
+                    await credential_actions.osmo_set_credential(
+                        self.context,
+                        'credential-name',
+                        cred_type,
+                        payload,
+                    )
+                self.assertNotIn(
+                    reflected_secret,
+                    str(raised.exception),
+                )
+                self.request_mutation.assert_not_awaited()
+
+    async def test_generic_payload_is_not_parsed_as_a_url(self) -> None:
+        opaque_value = (
+            'https://user:generic-secret@example.test/'
+            '?token=opaque#fragment'
+        )
+        self.request_mutation.return_value = None
+
+        result = await credential_actions.osmo_set_credential(
+            self.context,
+            'generic-cred',
+            'GENERIC',
+            {'signed_url': opaque_value},
+        )
+
+        self.assertTrue(result.saved)
+        self.request_mutation.assert_awaited_once_with(
+            self.context,
+            method='POST',
+            path='/api/credentials/generic-cred',
+            operation='set an OSMO credential',
+            max_response_bytes=1024,
+            payload={
+                'generic_credential': {
+                    'credential': {'signed_url': opaque_value},
+                },
+            },
+        )
+
+    async def test_data_endpoint_matches_cli_contract_and_normalization(
+        self,
+    ) -> None:
+        base_payload = {
+            'access_key_id': 'access-key-id',
+            'access_key': 'access-key-secret',
+        }
+
+        with self.assertRaisesRegex(
+            ToolError,
+            '^Invalid credential payload\\.$',
+        ):
+            await credential_actions.osmo_set_credential(
+                self.context,
+                'data-cred',
+                'DATA',
+                {
+                    **base_payload,
+                    'endpoint': 'https://storage.example.test',
+                },
+            )
+        self.request_mutation.assert_not_awaited()
+
+        self.request_mutation.return_value = None
+        await credential_actions.osmo_set_credential(
+            self.context,
+            'data-cred',
+            'DATA',
+            {
+                **base_payload,
+                'endpoint': 's3://example-bucket/',
+            },
+        )
+        self.request_mutation.assert_awaited_once_with(
+            self.context,
+            method='POST',
+            path='/api/credentials/data-cred',
+            operation='set an OSMO credential',
+            max_response_bytes=1024,
+            payload={
+                'data_credential': {
+                    **base_payload,
+                    'endpoint': 's3://example-bucket',
+                },
+            },
+        )
+
+    async def test_oversized_payload_fails_without_reflection_or_transport(
+        self,
+    ) -> None:
+        secret_prefix = 'oversized-secret-prefix'
+        oversized_payloads = (
+            {
+                'token': secret_prefix + (
+                    'x' * MAX_CREDENTIAL_PAYLOAD_VALUE_LENGTH
+                ),
+            },
+            {
+                'token_a': 'a' * (
+                    MAX_CREDENTIAL_PAYLOAD_VALUE_LENGTH
+                ),
+                'token_b': 'b' * (
+                    MAX_CREDENTIAL_PAYLOAD_VALUE_LENGTH
+                ),
+            },
+        )
+
+        for payload in oversized_payloads:
+            with self.subTest(keys=tuple(payload)):
+                self.request_mutation.reset_mock()
+                with self.assertRaisesRegex(
+                    ToolError,
+                    '^Invalid credential payload\\.$',
+                ) as raised:
+                    await credential_actions.osmo_set_credential(
+                        self.context,
+                        'generic-cred',
+                        'GENERIC',
+                        payload,
+                    )
+                self.assertNotIn(secret_prefix, str(raised.exception))
+                self.request_mutation.assert_not_awaited()
+
+    async def test_malformed_successes_are_ambiguous_and_not_reflected(
+        self,
+    ) -> None:
+        upstream_secret = 'malformed-upstream-secret'
+        self.request_mutation.return_value = {
+            'message': upstream_secret,
+        }
+
+        with self.assertRaisesRegex(
+            ToolError,
+            'write outcome is unknown',
+        ) as set_error:
+            await credential_actions.osmo_set_credential(
+                self.context,
+                'generic-cred',
+                'GENERIC',
+                {'token': 'set-input-secret'},
+            )
+        self.assertNotIn(upstream_secret, str(set_error.exception))
+        self.assertEqual(self.request_mutation.await_count, 1)
+
+        malformed_delete_responses: tuple[object, ...] = (
+            upstream_secret,
+            {},
+            {'credentials': []},
+            {
+                'credentials': [
+                    {
+                        'cred_name': 'generic-cred',
+                        'cred_type': 'GENERIC',
+                    },
+                    {
+                        'cred_name': 'second-credential',
+                        'cred_type': 'GENERIC',
+                    },
+                ],
+            },
+            {
+                'credentials': [{
+                    'cred_name': upstream_secret,
+                    'cred_type': 'GENERIC',
+                }],
+            },
+            {
+                'credentials': [{
+                    'cred_name': 'generic-cred',
+                    'cred_type': upstream_secret,
+                }],
+            },
+        )
+        for response in malformed_delete_responses:
+            with self.subTest(response_type=type(response).__name__):
+                self.request_mutation.reset_mock()
+                self.request_mutation.return_value = response
+                with self.assertRaisesRegex(
+                    ToolError,
+                    'write outcome is unknown',
+                ) as delete_error:
+                    await credential_actions.osmo_delete_credential(
+                        self.context,
+                        'generic-cred',
+                    )
+                self.assertNotIn(
+                    upstream_secret,
+                    str(delete_error.exception),
+                )
+                self.assertEqual(self.request_mutation.await_count, 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_credential_actions.py
+++ b/src/service/mcp/tests/test_credential_actions.py
@@ -44,6 +44,10 @@ _DESTRUCTIVE_IDEMPOTENT_ANNOTATIONS = {
     **protocol_harness.DESTRUCTIVE_WRITE_ANNOTATIONS,
     'idempotentHint': True,
 }
+_DESTRUCTIVE_IDEMPOTENT_OPEN_WORLD_ANNOTATIONS = {
+    **_DESTRUCTIVE_IDEMPOTENT_ANNOTATIONS,
+    'openWorldHint': True,
+}
 
 
 class CredentialActionProtocolTest(unittest.IsolatedAsyncioTestCase):
@@ -58,7 +62,7 @@ class CredentialActionProtocolTest(unittest.IsolatedAsyncioTestCase):
             response,
             expected_annotations={
                 'osmo_set_credential':
-                    _DESTRUCTIVE_IDEMPOTENT_ANNOTATIONS,
+                    _DESTRUCTIVE_IDEMPOTENT_OPEN_WORLD_ANNOTATIONS,
                 'osmo_delete_credential':
                     _DESTRUCTIVE_IDEMPOTENT_ANNOTATIONS,
             },

--- a/src/service/mcp/tests/test_telemetry.py
+++ b/src/service/mcp/tests/test_telemetry.py
@@ -33,6 +33,9 @@ class TelemetryTest(unittest.TestCase):
                 '/api/workflow/{workflow_id}/cancel'
             ),
             '/api/app/user/private-app/spec': '/api/app/user/{app_name}/spec',
+            '/api/credentials/private-credential': (
+                '/api/credentials/{credential_name}'
+            ),
             '/api/resources/private-node': '/api/resources/{node_name}',
             '/api/pool/private-pool/workflow': (
                 '/api/pool/{pool}/workflow'
@@ -50,6 +53,7 @@ class TelemetryTest(unittest.TestCase):
                 for secret in (
                     'private-workflow-1',
                     'private-app',
+                    'private-credential',
                     'private-node',
                     'private-pool',
                 ):

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -24,6 +24,7 @@ from mcp.types import ToolAnnotations
 
 from src.service.mcp import (
     apps,
+    credential_actions,
     credentials,
     health,
     pools,
@@ -245,6 +246,35 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         description=(
             'List only the active user\'s credential names and types. '
             'Profiles and credential payloads are never returned.'
+        ),
+    ),
+    ToolSpec(
+        function=credential_actions.osmo_set_credential,
+        name='osmo_set_credential',
+        title='Set OSMO credential',
+        description=(
+            'Set one credential. REGISTRY requires auth and optionally '
+            'registry/username; DATA requires access_key_id, access_key, and '
+            'endpoint and optionally region/override_url/addressing_style; '
+            'GENERIC accepts string key/value pairs. MCP does not return or '
+            'log payload values; the calling client may retain its arguments.'
+        ),
+        annotations=_write_annotations(
+            destructive=True,
+            idempotent=True,
+        ),
+    ),
+    ToolSpec(
+        function=credential_actions.osmo_delete_credential,
+        name='osmo_delete_credential',
+        title='Delete OSMO credential',
+        description=(
+            'Delete one active-user credential without returning its payload '
+            'or legacy profile value.'
+        ),
+        annotations=_write_annotations(
+            destructive=True,
+            idempotent=True,
         ),
     ),
 )

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -48,12 +48,13 @@ def _write_annotations(
     *,
     destructive: bool,
     idempotent: bool = False,
+    open_world: bool = False,
 ) -> ToolAnnotations:
     return ToolAnnotations(
         readOnlyHint=False,
         destructiveHint=destructive,
         idempotentHint=idempotent,
-        openWorldHint=False,
+        openWorldHint=open_world,
     )
 
 
@@ -262,6 +263,7 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
         annotations=_write_annotations(
             destructive=True,
             idempotent=True,
+            open_world=True,
         ),
     ),
     ToolSpec(

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -22,6 +22,7 @@ from test.oetf.smoke_fixture import SmokeFixture
 
 _EXPECTED_TOOL_NAMES = frozenset({
     "osmo_cancel_workflow",
+    "osmo_delete_credential",
     "osmo_get_app",
     "osmo_get_app_spec",
     "osmo_get_profile",
@@ -38,6 +39,7 @@ _EXPECTED_TOOL_NAMES = frozenset({
     "osmo_search_pools",
     "osmo_restart_workflow",
     "osmo_set_profile",
+    "osmo_set_credential",
     "osmo_submit_workflow",
     "osmo_validate_workflow",
 })


### PR DESCRIPTION
## Summary

Adds the two external MCP credential mutations:

- `osmo_set_credential`
- `osmo_delete_credential`

This is Phase 3 PR 2/4. The prerequisite profile-setting support landed in
#1238, and this PR now targets `feature/mcp` directly. #1240 remains stacked on
this PR; nothing in this series targets `main`.

## Contract

- Reuses the canonical documented CLI/Core REGISTRY, DATA, and GENERIC request
  envelopes.
- Extracts the existing storage URI regex into a dependency-light public
  contract so DATA endpoint validation cannot drift between CLI/Core and MCP.
- Uses fixed credential routes, bounded string-only payloads, and one-shot
  writes with no automatic retry.
- Marks credential setting as open-world because Core may validate REGISTRY
  and DATA credentials against their external providers.
- Returns only credential name/type confirmation; payloads and legacy profile
  values are never projected.
- Rejects userinfo, query, and fragment components in registry/data profile
  fields before writing.
- Suppresses arbitrary upstream write details and reports an unknown outcome
  for ambiguous failures.
- Removes credential identifiers and payload data from telemetry.

The caller's MCP client owns the secret-bearing tool arguments it submits and
may retain them in its own transcript or logs. Core currently authorizes the
CLI's credential set POST route as `credentials:Create` and conflicts records
by profile, so some same-name updates are rejected rather than replaced. This
PR preserves that existing API/RBAC behavior.

## Validation

- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors //src/cli/tests:test_credential //src/service/mcp/tests:test_credential_actions //src/service/mcp/tests:test_credentials //src/service/mcp/tests:test_catalog //src/service/mcp/tests:test_telemetry //test/smoke:mcp-checks-pylint`
- `bazel --output_user_root=/tmp/osmo-bazel build //src/service/mcp:mcp_binary //test/smoke:mcp-checks`
- `git diff --check`

Credential mutations remain manual Inspector checks against disposable
user-owned state; the automated deployment smoke test verifies discovery only.

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
