### PR TITLE
testbot: include the test rules in the prompt, default to Opus 5

### DIFF
--- a/.github/workflows/testbot-respond.yaml
+++ b/.github/workflows/testbot-respond.yaml
@@ -105,7 +105,7 @@ jobs:
             --max-responses 10 \
             --max-turns 200 \
             --timeout 900 \
-            --model aws/anthropic/bedrock-claude-opus-4-7
+            --model aws/anthropic/bedrock-claude-opus-5
         env:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -235,7 +235,17 @@ jobs:
           fi
 
           TARGETS=$(cat "$RUNNER_TEMP/targets.txt")
+          # Splice TESTBOT_RULES.md in rather than letting the prompt point at
+          # it. TESTBOT_PROMPT.md used to say "Read TESTBOT_RULES.md for test
+          # quality rules ... and verification steps", and on run/30499270675
+          # the generator never opened it: 23 Read calls, none for that file.
+          # It therefore missed both "test PUBLIC behavior only" and the lint
+          # step, and PR #1253 landed with 9 pylint errors. An instruction
+          # nothing verifies is followed only sometimes — the targets below
+          # are inlined for the same reason.
           PROMPT="$(cat src/scripts/testbot/TESTBOT_PROMPT.md)
+
+          $(cat src/scripts/testbot/TESTBOT_RULES.md)
 
           Coverage targets:
           $TARGETS"

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -235,10 +235,7 @@ jobs:
           fi
 
           TARGETS=$(cat "$RUNNER_TEMP/targets.txt")
-          # Splice the rules in rather than pointing at them: on
-          # run/30499270675 the generator never opened TESTBOT_RULES.md
-          # (23 Read calls, none for it) and shipped PR #1253 with 9
-          # pylint errors.
+          # Include the rules inline rather than pointing at them.
           PROMPT="$(cat src/scripts/testbot/TESTBOT_PROMPT.md)
 
           $(cat src/scripts/testbot/TESTBOT_RULES.md)

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -235,14 +235,10 @@ jobs:
           fi
 
           TARGETS=$(cat "$RUNNER_TEMP/targets.txt")
-          # Splice TESTBOT_RULES.md in rather than letting the prompt point at
-          # it. TESTBOT_PROMPT.md used to say "Read TESTBOT_RULES.md for test
-          # quality rules ... and verification steps", and on run/30499270675
-          # the generator never opened it: 23 Read calls, none for that file.
-          # It therefore missed both "test PUBLIC behavior only" and the lint
-          # step, and PR #1253 landed with 9 pylint errors. An instruction
-          # nothing verifies is followed only sometimes — the targets below
-          # are inlined for the same reason.
+          # Splice the rules in rather than pointing at them: on
+          # run/30499270675 the generator never opened TESTBOT_RULES.md
+          # (23 Read calls, none for it) and shipped PR #1253 with 9
+          # pylint errors.
           PROMPT="$(cat src/scripts/testbot/TESTBOT_PROMPT.md)
 
           $(cat src/scripts/testbot/TESTBOT_RULES.md)

--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -42,7 +42,7 @@ on:
         default: '60'
       model:
         description: 'LLM model name on NVIDIA gateway'
-        default: 'aws/anthropic/bedrock-claude-opus-4-7'
+        default: 'aws/anthropic/bedrock-claude-opus-5'
       dry_run:
         description: 'Generate but do not create PR'
         type: boolean
@@ -220,7 +220,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
-          ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/bedrock-claude-opus-4-7' }}
+          ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/bedrock-claude-opus-5' }}
           DISABLE_PROMPT_CACHING: "1"
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
 
@@ -314,7 +314,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
-          ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/bedrock-claude-opus-4-7' }}
+          ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/bedrock-claude-opus-5' }}
           MAX_TURNS: ${{ inputs.max_turns || '200' }}
           DISABLE_PROMPT_CACHING: "1"  # NVIDIA gateway rejects cache_control.ephemeral.scope
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"  # NVIDIA gateway rejects context_management

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -66,7 +66,7 @@ gh workflow run testbot.yaml --ref <branch> \
   -f max_targets=1 \
   -f max_uncovered=500 \
   -f max_turns=100 \
-  -f model=aws/anthropic/bedrock-claude-opus-4-7
+  -f model=aws/anthropic/bedrock-claude-opus-5
 ```
 
 ### Schedule
@@ -109,7 +109,7 @@ Then post a new `/testbot` comment with clearer instructions.
 | `max_uncovered` | `500` | Uncovered lines cap per target (0 = no cap) |
 | `max_turns` | `100` | Claude Code agent turns |
 | `timeout_minutes` | `30` | Workflow timeout |
-| `model` | `aws/anthropic/bedrock-claude-opus-4-7` | LLM model on API gateway |
+| `model` | `aws/anthropic/bedrock-claude-opus-5` | LLM model on API gateway |
 | `dry_run` | `false` | Generate without creating PR |
 
 ### Slack review requests
@@ -129,7 +129,7 @@ notification. Direct channel IDs are also accepted.
 | `--max-turns` | `200` | Claude Code agent turns |
 | `--max-responses` | `10` | Max threads to address per trigger |
 | `--timeout` | `720` | Claude Code CLI timeout in seconds |
-| `--model` | `aws/anthropic/bedrock-claude-opus-4-7` | LLM model |
+| `--model` | `aws/anthropic/bedrock-claude-opus-5` | LLM model |
 
 ### Coverage target selection
 

--- a/src/scripts/testbot/TESTBOT_PROMPT.md
+++ b/src/scripts/testbot/TESTBOT_PROMPT.md
@@ -1,9 +1,10 @@
 # Testbot Generate Instructions
 
 You are generating tests for the OSMO codebase to improve code coverage.
-Test quality rules, language conventions, and the verification steps you must
-run are appended below from `TESTBOT_RULES.md`. Project coding standards are in
-`AGENTS.md`, already in your context via the root `CLAUDE.md`.
+Read `AGENTS.md` at the repo root for project coding standards (import rules,
+naming conventions, type annotations, assertion style).
+Test quality rules, language conventions, and verification steps are appended
+below from `src/scripts/testbot/TESTBOT_RULES.md`.
 
 ## Primary Objective
 

--- a/src/scripts/testbot/TESTBOT_PROMPT.md
+++ b/src/scripts/testbot/TESTBOT_PROMPT.md
@@ -1,10 +1,14 @@
 # Testbot Generate Instructions
 
 You are generating tests for the OSMO codebase to improve code coverage.
-Read `AGENTS.md` at the repo root for project coding standards (import rules,
-naming conventions, type annotations, assertion style).
-Read `src/scripts/testbot/TESTBOT_RULES.md` for test quality rules, language
-conventions, and verification steps.
+
+The contents of `src/scripts/testbot/TESTBOT_RULES.md` — test quality rules,
+language conventions, and the verification steps you must run before
+finishing — are appended to this prompt by the workflow. They are not
+optional background reading; they are part of your instructions. Project
+coding standards (import rules, naming, type annotations, assertion style)
+come from `AGENTS.md`, which the repo's root `CLAUDE.md` already imports into
+your context.
 
 ## Primary Objective
 

--- a/src/scripts/testbot/TESTBOT_PROMPT.md
+++ b/src/scripts/testbot/TESTBOT_PROMPT.md
@@ -1,14 +1,9 @@
 # Testbot Generate Instructions
 
 You are generating tests for the OSMO codebase to improve code coverage.
-
-The contents of `src/scripts/testbot/TESTBOT_RULES.md` — test quality rules,
-language conventions, and the verification steps you must run before
-finishing — are appended to this prompt by the workflow. They are not
-optional background reading; they are part of your instructions. Project
-coding standards (import rules, naming, type annotations, assertion style)
-come from `AGENTS.md`, which the repo's root `CLAUDE.md` already imports into
-your context.
+Test quality rules, language conventions, and the verification steps you must
+run are appended below from `TESTBOT_RULES.md`. Project coding standards are in
+`AGENTS.md`, already in your context via the root `CLAUDE.md`.
 
 ## Primary Objective
 

--- a/src/scripts/testbot/TESTBOT_RULES.md
+++ b/src/scripts/testbot/TESTBOT_RULES.md
@@ -76,31 +76,23 @@ When a test fails:
 > wasted turns on run/26536045087. `Read` accepts absolute paths under
 > `bazel-out/` and `bazel-testlogs/`.
 
-1. **Run the test with the package pattern, not the single target**:
-   - Python/Go: `bazel test //<package>:all` (derive the package from the
-     directory containing the BUILD file).
-
-     Use `:all`, **not** `bazel test //<package>:<target>`. `osmo_py_test`
-     generates a sibling `<target>-pylint` test alongside every test target
-     (see `bzl/py.bzl`), and PR CI runs it. Naming the single target runs the
-     test but *not* the lint check, so it passes while CI fails — that is
-     exactly how PR #1253 shipped with 9 pylint errors. `:all` runs both.
-
+1. **Run the test**:
+   - Python/Go: `bazel test //<package>:all` — the package pattern, not the
+     single target. `osmo_py_test` generates a sibling `<target>-pylint` test
+     that PR CI runs; naming one target skips it, so the test goes green while
+     CI fails. `:all` runs both.
      If bazel reports `ERROR: No test targets were found, yet testing
      was requested`, the test file isn't wired into BUILD — see "BUILD wiring"
      below before retrying.
    - TypeScript: `pnpm --dir src/ui test -- --run <test_file_path>`
-2. If a test *or* a `-pylint` target fails, read the error and fix. Retry up
-   to 3 times. Two pylint failures are common in generated tests:
-   - `W0212 protected-access` — you called an underscore-prefixed member,
-     which the "Test PUBLIC behavior only" rule above already forbids. Test
-     through the public entry point instead. If a private function genuinely
-     needs direct coverage, add `# pylint: disable=protected-access` to the
-     test class, matching the existing test modules that do this.
-   - `C2801 unnecessary-dunder-call` — use `with <cm>:` rather than calling
-     `__enter__()` directly.
+2. If a test or `-pylint` target fails, read the error and fix. Retry up to 3
+   times. Common pylint failures in generated tests:
+   - `W0212 protected-access` — testing an underscore-prefixed member, which
+     the "Test PUBLIC behavior only" rule already forbids. Go through the
+     public entry point, or add `# pylint: disable=protected-access`.
+   - `C2801 unnecessary-dunder-call` — use `with <cm>:`, not `__enter__()`.
 3. **Remaining style checks** (same as PR CI). Fix and re-verify until clean:
-   - Python: already covered by step 1 — no separate command needed.
+   - Python: covered by step 1.
    - TypeScript: `pnpm --dir src/ui validate` (runs type-check, lint,
      format:check, tests, and build). If formatting fails, run
      `pnpm --dir src/ui format` to auto-fix.

--- a/src/scripts/testbot/TESTBOT_RULES.md
+++ b/src/scripts/testbot/TESTBOT_RULES.md
@@ -76,15 +76,31 @@ When a test fails:
 > wasted turns on run/26536045087. `Read` accepts absolute paths under
 > `bazel-out/` and `bazel-testlogs/`.
 
-1. **Run the test**:
-   - Python/Go: `bazel test <target>` (derive the Bazel target from the BUILD file).
-     If `bazel test` reports `ERROR: No test targets were found, yet testing
+1. **Run the test with the package pattern, not the single target**:
+   - Python/Go: `bazel test //<package>:all` (derive the package from the
+     directory containing the BUILD file).
+
+     Use `:all`, **not** `bazel test //<package>:<target>`. `osmo_py_test`
+     generates a sibling `<target>-pylint` test alongside every test target
+     (see `bzl/py.bzl`), and PR CI runs it. Naming the single target runs the
+     test but *not* the lint check, so it passes while CI fails — that is
+     exactly how PR #1253 shipped with 9 pylint errors. `:all` runs both.
+
+     If bazel reports `ERROR: No test targets were found, yet testing
      was requested`, the test file isn't wired into BUILD — see "BUILD wiring"
      below before retrying.
    - TypeScript: `pnpm --dir src/ui test -- --run <test_file_path>`
-2. If the test fails, read the error and fix. Retry up to 3 times.
-3. **Verify code style** (same checks as PR CI). Fix and re-verify until clean:
-   - Python: `bazel test <target>-pylint` (append `-pylint` to the test target name)
+2. If a test *or* a `-pylint` target fails, read the error and fix. Retry up
+   to 3 times. Two pylint failures are common in generated tests:
+   - `W0212 protected-access` — you called an underscore-prefixed member,
+     which the "Test PUBLIC behavior only" rule above already forbids. Test
+     through the public entry point instead. If a private function genuinely
+     needs direct coverage, add `# pylint: disable=protected-access` to the
+     test class, matching the existing test modules that do this.
+   - `C2801 unnecessary-dunder-call` — use `with <cm>:` rather than calling
+     `__enter__()` directly.
+3. **Remaining style checks** (same as PR CI). Fix and re-verify until clean:
+   - Python: already covered by step 1 — no separate command needed.
    - TypeScript: `pnpm --dir src/ui validate` (runs type-check, lint,
      format:check, tests, and build). If formatting fails, run
      `pnpm --dir src/ui format` to auto-fix.

--- a/src/scripts/testbot/TESTBOT_RULES.md
+++ b/src/scripts/testbot/TESTBOT_RULES.md
@@ -77,22 +77,14 @@ When a test fails:
 > `bazel-out/` and `bazel-testlogs/`.
 
 1. **Run the test**:
-   - Python/Go: `bazel test //<package>:all` — the package pattern, not the
-     single target. `osmo_py_test` generates a sibling `<target>-pylint` test
-     that PR CI runs; naming one target skips it, so the test goes green while
-     CI fails. `:all` runs both.
-     If bazel reports `ERROR: No test targets were found, yet testing
+   - Python/Go: `bazel test <target>` (derive the Bazel target from the BUILD file).
+     If `bazel test` reports `ERROR: No test targets were found, yet testing
      was requested`, the test file isn't wired into BUILD — see "BUILD wiring"
      below before retrying.
    - TypeScript: `pnpm --dir src/ui test -- --run <test_file_path>`
-2. If a test or `-pylint` target fails, read the error and fix. Retry up to 3
-   times. Common pylint failures in generated tests:
-   - `W0212 protected-access` — testing an underscore-prefixed member, which
-     the "Test PUBLIC behavior only" rule already forbids. Go through the
-     public entry point, or add `# pylint: disable=protected-access`.
-   - `C2801 unnecessary-dunder-call` — use `with <cm>:`, not `__enter__()`.
-3. **Remaining style checks** (same as PR CI). Fix and re-verify until clean:
-   - Python: covered by step 1.
+2. If the test fails, read the error and fix. Retry up to 3 times.
+3. **Verify code style** (same checks as PR CI). Fix and re-verify until clean:
+   - Python: `bazel test <target>-pylint` (append `-pylint` to the test target name)
    - TypeScript: `pnpm --dir src/ui validate` (runs type-check, lint,
      format:check, tests, and build). If formatting fails, run
      `pnpm --dir src/ui format` to auto-fix.

--- a/src/scripts/testbot/respond.py
+++ b/src/scripts/testbot/respond.py
@@ -311,7 +311,7 @@ def build_prompt(threads: list[dict], pr_number: int) -> str:
 
 def run_claude(
     prompt: str,
-    model: str = "aws/anthropic/bedrock-claude-opus-4-7",
+    model: str = "aws/anthropic/bedrock-claude-opus-5",
     max_turns: int = 50,
     timeout: int = 720,
 ) -> dict:
@@ -488,8 +488,8 @@ def main() -> None:
                         help="Max Claude Code agent turns (default: 50)")
     parser.add_argument("--timeout", type=int, default=720,
                         help="Claude Code CLI timeout in seconds (default: 720)")
-    parser.add_argument("--model", default="aws/anthropic/bedrock-claude-opus-4-7",
-                        help="LLM model name (default: aws/anthropic/bedrock-claude-opus-4-7)")
+    parser.add_argument("--model", default="aws/anthropic/bedrock-claude-opus-5",
+                        help="LLM model name (default: aws/anthropic/bedrock-claude-opus-5)")
     args = parser.parse_args()
 
     github_repository = os.environ.get("GITHUB_REPOSITORY", "NVIDIA/OSMO")

--- a/src/scripts/testbot/select_targets_agent.py
+++ b/src/scripts/testbot/select_targets_agent.py
@@ -354,7 +354,7 @@ def main() -> None:
     parser.add_argument("--model",
                         default=os.environ.get(
                             "ANTHROPIC_MODEL",
-                            "aws/anthropic/bedrock-claude-opus-4-7",
+                            "aws/anthropic/bedrock-claude-opus-5",
                         ))
     parser.add_argument("--output", default="-",
                         help="Output path; '-' (default) writes to stdout")


### PR DESCRIPTION
## Description

Two changes to the testbot harness.

**1. Put the test rules in the prompt.** Testbot PRs keep failing `ci-internal` on pylint — #1253 opened with 9 errors, #1184 needed a "fix pylint failures" follow-up, #1245 a lint-fix commit.

`TESTBOT_PROMPT.md` told the generator to *read* `TESTBOT_RULES.md`, which is the only place documenting the `bazel test <target>-pylint` verification step and the "Test PUBLIC behavior only. Never call underscore-prefixed methods" rule. In the trace for run/30499270675 the generator made 23 `Read` calls and opened that file in none of them, so it followed neither.

The workflow now passes the rules in with the prompt, the same way coverage targets already are. No change to the rules themselves.

**2. Default to Opus 5.** `bedrock-claude-opus-4-7` → `bedrock-claude-opus-5` across the testbot generate and respond paths (workflow input default, both `ANTHROPIC_MODEL` fallbacks, `testbot-respond.yaml`, `select_targets_agent.py`, `respond.py`, README). `draft-release-notes.yaml` still defaults to 4-7 and is unchanged.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test generation with documented quality and verification requirements.
  * Clarified that project coding standards are applied automatically when generating tests.
  * Updated automated test generation, target selection, and review responses to use Claude Opus 5 by default.

* **Documentation**
  * Updated test automation documentation to reflect the new default model and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->