### PR TITLE
Fix fractional CPU example in resource tutorial

### DIFF
--- a/docs/user_guide/tutorials/requesting_resources.rst
+++ b/docs/user_guide/tutorials/requesting_resources.rst
@@ -37,7 +37,7 @@ Understanding Resources
 
 Resources in OSMO are specified using standard Kubernetes resource notation:
 
-- CPU: Cores (e.g., ``1``, ``2``, ``0.5``)
+- CPU: Whole CPU cores (integers only; e.g., ``1``, ``2``)
 - Memory: Bytes with units (e.g., ``1Gi``, ``512Mi``, ``2Gi``)
 - Storage: Bytes with units (e.g., ``10Gi``, ``100Mi``)
 - GPU: Count (e.g., ``1``, ``2``, ``4``)


### PR DESCRIPTION
## Description

Corrects the Requesting Resources tutorial to match the OSMO workflow schema. CPU requests are documented as whole integer cores, and the unsupported 0.5 example is removed.

Fractional CPU support would require a separate product and schema change; OSMO 6.3 and current main validate workflow CPU as an integer.

Issue - None

## Verification

- git diff --check
- Confirmed the corrected CPU guidance is present and the old 0.5 CPU example is absent from the documentation sources
- Reviewed the guidance against the ResourceSpec CPU integer schema

Full local Sphinx build and spelling checks were attempted but could not complete because the existing docs environment scans docs/.venv and hits an unrelated autodoc syntax error. No tracked build artifacts were produced.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that CPU resource requests must use whole CPU cores.
  * Updated the example to remove fractional CPU values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->