### PR TITLE
Keep service auth PostgreSQL-owned in ConfigMap mode

### DIFF
--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -131,10 +131,8 @@ class ConfigMapWatcher:
         backend_queue_updater: Callable[..., bool] | None = None,
         backend_test_updater: Callable[..., bool] | None = None,
     ):
-        # Kept for existing service/test wiring. ConfigMap loads must not
-        # hydrate ConfigMap-managed values from Postgres.
-        del postgres
         self._config_file_path = config_file_path
+        self._postgres = postgres
         self._event_recorder = event_recorder
         self._enable_reconciliation = enable_reconciliation
         self._backend_queue_updater = backend_queue_updater
@@ -244,6 +242,8 @@ class ConfigMapWatcher:
             if isinstance(section, dict):
                 _resolve_secret_file_references(section)
 
+        self._hydrate_service_auth(managed_configs)
+
         validation_errors = _validate_configmap_runtime_contract(managed_configs)
         validation_errors.extend(_validate_configs(managed_configs))
         if validation_errors:
@@ -282,6 +282,32 @@ class ConfigMapWatcher:
 
         return LoadResult.SUCCESS
 
+    def _hydrate_service_auth(
+        self, managed_configs: Dict[str, Any],
+    ) -> None:
+        """Preserve the stable JWT signing identity in ConfigMap mode."""
+        service_config = managed_configs.setdefault('service', {})
+        if not isinstance(service_config, dict):
+            return
+        if 'service_auth' in service_config:
+            return
+
+        previous_snapshot = configmap_guard.get_snapshot()
+        if previous_snapshot is not None:
+            previous_service_config = previous_snapshot.get('service', {})
+        elif self._postgres is not None:
+            persisted_service_config = self._postgres.get_service_configs()
+            previous_service_config = persisted_service_config.plaintext_dict(
+                by_alias=True, exclude_unset=True)
+        else:
+            previous_service_config = {}
+
+        if (isinstance(previous_service_config, dict)
+                and 'service_auth' in previous_service_config):
+            service_config['service_auth'] = copy.deepcopy(
+                previous_service_config['service_auth'])
+
+
 def start_config_watcher(
     config_file: str | None,
     postgres: connectors.PostgresConnector | None = None,
@@ -304,8 +330,10 @@ def start_config_watcher(
     are handled defensively by configmap_events; this gate just avoids
     cross-service duplication.)
 
-    ConfigMap mode is authoritative for service config. The watcher does
-    not read config rows from Postgres.
+    ConfigMap mode is authoritative for managed config. On the first load,
+    the watcher recovers the stable service-auth signing identity from
+    Postgres when it is not supplied explicitly; reloads preserve the identity
+    from the previous in-memory snapshot.
     """
     if not config_file:
         return None
@@ -723,11 +751,17 @@ def _validate_configmap_runtime_contract(
 ) -> List[str]:
     """Validate runtime fields that ConfigMap mode must own.
 
-    ConfigMap mode does not hydrate config from DB. Fields that used to be
-    DB/runtime-derived but are required for backend side effects must therefore
-    be present in the ConfigMap.
+    Runtime fields must be present after explicit secret resolution and
+    compatibility hydration.
     """
     errors: List[str] = []
+
+    service_config = managed_configs.get('service')
+    if (not isinstance(service_config, dict)
+            or 'service_auth' not in service_config):
+        errors.append(
+            'service.service_auth: required in ConfigMap mode; configure it '
+            'from a Secret or preserve the persisted service configuration')
 
     backends = managed_configs.get('backends', {})
     if isinstance(backends, dict):

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -133,6 +133,7 @@ class ConfigMapWatcher:
     ):
         self._config_file_path = config_file_path
         self._postgres = postgres
+        self._db_service_auth: Dict[str, Any] | None = None
         self._event_recorder = event_recorder
         self._enable_reconciliation = enable_reconciliation
         self._backend_queue_updater = backend_queue_updater
@@ -237,6 +238,12 @@ class ConfigMapWatcher:
         # Dataset config is deprecated; tolerate stale ConfigMap blocks without loading them.
         managed_configs.pop('dataset', None)
 
+        # JWT signing identity is PostgreSQL-owned. Discard ConfigMap input before
+        # resolving secret references so it is never interpreted as runtime auth.
+        service_config = managed_configs.get('service')
+        if isinstance(service_config, dict):
+            service_config.pop('service_auth', None)
+
         # Resolve secret file references (reads mounted K8s Secret files)
         for section in managed_configs.values():
             if isinstance(section, dict):
@@ -285,27 +292,24 @@ class ConfigMapWatcher:
     def _hydrate_service_auth(
         self, managed_configs: Dict[str, Any],
     ) -> None:
-        """Preserve the stable JWT signing identity in ConfigMap mode."""
+        """Hydrate the stable JWT signing identity from Postgres."""
         service_config = managed_configs.setdefault('service', {})
         if not isinstance(service_config, dict):
             return
-        if 'service_auth' in service_config:
-            return
 
-        previous_snapshot = configmap_guard.get_snapshot()
-        if previous_snapshot is not None:
-            previous_service_config = previous_snapshot.get('service', {})
-        elif self._postgres is not None:
+        if self._db_service_auth is None and self._postgres is not None:
             persisted_service_config = self._postgres.get_service_configs()
-            previous_service_config = persisted_service_config.plaintext_dict(
-                by_alias=True, exclude_unset=True)
-        else:
-            previous_service_config = {}
+            persisted_service_config_dict = (
+                persisted_service_config.plaintext_dict(
+                    by_alias=True, exclude_unset=True))
+            persisted_service_auth = persisted_service_config_dict.get(
+                'service_auth')
+            if isinstance(persisted_service_auth, dict):
+                self._db_service_auth = copy.deepcopy(persisted_service_auth)
 
-        if (isinstance(previous_service_config, dict)
-                and 'service_auth' in previous_service_config):
+        if self._db_service_auth is not None:
             service_config['service_auth'] = copy.deepcopy(
-                previous_service_config['service_auth'])
+                self._db_service_auth)
 
 
 def start_config_watcher(
@@ -330,10 +334,10 @@ def start_config_watcher(
     are handled defensively by configmap_events; this gate just avoids
     cross-service duplication.)
 
-    ConfigMap mode is authoritative for managed config. On the first load,
-    the watcher recovers the stable service-auth signing identity from
-    Postgres when it is not supplied explicitly; reloads preserve the identity
-    from the previous in-memory snapshot.
+    ConfigMap mode is authoritative for managed config except service auth.
+    ConfigMap-supplied service auth is ignored. On the first load, the watcher
+    recovers the stable signing identity from Postgres; reloads preserve only
+    that watcher-local, DB-derived identity.
     """
     if not config_file:
         return None
@@ -752,7 +756,7 @@ def _validate_configmap_runtime_contract(
     """Validate runtime fields that ConfigMap mode must own.
 
     Runtime fields must be present after explicit secret resolution and
-    compatibility hydration.
+    PostgreSQL auth hydration.
     """
     errors: List[str] = []
 
@@ -760,8 +764,7 @@ def _validate_configmap_runtime_contract(
     if (not isinstance(service_config, dict)
             or 'service_auth' not in service_config):
         errors.append(
-            'service.service_auth: required in ConfigMap mode; configure it '
-            'from a Secret or preserve the persisted service configuration')
+            'service.service_auth: required from PostgreSQL in ConfigMap mode')
 
     backends = managed_configs.get('backends', {})
     if isinstance(backends, dict):

--- a/src/service/core/config/tests/test_configmap_loader_integration.py
+++ b/src/service/core/config/tests/test_configmap_loader_integration.py
@@ -327,7 +327,8 @@ class ConfigMapModeReadIntegrationTest(fixture.ServiceTestFixture):
                 mode='w', suffix='.yaml', delete=False) as temp_file:
             yaml.dump(_with_service_auth(config), temp_file)
         try:
-            watcher = configmap_loader.ConfigMapWatcher(temp_file.name)
+            watcher = configmap_loader.ConfigMapWatcher(
+                temp_file.name, self._get_postgres())
             result = watcher._load_and_apply()
             self.assertTrue(result)
 
@@ -381,7 +382,8 @@ class ConfigMapModeReadIntegrationTest(fixture.ServiceTestFixture):
                 mode='w', suffix='.yaml', delete=False) as temp_file:
             yaml.dump(_with_service_auth(config), temp_file)
         try:
-            watcher = configmap_loader.ConfigMapWatcher(temp_file.name)
+            watcher = configmap_loader.ConfigMapWatcher(
+                temp_file.name, self._get_postgres())
             result = watcher._load_and_apply()
             self.assertTrue(result)
 

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -60,6 +60,19 @@ def _with_service_auth(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _postgres_with_service_auth(
+        service_auth: Dict[str, Any] | None = None) -> mock.MagicMock:
+    persisted_service_config = mock.MagicMock()
+    persisted_service_config.plaintext_dict.return_value = {
+        'service_auth': (
+            service_auth if service_auth is not None
+            else _service_auth_config()),
+    }
+    postgres = mock.MagicMock()
+    postgres.get_service_configs.return_value = persisted_service_config
+    return postgres
+
+
 class TestConfigmapGuard(unittest.TestCase):
     """Tests for the global ConfigMap mode guard."""
 
@@ -592,7 +605,8 @@ class TestConfigMapWatcherStart(unittest.TestCase):
             yaml.dump(_with_service_auth(config), temp)
             path = temp.name
         try:
-            watcher = configmap_loader.ConfigMapWatcher(path)
+            watcher = configmap_loader.ConfigMapWatcher(
+                path, _postgres_with_service_auth())
             watcher.start()
             self.assertTrue(configmap_guard.is_configmap_mode())
             self.assertIsNotNone(watcher._observer)
@@ -617,7 +631,8 @@ class TestConfigMapWatcherStart(unittest.TestCase):
             yaml.dump(_with_service_auth(config), temp)
             path = temp.name
         try:
-            watcher = configmap_loader.ConfigMapWatcher(path)
+            watcher = configmap_loader.ConfigMapWatcher(
+                path, _postgres_with_service_auth())
             try:
                 watcher.start()
                 snapshot = configmap_guard.get_snapshot()
@@ -690,7 +705,8 @@ class TestConfigMapWatcherEvents(unittest.TestCase):
         try:
             recorder = _FakeEventRecorder()
             watcher = configmap_loader.ConfigMapWatcher(
-                good_path, event_recorder=recorder)
+                good_path, _postgres_with_service_auth(),
+                event_recorder=recorder)
             result = watcher._load_and_apply()
             self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
             self.assertEqual(recorder.failures, [])
@@ -707,7 +723,8 @@ class TestConfigMapWatcherEvents(unittest.TestCase):
         try:
             recorder = _FakeEventRecorder()
             watcher = configmap_loader.ConfigMapWatcher(
-                bad_path, event_recorder=recorder)
+                bad_path, _postgres_with_service_auth(),
+                event_recorder=recorder)
             watcher._load_and_apply()  # fails
             watcher._config_file_path = good_path
             watcher._load_and_apply()  # recovers
@@ -925,6 +942,14 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             yaml.dump(config, temp)
             return temp.name
 
+    def _watcher(
+        self,
+        config_file_path: str,
+        **kwargs: Any,
+    ) -> configmap_loader.ConfigMapWatcher:
+        return configmap_loader.ConfigMapWatcher(
+            config_file_path, _postgres_with_service_auth(), **kwargs)
+
     def _wire_reconciliation_callbacks(
         self,
         watcher: configmap_loader.ConfigMapWatcher,
@@ -950,7 +975,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             temp.write('')
             path = temp.name
         try:
-            watcher = configmap_loader.ConfigMapWatcher(path)
+            watcher = self._watcher(path)
             result = watcher._load_and_apply()
             self.assertEqual(
                 result, configmap_loader.LoadResult.PERMANENT_FAILURE)
@@ -965,7 +990,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(path)
+            watcher = self._watcher(path)
             result = watcher._load_and_apply()
             self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
 
@@ -1010,42 +1035,53 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_reload_carries_forward_service_auth(self):
-        previous_auth = _service_auth_config()
-        configmap_state.set_parsed_configs({
-            'service': {'service_auth': previous_auth},
-        })
-        config: Dict[str, Any] = {
+    def test_reload_carries_forward_db_service_auth(self):
+        persisted_auth = _service_auth_config()
+        persisted_auth['issuer'] = 'postgres-issuer'
+        configmap_auth = _service_auth_config()
+        configmap_auth['issuer'] = 'configmap-issuer'
+        postgres = _postgres_with_service_auth(persisted_auth)
+        initial_config: Dict[str, Any] = {
             'service': {
-                'max_pod_restart_limit': '45m',
+                'max_pod_restart_limit': '30m',
             },
         }
-        path = self._write_config_file(config)
+        path = self._write_config_file(initial_config)
         try:
-            watcher = configmap_loader.ConfigMapWatcher(path)
+            watcher = configmap_loader.ConfigMapWatcher(path, postgres)
+            result = watcher._load_and_apply()
+            self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
+
+            with open(path, 'w', encoding='utf-8') as config_file:
+                yaml.dump({
+                    'service': {
+                        'service_auth': configmap_auth,
+                        'max_pod_restart_limit': '45m',
+                    },
+                }, config_file)
             result = watcher._load_and_apply()
             self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
 
             snapshot = configmap_state.get_snapshot()
             assert snapshot is not None
             service_config = snapshot['service']
-            self.assertEqual(service_config['service_auth'], previous_auth)
+            self.assertEqual(service_config['service_auth'], persisted_auth)
             self.assertEqual(
                 service_config['max_pod_restart_limit'], '45m')
+            postgres.get_service_configs.assert_called_once_with()
         finally:
             os.unlink(path)
 
-    def test_explicit_service_auth_takes_precedence(self):
-        explicit_auth = _service_auth_config()
-        persisted_service_config = mock.MagicMock()
-        persisted_service_config.plaintext_dict.return_value = {
-            'service_auth': {'unexpected': 'persisted-auth'},
+    def test_configmap_service_auth_cannot_override_postgres(self):
+        configmap_auth = {
+            'secret_file': '/configmap/service-auth-must-not-be-read',
         }
-        postgres = mock.MagicMock()
-        postgres.get_service_configs.return_value = persisted_service_config
+        persisted_auth = _service_auth_config()
+        persisted_auth['issuer'] = 'postgres-issuer'
+        postgres = _postgres_with_service_auth(persisted_auth)
         path = self._write_config_file({
             'service': {
-                'service_auth': explicit_auth,
+                'service_auth': configmap_auth,
                 'max_pod_restart_limit': '30m',
             },
         })
@@ -1056,7 +1092,38 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             snapshot = configmap_state.get_snapshot()
             assert snapshot is not None
             self.assertEqual(
-                snapshot['service']['service_auth'], explicit_auth)
+                snapshot['service']['service_auth'], persisted_auth)
+            self.assertNotEqual(
+                snapshot['service']['service_auth'], configmap_auth)
+            postgres.get_service_configs.assert_called_once_with()
+        finally:
+            os.unlink(path)
+
+    def test_new_watcher_hydrates_service_auth_from_postgres(self):
+        previous_auth = _service_auth_config()
+        previous_auth['issuer'] = 'previous-issuer'
+        persisted_auth = _service_auth_config()
+        persisted_auth['issuer'] = 'postgres-issuer'
+        configmap_state.set_parsed_configs({
+            'service': {'service_auth': previous_auth},
+        })
+        postgres = _postgres_with_service_auth(persisted_auth)
+        path = self._write_config_file({
+            'service': {
+                'max_pod_restart_limit': '30m',
+            },
+        })
+        try:
+            watcher = configmap_loader.ConfigMapWatcher(path, postgres)
+            result = watcher._load_and_apply()
+            self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
+            snapshot = configmap_state.get_snapshot()
+            assert snapshot is not None
+            self.assertEqual(
+                snapshot['service']['service_auth'], persisted_auth)
+            self.assertNotEqual(
+                snapshot['service']['service_auth'], previous_auth)
+            postgres.get_service_configs.assert_called_once_with()
         finally:
             os.unlink(path)
 
@@ -1083,7 +1150,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         })
         path = self._write_config_file(config)
         try:
-            watcher = configmap_loader.ConfigMapWatcher(path)
+            watcher = self._watcher(path)
             result = watcher._load_and_apply()
             self.assertEqual(
                 result, configmap_loader.LoadResult.PERMANENT_FAILURE)
@@ -1098,7 +1165,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         good_path = self._write_config_file(_with_service_auth(good_config))
 
-        watcher = configmap_loader.ConfigMapWatcher(good_path)
+        watcher = self._watcher(good_path)
         watcher._load_and_apply()
 
         old_snapshot = configmap_state.get_snapshot()
@@ -1110,7 +1177,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         bad_path = self._write_config_file(bad_config)
         try:
-            watcher2 = configmap_loader.ConfigMapWatcher(bad_path)
+            watcher2 = self._watcher(bad_path)
             result = watcher2._load_and_apply()
             self.assertEqual(
                 result, configmap_loader.LoadResult.PERMANENT_FAILURE)
@@ -1145,7 +1212,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
             old_snapshot = copy.deepcopy(config)
             old_snapshot['backends']['backend-a']['tests'] = []
@@ -1199,7 +1266,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=False)
 
             with mock.patch(
@@ -1245,7 +1312,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(new_config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
             watcher._last_reconciled_snapshot = old_snapshot
 
@@ -1331,7 +1398,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             'scheduler_timeout'] = 60
         path = self._write_config_file(_with_service_auth(new_config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
             watcher._last_reconciled_snapshot = old_snapshot
 
@@ -1408,7 +1475,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(new_config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
             watcher._last_reconciled_snapshot = old_snapshot
 
@@ -1448,7 +1515,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
 
             with mock.patch(
@@ -1485,7 +1552,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
 
             with mock.patch(
@@ -1561,7 +1628,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         path = self._write_config_file(_with_service_auth(new_config))
         try:
             configmap_state.set_parsed_configs(old_snapshot)
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
 
             with mock.patch(
@@ -1631,7 +1698,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(new_config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
             watcher._last_reconciled_snapshot = old_snapshot
 
@@ -1709,7 +1776,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(new_config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
             watcher._last_reconciled_snapshot = old_snapshot
 
@@ -1756,7 +1823,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
 
             with mock.patch(
@@ -1797,7 +1864,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
 
             with mock.patch(
@@ -1859,7 +1926,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(_with_service_auth(new_config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
             watcher._last_reconciled_snapshot = old_snapshot
 
@@ -1901,7 +1968,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         new_config['service']['max_pod_restart_limit'] = '45m'
         path = self._write_config_file(_with_service_auth(new_config))
         try:
-            watcher = configmap_loader.ConfigMapWatcher(
+            watcher = self._watcher(
                 path, enable_reconciliation=True)
             watcher._last_reconciled_snapshot = old_snapshot
 
@@ -2358,7 +2425,8 @@ class TestResolvePoolComputedFields(unittest.TestCase):
 
         try:
             configmap_state.set_parsed_configs(None)
-            watcher = configmap_loader.ConfigMapWatcher(path)
+            watcher = configmap_loader.ConfigMapWatcher(
+                path, _postgres_with_service_auth())
             result = watcher._load_and_apply()
             self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
 
@@ -2431,14 +2499,14 @@ class TestStartConfigWatcher(unittest.TestCase):
         self.assertIsNone(watcher)
         self.assertFalse(configmap_state.is_configmap_mode())
 
-    def test_non_api_service_with_explicit_auth_skips_event_recorder_and_db(self):
-        """Explicit auth avoids DB hydration and non-API event duplication."""
+    def test_non_api_service_hydrates_db_auth_without_event_recorder(self):
+        """All services hydrate DB auth; non-API replicas skip K8s events."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             config_path = os.path.join(tmp_dir, 'config.yaml')
             with open(config_path, 'w', encoding='utf-8') as f:
                 yaml.dump(_with_service_auth({'service': {}}), f)
 
-            postgres = mock.MagicMock()
+            postgres = _postgres_with_service_auth()
             with mock.patch.object(
                 configmap_events, 'ConfigMapEventRecorder',
             ) as mock_recorder:
@@ -2448,7 +2516,7 @@ class TestStartConfigWatcher(unittest.TestCase):
                 try:
                     self.assertIsNone(watcher._event_recorder)
                     mock_recorder.assert_not_called()
-                    postgres.get_service_configs.assert_not_called()
+                    postgres.get_service_configs.assert_called_once_with()
                 finally:
                     watcher.stop()
 
@@ -2479,7 +2547,8 @@ class TestStartConfigWatcher(unittest.TestCase):
                 watcher = None
                 try:
                     watcher = configmap_loader.start_config_watcher(
-                        config_path, is_api_service=False)
+                        config_path, _postgres_with_service_auth(),
+                        is_api_service=False)
                     self.assertIsNotNone(watcher)
                     # First call(s) must fail (file not yet present), then
                     # the writer thread creates the file and a later call

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -976,7 +976,14 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_cold_load_allows_missing_service_auth(self):
+    def test_cold_load_hydrates_service_auth_from_postgres(self):
+        persisted_auth = _service_auth_config()
+        persisted_service_config = mock.MagicMock()
+        persisted_service_config.plaintext_dict.return_value = {
+            'service_auth': persisted_auth,
+        }
+        postgres = mock.MagicMock()
+        postgres.get_service_configs.return_value = persisted_service_config
         config: Dict[str, Any] = {
             'service': {
                 'max_pod_restart_limit': '30m',
@@ -984,16 +991,26 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         }
         path = self._write_config_file(config)
         try:
-            watcher = configmap_loader.ConfigMapWatcher(path)
+            watcher = configmap_loader.ConfigMapWatcher(path, postgres)
             result = watcher._load_and_apply()
             self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
             snapshot = configmap_state.get_snapshot()
             assert snapshot is not None
-            self.assertNotIn('service_auth', snapshot['service'])
+            self.assertEqual(
+                snapshot['service']['service_auth'], persisted_auth)
+            self.assertEqual(
+                snapshot['service']['max_pod_restart_limit'], '30m')
+            first_service_config = configmap_loader.connectors.ServiceConfig(
+                **snapshot['service'])
+            second_service_config = configmap_loader.connectors.ServiceConfig(
+                **snapshot['service'])
+            self.assertEqual(
+                first_service_config.service_auth.active_key,
+                second_service_config.service_auth.active_key)
         finally:
             os.unlink(path)
 
-    def test_reload_does_not_carry_forward_service_auth(self):
+    def test_reload_carries_forward_service_auth(self):
         previous_auth = _service_auth_config()
         configmap_state.set_parsed_configs({
             'service': {'service_auth': previous_auth},
@@ -1012,9 +1029,49 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             snapshot = configmap_state.get_snapshot()
             assert snapshot is not None
             service_config = snapshot['service']
-            self.assertNotIn('service_auth', service_config)
+            self.assertEqual(service_config['service_auth'], previous_auth)
             self.assertEqual(
                 service_config['max_pod_restart_limit'], '45m')
+        finally:
+            os.unlink(path)
+
+    def test_explicit_service_auth_takes_precedence(self):
+        explicit_auth = _service_auth_config()
+        persisted_service_config = mock.MagicMock()
+        persisted_service_config.plaintext_dict.return_value = {
+            'service_auth': {'unexpected': 'persisted-auth'},
+        }
+        postgres = mock.MagicMock()
+        postgres.get_service_configs.return_value = persisted_service_config
+        path = self._write_config_file({
+            'service': {
+                'service_auth': explicit_auth,
+                'max_pod_restart_limit': '30m',
+            },
+        })
+        try:
+            watcher = configmap_loader.ConfigMapWatcher(path, postgres)
+            result = watcher._load_and_apply()
+            self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
+            snapshot = configmap_state.get_snapshot()
+            assert snapshot is not None
+            self.assertEqual(
+                snapshot['service']['service_auth'], explicit_auth)
+        finally:
+            os.unlink(path)
+
+    def test_missing_service_auth_without_runtime_source_fails(self):
+        path = self._write_config_file({
+            'service': {
+                'max_pod_restart_limit': '30m',
+            },
+        })
+        try:
+            watcher = configmap_loader.ConfigMapWatcher(path)
+            result = watcher._load_and_apply()
+            self.assertEqual(
+                result, configmap_loader.LoadResult.PERMANENT_FAILURE)
+            self.assertIsNone(configmap_state.get_snapshot())
         finally:
             os.unlink(path)
 
@@ -1272,7 +1329,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         new_config = copy.deepcopy(old_snapshot)
         new_config['backends']['backend-a']['scheduler_settings'][
             'scheduler_timeout'] = 60
-        path = self._write_config_file(new_config)
+        path = self._write_config_file(_with_service_auth(new_config))
         try:
             watcher = configmap_loader.ConfigMapWatcher(
                 path, enable_reconciliation=True)
@@ -1349,7 +1406,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         new_config['pools']['pool-a']['platforms']['gpu'] = {
             'default_variables': {'A': 2},
         }
-        path = self._write_config_file(new_config)
+        path = self._write_config_file(_with_service_auth(new_config))
         try:
             watcher = configmap_loader.ConfigMapWatcher(
                 path, enable_reconciliation=True)
@@ -1572,7 +1629,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         new_config['pod_templates']['tmpl-a'] = {
             'spec': {'containers': [{'name': 'main'}]},
         }
-        path = self._write_config_file(new_config)
+        path = self._write_config_file(_with_service_auth(new_config))
         try:
             watcher = configmap_loader.ConfigMapWatcher(
                 path, enable_reconciliation=True)
@@ -1650,7 +1707,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         new_config['pod_templates']['tmpl-a'] = {
             'spec': {'containers': [{'name': 'main'}]},
         }
-        path = self._write_config_file(new_config)
+        path = self._write_config_file(_with_service_auth(new_config))
         try:
             watcher = configmap_loader.ConfigMapWatcher(
                 path, enable_reconciliation=True)
@@ -2296,7 +2353,7 @@ class TestResolvePoolComputedFields(unittest.TestCase):
         }
         with tempfile.NamedTemporaryFile(
                 mode='w', suffix='.yaml', delete=False) as temp:
-            yaml.dump(config, temp)
+            yaml.dump(_with_service_auth(config), temp)
             path = temp.name
 
         try:
@@ -2374,11 +2431,8 @@ class TestStartConfigWatcher(unittest.TestCase):
         self.assertIsNone(watcher)
         self.assertFalse(configmap_state.is_configmap_mode())
 
-    def test_non_api_service_skips_event_recorder_and_db_config_load(self):
-        """Worker/agent/logger must NOT emit K8s reload events (replicas
-        would race on the same Event object) and must not hydrate config
-        from Postgres when ConfigMap mode is active.
-        """
+    def test_non_api_service_with_explicit_auth_skips_event_recorder_and_db(self):
+        """Explicit auth avoids DB hydration and non-API event duplication."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             config_path = os.path.join(tmp_dir, 'config.yaml')
             with open(config_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Description

Issue - None

ConfigMap mode currently drops `service_auth` from the in-memory snapshot when the field is omitted from the ConfigMap. Every subsequent `ServiceConfig` construction then invokes the default factory and generates a new RSA signing identity. Tokens minted by one request can therefore fail validation against JWKS returned by the next request, which prevents backend listeners and workers from authenticating.

This change keeps the JWT signing identity PostgreSQL-owned while leaving ConfigMap data authoritative for all other managed configuration:

- ConfigMap-supplied `service.service_auth` is discarded before secret resolution and cannot override the persisted identity;
- every new watcher hydrates the identity from PostgreSQL, even when an older global snapshot exists;
- reloads reuse only the watcher-local identity originally derived from PostgreSQL;
- loads fail closed if PostgreSQL does not provide a stable identity.

The change does not generate or persist new signing keys and does not hydrate any other ConfigMap-managed field from PostgreSQL.

## Validation

- `bazel test //src/service/core/config/tests:test_configmap_loader_unit --test_output=errors` (93 tests passed; target also ran mypy)
- Regression coverage verifies cold-start PostgreSQL hydration, ConfigMap override rejection before secret-file access, and DB-derived identity reuse across reloads.
- Live dev instance ConfigMap-mode verification using the initial fix confirmed stable JWKS keys, connected Isaac HIL listener/worker streams, successful queue synchronization, and healthy Argo applications.

Local testcontainer-backed integration targets could not start because this machine has no Docker socket; they run in the supported GitHub CI environment instead.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] No user-facing documentation change is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Service authentication is now restored from persisted configuration when it is missing from a ConfigMap.
- Persisted authentication is retained across configuration reloads and takes precedence over ConfigMap-provided values.
- Configuration validation now requires service authentication and reports a permanent failure when no valid source is available.
- Configuration startup and reconciliation now consistently support persisted authentication.

## Documentation
- Startup behavior and authentication fallback handling have been clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->