### PR TITLE
Add external MCP app submission

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -109,7 +109,7 @@ not mount a service-account token, and the chart creates no MCP credential
 Secret. Gateway-to-MCP TLS continues to use the shared `gateway.tls`
 configuration described below.
 
-The external MCP exposes a 25-tool catalog with fixed API routes and no
+The external MCP exposes a 26-tool catalog with fixed API routes and no
 caller-selected origin, method, route, or headers. See the
 [external MCP tool plan](../../../src/service/mcp/TOOLS.md) for its exact
 contracts and API mappings. MCP health probes do not call these APIs; a

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -133,6 +133,8 @@ osmo_py_library(
         requirement("pydantic"),
         ":app_models",
         ":tool_models",
+        ":workflow_action_models",
+        ":workflow_models",
     ],
     visibility = ["//visibility:public"],
 )
@@ -259,17 +261,32 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "workflow_submission",
+    srcs = ["workflow_submission.py"],
+    deps = [
+        requirement("mcp"),
+        ":access_scope",
+        ":tool_errors",
+        ":tool_requests",
+        ":tool_validation",
+        ":workflow_action_models",
+        ":workflow_models",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "workflow_action_tools",
     srcs = ["workflow_actions.py"],
     deps = [
         requirement("mcp"),
-        ":access_scope",
         ":gateway",
         ":tool_errors",
         ":tool_requests",
         ":tool_validation",
         ":workflow_action_models",
         ":workflow_models",
+        ":workflow_submission",
         ":workflow_tools",
     ],
     visibility = ["//visibility:public"],
@@ -300,6 +317,23 @@ osmo_py_library(
         ":tool_errors",
         ":tool_requests",
         ":tool_validation",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "app_submission_tools",
+    srcs = ["app_submission.py"],
+    deps = [
+        requirement("mcp"),
+        ":app_action_models",
+        ":app_models",
+        ":app_tools",
+        ":tool_requests",
+        ":tool_validation",
+        ":workflow_action_models",
+        ":workflow_models",
+        ":workflow_submission",
     ],
     visibility = ["//visibility:public"],
 )
@@ -336,6 +370,7 @@ osmo_py_library(
     deps = [
         requirement("mcp"),
         ":app_action_tools",
+        ":app_submission_tools",
         ":app_tools",
         ":credential_action_tools",
         ":credential_tools",

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -100,14 +100,15 @@ authorization value.
 
 ## Available tools
 
-The external catalog contains 14 read-only tools for caller-bound health,
-profile, pool, resource, workflow, application, and credential-metadata
-inspection, plus four workflow actions, one profile-setting action, and two
-credential actions, and four app lifecycle actions. Each tool maps to a fixed
-external API, returns a structured allowlisted result, and applies a
-domain-specific response limit. Credential inspection returns names and types
-only. Profile inspection intentionally includes non-secret access-token
-identity metadata (name and expiry). Bearer values are never returned.
+The external catalog contains 26 tools: 14 read-only tools for caller-bound
+health, profile, pool, resource, workflow, application, and
+credential-metadata inspection, plus four workflow actions, one
+profile-setting action, two credential actions, four app lifecycle actions,
+and app submission. Each tool maps to a fixed external API, returns a
+structured allowlisted result, and applies a domain-specific response limit.
+Credential inspection returns names and types only. Profile inspection
+intentionally includes non-secret access-token identity metadata (name and
+expiry). Bearer values are never returned.
 
 `osmo_set_profile` updates only the default pool or email/Slack notification
 state supported by the external CLI and Core contract. Other profile settings
@@ -147,6 +148,20 @@ version is a successful no-op. Rename is synchronous and one-shot. App
 descriptions are non-secret query values and may appear in Gateway/authz
 access logs. Core currently authorizes rename's POST route as `app:Create`;
 the external MCP preserves that existing API/RBAC contract.
+
+`osmo_submit_app` resolves and pins one concrete READY version, reads its
+complete spec under a 128-KiB ceiling, and submits it through the same shared
+workflow-submission path as raw YAML. This avoids the CLI's independent
+metadata/spec resolution while preserving its template overrides and priority
+semantics. Overrides may contain sensitive values, so callers should prefer
+OSMO credentials for secrets; MCP does not return or log overrides, but the
+calling client may retain its arguments. Explicit pools rely on the
+authoritative `workflow:Create` check; an omitted pool additionally reads the
+profile to select its accessible default or sole pool. The preflight app reads
+require `app:Read`. Local paths, environment injection, dry-run, rsync, and
+local-file expansion remain excluded. Submission consumes compute, can create
+a `FAILED_SUBMISSION` record when Core rejects the workflow during validation,
+and is never automatically retried.
 
 Workflow validation calls Core's submission endpoint with
 `validation_only=true`. It is intentionally annotated as a non-idempotent
@@ -242,14 +257,14 @@ authentication. Its token needs `mcp:Access`, `profile:Read`, and
 bazel run //test/oetf:run -- --env <mcp-enabled-env> --tags mcp
 ```
 
-The smoke test rejects unauthenticated access, verifies the exact 25-tool
+The smoke test rejects unauthenticated access, verifies the exact 26-tool
 catalog, compares the profile projection with Core, checks caller-bound
 health, and validates a small workflow through Gateway → MCP → Gateway → Core.
 A successful validation does not enqueue compute or create a workflow row.
 The smoke suite intentionally sends only this known-good case because a failed
 Core validation can create a `FAILED_SUBMISSION` row.
-Profile, credential, and app mutations remain manual Inspector checks against
-disposable user-owned state.
+Profile, credential, app lifecycle, and app-submission mutations remain manual
+Inspector checks against disposable user-owned state.
 
 When the deployment cannot validate the default public `ubuntu:22.04` image,
 pass an approved image into the Bazel test environment:
@@ -261,7 +276,7 @@ bazel run //test/oetf:run -- \
   --bazel-arg=--test_env=OETF_DEFAULT_IMAGE=<registry/image:tag>
 ```
 
-Profile updates, submission, restart, and cancellation remain deliberate
-Inspector checks. They are not automated in the smoke target because doing so
-would mutate saved user or workflow state or consume compute. For each
+Profile updates, workflow and app submission, restart, and cancellation remain
+deliberate Inspector checks. They are not automated in the smoke target because
+doing so would mutate saved user or workflow state or consume compute. For each
 one-shot action, inspect OSMO state after an ambiguous error before retrying.

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -68,8 +68,8 @@ fragments; the external projection therefore returns only `cred_name` and
 `osmo_restart_workflow`, and `osmo_cancel_workflow` are implemented.
 Validation sets `validation_only=true` and is a non-idempotent write because a
 failed validation can create a `FAILED_SUBMISSION` workflow record. Submission
-accepts raw YAML and preserves the original template when it detects the same
-template markers as the CLI. It returns only the new workflow ID, selected
+accepts raw YAML and preserves the original template when it detects standard
+Jinja and OSMO template markers. It returns only the new workflow ID, selected
 pool, and effective priority. Restart and cancel are destructive one-shot
 operations.
 

--- a/src/service/mcp/TOOLS.md
+++ b/src/service/mcp/TOOLS.md
@@ -93,15 +93,16 @@ launching compute. It must pass against an MCP-enabled deployment before Phase
 Inspector checks against disposable workflows so the smoke suite does not
 consume compute or mutate existing workflow state.
 
-## Phase 3: user-owned mutations (in progress)
+## Phase 3: user-owned mutations (implemented; deployment verification pending)
 
 `osmo_set_profile`, `osmo_set_credential`, `osmo_delete_credential`,
 `osmo_create_app`, `osmo_update_app`, `osmo_delete_app`, and
-`osmo_rename_app` are implemented. Profile updates change exactly one external
-CLI-supported setting per call: the default pool, email notifications, or
-Slack notifications. Other profile settings are outside this tool's public
-contract. Core returns JSON `null` after accepting the write, so MCP returns a
-compact confirmation rather than implying it read back authoritative state.
+`osmo_rename_app` and `osmo_submit_app` are implemented. Profile updates
+change exactly one external CLI-supported setting per call: the default pool,
+email notifications, or Slack notifications. Other profile settings are
+outside this tool's public contract. Core returns JSON `null` after accepting
+the write, so MCP returns a compact confirmation rather than implying it read
+back authoritative state.
 
 Credential writes accept the canonical documented REGISTRY, DATA, and GENERIC
 payload shapes used by the CLI and Core. Values are bounded strings and are
@@ -127,7 +128,26 @@ arguments. Descriptions are non-secret query values that may appear in
 Gateway/authz logs. Core currently authorizes rename's POST as `app:Create`;
 MCP preserves that existing API/RBAC behavior.
 
-Remaining work adds `osmo_submit_app`.
+App submission uses `GET /api/app/user/{name}` to pin an exact READY version,
+then retrieves the complete spec with
+`GET /api/app/user/{name}/spec?version=...` under a 128-KiB ceiling and sends
+one `POST /api/pool/{pool}/workflow` with the matching `app_uuid` and
+`app_version`. This intentionally avoids the CLI's independent metadata/spec
+resolution, which can associate a newer PENDING version with a spec resolved
+from a READY version. The result contains only the workflow ID, app name and
+version, pool, priority, and confirmation.
+
+App metadata/spec reads require `app:Read`. An omitted pool additionally
+requires `profile:Read`; an explicit pool skips that profile read and relies on
+the final request's pool-scoped `workflow:Create` decision. Template overrides
+and priority match the shared workflow-submission path. Overrides may be
+sensitive; callers should prefer OSMO credentials for secrets because their
+MCP client may retain submitted arguments. Local paths, environment injection,
+dry-run, rsync, and local-file expansion are excluded. Submission consumes
+compute, can leave a `FAILED_SUBMISSION` record when Core rejects the workflow
+during validation, and is never automatically retried. Deployment smoke
+verifies discovery only; app submission remains a manual Inspector check
+against disposable user-owned state.
 
 ## Out of scope
 

--- a/src/service/mcp/app_action_models.py
+++ b/src/service/mcp/app_action_models.py
@@ -22,6 +22,8 @@ import pydantic
 
 from src.service.mcp.app_models import AppName, AppVersionNumber
 from src.service.mcp.tool_models import ClosedToolModel, ExtensibleUpstreamModel
+from src.service.mcp.workflow_action_models import PoolName
+from src.service.mcp.workflow_models import WorkflowId, WorkflowPriority
 
 
 MAX_APP_DESCRIPTION_BYTES = 2048
@@ -131,3 +133,14 @@ class RenameAppResult(ClosedToolModel):
     original_name: AppName
     new_name: AppName
     renamed: Literal[True]
+
+
+class SubmitAppResult(ClosedToolModel):
+    """Compact confirmation that Core accepted one app submission."""
+
+    workflow_id: WorkflowId
+    app_name: AppName
+    app_version: AppVersionNumber
+    pool: PoolName
+    priority: WorkflowPriority
+    submitted: Literal[True]

--- a/src/service/mcp/app_submission.py
+++ b/src/service/mcp/app_submission.py
@@ -1,0 +1,107 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from mcp.server.fastmcp import Context
+
+from src.service.mcp import (
+    apps,
+    tool_requests,
+    tool_validation,
+    workflow_submission,
+)
+from src.service.mcp.app_action_models import (
+    MAX_APP_SPEC_BYTES,
+    SubmitAppResult,
+)
+from src.service.mcp.app_models import AppName, AppVersionNumber
+from src.service.mcp.workflow_action_models import (
+    PoolName,
+    VariableOverrides,
+)
+from src.service.mcp.workflow_models import WorkflowPriority
+
+
+async def osmo_submit_app(
+    context: Context,
+    name: AppName,
+    pool: PoolName | None = None,
+    version: AppVersionNumber | None = None,
+    set_variables: VariableOverrides | None = None,
+    set_string_variables: VariableOverrides | None = None,
+    priority: WorkflowPriority = 'NORMAL',
+) -> SubmitAppResult:
+    """Resolve and submit one concrete READY OSMO app version."""
+    apps.validated_app_name(name)
+    validated_version = tool_validation.validate_optional_integer(
+        version,
+        field='app version',
+        minimum=1,
+    )
+    validated_pool = workflow_submission.validate_pool_name(pool)
+    validated_set_variables = (
+        workflow_submission.validate_variable_overrides(
+            set_variables,
+            field='set_variables',
+        )
+    )
+    validated_set_string_variables = (
+        workflow_submission.validate_variable_overrides(
+            set_string_variables,
+            field='set_string_variables',
+        )
+    )
+    validated_priority = workflow_submission.validate_priority(priority)
+    pool_name = await workflow_submission.resolve_pool(
+        context,
+        validated_pool,
+    )
+    resolved = await apps.resolve_ready_app_version(
+        context,
+        name=name,
+        version=validated_version,
+        operation='resolve an OSMO app submission version',
+    )
+    workflow_spec = await tool_requests.request_text(
+        context,
+        path=f'/api/app/user/{resolved.encoded_name}/spec',
+        operation='get an OSMO app spec for submission',
+        max_response_bytes=MAX_APP_SPEC_BYTES,
+        query={'version': resolved.version},
+    )
+    payload = workflow_submission.build_submission_payload(
+        workflow_spec,
+        set_variables=validated_set_variables,
+        set_string_variables=validated_set_string_variables,
+    )
+    upstream = await workflow_submission.request_submission(
+        context,
+        pool=pool_name,
+        priority=validated_priority,
+        payload=payload,
+        operation='submit an OSMO app',
+        app_uuid=resolved.uuid,
+        app_version=resolved.version,
+    )
+    return SubmitAppResult(
+        workflow_id=upstream.name,
+        app_name=name,
+        app_version=resolved.version,
+        pool=pool_name,
+        priority=validated_priority,
+        submitted=True,
+    )

--- a/src/service/mcp/apps.py
+++ b/src/service/mcp/apps.py
@@ -16,6 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import dataclasses
 import re
 
 from mcp.server.fastmcp import Context
@@ -45,6 +46,15 @@ _MAX_APP_RESPONSE_BYTES = 1024 * 1024
 _MAX_APP_SPEC_BYTES = 32 * 1024
 _DEFAULT_APP_LIST_LIMIT = 50
 _APP_VERSION_RESOLUTION_LIMIT = 200
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ResolvedAppVersion:
+    """Validated app identity and one concrete READY version."""
+
+    encoded_name: str
+    uuid: str
+    version: int
 
 
 async def osmo_list_apps(
@@ -131,33 +141,14 @@ async def osmo_get_app_spec(
     encoded_name = validated_app_name(name)
     resolved_version = version
     if resolved_version is None:
-        upstream = await _request_app(
+        resolved = await resolve_ready_app_version(
             context,
-            encoded_name=encoded_name,
+            name=name,
             version=None,
-            limit=_APP_VERSION_RESOLUTION_LIMIT + 1,
             operation='resolve the newest READY OSMO app version',
         )
-        resolved_version = max(
-            (
-                app_version.version
-                for app_version in upstream.versions[
-                    :_APP_VERSION_RESOLUTION_LIMIT
-                ]
-                if app_version.status == 'READY'
-            ),
-            default=None,
-        )
-        if resolved_version is None:
-            if len(upstream.versions) > _APP_VERSION_RESOLUTION_LIMIT:
-                raise PublicToolError(
-                    'Unable to resolve the newest READY OSMO app version '
-                    'within the bounded version history; specify version '
-                    'explicitly.'
-                )
-            raise PublicToolError(
-                'The requested OSMO app has no READY versions.'
-            )
+        encoded_name = resolved.encoded_name
+        resolved_version = resolved.version
 
     spec_result = await tool_requests.request_truncated_text(
         context,
@@ -187,6 +178,100 @@ def validated_app_name(
     ):
         raise PublicToolError(f'Invalid {field}.')
     return tool_validation.safe_path_segment(name, field=field)
+
+
+async def resolve_ready_app_version(
+    context: Context,
+    *,
+    name: AppName,
+    version: AppVersionNumber | None,
+    operation: str,
+) -> ResolvedAppVersion:
+    """Resolve and validate one concrete READY app version for reuse."""
+    encoded_name = validated_app_name(name)
+    validated_version = tool_validation.validate_optional_integer(
+        version,
+        field='app version',
+        minimum=1,
+    )
+    upstream = await _request_app(
+        context,
+        encoded_name=encoded_name,
+        version=validated_version,
+        limit=(
+            1
+            if validated_version is not None
+            else _APP_VERSION_RESOLUTION_LIMIT + 1
+        ),
+        operation=operation,
+    )
+    if upstream.name != name:
+        raise PublicToolError(
+            f'OSMO returned an invalid response while attempting to {operation}.'
+        )
+    try:
+        uuid = tool_validation.validate_query_text(
+            upstream.uuid,
+            field='app UUID',
+            max_bytes=512,
+        )
+    except PublicToolError:
+        raise PublicToolError(
+            f'OSMO returned an invalid response while attempting to {operation}.'
+        ) from None
+    if len(upstream.versions) != len({
+        app_version.version for app_version in upstream.versions
+    }):
+        raise PublicToolError(
+            f'OSMO returned an invalid response while attempting to {operation}.'
+        )
+
+    resolved_version: int | None
+    if validated_version is not None:
+        if not upstream.versions:
+            raise PublicToolError(
+                'The requested OSMO app version is not READY.'
+            )
+        app_version = upstream.versions[0]
+        if (
+            len(upstream.versions) != 1
+            or app_version.version != validated_version
+        ):
+            raise PublicToolError(
+                f'OSMO returned an invalid response while attempting to {operation}.'
+            )
+        if app_version.status != 'READY':
+            raise PublicToolError(
+                'The requested OSMO app version is not READY.'
+            )
+        resolved_version = validated_version
+    else:
+        resolved_version = max(
+            (
+                app_version.version
+                for app_version in upstream.versions[
+                    :_APP_VERSION_RESOLUTION_LIMIT
+                ]
+                if app_version.status == 'READY'
+            ),
+            default=None,
+        )
+        if resolved_version is None:
+            if len(upstream.versions) > _APP_VERSION_RESOLUTION_LIMIT:
+                raise PublicToolError(
+                    'Unable to resolve the newest READY OSMO app version '
+                    'within the bounded version history; specify version '
+                    'explicitly.'
+                )
+            raise PublicToolError(
+                'The requested OSMO app has no READY versions.'
+            )
+
+    return ResolvedAppVersion(
+        encoded_name=encoded_name,
+        uuid=uuid,
+        version=resolved_version,
+    )
 
 
 async def _request_app(

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -43,6 +43,15 @@ osmo_py_test(
 )
 
 osmo_py_test(
+    name = "test_app_submission",
+    srcs = ["test_app_submission.py"],
+    deps = [
+        requirement("httpx"),
+        ":protocol_harness",
+    ],
+)
+
+osmo_py_test(
     name = "test_apps",
     srcs = ["test_apps.py"],
     deps = [
@@ -56,6 +65,7 @@ osmo_py_test(
     srcs = ["test_catalog.py"],
     deps = [
         "//src/service/mcp:app_action_tools",
+        "//src/service/mcp:app_submission_tools",
         "//src/service/mcp:app_tools",
         "//src/service/mcp:credential_action_tools",
         "//src/service/mcp:credential_tools",

--- a/src/service/mcp/tests/test_app_submission.py
+++ b/src/service/mcp/tests/test_app_submission.py
@@ -1,0 +1,503 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import unittest
+
+import httpx
+
+from src.service.mcp.tests import protocol_harness
+
+
+_BEARER_SECRET = 'phase-three-app-submit-bearer-secret'
+_HARNESS = protocol_harness.ProtocolHarness(
+    tool_names=('osmo_submit_app',),
+    bearer_secret=_BEARER_SECRET,
+    request_id='app-submit-request-123',
+)
+_PROFILE_RESULT = {
+    'profile': {
+        'username': 'alice@example.com',
+        'pool': 'pool-default',
+    },
+    'roles': ['osmo-user'],
+    'pools': ['pool-default', 'pool-other'],
+    'token': None,
+}
+_PLAIN_SPEC = """\
+version: 2
+workflow:
+  name: app-submission
+  tasks:
+  - name: check
+    image: ubuntu:22.04
+    command: [echo]
+    args: [ok]
+"""
+
+
+def _app_metadata(
+    versions: list[tuple[int, str]],
+    *,
+    name: str = 'training_app',
+    uuid: str = 'app-uuid-123',
+) -> dict[str, object]:
+    return {
+        'uuid': uuid,
+        'name': name,
+        'description': 'app metadata',
+        'created_date': '2026-07-27T12:00:00Z',
+        'owner': 'alice@example.com',
+        'versions': [
+            {
+                'version': version,
+                'created_by': 'alice@example.com',
+                'created_date': '2026-07-27T12:00:00Z',
+                'status': status,
+            }
+            for version, status in versions
+        ],
+    }
+
+
+def _metadata_only_handler(
+    metadata: dict[str, object],
+    captured_requests: list[httpx.Request],
+) -> protocol_harness.AsyncUpstreamHandler:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(200, json=metadata)
+
+    return handler
+
+
+def _submission_result_handler(
+    post_response: httpx.Response,
+    captured_requests: list[httpx.Request],
+) -> protocol_harness.AsyncUpstreamHandler:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        if request.url.path.endswith('/spec'):
+            return httpx.Response(200, text=_PLAIN_SPEC)
+        if request.method == 'GET':
+            return httpx.Response(
+                200,
+                json=_app_metadata([(3, 'READY')]),
+            )
+        return post_response
+
+    return handler
+
+
+class AppSubmissionProtocolTest(unittest.IsolatedAsyncioTestCase):
+    """Exercise app submission through the real Streamable HTTP protocol."""
+
+    async def test_catalog_is_closed_and_declares_only_remote_inputs(
+        self,
+    ) -> None:
+        response = await _HARNESS.list_tools()
+        tools = _HARNESS.assert_closed_catalog(
+            self,
+            response,
+            expected_annotations={
+                'osmo_submit_app': protocol_harness.WRITE_ANNOTATIONS,
+            },
+        )
+        schema = tools['osmo_submit_app']['inputSchema']
+        self.assertEqual(schema['required'], ['name'])
+        self.assertEqual(schema['properties']['pool']['default'], None)
+        self.assertEqual(schema['properties']['version']['default'], None)
+        self.assertEqual(
+            schema['properties']['set_variables']['default'],
+            None,
+        )
+        self.assertEqual(
+            schema['properties']['set_string_variables']['default'],
+            None,
+        )
+        self.assertEqual(
+            schema['properties']['priority']['default'],
+            'NORMAL',
+        )
+        for field in ('set_variables', 'set_string_variables'):
+            self.assertTrue(
+                schema['properties'][field]['anyOf'][0]['writeOnly']
+            )
+        for excluded_argument in (
+            'dry_run',
+            'local_path',
+            'set_env',
+            'rsync',
+        ):
+            self.assertNotIn(excluded_argument, schema['properties'])
+
+    async def test_explicit_version_posts_exact_template_submission(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+        spec_secret = 'synthetic-app-spec-secret'
+        upstream_secret = 'synthetic-submit-response-secret'
+        templated_spec = (
+            _PLAIN_SPEC
+            + '\ndefault-values:\n  replicas: 1\n'
+            + f'# {{{{ replicas }}}} {spec_secret}\n'
+        )
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.method == 'GET' and request.url.path.endswith(
+                '/spec'
+            ):
+                return httpx.Response(200, text=templated_spec)
+            if request.method == 'GET':
+                return httpx.Response(
+                    200,
+                    json=_app_metadata([(3, 'READY')]),
+                )
+            return httpx.Response(200, json={
+                'name': 'app-run-1',
+                'overview': (
+                    f'https://example.test/?secret={upstream_secret}'
+                ),
+                'logs': (
+                    f'https://example.test/logs?secret={upstream_secret}'
+                ),
+            })
+
+        with self.assertLogs(
+            'src.service.mcp.telemetry',
+            level='INFO',
+        ) as captured_logs:
+            response = await _HARNESS.call_tool(
+                handler,
+                'osmo_submit_app',
+                {
+                    'name': 'training_app',
+                    'pool': 'pool-a',
+                    'version': 3,
+                    'set_variables': ['replicas=2'],
+                    'set_string_variables': ['image_tag=latest'],
+                    'priority': 'HIGH',
+                },
+            )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'workflow_id': 'app-run-1',
+            'app_name': 'training_app',
+            'app_version': 3,
+            'pool': 'pool-a',
+            'priority': 'HIGH',
+            'submitted': True,
+        })
+        self.assertNotIn(spec_secret, response.text)
+        self.assertNotIn(upstream_secret, response.text)
+        self.assertNotIn('app-uuid-123', response.text)
+        self.assertEqual(len(captured_requests), 3)
+
+        metadata_request = captured_requests[0]
+        spec_request = captured_requests[1]
+        submit_request = captured_requests[2]
+        self.assertEqual(metadata_request.method, 'GET')
+        self.assertEqual(
+            metadata_request.url.path,
+            '/api/app/user/training_app',
+        )
+        self.assertEqual(
+            metadata_request.url.params.multi_items(),
+            [('order', 'DESC'), ('limit', '1'), ('version', '3')],
+        )
+        self.assertEqual(
+            spec_request.url.path,
+            '/api/app/user/training_app/spec',
+        )
+        self.assertEqual(
+            spec_request.url.params.multi_items(),
+            [('version', '3')],
+        )
+        self.assertEqual(submit_request.method, 'POST')
+        self.assertEqual(
+            submit_request.url.path,
+            '/api/pool/pool-a/workflow',
+        )
+        self.assertEqual(
+            submit_request.url.params.multi_items(),
+            [
+                ('app_uuid', 'app-uuid-123'),
+                ('app_version', '3'),
+                ('priority', 'HIGH'),
+            ],
+        )
+        self.assertEqual(json.loads(submit_request.content), {
+            'file': templated_spec,
+            'set_variables': ['replicas=2'],
+            'set_string_variables': ['image_tag=latest'],
+            'uploaded_templated_spec': templated_spec,
+        })
+
+        telemetry_text = '\n'.join(captured_logs.output)
+        self.assertIn('tool=osmo_submit_app', telemetry_text)
+        self.assertIn(
+            'route=/api/app/user/{app_name}',
+            telemetry_text,
+        )
+        self.assertIn(
+            'route=/api/app/user/{app_name}/spec',
+            telemetry_text,
+        )
+        self.assertIn(
+            'route=/api/pool/{pool}/workflow',
+            telemetry_text,
+        )
+        self.assertNotIn(spec_secret, telemetry_text)
+        self.assertNotIn('app-uuid-123', telemetry_text)
+
+    async def test_omitted_version_pins_newest_ready_and_default_pool(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.url.path == '/api/profile/settings':
+                return httpx.Response(200, json=_PROFILE_RESULT)
+            if request.url.path.endswith('/spec'):
+                self.assertEqual(
+                    request.url.params.multi_items(),
+                    [('version', '8')],
+                )
+                return httpx.Response(200, text=_PLAIN_SPEC)
+            if request.method == 'GET':
+                return httpx.Response(200, json=_app_metadata([
+                    (9, 'PENDING'),
+                    (8, 'READY'),
+                    (7, 'READY'),
+                ]))
+            return httpx.Response(200, json={
+                'name': 'app-run-2',
+                'overview': 'https://example.test/workflow',
+                'logs': 'https://example.test/logs',
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_submit_app',
+            {'name': 'training_app'},
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(result['structuredContent'], {
+            'workflow_id': 'app-run-2',
+            'app_name': 'training_app',
+            'app_version': 8,
+            'pool': 'pool-default',
+            'priority': 'NORMAL',
+            'submitted': True,
+        })
+        self.assertEqual(
+            [request.url.path for request in captured_requests],
+            [
+                '/api/profile/settings',
+                '/api/app/user/training_app',
+                '/api/app/user/training_app/spec',
+                '/api/pool/pool-default/workflow',
+            ],
+        )
+        self.assertEqual(
+            captured_requests[1].url.params.multi_items(),
+            [('order', 'DESC'), ('limit', '201')],
+        )
+        self.assertEqual(
+            captured_requests[3].url.params.multi_items(),
+            [
+                ('app_uuid', 'app-uuid-123'),
+                ('app_version', '8'),
+            ],
+        )
+        self.assertEqual(json.loads(captured_requests[3].content), {
+            'file': _PLAIN_SPEC,
+            'set_variables': [],
+            'set_string_variables': [],
+        })
+
+    async def test_invalid_arguments_are_rejected_before_relay(
+        self,
+    ) -> None:
+        transport_calls = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            del request
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(200, json={})
+
+        invalid_arguments: tuple[dict[str, object], ...] = (
+            {'name': '../training_app'},
+            {'name': 'training_app', 'pool': ' pool-a'},
+            {'name': 'training_app', 'pool': '../other-pool'},
+            {'name': 'training_app', 'version': True},
+            {'name': 'training_app', 'pool': 'pool-a', 'priority': 'URGENT'},
+            {
+                'name': 'training_app',
+                'pool': 'pool-a',
+                'set_variables': ['missing-separator'],
+            },
+            {
+                'name': 'training_app',
+                'pool': 'pool-a',
+                'local_path': '/private/data',
+            },
+        )
+        async with _HARNESS.client(handler) as client:
+            for request_id, arguments in enumerate(
+                invalid_arguments,
+                start=1,
+            ):
+                with self.subTest(arguments=arguments):
+                    response = await _HARNESS.call_tool_with_client(
+                        client,
+                        'osmo_submit_app',
+                        arguments,
+                        request_id=request_id,
+                    )
+                    self.assertTrue(response.json()['result']['isError'])
+
+        self.assertEqual(transport_calls, 0)
+
+    async def test_invalid_app_metadata_never_fetches_or_submits_spec(
+        self,
+    ) -> None:
+        invalid_cases = (
+            (
+                _app_metadata([(3, 'READY')], name='different_app'),
+                3,
+            ),
+            (_app_metadata([(3, 'PENDING')]), 3),
+            (_app_metadata([]), 3),
+            (_app_metadata([(3, 'READY'), (3, 'READY')]), None),
+            (_app_metadata([(4, 'READY')]), 3),
+        )
+
+        for request_id, (metadata, version) in enumerate(
+            invalid_cases,
+            start=1,
+        ):
+            with self.subTest(metadata=metadata, version=version):
+                captured_requests: list[httpx.Request] = []
+
+                arguments: dict[str, object] = {
+                    'name': 'training_app',
+                    'pool': 'pool-a',
+                }
+                if version is not None:
+                    arguments['version'] = version
+                response = await _HARNESS.call_tool(
+                    _metadata_only_handler(
+                        metadata,
+                        captured_requests,
+                    ),
+                    'osmo_submit_app',
+                    arguments,
+                    request_id=request_id,
+                )
+                self.assertTrue(response.json()['result']['isError'])
+                self.assertEqual(len(captured_requests), 1)
+                self.assertEqual(captured_requests[0].method, 'GET')
+
+    async def test_oversized_spec_fails_before_submission(self) -> None:
+        captured_requests: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            if request.url.path.endswith('/spec'):
+                return httpx.Response(
+                    200,
+                    content=b'x' * (128 * 1024 + 1),
+                )
+            return httpx.Response(
+                200,
+                json=_app_metadata([(3, 'READY')]),
+            )
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_submit_app',
+            {
+                'name': 'training_app',
+                'pool': 'pool-a',
+                'version': 3,
+            },
+        )
+
+        self.assertTrue(response.json()['result']['isError'])
+        self.assertEqual(len(captured_requests), 2)
+        self.assertTrue(all(
+            request.method == 'GET' for request in captured_requests
+        ))
+
+    async def test_ambiguous_or_malformed_submission_is_not_retried(
+        self,
+    ) -> None:
+        private_detail = 'private-app-submit-server-detail'
+        post_responses = (
+            httpx.Response(503, text=private_detail),
+            httpx.Response(200, json={'name': 'app-run-3'}),
+        )
+
+        for request_id, post_response in enumerate(
+            post_responses,
+            start=1,
+        ):
+            with self.subTest(status_code=post_response.status_code):
+                captured_requests: list[httpx.Request] = []
+
+                response = await _HARNESS.call_tool(
+                    _submission_result_handler(
+                        post_response,
+                        captured_requests,
+                    ),
+                    'osmo_submit_app',
+                    {
+                        'name': 'training_app',
+                        'pool': 'pool-a',
+                        'version': 3,
+                    },
+                    request_id=request_id,
+                )
+
+                self.assertTrue(response.json()['result']['isError'])
+                self.assertIn('write outcome is unknown', response.text)
+                self.assertIn(
+                    'Inspect OSMO state before retrying',
+                    response.text,
+                )
+                self.assertNotIn(private_detail, response.text)
+                self.assertEqual(len(captured_requests), 3)
+                self.assertEqual(
+                    sum(
+                        request.method == 'POST'
+                        for request in captured_requests
+                    ),
+                    1,
+                )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -22,6 +22,7 @@ import unittest
 
 from src.service.mcp import (
     app_actions,
+    app_submission,
     apps,
     credential_actions,
     credentials,
@@ -194,6 +195,13 @@ _EXPECTED_SPECS: tuple[_ExpectedSpec, ...] = (
         'app identifier and is not automatically retried.',
     ),
     (
+        app_submission.osmo_submit_app,
+        'osmo_submit_app',
+        'Submit OSMO app',
+        'Resolve and pin a READY app version, then submit it to run in '
+        'OSMO. This consumes real compute and is not automatically retried.',
+    ),
+    (
         credentials.osmo_list_credentials,
         'osmo_list_credentials',
         'List OSMO credentials',
@@ -242,6 +250,7 @@ _EXPECTED_REQUIRED_FIELDS = {
     'osmo_update_app': ['name', 'spec_content'],
     'osmo_delete_app': ['name'],
     'osmo_rename_app': ['original_name', 'new_name'],
+    'osmo_submit_app': ['name'],
     'osmo_list_credentials': [],
     'osmo_set_credential': ['name', 'cred_type', 'payload'],
     'osmo_delete_credential': ['name'],
@@ -300,6 +309,13 @@ _EXPECTED_DEFAULTS: dict[str, dict[str, object]] = {
     'osmo_get_app': {'version': None, 'limit': 50},
     'osmo_get_app_spec': {'version': None},
     'osmo_delete_app': {'version': None, 'all_versions': False},
+    'osmo_submit_app': {
+        'pool': None,
+        'version': None,
+        'set_variables': None,
+        'set_string_variables': None,
+        'priority': 'NORMAL',
+    },
 }
 
 _WRITE_TOOL_NAMES = frozenset({
@@ -312,6 +328,7 @@ _WRITE_TOOL_NAMES = frozenset({
     'osmo_set_credential',
     'osmo_set_profile',
     'osmo_submit_workflow',
+    'osmo_submit_app',
     'osmo_update_app',
     'osmo_validate_workflow',
 })

--- a/src/service/mcp/tests/test_workflow_actions.py
+++ b/src/service/mcp/tests/test_workflow_actions.py
@@ -248,6 +248,45 @@ class WorkflowActionProtocolTest(unittest.IsolatedAsyncioTestCase):
             'uploaded_templated_spec': templated_spec,
         })
 
+    async def test_submit_preserves_control_block_only_template(
+        self,
+    ) -> None:
+        captured_requests: list[httpx.Request] = []
+        templated_spec = (
+            _WORKFLOW_SPEC
+            + '\n{% if enabled %}\n'
+            + '# enabled\n'
+            + '{% endif %}\n'
+        )
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_requests.append(request)
+            return httpx.Response(200, json={
+                'name': 'mcp-control-template-1',
+                'overview': 'https://example.test/workflow',
+                'logs': 'https://example.test/logs',
+            })
+
+        response = await _HARNESS.call_tool(
+            handler,
+            'osmo_submit_workflow',
+            {
+                'workflow_spec': templated_spec,
+                'pool': 'pool-a',
+                'set_variables': ['enabled=true'],
+            },
+        )
+
+        result = response.json()['result']
+        self.assertFalse(result['isError'])
+        self.assertEqual(len(captured_requests), 1)
+        self.assertEqual(json.loads(captured_requests[0].content), {
+            'file': templated_spec,
+            'set_variables': ['enabled=true'],
+            'set_string_variables': [],
+            'uploaded_templated_spec': templated_spec,
+        })
+
     async def test_submit_rejects_unsupported_or_invalid_arguments(
         self,
     ) -> None:

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -24,6 +24,7 @@ from mcp.types import ToolAnnotations
 
 from src.service.mcp import (
     app_actions,
+    app_submission,
     apps,
     credential_actions,
     credentials,
@@ -282,6 +283,16 @@ TOOL_SPECS: tuple[ToolSpec, ...] = (
             'the app identifier and is not automatically retried.'
         ),
         annotations=_write_annotations(destructive=True),
+    ),
+    ToolSpec(
+        function=app_submission.osmo_submit_app,
+        name='osmo_submit_app',
+        title='Submit OSMO app',
+        description=(
+            'Resolve and pin a READY app version, then submit it to run in '
+            'OSMO. This consumes real compute and is not automatically retried.'
+        ),
+        annotations=_write_annotations(destructive=False),
     ),
     ToolSpec(
         function=credentials.osmo_list_credentials,

--- a/src/service/mcp/workflow_action_models.py
+++ b/src/service/mcp/workflow_action_models.py
@@ -42,7 +42,16 @@ VariableOverride = Annotated[
 ]
 VariableOverrides = Annotated[
     list[VariableOverride],
-    pydantic.Field(max_length=50),
+    pydantic.Field(
+        max_length=50,
+        description=(
+            'Workflow template field=value overrides. Values may be '
+            'sensitive: prefer OSMO credentials for secrets. MCP does not '
+            'return or log overrides, but the calling client may retain its '
+            'submitted arguments.'
+        ),
+        json_schema_extra={'writeOnly': True},
+    ),
 ]
 ForceCancel = Annotated[
     pydantic.StrictBool,

--- a/src/service/mcp/workflow_actions.py
+++ b/src/service/mcp/workflow_actions.py
@@ -19,11 +19,11 @@ SPDX-License-Identifier: Apache-2.0
 from mcp.server.fastmcp import Context
 
 from src.service.mcp import (
-    access_scope,
     gateway,
     tool_errors,
     tool_requests,
     tool_validation,
+    workflow_submission,
     workflows,
 )
 from src.service.mcp.workflow_action_models import (
@@ -41,18 +41,11 @@ from src.service.mcp.workflow_action_models import (
     WorkflowSpecText,
     WorkflowTemplatePayload,
 )
-from src.service.mcp.workflow_models import (
-    WORKFLOW_PRIORITIES,
-    WorkflowId,
-    WorkflowPriority,
-)
+from src.service.mcp.workflow_models import WorkflowId, WorkflowPriority
 
 
 _MAX_JSON_RESPONSE_BYTES = 64 * 1024
 _MAX_VALIDATION_SPEC_BYTES = 256 * 1024
-_MAX_SUBMISSION_SPEC_BYTES = 128 * 1024
-_MAX_OVERRIDE_BYTES = 2048
-_CLI_TEMPLATE_MARKERS = ('{%%', '{{', '{#', 'default-values')
 
 
 async def osmo_submit_workflow(
@@ -64,59 +57,38 @@ async def osmo_submit_workflow(
     priority: WorkflowPriority = 'NORMAL',
 ) -> SubmitWorkflowResult:
     """Submit raw workflow YAML to Core using the caller's OSMO identity."""
-    validated_spec = tool_validation.validate_inline_text(
-        workflow_spec,
-        field='workflow_spec',
-        max_bytes=_MAX_SUBMISSION_SPEC_BYTES,
-    )
-    validated_set_variables = _validate_overrides(
+    validated_set_variables = workflow_submission.validate_variable_overrides(
         set_variables,
         field='set_variables',
     )
-    validated_set_string_variables = _validate_overrides(
-        set_string_variables,
-        field='set_string_variables',
+    validated_set_string_variables = (
+        workflow_submission.validate_variable_overrides(
+            set_string_variables,
+            field='set_string_variables',
+        )
     )
-    if priority not in WORKFLOW_PRIORITIES:
-        raise tool_errors.PublicToolError('Invalid workflow priority.')
-
-    pool_name = await _resolve_pool(context, pool)
-    encoded_pool = tool_validation.safe_path_segment(
-        pool_name,
-        field='pool',
-    )
-    payload = WorkflowTemplatePayload(
-        file=validated_spec,
+    validated_priority = workflow_submission.validate_priority(priority)
+    validated_pool = workflow_submission.validate_pool_name(pool)
+    payload = workflow_submission.build_submission_payload(
+        workflow_spec,
         set_variables=validated_set_variables,
         set_string_variables=validated_set_string_variables,
-        uploaded_templated_spec=(
-            validated_spec
-            if _is_templated_workflow(validated_spec)
-            else None
-        ),
     )
-    query = (
-        {'priority': priority}
-        if priority != 'NORMAL'
-        else None
-    )
-    response = await tool_requests.request_json_mutation(
+    pool_name = await workflow_submission.resolve_pool(
         context,
-        path=f'/api/pool/{encoded_pool}/workflow',
-        operation='submit a workflow',
-        max_response_bytes=_MAX_JSON_RESPONSE_BYTES,
-        query=query,
-        payload=payload.model_dump(mode='json', exclude_none=True),
+        validated_pool,
     )
-    upstream = tool_validation.validate_mutation_response(
-        UpstreamSubmitResult,
-        response,
+    upstream = await workflow_submission.request_submission(
+        context,
+        pool=pool_name,
+        priority=validated_priority,
+        payload=payload,
         operation='submit a workflow',
     )
     return SubmitWorkflowResult(
         workflow_id=upstream.name,
         pool=pool_name,
-        priority=priority,
+        priority=validated_priority,
         submitted=True,
     )
 
@@ -134,15 +106,21 @@ async def osmo_validate_workflow(
         field='workflow_spec',
         max_bytes=_MAX_VALIDATION_SPEC_BYTES,
     )
-    validated_set_variables = _validate_overrides(
+    validated_set_variables = workflow_submission.validate_variable_overrides(
         set_variables,
         field='set_variables',
     )
-    validated_set_string_variables = _validate_overrides(
-        set_string_variables,
-        field='set_string_variables',
+    validated_set_string_variables = (
+        workflow_submission.validate_variable_overrides(
+            set_string_variables,
+            field='set_string_variables',
+        )
     )
-    pool_name = await _resolve_pool(context, pool)
+    validated_pool = workflow_submission.validate_pool_name(pool)
+    pool_name = await workflow_submission.resolve_pool(
+        context,
+        validated_pool,
+    )
     encoded_pool = tool_validation.safe_path_segment(
         pool_name,
         field='pool',
@@ -178,14 +156,15 @@ async def osmo_restart_workflow(
     pool: PoolName | None = None,
 ) -> RestartWorkflowResult:
     """Restart a failed workflow after authorizing read access to its source."""
+    validated_pool = workflow_submission.validate_pool_name(pool)
     source = await workflows.osmo_get_workflow(
         context,
         workflow_id,
         skip_groups=True,
     )
     pool_name = (
-        await _resolve_pool(context, pool)
-        if pool is not None or source.workflow.pool is None
+        await workflow_submission.resolve_pool(context, validated_pool)
+        if validated_pool is not None or source.workflow.pool is None
         else source.workflow.pool
     )
     encoded_pool = tool_validation.safe_path_segment(
@@ -244,63 +223,3 @@ async def osmo_cancel_workflow(
         force=force,
         cancellation_submitted=True,
     )
-
-
-async def _resolve_pool(context: Context, pool: str | None) -> str:
-    if pool is not None:
-        return tool_validation.validate_query_text(
-            pool,
-            field='pool',
-            max_bytes=512,
-        )
-
-    scope = await access_scope.request_access_scope(context)
-    if scope.default_pool is not None:
-        return scope.default_pool
-    if len(scope.pools) == 1:
-        return scope.pools[0]
-    raise tool_errors.PublicToolError(
-        'No unambiguous accessible pool is configured.'
-    )
-
-
-def _is_templated_workflow(workflow_spec: str) -> bool:
-    """Match the CLI's lightweight template detection without its runtime."""
-    return any(marker in workflow_spec for marker in _CLI_TEMPLATE_MARKERS)
-
-
-def _validate_overrides(
-    values: list[str] | None,
-    *,
-    field: str,
-) -> list[str]:
-    if values is None:
-        return []
-    if (
-        not isinstance(values, list)
-        or len(values) > 50
-    ):
-        raise tool_errors.PublicToolError(f'Invalid {field}.')
-
-    validated: list[str] = []
-    for value in values:
-        try:
-            encoded_value = value.encode('utf-8')
-        except (AttributeError, UnicodeEncodeError):
-            encoded_value = b''
-        key, separator, _ = value.partition('=') if isinstance(
-            value, str
-        ) else ('', '', '')
-        if (
-            not separator
-            or not key
-            or key != key.strip()
-            or len(encoded_value) > _MAX_OVERRIDE_BYTES
-            or any(
-                ord(character) < 0x20 or ord(character) == 0x7F
-                for character in value
-            )
-        ):
-            raise tool_errors.PublicToolError(f'Invalid {field}.')
-        validated.append(value)
-    return validated

--- a/src/service/mcp/workflow_submission.py
+++ b/src/service/mcp/workflow_submission.py
@@ -37,7 +37,7 @@ from src.service.mcp.workflow_models import (
 _MAX_SUBMISSION_SPEC_BYTES = 128 * 1024
 _MAX_JSON_RESPONSE_BYTES = 64 * 1024
 _MAX_OVERRIDE_BYTES = 2048
-_CLI_TEMPLATE_MARKERS = ('{%%', '{{', '{#', 'default-values')
+_TEMPLATE_MARKERS = ('{%', '{{', '{#', 'default-values')
 
 
 def validate_pool_name(pool: str | None) -> str | None:
@@ -194,5 +194,5 @@ async def request_submission(
 
 
 def _is_templated_workflow(workflow_spec: str) -> bool:
-    """Match the CLI's lightweight template detection without its runtime."""
-    return any(marker in workflow_spec for marker in _CLI_TEMPLATE_MARKERS)
+    """Detect standard Jinja and OSMO workflow template markers."""
+    return any(marker in workflow_spec for marker in _TEMPLATE_MARKERS)

--- a/src/service/mcp/workflow_submission.py
+++ b/src/service/mcp/workflow_submission.py
@@ -1,0 +1,198 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+from mcp.server.fastmcp import Context
+
+from src.service.mcp import (
+    access_scope,
+    tool_errors,
+    tool_requests,
+    tool_validation,
+)
+from src.service.mcp.workflow_action_models import (
+    UpstreamSubmitResult,
+    WorkflowTemplatePayload,
+)
+from src.service.mcp.workflow_models import (
+    WORKFLOW_PRIORITIES,
+    WorkflowPriority,
+)
+
+
+_MAX_SUBMISSION_SPEC_BYTES = 128 * 1024
+_MAX_JSON_RESPONSE_BYTES = 64 * 1024
+_MAX_OVERRIDE_BYTES = 2048
+_CLI_TEMPLATE_MARKERS = ('{%%', '{{', '{#', 'default-values')
+
+
+def validate_pool_name(pool: str | None) -> str | None:
+    """Validate an optional explicit workflow-submission pool."""
+    if pool is None:
+        return None
+    validated_pool = tool_validation.validate_query_text(
+        pool,
+        field='pool',
+        max_bytes=512,
+    )
+    tool_validation.safe_path_segment(validated_pool, field='pool')
+    return validated_pool
+
+
+async def resolve_pool(context: Context, pool: str | None) -> str:
+    """Resolve an explicit pool or the caller's unambiguous profile default."""
+    validated_pool = validate_pool_name(pool)
+    if validated_pool is not None:
+        return validated_pool
+
+    scope = await access_scope.request_access_scope(context)
+    if scope.default_pool is not None:
+        validated_default = validate_pool_name(scope.default_pool)
+        if validated_default is not None:
+            return validated_default
+    if len(scope.pools) == 1:
+        validated_only_pool = validate_pool_name(scope.pools[0])
+        if validated_only_pool is not None:
+            return validated_only_pool
+    raise tool_errors.PublicToolError(
+        'No unambiguous accessible pool is configured.'
+    )
+
+
+def validate_priority(priority: WorkflowPriority) -> WorkflowPriority:
+    """Validate one workflow scheduling priority without coercion."""
+    if priority not in WORKFLOW_PRIORITIES:
+        raise tool_errors.PublicToolError('Invalid workflow priority.')
+    return priority
+
+
+def validate_variable_overrides(
+    values: list[str] | None,
+    *,
+    field: str,
+) -> list[str]:
+    """Validate bounded CLI-compatible workflow template overrides."""
+    if values is None:
+        return []
+    if (
+        not isinstance(values, list)
+        or len(values) > 50
+    ):
+        raise tool_errors.PublicToolError(f'Invalid {field}.')
+
+    validated: list[str] = []
+    for value in values:
+        try:
+            encoded_value = value.encode('utf-8')
+        except (AttributeError, UnicodeEncodeError):
+            encoded_value = b''
+        key, separator, _ = value.partition('=') if isinstance(
+            value, str
+        ) else ('', '', '')
+        if (
+            not separator
+            or not key
+            or key != key.strip()
+            or len(encoded_value) > _MAX_OVERRIDE_BYTES
+            or any(
+                ord(character) < 0x20 or ord(character) == 0x7F
+                for character in value
+            )
+        ):
+            raise tool_errors.PublicToolError(f'Invalid {field}.')
+        validated.append(value)
+    return validated
+
+
+def build_submission_payload(
+    workflow_spec: str,
+    *,
+    set_variables: list[str],
+    set_string_variables: list[str],
+) -> WorkflowTemplatePayload:
+    """Build the exact Core template payload for one bounded submission."""
+    validated_spec = tool_validation.validate_inline_text(
+        workflow_spec,
+        field='workflow_spec',
+        max_bytes=_MAX_SUBMISSION_SPEC_BYTES,
+    )
+    return WorkflowTemplatePayload(
+        file=validated_spec,
+        set_variables=set_variables,
+        set_string_variables=set_string_variables,
+        uploaded_templated_spec=(
+            validated_spec
+            if _is_templated_workflow(validated_spec)
+            else None
+        ),
+    )
+
+
+async def request_submission(
+    context: Context,
+    *,
+    pool: str,
+    priority: WorkflowPriority,
+    payload: WorkflowTemplatePayload,
+    operation: str,
+    app_uuid: str | None = None,
+    app_version: int | None = None,
+) -> UpstreamSubmitResult:
+    """Perform one non-retried Core workflow submission."""
+    validated_priority = validate_priority(priority)
+    encoded_pool = tool_validation.safe_path_segment(
+        pool,
+        field='pool',
+    )
+    if (app_uuid is None) != (app_version is None):
+        raise ValueError(
+            'App UUID and version must be provided together.'
+        )
+    submission_query: dict[str, str | int] = {}
+    if app_uuid is not None and app_version is not None:
+        submission_query['app_uuid'] = tool_validation.validate_query_text(
+            app_uuid,
+            field='app UUID',
+            max_bytes=512,
+        )
+        submission_query['app_version'] = (
+            tool_validation.validate_integer(
+                app_version,
+                field='app version',
+                minimum=1,
+            )
+        )
+    if validated_priority != 'NORMAL':
+        submission_query['priority'] = validated_priority
+    response = await tool_requests.request_json_mutation(
+        context,
+        path=f'/api/pool/{encoded_pool}/workflow',
+        operation=operation,
+        max_response_bytes=_MAX_JSON_RESPONSE_BYTES,
+        query=submission_query or None,
+        payload=payload.model_dump(mode='json', exclude_none=True),
+    )
+    return tool_validation.validate_mutation_response(
+        UpstreamSubmitResult,
+        response,
+        operation=operation,
+    )
+
+
+def _is_templated_workflow(workflow_spec: str) -> bool:
+    """Match the CLI's lightweight template detection without its runtime."""
+    return any(marker in workflow_spec for marker in _CLI_TEMPLATE_MARKERS)

--- a/test/smoke/mcp_checks.py
+++ b/test/smoke/mcp_checks.py
@@ -43,6 +43,7 @@ _EXPECTED_TOOL_NAMES = frozenset({
     "osmo_rename_app",
     "osmo_set_profile",
     "osmo_set_credential",
+    "osmo_submit_app",
     "osmo_submit_workflow",
     "osmo_update_app",
     "osmo_validate_workflow",


### PR DESCRIPTION
## Description

Adds `osmo_submit_app` and completes the external MCP's planned 26-tool catalog.

This is Phase 3 stack PR 4/4. It targets `feature/mcp`; nothing in this series targets `main`.

Issue - None

## Contract

- Validates all caller inputs before relay and resolves an explicit pool or the caller's accessible default/sole pool.
- Reads bounded app metadata, requires an exact matching name and UUID, and pins either the requested READY version or the newest READY version from at most 200 entries.
- Retrieves that concrete version's complete spec under a 128-KiB ceiling; it never submits a truncated spec.
- Reuses one shared workflow-submission path for pool encoding, template markers, overrides, priority, the fixed Core POST, response projection, and unknown-outcome handling.
- Sends only `app_uuid`, `app_version`, and non-default `priority` as fixed query options, then returns only workflow ID, app name/version, pool, priority, and confirmation.
- Does not expose local paths, environment injection, dry-run, rsync, or local-file expansion.

App metadata/spec reads require `app:Read`; an omitted pool additionally requires `profile:Read`; the final pool-scoped POST requires `workflow:Create`. Submission consumes compute, can leave a `FAILED_SUBMISSION` record, and is never automatically retried.

App specs and overrides are never returned or logged by MCP. Overrides are marked write-only, and callers are warned that their MCP client may retain submitted arguments.

## Validation

- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors //src/service/mcp/... //test/smoke:mcp-checks-pylint`
- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors //src/cli/tests:test_app`
- `bazel --output_user_root=/tmp/osmo-bazel build //src/service/mcp:mcp_binary //test/smoke:mcp-checks`

The deployment smoke test verifies the exact catalog but does not call `osmo_submit_app`; live submission remains a manual Inspector check against disposable user-owned state.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
