### PR TITLE
Fix CLI template block detection

### DIFF
--- a/src/cli/tests/BUILD
+++ b/src/cli/tests/BUILD
@@ -87,3 +87,13 @@ py_test(
         "//src/cli:cli_lib",
     ]
 )
+
+py_test(
+    name = "test_workflow",
+    srcs = [
+        "test_workflow.py"
+    ],
+    deps = [
+        "//src/cli:cli_lib",
+    ]
+)

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -1,0 +1,49 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+
+from src.cli import workflow
+
+
+class WorkflowTemplateDetectionTest(unittest.TestCase):
+    """Test CLI workflow template detection."""
+
+    def test_control_block_only_workflow_is_templated(self) -> None:
+        workflow_contents = """\
+version: 2
+{% if enabled %}
+workflow:
+  name: control-block-only
+{% endif %}
+"""
+
+        result = workflow.parse_file_for_template(
+            workflow_contents,
+            [],
+            [],
+        )
+
+        self.assertTrue(result.is_templated)
+        self.assertEqual(result.file, workflow_contents)
+        self.assertEqual(result.set_variables, [])
+        self.assertEqual(result.set_string_variables, [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -587,7 +587,7 @@ Stop a specific daemon::
 def parse_file_for_template(workflow_contents: str, set_variables: List[str],
                             set_string_variables: List[str]) -> TemplateData:
     # Check to see if the workflow is templated
-    is_templated = (workflow_contents.find('{%%') != -1) or (workflow_contents.find('{{') != -1) \
+    is_templated = (workflow_contents.find('{%') != -1) or (workflow_contents.find('{{') != -1) \
         or (workflow_contents.find('{#') != -1) or (workflow_contents.find('default-values') != -1)
 
     return TemplateData(


### PR DESCRIPTION
## Description

Corrects CLI workflow-template detection to recognize the standard Jinja control-block opener, `{%`.

The detector currently searches for `{%%`, so a template containing only control blocks can be misclassified as plain YAML. This can bypass the CLI's template-aware submission path even though OSMO supports standard Jinja block syntax.

The change corrects the marker and adds a focused regression test whose only template signal is `{% ... %}`.

Issue - None

## Validation

- `bazel --output_user_root=/tmp/osmo-bazel test --test_output=errors //src/cli/tests:test_workflow //src/cli/tests:test_app //src/cli:cli_lib-pylint`
- `bazel --output_user_root=/tmp/osmo-bazel build //src/cli:cli`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of templated workflow files containing Jinja control blocks.
  * Ensured these workflows are correctly recognized without altering their original content or variables.

* **Tests**
  * Added coverage for workflows containing only template control blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->