### PR TITLE
Fix shared pool capacity usage

### DIFF
--- a/src/ui/src/components/workflow/pool-picker.tsx
+++ b/src/ui/src/components/workflow/pool-picker.tsx
@@ -22,13 +22,14 @@ import type { Pool } from "@/lib/api/adapter/types";
 import { cn } from "@/lib/utils";
 import { PlatformPills } from "@/components/platform-pills";
 import { PoolSelect } from "@/components/workflow/pool-select";
+import { normalizePhysicalCapacity } from "@/lib/pool-capacity";
 
 const META_ROW = "grid grid-cols-[5.625rem_1fr] items-baseline gap-6";
 const META_LABEL = "text-muted-foreground text-xs font-medium uppercase";
 
 const PoolMetaCard = memo(function PoolMetaCard({ pool }: { pool: Pool }) {
   const quotaFree = pool.quota.limit - pool.quota.used;
-  const capacityFree = pool.quota.totalCapacity - pool.quota.totalUsage;
+  const physicalCapacity = normalizePhysicalCapacity(pool.quota);
 
   return (
     <div
@@ -55,13 +56,13 @@ const PoolMetaCard = memo(function PoolMetaCard({ pool }: { pool: Pool }) {
           <div className={META_LABEL}>GPU Capacity</div>
           <div className="flex flex-wrap items-baseline gap-y-1 tabular-nums">
             <span className="text-sm font-medium">
-              {pool.quota.totalUsage}
+              {physicalCapacity.used}
               <span className="text-muted-foreground/50"> / </span>
-              {pool.quota.totalCapacity}
+              {physicalCapacity.total}
             </span>
             <span className="text-muted-foreground pl-[0.3rem] text-xs font-medium">used</span>
             <span className="text-muted-foreground px-2">•</span>
-            <span className="text-xs font-medium">{capacityFree} free</span>
+            <span className="text-xs font-medium">{physicalCapacity.free} free</span>
           </div>
         </div>
 

--- a/src/ui/src/features/pools/components/panel/panel-content.tsx
+++ b/src/ui/src/features/pools/components/panel/panel-content.tsx
@@ -27,6 +27,7 @@ import { getSharingInfo } from "@/lib/api/adapter/transforms";
 import { PlatformSelector } from "@/features/pools/components/panel/platform-selector";
 import { PlatformConfigContent } from "@/features/pools/components/panel/platform-config";
 import { SharedPoolsChips } from "@/features/pools/components/panel/shared-pools-chips";
+import { normalizePhysicalCapacity } from "@/lib/pool-capacity";
 
 // =============================================================================
 // Types
@@ -109,6 +110,7 @@ export const PanelContent = memo(function PanelContent({
 
   const hasExitActions = Object.keys(pool.defaultExitActions).length > 0;
   const hasPoolDetails = pool.description || hasTimeouts || hasExitActions;
+  const physicalCapacity = normalizePhysicalCapacity(pool.quota);
 
   return (
     <div className="flex-1 overflow-auto p-4">
@@ -137,9 +139,9 @@ export const PanelContent = memo(function PanelContent({
               )}
             </span>
           }
-          used={pool.quota.totalUsage}
-          total={pool.quota.totalCapacity}
-          free={pool.quota.totalFree}
+          used={physicalCapacity.used}
+          total={physicalCapacity.total}
+          free={physicalCapacity.free}
         >
           {/* Shared pools info - colocated with capacity bar */}
           {sharedWith && sharedWith.length > 0 && (

--- a/src/ui/src/features/pools/components/pool-gpu-summary.tsx
+++ b/src/ui/src/features/pools/components/pool-gpu-summary.tsx
@@ -23,6 +23,7 @@ import { Skeleton } from "@/components/shadcn/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/shadcn/tooltip";
 import { formatCompact } from "@/lib/utils";
 import type { Quota } from "@/lib/api/adapter/types";
+import { normalizePhysicalCapacity } from "@/lib/pool-capacity";
 
 interface PoolGpuSummaryProps {
   summary: Quota;
@@ -106,6 +107,8 @@ const PoolGpuSummaryCard = memo(function PoolGpuSummaryCard({
 });
 
 export const PoolGpuSummary = memo(function PoolGpuSummary({ summary, isLoading = false }: PoolGpuSummaryProps) {
+  const physicalCapacity = normalizePhysicalCapacity(summary);
+
   return (
     <div className="contain-layout-style @container">
       <div className="grid grid-cols-2 gap-2 @[500px]:gap-3">
@@ -128,9 +131,9 @@ export const PoolGpuSummary = memo(function PoolGpuSummary({ summary, isLoading 
               label="GPU Capacity"
               tooltip="Total physical GPUs. Capacity may be shared across pools."
               icon={Server}
-              used={summary.totalUsage}
-              free={summary.totalFree}
-              total={summary.totalCapacity}
+              used={physicalCapacity.used}
+              free={physicalCapacity.free}
+              total={physicalCapacity.total}
             />
           </>
         )}

--- a/src/ui/src/features/pools/components/table/pool-column-defs.test.ts
+++ b/src/ui/src/features/pools/components/table/pool-column-defs.test.ts
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { ColumnDef } from "@tanstack/react-table";
+import { createPoolColumns } from "@/features/pools/components/table/pool-column-defs";
+import type { Pool } from "@/lib/api/adapter/types";
+import { createMockPool } from "@/testing/factories";
+
+function getAccessorValue(columns: ColumnDef<Pool, unknown>[], columnId: string, pool: Pool): unknown {
+  const column = columns.find(({ id }) => id === columnId);
+  if (!column || !("accessorFn" in column) || !column.accessorFn) {
+    throw new Error(`Missing accessor for ${columnId}`);
+  }
+  return column.accessorFn(pool, 0);
+}
+
+describe("capacity columns", () => {
+  it("exposes the same normalized used and free values shown by capacity surfaces", () => {
+    const columns = createPoolColumns({});
+    const negativeFree = createMockPool({
+      quota: {
+        used: 1,
+        free: 7,
+        limit: 8,
+        totalUsage: 1,
+        totalCapacity: 8,
+        totalFree: -1,
+      },
+    });
+    const excessiveFree = createMockPool({
+      quota: {
+        used: 1,
+        free: 7,
+        limit: 8,
+        totalUsage: 1,
+        totalCapacity: 8,
+        totalFree: 10,
+      },
+    });
+
+    expect(getAccessorValue(columns, "capacity", negativeFree)).toBe(8);
+    expect(getAccessorValue(columns, "capacityFree", negativeFree)).toBe(0);
+    expect(getAccessorValue(columns, "capacity", excessiveFree)).toBe(0);
+    expect(getAccessorValue(columns, "capacityFree", excessiveFree)).toBe(8);
+  });
+});

--- a/src/ui/src/features/pools/components/table/pool-column-defs.tsx
+++ b/src/ui/src/features/pools/components/table/pool-column-defs.tsx
@@ -24,6 +24,7 @@ import { InlineProgress } from "@/components/inline-progress";
 import { PlatformPills } from "@/components/platform-pills";
 import { POOL_COLUMN_SIZE_CONFIG, COLUMN_LABELS, type PoolColumnId } from "@/features/pools/lib/pool-columns";
 import { getStatusDisplay, STATUS_STYLES, type StatusCategory } from "@/lib/pool-status";
+import { normalizePhysicalCapacity } from "@/lib/pool-capacity";
 
 const STATUS_ICONS: Record<StatusCategory, typeof CheckCircle2> = {
   online: CheckCircle2,
@@ -157,27 +158,30 @@ export function createPoolColumns({
     },
     {
       id: "capacity",
-      accessorFn: (row) => row.quota.totalUsage,
+      accessorFn: (row) => normalizePhysicalCapacity(row.quota).used,
       header: COLUMN_LABELS.capacity,
       minSize: getMinSize("capacity"),
       enableSorting: true,
-      cell: ({ row }) => (
-        <InlineProgress
-          used={row.original.quota.totalUsage}
-          total={row.original.quota.totalCapacity}
-          compact={compact}
-        />
-      ),
+      cell: ({ row }) => {
+        const physicalCapacity = normalizePhysicalCapacity(row.original.quota);
+        return (
+          <InlineProgress
+            used={physicalCapacity.used}
+            total={physicalCapacity.total}
+            compact={compact}
+          />
+        );
+      },
     },
     {
       id: "capacityFree",
-      accessorFn: (row) => row.quota.totalFree,
+      accessorFn: (row) => normalizePhysicalCapacity(row.quota).free,
       header: COLUMN_LABELS.capacityFree,
       minSize: getMinSize("capacityFree"),
       enableSorting: true,
       cell: ({ row }) => (
         <span className="text-xs text-emerald-600 tabular-nums dark:text-emerald-400">
-          {Math.max(0, row.original.quota.totalFree)}
+          {normalizePhysicalCapacity(row.original.quota).free}
         </span>
       ),
     },

--- a/src/ui/src/features/pools/hooks/use-sorted-pools.test.ts
+++ b/src/ui/src/features/pools/hooks/use-sorted-pools.test.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { sortPools } from "@/features/pools/hooks/use-sorted-pools";
+import { createMockPool } from "@/testing/factories";
+
+describe("sortPools", () => {
+  it("sorts capacity by shared physical utilization", () => {
+    const halfUsed = createMockPool({
+      name: "half-used",
+      quota: {
+        used: 1,
+        free: 7,
+        limit: 8,
+        totalUsage: 1,
+        totalCapacity: 8,
+        totalFree: 4,
+      },
+    });
+    const quarterUsed = createMockPool({
+      name: "quarter-used",
+      quota: {
+        used: 3,
+        free: 5,
+        limit: 8,
+        totalUsage: 3,
+        totalCapacity: 8,
+        totalFree: 6,
+      },
+    });
+
+    const sorted = sortPools([halfUsed, quarterUsed], {
+      column: "capacity",
+      direction: "asc",
+    });
+
+    expect(sorted.map((pool) => pool.name)).toEqual(["quarter-used", "half-used"]);
+  });
+
+  it("sorts transient invalid used and free values by their normalized presentation", () => {
+    const negativeFree = createMockPool({
+      name: "negative-free",
+      quota: {
+        used: 1,
+        free: 7,
+        limit: 8,
+        totalUsage: 1,
+        totalCapacity: 8,
+        totalFree: -1,
+      },
+    });
+    const excessiveFree = createMockPool({
+      name: "excessive-free",
+      quota: {
+        used: 1,
+        free: 7,
+        limit: 8,
+        totalUsage: 1,
+        totalCapacity: 8,
+        totalFree: 10,
+      },
+    });
+
+    const byUsed = sortPools([negativeFree, excessiveFree], {
+      column: "capacity",
+      direction: "asc",
+    });
+    const byFree = sortPools([negativeFree, excessiveFree], {
+      column: "capacityFree",
+      direction: "asc",
+    });
+
+    expect(byUsed.map((pool) => pool.name)).toEqual(["excessive-free", "negative-free"]);
+    expect(byFree.map((pool) => pool.name)).toEqual(["negative-free", "excessive-free"]);
+  });
+});

--- a/src/ui/src/features/pools/hooks/use-sorted-pools.ts
+++ b/src/ui/src/features/pools/hooks/use-sorted-pools.ts
@@ -18,12 +18,13 @@ import { useMemo } from "react";
 import type { Pool } from "@/lib/api/adapter/types";
 import type { SortState } from "@/components/data-table/types";
 import { naturalCompare } from "@/lib/utils";
+import { normalizePhysicalCapacity } from "@/lib/pool-capacity";
 
 function utilization(used: number, total: number): number {
   return total > 0 ? used / total : 0;
 }
 
-function sortPools(pools: Pool[], sort: SortState<string> | null): Pool[] {
+export function sortPools(pools: Pool[], sort: SortState<string> | null): Pool[] {
   if (!sort?.column) return pools;
 
   return [...pools].sort((a, b) => {
@@ -44,13 +45,14 @@ function sortPools(pools: Pool[], sort: SortState<string> | null): Pool[] {
       case "quotaFree":
         cmp = a.quota.free - b.quota.free;
         break;
-      case "capacity":
-        cmp =
-          utilization(a.quota.totalUsage, a.quota.totalCapacity) -
-          utilization(b.quota.totalUsage, b.quota.totalCapacity);
+      case "capacity": {
+        const aCapacity = normalizePhysicalCapacity(a.quota);
+        const bCapacity = normalizePhysicalCapacity(b.quota);
+        cmp = utilization(aCapacity.used, aCapacity.total) - utilization(bCapacity.used, bCapacity.total);
         break;
+      }
       case "capacityFree":
-        cmp = a.quota.totalFree - b.quota.totalFree;
+        cmp = normalizePhysicalCapacity(a.quota).free - normalizePhysicalCapacity(b.quota).free;
         break;
     }
     return sort.direction === "asc" ? cmp : -cmp;

--- a/src/ui/src/features/pools/lib/pool-gpu-summary.test.ts
+++ b/src/ui/src/features/pools/lib/pool-gpu-summary.test.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { computePoolGpuSummary } from "@/features/pools/lib/pool-gpu-summary";
+import { normalizePhysicalCapacity } from "@/lib/pool-capacity";
+import { createMockPool } from "@/testing/factories";
+
+function createSharedPool(name: string) {
+  return createMockPool({
+    name,
+    quota: {
+      used: 1,
+      free: 7,
+      limit: 8,
+      totalUsage: 1,
+      totalCapacity: 8,
+      totalFree: 6,
+    },
+  });
+}
+
+describe("computePoolGpuSummary", () => {
+  it("deduplicates shared capacity while preserving pool-local usage", () => {
+    const pools = [createSharedPool("pool-a"), createSharedPool("pool-b")];
+
+    const summary = computePoolGpuSummary(pools, [["pool-a", "pool-b"]]);
+
+    expect(summary).toMatchObject({
+      totalUsage: 2,
+      totalCapacity: 8,
+      totalFree: 6,
+    });
+    expect(normalizePhysicalCapacity(summary).used).toBe(2);
+  });
+
+  it("shows full physical usage when a filtered subset contains one shared pool", () => {
+    const visiblePools = [createSharedPool("pool-a")];
+
+    const summary = computePoolGpuSummary(visiblePools, [["pool-a", "pool-b"]]);
+
+    expect(summary).toMatchObject({
+      totalUsage: 1,
+      totalCapacity: 8,
+      totalFree: 6,
+    });
+    expect(normalizePhysicalCapacity(summary).used).toBe(2);
+  });
+
+  it("normalizes each independent capacity before aggregating", () => {
+    const pools = [
+      createMockPool({
+        name: "negative-free",
+        quota: {
+          used: 1,
+          free: 7,
+          limit: 8,
+          totalUsage: 1,
+          totalCapacity: 8,
+          totalFree: -1,
+        },
+      }),
+      createMockPool({
+        name: "excessive-free",
+        quota: {
+          used: 1,
+          free: 7,
+          limit: 8,
+          totalUsage: 1,
+          totalCapacity: 8,
+          totalFree: 10,
+        },
+      }),
+    ];
+
+    const summary = computePoolGpuSummary(pools, []);
+
+    expect(summary).toMatchObject({
+      totalUsage: 2,
+      totalCapacity: 16,
+      totalFree: 8,
+    });
+    expect(normalizePhysicalCapacity(summary).used).toBe(8);
+  });
+});

--- a/src/ui/src/features/pools/lib/pool-gpu-summary.ts
+++ b/src/ui/src/features/pools/lib/pool-gpu-summary.ts
@@ -15,6 +15,7 @@
 //SPDX-License-Identifier: Apache-2.0
 
 import type { Pool, Quota } from "@/lib/api/adapter/types";
+import { normalizePhysicalCapacity } from "@/lib/pool-capacity";
 
 /**
  * Compute GPU summary for a filtered subset of pools, correctly handling
@@ -49,8 +50,9 @@ export function computePoolGpuSummary(pools: Pool[], sharingGroups: string[][]):
     }
 
     if (isUngrouped || isFirstInGroup) {
-      totalCapacity += pool.quota.totalCapacity;
-      totalFree += pool.quota.totalFree;
+      const physicalCapacity = normalizePhysicalCapacity(pool.quota);
+      totalCapacity += physicalCapacity.total;
+      totalFree += physicalCapacity.free;
     }
   }
 

--- a/src/ui/src/features/pools/lib/pool-search-fields.test.ts
+++ b/src/ui/src/features/pools/lib/pool-search-fields.test.ts
@@ -16,6 +16,59 @@
 
 import { describe, it, expect } from "vitest";
 import { parseNumericFilter, validateNumericFilter, compareNumeric } from "@/lib/filter-utils";
+import { createPoolSearchFields } from "@/features/pools/lib/pool-search-fields";
+import { createMockPool } from "@/testing/factories";
+
+describe("capacity used filter", () => {
+  it("matches physical usage across shared pools rather than pool-local usage", () => {
+    const pool = createMockPool({
+      quota: {
+        used: 1,
+        free: 7,
+        limit: 8,
+        totalUsage: 1,
+        totalCapacity: 8,
+        totalFree: 6,
+      },
+    });
+    const capacityUsed = createPoolSearchFields([]).find((field) => field.id === "capacity-used");
+
+    expect(capacityUsed?.match?.(pool, "=2")).toBe(true);
+    expect(capacityUsed?.match?.(pool, "=25%")).toBe(true);
+    expect(capacityUsed?.match?.(pool, "=1")).toBe(false);
+  });
+
+  it("normalizes used and free filters consistently for transient invalid values", () => {
+    const negativeFree = createMockPool({
+      quota: {
+        used: 1,
+        free: 7,
+        limit: 8,
+        totalUsage: 1,
+        totalCapacity: 8,
+        totalFree: -1,
+      },
+    });
+    const excessiveFree = createMockPool({
+      quota: {
+        used: 1,
+        free: 7,
+        limit: 8,
+        totalUsage: 1,
+        totalCapacity: 8,
+        totalFree: 10,
+      },
+    });
+    const fields = createPoolSearchFields([]);
+    const capacityUsed = fields.find((field) => field.id === "capacity-used");
+    const capacityFree = fields.find((field) => field.id === "capacity-free");
+
+    expect(capacityUsed?.match?.(negativeFree, "=8")).toBe(true);
+    expect(capacityFree?.match?.(negativeFree, "=0")).toBe(true);
+    expect(capacityUsed?.match?.(excessiveFree, "=0")).toBe(true);
+    expect(capacityFree?.match?.(excessiveFree, "=8")).toBe(true);
+  });
+});
 
 // =============================================================================
 // parseNumericFilter Tests

--- a/src/ui/src/features/pools/lib/pool-search-fields.ts
+++ b/src/ui/src/features/pools/lib/pool-search-fields.ts
@@ -18,6 +18,7 @@ import type { SearchField } from "@/components/filter-bar/lib/types";
 import type { Pool } from "@/lib/api/adapter/types";
 import { createNumericSearchFieldPair } from "@/lib/filter-utils";
 import { getStatusDisplay, POOL_STATUS_FILTER_VALUES } from "@/lib/pool-status";
+import { normalizePhysicalCapacity } from "@/lib/pool-capacity";
 
 // ============================================================================
 // Base Search Fields
@@ -94,10 +95,10 @@ const [capacityFree, capacityUsed] = createNumericSearchFieldPair<Pool>({
   category: "capacity",
   label: "Capacity",
   hintFree: "total GPUs available",
-  hintUsed: "pool consumption",
-  getFree: (p) => p.quota.totalFree,
-  getUsed: (p) => p.quota.totalUsage,
-  getMax: (p) => p.quota.totalCapacity,
+  hintUsed: "physical GPU consumption",
+  getFree: (p) => normalizePhysicalCapacity(p.quota).free,
+  getUsed: (p) => normalizePhysicalCapacity(p.quota).used,
+  getMax: (p) => normalizePhysicalCapacity(p.quota).total,
 });
 
 const NUMERIC_POOL_SEARCH_FIELDS: SearchField<Pool>[] = [quotaFree, quotaUsed, capacityFree, capacityUsed];

--- a/src/ui/src/lib/api/adapter/types.ts
+++ b/src/ui/src/lib/api/adapter/types.ts
@@ -50,8 +50,11 @@ export interface Quota {
   used: number;
   free: number;
   limit: number;
+  /** Running workflow usage assigned to this pool. */
   totalUsage: number;
+  /** Physical capacity of the node set backing this pool. */
   totalCapacity: number;
+  /** Physical capacity available across the node set backing this pool. */
   totalFree: number;
 }
 

--- a/src/ui/src/lib/pool-capacity.test.ts
+++ b/src/ui/src/lib/pool-capacity.test.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { normalizePhysicalCapacity } from "@/lib/pool-capacity";
+
+describe("normalizePhysicalCapacity", () => {
+  it("derives shared physical usage from capacity and free GPUs", () => {
+    expect(normalizePhysicalCapacity({ totalCapacity: 8, totalFree: 6 })).toEqual({
+      used: 2,
+      free: 6,
+      total: 8,
+    });
+  });
+
+  it("clamps inconsistent capacity values for presentation", () => {
+    expect(normalizePhysicalCapacity({ totalCapacity: 8, totalFree: 10 })).toEqual({
+      used: 0,
+      free: 8,
+      total: 8,
+    });
+    expect(normalizePhysicalCapacity({ totalCapacity: 8, totalFree: -1 })).toEqual({
+      used: 8,
+      free: 0,
+      total: 8,
+    });
+    expect(normalizePhysicalCapacity({ totalCapacity: -1, totalFree: 0 })).toEqual({
+      used: 0,
+      free: 0,
+      total: 0,
+    });
+  });
+});

--- a/src/ui/src/lib/pool-capacity.ts
+++ b/src/ui/src/lib/pool-capacity.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Quota } from "@/lib/api/adapter/types";
+
+export interface PhysicalCapacity {
+  used: number;
+  free: number;
+  total: number;
+}
+
+/**
+ * Normalize physical GPU capacity across the node set backing a pool.
+ *
+ * totalUsage is intentionally not used here: it only counts workflows assigned
+ * to one pool, while totalCapacity and totalFree cover the shared node set.
+ */
+export function normalizePhysicalCapacity(quota: Pick<Quota, "totalCapacity" | "totalFree">): PhysicalCapacity {
+  const total = Math.max(0, quota.totalCapacity);
+  const free = Math.min(total, Math.max(0, quota.totalFree));
+  return { used: total - free, free, total };
+}


### PR DESCRIPTION
## Description

Issue #None

The Pools UI labeled the API's pool-local `total_usage` value as physical "Capacity Used". For pools sharing the same node set, that omitted usage from sibling pools even though `total_capacity` and `total_free` already represented the complete shared hardware.

This change:

- derives physical capacity usage from normalized `total_capacity - total_free`
- uses the same normalized capacity tuple in the pools table, detail panel, aggregate summary, sorting, filtering, and workflow pool picker
- preserves `total_usage` as pool-local running workflow usage
- adds regression coverage for shared pools and transient inconsistent capacity values

## Verification

- `pnpm test` — 46 files, 1,016 tests passed
- focused capacity tests — 5 files, 68 tests passed
- isolated changed-file TypeScript check — passed
- touched-file ESLint — passed
- touched-file Prettier check — passed
- `git diff --check` — passed

The repository-wide `pnpm type-check` remains blocked by pre-existing stale `.next` dataset-route imports and unrelated Orval configuration type errors; no changed file produced a TypeScript error.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU capacity reporting across pool cards, tables, summaries, sorting, and search filters.
  * Corrected handling of inconsistent capacity data, including negative or excessive free-capacity values.
  * Preserved accurate shared GPU capacity calculations across pools.

* **Tests**
  * Added coverage for capacity normalization, aggregation, sorting, table values, and search filtering.

* **Documentation**
  * Clarified quota field descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->