### PR TITLE
Add labels_config.pod_label_prefix for namespaced pod labels

### DIFF
--- a/src/lib/utils/tests/test_validation.py
+++ b/src/lib/utils/tests/test_validation.py
@@ -447,8 +447,8 @@ class TestPodLabelPrefix(unittest.TestCase):
     def test_prefix_is_prepended_to_every_key(self):
         self.assertEqual(
             validation.apply_pod_label_prefix(
-                {'PPP': 'aurora', 'team': 'alpha'}, 'osmo.nvidia.com/'),
-            {'osmo.nvidia.com/PPP': 'aurora', 'osmo.nvidia.com/team': 'alpha'},
+                {'PPP': 'aurora', 'team': 'alpha'}, 'example.com/'),
+            {'example.com/PPP': 'aurora', 'example.com/team': 'alpha'},
         )
 
     def test_non_dns_prefix_is_prepended_verbatim(self):
@@ -464,23 +464,23 @@ class TestPodLabelPrefix(unittest.TestCase):
 
     def test_valid_merged_keys_pass_validation(self):
         validation.validate_prefixed_workflow_label_keys(
-            {'PPP': 'aurora', 'team': 'alpha'}, 'osmo.nvidia.com/')
+            {'PPP': 'aurora', 'team': 'alpha'}, 'example.com/')
 
     def test_merged_key_with_two_slashes_is_rejected(self):
         # A user key that already carries its own prefix would form a
         # double-slash key once the pod-label prefix is prepended.
         with self.assertRaisesRegex(
-                ValueError, r'osmo\.nvidia\.com/team\.example\.com/role'):
+                ValueError, r'example\.com/team\.example\.com/role'):
             validation.validate_prefixed_workflow_label_keys(
-                {'team.example.com/role': 'lead'}, 'osmo.nvidia.com/')
+                {'team.example.com/role': 'lead'}, 'example.com/')
 
     def test_error_names_the_key_and_prefix(self):
         with self.assertRaises(ValueError) as raised:
             validation.validate_prefixed_workflow_label_keys(
-                {'team.example.com/role': 'lead'}, 'osmo.nvidia.com/')
+                {'team.example.com/role': 'lead'}, 'example.com/')
         message = str(raised.exception)
         self.assertIn('team.example.com/role', message)
-        self.assertIn('osmo.nvidia.com/', message)
+        self.assertIn('example.com/', message)
 
 
 if __name__ == '__main__':

--- a/src/lib/utils/tests/test_validation.py
+++ b/src/lib/utils/tests/test_validation.py
@@ -437,5 +437,51 @@ class TestWorkflowLabelValidation(unittest.TestCase):
             validation.parse_workflow_label_selector('PPP=' + 'x' * 63 + '*')
 
 
+class TestPodLabelPrefix(unittest.TestCase):
+    """Tests for the pod-label prefix merge and its validation."""
+
+    def test_empty_prefix_returns_keys_unchanged(self):
+        labels = {'PPP': 'aurora', 'team': 'alpha'}
+        self.assertEqual(validation.apply_pod_label_prefix(labels, ''), labels)
+
+    def test_prefix_is_prepended_to_every_key(self):
+        self.assertEqual(
+            validation.apply_pod_label_prefix(
+                {'PPP': 'aurora', 'team': 'alpha'}, 'osmo.nvidia.com/'),
+            {'osmo.nvidia.com/PPP': 'aurora', 'osmo.nvidia.com/team': 'alpha'},
+        )
+
+    def test_non_dns_prefix_is_prepended_verbatim(self):
+        # The prefix is opaque; a bare (non-slash) prefix is merged as-is.
+        self.assertEqual(
+            validation.apply_pod_label_prefix({'PPP': 'aurora'}, 'osmo_'),
+            {'osmo_PPP': 'aurora'},
+        )
+
+    def test_empty_prefix_validation_is_a_no_op(self):
+        validation.validate_prefixed_workflow_label_keys(
+            {'anything/goes': 'value'}, '')
+
+    def test_valid_merged_keys_pass_validation(self):
+        validation.validate_prefixed_workflow_label_keys(
+            {'PPP': 'aurora', 'team': 'alpha'}, 'osmo.nvidia.com/')
+
+    def test_merged_key_with_two_slashes_is_rejected(self):
+        # A user key that already carries its own prefix would form a
+        # double-slash key once the pod-label prefix is prepended.
+        with self.assertRaisesRegex(
+                ValueError, r'osmo\.nvidia\.com/team\.example\.com/role'):
+            validation.validate_prefixed_workflow_label_keys(
+                {'team.example.com/role': 'lead'}, 'osmo.nvidia.com/')
+
+    def test_error_names_the_key_and_prefix(self):
+        with self.assertRaises(ValueError) as raised:
+            validation.validate_prefixed_workflow_label_keys(
+                {'team.example.com/role': 'lead'}, 'osmo.nvidia.com/')
+        message = str(raised.exception)
+        self.assertIn('team.example.com/role', message)
+        self.assertIn('osmo.nvidia.com/', message)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/lib/utils/validation.py
+++ b/src/lib/utils/validation.py
@@ -105,6 +105,41 @@ def validate_workflow_labels(labels: Mapping[str, str]) -> dict[str, str]:
     return dict(labels)
 
 
+def apply_pod_label_prefix(
+        labels: Mapping[str, str], pod_label_prefix: str) -> dict[str, str]:
+    """Prepend the configured pod-label prefix to every workflow label key.
+
+    Returns a copy with keys unchanged when the prefix is empty. The prefix is
+    an opaque string prepended verbatim; callers validate the resulting keys
+    with validate_prefixed_workflow_label_keys before stamping them onto pods.
+    """
+    if not pod_label_prefix:
+        return dict(labels)
+    return {f'{pod_label_prefix}{key}': value for key, value in labels.items()}
+
+
+def validate_prefixed_workflow_label_keys(
+        labels: Mapping[str, str], pod_label_prefix: str) -> None:
+    """Validate every label key once the pod-label prefix is prepended.
+
+    The prefix is not assumed to be a DNS prefix: the key and prefix are merged
+    first, then the result is validated as a Kubernetes label key. Raises
+    ValueError naming the key, the prefix, and the resulting key on the first
+    invalid merge.
+    """
+    if not pod_label_prefix:
+        return
+    for key in labels:
+        prefixed_key = f'{pod_label_prefix}{key}'
+        try:
+            validate_workflow_label_key(prefixed_key)
+        except ValueError as error:
+            raise ValueError(
+                f'Label key "{key}" with the configured pod label prefix '
+                f'"{pod_label_prefix}" forms an invalid Kubernetes label key '
+                f'"{prefixed_key}": {error}') from error
+
+
 def parse_workflow_label_assignment(assignment: str) -> tuple[str, str]:
     """Parse and validate a workflow label assignment in key=value form."""
     if '=' not in assignment:

--- a/src/service/core/workflow/objects.py
+++ b/src/service/core/workflow/objects.py
@@ -1063,7 +1063,14 @@ class WorkflowSubmitInfo(pydantic.BaseModel):
         messages, and raises OSMOUsageError on the first enforce-mode
         violation.
         """
-        policies = self.context.database.get_workflow_configs().labels_config.policy
+        labels_config = self.context.database.get_workflow_configs().labels_config
+        try:
+            validation.validate_prefixed_workflow_label_keys(
+                rendered_spec.labels, labels_config.pod_label_prefix)
+        except ValueError as error:
+            raise osmo_errors.OSMOUsageError(
+                str(error), workflow_id=self.name) from error
+        policies = labels_config.policy
         warnings: List[str] = []
         rejection: WorkflowLabelPolicyOutcome | None = None
 

--- a/src/service/core/workflow/tests/test_workflow_labels.py
+++ b/src/service/core/workflow/tests/test_workflow_labels.py
@@ -42,10 +42,13 @@ def _label_policy(
     )
 
 
-def _submit_info(policy: list[connectors.LabelPolicy]) -> objects.WorkflowSubmitInfo:
+def _submit_info(
+        policy: list[connectors.LabelPolicy],
+        pod_label_prefix: str = '') -> objects.WorkflowSubmitInfo:
     database = mock.Mock()
     database.get_workflow_configs.return_value = types.SimpleNamespace(
-        labels_config=types.SimpleNamespace(policy=policy),
+        labels_config=types.SimpleNamespace(
+            policy=policy, pod_label_prefix=pod_label_prefix),
     )
     context = cast(
         objects.WorkflowServiceContext,
@@ -494,6 +497,34 @@ class TestWorkflowLabelPolicy(unittest.TestCase):
             metric_creator.send_counter.call_args_list,
             expected_calls,
         )
+
+
+class TestPodLabelPrefixGate(unittest.TestCase):
+    """Covers the pod-label-prefix merge check in the submission gate."""
+
+    def test_no_prefix_accepts_any_valid_label_key(self):
+        submit_info = _submit_info([])
+        self.assertEqual(
+            submit_info.validate_workflow_label_policy(
+                _rendered_spec({'team.example.com/role': 'lead'})),
+            [],
+        )
+
+    def test_prefix_accepts_bare_keys(self):
+        submit_info = _submit_info([], pod_label_prefix='osmo.nvidia.com/')
+        self.assertEqual(
+            submit_info.validate_workflow_label_policy(
+                _rendered_spec({'PPP': 'aurora'})),
+            [],
+        )
+
+    def test_prefix_rejects_key_that_forms_an_invalid_merged_key(self):
+        submit_info = _submit_info([], pod_label_prefix='osmo.nvidia.com/')
+        with self.assertRaises(osmo_errors.OSMOUsageError) as raised:
+            submit_info.validate_workflow_label_policy(
+                _rendered_spec({'team.example.com/role': 'lead'}))
+        self.assertIn(
+            'osmo.nvidia.com/team.example.com/role', raised.exception.message)
 
 
 class TestWorkflowLabelResponses(unittest.TestCase):

--- a/src/service/core/workflow/tests/test_workflow_labels.py
+++ b/src/service/core/workflow/tests/test_workflow_labels.py
@@ -511,7 +511,7 @@ class TestPodLabelPrefixGate(unittest.TestCase):
         )
 
     def test_prefix_accepts_bare_keys(self):
-        submit_info = _submit_info([], pod_label_prefix='osmo.nvidia.com/')
+        submit_info = _submit_info([], pod_label_prefix='example.com/')
         self.assertEqual(
             submit_info.validate_workflow_label_policy(
                 _rendered_spec({'PPP': 'aurora'})),
@@ -519,12 +519,12 @@ class TestPodLabelPrefixGate(unittest.TestCase):
         )
 
     def test_prefix_rejects_key_that_forms_an_invalid_merged_key(self):
-        submit_info = _submit_info([], pod_label_prefix='osmo.nvidia.com/')
+        submit_info = _submit_info([], pod_label_prefix='example.com/')
         with self.assertRaises(osmo_errors.OSMOUsageError) as raised:
             submit_info.validate_workflow_label_policy(
                 _rendered_spec({'team.example.com/role': 'lead'}))
         self.assertIn(
-            'osmo.nvidia.com/team.example.com/role', raised.exception.message)
+            'example.com/team.example.com/role', raised.exception.message)
 
 
 class TestWorkflowLabelResponses(unittest.TestCase):

--- a/src/ui/openapi.json
+++ b/src/ui/openapi.json
@@ -8769,6 +8769,11 @@
             "type": "array",
             "title": "Policy",
             "default": []
+          },
+          "pod_label_prefix": {
+            "type": "string",
+            "title": "Pod Label Prefix",
+            "default": ""
           }
         },
         "additionalProperties": false,
@@ -8785,6 +8790,11 @@
             "type": "array",
             "title": "Policy",
             "default": []
+          },
+          "pod_label_prefix": {
+            "type": "string",
+            "title": "Pod Label Prefix",
+            "default": ""
           }
         },
         "additionalProperties": false,
@@ -13270,7 +13280,8 @@
           "labels_config": {
             "$ref": "#/components/schemas/LabelsConfig-Input",
             "default": {
-              "policy": []
+              "policy": [],
+              "pod_label_prefix": ""
             }
           },
           "max_num_tasks": {
@@ -13437,7 +13448,8 @@
           "labels_config": {
             "$ref": "#/components/schemas/LabelsConfig-Output",
             "default": {
-              "policy": []
+              "policy": [],
+              "pod_label_prefix": ""
             }
           },
           "max_num_tasks": {

--- a/src/ui/src/lib/api/generated.ts
+++ b/src/ui/src/lib/api/generated.ts
@@ -707,6 +707,7 @@ export interface LabelPolicy {
  */
 export interface LabelsConfigInput {
   policy?: LabelPolicy[];
+  pod_label_prefix?: string;
 }
 
 /**
@@ -715,6 +716,7 @@ export interface LabelsConfigInput {
  */
 export interface LabelsConfigOutput {
   policy?: LabelPolicy[];
+  pod_label_prefix?: string;
 }
 
 /**

--- a/src/ui/src/mocks/generated-mocks.ts
+++ b/src/ui/src/mocks/generated-mocks.ts
@@ -687,6 +687,7 @@ export interface LabelPolicy {
  */
 export interface LabelsConfigInput {
   policy?: LabelPolicy[];
+  pod_label_prefix?: string;
 }
 
 /**
@@ -695,6 +696,7 @@ export interface LabelsConfigInput {
  */
 export interface LabelsConfigOutput {
   policy?: LabelPolicy[];
+  pod_label_prefix?: string;
 }
 
 /**
@@ -8362,6 +8364,7 @@ export const getReadWorkflowConfigsApiConfigsWorkflowGetResponseMock = (
       enforcement: faker.helpers.arrayElement(Object.values(LabelEnforcement)),
       assert_message: faker.string.alpha({ length: { min: 10, max: 20 } }),
     })),
+    pod_label_prefix: faker.string.alpha({ length: { min: 10, max: 20 } }),
   },
   max_num_tasks: faker.number.int(),
   max_num_ports_per_task: faker.number.int(),

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -2980,6 +2980,12 @@ class LabelsConfig(ExtraArgBaseModel):
     """Curated workflow label policy; empty by default, so no policy
     applies until configured."""
     policy: List[LabelPolicy] = []
+    # Prepended to every workflow label key before it is stamped onto pod
+    # labels, so operators can namespace user labels (e.g. 'example.com/')
+    # without users typing the prefix on every spec or query. Empty by default
+    # to keep the OSS default deployment-neutral. Not assumed to be a DNS
+    # prefix: the merged key is validated at submission, not this field.
+    pod_label_prefix: str = ''
 
     @pydantic.field_validator('policy')
     @classmethod
@@ -2993,6 +2999,18 @@ class LabelsConfig(ExtraArgBaseModel):
         if len(keys) != len(set(keys)):
             raise ValueError('Duplicate label policy key.')
         return policy
+
+    @pydantic.field_validator('pod_label_prefix')
+    @classmethod
+    def validate_pod_label_prefix(cls, pod_label_prefix: str) -> str:
+        # Structure-agnostic sanity only; a whitespace-bearing or oversized
+        # prefix would make every label key invalid. Full validity is checked
+        # per-key at submission once the prefix is merged with the user's key.
+        if any(character in pod_label_prefix for character in ' \t\r\n'):
+            raise ValueError('Label pod_label_prefix must not contain whitespace.')
+        if len(pod_label_prefix) > 253:
+            raise ValueError('Label pod_label_prefix must be at most 253 characters.')
+        return pod_label_prefix
 
 
 class WorkflowConfig(DynamicConfig):

--- a/src/utils/connectors/tests/test_workflow_config.py
+++ b/src/utils/connectors/tests/test_workflow_config.py
@@ -31,15 +31,15 @@ class TestWorkflowLabelsConfig(unittest.TestCase):
 
     def test_accepts_pod_label_prefix(self):
         config = connectors.WorkflowConfig(labels_config={
-            'pod_label_prefix': 'osmo.nvidia.com/',
+            'pod_label_prefix': 'example.com/',
         })
         self.assertEqual(
-            config.labels_config.pod_label_prefix, 'osmo.nvidia.com/')
+            config.labels_config.pod_label_prefix, 'example.com/')
 
     def test_rejects_pod_label_prefix_with_whitespace_or_overlong(self):
         with self.assertRaisesRegex(pydantic.ValidationError, 'whitespace'):
             connectors.WorkflowConfig(labels_config={
-                'pod_label_prefix': 'osmo nvidia/',
+                'pod_label_prefix': 'has space/',
             })
         with self.assertRaisesRegex(pydantic.ValidationError, 'at most 253'):
             connectors.WorkflowConfig(labels_config={

--- a/src/utils/connectors/tests/test_workflow_config.py
+++ b/src/utils/connectors/tests/test_workflow_config.py
@@ -27,6 +27,24 @@ class TestWorkflowLabelsConfig(unittest.TestCase):
 
     def test_defaults_are_inert(self):
         self.assertEqual(connectors.WorkflowConfig().labels_config.policy, [])
+        self.assertEqual(connectors.WorkflowConfig().labels_config.pod_label_prefix, '')
+
+    def test_accepts_pod_label_prefix(self):
+        config = connectors.WorkflowConfig(labels_config={
+            'pod_label_prefix': 'osmo.nvidia.com/',
+        })
+        self.assertEqual(
+            config.labels_config.pod_label_prefix, 'osmo.nvidia.com/')
+
+    def test_rejects_pod_label_prefix_with_whitespace_or_overlong(self):
+        with self.assertRaisesRegex(pydantic.ValidationError, 'whitespace'):
+            connectors.WorkflowConfig(labels_config={
+                'pod_label_prefix': 'osmo nvidia/',
+            })
+        with self.assertRaisesRegex(pydantic.ValidationError, 'at most 253'):
+            connectors.WorkflowConfig(labels_config={
+                'pod_label_prefix': 'x' * 254,
+            })
 
     def test_accepts_independent_enforcement_modes(self):
         config = connectors.WorkflowConfig(labels_config={

--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -37,7 +37,7 @@ import pydantic
 import yaml
 
 from src.lib.data import storage
-from src.lib.utils import common, osmo_errors, priority as wf_priority
+from src.lib.utils import common, osmo_errors, priority as wf_priority, validation
 from src.lib.utils.redact import redact_pod_spec_env
 from src.utils import connectors
 from src.utils.job import app, backend_job_defs, common as task_common, kb_objects, task, workflow
@@ -512,7 +512,8 @@ class CreateGroup(BackendJob, WorkflowJob, backend_job_defs.BackendCreateGroupMi
                 progress_iter_freq,
                 workflow_obj.plugins,
                 workflow_obj.priority,
-                workflow_labels=workflow_obj.labels,
+                workflow_labels=validation.apply_pod_label_prefix(
+                    workflow_obj.labels, workflow_config.labels_config.pod_label_prefix),
             )
             self.k8s_resources = resources
             group_obj.update_group_template_resource_types()
@@ -1212,7 +1213,8 @@ class UpdateGroup(WorkflowJob):
             workflow_config,
             backend_config,
             workflow_obj.priority,
-            workflow_labels=workflow_obj.labels,
+            workflow_labels=validation.apply_pod_label_prefix(
+                workflow_obj.labels, workflow_config.labels_config.pod_label_prefix),
             skip_refresh_token=True,
         )
         k8s_factory.update_pod_k8s_resource(pod, group.group_uuid, pool, workflow_obj.priority)

--- a/src/utils/job/tests/test_jobs_pure.py
+++ b/src/utils/job/tests/test_jobs_pure.py
@@ -1370,7 +1370,9 @@ class CreateGroupPrepareExecuteTest(unittest.TestCase):
         wf.labels = {'project': 'project-a'}
 
         ctx = mock.Mock()
-        ctx.postgres.get_workflow_configs.return_value = mock.Mock()
+        wf_config = mock.Mock()
+        wf_config.labels_config.pod_label_prefix = ''
+        ctx.postgres.get_workflow_configs.return_value = wf_config
 
         with mock.patch.object(task.TaskGroup, 'fetch_from_db', return_value=group), \
              mock.patch.object(connectors, 'BackendConfigCache',
@@ -1380,7 +1382,7 @@ class CreateGroupPrepareExecuteTest(unittest.TestCase):
                                side_effect=lambda x: x), \
              mock.patch.object(jobs.UploadWorkflowFiles, 'send_job_to_queue') \
                  as mock_send:
-            ready, error = cg.prepare_execute(mock.Mock(), mock.Mock())
+            ready, error = cg.prepare_execute(ctx, mock.Mock())
         self.assertTrue(ready)
         self.assertEqual(error, '')
         mock_send.assert_called_once()

--- a/src/utils/job/tests/test_task_pure.py
+++ b/src/utils/job/tests/test_task_pure.py
@@ -284,6 +284,8 @@ class RetryTaskK8sResourcesTest(unittest.TestCase):
         workflow_obj.plugins = mock.Mock()
         workflow_obj.priority = wf_priority.WorkflowPriority.NORMAL
         workflow_obj.labels = {'project': 'project-a'}
+        workflow_config = mock.Mock(max_error_log_lines=1000)
+        workflow_config.labels_config.pod_label_prefix = ''
         update_job = jobs.UpdateGroup(
             workflow_id='workflow-1',
             workflow_uuid=workflow_uuid,
@@ -303,7 +305,7 @@ class RetryTaskK8sResourcesTest(unittest.TestCase):
                 task_obj,
                 group,
                 'default',
-                mock.Mock(max_error_log_lines=1000),
+                workflow_config,
                 mock.Mock(),
                 context,
                 progress_writer,


### PR DESCRIPTION
## Summary

Issue - None

Adds `labels_config.pod_label_prefix` (empty by default) so an operator can namespace user workflow labels **on pods** without users typing the prefix on every spec or query.

Motivation: on a shared cluster, cluster-level label-based telemetry (for example a kube-state-metrics label allowlist) keyed on a short label name can accidentally match an unrelated pod that happens to carry the same key. Namespacing the label key with a domain prefix avoids that. Keeping the prefix in `labels_config` (rather than in every spec and filter) means users are unaffected and the OSS repo stays deployment-neutral.

## Design

- **Prefix at stamp time only.** The workflow row (`workflows.labels`), list filters (`label=`/`no_label=`), CLI, UI, and service metrics keep operating on the **bare** keys the user typed. The prefix is prepended to each key only when the labels are stamped onto pod `metadata.labels`, so submit/query UX is unchanged.
- **Opaque prefix, merge-then-validate.** The prefix is not assumed to be a DNS prefix. The key and prefix are concatenated first, then the merged key is validated as a Kubernetes label key **at submission** (including validation-only submits). A user key that would form an invalid merged key (e.g. one that already carries its own `/` prefix) is rejected with a message naming the key, the configured prefix, and the resulting key.
- **Deployment-neutral default.** OSS ships `pod_label_prefix: ''`. An operator sets it (e.g. a domain it controls, `example.com/`) in its own `labels_config`.
- **Unaffected:** system `osmo.*` labels, the `osmo.*`→env-var derivation (it runs on the system label dict, never on user `workflow_labels`), and all read paths.

## Changes

- `LabelsConfig.pod_label_prefix` field + light structure-agnostic validator (no whitespace, ≤253 chars); full validity is enforced per-key at submission.
- `validation.apply_pod_label_prefix` (stamp transform) and `validate_prefixed_workflow_label_keys` (submission check).
- Submission gate (`validate_workflow_label_policy`) validates merged keys; stamping applies the prefix at both pod-build sites in `jobs.py`.
- Regenerated `openapi.json`, `generated.ts`, `generated-mocks.ts` (additive optional field only).

## Testing

- `bazel test //src/lib/utils/tests:test_validation //src/service/core/workflow/tests:test_workflow_labels //src/utils/connectors/tests:test_workflow_config //src/utils/job/tests:test_jobs_pure //src/utils/job/tests:test_task_pure` — pass (mypy aspect clean).
- pylint on validation/objects/postgres/jobs — pass.
- `pnpm type-check` — pass.
- New unit tests: the prefix transform (empty/bare/non-DNS/two-slash), the schema field + validator, and the submission gate (accepts bare keys, rejects invalid merged keys, no-ops when unset).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
