### PR TITLE
fix: restore docs multiversion dependency

### DIFF
--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -37,5 +37,5 @@ sphinx-substitution-extensions==2024.2.25
 sphinxcontrib-mermaid==1.0.0
 sphinxcontrib-spelling==8.0.2
 sphinx-reredirects==0.1.6
-# The fork below uses sphinx-multiversion==0.2.4
-https://github.com/RyaliNvidia/sphinx-multiversion/archive/refs/tags/v0.2.5.zip
+# This fork provides the --run-markdown-build option used by docs/Makefile.
+https://github.com/RyaliNvidia/sphinx-multiversion/archive/refs/tags/v0.2.7.zip

--- a/docs/locked_requirements.txt
+++ b/docs/locked_requirements.txt
@@ -878,8 +878,8 @@ sphinx-markdown-builder==0.6.8 \
     # via
     #   -r docs_requirements.txt
     #   sphinx-multiversion
-sphinx-multiversion @ https://github.com/RyaliNvidia/sphinx-multiversion/archive/refs/tags/v0.2.5.zip \
-    --hash=sha256:2616bde204930ed6995d9acd86f35770c1d8b02b37383e0653a706b1306f2406
+sphinx-multiversion @ https://github.com/RyaliNvidia/sphinx-multiversion/archive/refs/tags/v0.2.7.zip \
+    --hash=sha256:f8d597ad5e2cd012f08808fe58d712701eacc2eae96e233b73d52956edf48c38
     # via -r docs_requirements.txt
 sphinx-new-tab-link==0.8.0 \
     --hash=sha256:6c757d99f559224a04142c3971c8baa6ac90aca905f15b129d57eeca0ece9582 \


### PR DESCRIPTION
## Description

The documentation requirements declared the custom `sphinx-multiversion` fork at `v0.2.5`, while the previously generated lockfile installed `v0.2.7`. Regenerating the lockfile exposed that mismatch and downgraded the fork. Version `v0.2.5` does not recognize the `--run-markdown-build` option used by `docs/Makefile`, causing the post-merge Docs Deployment workflow to fail.

Pin both the source requirements and lockfile to the previously working `v0.2.7`, which provides the required option, and correct the stale explanatory comment.

Validated with Python 3.14.6 by installing the locked docs, main source, and release/6.3 source requirements in an isolated environment and running the multiversion HTML and Markdown build successfully.

Issue #None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation build tooling to a newer `sphinx-multiversion` release.
  * Documented support for the `--run-markdown-build` option used during documentation builds.
  * Refreshed the locked dependency checksum for reproducible builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->