### PR TITLE
Fix documentation spelling wordlist

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -36,6 +36,7 @@ benchtop
 Bitnami
 boto
 botocore
+cardinality
 Ceph
 checkpointing
 Checkpointing
@@ -262,6 +263,7 @@ redis
 repo
 requeued
 reschedulable
+resubmission
 resrcs
 restitutions
 retryable


### PR DESCRIPTION


## Description
Fixed the three docs spell-check warnings by adding cardinality and resubmission to the external docs wordlist.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added “cardinality” and “resubmission” to the spelling wordlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->