### PR TITLE
Add external MCP app lifecycle mutations

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -109,7 +109,7 @@ not mount a service-account token, and the chart creates no MCP credential
 Secret. Gateway-to-MCP TLS continues to use the shared `gateway.tls`
 configuration described below.
 
-The external MCP exposes a 21-tool catalog with fixed API routes and no
+The external MCP exposes a 25-tool catalog with fixed API routes and no
 caller-selected origin, method, route, or headers. See the
 [external MCP tool plan](../../../src/service/mcp/TOOLS.md) for its exact
 contracts and API mappings. MCP health probes do not call these APIs; a

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -127,6 +127,17 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "app_action_models",
+    srcs = ["app_action_models.py"],
+    deps = [
+        requirement("pydantic"),
+        ":app_models",
+        ":tool_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "pool_models",
     srcs = ["pool_models.py"],
     deps = [
@@ -278,6 +289,22 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "app_action_tools",
+    srcs = ["app_actions.py"],
+    deps = [
+        requirement("mcp"),
+        requirement("pydantic"),
+        ":app_action_models",
+        ":app_models",
+        ":app_tools",
+        ":tool_errors",
+        ":tool_requests",
+        ":tool_validation",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "credential_tools",
     srcs = ["credentials.py"],
     deps = [
@@ -308,6 +335,7 @@ osmo_py_library(
     srcs = ["tool_registry.py"],
     deps = [
         requirement("mcp"),
+        ":app_action_tools",
         ":app_tools",
         ":credential_action_tools",
         ":credential_tools",

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -103,11 +103,11 @@ authorization value.
 The external catalog contains 14 read-only tools for caller-bound health,
 profile, pool, resource, workflow, application, and credential-metadata
 inspection, plus four workflow actions, one profile-setting action, and two
-credential actions. Each tool maps to a fixed external API, returns a
-structured allowlisted result, and applies a domain-specific response limit.
-Credential inspection returns names and types only. Profile inspection
-intentionally includes non-secret access-token identity metadata (name and
-expiry). Bearer values are never returned.
+credential actions, and four app lifecycle actions. Each tool maps to a fixed
+external API, returns a structured allowlisted result, and applies a
+domain-specific response limit. Credential inspection returns names and types
+only. Profile inspection intentionally includes non-secret access-token
+identity metadata (name and expiry). Bearer values are never returned.
 
 `osmo_set_profile` updates only the default pool or email/Slack notification
 state supported by the external CLI and Core contract. Other profile settings
@@ -131,6 +131,22 @@ even though it is the CLI's set route. Core also conflicts records by profile,
 so a same-name update with a different or null profile can be rejected instead
 of replaced. The external MCP preserves those API/RBAC semantics and reports
 the Core failure rather than emulating a replacement.
+
+App create and update accept bounded inline workflow YAML. Callers should
+reference OSMO credentials rather than inline secrets; MCP does not return or
+log the submitted spec, but the calling client may retain its original tool
+arguments. Create synchronously creates version 1 and schedules its upload.
+Update always creates and schedules a new version, even when the submitted
+content matches the current spec; it intentionally omits the CLI's local
+editor/read-before-write behavior.
+
+App deletion schedules either one requested version or every non-deleted
+version. Its compact result returns at most 200 version numbers plus the total
+scheduled count and a `more_versions` marker. An already-deleted requested
+version is a successful no-op. Rename is synchronous and one-shot. App
+descriptions are non-secret query values and may appear in Gateway/authz
+access logs. Core currently authorizes rename's POST route as `app:Create`;
+the external MCP preserves that existing API/RBAC contract.
 
 Workflow validation calls Core's submission endpoint with
 `validation_only=true`. It is intentionally annotated as a non-idempotent
@@ -226,13 +242,13 @@ authentication. Its token needs `mcp:Access`, `profile:Read`, and
 bazel run //test/oetf:run -- --env <mcp-enabled-env> --tags mcp
 ```
 
-The smoke test rejects unauthenticated access, verifies the exact 21-tool
+The smoke test rejects unauthenticated access, verifies the exact 25-tool
 catalog, compares the profile projection with Core, checks caller-bound
 health, and validates a small workflow through Gateway → MCP → Gateway → Core.
 A successful validation does not enqueue compute or create a workflow row.
 The smoke suite intentionally sends only this known-good case because a failed
 Core validation can create a `FAILED_SUBMISSION` row.
-Profile and credential mutations remain manual Inspector checks against
+Profile, credential, and app mutations remain manual Inspector checks against
 disposable user-owned state.
 
 When the deployment cannot validate the default public `ubuntu:22.04` image,

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -95,12 +95,13 @@ consume compute or mutate existing workflow state.
 
 ## Phase 3: user-owned mutations (in progress)
 
-`osmo_set_profile`, `osmo_set_credential`, and `osmo_delete_credential` are
-implemented. Profile updates change exactly one external CLI-supported
-setting per call: the default pool, email notifications, or Slack
-notifications. Other profile settings are outside this tool's public contract.
-Core returns JSON `null` after accepting the write, so MCP returns a compact
-confirmation rather than implying it read back authoritative state.
+`osmo_set_profile`, `osmo_set_credential`, `osmo_delete_credential`,
+`osmo_create_app`, `osmo_update_app`, `osmo_delete_app`, and
+`osmo_rename_app` are implemented. Profile updates change exactly one external
+CLI-supported setting per call: the default pool, email notifications, or
+Slack notifications. Other profile settings are outside this tool's public
+contract. Core returns JSON `null` after accepting the write, so MCP returns a
+compact confirmation rather than implying it read back authoritative state.
 
 Credential writes accept the canonical documented REGISTRY, DATA, and GENERIC
 payload shapes used by the CLI and Core. Values are bounded strings and are
@@ -115,9 +116,18 @@ Core currently maps the CLI's credential set POST route to
 a different or null profile can therefore be rejected instead of replaced;
 MCP preserves that existing API/RBAC behavior.
 
-Remaining work adds `osmo_create_app`, `osmo_update_app`, `osmo_delete_app`,
-`osmo_rename_app`, and `osmo_submit_app`. Application writes must preserve
-their asynchronous API semantics.
+App create synchronously creates version 1 and schedules its upload. Update
+always creates and schedules a new version from the submitted inline YAML; it
+does not reproduce the CLI editor's read-before-write unchanged-content check.
+Delete schedules one version or all non-deleted versions and returns a bounded
+version prefix plus total count. Rename is synchronous. App specs may contain
+sensitive values, so callers should reference OSMO credentials instead; MCP
+does not return or log submitted specs, but the calling client may retain its
+arguments. Descriptions are non-secret query values that may appear in
+Gateway/authz logs. Core currently authorizes rename's POST as `app:Create`;
+MCP preserves that existing API/RBAC behavior.
+
+Remaining work adds `osmo_submit_app`.
 
 ## Out of scope
 

--- a/src/service/mcp/app_action_models.py
+++ b/src/service/mcp/app_action_models.py
@@ -1,0 +1,133 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from typing import Annotated, Literal, TypeAlias
+
+import pydantic
+
+from src.service.mcp.app_models import AppName, AppVersionNumber
+from src.service.mcp.tool_models import ClosedToolModel, ExtensibleUpstreamModel
+
+
+MAX_APP_DESCRIPTION_BYTES = 2048
+MAX_APP_SPEC_BYTES = 128 * 1024
+MAX_PROJECTED_DELETE_VERSIONS = 200
+
+AppDescription: TypeAlias = Annotated[
+    str,
+    pydantic.Field(
+        min_length=1,
+        max_length=MAX_APP_DESCRIPTION_BYTES,
+        description=(
+            'Non-secret app description, bounded to 2 KiB UTF-8. This value '
+            'is sent as an OSMO query parameter and may appear in Gateway '
+            'access logs.'
+        ),
+    ),
+]
+AppSpecText: TypeAlias = Annotated[
+    str,
+    pydantic.Field(
+        min_length=1,
+        max_length=MAX_APP_SPEC_BYTES,
+        description=(
+            'Inline OSMO app workflow YAML, bounded to 128 KiB UTF-8. Do not '
+            'inline secrets; reference OSMO credentials instead. MCP does not '
+            'return or log this value, but the calling client may retain its '
+            'submitted arguments.'
+        ),
+        json_schema_extra={'writeOnly': True},
+    ),
+]
+DeleteAppVersion: TypeAlias = Annotated[
+    int,
+    pydantic.Field(
+        strict=True,
+        ge=1,
+        description=(
+            'App version to delete. Specify exactly one of version or '
+            'all_versions=true.'
+        ),
+    ),
+]
+DeleteAllVersions: TypeAlias = Annotated[
+    pydantic.StrictBool,
+    pydantic.Field(
+        description=(
+            'Delete every non-deleted version. Specify exactly one of version '
+            'or all_versions=true.'
+        ),
+    ),
+]
+
+
+class CreateAppResult(ClosedToolModel):
+    """Confirmation that Core created an app and scheduled its upload."""
+
+    name: AppName
+    version: Literal[1]
+    created: Literal[True]
+    upload_scheduled: Literal[True]
+
+
+class UpstreamUpdateAppResult(ExtensibleUpstreamModel):
+    """Allowlisted fields from Core's app update response."""
+
+    uuid: Annotated[str, pydantic.Field(min_length=1, max_length=512)]
+    version: AppVersionNumber
+    name: AppName
+    created_by: Annotated[str, pydantic.Field(min_length=1, max_length=512)]
+    created_date: Annotated[str, pydantic.Field(min_length=1, max_length=128)]
+
+
+class UpdateAppResult(ClosedToolModel):
+    """Confirmation that Core scheduled upload of one new app version."""
+
+    name: AppName
+    version: AppVersionNumber
+    upload_scheduled: Literal[True]
+
+
+class UpstreamDeleteAppResult(ExtensibleUpstreamModel):
+    """Allowlisted fields from Core's app deletion response."""
+
+    versions: list[AppVersionNumber]
+
+
+class DeleteAppResult(ClosedToolModel):
+    """Versions Core accepted for asynchronous deletion."""
+
+    name: AppName
+    scheduled_versions: Annotated[
+        list[AppVersionNumber],
+        pydantic.Field(max_length=MAX_PROJECTED_DELETE_VERSIONS),
+    ]
+    scheduled_version_count: Annotated[
+        int,
+        pydantic.Field(strict=True, ge=0),
+    ]
+    more_versions: bool
+    deletion_scheduled: bool
+
+
+class RenameAppResult(ClosedToolModel):
+    """Confirmation that Core synchronously renamed one app."""
+
+    original_name: AppName
+    new_name: AppName
+    renamed: Literal[True]

--- a/src/service/mcp/app_actions.py
+++ b/src/service/mcp/app_actions.py
@@ -1,0 +1,228 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from mcp.server.fastmcp import Context
+import pydantic
+
+from src.service.mcp import apps, tool_errors, tool_requests, tool_validation
+from src.service.mcp.app_action_models import (
+    MAX_APP_DESCRIPTION_BYTES,
+    MAX_APP_SPEC_BYTES,
+    MAX_PROJECTED_DELETE_VERSIONS,
+    AppDescription,
+    AppSpecText,
+    CreateAppResult,
+    DeleteAllVersions,
+    DeleteAppVersion,
+    DeleteAppResult,
+    RenameAppResult,
+    UpdateAppResult,
+    UpstreamDeleteAppResult,
+    UpstreamUpdateAppResult,
+)
+from src.service.mcp.app_models import AppName
+
+
+_MAX_NULL_RESPONSE_BYTES = 1024
+_MAX_MUTATION_RESPONSE_BYTES = 64 * 1024
+_APP_NAME_ADAPTER = pydantic.TypeAdapter(AppName)
+_DELETE_SELECTOR_ERROR = (
+    'Specify exactly one of version or all_versions=true.'
+)
+
+
+async def osmo_create_app(
+    context: Context,
+    name: AppName,
+    description: AppDescription,
+    spec_content: AppSpecText,
+) -> CreateAppResult:
+    """Create an OSMO app and schedule upload of its first version."""
+    encoded_name = apps.validated_app_name(name)
+    validated_description = tool_validation.validate_query_text(
+        description,
+        field='app description',
+        max_bytes=MAX_APP_DESCRIPTION_BYTES,
+    )
+    validated_spec = _validate_app_spec(spec_content)
+    response = await tool_requests.request_json_mutation(
+        context,
+        method='POST',
+        path=f'/api/app/user/{encoded_name}',
+        operation='create an OSMO app',
+        max_response_bytes=_MAX_NULL_RESPONSE_BYTES,
+        query={'description': validated_description},
+        payload=validated_spec,
+    )
+    _require_null_response(response, operation='create an OSMO app')
+    return CreateAppResult(
+        name=name,
+        version=1,
+        created=True,
+        upload_scheduled=True,
+    )
+
+
+async def osmo_update_app(
+    context: Context,
+    name: AppName,
+    spec_content: AppSpecText,
+) -> UpdateAppResult:
+    """Create and schedule upload of one new OSMO app version."""
+    encoded_name = apps.validated_app_name(name)
+    validated_spec = _validate_app_spec(spec_content)
+    response = await tool_requests.request_json_mutation(
+        context,
+        method='PATCH',
+        path=f'/api/app/user/{encoded_name}',
+        operation='update an OSMO app',
+        max_response_bytes=_MAX_MUTATION_RESPONSE_BYTES,
+        payload=validated_spec,
+    )
+    upstream = tool_validation.validate_mutation_response(
+        UpstreamUpdateAppResult,
+        response,
+        operation='update an OSMO app',
+    )
+    if upstream.name != name:
+        raise tool_errors.uncertain_write_error('update an OSMO app')
+    return UpdateAppResult(
+        name=upstream.name,
+        version=upstream.version,
+        upload_scheduled=True,
+    )
+
+
+async def osmo_delete_app(
+    context: Context,
+    name: AppName,
+    version: DeleteAppVersion | None = None,
+    all_versions: DeleteAllVersions = False,
+) -> DeleteAppResult:
+    """Schedule deletion of one app version or every non-deleted version."""
+    encoded_name = apps.validated_app_name(name)
+    validated_version = tool_validation.validate_optional_integer(
+        version,
+        field='app version',
+        minimum=1,
+    )
+    if (
+        not isinstance(all_versions, bool)
+        or (validated_version is None) == (not all_versions)
+    ):
+        raise tool_errors.PublicToolError(_DELETE_SELECTOR_ERROR)
+
+    query: dict[str, int | bool]
+    if all_versions:
+        query = {'all_versions': True}
+    elif validated_version is not None:
+        query = {'version': validated_version}
+    else:
+        raise tool_errors.PublicToolError(_DELETE_SELECTOR_ERROR)
+    response = await tool_requests.request_json_mutation(
+        context,
+        method='DELETE',
+        path=f'/api/app/user/{encoded_name}',
+        operation='delete an OSMO app',
+        max_response_bytes=_MAX_MUTATION_RESPONSE_BYTES,
+        query=query,
+    )
+    upstream = tool_validation.validate_mutation_response(
+        UpstreamDeleteAppResult,
+        response,
+        operation='delete an OSMO app',
+    )
+    if (
+        len(upstream.versions) != len(set(upstream.versions))
+        or (
+            validated_version is not None
+            and upstream.versions not in ([], [validated_version])
+        )
+    ):
+        raise tool_errors.uncertain_write_error('delete an OSMO app')
+    scheduled_version_count = len(upstream.versions)
+    return DeleteAppResult(
+        name=name,
+        scheduled_versions=(
+            upstream.versions[:MAX_PROJECTED_DELETE_VERSIONS]
+        ),
+        scheduled_version_count=scheduled_version_count,
+        more_versions=(
+            scheduled_version_count > MAX_PROJECTED_DELETE_VERSIONS
+        ),
+        deletion_scheduled=scheduled_version_count > 0,
+    )
+
+
+async def osmo_rename_app(
+    context: Context,
+    original_name: AppName,
+    new_name: AppName,
+) -> RenameAppResult:
+    """Synchronously rename one OSMO app owned by the active user."""
+    encoded_original_name = apps.validated_app_name(
+        original_name,
+        field='original app name',
+    )
+    apps.validated_app_name(new_name, field='new app name')
+    if original_name == new_name:
+        raise tool_errors.PublicToolError(
+            'Original and new app names must differ.'
+        )
+
+    response = await tool_requests.request_json_mutation(
+        context,
+        method='POST',
+        path=f'/api/app/user/{encoded_original_name}/rename',
+        operation='rename an OSMO app',
+        max_response_bytes=_MAX_MUTATION_RESPONSE_BYTES,
+        payload=new_name,
+    )
+    try:
+        renamed_to = _APP_NAME_ADAPTER.validate_python(
+            response,
+            strict=True,
+        )
+    except pydantic.ValidationError:
+        raise tool_errors.uncertain_write_error(
+            'rename an OSMO app'
+        ) from None
+    if renamed_to != new_name:
+        raise tool_errors.uncertain_write_error('rename an OSMO app')
+    return RenameAppResult(
+        original_name=original_name,
+        new_name=renamed_to,
+        renamed=True,
+    )
+
+
+def _validate_app_spec(spec_content: str) -> str:
+    return tool_validation.validate_inline_text(
+        spec_content,
+        field='spec_content',
+        max_bytes=MAX_APP_SPEC_BYTES,
+    )
+
+
+def _require_null_response(
+    response: pydantic.JsonValue,
+    *,
+    operation: str,
+) -> None:
+    if response is not None:
+        raise tool_errors.uncertain_write_error(operation)

--- a/src/service/mcp/apps.py
+++ b/src/service/mcp/apps.py
@@ -104,7 +104,7 @@ async def osmo_get_app(
     limit: AppListLimit = _DEFAULT_APP_LIST_LIMIT,
 ) -> AppResult:
     """Get OSMO app metadata and versions, newest version first."""
-    encoded_name = _validated_app_name(name)
+    encoded_name = validated_app_name(name)
     upstream = await _request_app(
         context,
         encoded_name=encoded_name,
@@ -128,7 +128,7 @@ async def osmo_get_app_spec(
     version: AppVersionNumber | None = None,
 ) -> AppSpecResult:
     """Get an app spec, resolving READY metadata from bounded history."""
-    encoded_name = _validated_app_name(name)
+    encoded_name = validated_app_name(name)
     resolved_version = version
     if resolved_version is None:
         upstream = await _request_app(
@@ -175,10 +175,18 @@ async def osmo_get_app_spec(
     )
 
 
-def _validated_app_name(name: str) -> str:
-    if re.fullmatch(_APP_NAME_PATTERN, name) is None:
-        raise PublicToolError('Invalid app name.')
-    return tool_validation.safe_path_segment(name, field='app name')
+def validated_app_name(
+    name: object,
+    *,
+    field: str = 'app name',
+) -> str:
+    """Validate and encode one app name for a fixed Core route."""
+    if (
+        not isinstance(name, str)
+        or re.fullmatch(_APP_NAME_PATTERN, name) is None
+    ):
+        raise PublicToolError(f'Invalid {field}.')
+    return tool_validation.safe_path_segment(name, field=field)
 
 
 async def _request_app(

--- a/src/service/mcp/telemetry.py
+++ b/src/service/mcp/telemetry.py
@@ -57,8 +57,8 @@ def route_template(path: str) -> str:
         and parts[:4] == ['', 'api', 'app', 'user']
     ):
         template = '/api/app/user/{app_name}'
-        if len(parts) == 6 and parts[5] == 'spec':
-            return f'{template}/spec'
+        if len(parts) == 6 and parts[5] in ('rename', 'spec'):
+            return f'{template}/{parts[5]}'
         if len(parts) == 5:
             return template
 

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -34,6 +34,15 @@ osmo_py_library(
 )
 
 osmo_py_test(
+    name = "test_app_actions",
+    srcs = ["test_app_actions.py"],
+    deps = [
+        requirement("httpx"),
+        ":protocol_harness",
+    ],
+)
+
+osmo_py_test(
     name = "test_apps",
     srcs = ["test_apps.py"],
     deps = [
@@ -46,6 +55,7 @@ osmo_py_test(
     name = "test_catalog",
     srcs = ["test_catalog.py"],
     deps = [
+        "//src/service/mcp:app_action_tools",
         "//src/service/mcp:app_tools",
         "//src/service/mcp:credential_action_tools",
         "//src/service/mcp:credential_tools",

--- a/src/service/mcp/tests/test_app_actions.py
+++ b/src/service/mcp/tests/test_app_actions.py
@@ -1,0 +1,595 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import unittest
+
+import httpx
+
+from src.service.mcp.tests import protocol_harness
+
+
+_BEARER_SECRET = 'app-action-bearer-secret'
+_INPUT_SECRET = 'app-spec-sensitive-canary'
+_APP_SPEC = f"""\
+version: 2
+workflow:
+  name: app-action-test
+  tasks:
+  - name: check
+    image: ubuntu:22.04
+    command: [echo]
+    args: [{_INPUT_SECRET}]
+"""
+_HARNESS = protocol_harness.ProtocolHarness(
+    tool_names=(
+        'osmo_create_app',
+        'osmo_update_app',
+        'osmo_delete_app',
+        'osmo_rename_app',
+    ),
+    bearer_secret=_BEARER_SECRET,
+    request_id='app-action-request-123',
+)
+_UPDATE_RESPONSE = {
+    'uuid': '0123456789abcdef0123456789abcdef',
+    'version': 4,
+    'name': 'training_app',
+    'created_by': 'alice@example.com',
+    'created_date': '2026-07-27T12:00:00Z',
+}
+
+
+class AppActionProtocolTest(unittest.IsolatedAsyncioTestCase):
+    """Exercise app mutations through the real Streamable HTTP protocol."""
+
+    async def _invoke_tool(
+        self,
+        handler: protocol_harness.UpstreamHandler,
+        tool_name: str,
+        arguments: dict[str, object],
+    ) -> httpx.Response:
+        return await _HARNESS.call_tool(
+            handler,
+            tool_name,
+            arguments,
+        )
+
+    async def test_catalog_is_closed_and_marks_destructive_actions(self) -> None:
+        response = await _HARNESS.list_tools()
+        tools = _HARNESS.assert_closed_catalog(
+            self,
+            response,
+            expected_annotations={
+                'osmo_create_app': protocol_harness.WRITE_ANNOTATIONS,
+                'osmo_update_app': protocol_harness.WRITE_ANNOTATIONS,
+                'osmo_delete_app':
+                    protocol_harness.DESTRUCTIVE_WRITE_ANNOTATIONS,
+                'osmo_rename_app':
+                    protocol_harness.DESTRUCTIVE_WRITE_ANNOTATIONS,
+            },
+        )
+
+        create_schema = tools['osmo_create_app']['inputSchema']
+        self.assertEqual(
+            create_schema['required'],
+            ['name', 'description', 'spec_content'],
+        )
+        self.assertEqual(
+            create_schema['properties']['description']['maxLength'],
+            2048,
+        )
+        self.assertEqual(
+            create_schema['properties']['spec_content']['maxLength'],
+            128 * 1024,
+        )
+        delete_schema = tools['osmo_delete_app']['inputSchema']
+        self.assertEqual(delete_schema['required'], ['name'])
+        self.assertEqual(
+            delete_schema['properties']['version']['default'],
+            None,
+        )
+        self.assertFalse(
+            delete_schema['properties']['all_versions']['default']
+        )
+        self.assertIn(
+            'Specify exactly one',
+            delete_schema['properties']['version']['anyOf'][0][
+                'description'
+            ],
+        )
+        self.assertTrue(
+            create_schema['properties']['spec_content']['writeOnly']
+        )
+        self.assertEqual(
+            tools['osmo_delete_app']['outputSchema']['properties'][
+                'scheduled_versions'
+            ]['maxItems'],
+            200,
+        )
+        for excluded_argument in ('file', 'force', 'method', 'route'):
+            for tool in tools.values():
+                self.assertNotIn(
+                    excluded_argument,
+                    tool['inputSchema']['properties'],
+                )
+
+    async def test_create_posts_exact_string_body_and_accepts_null(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(
+                200,
+                content=b'null',
+                headers={'content-type': 'application/json'},
+            )
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured_logs:
+            response = await self._invoke_tool(
+                handler,
+                'osmo_create_app',
+                {
+                    'name': 'training_app',
+                    'description': 'Non-secret training app',
+                    'spec_content': _APP_SPEC,
+                },
+            )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'name': 'training_app',
+            'version': 1,
+            'created': True,
+            'upload_scheduled': True,
+        })
+        self.assertNotIn(_INPUT_SECRET, response.text)
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.url.path, '/api/app/user/training_app')
+        self.assertEqual(request.url.params.multi_items(), [
+            ('description', 'Non-secret training app'),
+        ])
+        self.assertEqual(json.loads(request.content), _APP_SPEC)
+        self.assertEqual(
+            request.headers['authorization'],
+            f'Bearer {_BEARER_SECRET}',
+        )
+        self.assertEqual(
+            request.headers['x-request-id'],
+            'app-action-request-123',
+        )
+        telemetry_text = '\n'.join(captured_logs.output)
+        self.assertIn('tool=osmo_create_app', telemetry_text)
+        self.assertIn(
+            'route=/api/app/user/{app_name}',
+            telemetry_text,
+        )
+        self.assertNotIn(_INPUT_SECRET, telemetry_text)
+        self.assertNotIn('Non-secret training app', telemetry_text)
+        self.assertNotIn('training_app', telemetry_text)
+
+    async def test_update_patches_spec_and_projects_scheduled_version(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+        upstream_secret = 'app-update-upstream-sensitive-value'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                **_UPDATE_RESPONSE,
+                'storage_uri': (
+                    's3://bucket?X-Amz-Signature=' + upstream_secret
+                ),
+            })
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_update_app',
+            {
+                'name': 'training_app',
+                'spec_content': _APP_SPEC,
+            },
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'name': 'training_app',
+            'version': 4,
+            'upload_scheduled': True,
+        })
+        self.assertNotIn(_INPUT_SECRET, response.text)
+        self.assertNotIn(upstream_secret, response.text)
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'PATCH')
+        self.assertEqual(request.url.path, '/api/app/user/training_app')
+        self.assertEqual(request.url.params.multi_items(), [])
+        self.assertEqual(json.loads(request.content), _APP_SPEC)
+
+    async def test_delete_requires_and_maps_exactly_one_selector(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.url.params.get('all_versions') == 'true':
+                versions = list(range(205, 0, -1))
+            elif request.url.params.get('version') == '7':
+                versions = []
+            else:
+                versions = [3]
+            return httpx.Response(200, json={'versions': versions})
+
+        async with _HARNESS.client(handler) as client:
+            version_response = await _HARNESS.call_tool_with_client(
+                client,
+                'osmo_delete_app',
+                {'name': 'training_app', 'version': 3},
+                request_id=1,
+            )
+            all_response = await _HARNESS.call_tool_with_client(
+                client,
+                'osmo_delete_app',
+                {'name': 'training_app', 'all_versions': True},
+                request_id=2,
+            )
+            already_deleted_response = (
+                await _HARNESS.call_tool_with_client(
+                    client,
+                    'osmo_delete_app',
+                    {'name': 'training_app', 'version': 7},
+                    request_id=3,
+                )
+            )
+
+        self.assertEqual(
+            version_response.json()['result']['structuredContent'],
+            {
+                'name': 'training_app',
+                'scheduled_versions': [3],
+                'scheduled_version_count': 1,
+                'more_versions': False,
+                'deletion_scheduled': True,
+            },
+        )
+        all_content = all_response.json()['result']['structuredContent']
+        self.assertEqual(all_content['name'], 'training_app')
+        self.assertEqual(
+            all_content['scheduled_versions'],
+            list(range(205, 5, -1)),
+        )
+        self.assertEqual(all_content['scheduled_version_count'], 205)
+        self.assertTrue(all_content['more_versions'])
+        self.assertTrue(all_content['deletion_scheduled'])
+        self.assertEqual(
+            already_deleted_response.json()['result'][
+                'structuredContent'
+            ],
+            {
+                'name': 'training_app',
+                'scheduled_versions': [],
+                'scheduled_version_count': 0,
+                'more_versions': False,
+                'deletion_scheduled': False,
+            },
+        )
+        self.assertEqual(
+            [
+                (request.method, request.url.path, request.url.params.multi_items())
+                for request in captured_requests
+            ],
+            [
+                (
+                    'DELETE',
+                    '/api/app/user/training_app',
+                    [('version', '3')],
+                ),
+                (
+                    'DELETE',
+                    '/api/app/user/training_app',
+                    [('all_versions', 'true')],
+                ),
+                (
+                    'DELETE',
+                    '/api/app/user/training_app',
+                    [('version', '7')],
+                ),
+            ],
+        )
+        self.assertTrue(all(not request.content for request in captured_requests))
+
+    async def test_rename_posts_exact_scalar_and_requires_matching_response(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json='renamed_app')
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured_logs:
+            response = await self._invoke_tool(
+                handler,
+                'osmo_rename_app',
+                {
+                    'original_name': 'training_app',
+                    'new_name': 'renamed_app',
+                },
+            )
+
+        self.assertEqual(
+            response.json()['result']['structuredContent'],
+            {
+                'original_name': 'training_app',
+                'new_name': 'renamed_app',
+                'renamed': True,
+            },
+        )
+        self.assertEqual(len(captured_requests), 1)
+        request = captured_requests[0]
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(
+            request.url.path,
+            '/api/app/user/training_app/rename',
+        )
+        self.assertEqual(json.loads(request.content), 'renamed_app')
+        telemetry_text = '\n'.join(captured_logs.output)
+        self.assertIn('tool=osmo_rename_app', telemetry_text)
+        self.assertIn(
+            'route=/api/app/user/{app_name}/rename',
+            telemetry_text,
+        )
+        self.assertNotIn('training_app', telemetry_text)
+        self.assertNotIn('renamed_app', telemetry_text)
+
+    async def test_invalid_arguments_fail_before_transport(self) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(
+                200,
+                content=b'null',
+                headers={'content-type': 'application/json'},
+            )
+
+        invalid_calls: tuple[tuple[str, dict[str, object]], ...] = (
+            (
+                'osmo_create_app',
+                {
+                    'name': 'bad/name',
+                    'description': 'description',
+                    'spec_content': _APP_SPEC,
+                },
+            ),
+            (
+                'osmo_create_app',
+                {
+                    'name': 'training_app',
+                    'description': '\u00e9' * 1025,
+                    'spec_content': _APP_SPEC,
+                },
+            ),
+            (
+                'osmo_create_app',
+                {
+                    'name': 'training_app',
+                    'description': 'description',
+                    'spec_content': '\u00e9' * (64 * 1024 + 1),
+                },
+            ),
+            (
+                'osmo_delete_app',
+                {'name': 'training_app'},
+            ),
+            (
+                'osmo_delete_app',
+                {
+                    'name': 'training_app',
+                    'version': 3,
+                    'all_versions': True,
+                },
+            ),
+            (
+                'osmo_delete_app',
+                {'name': 'training_app', 'all_versions': 1},
+            ),
+            (
+                'osmo_rename_app',
+                {
+                    'original_name': 'training_app',
+                    'new_name': 'training_app',
+                },
+            ),
+            (
+                'osmo_update_app',
+                {
+                    'name': 'training_app',
+                    'spec_content': _APP_SPEC,
+                    'route': '/api/credentials',
+                },
+            ),
+        )
+        async with _HARNESS.client(handler) as client:
+            for request_id, (tool_name, arguments) in enumerate(
+                invalid_calls,
+                start=1,
+            ):
+                with self.subTest(tool_name=tool_name, arguments=arguments):
+                    response = await _HARNESS.call_tool_with_client(
+                        client,
+                        tool_name,
+                        arguments,
+                        request_id=request_id,
+                    )
+                    self.assertTrue(
+                        response.json()['result']['isError']
+                    )
+
+        self.assertEqual(transport_calls, 0)
+
+    async def test_mismatched_successes_are_unknown_and_not_retried(
+        self,
+    ) -> None:
+        calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal calls
+            calls += 1
+            if request.method == 'PATCH':
+                return httpx.Response(200, json={
+                    **_UPDATE_RESPONSE,
+                    'name': 'different_app',
+                })
+            if request.method == 'DELETE':
+                return httpx.Response(200, json={'versions': [2]})
+            if request.url.path.endswith('/rename'):
+                return httpx.Response(200, json='different_app')
+            return httpx.Response(200, json={})
+
+        calls_and_arguments: tuple[
+            tuple[str, dict[str, object]],
+            ...,
+        ] = (
+            (
+                'osmo_create_app',
+                {
+                    'name': 'training_app',
+                    'description': 'description',
+                    'spec_content': _APP_SPEC,
+                },
+            ),
+            (
+                'osmo_update_app',
+                {
+                    'name': 'training_app',
+                    'spec_content': _APP_SPEC,
+                },
+            ),
+            (
+                'osmo_delete_app',
+                {'name': 'training_app', 'version': 3},
+            ),
+            (
+                'osmo_rename_app',
+                {
+                    'original_name': 'training_app',
+                    'new_name': 'renamed_app',
+                },
+            ),
+        )
+        async with _HARNESS.client(handler) as client:
+            for request_id, (tool_name, arguments) in enumerate(
+                calls_and_arguments,
+                start=1,
+            ):
+                response = await _HARNESS.call_tool_with_client(
+                    client,
+                    tool_name,
+                    arguments,
+                    request_id=request_id,
+                )
+                self.assertTrue(response.json()['result']['isError'])
+                self.assertIn(
+                    'write outcome is unknown',
+                    response.text,
+                )
+                self.assertIn(
+                    'Inspect OSMO state before retrying',
+                    response.text,
+                )
+
+        self.assertEqual(calls, len(calls_and_arguments))
+
+    async def test_write_errors_do_not_reflect_app_content_or_retry(
+        self,
+    ) -> None:
+        calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal calls
+            calls += 1
+            return httpx.Response(422, json={
+                'message': _INPUT_SECRET,
+                'error_code': 'USAGE',
+                'spec': _APP_SPEC,
+            })
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_create_app',
+            {
+                'name': 'training_app',
+                'description': 'description',
+                'spec_content': _APP_SPEC,
+            },
+        )
+
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('HTTP 422', response.text)
+        self.assertNotIn(_INPUT_SECRET, response.text)
+        self.assertNotIn('error_code', response.text)
+        self.assertEqual(calls, 1)
+
+    async def test_server_failure_is_unknown_and_not_retried(self) -> None:
+        calls = 0
+        upstream_secret = 'app-server-sensitive-detail'
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal calls
+            calls += 1
+            return httpx.Response(
+                503,
+                json={'message': upstream_secret},
+            )
+
+        response = await self._invoke_tool(
+            handler,
+            'osmo_update_app',
+            {
+                'name': 'training_app',
+                'spec_content': _APP_SPEC,
+            },
+        )
+
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertIn('write outcome is unknown', response.text)
+        self.assertNotIn(upstream_secret, response.text)
+        self.assertEqual(calls, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -21,6 +21,7 @@ from unittest import mock
 import unittest
 
 from src.service.mcp import (
+    app_actions,
     apps,
     credential_actions,
     credentials,
@@ -163,6 +164,36 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'bounded version history.',
     ),
     (
+        app_actions.osmo_create_app,
+        'osmo_create_app',
+        'Create OSMO app',
+        'Create an app from bounded inline workflow YAML and schedule '
+        'version 1 for upload. The non-secret description is sent as a '
+        'query parameter and may appear in Gateway logs.',
+    ),
+    (
+        app_actions.osmo_update_app,
+        'osmo_update_app',
+        'Update OSMO app',
+        'Always create and schedule upload of a new app version from bounded '
+        'inline workflow YAML; unlike the CLI editor flow, this tool does not '
+        'skip unchanged content.',
+    ),
+    (
+        app_actions.osmo_delete_app,
+        'osmo_delete_app',
+        'Delete OSMO app',
+        'Schedule deletion of one version or all non-deleted versions. '
+        'Specify exactly one of version or all_versions=true.',
+    ),
+    (
+        app_actions.osmo_rename_app,
+        'osmo_rename_app',
+        'Rename OSMO app',
+        'Synchronously rename one active-user-owned app. This changes the '
+        'app identifier and is not automatically retried.',
+    ),
+    (
         credentials.osmo_list_credentials,
         'osmo_list_credentials',
         'List OSMO credentials',
@@ -207,6 +238,10 @@ _EXPECTED_REQUIRED_FIELDS = {
     'osmo_list_apps': [],
     'osmo_get_app': ['name'],
     'osmo_get_app_spec': ['name'],
+    'osmo_create_app': ['name', 'description', 'spec_content'],
+    'osmo_update_app': ['name', 'spec_content'],
+    'osmo_delete_app': ['name'],
+    'osmo_rename_app': ['original_name', 'new_name'],
     'osmo_list_credentials': [],
     'osmo_set_credential': ['name', 'cred_type', 'payload'],
     'osmo_delete_credential': ['name'],
@@ -264,20 +299,27 @@ _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
     },
     'osmo_get_app': {'version': None, 'limit': 50},
     'osmo_get_app_spec': {'version': None},
+    'osmo_delete_app': {'version': None, 'all_versions': False},
 }
 
 _WRITE_TOOL_NAMES = frozenset({
     'osmo_cancel_workflow',
+    'osmo_create_app',
+    'osmo_delete_app',
     'osmo_delete_credential',
+    'osmo_rename_app',
     'osmo_restart_workflow',
     'osmo_set_credential',
     'osmo_set_profile',
     'osmo_submit_workflow',
+    'osmo_update_app',
     'osmo_validate_workflow',
 })
 _DESTRUCTIVE_TOOL_NAMES = frozenset({
     'osmo_cancel_workflow',
+    'osmo_delete_app',
     'osmo_delete_credential',
+    'osmo_rename_app',
     'osmo_restart_workflow',
     'osmo_set_credential',
     'osmo_set_profile',

--- a/src/service/mcp/tests/test_telemetry.py
+++ b/src/service/mcp/tests/test_telemetry.py
@@ -33,6 +33,9 @@ class TelemetryTest(unittest.TestCase):
                 '/api/workflow/{workflow_id}/cancel'
             ),
             '/api/app/user/private-app/spec': '/api/app/user/{app_name}/spec',
+            '/api/app/user/private-app/rename': (
+                '/api/app/user/{app_name}/rename'
+            ),
             '/api/credentials/private-credential': (
                 '/api/credentials/{credential_name}'
             ),

--- a/src/service/mcp/tests/test_tool_support.py
+++ b/src/service/mcp/tests/test_tool_support.py
@@ -65,6 +65,36 @@ class ToolSupportTest(unittest.TestCase):
                 with self.assertRaisesRegex(ToolError, 'Invalid workflow_id'):
                     tool_validation.safe_path_segment(value, field='workflow_id')
 
+    def test_inline_text_validation_is_utf8_bounded_and_multiline_safe(
+        self,
+    ) -> None:
+        value = 'version: 2\nworkflow:\n\tname: test\n'
+        self.assertEqual(
+            tool_validation.validate_inline_text(
+                value,
+                field='workflow_spec',
+                max_bytes=len(value.encode('utf-8')),
+            ),
+            value,
+        )
+        for invalid_value in (
+            '',
+            ' \n\t',
+            'control\x00value',
+            '\u00e9' * 3,
+            1,
+        ):
+            with self.subTest(value=invalid_value):
+                with self.assertRaisesRegex(
+                    ToolError,
+                    '^Invalid workflow_spec\\.$',
+                ):
+                    tool_validation.validate_inline_text(
+                        invalid_value,
+                        field='workflow_spec',
+                        max_bytes=5,
+                    )
+
     def test_actionable_core_errors_preserve_only_safe_known_fields(self) -> None:
         body = (
             b'{"message":"Invalid request; password=\'correct horse battery '

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -23,6 +23,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from src.service.mcp import (
+    app_actions,
     apps,
     credential_actions,
     credentials,
@@ -239,6 +240,48 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
             'When version is omitted, resolve the newest READY version from '
             'bounded version history.'
         ),
+    ),
+    ToolSpec(
+        function=app_actions.osmo_create_app,
+        name='osmo_create_app',
+        title='Create OSMO app',
+        description=(
+            'Create an app from bounded inline workflow YAML and schedule '
+            'version 1 for upload. The non-secret description is sent as a '
+            'query parameter and may appear in Gateway logs.'
+        ),
+        annotations=_write_annotations(destructive=False),
+    ),
+    ToolSpec(
+        function=app_actions.osmo_update_app,
+        name='osmo_update_app',
+        title='Update OSMO app',
+        description=(
+            'Always create and schedule upload of a new app version from '
+            'bounded inline workflow YAML; unlike the CLI editor flow, this '
+            'tool does not skip unchanged content.'
+        ),
+        annotations=_write_annotations(destructive=False),
+    ),
+    ToolSpec(
+        function=app_actions.osmo_delete_app,
+        name='osmo_delete_app',
+        title='Delete OSMO app',
+        description=(
+            'Schedule deletion of one version or all non-deleted versions. '
+            'Specify exactly one of version or all_versions=true.'
+        ),
+        annotations=_write_annotations(destructive=True),
+    ),
+    ToolSpec(
+        function=app_actions.osmo_rename_app,
+        name='osmo_rename_app',
+        title='Rename OSMO app',
+        description=(
+            'Synchronously rename one active-user-owned app. This changes '
+            'the app identifier and is not automatically retried.'
+        ),
+        annotations=_write_annotations(destructive=True),
     ),
     ToolSpec(
         function=credentials.osmo_list_credentials,

--- a/src/service/mcp/tool_validation.py
+++ b/src/service/mcp/tool_validation.py
@@ -208,6 +208,34 @@ def validate_query_values(
     return list(dict.fromkeys(validated)) if deduplicate else validated
 
 
+def validate_inline_text(
+    value: object,
+    *,
+    field: str,
+    max_bytes: int,
+) -> str:
+    """Validate bounded, non-empty multiline UTF-8 tool input."""
+    if not isinstance(value, str):
+        encoded_value = b''
+    else:
+        try:
+            encoded_value = value.encode('utf-8')
+        except UnicodeEncodeError:
+            encoded_value = b''
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or len(encoded_value) > max_bytes
+        or any(
+            not character.isprintable()
+            and character not in '\n\r\t'
+            for character in value
+        )
+    ):
+        raise PublicToolError(f'Invalid {field}.')
+    return value
+
+
 def _is_valid_integer(
     value: object,
     *,

--- a/src/service/mcp/workflow_actions.py
+++ b/src/service/mcp/workflow_actions.py
@@ -64,8 +64,9 @@ async def osmo_submit_workflow(
     priority: WorkflowPriority = 'NORMAL',
 ) -> SubmitWorkflowResult:
     """Submit raw workflow YAML to Core using the caller's OSMO identity."""
-    validated_spec = _validate_workflow_spec(
+    validated_spec = tool_validation.validate_inline_text(
         workflow_spec,
+        field='workflow_spec',
         max_bytes=_MAX_SUBMISSION_SPEC_BYTES,
     )
     validated_set_variables = _validate_overrides(
@@ -128,8 +129,9 @@ async def osmo_validate_workflow(
     set_string_variables: VariableOverrides | None = None,
 ) -> ValidateWorkflowResult:
     """Validate workflow YAML using Core's authoritative submission checks."""
-    validated_spec = _validate_workflow_spec(
+    validated_spec = tool_validation.validate_inline_text(
         workflow_spec,
+        field='workflow_spec',
         max_bytes=_MAX_VALIDATION_SPEC_BYTES,
     )
     validated_set_variables = _validate_overrides(
@@ -260,29 +262,6 @@ async def _resolve_pool(context: Context, pool: str | None) -> str:
     raise tool_errors.PublicToolError(
         'No unambiguous accessible pool is configured.'
     )
-
-
-def _validate_workflow_spec(
-    workflow_spec: str,
-    *,
-    max_bytes: int,
-) -> str:
-    try:
-        encoded_spec = workflow_spec.encode('utf-8')
-    except (AttributeError, UnicodeEncodeError):
-        encoded_spec = b''
-    if (
-        not isinstance(workflow_spec, str)
-        or not workflow_spec.strip()
-        or len(encoded_spec) > max_bytes
-        or any(
-            not character.isprintable()
-            and character not in '\n\r\t'
-            for character in workflow_spec
-        )
-    ):
-        raise tool_errors.PublicToolError('Invalid workflow_spec.')
-    return workflow_spec
 
 
 def _is_templated_workflow(workflow_spec: str) -> bool:

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -22,6 +22,8 @@ from test.oetf.smoke_fixture import SmokeFixture
 
 _EXPECTED_TOOL_NAMES = frozenset({
     "osmo_cancel_workflow",
+    "osmo_create_app",
+    "osmo_delete_app",
     "osmo_delete_credential",
     "osmo_get_app",
     "osmo_get_app_spec",
@@ -38,9 +40,11 @@ _EXPECTED_TOOL_NAMES = frozenset({
     "osmo_list_workflows",
     "osmo_search_pools",
     "osmo_restart_workflow",
+    "osmo_rename_app",
     "osmo_set_profile",
     "osmo_set_credential",
     "osmo_submit_workflow",
+    "osmo_update_app",
     "osmo_validate_workflow",
 })
 _MCP_ACCEPT_HEADERS = {


### PR DESCRIPTION
## Summary

Adds four external MCP app lifecycle mutations:

- `osmo_create_app`
- `osmo_update_app`
- `osmo_delete_app`
- `osmo_rename_app`

This is Phase 3 PR 3/4. The prerequisite credential support landed in #1239,
and this PR now targets `feature/mcp` directly. #1241 remains stacked on this
PR; nothing in this series targets `main`.

## Contract

- Reuses the existing CLI/Core app routes and inline string request bodies.
- Shares app-name and bounded multiline-text validation with the existing
  read/workflow tools.
- Create synchronously creates version 1 and reports that its upload was
  scheduled.
- Update always creates and schedules a new version; unlike the CLI editor
  flow, it intentionally does not read first or skip unchanged content.
- Delete requires exactly one selector, accepts Core's already-deleted
  `versions=[]` no-op, and returns at most 200 version IDs plus the
  authoritative total count.
- Rename is synchronous, destructive, one-shot, and has an identifier-free
  telemetry route.
- App specs are write-only in the tool schema and never returned/logged by
  MCP. Callers should reference OSMO credentials rather than inline secrets;
  the calling client may retain submitted arguments.
- Descriptions are explicitly non-secret because Core carries them in a query
  parameter that may appear in Gateway/authz logs.
- Ambiguous write failures are never retried and return fixed
  inspect-before-retry guidance.

Core currently authorizes the rename POST route as `app:Create`; this PR
preserves that existing API/RBAC behavior.

## Validation

- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors //src/service/mcp/tests:test_app_actions //src/service/mcp/tests:test_apps //src/service/mcp/tests:test_catalog //src/service/mcp/tests:test_telemetry //src/service/mcp/tests:test_tool_support //src/service/mcp/tests:test_workflow_actions //src/cli/tests:test_app //test/smoke:mcp-checks-pylint`
- `bazel --output_user_root=/tmp/osmo-bazel build //src/service/mcp:mcp_binary //test/smoke:mcp-checks`
- `git diff --check`

App mutations remain manual Inspector checks against disposable user-owned
state; the automated deployment smoke test verifies discovery only.

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
