### PR TITLE
Unify MCP container image repository

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -91,6 +91,8 @@ destination, but it cannot validate external DNS.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `services.mcp.enabled` | Deploy the MCP workload and Gateway routes. | `false` |
+| `services.mcp.imageName` | MCP image repository name. | `mcp` |
+| `services.mcp.imageTag` | Per-MCP image tag override; falls back to `global.osmoImageTag` when empty. | `""` |
 | `services.mcp.resourceUrl` | Canonical public HTTPS MCP URL ending in exact `/mcp`; also determines the fixed outbound Gateway origin. | `""` |
 | `services.mcp.authorizationServers` | OAuth/OIDC issuer identifiers advertised in protected-resource metadata. At least one is required when enabled. | `[]` |
 | `services.mcp.scopes` | OAuth scopes advertised in protected-resource metadata. | `[]` |

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -87,6 +87,7 @@ done
 assert_mcp_rendered 'kind: Deployment'
 assert_mcp_rendered 'kind: Service'
 assert_mcp_rendered 'name: osmo-mcp'
+assert_mcp_rendered 'image: nvcr.io/nvidia/osmo/mcp:latest'
 assert_mcp_rendered 'name: OSMO_GATEWAY_URL'
 assert_mcp_rendered 'name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS'
 assert_mcp_rendered 'kind: NetworkPolicy'

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -127,7 +127,7 @@ services:
     ## Docker image name and optional tag override. An empty imageTag uses
     ## global.osmoImageTag.
     ##
-    imageName: mcp-self-hosted
+    imageName: mcp
     imageTag: ""
     imagePullPolicy: Always
 

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -462,7 +462,7 @@ oci_image(
 oci_load(
     name = "mcp_image_load_x86_64",
     image = ":mcp_image_x86_64",
-    repo_tags = ["osmo.local/mcp-self-hosted:latest-x86_64"],
+    repo_tags = ["osmo.local/mcp:latest-x86_64"],
     tags = ["manual"],
     target_compatible_with = ["@platforms//cpu:x86_64"],
 )
@@ -470,7 +470,7 @@ oci_load(
 oci_push(
     name = "mcp_push_x86_64",
     image = ":mcp_image_x86_64",
-    repository = BASE_IMAGE_URL + "mcp-self-hosted",
+    repository = BASE_IMAGE_URL + "mcp",
     remote_tags = [IMAGE_TAG + "-amd64"] if IMAGE_TAG else None,
     tags = ["manual"],
     target_compatible_with = ["@platforms//cpu:x86_64"],
@@ -492,7 +492,7 @@ oci_image(
 oci_load(
     name = "mcp_image_load_arm64",
     image = ":mcp_image_arm64",
-    repo_tags = ["osmo.local/mcp-self-hosted:latest-arm64"],
+    repo_tags = ["osmo.local/mcp:latest-arm64"],
     tags = ["manual"],
     target_compatible_with = ["@platforms//cpu:arm64"],
 )
@@ -500,7 +500,7 @@ oci_load(
 oci_push(
     name = "mcp_push_arm64",
     image = ":mcp_image_arm64",
-    repository = BASE_IMAGE_URL + "mcp-self-hosted",
+    repository = BASE_IMAGE_URL + "mcp",
     remote_tags = [IMAGE_TAG + "-arm64"] if IMAGE_TAG else None,
     tags = ["manual"],
     target_compatible_with = ["@platforms//cpu:arm64"],

--- a/test/oetf/local_images.py
+++ b/test/oetf/local_images.py
@@ -78,7 +78,7 @@ def image_specs(arch: HostArch) -> List[ImageSpec]:
         ImageSpec(
             "mcp",
             _t("//src/service/mcp:mcp_image_load_{arch}", arch),
-            _t("osmo.local/mcp-self-hosted:latest-{arch}", arch),
+            _t("osmo.local/mcp:latest-{arch}", arch),
         ),
         ImageSpec(
             "logger",

--- a/test/oetf/tests/test_local_images.py
+++ b/test/oetf/tests/test_local_images.py
@@ -67,7 +67,7 @@ class TestImageSpecs(unittest.TestCase):
         )
         self.assertEqual(
             mcp.docker_tag,
-            "osmo.local/mcp-self-hosted:latest-arm64",
+            "osmo.local/mcp:latest-arm64",
         )
 
 


### PR DESCRIPTION
## Description

Unify the external OSMO MCP container with the existing `mcp` image repository.

This changes the public Bazel push targets, Helm default, and OETF local image tags from `mcp-self-hosted` to `mcp`. The deployment model remains self-hosted; only the registry repository name changes.

The coordinated internal change reserves `*-maas` tags for the hosted MaaS implementation. Unsuffixed development, RC, release, and `latest` tags remain owned by the external MCP, preventing the two producers from overwriting one another.

Rollout gates:
- Merge the internal MaaS tag-isolation change before activating this publisher.
- Register and scan the new `mcp:6.4.0` artifact URI in nSpect for both architectures before stable promotion.
- Keep `mcp-self-hosted` tags available during the rollback window.

Issue #None

## Validation

- `bash deployments/charts/service/ci/validate-mcp-chart.sh`
- `bazel test //test/oetf/tests:test_local_images`
- Verified no `mcp-self-hosted` image-name references remain.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration options for customizing the MCP container image name and tag.
  - Documented fallback behavior when no image tag is specified.

- **Updates**
  - Updated the default MCP image name to `mcp`.
  - Standardized MCP image references across supported architectures and local environments.

- **Tests**
  - Added validation to confirm deployments use the expected MCP container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->