### PR TITLE
fix: update distroless Python and Node images

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -366,8 +366,8 @@ apt.install(
 
 oci.pull(
     name = "distroless_python3_14",
-    digest = "sha256:e75772d395b9053b65f95009f0389a0216d42617adc01d3295bd7664f982a2dc",
-    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.9",
+    digest = "sha256:0897284378754fcf98fa722801a06a52fdb24260eb90b88fcb0c1bc8555d8646",
+    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.10",
     platforms = [
         "linux/arm64/v8",
         "linux/amd64",
@@ -377,8 +377,8 @@ oci.pull(
 # Used for local debugging
 # oci.pull(
 #     name = "distroless_python3_14_dev",
-#     digest = "sha256:23685736e38e60fba8db553bb2d6ddfaa3ea1a445eac51c4a99f25cdf7fdd1c4",
-#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.9-dev",
+#     digest = "sha256:68537466f9c3229687f9a2ebefec2d61d28a7f52ca9d5081e581a64a7566f8dc",
+#     image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.10-dev",
 #     platforms = [
 #          "linux/amd64",
 #          "linux/arm64/v8"

--- a/scripts/distroless/tests/test_update_distroless.py
+++ b/scripts/distroless/tests/test_update_distroless.py
@@ -5,10 +5,13 @@ SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 
+import io
 import importlib.util
 import sys
+import urllib.error
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "update_distroless.py"
@@ -23,6 +26,52 @@ SPEC.loader.exec_module(update_distroless)
 
 
 class UpdateDistrolessTest(unittest.TestCase):
+    def test_fetch_latest_probes_manifest_tags_omitted_from_catalog(self):
+        catalog_tags = {
+            update_distroless.PYTHON_REPO: [
+                "3.14-v4.0.9",
+                "3.14-v4.0.9-dev",
+            ],
+            update_distroless.NODE_REPO: ["24-v4.0.9"],
+        }
+        available_tags = {
+            (update_distroless.PYTHON_REPO, "3.14-v4.0.9"),
+            (update_distroless.PYTHON_REPO, "3.14-v4.0.9-dev"),
+            (update_distroless.PYTHON_REPO, "3.14-v4.0.10"),
+            (update_distroless.PYTHON_REPO, "3.14-v4.0.10-dev"),
+            (update_distroless.NODE_REPO, "24-v4.0.9"),
+            (update_distroless.NODE_REPO, "24-v4.0.10"),
+            (update_distroless.NODE_REPO, "24-v4.0.11"),
+        }
+
+        def manifest_digest(repository: str, tag: str) -> str:
+            if (repository, tag) not in available_tags:
+                raise urllib.error.HTTPError(
+                    url="https://nvcr.io",
+                    code=404,
+                    msg="Not Found",
+                    hdrs=None,
+                    fp=io.BytesIO(),
+                )
+            return "sha256:" + "a" * 64
+
+        with (
+            patch.object(
+                update_distroless,
+                "_repo_tags",
+                side_effect=lambda repository: catalog_tags[repository],
+            ),
+            patch.object(
+                update_distroless,
+                "_manifest_digest",
+                side_effect=manifest_digest,
+            ),
+        ):
+            latest = update_distroless.fetch_latest()
+
+        self.assertEqual(latest.python_version, "4.0.10")
+        self.assertEqual(latest.node_version, "4.0.11")
+
     def test_latest_version_for_prefix_ignores_attestations_and_dev_tags(self):
         tags = [
             "3.14-v4.0.8-dev",

--- a/scripts/distroless/update_distroless.py
+++ b/scripts/distroless/update_distroless.py
@@ -24,6 +24,7 @@ import json
 import os
 import re
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
@@ -99,6 +100,30 @@ def latest_version_for_prefix(tags: Iterable[str], prefix: str, dev: bool = Fals
     return max(versions, key=_version_tuple)
 
 
+def latest_manifest_version_for_prefix(
+    repo: str,
+    prefix: str,
+    catalog_version: str,
+    dev: bool = False,
+) -> str:
+    """Return the latest contiguous patch version resolvable from the registry."""
+    suffix = "-dev" if dev else ""
+    latest_version = catalog_version
+
+    while True:
+        major, minor, patch = _version_tuple(latest_version)
+        candidate_version = f"{major}.{minor}.{patch + 1}"
+        candidate_tag = f"{prefix}-v{candidate_version}{suffix}"
+        try:
+            _manifest_digest(repo, candidate_tag)
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                error.close()
+                return latest_version
+            raise
+        latest_version = candidate_version
+
+
 def _registry_token(repo: str) -> str:
     query = urllib.parse.urlencode({"scope": f"repository:{repo}:pull"})
     url = f"{REGISTRY}/proxy_auth?{query}"
@@ -152,10 +177,19 @@ def fetch_latest() -> DistrolessLatest:
     python_tags = _repo_tags(PYTHON_REPO)
     node_tags = _repo_tags(NODE_REPO)
 
-    python_version = latest_version_for_prefix(python_tags, PYTHON_IMAGE_VERSION)
-    python_dev_version = latest_version_for_prefix(
-        python_tags,
+    python_version = latest_manifest_version_for_prefix(
+        PYTHON_REPO,
         PYTHON_IMAGE_VERSION,
+        latest_version_for_prefix(python_tags, PYTHON_IMAGE_VERSION),
+    )
+    python_dev_version = latest_manifest_version_for_prefix(
+        PYTHON_REPO,
+        PYTHON_IMAGE_VERSION,
+        latest_version_for_prefix(
+            python_tags,
+            PYTHON_IMAGE_VERSION,
+            dev=True,
+        ),
         dev=True,
     )
     if python_dev_version != python_version:
@@ -164,7 +198,11 @@ def fetch_latest() -> DistrolessLatest:
             f"runtime={python_version} dev={python_dev_version}"
         )
 
-    node_version = latest_version_for_prefix(node_tags, NODE_IMAGE_VERSION)
+    node_version = latest_manifest_version_for_prefix(
+        NODE_REPO,
+        NODE_IMAGE_VERSION,
+        latest_version_for_prefix(node_tags, NODE_IMAGE_VERSION),
+    )
 
     python_tag = f"{PYTHON_IMAGE_VERSION}-v{python_version}"
     python_dev_tag = f"{PYTHON_IMAGE_VERSION}-v{python_version}-dev"

--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -56,7 +56,7 @@
 # Stage 1: Dependencies (cached unless package.json/pnpm-lock.yaml change)
 # =============================================================================
 ARG NODE_BUILD_IMAGE=node:24-slim
-ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/node:24-v4.0.10
+ARG NODE_DISTROLESS_IMAGE=nvcr.io/nvidia/distroless/node:24-v4.0.11
 
 FROM ${NODE_BUILD_IMAGE} AS deps
 


### PR DESCRIPTION
## Description

Update NVIDIA distroless base images and make the updater resilient to an incomplete NGC tag catalog:
- Python runtime: `3.14-v4.0.9` -> `3.14-v4.0.10`, with refreshed runtime and debug OCI digests.
- UI Node runtime: `24-v4.0.10` -> `24-v4.0.11`.
- Probe directly for sequential patch manifests after the catalog result. This detects published versions omitted by `/tags/list` and stops at the first unavailable patch.

Validation:
- `python3 -m unittest scripts/distroless/tests/test_update_distroless.py -v`
- `bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //src:osmo_docker_distroless_image_amd64`
- `bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //src:osmo_docker_distroless_image_arm64`
- Live NGC dry run reports `updated=false` at Python `3.14-v4.0.10` and Node `24-v4.0.11`.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime version detection so updates remain accurate even when the latest patch versions are not yet listed in the catalog.
  * Registry errors are now handled more reliably during runtime updates.

* **Chores**
  * Updated Python and Node.js runtime images to newer patched releases, including development images.

* **Tests**
  * Added coverage for discovering the newest available runtime versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->