### PR TITLE
docs: add internal Getting Started hook

### DIFF
--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -221,6 +221,7 @@ Connect any S3-compatible object storage or Azure Blob Storage. Store artifacts 
   :hidden:
   :caption: Getting Started
 
+  .. auto-include:: getting_started/index.in.rst
   getting_started/system_requirements
   getting_started/install/index
   getting_started/profile

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -221,9 +221,9 @@ Connect any S3-compatible object storage or Azure Blob Storage. Store artifacts 
   :hidden:
   :caption: Getting Started
 
-  .. auto-include:: getting_started/index.in.rst
   getting_started/system_requirements
   getting_started/install/index
+  .. auto-include:: getting_started/index.in.rst
   getting_started/profile
   getting_started/credentials
   getting_started/next_steps


### PR DESCRIPTION
Issue - None

## Summary

- add an optional internal overlay hook as the first entry in the Getting Started toctree
- keep public documentation navigation unchanged when no overlay file exists

## Downstream dependency

Internal GitLab MR https://gitlab-master.nvidia.com/isaac-infrastructure/osmo/-/merge_requests/6276 supplies `getting_started/index.in.rst`. Its source branch intentionally does not update the external submodule pin. Merge this PR and advance the target branch's external pin separately before merging the internal MR.

## Verification

- `make -C docs build`
- `make -C docs spelling`
- confirmed rendered public Getting Started navigation is unchanged
- confirmed the combined internal overlay renders the DL page first under Getting Started

## Checklist
- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the Getting Started documentation navigation by automatically including available introductory pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->