### PR TITLE
Linkify URLs in workflow warning and error messages

### DIFF
--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -81,6 +81,8 @@
     "cmdk": "^1.1.1",
     "immer": "^11.1.3",
     "jwt-decode": "^4.0.0",
+    "linkify-react": "^4.3.3",
+    "linkifyjs": "^4.3.3",
     "lucide-react": "^0.562.0",
     "next": "^16.2.11",
     "next-themes": "^0.4.6",

--- a/src/ui/pnpm-lock.yaml
+++ b/src/ui/pnpm-lock.yaml
@@ -166,6 +166,12 @@ importers:
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
+      linkify-react:
+        specifier: ^4.3.3
+        version: 4.3.3(linkifyjs@4.3.3)(react@19.2.8)
+      linkifyjs:
+        specifier: ^4.3.3
+        version: 4.3.3
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.8)
@@ -3783,6 +3789,15 @@ packages:
 
   linkify-it@5.0.1:
     resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
+
+  linkify-react@4.3.3:
+    resolution: {integrity: sha512-bMWuN1YJ3hyDyojk4hzUugecN2RsTuibKAQBplUT2o+3uK33THdRL2qD0Zf3ibCXuBLBCyOE6Uj/S/1cY48Ygw==}
+    peerDependencies:
+      linkifyjs: '==4.3.3'
+      react: '>= 15.0.0'
+
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -8979,6 +8994,13 @@ snapshots:
   linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
+
+  linkify-react@4.3.3(linkifyjs@4.3.3)(react@19.2.8):
+    dependencies:
+      linkifyjs: 4.3.3
+      react: 19.2.8
+
+  linkifyjs@4.3.3: {}
 
   locate-path@6.0.0:
     dependencies:

--- a/src/ui/src/components/linkified-text.test.tsx
+++ b/src/ui/src/components/linkified-text.test.tsx
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { LinkifiedText } from "@/components/linkified-text";
+
+describe("LinkifiedText", () => {
+  it("turns an embedded URL into a safe external link", () => {
+    const html = renderToStaticMarkup(
+      <LinkifiedText text="Look up valid PPP values at https://aihub.nvidia.com/home." />,
+    );
+    // URL is a real anchor with the exact href (trailing sentence period excluded)
+    expect(html).toContain('href="https://aihub.nvidia.com/home"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    // surrounding text is preserved as text
+    expect(html).toContain("Look up valid PPP values at");
+  });
+
+  it("leaves the trailing period outside the link", () => {
+    const html = renderToStaticMarkup(<LinkifiedText text="See https://aihub.nvidia.com/home." />);
+    expect(html).toContain("</a>.");
+    expect(html).not.toContain('href="https://aihub.nvidia.com/home."');
+  });
+
+  it("renders plain text without any links unchanged", () => {
+    const html = renderToStaticMarkup(<LinkifiedText text="No links in this message" />);
+    expect(html).not.toContain("<a ");
+    expect(html).toContain("No links in this message");
+  });
+});

--- a/src/ui/src/components/linkified-text.tsx
+++ b/src/ui/src/components/linkified-text.tsx
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * LinkifiedText
+ *
+ * Renders plain message text with any URLs/emails turned into safe external
+ * links. Used for operator-authored workflow warnings and policy error
+ * messages, which may embed a help URL (e.g. a label-policy assert_message).
+ *
+ * Injection-safe: linkify-react only wraps detected links and escapes the
+ * surrounding text — no dangerouslySetInnerHTML. Links inherit the ambient
+ * text color (amber for warnings, red for errors) and only add an underline.
+ */
+
+import Linkify from "linkify-react";
+
+const LINK_OPTIONS = {
+  defaultProtocol: "https",
+  target: "_blank",
+  rel: "noopener noreferrer",
+  className: "underline underline-offset-2 hover:opacity-80",
+} as const;
+
+export function LinkifiedText({ text }: { text: string }) {
+  return <Linkify options={LINK_OPTIONS}>{text}</Linkify>;
+}

--- a/src/ui/src/components/submit-workflow/submit-workflow-config-panel.tsx
+++ b/src/ui/src/components/submit-workflow/submit-workflow-config-panel.tsx
@@ -21,6 +21,7 @@ import { Loader2, TriangleAlert, CircleCheck, CircleX, ChevronDown } from "lucid
 import { WorkflowPriority } from "@/lib/api/generated";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/shadcn/button";
+import { LinkifiedText } from "@/components/linkified-text";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -182,7 +183,9 @@ export const SubmitWorkflowConfigPanel = memo(function SubmitWorkflowConfigPanel
               className="mt-px size-3.5 shrink-0"
               aria-hidden="true"
             />
-            <span className="min-w-0 [overflow-wrap:anywhere] whitespace-pre-wrap">{dryRunError}</span>
+            <span className="min-w-0 [overflow-wrap:anywhere] whitespace-pre-wrap">
+              <LinkifiedText text={dryRunError} />
+            </span>
           </div>
         )}
 
@@ -202,7 +205,9 @@ export const SubmitWorkflowConfigPanel = memo(function SubmitWorkflowConfigPanel
             role="status"
           >
             {validationWarnings.map((warning, index) => (
-              <p key={`${warning}-${index}`}>{warning}</p>
+              <p key={`${warning}-${index}`}>
+                <LinkifiedText text={warning} />
+              </p>
             ))}
           </div>
         )}
@@ -212,7 +217,9 @@ export const SubmitWorkflowConfigPanel = memo(function SubmitWorkflowConfigPanel
               className="mt-px size-3.5 shrink-0"
               aria-hidden="true"
             />
-            <span className="min-w-0 [overflow-wrap:anywhere] whitespace-pre-wrap">{validationError}</span>
+            <span className="min-w-0 [overflow-wrap:anywhere] whitespace-pre-wrap">
+              <LinkifiedText text={validationError} />
+            </span>
           </div>
         )}
 
@@ -222,7 +229,9 @@ export const SubmitWorkflowConfigPanel = memo(function SubmitWorkflowConfigPanel
             className="rounded bg-red-50 px-3 py-1.5 font-mono text-[11px] text-red-700 dark:bg-red-900/30 dark:text-red-300"
             role="alert"
           >
-            <span className="[overflow-wrap:anywhere] whitespace-pre-wrap">{error}</span>
+            <span className="[overflow-wrap:anywhere] whitespace-pre-wrap">
+              <LinkifiedText text={error} />
+            </span>
           </div>
         )}
 

--- a/src/ui/src/components/submit-workflow/use-submit-workflow-form.ts
+++ b/src/ui/src/components/submit-workflow/use-submit-workflow-form.ts
@@ -23,8 +23,9 @@
 
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { createElement, useState, useCallback, useMemo } from "react";
 import { toast } from "sonner";
+import { LinkifiedText } from "@/components/linkified-text";
 import { useNavigationRouter } from "@/hooks/use-navigation-router";
 import { useServices } from "@/contexts/service-context";
 import { WorkflowPriority, useSubmitWorkflowApiPoolPoolNameWorkflowPost } from "@/lib/api/generated";
@@ -128,7 +129,7 @@ export function useSubmitWorkflowForm(initialSpec = ""): UseSubmitWorkflowFormRe
       onSuccess: (response) => {
         const newName = response.name;
         for (const warning of response.warnings ?? []) {
-          toast.warning(warning);
+          toast.warning(createElement(LinkifiedText, { text: warning }));
         }
         toast.success(`Workflow submitted as ${newName}`, {
           action: {

--- a/src/ui/src/features/workflows/detail/components/panel/ui/workflow/workflow-details.tsx
+++ b/src/ui/src/features/workflows/detail/components/panel/ui/workflow/workflow-details.tsx
@@ -38,6 +38,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Card, CardContent } from "@/components/shadcn/card";
+import { LinkifiedText } from "@/components/linkified-text";
 import { Skeleton } from "@/components/shadcn/skeleton";
 import { CopyButton } from "@/components/copyable-value";
 import { ActionsSection, type ActionItem } from "@/components/panel/actions-section";
@@ -206,7 +207,9 @@ const WorkflowWarnings = memo(function WorkflowWarnings({ warnings }: { warnings
         <div className="min-w-0">
           <ul className="mt-1 list-disc space-y-1 pl-4 text-xs">
             {warnings.map((warning, index) => (
-              <li key={`${warning}-${index}`}>{warning}</li>
+              <li key={`${warning}-${index}`}>
+                <LinkifiedText text={warning} />
+              </li>
             ))}
           </ul>
         </div>

--- a/src/ui/src/features/workflows/detail/components/resubmit/resubmit-panel-content.tsx
+++ b/src/ui/src/features/workflows/detail/components/resubmit/resubmit-panel-content.tsx
@@ -28,6 +28,7 @@ import { Loader2 } from "lucide-react";
 import type { WorkflowQueryResponse } from "@/lib/api/adapter/types";
 import { WorkflowPriority } from "@/lib/api/generated";
 import { Button } from "@/components/shadcn/button";
+import { LinkifiedText } from "@/components/linkified-text";
 import { usePanelFocus } from "@/components/panel/hooks/use-panel-focus";
 import { CollapsibleSection } from "@/components/workflow/collapsible-section";
 import { PoolPicker } from "@/components/workflow/pool-picker";
@@ -149,7 +150,7 @@ export const ResubmitPanelContent = memo(function ResubmitPanelContent({
           className="mx-6 mb-2 rounded-md bg-red-50 p-3 text-sm text-red-800 dark:bg-red-900/30 dark:text-red-300"
           role="alert"
         >
-          {form.error}
+          <LinkifiedText text={form.error} />
         </div>
       )}
 

--- a/src/ui/src/features/workflows/detail/components/resubmit/use-resubmit-form.ts
+++ b/src/ui/src/features/workflows/detail/components/resubmit/use-resubmit-form.ts
@@ -23,11 +23,12 @@
 
 "use client";
 
-import { useState, useCallback, useMemo } from "react";
+import { createElement, useState, useCallback, useMemo } from "react";
 import { useNavigationRouter } from "@/hooks/use-navigation-router";
 import { toast } from "sonner";
 import type { WorkflowQueryResponse } from "@/lib/api/adapter/types";
 import { WorkflowPriority } from "@/lib/api/generated";
+import { LinkifiedText } from "@/components/linkified-text";
 import { usePoolSelection } from "@/components/workflow/use-pool-selection";
 import { useResubmitMutation } from "@/features/workflows/detail/components/resubmit/use-resubmit-mutation";
 import {
@@ -96,7 +97,7 @@ export function useResubmitForm({ workflow, onSuccess }: UseResubmitFormOptions)
         : "Workflow resubmitted successfully";
 
       for (const warning of warnings) {
-        toast.warning(warning);
+        toast.warning(createElement(LinkifiedText, { text: warning }));
       }
       toast.success(message, {
         action: newWorkflowName


### PR DESCRIPTION
## Summary

Issue - None

Operator-authored label-policy messages (`assert_message`) can embed a help URL — e.g. `See the label guide at https://example.com/labels.` — which the UI previously rendered as **inert plain text** in workflow warnings and policy errors.

This adds a small, reusable, injection-safe `LinkifiedText` component (via `linkify-react`) and uses it everywhere those messages surface:

- **Submit panel** — validation warnings, validation error, submit error, dry-run error
- **Workflow detail** — the warnings section
- **Resubmit panel** — the error message
- **Toasts** — the submit / resubmit warning toasts

Links open in a new tab (`rel="noopener noreferrer"`), inherit the ambient warning/error color (amber/red) with just an underline, and are XSS-safe: `linkify-react` only wraps detected links and escapes the surrounding text (no `dangerouslySetInnerHTML`).

## Verification

- `pnpm test` — **1030 unit tests pass**, including a new `linkified-text.test.tsx` (URL → anchor with correct `href`/`target`/`rel`, trailing sentence punctuation excluded, plain text left untouched).
- `pnpm run type-check` and `pnpm run lint` pass.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically converts URLs and email addresses in workflow messages, warnings, validation errors, dry-run errors, resubmission errors, and submission errors into clickable links.
  * Links open securely in a new browser tab with clear hover styling.
  * Preserves surrounding text and avoids including sentence punctuation in links.

* **Tests**
  * Added coverage for link rendering, plain-text preservation, exact URL handling, and safe external-link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->