### PR TITLE
Improve Azure deployment test diagnostics

### DIFF
--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -65,6 +65,9 @@ on:
       - '.github/workflows/deployment-test.yaml'
       - 'deployments/scripts/run-deployment-test.sh'
       - 'deployments/terraform/azure/**'
+      - 'test/oetf/ci_summary.py'
+      - 'test/oetf/runner_fixture.py'
+      - 'test/scenarios/logger_connectivity/**'
   schedule:
     # Daily at 00:00 UTC = 5pm PDT (16:00 PST during winter — GitHub cron
     # is UTC, doesn't track DST). Schedule fires only on main, not on
@@ -88,7 +91,7 @@ jobs:
   # azurerm provider plugin from the Terraform Registry (HTTPS, no Azure
   # API call). terraform validate + fmt are purely local.
   init-only:
-    if: >
+    if: >-
       ${{ github.event_name == 'pull_request'
           || github.event.inputs.mode == 'init-only' }}
     runs-on: ubuntu-latest
@@ -172,7 +175,7 @@ jobs:
   # separate them from dev's `YYYY.MM.DD.hash.stgN` tags. Cleanup uses
   # the tag prefix.
   build-images:
-    if: >
+    if: >-
       ${{ github.event_name == 'schedule'
           || github.event.inputs.mode == 'full-deployment'
           || (github.event_name == 'pull_request'
@@ -794,6 +797,11 @@ jobs:
   # + oetf-smoke stages run. The wrapper sets up its own kubectl
   # port-forward to osmo-gateway and runs `bazel run //test/oetf:run`.
   oetf:
+    outputs:
+      failure_category: ${{ steps.classify_oetf.outputs.failure_category }}
+      failure_summary: ${{ steps.classify_oetf.outputs.failure_summary }}
+      next_action: ${{ steps.classify_oetf.outputs.next_action }}
+      failed_target: ${{ steps.classify_oetf.outputs.failed_target }}
     needs: [build-images, tf-apply, deploy-osmo]
     if: ${{ needs.deploy-osmo.result == 'success' }}
     runs-on: ubuntu-latest
@@ -805,6 +813,7 @@ jobs:
       ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       RUN_DIR: ${{ github.workspace }}/runs/deployment-test-azure
+      OSMO_DEPLOYMENT_TEST_TIMEOUT_SECONDS: "1200"
       OSMO_IMAGE_REGISTRY: ${{ needs.build-images.outputs.image_registry }}
       OSMO_IMAGE_TAG: ${{ needs.build-images.outputs.image_tag }}
       # OETF lives at <repo>/test/oetf in the public repo; the wrapper's
@@ -932,42 +941,63 @@ jobs:
           bash deployments/scripts/run-deployment-test.sh --provider azure
           echo "▶ $(date -u +%H:%M:%S) OETF stage done"
 
-      - name: OETF result summary
-        if: always() && steps.run_oetf.conclusion != 'skipped'
-        env:
-          RUN_DIR: ${{ github.workspace }}/runs/deployment-test-azure
+
+      - name: capture OETF failure diagnostics
+        if: always() && steps.run_oetf.conclusion == 'failure'
+        timeout-minutes: 3
         run: |
           set +e
-          oetf_json="$RUN_DIR/oetf-result.json"
-          if [ ! -f "$oetf_json" ]; then
-            { echo "### OETF stage ⚠️"; echo ""; echo "_no result JSON found at \`$oetf_json\` — wrapper likely died before OETF ran_"; } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
-          import json, os, pathlib
-          data = json.loads(pathlib.Path(os.environ["RUN_DIR"], "oetf-result.json").read_text())
-          total = data.get("total", 0)
-          passed = data.get("passed", 0)
-          failed = data.get("failed", 0)
-          errored = data.get("errored", 0)
-          skipped = data.get("skipped", 0)
-          status_icon = "✅" if (failed == 0 and errored == 0) else "❌"
-          row_icon = {"pass": "✅", "fail": "❌", "error": "⚠️", "skip": "⏭️"}
-          print(f"### OETF stage {status_icon}")
-          print()
-          print(f"- tags:    `{data.get('tags','-')}`")
-          print(f"- url:     `{data.get('url','-')}`")
-          print(f"- totals:  ✅ {passed} passed · ❌ {failed} failed · ⚠️ {errored} errored · ⏭️ {skipped} skipped (of {total})")
-          print()
-          print("| | Target | Time | Message |")
-          print("|---|---|---:|---|")
-          for r in data.get("results", []):
-              msg = (r.get("message") or "").strip().replace("\n", " ")
-              if len(msg) > 200:
-                  msg = msg[:200] + "…"
-              msg = msg.replace("|", "\\|")
-              print(f"| {row_icon.get(r.get('status'),'?')} | `{r.get('target','?')}` | {r.get('time',0):.1f}s | {msg} |")
-          PY
+          diagnostics="$RUN_DIR/oetf-local-diagnostics"
+          namespace=osmo-minimal
+          mkdir -p "$diagnostics"
+          date -u +%Y-%m-%dT%H:%M:%SZ > "$diagnostics/captured-at.txt"
+          tail -200 "$RUN_DIR/oetf-pf.log" > "$diagnostics/oetf-pf-tail.log" 2>&1
+          kubectl --request-timeout=10s get svc,endpoints \
+            -n "$namespace" -o wide > "$diagnostics/gateway-network.txt" 2>&1
+          kubectl --request-timeout=10s get endpointslices \
+            -n "$namespace" -o wide >> "$diagnostics/gateway-network.txt" 2>&1
+          kubectl --request-timeout=10s get pods -A -o wide \
+            > "$diagnostics/pods.txt" 2>&1
+          kubectl --request-timeout=10s get events -A --sort-by='.lastTimestamp' \
+            | tail -200 > "$diagnostics/events.txt" 2>&1
+
+          kubectl --request-timeout=10s get pods \
+            -n "$namespace" -o name 2>/dev/null \
+            | grep -E '(gateway|service|logger)' \
+            | while read -r pod; do
+                name="${pod#pod/}"
+                kubectl --request-timeout=10s describe "$pod" -n "$namespace" \
+                  > "$diagnostics/describe-${name}.txt" 2>&1
+                kubectl --request-timeout=10s logs "$pod" -n "$namespace" \
+                  --all-containers --tail=500 --since=20m --timestamps --prefix \
+                  > "$diagnostics/logs-${name}.log" 2>&1
+                kubectl --request-timeout=10s logs "$pod" -n "$namespace" \
+                  --all-containers --previous --tail=500 \
+                  --since=20m --timestamps --prefix \
+                  > "$diagnostics/logs-${name}-previous.log" 2>&1
+              done
+
+          kubectl --request-timeout=10s get pods \
+            -n kube-system -o name 2>/dev/null \
+            | grep 'konnectivity-agent' \
+            | while read -r pod; do
+                name="${pod#pod/}"
+                kubectl --request-timeout=10s describe "$pod" -n kube-system \
+                  > "$diagnostics/describe-kube-system-${name}.txt" 2>&1
+                kubectl --request-timeout=10s logs "$pod" -n kube-system \
+                  --all-containers --tail=500 --since=20m --timestamps --prefix \
+                  > "$diagnostics/logs-kube-system-${name}.log" 2>&1
+              done
+          exit 0
+
+      - name: classify OETF result
+        id: classify_oetf
+        if: always() && steps.run_oetf.conclusion != 'skipped'
+        run: |
+          python3 test/oetf/ci_summary.py \
+            --run-dir "$RUN_DIR" \
+            --github-output "$GITHUB_OUTPUT" \
+            --github-summary "$GITHUB_STEP_SUMMARY"
 
       - name: upload OETF logs
         if: always()
@@ -976,13 +1006,163 @@ jobs:
           name: oetf-${{ github.run_id }}
           path: runs/deployment-test-azure/**
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
-  # ── Stage 4: terraform destroy + cluster diagnostics ─────────────────────
-  # Downloads the tfstate artifact tf-apply uploaded, captures a final
-  # cluster snapshot before destroy, then tears everything down.
-  tf-destroy:
+  # ── Stage 4: cluster diagnostics (must finish before destroy) ─────────────
+  azure-diagnostics:
     needs: [build-images, tf-apply, deploy-osmo, oetf]
+    if: ${{ always() && needs.tf-apply.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: internal-ci
+    env:
+      ARM_USE_OIDC: true
+      ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      ARM_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
+      RUN_DIR: ${{ github.workspace }}/runs/deployment-test-azure
+      OETF_FAILURE_CATEGORY: ${{ needs.oetf.outputs.failure_category }}
+      OETF_FAILURE_SUMMARY: ${{ needs.oetf.outputs.failure_summary }}
+      OETF_FAILED_TARGET: ${{ needs.oetf.outputs.failed_target }}
+      OETF_NEXT_ACTION: ${{ needs.oetf.outputs.next_action }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: azure login (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: install kubectl
+        if: always()
+        run: |
+          set -euo pipefail
+          KUBECTL_VERSION=v1.31.0
+          curl -fsSLo /tmp/kubectl \
+            "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+          curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
+            | awk '{print $1"  /tmp/kubectl"}' | sha256sum -c -
+          sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
+
+      - name: download OETF evidence
+        if: always()
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: oetf-${{ github.run_id }}
+          path: runs/deployment-test-azure/oetf-runner/
+
+      - name: collect Azure, cluster, and OSMO diagnostics
+        if: always()
+        timeout-minutes: 5
+        run: |
+          set +e
+          diagnostics="$RUN_DIR/diagnostics"
+          mkdir -p "$diagnostics"
+          date -u +%Y-%m-%dT%H:%M:%SZ > "$diagnostics/captured-at.txt"
+
+          az resource list --resource-group "$AZURE_RESOURCE_GROUP" -o json \
+            > "$diagnostics/azure-resources.json" 2>&1
+          az aks show --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_CLUSTER_NAME" -o json \
+            > "$diagnostics/azure-aks.json" 2>&1
+          start_time="$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)"
+          az monitor activity-log list --resource-group "$AZURE_RESOURCE_GROUP" \
+            --start-time "$start_time" --status Failed -o json \
+            > "$diagnostics/azure-failed-activity.json" 2>&1
+
+          az aks get-credentials \
+            --resource-group "$AZURE_RESOURCE_GROUP" \
+            --name "$AZURE_CLUSTER_NAME" \
+            --overwrite-existing --admin > "$diagnostics/az-creds.log" 2>&1
+
+          cluster_reachable=false
+          if kubectl --request-timeout=10s cluster-info \
+            > "$diagnostics/cluster-info.txt" 2>&1; then
+            cluster_reachable=true
+            kubectl --request-timeout=10s get pods -A -o wide \
+              > "$diagnostics/pods.txt" 2>&1
+            kubectl --request-timeout=10s get svc,endpoints \
+              -n osmo-minimal -o wide > "$diagnostics/osmo-network.txt" 2>&1
+            kubectl --request-timeout=10s get endpointslices \
+              -n osmo-minimal -o wide >> "$diagnostics/osmo-network.txt" 2>&1
+            kubectl --request-timeout=10s get events \
+              -A --sort-by='.lastTimestamp' \
+              | tail -200 > "$diagnostics/events.txt" 2>&1
+            kubectl --request-timeout=10s get pods -A \
+              --field-selector=status.phase!=Running -o wide \
+              > "$diagnostics/non-running.txt" 2>&1
+            kubectl --request-timeout=10s get pods -A \
+              -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{","}{end}{"\n"}{end}' \
+              | sort > "$diagnostics/image-refs.txt" 2>&1
+
+            for namespace in osmo-minimal osmo-operator osmo-workflows; do
+              kubectl --request-timeout=10s get pods \
+                -n "$namespace" -o name 2>/dev/null \
+                | while read -r pod; do
+                    [[ -z "$pod" ]] && continue
+                    name="${pod#pod/}"
+                    kubectl --request-timeout=10s logs "$pod" -n "$namespace" \
+                      --all-containers --tail=500 \
+                      --since=30m --prefix --timestamps \
+                      > "$diagnostics/logs-${namespace}-${name}.log" 2>&1
+                    kubectl --request-timeout=10s logs "$pod" -n "$namespace" \
+                      --all-containers --previous --tail=500 \
+                      --since=30m --prefix --timestamps \
+                      > "$diagnostics/logs-${namespace}-${name}-previous.log" 2>&1
+                  done
+            done
+
+            kubectl --request-timeout=10s get pods \
+              -n kube-system -o name 2>/dev/null \
+              | grep 'konnectivity-agent' \
+              | while read -r pod; do
+                  name="${pod#pod/}"
+                  kubectl --request-timeout=10s describe "$pod" -n kube-system \
+                    > "$diagnostics/describe-kube-system-${name}.txt" 2>&1
+                  kubectl --request-timeout=10s logs "$pod" -n kube-system \
+                    --all-containers --tail=500 \
+                    --since=30m --prefix --timestamps \
+                    > "$diagnostics/logs-kube-system-${name}.log" 2>&1
+                done
+          fi
+
+          {
+            echo "### Azure deployment diagnostics"
+            echo ""
+            echo "- cluster reachable: \`$cluster_reachable\`"
+            echo "- OETF category: \`${OETF_FAILURE_CATEGORY:-unknown}\`"
+            echo "- failed target: \`${OETF_FAILED_TARGET:--}\`"
+            echo "- summary: ${OETF_FAILURE_SUMMARY:-unavailable}"
+            echo "- next action: **${OETF_NEXT_ACTION:-Inspect this artifact and the failed job step.}**"
+            echo ""
+            echo "Raw Helm values, Terraform state/variables, Kubernetes Secrets,"
+            echo "and environment dumps are intentionally excluded."
+          } | tee "$diagnostics/diagnostic-summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: upload diagnostics before destroy
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: azure-deployment-diagnostics-${{ github.run_id }}
+          path: |
+            runs/deployment-test-azure/diagnostics/**
+            runs/deployment-test-azure/oetf-runner/**
+          retention-days: 14
+          if-no-files-found: error
+
+
+  # ── Stage 5: terraform destroy (after diagnostics upload) ─────────────────
+  # Waits for evidence capture, then tears down the ephemeral Azure resources.
+  tf-destroy:
+    needs: [build-images, tf-apply, deploy-osmo, oetf, azure-diagnostics]
     # Run whenever tf-apply ran (any result) — a failed apply usually
     # leaves partial resources to tear down. Skip only if tf-apply never
     # ran.
@@ -1015,22 +1195,6 @@ jobs:
         with:
           terraform_version: 1.9.8
 
-      - name: install kubectl + helm
-        run: |
-          set -euo pipefail
-          KUBECTL_VERSION=v1.31.0
-          curl -fsSLo /tmp/kubectl \
-            "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
-          curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" \
-            | awk '{print $1"  /tmp/kubectl"}' | sha256sum -c -
-          sudo install -m 0755 /tmp/kubectl /usr/local/bin/kubectl
-
-          HELM_VERSION=v3.16.2
-          HELM_SHA256=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb
-          curl -fsSLo /tmp/helm.tgz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
-          echo "${HELM_SHA256}  /tmp/helm.tgz" | sha256sum -c -
-          tar -xzf /tmp/helm.tgz -C /tmp linux-amd64/helm
-          sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
 
       # The STASH_RAN marker guarantees this artifact exists, so a download
       # failure here is transient and should fail teardown loudly.
@@ -1048,103 +1212,13 @@ jobs:
           cp tf-state-download/azure.tfvars          "$RUNNER_TEMP/azure.tfvars" 2>/dev/null || true
           ls -la deployments/terraform/azure/example/terraform.tfstate "$RUNNER_TEMP/azure.tfvars" || true
 
-      # Capture a snapshot of cluster + OSMO state BEFORE terraform destroys
-      # everything. Self-contained: re-mints kubectl context up front in
-      # case anything along the way mangled the kubeconfig.
-      - name: dump cluster + OSMO diagnostics (always)
-        if: always()
-        timeout-minutes: 5
-        run: |
-          set +e
-          DIAG="$RUN_DIR/diagnostics"
-          mkdir -p "$DIAG"
-
-          echo "▶ refreshing kubectl context"
-          az aks get-credentials \
-            --resource-group "$AZURE_RESOURCE_GROUP" \
-            --name "$AZURE_CLUSTER_NAME" \
-            --overwrite-existing --admin > "$DIAG/az_creds.log" 2>&1 || true
-          kubectl cluster-info > "$DIAG/cluster-info.txt" 2>&1 || \
-            { echo "::warning::kubectl can't reach the cluster — skipping in-cluster diagnostics"; exit 0; }
-
-          echo "::group::pods (all namespaces)"
-          kubectl get pods -A -o wide | tee "$DIAG/pods.txt"
-          echo "::endgroup::"
-
-          echo "::group::events (last 200, sorted by lastTimestamp)"
-          kubectl get events -A --sort-by='.lastTimestamp' 2>/dev/null | tail -200 | tee "$DIAG/events.txt"
-          echo "::endgroup::"
-
-          echo "::group::non-Running pods + describe"
-          kubectl get pods -A --field-selector=status.phase!=Running -o wide | tee "$DIAG/non-running.txt"
-          kubectl get pods -A --field-selector=status.phase!=Running \
-            -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
-            | while read -r ns pod; do
-                [[ -z "$ns" || -z "$pod" ]] && continue
-                kubectl describe pod "$pod" -n "$ns" > "$DIAG/describe-${ns}-${pod}.txt" 2>&1
-                kubectl logs "$pod" -n "$ns" --all-containers --tail=200 --prefix \
-                  > "$DIAG/logs-${ns}-${pod}.log" 2>&1
-              done
-          echo "::endgroup::"
-
-          echo "::group::image refs on running pods"
-          kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\t"}{range .spec.containers[*]}{.image}{","}{end}{"\n"}{end}' \
-            | sort | tee "$DIAG/image-refs.txt"
-          echo "::endgroup::"
-
-          echo "::group::OSMO pod logs (tail 500)"
-          for ns in osmo-minimal osmo-operator osmo-workflows; do
-            kubectl get pods -n "$ns" --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null \
-              | while read -r pod; do
-                  [[ -z "$pod" ]] && continue
-                  kubectl logs "$pod" -n "$ns" --tail=500 --all-containers --prefix --timestamps \
-                    > "$DIAG/podlog-${ns}-${pod}.log" 2>&1
-                done
-          done
-          echo "::endgroup::"
-
-          echo "::group::helm releases + values"
-          helm list -A -o yaml > "$DIAG/helm-releases.yaml" 2>&1
-          while IFS='|' read -r r ns; do
-            [[ -z "$r" ]] && continue
-            helm status "$r" -n "$ns"     > "$DIAG/helm-status-${r}.txt"   2>&1
-            helm get values "$r" -n "$ns" > "$DIAG/helm-values-${r}.yaml" 2>&1
-          done < <(helm list -A -o json 2>/dev/null | jq -r '.[] | "\(.name)|\(.namespace)"')
-          echo "::endgroup::"
-
-          {
-            echo "### Cluster diagnostic snapshot"
-            echo ""
-            echo "Captured under \`$DIAG\` (uploaded as part of the \`tf-destroy-${GITHUB_RUN_ID}\` artifact)."
-            echo ""
-            echo "#### Pods not Running"
-            if [ -s "$DIAG/non-running.txt" ] && [ "$(wc -l < "$DIAG/non-running.txt")" -gt 1 ]; then
-              echo '```'
-              head -20 "$DIAG/non-running.txt"
-              echo '```'
-            else
-              echo "_(all pods Running)_"
-            fi
-            echo ""
-            echo "#### Image refs (first 30)"
-            echo '```'
-            head -30 "$DIAG/image-refs.txt"
-            echo '```'
-            echo ""
-            echo "#### Last 30 cluster events"
-            echo '```'
-            tail -30 "$DIAG/events.txt"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          # Never fail — diagnostics are best-effort, must not block teardown.
-          exit 0
 
       - name: TEMP — terraform destroy
         if: always()
         working-directory: deployments/terraform/azure/example
         run: |
           set -euo pipefail
+          mkdir -p "$RUN_DIR"
           echo "::notice::terraform destroy starting — expected ~10–15 min"
 
           echo "::group::terraform init (refresh provider)"
@@ -1152,9 +1226,15 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::terraform destroy (streaming)"
+          set +e
           terraform destroy -input=false -auto-approve -no-color \
-            -var-file="$RUNNER_TEMP/azure.tfvars" \
-            || echo "::warning::terraform destroy failed — orphan resources in $AZURE_RESOURCE_GROUP may remain"
+            -var-file="$RUNNER_TEMP/azure.tfvars" 2>&1 \
+            | tee "$RUN_DIR/terraform-destroy.log"
+          destroy_rc="${PIPESTATUS[0]}"
+          set -e
+          if [[ "$destroy_rc" -ne 0 ]]; then
+            echo "::warning::terraform destroy failed — orphan resources in $AZURE_RESOURCE_GROUP may remain"
+          fi
           echo "::endgroup::"
 
           REMAINING=$(az resource list --resource-group "$AZURE_RESOURCE_GROUP" --query 'length(@)' -o tsv || echo "?")
@@ -1173,14 +1253,18 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: upload destroy logs + diagnostics
+          if [[ "$destroy_rc" -ne 0 || "$REMAINING" != "0" ]]; then
+            exit 1
+          fi
+
+      - name: upload terraform destroy log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: tf-destroy-${{ github.run_id }}
-          path: runs/deployment-test-azure/**
+          name: azure-terraform-destroy-${{ github.run_id }}
+          path: runs/deployment-test-azure/terraform-destroy.log
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
 
 
   # ── Slack failure-notification (schedule-only) ───────────────────────────
@@ -1192,20 +1276,24 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
 
   notify-slack-on-azure-deployment-test-failure:
-    needs: [build-images, tf-apply, deploy-osmo, oetf, tf-destroy]
+    needs: [build-images, tf-apply, deploy-osmo, oetf, azure-diagnostics, tf-destroy]
     # always() so this evaluates even when an upstream `needs:` failed.
     # Fires only on scheduled-run failures — PR-label and workflow_dispatch
     # runs surface their own status interactively.
-    if: >
+    if: >-
       ${{ always()
           && github.event_name == 'schedule'
           && (needs.build-images.result == 'failure'
               || needs.tf-apply.result == 'failure'
               || needs.deploy-osmo.result == 'failure'
               || needs.oetf.result == 'failure'
+              || needs.azure-diagnostics.result == 'failure'
               || needs.tf-destroy.result == 'failure') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
     steps:
       # Best-effort decoration (author/subject/links) — must never block
       # the notification; the post step has fallbacks for every output.
@@ -1243,7 +1331,6 @@ jobs:
           # commits — a single "current SHA" link is misleading.
           # Fall back to a plain "recent commits on main" view when this
           # is the first scheduled run (no prior green to compare against).
-          wf_name='Deployment Test'
           wf_runs=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
                           -H 'Accept: application/vnd.github+json' \
                           "https://api.github.com/repos/${REPO}/actions/workflows/deployment-test.yaml/runs?event=schedule&status=success&per_page=2")
@@ -1263,41 +1350,58 @@ jobs:
             compare_label="Recent commits on main"
           fi
 
-          # 3) Resolve the artifact ID for THIS run so the Slack button
-          # deep-links directly to the artifact's download page. GitHub
-          # has no `#artifacts` anchor on the run page — links with that
-          # fragment land at the top of the page with no scroll. The
-          # working URL shape is:
-          #   https://github.com/<owner>/<repo>/actions/runs/<run_id>/artifacts/<artifact_id>
-          # which renders the artifact's download flow directly. We pick
-          # the first non-expired artifact (full-deployment uploads a
-          # single one named `deployment-test-run-<run_id>`); fall back
-          # to the run page when none is found (e.g. job aborted before
-          # the always() upload step ran).
+          # 3) Resolve evidence artifacts by exact name. Artifact ordering is
+          # not stable and must not decide which bundle the on-call receives.
           artifacts_resp=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
                                  -H 'Accept: application/vnd.github+json' \
-                                 "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=10")
-          # `.artifacts // []` — an API error response has no .artifacts, and
-          # iterating null aborts jq (and the step) with exit 5.
-          artifact_id=$(jq -r '[(.artifacts // [])[] | select(.expired==false)] | .[0].id // empty' <<<"$artifacts_resp")
-          artifact_name=$(jq -r '[(.artifacts // [])[] | select(.expired==false)] | .[0].name // empty' <<<"$artifacts_resp")
-          if [[ -n "$artifact_id" ]]; then
-            artifact_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}/artifacts/${artifact_id}"
-            artifact_label="Download ${artifact_name}"
-          else
-            artifact_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-            artifact_label="(no artifact yet — open run page)"
+                                 "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/artifacts?per_page=100")
+          diagnostics_name="azure-deployment-diagnostics-${RUN_ID}"
+          oetf_name="oetf-${RUN_ID}"
+          diagnostics_id=$(jq -r --arg name "$diagnostics_name" \
+            '[(.artifacts // [])[] | select(.expired==false and .name==$name)] | .[0].id // empty' \
+            <<<"$artifacts_resp")
+          oetf_id=$(jq -r --arg name "$oetf_name" \
+            '[(.artifacts // [])[] | select(.expired==false and .name==$name)] | .[0].id // empty' \
+            <<<"$artifacts_resp")
+          diagnostics_url=""
+          oetf_url=""
+          if [[ -n "$diagnostics_id" ]]; then
+            diagnostics_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}/artifacts/${diagnostics_id}"
+          fi
+          if [[ -n "$oetf_id" ]]; then
+            oetf_url="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}/artifacts/${oetf_id}"
           fi
 
-          # 4) Persist outputs (escape multi-line values).
+          # 4) Resolve the first failed job and step. Use GitHub's html_url
+          # rather than reconstructing the job URL.
+          jobs_resp=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
+                            -H 'Accept: application/vnd.github+json' \
+                            "https://api.github.com/repos/${REPO}/actions/runs/${RUN_ID}/jobs?filter=latest&per_page=100")
+          failed_job_json=$(jq -c '[(.jobs // [])[] | select(.conclusion=="failure")] | .[0] // {}' \
+            <<<"$jobs_resp")
+          failed_job=$(jq -r '.name // "unknown job"' <<<"$failed_job_json")
+          failed_job_url=$(jq -r '.html_url // empty' <<<"$failed_job_json")
+          failed_step_json=$(jq -c '[.steps[]? | select(.conclusion=="failure")] | .[0] // {}' \
+            <<<"$failed_job_json")
+          failed_step=$(jq -r '.name // "unknown step"' <<<"$failed_step_json")
+          failed_step_number=$(jq -r '.number // empty' <<<"$failed_step_json")
+          failed_step_url="$failed_job_url"
+          if [[ -n "$failed_step_url" && -n "$failed_step_number" ]]; then
+            failed_step_url="${failed_step_url}#step:${failed_step_number}:1"
+          fi
+
+          # 5) Persist outputs (escape multi-line values).
           {
             echo "author<<__GHA_EOF__"; echo "$author"; echo "__GHA_EOF__"
             echo "subject<<__GHA_EOF__"; echo "$subject"; echo "__GHA_EOF__"
             echo "short_sha=${SHA:0:7}"
             echo "compare_url=$compare_url"
             echo "compare_label=$compare_label"
-            echo "artifact_url=$artifact_url"
-            echo "artifact_label=$artifact_label"
+            echo "diagnostics_url=$diagnostics_url"
+            echo "oetf_url=$oetf_url"
+            echo "failed_job=$failed_job"
+            echo "failed_step=$failed_step"
+            echo "failed_step_url=$failed_step_url"
           } >> "$GITHUB_OUTPUT"
 
       - name: Post failure notification to Slack
@@ -1315,7 +1419,12 @@ jobs:
           APPLY_RESULT: ${{ needs.tf-apply.result }}
           DEPLOY_RESULT: ${{ needs.deploy-osmo.result }}
           OETF_RESULT: ${{ needs.oetf.result }}
+          DIAGNOSTICS_RESULT: ${{ needs.azure-diagnostics.result }}
           DESTROY_RESULT: ${{ needs.tf-destroy.result }}
+          OETF_FAILURE_CATEGORY: ${{ needs.oetf.outputs.failure_category }}
+          OETF_FAILURE_SUMMARY: ${{ needs.oetf.outputs.failure_summary }}
+          OETF_FAILED_TARGET: ${{ needs.oetf.outputs.failed_target }}
+          OETF_NEXT_ACTION: ${{ needs.oetf.outputs.next_action }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -1328,8 +1437,11 @@ jobs:
           WORKFLOW: ${{ github.workflow }}
           COMPARE_URL: ${{ steps.ctx.outputs.compare_url }}
           COMPARE_LABEL: ${{ steps.ctx.outputs.compare_label }}
-          ARTIFACT_URL: ${{ steps.ctx.outputs.artifact_url }}
-          ARTIFACT_LABEL: ${{ steps.ctx.outputs.artifact_label }}
+          DIAGNOSTICS_URL: ${{ steps.ctx.outputs.diagnostics_url }}
+          OETF_URL: ${{ steps.ctx.outputs.oetf_url }}
+          FAILED_JOB: ${{ steps.ctx.outputs.failed_job }}
+          FAILED_STEP: ${{ steps.ctx.outputs.failed_step }}
+          FAILED_STEP_URL: ${{ steps.ctx.outputs.failed_step_url }}
           EVENT: ${{ github.event_name }}
         run: |
           set -uo pipefail
@@ -1351,33 +1463,82 @@ jobs:
           SHORT_SHA="${SHORT_SHA:-${FULL_SHA:0:7}}"
           COMPARE_URL="${COMPARE_URL:-${SERVER_URL}/${REPO}/commits/${REF_NAME}}"
           COMPARE_LABEL="${COMPARE_LABEL:-Recent commits}"
-          artifact_url="${ARTIFACT_URL:-$run_url}"
-          artifact_label="${ARTIFACT_LABEL:-Open run page}"
+          diagnostics_url="${DIAGNOSTICS_URL:-}"
+          oetf_url="${OETF_URL:-}"
+          FAILED_JOB="${FAILED_JOB:-unknown job}"
+          FAILED_STEP="${FAILED_STEP:-unknown step}"
+          failed_step_url="${FAILED_STEP_URL:-$run_url}"
+          failure_category="${OETF_FAILURE_CATEGORY:-}"
+          failure_summary="${OETF_FAILURE_SUMMARY:-}"
+          failed_target="${OETF_FAILED_TARGET:-}"
+          next_action="${OETF_NEXT_ACTION:-}"
+          if [[ "$OETF_RESULT" != "failure" || -z "$failure_category" || "$failure_category" == "none" ]]; then
+            failure_category="pipeline/${FAILED_JOB}"
+            failure_summary="${FAILED_JOB} / ${FAILED_STEP} failed."
+            failed_target="-"
+            if [[ -n "$diagnostics_url" ]]; then
+              next_action="Open the failed step and the named diagnostics artifact."
+            else
+              next_action="Open the failed step; diagnostics were not uploaded."
+            fi
+          fi
+
+          if [[ -n "$diagnostics_url" ]]; then
+            evidence_context="Diagnostics were uploaded before Terraform destroy started."
+          else
+            evidence_context="Diagnostics were not uploaded; use the failed step and any OETF logs."
+          fi
+
+          # OETF output can contain workload-controlled text. Prevent it from
+          # creating Slack mentions or links before rendering the message.
+          sanitize_for_slack() {
+            local value="$1"
+            value="${value//</(}"
+            value="${value//>/)}"
+            value="${value//@/at}"
+            printf '%s' "$value"
+          }
+          failure_summary="$(sanitize_for_slack "$failure_summary")"
+          failed_target="$(sanitize_for_slack "$failed_target")"
+          next_action="$(sanitize_for_slack "$next_action")"
+          failure_category="$(sanitize_for_slack "$failure_category")"
+          AUTHOR="$(sanitize_for_slack "$AUTHOR")"
+          SUBJECT="$(sanitize_for_slack "$SUBJECT")"
+          FAILED_JOB="$(sanitize_for_slack "$FAILED_JOB")"
+          FAILED_STEP="$(sanitize_for_slack "$FAILED_STEP")"
           header_text=":x: OSMO Azure deployment-test FAILED"
           trigger_label="Daily schedule (00:00 UTC = 5pm PDT)"
 
           payload=$(jq -n \
-            --arg channel       "$SLACK_CHANNEL" \
-            --arg header_text   "$header_text" \
-            --arg trigger_label "$trigger_label" \
-            --arg branch        "$REF_NAME" \
-            --arg short_sha     "$SHORT_SHA" \
-            --arg author        "$AUTHOR" \
-            --arg subject       "$SUBJECT" \
-            --arg bi            "$BI_RESULT" \
-            --arg apply         "$APPLY_RESULT" \
-            --arg deploy        "$DEPLOY_RESULT" \
-            --arg oetf          "$OETF_RESULT" \
-            --arg destroy       "$DESTROY_RESULT" \
-            --arg workflow      "$WORKFLOW" \
-            --arg run_url       "$run_url" \
-            --arg commit_url    "$commit_url" \
-            --arg workflow_url  "$workflow_url" \
-            --arg artifact_url  "$artifact_url" \
-            --arg artifact_label "$artifact_label" \
-            --arg compare_url   "$COMPARE_URL" \
-            --arg compare_label "$COMPARE_LABEL" \
-            --arg run_id        "$RUN_ID" \
+            --arg channel          "$SLACK_CHANNEL" \
+            --arg header_text      "$header_text" \
+            --arg trigger_label    "$trigger_label" \
+            --arg branch           "$REF_NAME" \
+            --arg short_sha        "$SHORT_SHA" \
+            --arg author           "$AUTHOR" \
+            --arg subject          "$SUBJECT" \
+            --arg bi               "$BI_RESULT" \
+            --arg apply            "$APPLY_RESULT" \
+            --arg deploy           "$DEPLOY_RESULT" \
+            --arg oetf             "$OETF_RESULT" \
+            --arg diagnostics      "$DIAGNOSTICS_RESULT" \
+            --arg destroy          "$DESTROY_RESULT" \
+            --arg workflow         "$WORKFLOW" \
+            --arg commit_url       "$commit_url" \
+            --arg workflow_url     "$workflow_url" \
+            --arg failed_job       "$FAILED_JOB" \
+            --arg failed_step      "$FAILED_STEP" \
+            --arg failed_step_url  "$failed_step_url" \
+            --arg failure_category "$failure_category" \
+            --arg failure_summary  "$failure_summary" \
+            --arg failed_target    "$failed_target" \
+            --arg next_action      "$next_action" \
+            --arg diagnostics_url  "$diagnostics_url" \
+            --arg evidence_context  "$evidence_context" \
+            --arg oetf_url         "$oetf_url" \
+            --arg compare_url      "$COMPARE_URL" \
+            --arg compare_label    "$COMPARE_LABEL" \
+            --arg run_id           "$RUN_ID" \
             '{
               channel: $channel,
               text: "\($header_text) — \($workflow) run #\($run_id) (branch \($branch))",
@@ -1390,38 +1551,44 @@ jobs:
                     { type: "mrkdwn", text: "*tf-apply*\n`\($apply)`" },
                     { type: "mrkdwn", text: "*deploy-osmo*\n`\($deploy)`" },
                     { type: "mrkdwn", text: "*oetf*\n`\($oetf)`" },
+                    { type: "mrkdwn", text: "*diagnostics*\n`\($diagnostics)`" },
                     { type: "mrkdwn", text: "*tf-destroy*\n`\($destroy)`" },
                     { type: "mrkdwn", text: "*Trigger*\n\($trigger_label)" }
                   ] },
                 { type: "section",
                   text: { type: "mrkdwn",
                           text: "*Branch:* `\($branch)`  •  *Tested commit:* <\($commit_url)|`\($short_sha)`> by *\($author)*\n>\($subject)" } },
+                { type: "section",
+                  text: { type: "mrkdwn",
+                          text: "*Automated diagnosis:* `\($failure_category)`\n*Failed step:* <\($failed_step_url)|\($failed_job) / \($failed_step)>\n*OETF target:* `\($failed_target)`\n*Summary:* \($failure_summary)\n*Next action:* *\($next_action)*" } },
                 { type: "context",
                   elements: [
                     { type: "mrkdwn",
-                      text: "Daily cron can span many commits since the last green run. Use the *\($compare_label)* button to see everything that landed in between — narrowing blame from a single SHA to the actual contributing change is usually faster from the compare view." }
+                      text: $evidence_context }
                   ] },
                 { type: "actions",
-                  elements: [
+                  elements: ([
                     { type: "button",
-                      text: { type: "plain_text", text: "View run + logs" },
-                      url:  $run_url,
+                      text: { type: "plain_text", text: "Open failed step" },
+                      url: $failed_step_url,
                       style: "danger" },
-                    { type: "button",
-                      text: { type: "plain_text", text: $artifact_label },
-                      url:  $artifact_url },
+                    (if $diagnostics_url != "" then
+                      { type: "button",
+                        text: { type: "plain_text", text: "Download diagnostics" },
+                        url: $diagnostics_url }
+                     else null end),
+                    (if $oetf_url != "" then
+                      { type: "button",
+                        text: { type: "plain_text", text: "Download OETF logs" },
+                        url: $oetf_url }
+                     else null end),
                     { type: "button",
                       text: { type: "plain_text", text: $compare_label },
-                      url:  $compare_url },
+                      url: $compare_url },
                     { type: "button",
                       text: { type: "plain_text", text: "Workflow file" },
-                      url:  $workflow_url }
-                  ] },
-                { type: "context",
-                  elements: [
-                    { type: "mrkdwn",
-                      text: ":bulb: First-look investigation: open *Download artifacts* → unzip → check `deployment-test-result.json` (which wrapper stage failed) and `diagnostics/` (cluster state at teardown)." }
-                  ] }
+                      url: $workflow_url }
+                  ] | map(select(. != null))) }
               ]
             }')
 

--- a/deployments/scripts/README.md
+++ b/deployments/scripts/README.md
@@ -90,6 +90,7 @@ scripts/
 ├── storage/                  # Per-backend storage logic (minio, azure-blob, s3, byo)
 ├── port-forward.sh           # One-shot or watchdog kubectl port-forward
 ├── verify.sh                 # End-to-end smoke tests (hello + GPU workflows)
+├── run-deployment-test.sh    # CI deployment gate and OETF runner
 ├── azure/terraform.sh        # Azure Terraform driver
 ├── aws/terraform.sh          # AWS Terraform driver
 ├── microk8s/install.sh       # Single-node MicroK8s bootstrap
@@ -128,6 +129,18 @@ When invoked, the entry-point runs these phases in order. Each is idempotent and
 6. **Watchdog port-forwards** (optional, default on for non-CI invocations) — `port-forward.sh --watchdog` for `osmo-service` (:9000) and `osmo-ui` (:3000).
 
 ## Scripts Overview
+### `run-deployment-test.sh`
+
+Runs the deployment gate and writes structured results under `RUN_DIR`. For
+Azure OETF runs, its localhost gateway port-forward may restart once after a
+transient tunnel failure. The attempt history and final health state are saved
+as `oetf-pf.log` and `oetf-pf-status.txt`.
+
+The GitHub workflow uploads OETF evidence and a named Azure diagnostic snapshot
+before Terraform destroy starts. Diagnostic collection does not query raw Helm
+values, Terraform state or variables, Kubernetes Secret objects, or process
+environment dumps.
+
 
 ### `deploy-osmo-minimal.sh`
 

--- a/deployments/scripts/run-deployment-test.sh
+++ b/deployments/scripts/run-deployment-test.sh
@@ -32,7 +32,7 @@
 #   2. Self-contained: ephemeral cluster + DB + Redis, torn down on EXIT.
 #   3. Identity-agnostic: no cloud creds, Vault, or Kargo tokens needed.
 #   4. Reproducible: no $RANDOM, no wall-clock dependencies in test logic.
-#   5. Bounded: 45-min hard timeout; every kubectl wait has --timeout.
+#   5. Bounded: configurable 45-min hard timeout; every kubectl wait has --timeout.
 #   6. Structured output: JSON result + per-stage logs in $RUN_DIR.
 #   7. Idempotent teardown: --destroy + kind delete + docker prune.
 #   8. Categorized exit codes:
@@ -146,7 +146,7 @@ JUNIT_XML="$RUN_DIR/junit.xml"
 
 KIND_CLUSTER_NAME="osmo-deployment-test"
 OSMO_NAMESPACE="osmo-minimal"
-HARD_TIMEOUT_SECONDS=2700  # 45 minutes
+HARD_TIMEOUT_SECONDS="${OSMO_DEPLOYMENT_TEST_TIMEOUT_SECONDS:-2700}"
 
 # Per-stage state for the final JSON.
 declare -a STAGE_NAMES=()
@@ -154,6 +154,7 @@ declare -a STAGE_EXIT_CODES=()
 declare -a STAGE_DURATIONS=()
 OVERALL_EXIT_CODE=0
 FAILED_STAGE=""
+OETF_PF_SUPERVISOR_PID=""
 
 log_info()  { printf '[%s] [INFO]  %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 log_error() { printf '[%s] [ERROR] %s\n' "$(date -u +%H:%M:%S)" "$*" >&2; }
@@ -231,8 +232,18 @@ emit_junit_xml() {
     } > "$JUNIT_XML"
 }
 
+stop_oetf_port_forward() {
+    if [[ -n "$OETF_PF_SUPERVISOR_PID" ]]; then
+        kill "$OETF_PF_SUPERVISOR_PID" 2>/dev/null || true
+        wait "$OETF_PF_SUPERVISOR_PID" 2>/dev/null || true
+    fi
+    OETF_PF_SUPERVISOR_PID=""
+}
+
 cleanup() {
     local rc=$?
+    trap - RETURN
+    stop_oetf_port_forward
     # If we're here because a stage already set OVERALL_EXIT_CODE, preserve it;
     # otherwise infer from $rc (e.g. ERR-on-set -e from an unguarded command).
     if [[ "$OVERALL_EXIT_CODE" -eq 0 && "$rc" -ne 0 ]]; then
@@ -304,7 +315,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# ── Hard 45-minute timeout ───────────────────────────────────────────────────
+# ── Bounded hard timeout ─────────────────────────────────────────────────────
 # Background watchdog process signals the main script if a stage hangs past
 # the bounded duration invariant. We send SIGTERM to the main shell ($$) only
 # --- not to the whole process group (`kill -- -$$`) --- because this script
@@ -604,30 +615,61 @@ stage_oetf_smoke() {
                 log_error "Neither osmo-gateway nor osmo-gateway-envoy found in $OSMO_NAMESPACE"
                 return 1
             fi
-            # nohup + & so the PF outlives this function's subshells.
-            # Also drop output to a per-run log so we can debug PF crashes.
-            nohup kubectl port-forward -n "$OSMO_NAMESPACE" \
-                "svc/${pf_svc}" "${pf_port}:80" \
-                > "$RUN_DIR/oetf-pf.log" 2>&1 &
-            local pf_pid=$!
-            # Smoke the PF before we hand off to OETF; OETF will retry on
-            # its own but a hard-fail here surfaces PF problems immediately.
+            # Keep one bounded restart available for transient AKS control-plane
+            # tunnel loss. The strict OETF log reader retries one idempotent GET
+            # after two seconds, giving this supervisor time to restore the port.
+            local pf_log="$RUN_DIR/oetf-pf.log"
+            : > "$pf_log"
+            (
+                local active_pf_pid=""
+                stop_active_pf() {
+                    if [[ -n "$active_pf_pid" ]] && kill -0 "$active_pf_pid" 2>/dev/null; then
+                        kill "$active_pf_pid" 2>/dev/null || true
+                        wait "$active_pf_pid" 2>/dev/null || true
+                    fi
+                }
+                trap 'stop_active_pf; exit 0' TERM INT
+                local attempt pf_rc
+                for attempt in 1 2; do
+                    printf '[%s] attempt=%s/2 start service=%s local_port=%s\n' \
+                        "$(date -u +%H:%M:%S)" "$attempt" "$pf_svc" "$pf_port" >> "$pf_log"
+                    kubectl port-forward -n "$OSMO_NAMESPACE" \
+                        "svc/${pf_svc}" "${pf_port}:80" >> "$pf_log" 2>&1 &
+                    active_pf_pid=$!
+                    if wait "$active_pf_pid"; then
+                        pf_rc=0
+                    else
+                        pf_rc=$?
+                    fi
+                    active_pf_pid=""
+                    printf '[%s] attempt=%s/2 exit rc=%s\n' \
+                        "$(date -u +%H:%M:%S)" "$attempt" "$pf_rc" >> "$pf_log"
+                    [[ "$attempt" -eq 2 ]] || sleep 1
+                done
+                printf '[%s] supervisor exhausted attempts=2\n' \
+                    "$(date -u +%H:%M:%S)" >> "$pf_log"
+            ) &
+            OETF_PF_SUPERVISOR_PID=$!
+            # RETURN fires for success and failure. The supervisor's TERM trap
+            # also stops and waits for its active kubectl child.
+            trap 'trap - RETURN; stop_oetf_port_forward' RETURN
+
             local pf_ready=""
             for _ in 1 2 3 4 5 6 7 8 9 10; do
+                if ! kill -0 "$OETF_PF_SUPERVISOR_PID" 2>/dev/null; then
+                    break
+                fi
                 if curl -sS -o /dev/null -m 2 "http://localhost:${pf_port}/api/version" 2>/dev/null; then
-                    pf_ready=1; break
+                    pf_ready=1
+                    break
                 fi
                 sleep 1
             done
             if [[ -z "$pf_ready" ]]; then
-                log_error "port-forward to ${pf_svc}:80 didn't become reachable on localhost:${pf_port}; check $RUN_DIR/oetf-pf.log"
-                kill "$pf_pid" 2>/dev/null || true
+                log_error "port-forward to ${pf_svc}:80 didn't become reachable on localhost:${pf_port}; check $pf_log"
                 return 1
             fi
-            log_info "Port-forward healthy (PID=$pf_pid). OETF will use http://localhost:${pf_port}"
-            # Ensure PF dies on function return (success OR failure).
-            # Bash RETURN trap is per-function — re-arm here.
-            trap "kill $pf_pid 2>/dev/null || true" RETURN
+            log_info "Port-forward healthy (supervisor PID=$OETF_PF_SUPERVISOR_PID). OETF will use http://localhost:${pf_port}"
             osmo_url="http://localhost:${pf_port}"
 
             # Set admin's profile-level default pool. Required because:
@@ -700,6 +742,28 @@ stage_oetf_smoke() {
             --output-json "$RUN_DIR/oetf-result.json"
     ) 2>&1 | tee "$OETF_LOG"
     local rc="${PIPESTATUS[0]}"
+    if [[ "$PROVIDER" == "azure" ]]; then
+        local pf_supervisor_alive=false
+        local pf_endpoint_healthy=false
+        local pf_restart_count
+        if kill -0 "$OETF_PF_SUPERVISOR_PID" 2>/dev/null; then
+            pf_supervisor_alive=true
+        fi
+        if curl -sS -o /dev/null -m 2 "http://localhost:${pf_port}/api/version" 2>/dev/null; then
+            pf_endpoint_healthy=true
+        fi
+        pf_restart_count="$(grep -c 'attempt=2/2 start' "$pf_log" || true)"
+        {
+            printf 'service=%s\n' "$pf_svc"
+            printf 'local_port=%s\n' "$pf_port"
+            printf 'supervisor_alive=%s\n' "$pf_supervisor_alive"
+            printf 'endpoint_healthy=%s\n' "$pf_endpoint_healthy"
+            printf 'restart_count=%s\n' "$pf_restart_count"
+        } > "$RUN_DIR/oetf-pf-status.txt"
+        if [[ "$pf_restart_count" -gt 0 ]]; then
+            log_info "WARNING: OETF port-forward required one restart; see $pf_log"
+        fi
+    fi
     return "$rc"
 }
 

--- a/test/oetf/BUILD
+++ b/test/oetf/BUILD
@@ -138,6 +138,11 @@ osmo_py_library(
 )
 
 osmo_py_library(
+    name = "ci_summary",
+    srcs = ["ci_summary.py"],
+)
+
+osmo_py_library(
     name = "reporter",
     srcs = ["reporter.py"],
 )

--- a/test/oetf/ci_summary.py
+++ b/test/oetf/ci_summary.py
@@ -1,0 +1,263 @@
+"""
+Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+NVIDIA CORPORATION and its licensors retain all intellectual property
+and proprietary rights in and to this software, related documentation
+and any modifications thereto. Any use, reproduction, disclosure or
+distribution of this software and related documentation without an express
+license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""
+
+# Classify an OETF CI result and render an actionable GitHub summary.
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import pathlib
+from typing import Dict, List
+
+
+@dataclasses.dataclass(frozen=True)
+class OetfCiSummary:
+    status: str
+    category: str
+    failed_target: str
+    summary: str
+    next_action: str
+    port_forward_restarted: bool
+
+    def as_dict(self) -> Dict[str, object]:
+        return dataclasses.asdict(self)
+
+
+def _read_text(path: pathlib.Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _read_result(path: pathlib.Path) -> Dict:
+    try:
+        result = json.loads(path.read_text(encoding="utf-8"))
+        return result if isinstance(result, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _read_key_values(path: pathlib.Path) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for line in _read_text(path).splitlines():
+        key, separator, value = line.partition("=")
+        if separator:
+            values[key] = value
+    return values
+
+
+def classify_oetf_run(run_directory: pathlib.Path) -> OetfCiSummary:
+    result = _read_result(run_directory / "oetf-result.json")
+    wrapper_result = _read_result(
+        run_directory / "deployment-test-result.json"
+    )
+    port_forward_log = _read_text(run_directory / "oetf-pf.log")
+    raw_results = result.get("results", [])
+    results: List[Dict] = (
+        [row for row in raw_results if isinstance(row, dict)]
+        if isinstance(raw_results, list) else []
+    )
+    failing_rows = [
+        row for row in results if row.get("status") in {"fail", "error"}
+    ]
+    transport_failure = next(
+        (
+            row for row in failing_rows
+            if (
+                "localhost:" in str(row.get("message") or "").lower()
+                or "127.0.0.1:" in str(row.get("message") or "").lower()
+            )
+            and (
+                "connection refused" in str(row.get("message") or "").lower()
+                or "failed to fetch logs" in str(row.get("message") or "").lower()
+            )
+        ),
+        {},
+    )
+    failing = transport_failure or (failing_rows[0] if failing_rows else {})
+    failed_count = int(result.get("failed", 0)) + int(result.get("errored", 0))
+    failed_target = str(failing.get("target") or "")
+    failed_message = str(failing.get("message") or "").strip().replace("\n", " ")
+    port_forward_status = _read_key_values(
+        run_directory / "oetf-pf-status.txt"
+    )
+    port_forward_evidence = port_forward_log.lower()
+    port_forward_restarted = "attempt=2/2 start" in port_forward_log
+    local_request_failed = bool(transport_failure)
+    historical_disconnect = "lost connection to pod" in port_forward_evidence
+    port_forward_failed = (
+        local_request_failed
+        or "supervisor exhausted attempts=2" in port_forward_evidence
+        or (
+            historical_disconnect
+            and port_forward_status.get("endpoint_healthy") != "true"
+        )
+    )
+    runner_succeeded = wrapper_result.get("overall") == "pass"
+    runner_failed_with_passing_tests = (
+        bool(result and results) and failed_count == 0 and not runner_succeeded
+    )
+
+    if result and results and failed_count == 0 and runner_succeeded:
+        if port_forward_restarted:
+            return OetfCiSummary(
+                status="pass",
+                category="transport/recovered",
+                failed_target="",
+                summary="The local kubectl port-forward recovered after one restart.",
+                next_action=(
+                    "No rerun is required; inspect oetf-pf.log if this becomes frequent."
+                ),
+                port_forward_restarted=True,
+            )
+        return OetfCiSummary(
+            status="pass",
+            category="none",
+            failed_target="",
+            summary="All OETF checks passed.",
+            next_action="None.",
+            port_forward_restarted=False,
+        )
+
+    if port_forward_failed:
+        return OetfCiSummary(
+            status="failure",
+            category="transport/port-forward",
+            failed_target=failed_target,
+            summary=(
+                "The local kubectl port-forward failed; the final OSMO API "
+                "assertion is inconclusive."
+            ),
+            next_action=(
+                "Rerun OETF and inspect oetf-pf.log plus the gateway and AKS "
+                "connectivity diagnostics."
+            ),
+            port_forward_restarted=port_forward_restarted,
+        )
+
+    if not result or not results or runner_failed_with_passing_tests:
+        runner_summary = (
+            "OETF checks passed, but the deployment-test wrapper failed."
+            if runner_failed_with_passing_tests
+            else "OETF did not produce a readable result JSON."
+        )
+        return OetfCiSummary(
+            status="failure",
+            category="oetf-runner",
+            failed_target="",
+            summary=runner_summary,
+            next_action="Inspect oetf.log and the deployment-test wrapper result.",
+            port_forward_restarted=port_forward_restarted,
+        )
+
+    message = failed_message[:240] if failed_message else "OETF reported a failed target."
+    return OetfCiSummary(
+        status="failure",
+        category="oetf-test",
+        failed_target=failed_target,
+        summary=message,
+        next_action=(
+            f"Inspect the {failed_target} result and related service logs."
+            if failed_target else "Inspect oetf.log and the related service logs."
+        ),
+        port_forward_restarted=port_forward_restarted,
+    )
+
+
+def render_markdown(run_directory: pathlib.Path, summary: OetfCiSummary) -> str:
+    result = _read_result(run_directory / "oetf-result.json")
+    icon = "PASS" if summary.status == "pass" else "FAIL"
+    lines = [
+        f"### OETF stage: {icon}",
+        "",
+        f"- failure category: `{summary.category}`",
+        f"- failed target: `{summary.failed_target or "-"}`",
+        f"- summary: {summary.summary}",
+        f"- next action: **{summary.next_action}**",
+        "",
+    ]
+    if result:
+        lines.extend([
+            (
+                f"- totals: {result.get("passed", 0)} passed, "
+                f"{result.get("failed", 0)} failed, "
+                f"{result.get("errored", 0)} errored, "
+                f"{result.get("skipped", 0)} skipped"
+            ),
+            "",
+            "| Status | Target | Time | Message |",
+            "|---|---|---:|---|",
+        ])
+        for row in result.get("results", []):
+            message = str(row.get("message") or "").strip().replace("\n", " ")
+            message = message[:200] + ("..." if len(message) > 200 else "")
+            message = message.replace("|", "\\|")
+            lines.append(
+                f"| {row.get("status", "?")} | `{row.get("target", "?")}` | "
+                f"{float(row.get("time", 0)):.1f}s | {message} |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def _write_github_outputs(path: pathlib.Path, summary: OetfCiSummary) -> None:
+    values = {
+        "failure_category": summary.category,
+        "failure_summary": summary.summary,
+        "next_action": summary.next_action,
+        "failed_target": summary.failed_target,
+    }
+    with path.open("a", encoding="utf-8") as output:
+        for key, value in values.items():
+            output.write(f"{key}={value.replace(chr(10), " ")}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--github-output", type=pathlib.Path)
+    parser.add_argument("--github-summary", type=pathlib.Path)
+    arguments = parser.parse_args()
+
+    arguments.run_dir.mkdir(parents=True, exist_ok=True)
+    summary = classify_oetf_run(arguments.run_dir)
+    markdown = render_markdown(arguments.run_dir, summary)
+    (arguments.run_dir / "failure-summary.json").write_text(
+        json.dumps(summary.as_dict(), indent=2) + "\n", encoding="utf-8",
+    )
+    (arguments.run_dir / "failure-summary.md").write_text(markdown, encoding="utf-8")
+
+    output_path = arguments.github_output
+    if output_path is None and os.environ.get("GITHUB_OUTPUT"):
+        output_path = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+    if output_path is not None:
+        _write_github_outputs(output_path, summary)
+
+    summary_path = arguments.github_summary
+    if summary_path is None and os.environ.get("GITHUB_STEP_SUMMARY"):
+        summary_path = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
+    if summary_path is not None:
+        with summary_path.open("a", encoding="utf-8") as github_summary:
+            github_summary.write(markdown)
+
+    if (
+        os.environ.get("GITHUB_ACTIONS") == "true"
+        and summary.category == "transport/recovered"
+    ):
+        print("::warning title=OETF port-forward recovered::One restart was required")
+
+    print(markdown, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/oetf/runner_fixture.py
+++ b/test/oetf/runner_fixture.py
@@ -1123,7 +1123,7 @@ class WorkflowHandle:
         # response (ChunkedEncodingError), producing a partial/empty fetch.
         # Caching an empty result would permanently hide logs that arrive later.
         if not self._logs_cache:
-            self._logs_cache = self._fetch_logs()
+            self._logs_cache = self._fetch_logs(raise_on_error=True)
         return self._logs_cache or ""
 
     # --- In-task check integration (for scenarios that inject task.py) ---
@@ -1141,7 +1141,7 @@ class WorkflowHandle:
         `assert_all_task_checks_passed(task_names=[...])`.
         """
         logs = self._fetch_logs(
-            task_name=task_name, regexes=[CHECK_RESULTS_REGEX],
+            task_name=task_name, regexes=[CHECK_RESULTS_REGEX], raise_on_error=True,
         )
         if not logs:
             self._fixture.fail(
@@ -1170,7 +1170,7 @@ class WorkflowHandle:
         missing: List[str] = []
         for task in task_names:
             logs = self._fetch_logs(
-                task_name=task, regexes=[CHECK_RESULTS_REGEX],
+                task_name=task, regexes=[CHECK_RESULTS_REGEX], raise_on_error=True,
             )
             results = _parse_check_results(logs) if logs else None
             if not results or not results.get("checks"):
@@ -1256,6 +1256,7 @@ class WorkflowHandle:
         task_name: Optional[str] = None,
         regexes: Optional[List[str]] = None,
         last_n_lines: int = 500,
+        raise_on_error: bool = False,
     ) -> str:
         """Fetch a fresh copy of the workflow's logs (bypassing the `logs`
         property cache).
@@ -1271,6 +1272,14 @@ class WorkflowHandle:
             the caller cares about" (e.g. `[CHECKPOINT_PREFIX]` for sync
             markers — drops 99%+ of noise in active workflows).
 
+        ``raise_on_error`` distinguishes a failed request from a successful
+        response containing no log lines. Polling callers retain best-effort
+        behavior by default; assertion-style callers enable strict behavior.
+
+        Strict reads retry one request or incomplete-stream error after two
+        seconds, allowing a supervised local port-forward to recover without
+        hiding a persistent transport failure.
+
         Uses STREAMING mode because the server streams logs via chunked
         transfer and PLAIN_TEXT's `response.text` doesn't consume it
         reliably (observed empty strings while logs were clearly being
@@ -1281,34 +1290,65 @@ class WorkflowHandle:
             params["task_name"] = task_name
         if regexes:
             params["regexes"] = regexes
-        try:
-            response = self._fixture.service_client.request(
-                method=RequestMethod.GET,
-                endpoint=f"api/workflow/{self.workflow_id}/logs",
-                mode=ResponseMode.STREAMING,
-                params=params,
+        request_attempts = 2 if raise_on_error else 1
+        last_error: Optional[Exception] = None
+        for attempt in range(1, request_attempts + 1):
+            response = None
+            lines: List[str] = []
+            attempt_error: Optional[Exception] = None
+            try:
+                response = self._fixture.service_client.request(
+                    method=RequestMethod.GET,
+                    endpoint=f"api/workflow/{self.workflow_id}/logs",
+                    mode=ResponseMode.STREAMING,
+                    params=params,
+                )
+            except Exception as error:  # pylint: disable=broad-except
+                attempt_error = error
+            else:
+                if response is None:
+                    attempt_error = RuntimeError("service returned no response")
+                else:
+                    try:
+                        for line in response.iter_lines():
+                            if isinstance(line, bytes):
+                                lines.append(
+                                    line.decode("utf-8", errors="replace")
+                                )
+                            elif line:
+                                lines.append(line)
+                    except requests.exceptions.RequestException as error:
+                        attempt_error = error
+                        if not raise_on_error:
+                            logger.warning(
+                                "logs stream ended early; returning %d partial lines",
+                                len(lines),
+                            )
+                            return "\n".join(lines)
+                    finally:
+                        response.close()
+                    if attempt_error is None:
+                        return "\n".join(lines)
+
+            last_error = attempt_error
+            logger.warning(
+                "logs fetch error (attempt %d/%d): %s",
+                attempt, request_attempts, attempt_error,
             )
-        except Exception as error:  # pylint: disable=broad-except
-            logger.warning("logs fetch error: %s", error)
-            return ""
-        if response is None:
-            return ""
-        # Collect lines eagerly — the server often terminates the chunked
-        # stream mid-response with `ChunkedEncodingError: Response ended
-        # prematurely`. Keep whatever we got before the drop; the CLI does
-        # the same (see external/src/cli/workflow.py:_workflow_logs).
-        lines: List[str] = []
-        try:
-            for line in response.iter_lines():
-                if isinstance(line, bytes):
-                    lines.append(line.decode("utf-8", errors="replace"))
-                elif line:
-                    lines.append(line)
-        except requests.exceptions.ChunkedEncodingError:
-            pass
-        finally:
-            response.close()
-        return "\n".join(lines)
+            if not raise_on_error:
+                return ""
+            if attempt < request_attempts:
+                time.sleep(2)
+
+        if last_error is not None:
+            raise RuntimeError(
+                f"Failed to fetch logs for workflow {self._id_with_url()}: "
+                f"{last_error}"
+            ) from last_error
+        raise RuntimeError(
+            f"Failed to fetch logs for workflow {self._id_with_url()}: "
+            "unknown error"
+        )
 
     def _terminal_status_or_none(self) -> Optional[str]:
         """Return the current status string if the workflow is terminal,

--- a/test/oetf/tests/BUILD
+++ b/test/oetf/tests/BUILD
@@ -24,6 +24,12 @@ osmo_py_test(
 )
 
 osmo_py_test(
+    name = "test_ci_summary",
+    srcs = ["test_ci_summary.py"],
+    deps = ["//test/oetf:ci_summary"],
+)
+
+osmo_py_test(
     name = "test_models_env",
     srcs = ["test_models_env.py"],
     main = "test_models_env.py",
@@ -43,6 +49,7 @@ osmo_py_test(
     deps = [
         "//test/oetf:models",
         "//test/oetf:runner_fixture",
+        requirement("requests"),
         requirement("pyyaml"),
     ],
 )

--- a/test/oetf/tests/test_ci_summary.py
+++ b/test/oetf/tests/test_ci_summary.py
@@ -1,0 +1,212 @@
+"""
+Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+NVIDIA CORPORATION and its licensors retain all intellectual property
+and proprietary rights in and to this software, related documentation
+and any modifications thereto. Any use, reproduction, disclosure or
+distribution of this software and related documentation without an express
+license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""
+
+import json
+import pathlib
+import tempfile
+import unittest
+
+from test.oetf.ci_summary import classify_oetf_run, render_markdown
+
+
+class ClassifyOetfRunTest(unittest.TestCase):
+
+    def _run_directory(self):
+        temporary_directory = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        self.addCleanup(temporary_directory.cleanup)
+        return pathlib.Path(temporary_directory.name)
+
+    def _write_result(self, run_directory, *, failed=0, errored=0, results=None):
+        if results is None:
+            results = [{
+                "status": "pass",
+                "target": "//test/scenarios:smoke",
+                "message": "",
+                "time": 1,
+            }]
+        data = {
+            "total": len(results),
+            "passed": 1 if failed == 0 and errored == 0 else 0,
+            "failed": failed,
+            "errored": errored,
+            "skipped": 0,
+            "results": results,
+        }
+        (run_directory / "oetf-result.json").write_text(json.dumps(data))
+        wrapper = {"overall": "fail" if failed or errored else "pass"}
+        (run_directory / "deployment-test-result.json").write_text(
+            json.dumps(wrapper)
+        )
+
+    def test_classifies_port_forward_failure_before_logger_assertion(self):
+        run_directory = self._run_directory()
+        self._write_result(
+            run_directory,
+            failed=1,
+            results=[{
+                "status": "fail",
+                "target": "//test/scenarios:logger-connectivity",
+                "message": "localhost:9100: Connection refused",
+                "time": 40,
+            }],
+        )
+        (run_directory / "oetf-pf.log").write_text(
+            "error: lost connection to pod\n"
+        )
+
+        summary = classify_oetf_run(run_directory)
+
+        self.assertEqual(summary.category, "transport/port-forward")
+        self.assertEqual(
+            summary.failed_target, "//test/scenarios:logger-connectivity",
+        )
+        self.assertIn("inconclusive", summary.summary)
+
+    def test_classifies_ordinary_oetf_failure(self):
+        run_directory = self._run_directory()
+        self._write_result(
+            run_directory,
+            failed=1,
+            results=[{
+                "status": "fail",
+                "target": "//test/scenarios:task-env",
+                "message": "AssertionError: expected value",
+            }],
+        )
+
+        summary = classify_oetf_run(run_directory)
+
+        self.assertEqual(summary.category, "oetf-test")
+        self.assertIn("expected value", summary.summary)
+
+    def test_later_transport_failure_takes_precedence(self):
+        run_directory = self._run_directory()
+        self._write_result(
+            run_directory,
+            failed=2,
+            results=[
+                {
+                    "status": "fail",
+                    "target": "//test/scenarios:task-env",
+                    "message": "AssertionError: expected value",
+                },
+                {
+                    "status": "error",
+                    "target": "//test/scenarios:logger-connectivity",
+                    "message": "Failed to fetch logs via http://localhost:9100",
+                },
+            ],
+        )
+
+        summary = classify_oetf_run(run_directory)
+
+        self.assertEqual(summary.category, "transport/port-forward")
+        self.assertEqual(
+            summary.failed_target, "//test/scenarios:logger-connectivity",
+        )
+
+    def test_remote_connection_refusal_is_not_a_port_forward_failure(self):
+        run_directory = self._run_directory()
+        self._write_result(
+            run_directory,
+            failed=1,
+            results=[{
+                "status": "fail",
+                "target": "//test/scenarios:remote-service",
+                "message": "service.example:443: Connection refused",
+            }],
+        )
+
+        summary = classify_oetf_run(run_directory)
+
+        self.assertEqual(summary.category, "oetf-test")
+
+    def test_recovered_tunnel_does_not_mask_unrelated_failure(self):
+        run_directory = self._run_directory()
+        self._write_result(
+            run_directory,
+            failed=1,
+            results=[{
+                "status": "fail",
+                "target": "//test/scenarios:task-env",
+                "message": "AssertionError: expected value",
+            }],
+        )
+        (run_directory / "oetf-pf.log").write_text(
+            "error: lost connection to pod\nattempt=2/2 start\n"
+        )
+        (run_directory / "oetf-pf-status.txt").write_text(
+            "supervisor_alive=true\nendpoint_healthy=true\nrestart_count=1\n"
+        )
+
+        summary = classify_oetf_run(run_directory)
+
+        self.assertEqual(summary.category, "oetf-test")
+
+    def test_empty_result_set_is_a_runner_failure(self):
+        run_directory = self._run_directory()
+        self._write_result(run_directory, results=[])
+
+        summary = classify_oetf_run(run_directory)
+
+        self.assertEqual(summary.category, "oetf-runner")
+
+    def test_all_pass_results_with_failed_wrapper_is_a_runner_failure(self):
+        run_directory = self._run_directory()
+        self._write_result(run_directory)
+        (run_directory / "deployment-test-result.json").write_text(
+            json.dumps({"overall": "fail", "exit_code": 1})
+        )
+
+        summary = classify_oetf_run(run_directory)
+
+        self.assertEqual(summary.category, "oetf-runner")
+        self.assertIn("wrapper failed", summary.summary)
+
+    def test_classifies_missing_result(self):
+        summary = classify_oetf_run(self._run_directory())
+
+        self.assertEqual(summary.category, "oetf-runner")
+
+    def test_reports_recovered_port_forward_without_failing(self):
+        run_directory = self._run_directory()
+        self._write_result(run_directory)
+        (run_directory / "oetf-pf.log").write_text(
+            "attempt=1/2 exit rc=1\nattempt=2/2 start\n"
+        )
+
+        summary = classify_oetf_run(run_directory)
+
+        self.assertEqual(summary.status, "pass")
+        self.assertEqual(summary.category, "transport/recovered")
+        self.assertTrue(summary.port_forward_restarted)
+
+    def test_markdown_contains_action_and_target(self):
+        run_directory = self._run_directory()
+        self._write_result(
+            run_directory,
+            errored=1,
+            results=[{
+                "status": "error",
+                "target": "//test/scenarios:logger-connectivity",
+                "message": "RuntimeError: request failed",
+                "time": 2.5,
+            }],
+        )
+        summary = classify_oetf_run(run_directory)
+
+        markdown = render_markdown(run_directory, summary)
+
+        self.assertIn("next action", markdown)
+        self.assertIn("//test/scenarios:logger-connectivity", markdown)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/oetf/tests/test_runner_fixture.py
+++ b/test/oetf/tests/test_runner_fixture.py
@@ -17,8 +17,9 @@ import os
 import pathlib
 import tempfile
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import requests
 import yaml
 
 from test.oetf.models import WorkflowServerStatus
@@ -396,6 +397,174 @@ class WaitForTaskCheckpointTest(unittest.TestCase):
         )
         with self.assertRaises(TypeError):
             handle.wait_for_task_checkpoint("ready")  # type: ignore[call-arg]
+
+
+class WorkflowLogsTest(unittest.TestCase):
+    """Strict terminal log reads distinguish transport errors from empty logs."""
+
+    def _make_handle(self):
+        fixture = MagicMock()
+        fixture.config.url = "http://localhost:9100"
+        handle = WorkflowHandle(
+            fixture=fixture, workflow_id="wf-test-1", timeout_seconds=60,
+        )
+        return fixture, handle
+
+    def test_best_effort_fetch_returns_empty_on_request_error(self):
+        fixture, handle = self._make_handle()
+        fixture.service_client.request.side_effect = ConnectionError(
+            "[Errno 111] Connection refused"
+        )
+
+        self.assertEqual(handle._fetch_logs(), "")  # pylint: disable=protected-access
+        fixture.service_client.request.assert_called_once()
+
+    def test_logs_raise_contextual_error_after_retry(self):
+        fixture, handle = self._make_handle()
+        error = ConnectionError("[Errno 111] Connection refused")
+        fixture.service_client.request.side_effect = error
+
+        with patch("test.oetf.runner_fixture.time.sleep") as sleep:
+            with self.assertRaises(RuntimeError) as raised:
+                _ = handle.logs
+
+        message = str(raised.exception)
+        self.assertIn("wf-test-1", message)
+        self.assertIn("http://localhost:9100/workflows/wf-test-1", message)
+        self.assertIn("Connection refused", message)
+        self.assertIs(raised.exception.__cause__, error)
+        self.assertEqual(fixture.service_client.request.call_count, 2)
+        sleep.assert_called_once_with(2)
+
+    def test_logs_recover_on_second_request(self):
+        fixture, handle = self._make_handle()
+        marker = "[OETF-MARKER] OETF_LOGGER_PROBE_RECOVERED"
+        response = MagicMock()
+        response.iter_lines.return_value = [marker.encode("utf-8")]
+        fixture.service_client.request.side_effect = [
+            ConnectionError("[Errno 111] Connection refused"), response,
+        ]
+
+        with patch("test.oetf.runner_fixture.time.sleep") as sleep:
+            self.assertEqual(handle.logs, marker)
+
+        self.assertEqual(fixture.service_client.request.call_count, 2)
+        sleep.assert_called_once_with(2)
+        response.close.assert_called_once_with()
+
+    def test_best_effort_stream_keeps_partial_lines(self):
+        fixture, handle = self._make_handle()
+        response = MagicMock()
+
+        def broken_stream():
+            yield b"partial"
+            raise requests.exceptions.ChunkedEncodingError("stream ended")
+
+        response.iter_lines.return_value = broken_stream()
+        fixture.service_client.request.return_value = response
+
+        self.assertEqual(
+            handle._fetch_logs(), "partial",  # pylint: disable=protected-access
+        )
+        fixture.service_client.request.assert_called_once()
+        response.close.assert_called_once_with()
+
+    def test_strict_stream_recovers_on_second_request(self):
+        fixture, handle = self._make_handle()
+        first_response = MagicMock()
+
+        def broken_stream():
+            yield b"partial"
+            raise requests.exceptions.ChunkedEncodingError("stream ended")
+
+        first_response.iter_lines.return_value = broken_stream()
+        marker = "[OETF-MARKER] OETF_LOGGER_PROBE_STREAM_RECOVERED"
+        second_response = MagicMock()
+        second_response.iter_lines.return_value = [marker.encode("utf-8")]
+        fixture.service_client.request.side_effect = [
+            first_response, second_response,
+        ]
+
+        with patch("test.oetf.runner_fixture.time.sleep") as sleep:
+            self.assertEqual(handle.logs, marker)
+
+        self.assertEqual(fixture.service_client.request.call_count, 2)
+        sleep.assert_called_once_with(2)
+        first_response.close.assert_called_once_with()
+        second_response.close.assert_called_once_with()
+
+    def test_strict_stream_retries_connection_error(self):
+        fixture, handle = self._make_handle()
+        first_response = MagicMock()
+        first_response.iter_lines.side_effect = requests.exceptions.ConnectionError(
+            "port-forward disconnected"
+        )
+        marker = "[OETF-MARKER] OETF_LOGGER_PROBE_CONNECTION_RECOVERED"
+        second_response = MagicMock()
+        second_response.iter_lines.return_value = [marker.encode("utf-8")]
+        fixture.service_client.request.side_effect = [
+            first_response, second_response,
+        ]
+
+        with patch("test.oetf.runner_fixture.time.sleep") as sleep:
+            self.assertEqual(handle.logs, marker)
+
+        self.assertEqual(fixture.service_client.request.call_count, 2)
+        sleep.assert_called_once_with(2)
+        first_response.close.assert_called_once_with()
+        second_response.close.assert_called_once_with()
+
+    def test_strict_stream_raises_after_second_incomplete_response(self):
+        fixture, handle = self._make_handle()
+        first_error = requests.exceptions.ChunkedEncodingError("first stream ended")
+        second_error = requests.exceptions.ChunkedEncodingError("second stream ended")
+        first_response = MagicMock()
+        first_response.iter_lines.side_effect = first_error
+        second_response = MagicMock()
+        second_response.iter_lines.side_effect = second_error
+        fixture.service_client.request.side_effect = [
+            first_response, second_response,
+        ]
+
+        with patch("test.oetf.runner_fixture.time.sleep") as sleep:
+            with self.assertRaisesRegex(RuntimeError, "second stream ended") as raised:
+                _ = handle.logs
+
+        self.assertIs(raised.exception.__cause__, second_error)
+        self.assertEqual(fixture.service_client.request.call_count, 2)
+        sleep.assert_called_once_with(2)
+        first_response.close.assert_called_once_with()
+        second_response.close.assert_called_once_with()
+
+    def test_task_check_raises_transport_error(self):
+        fixture, handle = self._make_handle()
+        fixture.service_client.request.side_effect = ConnectionError(
+            "[Errno 111] Connection refused"
+        )
+
+        with patch("test.oetf.runner_fixture.time.sleep"):
+            with self.assertRaisesRegex(RuntimeError, "Connection refused"):
+                handle.assert_in_task_checks_passed("logger-probe")
+
+    def test_logs_accept_successful_empty_response(self):
+        fixture, handle = self._make_handle()
+        response = MagicMock()
+        response.iter_lines.return_value = []
+        fixture.service_client.request.return_value = response
+
+        self.assertEqual(handle.logs, "")
+        response.close.assert_called_once_with()
+
+    def test_logs_return_and_cache_marker(self):
+        fixture, handle = self._make_handle()
+        marker = "[OETF-MARKER] OETF_LOGGER_PROBE_2026-08-10T00:00:00Z"
+        response = MagicMock()
+        response.iter_lines.return_value = [marker.encode("utf-8")]
+        fixture.service_client.request.return_value = response
+
+        self.assertEqual(handle.logs, marker)
+        self.assertEqual(handle.logs, marker)
+        fixture.service_client.request.assert_called_once()
 
 
 class TestRunnerFixtureDefaults(unittest.TestCase):

--- a/test/scenarios/logger_connectivity/test_runner.py
+++ b/test/scenarios/logger_connectivity/test_runner.py
@@ -31,8 +31,9 @@ class LoggerConnectivity(RunnerFixture):
 
         self.assertIn(
             "OETF_LOGGER_PROBE", handle.logs,
-            "Log marker 'OETF_LOGGER_PROBE' not found in logs — the probe ran "
-            "but its output never surfaced via the logs API. Log pipeline "
+            "The logs API request succeeded, but log marker "
+            "'OETF_LOGGER_PROBE' was not found. The probe ran, but its output "
+            "never surfaced via the logs API. Log pipeline "
             "(ctrl → logger → DB → API) may be broken.",
         )
 


### PR DESCRIPTION
## Description

The Azure deployment test could mistake a broken local `kubectl port-forward` for a logger failure, and teardown could remove the cluster before CI saved enough evidence.

This PR:
- retries strict log reads and restarts the port-forward once;
- classifies transport, OETF runner, and test failures separately;
- captures bounded, secret-conscious diagnostics before Terraform destroy;
- links Slack alerts to the failed step and named artifacts.

The full Azure deployment remains label-gated, so this PR does not start cloud infrastructure.

Issue - None

## Validation

- `bazel test --noshow_progress --test_summary=terse //test/oetf/tests/...`
- focused Python lint and type checks
- actionlint with ShellCheck, `bash -n`, and YAML duplicate-key validation

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
