### PR TITLE
feat: add PKCE login to OSMO CLI

### DIFF
--- a/docs/deployment_guide/appendix/authentication/authentication_flow.rst
+++ b/docs/deployment_guide/appendix/authentication/authentication_flow.rst
@@ -54,7 +54,9 @@ You enable a **default admin** user via Helm (see :ref:`default_admin_setup`). O
 - Assigns that user the ``osmo-admin`` role.
 - Creates an access token for that user whose secret is the password you stored in a Kubernetes secret.
 
-So the "password" you set for the default admin is effectively the access token value. You use it with the CLI (e.g. ``osmo login``) or with the API as ``Authorization: Bearer <that-password>``.
+So the "password" you set for the default admin is effectively the access token value. Use it with
+the CLI via ``osmo login <url> --method token --token '<that-password>'``, or with the API as
+``Authorization: Bearer <that-password>``.
 
 Access tokens
 -------------
@@ -93,20 +95,41 @@ Browser login
 -------------
 
 1. The user opens the OSMO UI or an API URL that requires authentication.
-2. Envoy's OAuth2 filter sees that the user is not authenticated (no valid session cookie or ``x-osmo-auth`` header).
-3. Envoy redirects the browser to the IdP's authorization endpoint. The user signs in at the IdP (e.g. Microsoft, Google).
-4. The IdP redirects back to Envoy with an authorization code (e.g. to ``/api/auth/getAToken``).
-5. Envoy exchanges the code for tokens (access token, ID token, optionally refresh token) at the IdP's token endpoint.
-6. Envoy sets session cookies (e.g. ``OAuthHMAC``, ``IdToken``, ``BearerToken``) and forwards the user to the original URL.
-7. On subsequent requests, Envoy reads the ``IdToken`` (JWT) from the cookie, validates it (signature, expiry, issuer, audience), and sets ``x-osmo-user`` and ``x-osmo-roles`` from the JWT claims (and/or from OSMO's database after syncing the user).
-8. The OSMO service receives the request with those headers and authorizes using its role/policy database.
+2. Envoy asks OAuth2 Proxy to validate the browser's session cookie. With no valid session, OAuth2
+   Proxy redirects the browser to the IdP's authorization endpoint.
+3. The user signs in at the IdP (e.g. Microsoft or Google).
+4. The IdP redirects back with an authorization code to ``https://<your-domain>/oauth2/callback``.
+5. OAuth2 Proxy exchanges the code for tokens at the IdP's token endpoint and establishes its
+   session cookie.
+6. On subsequent requests, Envoy asks OAuth2 Proxy to validate the cookie. OAuth2 Proxy returns the
+   ID token in the ``Authorization`` header.
+7. Envoy validates the ID token (signature, expiry, issuer, and audience) and sets ``x-osmo-user``
+   and ``x-osmo-roles`` from its claims.
+8. The OSMO service receives the request with those headers and authorizes it using its role and
+   policy database.
 
 So the IdP is the source of "who is this?"; OSMO is the source of "what can they do?" (roles and policies), possibly combined with role information from the IdP (e.g. groups mapped to OSMO roles).
 
-CLI / device flow
------------------
+CLI login
+---------
 
-For the CLI, use ``osmo login`` to authenticate with an IdP. The CLI initiates a device-authorization flow, opens a browser for the user to sign in at the IdP, and receives tokens upon completion. Once authenticated, the CLI uses the token for subsequent requests. Envoy validates the token and sets ``x-osmo-user`` and ``x-osmo-roles`` as for browser requests.
+For the CLI, use ``osmo login`` to authenticate with an IdP. Authorization code flow with PKCE is
+the default. Use ``osmo login --method code`` to use device authorization instead. The PKCE flow
+opens the system browser and receives the authorization response on a temporary loopback listener.
+It uses an ``S256`` code challenge plus ``state`` and OpenID Connect ``nonce`` validation, and does
+not use a client secret.
+
+For Microsoft Entra ID, add ``http://localhost`` under the app registration's **Mobile and desktop
+applications** platform and enable public client flows. Existing web and implicit-flow settings are
+independent and do not need to be changed. In particular, enabling ID tokens under **Implicit grant
+and hybrid flows** is not a replacement for delegated permissions and is not used by the CLI's PKCE
+token exchange. Do not disable an existing implicit or hybrid-flow setting as part of enabling PKCE.
+
+The CLI requests the standard OpenID Connect ``openid``, ``profile``, and ``offline_access`` scopes,
+then uses the returned ID token for OSMO API requests to preserve the same gateway contract as
+device authorization. The current flow does not request Microsoft Graph or an OSMO API scope, so do
+not add a delegated API permission solely for CLI sign-in. Add delegated permissions only when the
+client actually calls the protected API represented by that scope.
 
 Role resolution with an IdP
 ---------------------------

--- a/docs/deployment_guide/appendix/authentication/identity_provider_setup.rst
+++ b/docs/deployment_guide/appendix/authentication/identity_provider_setup.rst
@@ -37,7 +37,9 @@ If you are evaluating OSMO or running in an environment without an IdP, use the 
 How it works
 ====================
 
-1. You register OSMO as an application (OAuth2 / OIDC client) in your IdP and get a client ID and client secret.
+1. You register OSMO as an application (OAuth2 / OIDC client) in your IdP and get a client ID. The
+   confidential web client also needs a client secret; the public CLI client uses PKCE and must not
+   use one.
 2. When a user visits the OSMO UI or API without a session, Envoy redirects them to the IdP to log in. After login, the IdP returns a JWT. Envoy validates the JWT and forwards the request to the OSMO service with ``x-osmo-user`` and ``x-osmo-roles`` set.
 3. OSMO roles can be assigned from two sources: directly via the OSMO user/role APIs, or from an IdP. When using an IdP, external claims (e.g., LDAP groups, OIDC roles) are mapped to OSMO roles through the :ref:`idp_role_mapping`.
 
@@ -73,10 +75,24 @@ Identity Provider Configuration Reference
 Microsoft Entra ID (Azure AD)
 --------------------------------
 
-1. **Register an application** in Azure Portal → Microsoft Entra ID → App registrations → New registration. Set redirect URI (Web) to ``https://<your-domain>/api/auth/getAToken``.
-2. **Create a client secret** under Certificates & secrets and copy the value.
-3. **Configure API permissions** (e.g. OpenID, profile, email, User.Read).
-4. **Optional:** Under Token configuration, add a “Groups” claim so group IDs (or names) are in the token for role mapping.
+You can use one existing app registration for the OSMO web client and CLI. Configure both client
+types explicitly:
+
+1. Under **Authentication**, add a **Web** redirect URI of
+   ``https://<your-domain>/oauth2/callback`` for OAuth2 Proxy.
+2. Under **Authentication**, add ``http://localhost`` to **Mobile and desktop applications** for the
+   CLI loopback callback, and enable **Allow public client flows**.
+3. Create a client secret under **Certificates & secrets** for OAuth2 Proxy. Do not distribute that
+   secret to the CLI; the CLI is a public client and uses an ``S256`` PKCE challenge instead.
+4. The CLI requests only the OpenID Connect ``openid``, ``profile``, and ``offline_access`` scopes.
+   It does not need Microsoft Graph ``User.Read`` or a delegated OSMO API permission for the current
+   ID-token gateway contract. Add a delegated permission only when the client requests and uses that
+   protected API's scope.
+5. **Implicit grant and hybrid flows** settings are independent of authorization code with PKCE.
+   PKCE does not require the implicit ID-token setting and does not replace delegated permissions.
+   Do not disable an existing implicit or hybrid-flow setting as part of enabling PKCE.
+6. **Optional:** Under Token configuration, add a “Groups” claim so group IDs (or names) are in the
+   token for role mapping.
 
 **Endpoints:**
 
@@ -125,7 +141,7 @@ Microsoft Entra ID (Azure AD)
 Google OAuth2
 --------------------------------
 
-1. In Google Cloud Console, create OAuth 2.0 credentials (Web application). Set authorized redirect URI to ``https://<your-domain>/api/auth/getAToken``.
+1. In Google Cloud Console, create OAuth 2.0 credentials (Web application). Set authorized redirect URI to ``https://<your-domain>/oauth2/callback``.
 2. Configure the OAuth consent screen and add scopes such as ``openid``, ``email``, ``profile``.
 
 **Endpoints:**
@@ -151,7 +167,7 @@ AWS IAM Identity Center (AWS SSO)
 -----------------------------------
 
 1. Enable AWS IAM Identity Center and note the instance ID and region.
-2. Create a “Customer managed” OAuth 2.0 application with redirect URI ``https://<your-domain>/api/auth/getAToken`` and scopes ``openid``, ``email``, ``profile``. Record client ID and client secret.
+2. Create a “Customer managed” OAuth 2.0 application with redirect URI ``https://<your-domain>/oauth2/callback`` and scopes ``openid``, ``email``, ``profile``. Record client ID and client secret.
 3. Assign users/groups to the application as needed.
 
 **Endpoints:**

--- a/docs/deployment_guide/appendix/authentication/index.rst
+++ b/docs/deployment_guide/appendix/authentication/index.rst
@@ -148,7 +148,9 @@ Then in your Helm values:
        passwordSecretName: default-admin-secret
        passwordSecretKey: password
 
-After deployment, use the default admin username and that password as the access token (e.g. with ``osmo login`` or ``Authorization: Bearer <password>``) to access the API and create more users and access tokens.
+After deployment, use that password as the access token. For the CLI, run
+``osmo login https://<your-domain> --method token --token '<password>'``. For direct API requests,
+send it as ``Authorization: Bearer <password>``. You can then create more users and access tokens.
 
 .. seealso::
 

--- a/docs/deployment_guide/requirements/networking.rst
+++ b/docs/deployment_guide/requirements/networking.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ Requirements
 
           If using an external IdP for browser SSO (e.g. Microsoft Entra ID, Google), ensure the OSMO service hostname has a dedicated FQDN and certificate. The IdP redirect URI will point to this host.
 
-          **Example**: ``https://<your-domain>/api/auth/getAToken``
+          **Example**: ``https://<your-domain>/oauth2/callback``
 
       .. grid-item-card:: :octicon:`plug` Port Forwarding (Optional)
           :class-card: optional-card
@@ -101,7 +101,5 @@ Requirements
         - `Cloud DNS <https://docs.cloud.google.com/dns/docs/overview>`_
         - `Certificate Manager <https://docs.cloud.google.com/certificate-manager/docs/overview>`_
         - `Load Balancer SSL <https://cloud.google.com/load-balancing/docs/ssl-certificates>`_
-
-
 
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -170,6 +170,7 @@ livestream
 Livestream
 LkXFR
 localhost
+loopback
 localpath
 Luhansk
 lustre

--- a/docs/user_guide/getting_started/install/index.rst
+++ b/docs/user_guide/getting_started/install/index.rst
@@ -65,6 +65,10 @@ To login to the client, can use the following command:
 
   $ osmo login https://<Your OSMO URL>/
 
+By default, this opens your system browser and uses the OAuth 2.0 authorization code flow with
+PKCE. If browser callbacks are unavailable in your environment, use ``--method code`` to select
+device authorization explicitly.
+
 After successful authentication, you are logged in. Welcome to OSMO.
 
 .. code-block:: bash

--- a/projects/PROJ-148-auth-rework/PROJ-148-oauth2-proxy-sidecar.md
+++ b/projects/PROJ-148-auth-rework/PROJ-148-oauth2-proxy-sidecar.md
@@ -59,7 +59,7 @@ The current Envoy OAuth2 filter implementation has several limitations:
 | Browser authentication | User authenticates via any supported IDP (Microsoft, Google, OIDC, etc.). OAuth2 Proxy handles the full OAuth2 flow including proper token refresh with `scope=openid` |
 | Token refresh without re-login | User's session is refreshed seamlessly without requiring re-authentication |
 | Service API authentication | API requests with JWT tokens are validated by Envoy's JWT filter (unchanged) |
-| CLI/Device flow authentication | Device flow continues to work through OSMO service (unchanged) |
+| CLI authentication | Authorization code with PKCE is the default; device flow remains available with `--method code` |
 | Logout | User initiates logout, OAuth2 Proxy clears session and redirects to IDP logout |
 
 ## Requirements
@@ -71,7 +71,7 @@ The current Envoy OAuth2 filter implementation has several limitations:
 | Multi-IDP support | OAuth2 Proxy shall support Microsoft Entra ID, Google, Keycloak, and any OIDC-compliant identity provider | Functional |
 | Session management | OAuth2 Proxy shall manage user sessions via secure cookies | Functional |
 | Header propagation | OAuth2 Proxy shall propagate user identity to Envoy via response headers (`X-Auth-Request-User`, `X-Auth-Request-Email`, `Authorization`) | Functional |
-| Backward compatibility | Existing CLI, device flow, and API authentication shall continue to work unchanged | Functional |
+| Backward compatibility | PKCE login, explicit device flow, and API authentication shall all bypass OAuth2 Proxy after token acquisition | Functional |
 | Authentication latency | OAuth2 Proxy shall add <10ms latency to authenticated requests (session validation subrequest) | KPI |
 | Secure cookie handling | Session cookies shall use Secure, HttpOnly, and SameSite attributes | Security |
 | No secrets in environment | OAuth2 client secrets shall be loaded from Kubernetes secrets or files | Security |
@@ -324,7 +324,7 @@ User must re-authenticate — this is expected behavior for expired sessions
 osmo workflow list
     │
     ▼
-CLI sends request with header: x-osmo-auth: <JWT from device flow>
+CLI sends request with header: x-osmo-auth: <JWT from PKCE or device flow>
     │
     ▼
 Envoy receives request
@@ -875,7 +875,7 @@ ext_authz (same pattern as the proposed OAuth2 Proxy approach).
 | Component | Impact |
 |-----------|--------|
 | Browser authentication | Users re-login once after migration (new session cookie format) |
-| CLI authentication | Unchanged — device flow goes through OSMO service |
+| CLI authentication | PKCE is the default; device flow remains available with `--method code`; both go through the OSMO service |
 | API authentication with JWT | Unchanged — JWT filter still validates tokens |
 | Service-to-service auth | Unchanged — internal OSMO tokens still work |
 
@@ -943,7 +943,8 @@ ext_authz (same pattern as the proposed OAuth2 Proxy approach).
 
 | Test | What the user does | Expected |
 |------|--------------------|----------|
-| Device flow login | `osmo login` | Opens browser for device code auth, completes, CLI receives JWT. Unchanged. |
+| PKCE login | `osmo login` | Opens the system browser, completes the loopback callback with PKCE, and receives an ID token. |
+| Device flow login | `osmo login --method code` | Opens the device authorization URL, completes, and receives an ID token. |
 | API calls with JWT | `osmo workflow list`, `osmo pool list`, etc. | Requests carry `x-osmo-auth` JWT. OAuth2 Proxy is skipped entirely. Unchanged. |
 | CLI token refresh | `osmo auth refresh-token` | Refreshes JWT via `/api/auth/jwt/refresh_token` (skip-auth path). Unchanged. |
 | Client download | `osmo` auto-update via `/client/*` | Downloads work. Unchanged. |
@@ -1057,5 +1058,4 @@ Note: `--upstream=static://200` means OAuth2 Proxy validates sessions and return
 with auth headers. It never proxies actual traffic — Envoy handles all routing.
 `--config` points to a file with `client_secret = "..."` and `cookie_secret = "..."` inline
 (NOT `_file` references, which don't exist in any OAuth2 Proxy version).
-
 

--- a/skills/osmo-user/references/cli-commands.md
+++ b/skills/osmo-user/references/cli-commands.md
@@ -25,12 +25,13 @@ references.
 ```bash
 osmo --version
 osmo version [--format-type json|text]
-osmo login [url] [--method code|password|token|dev]
+osmo login [url] [--method pkce|code|password|token|dev]
 osmo logout
 ```
 
-Prefer browser/device-code login. Do not ask the user to paste passwords or
-tokens into chat.
+`pkce` is the default login method. Use `--method code` explicitly when a
+device-authorization flow is required. Do not ask the user to paste passwords
+or tokens into chat.
 
 ## Profile
 

--- a/src/cli/login.py
+++ b/src/cli/login.py
@@ -36,22 +36,30 @@ def setup_parser(parser: argparse._SubParsersAction):
     Args:
         parser: The parser to be configured.
     '''
-    login_parser = parser.add_parser('login',
-                                     help='Log in with device flow or client credentials flow.')
+    login_parser = parser.add_parser(
+        'login', help='Log in with PKCE, device flow, or non-interactive credentials.')
     login_parser.set_defaults(func=_login)
     login_parser.add_argument('url', nargs='?', default=None,
                               help='The url of the osmo server to connect to. '
                                    'If not provided, uses the last used url.')
     login_parser.add_argument('--device-endpoint',
-                              help='The url to use to completed device flow authentication. ' +
+                              help='The url to use to complete device flow authentication. ' +
                                    'If not provided, it will be fetched from the service.')
-    login_parser.add_argument('--method', default='code', type=str,
-                              choices=('code', 'password', 'token', 'dev'),
-                              help='code: Get a device code and url to log in securely ' +
+    login_parser.add_argument('--browser-endpoint',
+                              help='The authorization endpoint for PKCE login. If not provided, '
+                                   'it will be fetched from the service.')
+    login_parser.add_argument('--callback-port', default=0, type=int,
+                              help='Local callback port for PKCE login. The default chooses an '
+                                   'available ephemeral port.')
+    login_parser.add_argument('--method', default='pkce', type=str,
+                              choices=('pkce', 'code', 'password', 'token', 'dev'),
+                              help='pkce: Log in through the system browser using authorization ' +
+                                   'code flow with PKCE (default). ' +
+                                   'code: Get a device code and url to log in securely ' +
                                    'through browser. ' +
                                    'password: Provide username and password directly ' +
                                    'through CLI. ' +
-                                   'token: Read an idToken directly from a file.')
+                                   'token: Exchange an OSMO access token for a login token.')
     login_parser.add_argument('--username',
                               help='Username if logging in with credentials. This should ' +
                                    'only be used for service accounts that cannot ' +
@@ -63,9 +71,9 @@ def setup_parser(parser: argparse._SubParsersAction):
                                      'logging in with credentials.').complete = shtab.FILE
 
     token_group = login_parser.add_mutually_exclusive_group()
-    token_group.add_argument('--token', help='Token if logging in with credentials.')
+    token_group.add_argument('--token', help='OSMO access token if logging in with a token.')
     token_group.add_argument('--token-file',
-                             help='File containing the refresh token.').complete = shtab.FILE
+                             help='File containing an OSMO access token.').complete = shtab.FILE
 
     logout_parser = parser.add_parser('logout',
         help='Remove stored access tokens.')
@@ -101,6 +109,14 @@ def _login(service_client: client.ServiceClient, args: argparse.Namespace):
     # Login through device code flow
     if args.method == 'code':
         service_client.login_manager.device_code_login(url, args.device_endpoint)
+
+    # Login through authorization code flow with PKCE
+    elif args.method == 'pkce':
+        service_client.login_manager.pkce_login(
+            url=url,
+            browser_endpoint=args.browser_endpoint,
+            callback_port=args.callback_port,
+        )
 
     # Login through resource owner password flow
     elif args.method == 'password':

--- a/src/cli/tests/BUILD
+++ b/src/cli/tests/BUILD
@@ -29,6 +29,16 @@ py_test(
 )
 
 py_test(
+    name = "test_login",
+    srcs = [
+        "test_login.py"
+    ],
+    deps = [
+        "//src/cli:cli_lib",
+    ]
+)
+
+py_test(
     name = "test_workflow",
     srcs = [
         "test_workflow.py"

--- a/src/cli/tests/test_login.py
+++ b/src/cli/tests/test_login.py
@@ -1,0 +1,84 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import unittest
+from unittest import mock
+
+from src.cli import login, main_parser
+
+
+class LoginCommandTests(unittest.TestCase):
+    """Tests for CLI login flow selection."""
+
+    def test_pkce_method_passes_browser_and_callback_options(self):
+        parser = main_parser.create_cli_parser()
+        arguments = parser.parse_args([
+            'login',
+            'https://osmo.example.com',
+            '--method', 'pkce',
+            '--browser-endpoint', 'https://idp.example.com/authorize',
+            '--callback-port', '49152',
+        ])
+        service_client = mock.MagicMock()
+
+        login._login(service_client, arguments)
+
+        service_client.login_manager.pkce_login.assert_called_once_with(
+            url='https://osmo.example.com',
+            browser_endpoint='https://idp.example.com/authorize',
+            callback_port=49152,
+        )
+        service_client.login_manager.device_code_login.assert_not_called()
+
+    def test_pkce_method_is_default(self):
+        parser = main_parser.create_cli_parser()
+        arguments = parser.parse_args([
+            'login',
+            'https://osmo.example.com',
+        ])
+        service_client = mock.MagicMock()
+
+        login._login(service_client, arguments)
+
+        service_client.login_manager.pkce_login.assert_called_once_with(
+            url='https://osmo.example.com',
+            browser_endpoint=None,
+            callback_port=0,
+        )
+        service_client.login_manager.device_code_login.assert_not_called()
+
+    def test_device_method_remains_available(self):
+        parser = main_parser.create_cli_parser()
+        arguments = parser.parse_args([
+            'login',
+            'https://osmo.example.com',
+            '--method', 'code',
+        ])
+        service_client = mock.MagicMock()
+
+        login._login(service_client, arguments)
+
+        service_client.login_manager.device_code_login.assert_called_once_with(
+            'https://osmo.example.com',
+            None,
+        )
+        service_client.login_manager.pkce_login.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/lib/utils/client.py
+++ b/src/lib/utils/client.py
@@ -17,16 +17,19 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import base64
+import dataclasses
 import enum
+import http.server
 import json
 import logging
 import os
 import ssl
 import sys
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 from typing_extensions import assert_never
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
+import webbrowser
 
 import certifi
 import requests
@@ -39,6 +42,99 @@ from . import client_configs, login, osmo_errors, version
 
 CLIENT_USER_AGENT_PREFIX = 'osmo-cli'
 LIB_USER_AGENT_PREFIX = 'osmo-lib'
+PKCE_CALLBACK_TIMEOUT_SECONDS = 300
+
+
+@dataclasses.dataclass
+class BrowserAuthorizationCallback:
+    """Authorization response delivered to the CLI loopback listener."""
+    code: str | None = None
+    error: str | None = None
+    error_description: str | None = None
+
+
+class _BrowserAuthorizationCallbackServer(http.server.HTTPServer):
+    """Single-use loopback server for an OAuth authorization response."""
+
+    def __init__(self, callback_port: int, expected_state: str,
+                 timeout_seconds: float = PKCE_CALLBACK_TIMEOUT_SECONDS):
+        super().__init__(('127.0.0.1', callback_port),
+                         _BrowserAuthorizationCallbackHandler)
+        self.callback: BrowserAuthorizationCallback | None = None
+        self.expected_state = expected_state
+        self.timeout_seconds = timeout_seconds
+
+    @property
+    def redirect_uri(self) -> str:
+        return f'http://localhost:{self.server_port}'
+
+    def wait_for_callback(self) -> BrowserAuthorizationCallback:
+        deadline = time.monotonic() + self.timeout_seconds
+        while self.callback is None:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                raise osmo_errors.OSMOUserError(
+                    'Timed out waiting for browser authentication to complete')
+            self.timeout = remaining_seconds
+            self.handle_request()
+        return self.callback
+
+
+class _BrowserAuthorizationCallbackHandler(http.server.BaseHTTPRequestHandler):
+    """Capture the authorization response without logging request details."""
+
+    def do_GET(self):  # pylint: disable=invalid-name
+        parsed_request = urlparse(self.path)
+        if parsed_request.path != '/':
+            self.send_error(404)
+            return
+
+        callback_server = cast(_BrowserAuthorizationCallbackServer, self.server)
+        query = parse_qs(parsed_request.query, keep_blank_values=True)
+        returned_state = query.get('state', [None])[0]
+        error = query.get('error', [None])[0]
+        error_description = query.get('error_description', [None])[0]
+        code = query.get('code', [None])[0]
+
+        if returned_state != callback_server.expected_state:
+            self._send_browser_response(
+                400, b'Authentication response rejected. Return to the OSMO CLI.')
+            return
+        if error:
+            callback_server.callback = BrowserAuthorizationCallback(
+                error=error,
+                error_description=error_description,
+            )
+        elif code:
+            callback_server.callback = BrowserAuthorizationCallback(code=code)
+        else:
+            callback_server.callback = BrowserAuthorizationCallback(
+                error='invalid_response',
+                error_description='The authorization response did not contain a code.',
+            )
+
+        callback = callback_server.callback
+        success = callback.code is not None
+        response = (
+            b'Authentication complete. You can close this window.'
+            if success else
+            b'Authentication failed. Return to the OSMO CLI for details.'
+        )
+        self._send_browser_response(200 if success else 400, response)
+
+    def _send_browser_response(self, status_code: int, response: bytes):
+        self.send_response(status_code)
+        self.send_header('Content-Type', 'text/plain; charset=utf-8')
+        self.send_header('Cache-Control', 'no-store')
+        self.send_header('Referrer-Policy', 'no-referrer')
+        self.send_header('X-Content-Type-Options', 'nosniff')
+        self.send_header('Content-Length', str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+    def log_message(self, format, *args):  # pylint: disable=redefined-builtin
+        del format, args
+
 
 class RequestMethod(enum.Enum):
     """ Represents a method for making http requests """
@@ -164,7 +260,7 @@ class LoginManager():
 
         response = requests.post(device_endpoint, data={
             'client_id': client_id,
-            'scope': 'openid offline_access profile'
+            'scope': login.DEFAULT_OAUTH_SCOPE
         }, timeout=login.TIMEOUT, headers={'User-Agent': self.user_agent})
 
         result = handle_response(response)
@@ -220,6 +316,74 @@ class LoginManager():
         )
         self._save_login_info(self._login_storage, welcome=True)
 
+    def pkce_login(self, url: str, browser_endpoint: str | None,
+                   callback_port: int = 0):
+        """Log in using OAuth authorization code flow with S256 PKCE."""
+        if callback_port < 0 or callback_port > 65535:
+            raise osmo_errors.OSMOUserError(
+                'PKCE callback port must be between 0 and 65535')
+
+        login_info = login.fetch_login_info(url)
+        browser_endpoint = browser_endpoint or login_info.get('browser_endpoint')
+        client_id = self._login_config.client_id or login_info.get('browser_client_id')
+        token_endpoint = self._login_config.token_endpoint or login_info.get('token_endpoint')
+        if not browser_endpoint:
+            raise osmo_errors.OSMOUserError(
+                'The OSMO service does not provide a browser endpoint for PKCE login')
+        if not client_id:
+            raise osmo_errors.OSMOUserError(
+                'The OSMO service does not provide a browser client ID for PKCE login')
+        if not token_endpoint:
+            raise osmo_errors.OSMOUserError(
+                'The OSMO service does not provide a token endpoint for PKCE login')
+
+        code_verifier = login.generate_pkce_code_verifier()
+        code_challenge = login.create_pkce_code_challenge(code_verifier)
+        state = login.generate_oauth_state()
+        nonce = login.generate_oidc_nonce()
+        try:
+            callback_server = _BrowserAuthorizationCallbackServer(callback_port, state)
+        except OSError as error:
+            raise osmo_errors.OSMOUserError(
+                f'Unable to listen for the PKCE callback on port {callback_port}: {error}') \
+                from error
+
+        with callback_server:
+            authorization_url = login.construct_pkce_authorization_url(
+                browser_endpoint=browser_endpoint,
+                client_id=client_id,
+                redirect_uri=callback_server.redirect_uri,
+                state=state,
+                nonce=nonce,
+                code_challenge=code_challenge,
+            )
+            print('Complete authentication in your browser. If it does not open, visit:')
+            print(authorization_url, flush=True)
+            webbrowser.open(authorization_url)
+            callback = callback_server.wait_for_callback()
+
+        if callback.error:
+            error_message = callback.error
+            if callback.error_description:
+                error_message += f': {callback.error_description}'
+            raise osmo_errors.OSMOUserError(
+                f'Browser authentication failed ({error_message})')
+        if callback.code is None:
+            raise osmo_errors.OSMOUserError(
+                'Browser authentication did not return an authorization code')
+
+        self._login_storage = login.authorization_code_login(
+            url=url,
+            token_endpoint=token_endpoint,
+            client_id=client_id,
+            authorization_code=callback.code,
+            code_verifier=code_verifier,
+            redirect_uri=callback_server.redirect_uri,
+            expected_nonce=nonce,
+            user_agent=self.user_agent,
+        )
+        self._save_login_info(self._login_storage, welcome=True)
+
     def owner_password_login(self, url: str, username: str, password: str):
         """ Log in using OAUTH2 resource owner password flow """
         self._login_storage = login.owner_password_login(self._login_config,
@@ -247,7 +411,14 @@ class LoginManager():
     def _save_login_info(self, login_storage: login.LoginStorage, welcome: bool = False):
         login_dir = client_configs.get_client_config_dir()
         login_file = login_dir  + '/login.yaml'
-        with open(os.path.expanduser(login_file), 'w', encoding='utf-8') as file:
+        expanded_login_file = os.path.expanduser(login_file)
+        file_descriptor = os.open(
+            expanded_login_file,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        os.chmod(expanded_login_file, 0o600)
+        with os.fdopen(file_descriptor, 'w', encoding='utf-8') as file:
             login_dict = login_storage.model_dump()
             login_dict['name'] = login_storage.name
             yaml.dump(login_dict, file)

--- a/src/lib/utils/client.py
+++ b/src/lib/utils/client.py
@@ -74,7 +74,9 @@ class _BrowserAuthorizationCallbackServer(http.server.HTTPServer):
             remaining_seconds = deadline - time.monotonic()
             if remaining_seconds <= 0:
                 raise osmo_errors.OSMOUserError(
-                    'Timed out waiting for browser authentication to complete')
+                    'Timed out waiting for browser authentication to complete. '
+                    'If this environment cannot receive localhost callbacks, '
+                    'retry with "--method code".')
             self.timeout = remaining_seconds
             self.handle_request()
         return self.callback
@@ -336,6 +338,8 @@ class LoginManager():
         if not token_endpoint:
             raise osmo_errors.OSMOUserError(
                 'The OSMO service does not provide a token endpoint for PKCE login')
+        login.validate_oauth_endpoint(browser_endpoint, 'authorization endpoint')
+        login.validate_oauth_endpoint(token_endpoint, 'token endpoint')
 
         code_verifier = login.generate_pkce_code_verifier()
         code_challenge = login.create_pkce_code_challenge(code_verifier)
@@ -417,7 +421,11 @@ class LoginManager():
             os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
             0o600,
         )
-        os.chmod(expanded_login_file, 0o600)
+        try:
+            os.fchmod(file_descriptor, 0o600)
+        except OSError:
+            os.close(file_descriptor)
+            raise
         with os.fdopen(file_descriptor, 'w', encoding='utf-8') as file:
             login_dict = login_storage.model_dump()
             login_dict['name'] = login_storage.name

--- a/src/lib/utils/login.py
+++ b/src/lib/utils/login.py
@@ -287,7 +287,7 @@ def authorization_code_login(url: str, token_endpoint: str, client_id: str,
         'code_verifier': code_verifier,
         'redirect_uri': redirect_uri,
         'scope': DEFAULT_OAUTH_SCOPE,
-    }, timeout=TIMEOUT, headers=headers)
+    }, timeout=TIMEOUT, headers=headers, allow_redirects=False)
     if result.status_code != 200:
         raise osmo_errors.OSMOServerError(
             f'Failed to exchange authorization code: {result.text}')
@@ -368,11 +368,12 @@ def refresh_id_token(config: LoginConfig, user_agent: str | None,
                                json={'token': token_login_storage.refresh_token},
                                timeout=TIMEOUT, headers=headers)
     else:
+        validate_oauth_endpoint(token_endpoint, 'token endpoint')
         result = requests.post(token_endpoint, data={
             'grant_type': 'refresh_token',
             'refresh_token': token_login_storage.refresh_token,
             'client_id': token_login_storage.client_id or config.client_id,
-        }, timeout=TIMEOUT, headers=headers)
+        }, timeout=TIMEOUT, headers=headers, allow_redirects=False)
 
     if result.status_code >= 300:
         raise osmo_errors.OSMOServerError('Unable to refresh login token (status code ' \
@@ -401,4 +402,3 @@ def parse_allowed_pools(allowed_pools_header: str | None) -> List[str]:
     if not allowed_pools_header:
         return []
     return [pool.strip() for pool in allowed_pools_header.split(',') if pool.strip()]
-

--- a/src/lib/utils/login.py
+++ b/src/lib/utils/login.py
@@ -98,6 +98,17 @@ def construct_pkce_authorization_url(browser_endpoint: str, client_id: str,
     return urlunparse(parsed_endpoint._replace(query=urlencode(query)))
 
 
+def validate_oauth_endpoint(endpoint: str, endpoint_name: str) -> None:
+    """Require OAuth authorization and token endpoints to use HTTPS."""
+    if not isinstance(endpoint, str):
+        raise osmo_errors.OSMOUserError(
+            f'The OAuth {endpoint_name} must use HTTPS')
+    parsed_endpoint = urlparse(endpoint)
+    if parsed_endpoint.scheme.lower() != 'https' or not parsed_endpoint.netloc:
+        raise osmo_errors.OSMOUserError(
+            f'The OAuth {endpoint_name} must use HTTPS')
+
+
 class LoginConfig(pydantic.BaseModel):
     """ Manages configuration specific to the login """
     username: str | None = pydantic.Field(
@@ -265,6 +276,7 @@ def authorization_code_login(url: str, token_endpoint: str, client_id: str,
                              redirect_uri: str, expected_nonce: str,
                              user_agent: str | None) -> LoginStorage:
     """Exchange an OAuth authorization code using an RFC 7636 verifier."""
+    validate_oauth_endpoint(token_endpoint, 'token endpoint')
     headers = {}
     if user_agent:
         headers['User-Agent'] = user_agent
@@ -368,10 +380,14 @@ def refresh_id_token(config: LoginConfig, user_agent: str | None,
             f'Please re-login with "osmo login"')
     result_json = result.json()
     if not osmo_token:
+        refreshed_id_token = result_json.get('id_token')
+        if not refreshed_id_token:
+            raise osmo_errors.OSMOServerError(
+                'The identity provider did not return an ID token while refreshing login.\n'
+                'Please re-login with "osmo login"')
         token_login_storage.refresh_token = result_json.get(
             'refresh_token', token_login_storage.refresh_token)
-        token_login_storage.update_id_token(result_json.get(
-            'id_token', token_login_storage.id_token))
+        token_login_storage.update_id_token(refreshed_id_token)
     else:
         token_login_storage.update_id_token(result_json['token'])
     return token_login_storage
@@ -385,5 +401,4 @@ def parse_allowed_pools(allowed_pools_header: str | None) -> List[str]:
     if not allowed_pools_header:
         return []
     return [pool.strip() for pool in allowed_pools_header.split(',') if pool.strip()]
-
 

--- a/src/lib/utils/login.py
+++ b/src/lib/utils/login.py
@@ -17,10 +17,13 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import base64
+import hashlib
 import json
 import os
+import secrets
 import time
 from typing import List, Literal
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import pydantic
 import requests  # type: ignore
@@ -40,6 +43,9 @@ OSMO_ALLOWED_POOLS = 'x-osmo-allowed-pools'
 EXPIRE_WINDOW = 3
 TIMEOUT = 60
 DEFAULT_TOKEN_AUTH_PATH = 'realms/osmo/protocol/openid-connect/token'
+DEFAULT_OAUTH_SCOPE = 'openid offline_access profile'
+PKCE_CODE_CHALLENGE_METHOD = 'S256'
+PKCE_CODE_VERIFIER_BYTES = 64
 
 
 def fetch_login_info(url: str):
@@ -49,6 +55,47 @@ def fetch_login_info(url: str):
         raise osmo_errors.OSMOUserError(f'Unexpected status code ({result.status_code}) when ' \
                                         f'fetching login info from {login_url}: {result.text}')
     return result.json()
+
+
+def generate_pkce_code_verifier() -> str:
+    """Generate an RFC 7636 code verifier using URL-safe characters."""
+    return secrets.token_urlsafe(PKCE_CODE_VERIFIER_BYTES)
+
+
+def create_pkce_code_challenge(code_verifier: str) -> str:
+    """Derive an S256 PKCE challenge from a code verifier."""
+    digest = hashlib.sha256(code_verifier.encode('ascii')).digest()
+    return base64.urlsafe_b64encode(digest).decode('ascii').rstrip('=')
+
+
+def generate_oauth_state() -> str:
+    """Generate state used to bind the authorization response to the request."""
+    return secrets.token_urlsafe(32)
+
+
+def generate_oidc_nonce() -> str:
+    """Generate a nonce used to bind an ID token to an authorization request."""
+    return secrets.token_urlsafe(32)
+
+
+def construct_pkce_authorization_url(browser_endpoint: str, client_id: str,
+                                     redirect_uri: str, state: str,
+                                     nonce: str, code_challenge: str) -> str:
+    """Construct an OAuth authorization URL for an S256 PKCE flow."""
+    parsed_endpoint = urlparse(browser_endpoint)
+    query = parse_qsl(parsed_endpoint.query, keep_blank_values=True)
+    query.extend([
+        ('client_id', client_id),
+        ('response_type', 'code'),
+        ('redirect_uri', redirect_uri),
+        ('response_mode', 'query'),
+        ('scope', DEFAULT_OAUTH_SCOPE),
+        ('state', state),
+        ('nonce', nonce),
+        ('code_challenge', code_challenge),
+        ('code_challenge_method', PKCE_CODE_CHALLENGE_METHOD),
+    ])
+    return urlunparse(parsed_endpoint._replace(query=urlencode(query)))
 
 
 class LoginConfig(pydantic.BaseModel):
@@ -124,6 +171,10 @@ class TokenLoginStorage(pydantic.BaseModel):
             self._id_token_jwt = Jwt(self.id_token)
         return self._id_token_jwt
 
+    def update_id_token(self, id_token: str) -> None:
+        self.id_token = id_token
+        self._id_token_jwt = None
+
 
 class DevLoginStorage(pydantic.BaseModel):
     """Stores info trying to provide username directly as developer"""
@@ -192,7 +243,7 @@ def owner_password_login(config: LoginConfig,
         'username': username,
         'password': password,
         'grant_type': 'password',
-        'scope': 'openid offline_access profile'
+        'scope': DEFAULT_OAUTH_SCOPE
     }, timeout=TIMEOUT, headers=headers)
     if result.status_code != 200:
         raise osmo_errors.OSMOServerError(f'Failed to log in: {result.text}')
@@ -205,6 +256,45 @@ def owner_password_login(config: LoginConfig,
             id_token=result_json['id_token'],
             refresh_token=result_json['refresh_token'],
             refresh_url=token_endpoint
+        )
+    )
+
+
+def authorization_code_login(url: str, token_endpoint: str, client_id: str,
+                             authorization_code: str, code_verifier: str,
+                             redirect_uri: str, expected_nonce: str,
+                             user_agent: str | None) -> LoginStorage:
+    """Exchange an OAuth authorization code using an RFC 7636 verifier."""
+    headers = {}
+    if user_agent:
+        headers['User-Agent'] = user_agent
+    result = requests.post(token_endpoint, data={
+        'grant_type': 'authorization_code',
+        'client_id': client_id,
+        'code': authorization_code,
+        'code_verifier': code_verifier,
+        'redirect_uri': redirect_uri,
+        'scope': DEFAULT_OAUTH_SCOPE,
+    }, timeout=TIMEOUT, headers=headers)
+    if result.status_code != 200:
+        raise osmo_errors.OSMOServerError(
+            f'Failed to exchange authorization code: {result.text}')
+    result_json = result.json()
+    id_token = result_json.get('id_token')
+    if not id_token:
+        raise osmo_errors.OSMOServerError(
+            'The identity provider did not return an ID token')
+    if Jwt(id_token).claims.get('nonce') != expected_nonce:
+        raise osmo_errors.OSMOServerError(
+            'The identity provider returned an ID token with an invalid nonce')
+
+    return LoginStorage(
+        url=url,
+        token_login=TokenLoginStorage(
+            id_token=id_token,
+            refresh_token=result_json.get('refresh_token'),
+            refresh_url=token_endpoint,
+            client_id=client_id,
         )
     )
 
@@ -278,10 +368,12 @@ def refresh_id_token(config: LoginConfig, user_agent: str | None,
             f'Please re-login with "osmo login"')
     result_json = result.json()
     if not osmo_token:
-        token_login_storage.refresh_token = result_json['refresh_token']
-        token_login_storage.id_token = result_json['id_token']
+        token_login_storage.refresh_token = result_json.get(
+            'refresh_token', token_login_storage.refresh_token)
+        token_login_storage.update_id_token(result_json.get(
+            'id_token', token_login_storage.id_token))
     else:
-        token_login_storage.id_token = result_json['token']
+        token_login_storage.update_id_token(result_json['token'])
     return token_login_storage
 
 

--- a/src/lib/utils/tests/test_client.py
+++ b/src/lib/utils/tests/test_client.py
@@ -16,10 +16,13 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import base64
+import concurrent.futures
+import http.client
 import io
 import json
 import os
 import shutil
+import stat
 import sys
 import tempfile
 import unittest
@@ -86,6 +89,36 @@ class HandleResponseSuccessTests(unittest.TestCase):
         result = client.handle_response(response, mode=client.ResponseMode.STREAMING)
 
         self.assertIs(result, response)
+
+
+class BrowserAuthorizationCallbackServerTests(unittest.TestCase):
+    """Tests for the single-use PKCE loopback callback listener."""
+
+    def test_rejects_wrong_state_then_accepts_expected_callback(self):
+        # pylint: disable=protected-access
+        with client._BrowserAuthorizationCallbackServer(
+                callback_port=0,
+                expected_state='expected-state',
+                timeout_seconds=2) as callback_server, \
+             concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            callback_future = executor.submit(callback_server.wait_for_callback)
+            connection = http.client.HTTPConnection(
+                '127.0.0.1', callback_server.server_port, timeout=1)
+            connection.request('GET', '/?code=attacker-code&state=wrong-state')
+            self.assertEqual(connection.getresponse().status, 400)
+            connection.close()
+
+            connection = http.client.HTTPConnection(
+                '127.0.0.1', callback_server.server_port, timeout=1)
+            connection.request('GET', '/?code=valid-code&state=expected-state')
+            response = connection.getresponse()
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.getheader('Cache-Control'), 'no-store')
+            connection.close()
+            callback = callback_future.result(timeout=1)
+
+        self.assertEqual(callback.code, 'valid-code')
+        self.assertIsNone(callback.error)
 
 
 class HandleResponseWarningHeaderTests(unittest.TestCase):
@@ -335,6 +368,7 @@ class LoginManagerLoginAndLogoutTests(unittest.TestCase):
         self.assertEqual(saved['url'], 'https://example.com')
         self.assertEqual(saved['dev_login']['username'], 'alice')
         self.assertEqual(saved['name'], 'alice')
+        self.assertEqual(stat.S_IMODE(os.stat(self.login_path).st_mode), 0o600)
 
     def test_dev_login_prints_welcome_message(self):
         manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
@@ -407,6 +441,76 @@ class LoginManagerLoginAndLogoutTests(unittest.TestCase):
         manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
 
         self.assertEqual(manager.get_access_token(), 'refresh-abc')
+
+
+class LoginManagerPkceTests(unittest.TestCase):
+    """Tests for browser authorization-code login orchestration."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        environment_patch = mock.patch.dict(
+            os.environ, {common.OSMO_CONFIG_OVERRIDE: self.tmpdir})
+        environment_patch.start()
+        self.addCleanup(environment_patch.stop)
+        self.addCleanup(lambda: shutil.rmtree(self.tmpdir, ignore_errors=True))
+
+    def test_uses_discovered_pkce_configuration(self):
+        manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
+        callback_server = mock.MagicMock()
+        callback_server.redirect_uri = 'http://localhost:49152'
+        callback_server.wait_for_callback.return_value = \
+            client.BrowserAuthorizationCallback(code='authorization-code')
+        id_token = _make_jwt({
+            'exp': 9_999_999_999,
+            'name': 'Alice',
+        })
+        login_storage = login.LoginStorage(
+            url='https://osmo.example.com',
+            token_login=login.TokenLoginStorage(
+                id_token=id_token,
+            ),
+        )
+        discovered_login_info = {
+            'browser_endpoint': 'https://idp.example.com/authorize',
+            'browser_client_id': 'cli-client',
+            'token_endpoint': 'https://idp.example.com/token',
+        }
+
+        with mock.patch('src.lib.utils.client.login.fetch_login_info',
+                        return_value=discovered_login_info), \
+             mock.patch('src.lib.utils.client.login.generate_pkce_code_verifier',
+                        return_value='code-verifier'), \
+             mock.patch('src.lib.utils.client.login.create_pkce_code_challenge',
+                        return_value='code-challenge'), \
+             mock.patch('src.lib.utils.client.login.generate_oauth_state',
+                        return_value='state'), \
+             mock.patch('src.lib.utils.client.login.generate_oidc_nonce',
+                        return_value='nonce'), \
+             mock.patch('src.lib.utils.client._BrowserAuthorizationCallbackServer',
+                        return_value=callback_server) as callback_server_class, \
+             mock.patch('src.lib.utils.client.webbrowser.open') as browser_open, \
+             mock.patch('src.lib.utils.client.login.authorization_code_login',
+                        return_value=login_storage) as authorization_code_login, \
+             mock.patch('builtins.print'):
+            manager.pkce_login(
+                url='https://osmo.example.com',
+                browser_endpoint=None,
+            )
+
+        callback_server_class.assert_called_once_with(0, 'state')
+        browser_open.assert_called_once()
+        authorization_url = browser_open.call_args.args[0]
+        self.assertIn('code_challenge_method=S256', authorization_url)
+        authorization_code_login.assert_called_once_with(
+            url='https://osmo.example.com',
+            token_endpoint='https://idp.example.com/token',
+            client_id='cli-client',
+            authorization_code='authorization-code',
+            code_verifier='code-verifier',
+            redirect_uri='http://localhost:49152',
+            expected_nonce='nonce',
+            user_agent=manager.user_agent,
+        )
 
 
 class LoginManagerRefreshTests(unittest.TestCase):

--- a/src/lib/utils/tests/test_client.py
+++ b/src/lib/utils/tests/test_client.py
@@ -27,6 +27,7 @@ import sys
 import tempfile
 import unittest
 from unittest import mock
+from urllib.parse import urlparse
 
 import yaml
 
@@ -102,14 +103,20 @@ class BrowserAuthorizationCallbackServerTests(unittest.TestCase):
                 timeout_seconds=2) as callback_server, \
              concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             callback_future = executor.submit(callback_server.wait_for_callback)
+            callback_url = urlparse(callback_server.redirect_uri)
+            self.assertEqual(callback_url.hostname, 'localhost')
+            if callback_url.hostname is None or callback_url.port is None:
+                self.fail('Callback redirect URI must include a hostname and port')
+            callback_hostname = callback_url.hostname
+            callback_port = callback_url.port
             connection = http.client.HTTPConnection(
-                '127.0.0.1', callback_server.server_port, timeout=1)
+                callback_hostname, callback_port, timeout=1)
             connection.request('GET', '/?code=attacker-code&state=wrong-state')
             self.assertEqual(connection.getresponse().status, 400)
             connection.close()
 
             connection = http.client.HTTPConnection(
-                '127.0.0.1', callback_server.server_port, timeout=1)
+                callback_hostname, callback_port, timeout=1)
             connection.request('GET', '/?code=valid-code&state=expected-state')
             response = connection.getresponse()
             self.assertEqual(response.status, 200)
@@ -119,6 +126,17 @@ class BrowserAuthorizationCallbackServerTests(unittest.TestCase):
 
         self.assertEqual(callback.code, 'valid-code')
         self.assertIsNone(callback.error)
+
+    def test_timeout_recommends_device_authorization(self):
+        # pylint: disable=protected-access
+        with client._BrowserAuthorizationCallbackServer(
+                callback_port=0,
+                expected_state='expected-state',
+                timeout_seconds=0) as callback_server:
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                callback_server.wait_for_callback()
+
+        self.assertIn('--method code', str(context.exception))
 
 
 class HandleResponseWarningHeaderTests(unittest.TestCase):
@@ -370,6 +388,17 @@ class LoginManagerLoginAndLogoutTests(unittest.TestCase):
         self.assertEqual(saved['name'], 'alice')
         self.assertEqual(stat.S_IMODE(os.stat(self.login_path).st_mode), 0o600)
 
+    def test_dev_login_restricts_preexisting_login_file_permissions(self):
+        manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
+        with open(self.login_path, 'w', encoding='utf-8') as file:
+            file.write('preexisting')
+        os.chmod(self.login_path, 0o644)
+
+        with mock.patch('builtins.print'):
+            manager.dev_login('https://example.com', 'alice')
+
+        self.assertEqual(stat.S_IMODE(os.stat(self.login_path).st_mode), 0o600)
+
     def test_dev_login_prints_welcome_message(self):
         manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
 
@@ -511,6 +540,105 @@ class LoginManagerPkceTests(unittest.TestCase):
             expected_nonce='nonce',
             user_agent=manager.user_agent,
         )
+
+    def test_missing_browser_endpoint_raises(self):
+        manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
+        login_info = {
+            'browser_client_id': 'cli-client',
+            'token_endpoint': 'https://idp.example.com/token',
+        }
+
+        with mock.patch('src.lib.utils.client.login.fetch_login_info',
+                        return_value=login_info):
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                manager.pkce_login('https://osmo.example.com', None)
+
+        self.assertIn('browser endpoint', str(context.exception))
+
+    def test_missing_browser_client_id_raises(self):
+        manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
+        login_info = {
+            'browser_endpoint': 'https://idp.example.com/authorize',
+            'token_endpoint': 'https://idp.example.com/token',
+        }
+
+        with mock.patch('src.lib.utils.client.login.fetch_login_info',
+                        return_value=login_info):
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                manager.pkce_login('https://osmo.example.com', None)
+
+        self.assertIn('browser client ID', str(context.exception))
+
+    def test_missing_token_endpoint_raises(self):
+        manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
+        login_info = {
+            'browser_endpoint': 'https://idp.example.com/authorize',
+            'browser_client_id': 'cli-client',
+        }
+
+        with mock.patch('src.lib.utils.client.login.fetch_login_info',
+                        return_value=login_info):
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                manager.pkce_login('https://osmo.example.com', None)
+
+        self.assertIn('token endpoint', str(context.exception))
+
+    def test_rejects_insecure_authorization_endpoint(self):
+        manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
+        login_info = {
+            'browser_endpoint': 'http://idp.example.com/authorize',
+            'browser_client_id': 'cli-client',
+            'token_endpoint': 'https://idp.example.com/token',
+        }
+
+        with mock.patch('src.lib.utils.client.login.fetch_login_info',
+                        return_value=login_info):
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                manager.pkce_login('https://osmo.example.com', None)
+
+        self.assertIn('authorization endpoint must use HTTPS', str(context.exception))
+
+    def test_rejects_insecure_token_endpoint(self):
+        manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
+        login_info = {
+            'browser_endpoint': 'https://idp.example.com/authorize',
+            'browser_client_id': 'cli-client',
+            'token_endpoint': 'http://idp.example.com/token',
+        }
+
+        with mock.patch('src.lib.utils.client.login.fetch_login_info',
+                        return_value=login_info):
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                manager.pkce_login('https://osmo.example.com', None)
+
+        self.assertIn('token endpoint must use HTTPS', str(context.exception))
+
+    def test_provider_error_raises(self):
+        manager = client.LoginManager(login.LoginConfig(), 'osmo-cli')
+        callback_server = mock.MagicMock()
+        callback_server.redirect_uri = 'http://localhost:49152'
+        callback_server.wait_for_callback.return_value = \
+            client.BrowserAuthorizationCallback(
+                error='access_denied',
+                error_description='The user cancelled sign-in',
+            )
+        login_info = {
+            'browser_endpoint': 'https://idp.example.com/authorize',
+            'browser_client_id': 'cli-client',
+            'token_endpoint': 'https://idp.example.com/token',
+        }
+
+        with mock.patch('src.lib.utils.client.login.fetch_login_info',
+                        return_value=login_info), \
+             mock.patch('src.lib.utils.client._BrowserAuthorizationCallbackServer',
+                        return_value=callback_server), \
+             mock.patch('src.lib.utils.client.webbrowser.open'), \
+             mock.patch('builtins.print'):
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                manager.pkce_login('https://osmo.example.com', None)
+
+        self.assertIn('access_denied', str(context.exception))
+        self.assertIn('cancelled', str(context.exception))
 
 
 class LoginManagerRefreshTests(unittest.TestCase):

--- a/src/lib/utils/tests/test_login.py
+++ b/src/lib/utils/tests/test_login.py
@@ -458,6 +458,61 @@ class AuthorizationCodeLoginTests(unittest.TestCase):
 
         self.assertIn('nonce', str(context.exception).lower())
 
+    def test_rejects_insecure_token_endpoint_without_posting(self):
+        with mock.patch('src.lib.utils.login.requests.post') as mock_post:
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                login.authorization_code_login(
+                    url='https://osmo.example.com',
+                    token_endpoint='http://idp.example.com/token',
+                    client_id='cli-client',
+                    authorization_code='authorization-code',
+                    code_verifier='code-verifier',
+                    redirect_uri='http://localhost:49152',
+                    expected_nonce='expected-nonce',
+                    user_agent=None,
+                )
+
+        self.assertIn('token endpoint must use HTTPS', str(context.exception))
+        mock_post.assert_not_called()
+
+    def test_non_200_token_response_raises(self):
+        token_response = _FakeResponse(status_code=400, text='invalid_grant')
+        with mock.patch('src.lib.utils.login.requests.post',
+                        return_value=token_response):
+            with self.assertRaises(osmo_errors.OSMOServerError) as context:
+                login.authorization_code_login(
+                    url='https://osmo.example.com',
+                    token_endpoint='https://idp.example.com/token',
+                    client_id='cli-client',
+                    authorization_code='authorization-code',
+                    code_verifier='code-verifier',
+                    redirect_uri='http://localhost:49152',
+                    expected_nonce='expected-nonce',
+                    user_agent=None,
+                )
+
+        self.assertIn('invalid_grant', str(context.exception))
+
+    def test_missing_id_token_raises(self):
+        token_response = _FakeResponse(status_code=200, json_body={
+            'access_token': 'api-access-token',
+        })
+        with mock.patch('src.lib.utils.login.requests.post',
+                        return_value=token_response):
+            with self.assertRaises(osmo_errors.OSMOServerError) as context:
+                login.authorization_code_login(
+                    url='https://osmo.example.com',
+                    token_endpoint='https://idp.example.com/token',
+                    client_id='cli-client',
+                    authorization_code='authorization-code',
+                    code_verifier='code-verifier',
+                    redirect_uri='http://localhost:49152',
+                    expected_nonce='expected-nonce',
+                    user_agent=None,
+                )
+
+        self.assertIn('did not return an ID token', str(context.exception))
+
 
 class ConstructTokenRefreshUrlTests(unittest.TestCase):
     """Tests for construct_token_refresh_url."""
@@ -641,6 +696,34 @@ class RefreshIdTokenTests(unittest.TestCase):
 
         self.assertEqual(mock_post.call_args.kwargs['data']['client_id'],
                          'config-client')
+
+    def test_oauth_flow_rejects_refresh_without_id_token(self):
+        expired_token = _make_jwt({'exp': int(time.time()) - 60})
+        storage = login.TokenLoginStorage(
+            id_token=expired_token,
+            refresh_token='old-refresh',
+            refresh_url='https://idp/token',
+            client_id='storage-client',
+        )
+        refresh_response = _FakeResponse(status_code=200, json_body={
+            'access_token': 'new-access-token',
+            'refresh_token': 'new-refresh',
+        })
+
+        with mock.patch('src.lib.utils.login.requests.post',
+                        return_value=refresh_response):
+            with self.assertRaises(osmo_errors.OSMOServerError) as context:
+                login.refresh_id_token(
+                    config=login.LoginConfig(),
+                    user_agent=None,
+                    token_login_storage=storage,
+                    osmo_token=False,
+                )
+
+        self.assertIn('did not return an ID token', str(context.exception))
+        self.assertIn('re-login', str(context.exception))
+        self.assertEqual(storage.id_token, expired_token)
+        self.assertEqual(storage.refresh_token, 'old-refresh')
 
     def test_osmo_token_flow_posts_token_json(self):
         expired_token = _make_jwt({'exp': int(time.time()) - 60})

--- a/src/lib/utils/tests/test_login.py
+++ b/src/lib/utils/tests/test_login.py
@@ -20,6 +20,7 @@ import json
 import time
 import unittest
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 from src.lib.utils import login, osmo_errors
 
@@ -139,6 +140,47 @@ class JwtTests(unittest.TestCase):
         jwt = login.Jwt(token)
 
         self.assertTrue(jwt.expired)
+
+
+class PkceUtilityTests(unittest.TestCase):
+    """Tests for PKCE and authorization-request helpers."""
+
+    def test_code_challenge_matches_rfc_7636_example(self):
+        code_verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk'
+
+        challenge = login.create_pkce_code_challenge(code_verifier)
+
+        self.assertEqual(challenge, 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM')
+
+    def test_generated_code_verifier_has_valid_length_and_characters(self):
+        code_verifier = login.generate_pkce_code_verifier()
+
+        self.assertGreaterEqual(len(code_verifier), 43)
+        self.assertLessEqual(len(code_verifier), 128)
+        self.assertTrue(set(code_verifier) <= set(
+            'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'))
+
+    def test_authorization_url_contains_security_parameters_and_scope(self):
+        authorization_url = login.construct_pkce_authorization_url(
+            browser_endpoint='https://idp.example.com/authorize?prompt=select_account',
+            client_id='cli-client',
+            redirect_uri='http://localhost:49152',
+            state='expected-state',
+            nonce='expected-nonce',
+            code_challenge='challenge',
+        )
+
+        query = parse_qs(urlparse(authorization_url).query)
+        self.assertEqual(query['client_id'], ['cli-client'])
+        self.assertEqual(query['redirect_uri'], ['http://localhost:49152'])
+        self.assertEqual(query['response_type'], ['code'])
+        self.assertEqual(query['response_mode'], ['query'])
+        self.assertEqual(query['scope'], ['openid offline_access profile'])
+        self.assertEqual(query['state'], ['expected-state'])
+        self.assertEqual(query['nonce'], ['expected-nonce'])
+        self.assertEqual(query['code_challenge'], ['challenge'])
+        self.assertEqual(query['code_challenge_method'], ['S256'])
+        self.assertEqual(query['prompt'], ['select_account'])
 
 
 class TokenLoginStorageTests(unittest.TestCase):
@@ -356,6 +398,65 @@ class OwnerPasswordLoginTests(unittest.TestCase):
                 )
 
         self.assertIn('invalid credentials', str(ctx.exception))
+
+
+class AuthorizationCodeLoginTests(unittest.TestCase):
+    """Tests for authorization-code exchange with PKCE."""
+
+    def test_success_validates_nonce_and_stores_tokens(self):
+        id_token = _make_jwt({'sub': 'user1', 'nonce': 'expected-nonce'})
+        token_response = _FakeResponse(status_code=200, json_body={
+            'id_token': id_token,
+            'refresh_token': 'refresh-token',
+        })
+        with mock.patch('src.lib.utils.login.requests.post',
+                        return_value=token_response) as mock_post:
+            storage = login.authorization_code_login(
+                url='https://osmo.example.com',
+                token_endpoint='https://idp.example.com/token',
+                client_id='cli-client',
+                authorization_code='authorization-code',
+                code_verifier='code-verifier',
+                redirect_uri='http://localhost:49152',
+                expected_nonce='expected-nonce',
+                user_agent='osmo-cli/1.2.3',
+            )
+
+        token_storage = storage.token_login
+        self.assertIsNotNone(token_storage)
+        assert token_storage is not None
+        self.assertEqual(token_storage.id_token, id_token)
+        self.assertEqual(token_storage.refresh_token, 'refresh-token')
+        request_data = mock_post.call_args.kwargs['data']
+        self.assertEqual(request_data['grant_type'], 'authorization_code')
+        self.assertEqual(request_data['client_id'], 'cli-client')
+        self.assertEqual(request_data['code'], 'authorization-code')
+        self.assertEqual(request_data['code_verifier'], 'code-verifier')
+        self.assertEqual(request_data['redirect_uri'], 'http://localhost:49152')
+        self.assertEqual(request_data['scope'], 'openid offline_access profile')
+        self.assertNotIn('client_secret', request_data)
+
+    def test_rejects_id_token_with_wrong_nonce(self):
+        id_token = _make_jwt({'sub': 'user1', 'nonce': 'wrong-nonce'})
+        token_response = _FakeResponse(status_code=200, json_body={
+            'id_token': id_token,
+            'access_token': 'api-access-token',
+        })
+        with mock.patch('src.lib.utils.login.requests.post',
+                        return_value=token_response):
+            with self.assertRaises(osmo_errors.OSMOServerError) as context:
+                login.authorization_code_login(
+                    url='https://osmo.example.com',
+                    token_endpoint='https://idp.example.com/token',
+                    client_id='cli-client',
+                    authorization_code='authorization-code',
+                    code_verifier='code-verifier',
+                    redirect_uri='http://localhost:49152',
+                    expected_nonce='expected-nonce',
+                    user_agent=None,
+                )
+
+        self.assertIn('nonce', str(context.exception).lower())
 
 
 class ConstructTokenRefreshUrlTests(unittest.TestCase):

--- a/src/lib/utils/tests/test_login.py
+++ b/src/lib/utils/tests/test_login.py
@@ -493,6 +493,25 @@ class AuthorizationCodeLoginTests(unittest.TestCase):
 
         self.assertIn('invalid_grant', str(context.exception))
 
+    def test_rejects_token_endpoint_redirect(self):
+        token_response = _FakeResponse(status_code=307,
+                                       text='redirected to http://collector.invalid')
+        with mock.patch('src.lib.utils.login.requests.post',
+                        return_value=token_response) as mock_post:
+            with self.assertRaises(osmo_errors.OSMOServerError):
+                login.authorization_code_login(
+                    url='https://osmo.example.com',
+                    token_endpoint='https://idp.example.com/token',
+                    client_id='cli-client',
+                    authorization_code='authorization-code',
+                    code_verifier='code-verifier',
+                    redirect_uri='http://localhost:49152',
+                    expected_nonce='expected-nonce',
+                    user_agent=None,
+                )
+
+        self.assertFalse(mock_post.call_args.kwargs['allow_redirects'])
+
     def test_missing_id_token_raises(self):
         token_response = _FakeResponse(status_code=200, json_body={
             'access_token': 'api-access-token',
@@ -724,6 +743,52 @@ class RefreshIdTokenTests(unittest.TestCase):
         self.assertIn('re-login', str(context.exception))
         self.assertEqual(storage.id_token, expired_token)
         self.assertEqual(storage.refresh_token, 'old-refresh')
+
+    def test_oauth_flow_rejects_insecure_refresh_url_without_posting(self):
+        expired_token = _make_jwt({'exp': int(time.time()) - 60})
+        storage = login.TokenLoginStorage(
+            id_token=expired_token,
+            refresh_token='old-refresh',
+            refresh_url='http://idp.example.com/token',
+            client_id='storage-client',
+        )
+
+        with mock.patch('src.lib.utils.login.requests.post') as mock_post:
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                login.refresh_id_token(
+                    config=login.LoginConfig(),
+                    user_agent=None,
+                    token_login_storage=storage,
+                    osmo_token=False,
+                )
+
+        self.assertIn('token endpoint must use HTTPS', str(context.exception))
+        mock_post.assert_not_called()
+
+    def test_oauth_flow_rejects_refresh_redirect(self):
+        expired_token = _make_jwt({'exp': int(time.time()) - 60})
+        storage = login.TokenLoginStorage(
+            id_token=expired_token,
+            refresh_token='old-refresh',
+            refresh_url='https://idp.example.com/token',
+            client_id='storage-client',
+        )
+        refresh_response = _FakeResponse(
+            status_code=308,
+            text='redirected to http://collector.invalid',
+        )
+
+        with mock.patch('src.lib.utils.login.requests.post',
+                        return_value=refresh_response) as mock_post:
+            with self.assertRaises(osmo_errors.OSMOServerError):
+                login.refresh_id_token(
+                    config=login.LoginConfig(),
+                    user_agent=None,
+                    token_login_storage=storage,
+                    osmo_token=False,
+                )
+
+        self.assertFalse(mock_post.call_args.kwargs['allow_redirects'])
 
     def test_osmo_token_flow_posts_token_json(self):
         expired_token = _make_jwt({'exp': int(time.time()) - 60})


### PR DESCRIPTION
## Summary

- add OAuth 2.0 authorization code login with PKCE to the OSMO CLI
- make PKCE the default `osmo login` method while retaining device authorization through `--method code`
- discover the authorization, token, and client endpoints from the OSMO service
- validate the loopback callback with state and OpenID Connect nonce checks
- retain the client ID for refresh-token exchanges
- document the CLI behavior, Entra app-registration requirements, delegated-permission guidance, OAuth2 Proxy callback, and token-only bootstrap login

Issue #148

## Why

Device authorization was the CLI default even on interactive workstations. PKCE provides the standard browser-based public-client flow without embedding a client secret, while preserving device flow for environments where a loopback callback is unavailable.

## User impact

Running `osmo login <url>` now opens the system browser and completes an S256 PKCE flow through a temporary localhost callback. Existing users can explicitly select the previous device flow with `--method code`.

For Microsoft Entra ID, the app registration needs `http://localhost` under Mobile and desktop applications and public client flows enabled. Existing implicit/hybrid ID-token settings are independent and are not changed. The current OSMO ID-token contract does not require a delegated Microsoft Graph or OSMO API permission solely for CLI sign-in.

## Validation

- `bazel test //src/cli/tests/... //src/lib/utils/tests:test_login //src/lib/utils/tests:test_client //src/lib/utils:client-pylint //src/lib/utils:login-pylint //src/cli:cli_lib-pylint`
- all 14 affected test and lint targets pass
- `bazel run //src/cli:cli -- login --help` shows PKCE first and marked as the default
- bare `osmo login` completed against the harnholm staging environment and subsequent authenticated profile access succeeded
- documentation build will be validated by this PR's documentation checks

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added browser-based OAuth 2.0 login with PKCE as the default authentication method.
  - Added callback handling, state and nonce validation, timeout support, and authorization-code exchange.
  - Retained device authorization as an explicit alternative when browser callbacks are unavailable.
  - Added browser endpoint and callback port options.
  - Improved token handling and login-file security.

- **Documentation**
  - Updated authentication, identity-provider setup, deployment, and login guidance, including redirects, scopes, and authorization examples.

- **Tests**
  - Expanded coverage for PKCE, callback validation, token exchange, device flow, and secure file permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->