### PR TITLE
Preserve service auth identity in ConfigMap mode

### DIFF
--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -131,10 +131,8 @@ class ConfigMapWatcher:
         backend_queue_updater: Callable[..., bool] | None = None,
         backend_test_updater: Callable[..., bool] | None = None,
     ):
-        # Kept for existing service/test wiring. ConfigMap loads must not
-        # hydrate ConfigMap-managed values from Postgres.
-        del postgres
         self._config_file_path = config_file_path
+        self._postgres = postgres
         self._event_recorder = event_recorder
         self._enable_reconciliation = enable_reconciliation
         self._backend_queue_updater = backend_queue_updater
@@ -244,6 +242,8 @@ class ConfigMapWatcher:
             if isinstance(section, dict):
                 _resolve_secret_file_references(section)
 
+        self._hydrate_service_auth(managed_configs)
+
         validation_errors = _validate_configmap_runtime_contract(managed_configs)
         validation_errors.extend(_validate_configs(managed_configs))
         if validation_errors:
@@ -282,6 +282,32 @@ class ConfigMapWatcher:
 
         return LoadResult.SUCCESS
 
+    def _hydrate_service_auth(
+        self, managed_configs: Dict[str, Any],
+    ) -> None:
+        """Preserve the stable JWT signing identity in ConfigMap mode."""
+        service_config = managed_configs.setdefault('service', {})
+        if not isinstance(service_config, dict):
+            return
+        if 'service_auth' in service_config:
+            return
+
+        previous_snapshot = configmap_guard.get_snapshot()
+        if previous_snapshot is not None:
+            previous_service_config = previous_snapshot.get('service', {})
+        elif self._postgres is not None:
+            persisted_service_config = self._postgres.get_service_configs()
+            previous_service_config = persisted_service_config.plaintext_dict(
+                by_alias=True, exclude_unset=True)
+        else:
+            previous_service_config = {}
+
+        if (isinstance(previous_service_config, dict)
+                and 'service_auth' in previous_service_config):
+            service_config['service_auth'] = copy.deepcopy(
+                previous_service_config['service_auth'])
+
+
 def start_config_watcher(
     config_file: str | None,
     postgres: connectors.PostgresConnector | None = None,
@@ -304,8 +330,10 @@ def start_config_watcher(
     are handled defensively by configmap_events; this gate just avoids
     cross-service duplication.)
 
-    ConfigMap mode is authoritative for service config. The watcher does
-    not read config rows from Postgres.
+    ConfigMap mode is authoritative for managed config. On the first load,
+    the watcher recovers the stable service-auth signing identity from
+    Postgres when it is not supplied explicitly; reloads preserve the identity
+    from the previous in-memory snapshot.
     """
     if not config_file:
         return None
@@ -723,11 +751,17 @@ def _validate_configmap_runtime_contract(
 ) -> List[str]:
     """Validate runtime fields that ConfigMap mode must own.
 
-    ConfigMap mode does not hydrate config from DB. Fields that used to be
-    DB/runtime-derived but are required for backend side effects must therefore
-    be present in the ConfigMap.
+    Runtime fields must be present after explicit secret resolution and
+    compatibility hydration.
     """
     errors: List[str] = []
+
+    service_config = managed_configs.get('service')
+    if (not isinstance(service_config, dict)
+            or 'service_auth' not in service_config):
+        errors.append(
+            'service.service_auth: required in ConfigMap mode; configure it '
+            'from a Secret or preserve the persisted service configuration')
 
     backends = managed_configs.get('backends', {})
     if isinstance(backends, dict):

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -976,7 +976,14 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_cold_load_allows_missing_service_auth(self):
+    def test_cold_load_hydrates_service_auth_from_postgres(self):
+        persisted_auth = _service_auth_config()
+        persisted_service_config = mock.MagicMock()
+        persisted_service_config.plaintext_dict.return_value = {
+            'service_auth': persisted_auth,
+        }
+        postgres = mock.MagicMock()
+        postgres.get_service_configs.return_value = persisted_service_config
         config: Dict[str, Any] = {
             'service': {
                 'max_pod_restart_limit': '30m',
@@ -984,16 +991,26 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(config)
         try:
-            watcher = configmap_loader.ConfigMapWatcher(path)
+            watcher = configmap_loader.ConfigMapWatcher(path, postgres)
             result = watcher._load_and_apply()
             self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
             snapshot = configmap_state.get_snapshot()
             assert snapshot is not None
-            self.assertNotIn('service_auth', snapshot['service'])
+            self.assertEqual(
+                snapshot['service']['service_auth'], persisted_auth)
+            self.assertEqual(
+                snapshot['service']['max_pod_restart_limit'], '30m')
+            first_service_config = configmap_loader.connectors.ServiceConfig(
+                **snapshot['service'])
+            second_service_config = configmap_loader.connectors.ServiceConfig(
+                **snapshot['service'])
+            self.assertEqual(
+                first_service_config.service_auth.active_key,
+                second_service_config.service_auth.active_key)
         finally:
             os.unlink(path)
 
-    def test_reload_does_not_carry_forward_service_auth(self):
+    def test_reload_carries_forward_service_auth(self):
         previous_auth = _service_auth_config()
         configmap_state.set_parsed_configs({
             'service': {'service_auth': previous_auth},
@@ -1012,9 +1029,49 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             snapshot = configmap_state.get_snapshot()
             assert snapshot is not None
             service_config = snapshot['service']
-            self.assertNotIn('service_auth', service_config)
+            self.assertEqual(service_config['service_auth'], previous_auth)
             self.assertEqual(
                 service_config['max_pod_restart_limit'], '45m')
+        finally:
+            os.unlink(path)
+
+    def test_explicit_service_auth_takes_precedence(self):
+        explicit_auth = _service_auth_config()
+        persisted_service_config = mock.MagicMock()
+        persisted_service_config.plaintext_dict.return_value = {
+            'service_auth': {'unexpected': 'persisted-auth'},
+        }
+        postgres = mock.MagicMock()
+        postgres.get_service_configs.return_value = persisted_service_config
+        path = self._write_config_file({
+            'service': {
+                'service_auth': explicit_auth,
+                'max_pod_restart_limit': '30m',
+            },
+        })
+        try:
+            watcher = configmap_loader.ConfigMapWatcher(path, postgres)
+            result = watcher._load_and_apply()
+            self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
+            snapshot = configmap_state.get_snapshot()
+            assert snapshot is not None
+            self.assertEqual(
+                snapshot['service']['service_auth'], explicit_auth)
+        finally:
+            os.unlink(path)
+
+    def test_missing_service_auth_without_runtime_source_fails(self):
+        path = self._write_config_file({
+            'service': {
+                'max_pod_restart_limit': '30m',
+            },
+        })
+        try:
+            watcher = configmap_loader.ConfigMapWatcher(path)
+            result = watcher._load_and_apply()
+            self.assertEqual(
+                result, configmap_loader.LoadResult.PERMANENT_FAILURE)
+            self.assertIsNone(configmap_state.get_snapshot())
         finally:
             os.unlink(path)
 
@@ -1272,7 +1329,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         new_config = copy.deepcopy(old_snapshot)
         new_config['backends']['backend-a']['scheduler_settings'][
             'scheduler_timeout'] = 60
-        path = self._write_config_file(new_config)
+        path = self._write_config_file(_with_service_auth(new_config))
         try:
             watcher = configmap_loader.ConfigMapWatcher(
                 path, enable_reconciliation=True)
@@ -1349,7 +1406,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         new_config['pools']['pool-a']['platforms']['gpu'] = {
             'default_variables': {'A': 2},
         }
-        path = self._write_config_file(new_config)
+        path = self._write_config_file(_with_service_auth(new_config))
         try:
             watcher = configmap_loader.ConfigMapWatcher(
                 path, enable_reconciliation=True)
@@ -1572,7 +1629,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         new_config['pod_templates']['tmpl-a'] = {
             'spec': {'containers': [{'name': 'main'}]},
         }
-        path = self._write_config_file(new_config)
+        path = self._write_config_file(_with_service_auth(new_config))
         try:
             watcher = configmap_loader.ConfigMapWatcher(
                 path, enable_reconciliation=True)
@@ -1650,7 +1707,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         new_config['pod_templates']['tmpl-a'] = {
             'spec': {'containers': [{'name': 'main'}]},
         }
-        path = self._write_config_file(new_config)
+        path = self._write_config_file(_with_service_auth(new_config))
         try:
             watcher = configmap_loader.ConfigMapWatcher(
                 path, enable_reconciliation=True)
@@ -2296,7 +2353,7 @@ class TestResolvePoolComputedFields(unittest.TestCase):
         }
         with tempfile.NamedTemporaryFile(
                 mode='w', suffix='.yaml', delete=False) as temp:
-            yaml.dump(config, temp)
+            yaml.dump(_with_service_auth(config), temp)
             path = temp.name
 
         try:
@@ -2374,11 +2431,8 @@ class TestStartConfigWatcher(unittest.TestCase):
         self.assertIsNone(watcher)
         self.assertFalse(configmap_state.is_configmap_mode())
 
-    def test_non_api_service_skips_event_recorder_and_db_config_load(self):
-        """Worker/agent/logger must NOT emit K8s reload events (replicas
-        would race on the same Event object) and must not hydrate config
-        from Postgres when ConfigMap mode is active.
-        """
+    def test_non_api_service_with_explicit_auth_skips_event_recorder_and_db(self):
+        """Explicit auth avoids DB hydration and non-API event duplication."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             config_path = os.path.join(tmp_dir, 'config.yaml')
             with open(config_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Description

Issue #None

ConfigMap mode currently drops `service_auth` from the in-memory snapshot when the field is omitted from the ConfigMap. Every subsequent `ServiceConfig` construction then invokes the default factory and generates a new RSA signing identity. Tokens minted by one request can therefore fail validation against JWKS returned by the next request, which prevents backend listeners and workers from authenticating.

This change treats `service_auth` as a stable runtime identity while leaving ConfigMap data authoritative for all managed configuration:

- explicit ConfigMap/Secret-resolved `service_auth` takes precedence;
- cold starts recover the existing identity from PostgreSQL;
- reloads carry the identity forward from the previous snapshot;
- loads fail closed if no stable identity is available.

The change does not generate or persist new signing keys and does not hydrate any other ConfigMap-managed field from PostgreSQL.

## Validation

- `bazel test //src/service/core/config/tests:test_configmap_loader_unit --test_output=errors`
- Red/green regression coverage for cold-start hydration, reload carry-forward, explicit precedence, fail-closed behavior, and repeated key stability.
- ConfigMap integration and auth-service targets were attempted locally but could not start because this machine has no Docker socket; both use testcontainers and ran zero tests. The draft PR CI is expected to run them in the supported environment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes; no user-facing documentation change is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration loading now preserves service authentication across reloads.
  * Missing authentication can be recovered from persisted configuration when available.
  * Explicit authentication settings take precedence over recovered values.
  * Invalid configurations without a usable authentication source are rejected earlier.

* **Documentation**
  * Clarified configuration authority and service-authentication recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->