### PR TITLE
feat(helm): add optional embedded Valkey

### DIFF
--- a/deployments/charts/osmo/Chart.lock
+++ b/deployments/charts/osmo/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: valkey
+  repository: oci://ghcr.io/valkey-io/valkey-helm
+  version: 0.11.0
+digest: sha256:ae07432cf278943cbce1cc10870f47daf360653e2554d115dfeb91bd380eaaab
+generated: "2026-08-13T09:31:35.816536897-04:00"

--- a/deployments/charts/osmo/Chart.yaml
+++ b/deployments/charts/osmo/Chart.yaml
@@ -17,3 +17,8 @@ keywords:
 - physical-ai
 - kubernetes
 icon: https://media.githubusercontent.com/media/NVIDIA/OSMO/main/docs/_static/osmo_favicon.png
+dependencies:
+- name: valkey
+  version: 0.11.0
+  repository: oci://ghcr.io/valkey-io/valkey-helm
+  condition: embeddedDependencies.valkey.enabled

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -138,10 +138,12 @@ may reference a separate Secret. The defaults expect these keys:
 | `secrets.objectStorage` | `object-storage.yaml` | Workflow data, logs, and apps |
 | `secrets.masterEncryptionKey` | `mek.yaml` | OSMO encryption-key configuration |
 
-For PostgreSQL or Valkey private CAs, enable TLS in the corresponding
-`externalDependencies` block and reference the CA Secret there. A Valkey
-`caKey` must contain the complete trust bundle; its default is
-`ca-bundle.crt`.
+For an external Valkey endpoint signed by a public CA, enable
+`externalDependencies.valkey.tls.enabled` and leave `caExistingSecret` empty to
+use the image's system trust store. For a private CA, set `caExistingSecret` and
+`caKey` in the same block. The selected key must contain the complete trust
+bundle because clients use it through `SSL_CERT_FILE`. PostgreSQL private CAs
+are also configured in its `externalDependencies` TLS block.
 
 ## Exposure
 

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -99,13 +99,11 @@ Valkey-backed OSMO operations are unavailable until it becomes Ready. Take a
 storage snapshot before upgrades and follow the CSI provider's guidance for
 volume expansion. Replication is available through
 `valkey.replica.enabled=true`, but the primary remains fixed and is not
-automatically failed over. Choose the topology before initial installation;
-changing between standalone and replication requires a planned data migration
-because the two modes use different PVCs. After arranging that migration, set
-`embeddedDependencies.valkey.topologyMigrationAcknowledged=true`. The safety
-check relies on live Kubernetes lookups, so inspect retained PVCs yourself when
-rendering offline or when Helm cannot list them. Use an external Valkey service
-for automatic primary promotion, multi-zone failover, managed backups, or TLS.
+automatically failed over. Standalone and replication use different persistent
+storage layouts. OSMO does not manage topology migrations, so review the
+[official Valkey chart documentation](https://github.com/valkey-io/valkey-helm/tree/main/valkey#deployment-modes)
+before changing `valkey.replica.enabled`. Use an external Valkey service for
+automatic primary promotion, multi-zone failover, managed backups, or TLS.
 
 To use external Valkey, keep `embeddedDependencies.valkey.enabled=false` and
 configure `externalDependencies.valkey` and

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -107,8 +107,11 @@ configure `externalDependencies.valkey` and
 
 ## Optional configuration
 
-- Configure component images and registry credentials under `global`,
-  `runtimeImage`, and each component's `image` block.
+- Configure the shared image registry under `global.imageRegistry`, OSMO-owned
+  pull credentials under `imagePullSecrets`, and component images under
+  `runtimeImage` and each component's `image` block. Configure dependency
+  images and pull credentials in their native values blocks; for example,
+  Valkey uses `valkey.image` and `valkey.imagePullSecrets`.
 - Configure replicas, autoscaling, resources, disruption budgets, scheduling,
   security contexts, probes, volumes, and ServiceAccounts under `services`,
   `gateway`, and `podDefaults`.

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -88,7 +88,10 @@ The generated Secret and 8 GiB `ReadWriteOnce` PVC are retained on uninstall.
 Back up both resources and restore the original Secret before reinstalling or
 recovering the PVC. To supply an existing Secret instead, disable
 `secrets.valkey.generate` and set both `secrets.valkey.existingSecret` and
-`valkey.auth.usersExistingSecret` to its name.
+`valkey.auth.usersExistingSecret` to its name. An existing Secret is recommended
+for production and GitOps installations. Generated credentials are retained in
+the Kubernetes Secret and Helm release history; restrict access to both and use
+`--hide-secret` when previewing an install or upgrade.
 
 The default standalone primary uses append-only persistence and a `Recreate`
 upgrade strategy. Kubernetes restarts a failed primary and reattaches its PVC;
@@ -98,8 +101,11 @@ volume expansion. Replication is available through
 `valkey.replica.enabled=true`, but the primary remains fixed and is not
 automatically failed over. Choose the topology before initial installation;
 changing between standalone and replication requires a planned data migration
-because the two modes use different PVCs. Use an external Valkey service for
-automatic primary promotion, multi-zone failover, managed backups, or TLS.
+because the two modes use different PVCs. After arranging that migration, set
+`embeddedDependencies.valkey.topologyMigrationAcknowledged=true`. The safety
+check relies on live Kubernetes lookups, so inspect retained PVCs yourself when
+rendering offline or when Helm cannot list them. Use an external Valkey service
+for automatic primary promotion, multi-zone failover, managed backups, or TLS.
 
 To use external Valkey, keep `embeddedDependencies.valkey.enabled=false` and
 configure `externalDependencies.valkey` and
@@ -107,11 +113,11 @@ configure `externalDependencies.valkey` and
 
 ## Optional configuration
 
-- Configure the shared image registry under `global.imageRegistry`, OSMO-owned
-  pull credentials under `imagePullSecrets`, and component images under
-  `runtimeImage` and each component's `image` block. Configure dependency
-  images and pull credentials in their native values blocks; for example,
-  Valkey uses `valkey.image` and `valkey.imagePullSecrets`.
+- Configure the OSMO image registry under `imageRegistry`, pull credentials
+  under `imagePullSecrets`, and component images under `runtimeImage` and each
+  component's `image` block. Configure dependency images and pull credentials
+  in their native values blocks; for example, Valkey uses `valkey.image` and
+  `valkey.imagePullSecrets`.
 - Configure replicas, autoscaling, resources, disruption budgets, scheduling,
   security contexts, probes, volumes, and ServiceAccounts under `services`,
   `gateway`, and `podDefaults`.

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -7,9 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 
 The `osmo` chart is the unified OSMO deployment entry point.
 
-The chart currently deploys the OSMO control-plane services and gateway.
-Compute-plane workloads and dependencies will be added to this chart in future
-work.
+The chart currently deploys the OSMO control-plane services and gateway, with
+an optional embedded Valkey dependency. Compute-plane workloads and other
+dependencies will be added in future work.
 
 ## Install the control plane
 
@@ -51,6 +51,7 @@ secrets:
 Install the chart by layering the environment values after the profile:
 
 ```bash
+helm dependency build deployments/charts/osmo
 helm upgrade --install osmo deployments/charts/osmo \
   --namespace osmo \
   --create-namespace \
@@ -60,6 +61,50 @@ helm upgrade --install osmo deployments/charts/osmo \
   --timeout 25m
 ```
 
+The dependency build is only needed for a source checkout. Packaged charts
+include the official `valkey/valkey` chart version `0.11.0`.
+
+## Embedded Valkey
+
+Embedded Valkey is disabled by default. Enable it with retained generated
+credentials as follows:
+
+```yaml
+embeddedDependencies:
+  valkey:
+    enabled: true
+
+externalDependencies:
+  valkey:
+    host: ''
+
+secrets:
+  valkey:
+    generate: true
+    existingSecret: ''
+```
+
+The generated Secret and 8 GiB `ReadWriteOnce` PVC are retained on uninstall.
+Back up both resources and restore the original Secret before reinstalling or
+recovering the PVC. To supply an existing Secret instead, disable
+`secrets.valkey.generate` and set both `secrets.valkey.existingSecret` and
+`valkey.auth.usersExistingSecret` to its name.
+
+The default standalone primary uses append-only persistence and a `Recreate`
+upgrade strategy. Kubernetes restarts a failed primary and reattaches its PVC;
+Valkey-backed OSMO operations are unavailable until it becomes Ready. Take a
+storage snapshot before upgrades and follow the CSI provider's guidance for
+volume expansion. Replication is available through
+`valkey.replica.enabled=true`, but the primary remains fixed and is not
+automatically failed over. Choose the topology before initial installation;
+changing between standalone and replication requires a planned data migration
+because the two modes use different PVCs. Use an external Valkey service for
+automatic primary promotion, multi-zone failover, managed backups, or TLS.
+
+To use external Valkey, keep `embeddedDependencies.valkey.enabled=false` and
+configure `externalDependencies.valkey` and
+`secrets.valkey.existingSecret` as shown in the installation example.
+
 ## Optional configuration
 
 - Configure component images and registry credentials under `global`,
@@ -68,7 +113,8 @@ helm upgrade --install osmo deployments/charts/osmo \
   security contexts, probes, volumes, and ServiceAccounts under `services`,
   `gateway`, and `podDefaults`.
 - Enable Prometheus Operator PodMonitors with `monitoring.podMonitor.enabled`.
-- Apply shared resource metadata with `commonLabels` and `commonAnnotations`.
+- Apply shared resource metadata to OSMO-owned resources with `commonLabels`
+  and `commonAnnotations`; configure dependency metadata under `valkey`.
 - Supply OSMO application configuration under `configuration`.
 
 See [`values.yaml`](values.yaml) for the complete configuration reference.

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -83,7 +83,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "osmo.component.image" -}}
 {{- $root := .root -}}
 {{- $component := .component -}}
-{{- $registry := $root.Values.global.imageRegistry | default $component.image.registry -}}
+{{- $registry := $root.Values.imageRegistry | default $component.image.registry -}}
 {{- $repository := required "component image.repository is required" $component.image.repository -}}
 {{- $base := ternary (printf "%s/%s" $registry $repository) $repository (ne $registry "") -}}
 {{- if $component.image.digest -}}
@@ -94,7 +94,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "osmo.component.imageRepository" -}}
-{{- $registry := .Values.global.imageRegistry | default .Values.runtimeImage.registry -}}
+{{- $registry := .Values.imageRegistry | default .Values.runtimeImage.registry -}}
 {{- ternary (printf "%s/%s" $registry .Values.runtimeImage.repository) .Values.runtimeImage.repository (ne $registry "") -}}
 {{- end -}}
 

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -115,7 +115,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "osmo.component.imagePullSecrets" -}}
 {{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-{{ toYaml . | nindent 2 }}
+{{- range . }}
+- name: {{ . }}
+{{- end }}
 {{- end }}
 {{- end -}}
 
@@ -292,13 +294,65 @@ data:
 {{- end }}
 {{- end -}}
 
+{{- define "osmo.valkey.fullname" -}}
+{{- $name := default "valkey" (dig "nameOverride" "" .Values.valkey) -}}
+{{- $fullnameOverride := dig "fullnameOverride" "" .Values.valkey -}}
+{{- if $fullnameOverride -}}
+{{- $fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.valkey.generatedSecretName" -}}
+{{- printf "%s-valkey-credentials" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "osmo.valkey.host" -}}
+{{- if .Values.embeddedDependencies.valkey.enabled -}}
+{{- include "osmo.valkey.fullname" . -}}
+{{- else -}}
+{{- .Values.externalDependencies.valkey.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.valkey.port" -}}
+{{- if .Values.embeddedDependencies.valkey.enabled -}}
+{{- .Values.valkey.service.port -}}
+{{- else -}}
+{{- .Values.externalDependencies.valkey.port -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.valkey.database" -}}
+{{- if .Values.embeddedDependencies.valkey.enabled -}}0{{- else -}}
+{{- .Values.externalDependencies.valkey.database -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.valkey.tlsEnabled" -}}
+{{- if .Values.embeddedDependencies.valkey.enabled -}}false{{- else -}}
+{{- .Values.externalDependencies.valkey.tls.enabled -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.valkey.secretName" -}}
+{{- if and .Values.embeddedDependencies.valkey.enabled .Values.secrets.valkey.generate -}}
+{{- include "osmo.valkey.generatedSecretName" . -}}
+{{- else -}}
+{{- .Values.secrets.valkey.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "osmo.externalDependencies.caVolumeMounts" -}}
 {{- if .Values.externalDependencies.postgresql.tls.enabled }}
 - name: postgresql-ca
   mountPath: /etc/osmo/ca/postgresql
   readOnly: true
 {{- end }}
-{{- if .Values.externalDependencies.valkey.tls.enabled }}
+{{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
 - name: valkey-ca
   mountPath: /etc/osmo/ca/valkey
   readOnly: true
@@ -314,7 +368,7 @@ data:
     - key: {{ .Values.externalDependencies.postgresql.tls.caKey }}
       path: ca.crt
 {{- end }}
-{{- if .Values.externalDependencies.valkey.tls.enabled }}
+{{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
 - name: valkey-ca
   secret:
     secretName: {{ .Values.externalDependencies.valkey.tls.caExistingSecret }}
@@ -332,7 +386,7 @@ data:
       name: {{ . }}
       key: {{ $.Values.secrets.postgresql.keys.password }}
 {{- end }}
-{{- with .Values.secrets.valkey.existingSecret }}
+{{- with (include "osmo.valkey.secretName" .) }}
 - name: OSMO_REDIS_PASSWORD
   valueFrom:
     secretKeyRef:
@@ -343,7 +397,7 @@ data:
 - name: PGSSLROOTCERT
   value: /etc/osmo/ca/postgresql/ca.crt
 {{- end }}
-{{- if .Values.externalDependencies.valkey.tls.enabled }}
+{{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
 - name: SSL_CERT_FILE
   value: /etc/osmo/ca/valkey/ca-bundle.crt
 {{- end }}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -113,11 +113,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "osmo.component.imagePullSecrets" -}}
-{{- with .Values.global.imagePullSecrets }}
+{{- with .Values.imagePullSecrets }}
 imagePullSecrets:
-{{- range . }}
-- name: {{ . }}
-{{- end }}
+{{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end -}}
 

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -336,6 +336,13 @@ data:
 {{- end -}}
 {{- end -}}
 
+{{- define "osmo.externalDependencies.valkeyCustomCaEnabled" -}}
+{{- if and
+  (not .Values.embeddedDependencies.valkey.enabled)
+  .Values.externalDependencies.valkey.tls.enabled
+  .Values.externalDependencies.valkey.tls.caExistingSecret -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
 {{- define "osmo.valkey.secretName" -}}
 {{- if and .Values.embeddedDependencies.valkey.enabled .Values.secrets.valkey.generate -}}
 {{- include "osmo.valkey.generatedSecretName" . -}}
@@ -350,7 +357,7 @@ data:
   mountPath: /etc/osmo/ca/postgresql
   readOnly: true
 {{- end }}
-{{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+{{- if eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true" }}
 - name: valkey-ca
   mountPath: /etc/osmo/ca/valkey
   readOnly: true
@@ -366,7 +373,7 @@ data:
     - key: {{ .Values.externalDependencies.postgresql.tls.caKey }}
       path: ca.crt
 {{- end }}
-{{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+{{- if eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true" }}
 - name: valkey-ca
   secret:
     secretName: {{ .Values.externalDependencies.valkey.tls.caExistingSecret }}
@@ -395,7 +402,7 @@ data:
 - name: PGSSLROOTCERT
   value: /etc/osmo/ca/postgresql/ca.crt
 {{- end }}
-{{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+{{- if eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true" }}
 - name: SSL_CERT_FILE
   value: /etc/osmo/ca/valkey/ca-bundle.crt
 {{- end }}

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -86,12 +86,12 @@ spec:
           containerPort: 9464
         args:
         - --redis_host
-        - {{ .Values.externalDependencies.valkey.host }}
+        - {{ include "osmo.valkey.host" . }}
         - --redis_port
-        - {{ .Values.externalDependencies.valkey.port | quote }}
+        - {{ include "osmo.valkey.port" . | quote }}
         - --redis_db_number
-        - {{ .Values.externalDependencies.valkey.database | quote }}
-        {{- if .Values.externalDependencies.valkey.tls.enabled }}
+        - {{ include "osmo.valkey.database" . | quote }}
+        {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
         - --redis_tls_enable
         - "true"
         {{- end}}

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -82,12 +82,12 @@ spec:
         - --metrics_otel_enable
         - "true"
         - --redis_host
-        - {{ .Values.externalDependencies.valkey.host }}
+        - {{ include "osmo.valkey.host" . }}
         - --redis_port
-        - {{ .Values.externalDependencies.valkey.port | quote }}
+        - {{ include "osmo.valkey.port" . | quote }}
         - --redis_db_number
-        - {{ .Values.externalDependencies.valkey.database | quote }}
-        {{- if .Values.externalDependencies.valkey.tls.enabled }}
+        - {{ include "osmo.valkey.database" . | quote }}
+        {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
         - --redis_tls_enable
         - "true"
         {{- end}}

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -78,12 +78,12 @@ spec:
         - --metrics_otel_enable
         - "true"
         - --redis_host
-        - {{ .Values.externalDependencies.valkey.host }}
+        - {{ include "osmo.valkey.host" . }}
         - --redis_port
-        - {{ .Values.externalDependencies.valkey.port | quote }}
+        - {{ include "osmo.valkey.port" . | quote }}
         - --redis_db_number
-        - {{ .Values.externalDependencies.valkey.database | quote }}
-        {{- if .Values.externalDependencies.valkey.tls.enabled }}
+        - {{ include "osmo.valkey.database" . | quote }}
+        {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
         - --redis_tls_enable
         - "true"
         {{- end}}

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -340,7 +340,7 @@ spec:
               secretKeyRef:
                 name: {{ include "osmo.valkey.secretName" . }}
                 key: {{ .Values.secrets.valkey.keys.password }}
-          {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+          {{- if eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true" }}
           - name: SSL_CERT_FILE
             value: /etc/osmo/ca/valkey/ca-bundle.crt
           {{- end }}
@@ -370,7 +370,7 @@ spec:
             mountPath: /etc/oauth2-proxy
             readOnly: true
           {{- end }}
-          {{- if and $gw.oauth2Proxy.redisSessionStore (eq (include "osmo.valkey.tlsEnabled" .) "true") }}
+          {{- if and $gw.oauth2Proxy.redisSessionStore (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") }}
           - name: valkey-ca
             mountPath: /etc/osmo/ca/valkey
             readOnly: true
@@ -389,7 +389,7 @@ spec:
             - key: {{ $gw.oauth2Proxy.cookieSecretKey | default "cookie_secret" }}
               path: cookie-secret
         {{- end }}
-        {{- if and $gw.oauth2Proxy.redisSessionStore (eq (include "osmo.valkey.tlsEnabled" .) "true") }}
+        {{- if and $gw.oauth2Proxy.redisSessionStore (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") }}
         - name: valkey-ca
           secret:
             secretName: {{ .Values.externalDependencies.valkey.tls.caExistingSecret }}
@@ -553,7 +553,7 @@ spec:
         env:
           {{- include "osmo.component.extraEnv" $gw.authz | nindent 10 }}
           {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 10 }}
-        {{- if or .Values.configuration.enabled $gw.authz.extraVolumeMounts .Values.externalDependencies.postgresql.tls.enabled (eq (include "osmo.valkey.tlsEnabled" .) "true") }}
+        {{- if or .Values.configuration.enabled $gw.authz.extraVolumeMounts .Values.externalDependencies.postgresql.tls.enabled (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") }}
         volumeMounts:
           {{- if .Values.configuration.enabled }}
           - name: configs
@@ -756,7 +756,7 @@ spec:
               key: {{ .Values.secrets.valkey.keys.password }}
         - name: REDIS_TLS
           value: {{ include "osmo.valkey.tlsEnabled" . | quote }}
-        {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+        {{- if eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true" }}
         - name: SSL_CERT_FILE
           value: /etc/osmo/ca/valkey/ca-bundle.crt
         {{- end }}
@@ -783,7 +783,7 @@ spec:
         volumeMounts:
         - name: ratelimit-config
           mountPath: /data/ratelimit/config
-        {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+        {{- if eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true" }}
         - name: valkey-ca
           mountPath: /etc/osmo/ca/valkey
           readOnly: true
@@ -804,7 +804,7 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-      {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+      {{- if eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true" }}
       - name: valkey-ca
         secret:
           secretName: {{ .Values.externalDependencies.valkey.tls.caExistingSecret }}

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -319,10 +319,10 @@ spec:
           - --set-xauthrequest=true
           - --set-authorization-header=true
           - --pass-access-token={{ $gw.oauth2Proxy.passAccessToken }}
-          {{- $valkey := $.Values.externalDependencies.valkey }}
+          {{- $valkeyHost := include "osmo.valkey.host" $ }}
           {{- if $gw.oauth2Proxy.redisSessionStore }}
           - --session-store-type=redis
-          - --redis-connection-url={{ if $valkey.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ $valkey.host }}:{{ $valkey.port }}/{{ $valkey.database }}
+          - --redis-connection-url={{ if eq (include "osmo.valkey.tlsEnabled" $) "true" }}rediss{{ else }}redis{{ end }}://{{ $valkeyHost }}:{{ include "osmo.valkey.port" $ }}/{{ include "osmo.valkey.database" $ }}
           {{- end }}
           - --upstream=static://200
           - --redirect-url={{ trimSuffix "/" $.Values.externalUrl }}/oauth2/callback
@@ -338,8 +338,12 @@ spec:
           - name: OAUTH2_PROXY_REDIS_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.secrets.valkey.existingSecret }}
+                name: {{ include "osmo.valkey.secretName" . }}
                 key: {{ .Values.secrets.valkey.keys.password }}
+          {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+          - name: SSL_CERT_FILE
+            value: /etc/osmo/ca/valkey/ca-bundle.crt
+          {{- end }}
           {{- end }}
           {{- include "osmo.component.extraEnv" $gw.oauth2Proxy | nindent 10 }}
         {{- end }}
@@ -366,6 +370,11 @@ spec:
             mountPath: /etc/oauth2-proxy
             readOnly: true
           {{- end }}
+          {{- if and $gw.oauth2Proxy.redisSessionStore (eq (include "osmo.valkey.tlsEnabled" .) "true") }}
+          - name: valkey-ca
+            mountPath: /etc/osmo/ca/valkey
+            readOnly: true
+          {{- end }}
           {{- with $gw.oauth2Proxy.extraVolumeMounts }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
@@ -379,6 +388,14 @@ spec:
               path: client-secret
             - key: {{ $gw.oauth2Proxy.cookieSecretKey | default "cookie_secret" }}
               path: cookie-secret
+        {{- end }}
+        {{- if and $gw.oauth2Proxy.redisSessionStore (eq (include "osmo.valkey.tlsEnabled" .) "true") }}
+        - name: valkey-ca
+          secret:
+            secretName: {{ .Values.externalDependencies.valkey.tls.caExistingSecret }}
+            items:
+            - key: {{ .Values.externalDependencies.valkey.tls.caKey }}
+              path: ca-bundle.crt
         {{- end }}
         {{- with $gw.oauth2Proxy.pod.extraVolumes }}
           {{- toYaml . | nindent 8 }}
@@ -536,7 +553,7 @@ spec:
         env:
           {{- include "osmo.component.extraEnv" $gw.authz | nindent 10 }}
           {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 10 }}
-        {{- if or .Values.configuration.enabled $gw.authz.extraVolumeMounts .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
+        {{- if or .Values.configuration.enabled $gw.authz.extraVolumeMounts .Values.externalDependencies.postgresql.tls.enabled (eq (include "osmo.valkey.tlsEnabled" .) "true") }}
         volumeMounts:
           {{- if .Values.configuration.enabled }}
           - name: configs
@@ -731,14 +748,18 @@ spec:
         - name: REDIS_SOCKET_TYPE
           value: tcp
         - name: REDIS_URL
-          value: {{ .Values.externalDependencies.valkey.host }}:{{ .Values.externalDependencies.valkey.port }}
+          value: {{ include "osmo.valkey.host" . }}:{{ include "osmo.valkey.port" . }}
         - name: REDIS_AUTH
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.secrets.valkey.existingSecret }}
+              name: {{ include "osmo.valkey.secretName" . }}
               key: {{ .Values.secrets.valkey.keys.password }}
         - name: REDIS_TLS
-          value: {{ .Values.externalDependencies.valkey.tls.enabled | quote }}
+          value: {{ include "osmo.valkey.tlsEnabled" . | quote }}
+        {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+        - name: SSL_CERT_FILE
+          value: /etc/osmo/ca/valkey/ca-bundle.crt
+        {{- end }}
         - name: USE_STATSD
           value: "false"
         - name: RUNTIME_ROOT
@@ -762,6 +783,11 @@ spec:
         volumeMounts:
         - name: ratelimit-config
           mountPath: /data/ratelimit/config
+        {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+        - name: valkey-ca
+          mountPath: /etc/osmo/ca/valkey
+          readOnly: true
+        {{- end }}
         {{- with $gw.rateLimit.extraVolumeMounts }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -778,6 +804,14 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+      {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
+      - name: valkey-ca
+        secret:
+          secretName: {{ .Values.externalDependencies.valkey.tls.caExistingSecret }}
+          items:
+          - key: {{ .Values.externalDependencies.valkey.tls.caKey }}
+            path: ca-bundle.crt
+      {{- end }}
       {{- with $gw.rateLimit.pod.extraVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -86,12 +86,12 @@ spec:
         - logger
         args:
         - --redis_host
-        - {{ .Values.externalDependencies.valkey.host }}
+        - {{ include "osmo.valkey.host" . }}
         - --redis_port
-        - {{ .Values.externalDependencies.valkey.port | quote }}
+        - {{ include "osmo.valkey.port" . | quote }}
         - --redis_db_number
-        - {{ .Values.externalDependencies.valkey.database | quote }}
-        {{- if .Values.externalDependencies.valkey.tls.enabled }}
+        - {{ include "osmo.valkey.database" . | quote }}
+        {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
         - --redis_tls_enable
         - "true"
         {{- end}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -67,23 +67,6 @@
 {{- if ne $passwordKey .Values.secrets.valkey.keys.password -}}
 {{- fail "valkey.auth.aclUsers.default.passwordKey must match secrets.valkey.keys.password" -}}
 {{- end -}}
-{{- $embeddedName := include "osmo.valkey.fullname" . -}}
-{{- $standalonePvcName := default $embeddedName .Values.valkey.dataStorage.persistentVolumeClaimName -}}
-{{- $standalonePvc := lookup "v1" "PersistentVolumeClaim" .Release.Namespace $standalonePvcName -}}
-{{- $replicaPvcPrefix := printf "valkey-data-%s-" $embeddedName -}}
-{{- $persistentVolumeClaims := lookup "v1" "PersistentVolumeClaim" .Release.Namespace "" -}}
-{{- $hasReplicaPvc := false -}}
-{{- range (default list $persistentVolumeClaims.items) -}}
-{{- if hasPrefix $replicaPvcPrefix .metadata.name -}}
-{{- $hasReplicaPvc = true -}}
-{{- end -}}
-{{- end -}}
-{{- if and .Values.valkey.replica.enabled $standalonePvc (not .Values.embeddedDependencies.valkey.topologyMigrationAcknowledged) -}}
-{{- fail "changing embedded Valkey from standalone to replication requires a planned data migration" -}}
-{{- end -}}
-{{- if and (not .Values.valkey.replica.enabled) $hasReplicaPvc (not .Values.embeddedDependencies.valkey.topologyMigrationAcknowledged) -}}
-{{- fail "changing embedded Valkey from replication to standalone requires a planned data migration" -}}
-{{- end -}}
 {{- else if .Values.secrets.valkey.generate -}}
 {{- fail "secrets.valkey.generate is supported only when embedded Valkey is enabled" -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -173,6 +173,3 @@
 {{- if and .Values.externalDependencies.postgresql.tls.enabled (not .Values.externalDependencies.postgresql.tls.caExistingSecret) -}}
 {{- fail "externalDependencies.postgresql.tls.caExistingSecret is required when TLS is enabled" -}}
 {{- end -}}
-{{- if and .Values.externalDependencies.valkey.tls.enabled (not .Values.externalDependencies.valkey.tls.caExistingSecret) -}}
-{{- fail "externalDependencies.valkey.tls.caExistingSecret is required when TLS is enabled" -}}
-{{- end -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -22,6 +22,9 @@
 {{- if .Values.externalDependencies.valkey.tls.enabled -}}
 {{- fail "externalDependencies.valkey.tls must be disabled when embedded Valkey is enabled" -}}
 {{- end -}}
+{{- if ne (int .Values.externalDependencies.valkey.database) 0 -}}
+{{- fail "externalDependencies.valkey.database must be 0 when embedded Valkey is enabled" -}}
+{{- end -}}
 {{- if and .Values.secrets.valkey.generate .Values.secrets.valkey.existingSecret -}}
 {{- fail "secrets.valkey.generate and existingSecret are mutually exclusive" -}}
 {{- end -}}
@@ -52,10 +55,6 @@
 {{- $configuredSecretValue := required "valkey.auth.usersExistingSecret is required" .Values.valkey.auth.usersExistingSecret -}}
 {{- $configuredSecret := $configuredSecretValue -}}
 {{- if .Values.secrets.valkey.generate -}}
-{{- $generatedSecretTemplate := "{{ printf \"%s-valkey-credentials\" .Release.Name | trunc 63 | trimSuffix \"-\" }}" -}}
-{{- if ne $configuredSecretValue $generatedSecretTemplate -}}
-{{- fail "valkey.auth.usersExistingSecret must use the chart default when generating credentials" -}}
-{{- end -}}
 {{- $configuredSecret = tpl $configuredSecretValue . -}}
 {{- else if or (contains "{{" $configuredSecretValue) (contains "}}" $configuredSecretValue) -}}
 {{- fail "valkey.auth.usersExistingSecret must not contain templates when using an existing Secret" -}}
@@ -79,10 +78,10 @@
 {{- $hasReplicaPvc = true -}}
 {{- end -}}
 {{- end -}}
-{{- if and .Values.valkey.replica.enabled $standalonePvc -}}
+{{- if and .Values.valkey.replica.enabled $standalonePvc (not .Values.embeddedDependencies.valkey.topologyMigrationAcknowledged) -}}
 {{- fail "changing embedded Valkey from standalone to replication requires a planned data migration" -}}
 {{- end -}}
-{{- if and (not .Values.valkey.replica.enabled) $hasReplicaPvc -}}
+{{- if and (not .Values.valkey.replica.enabled) $hasReplicaPvc (not .Values.embeddedDependencies.valkey.topologyMigrationAcknowledged) -}}
 {{- fail "changing embedded Valkey from replication to standalone requires a planned data migration" -}}
 {{- end -}}
 {{- else if .Values.secrets.valkey.generate -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -9,14 +9,84 @@
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}
 {{- fail "embeddedDependencies.postgresql.enabled: embedded PostgreSQL is not implemented" -}}
 {{- end -}}
-{{- if .Values.embeddedDependencies.valkey.enabled -}}
-{{- fail "embeddedDependencies.valkey.enabled: embedded Valkey is not implemented" -}}
-{{- end -}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
 {{- fail "embeddedDependencies.objectStorage.enabled: embedded object storage is not implemented" -}}
 {{- end -}}
 {{- if .Values.embeddedDependencies.kaiScheduler.enabled -}}
 {{- fail "embeddedDependencies.kaiScheduler.enabled: embedded KAI Scheduler is not implemented" -}}
+{{- end -}}
+{{- if .Values.embeddedDependencies.valkey.enabled -}}
+{{- if .Values.externalDependencies.valkey.host -}}
+{{- fail "externalDependencies.valkey.host must be empty when embedded Valkey is enabled" -}}
+{{- end -}}
+{{- if .Values.externalDependencies.valkey.tls.enabled -}}
+{{- fail "externalDependencies.valkey.tls must be disabled when embedded Valkey is enabled" -}}
+{{- end -}}
+{{- if and .Values.secrets.valkey.generate .Values.secrets.valkey.existingSecret -}}
+{{- fail "secrets.valkey.generate and existingSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if and (not .Values.secrets.valkey.generate) (not .Values.secrets.valkey.existingSecret) -}}
+{{- fail "embedded Valkey requires generated or existing credentials" -}}
+{{- end -}}
+{{- if not .Values.valkey.auth.enabled -}}
+{{- fail "valkey.auth.enabled must be true for embedded Valkey" -}}
+{{- end -}}
+{{- if ne (int .Values.valkey.service.port) 6379 -}}
+{{- fail "embedded Valkey requires service port 6379" -}}
+{{- end -}}
+{{- if .Values.valkey.tls.enabled -}}
+{{- fail "embedded Valkey TLS is not supported; use an external TLS endpoint" -}}
+{{- end -}}
+{{- if .Values.valkey.auth.aclConfig -}}
+{{- fail "valkey.auth.aclConfig is not supported because credentials must come from a Kubernetes Secret" -}}
+{{- end -}}
+{{- range $username, $user := .Values.valkey.auth.aclUsers -}}
+{{- if $user.password -}}
+{{- fail (printf "inline Valkey passwords are not supported for ACL user %s" $username) -}}
+{{- end -}}
+{{- end -}}
+{{- if not (hasKey .Values.valkey.auth.aclUsers "default") -}}
+{{- fail "valkey.auth.aclUsers.default is required for OSMO clients" -}}
+{{- end -}}
+{{- $effectiveSecret := include "osmo.valkey.secretName" . -}}
+{{- $configuredSecretValue := required "valkey.auth.usersExistingSecret is required" .Values.valkey.auth.usersExistingSecret -}}
+{{- $configuredSecret := $configuredSecretValue -}}
+{{- if .Values.secrets.valkey.generate -}}
+{{- $generatedSecretTemplate := "{{ printf \"%s-valkey-credentials\" .Release.Name | trunc 63 | trimSuffix \"-\" }}" -}}
+{{- if ne $configuredSecretValue $generatedSecretTemplate -}}
+{{- fail "valkey.auth.usersExistingSecret must use the chart default when generating credentials" -}}
+{{- end -}}
+{{- $configuredSecret = tpl $configuredSecretValue . -}}
+{{- else if or (contains "{{" $configuredSecretValue) (contains "}}" $configuredSecretValue) -}}
+{{- fail "valkey.auth.usersExistingSecret must not contain templates when using an existing Secret" -}}
+{{- end -}}
+{{- if ne $configuredSecret $effectiveSecret -}}
+{{- fail "valkey.auth.usersExistingSecret must match the effective Valkey Secret" -}}
+{{- end -}}
+{{- $defaultUser := index .Values.valkey.auth.aclUsers "default" -}}
+{{- $passwordKey := dig "passwordKey" "default" $defaultUser -}}
+{{- if ne $passwordKey .Values.secrets.valkey.keys.password -}}
+{{- fail "valkey.auth.aclUsers.default.passwordKey must match secrets.valkey.keys.password" -}}
+{{- end -}}
+{{- $embeddedName := include "osmo.valkey.fullname" . -}}
+{{- $standalonePvcName := default $embeddedName .Values.valkey.dataStorage.persistentVolumeClaimName -}}
+{{- $standalonePvc := lookup "v1" "PersistentVolumeClaim" .Release.Namespace $standalonePvcName -}}
+{{- $replicaPvcPrefix := printf "valkey-data-%s-" $embeddedName -}}
+{{- $persistentVolumeClaims := lookup "v1" "PersistentVolumeClaim" .Release.Namespace "" -}}
+{{- $hasReplicaPvc := false -}}
+{{- range (default list $persistentVolumeClaims.items) -}}
+{{- if hasPrefix $replicaPvcPrefix .metadata.name -}}
+{{- $hasReplicaPvc = true -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.valkey.replica.enabled $standalonePvc -}}
+{{- fail "changing embedded Valkey from standalone to replication requires a planned data migration" -}}
+{{- end -}}
+{{- if and (not .Values.valkey.replica.enabled) $hasReplicaPvc -}}
+{{- fail "changing embedded Valkey from replication to standalone requires a planned data migration" -}}
+{{- end -}}
+{{- else if .Values.secrets.valkey.generate -}}
+{{- fail "secrets.valkey.generate is supported only when embedded Valkey is enabled" -}}
 {{- end -}}
 {{- if not .Values.externalUrl -}}
 {{- fail "externalUrl is required for the control plane" -}}
@@ -33,7 +103,7 @@
 {{- if and .Values.httproute.enabled (eq (len .Values.httproute.parentRefs) 0) -}}
 {{- fail "httproute.parentRefs requires at least one entry when httproute.enabled=true" -}}
 {{- end -}}
-{{- if or .Values.secrets.postgresql.generate .Values.secrets.valkey.generate .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
+{{- if or .Values.secrets.postgresql.generate .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
 {{- fail "secrets: generated Secrets are not implemented; configure existingSecret" -}}
 {{- end -}}
 {{- $autoscaledComponents := list
@@ -91,7 +161,7 @@
 {{- if not .Values.externalDependencies.postgresql.host -}}
 {{- fail "externalDependencies.postgresql.host is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.valkey.host -}}
+{{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.externalDependencies.valkey.host) -}}
 {{- fail "externalDependencies.valkey.host is required for the control plane" -}}
 {{- end -}}
 {{- if not .Values.externalDependencies.objectStorage.endpoint -}}
@@ -109,7 +179,7 @@
 {{- if not .Values.secrets.postgresql.existingSecret -}}
 {{- fail "secrets.postgresql.existingSecret is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.secrets.valkey.existingSecret -}}
+{{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.secrets.valkey.existingSecret) -}}
 {{- fail "secrets.valkey.existingSecret is required for the control plane" -}}
 {{- end -}}
 {{- if not .Values.secrets.objectStorage.existingSecret -}}

--- a/deployments/charts/osmo/templates/valkey-secret.yaml
+++ b/deployments/charts/osmo/templates/valkey-secret.yaml
@@ -20,10 +20,14 @@
 {{- end -}}
 {{- $hasEmbeddedState := or $existingDeployment $existingStatefulSet $existingStandalonePvc $hasReplicaPvc -}}
 {{- if $existingSecret -}}
-{{- if not (hasKey (default dict $existingSecret.data) $passwordKey) -}}
+{{- $existingData := default dict $existingSecret.data -}}
+{{- if not (hasKey $existingData $passwordKey) -}}
 {{- fail (printf "generated Valkey Secret %s is missing key %s; restore it before upgrading or reinstalling" $secretName $passwordKey) -}}
 {{- end -}}
-{{- $password = index $existingSecret.data $passwordKey -}}
+{{- $password = index $existingData $passwordKey -}}
+{{- if not $password -}}
+{{- fail (printf "generated Valkey Secret %s has an empty key %s; restore it before upgrading or reinstalling" $secretName $passwordKey) -}}
+{{- end -}}
 {{- else if $hasEmbeddedState -}}
 {{- fail (printf "generated Valkey Secret %s is missing; restore it before upgrading or reinstalling" $secretName) -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/valkey-secret.yaml
+++ b/deployments/charts/osmo/templates/valkey-secret.yaml
@@ -1,0 +1,42 @@
+{{/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.embeddedDependencies.valkey.enabled .Values.secrets.valkey.generate -}}
+{{- $secretName := include "osmo.valkey.generatedSecretName" . -}}
+{{- $passwordKey := .Values.secrets.valkey.keys.password -}}
+{{- $password := randAlphaNum 64 | b64enc -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $embeddedName := include "osmo.valkey.fullname" . -}}
+{{- $existingDeployment := lookup "apps/v1" "Deployment" .Release.Namespace $embeddedName -}}
+{{- $existingStatefulSet := lookup "apps/v1" "StatefulSet" .Release.Namespace $embeddedName -}}
+{{- $standalonePvcName := default $embeddedName .Values.valkey.dataStorage.persistentVolumeClaimName -}}
+{{- $existingStandalonePvc := lookup "v1" "PersistentVolumeClaim" .Release.Namespace $standalonePvcName -}}
+{{- $replicaPvcPrefix := printf "valkey-data-%s-" $embeddedName -}}
+{{- $persistentVolumeClaims := lookup "v1" "PersistentVolumeClaim" .Release.Namespace "" -}}
+{{- $hasReplicaPvc := false -}}
+{{- range (default list $persistentVolumeClaims.items) -}}
+{{- if hasPrefix $replicaPvcPrefix .metadata.name -}}
+{{- $hasReplicaPvc = true -}}
+{{- end -}}
+{{- end -}}
+{{- $hasEmbeddedState := or $existingDeployment $existingStatefulSet $existingStandalonePvc $hasReplicaPvc -}}
+{{- if $existingSecret -}}
+{{- if not (hasKey (default dict $existingSecret.data) $passwordKey) -}}
+{{- fail (printf "generated Valkey Secret %s is missing key %s; restore it before upgrading or reinstalling" $secretName $passwordKey) -}}
+{{- end -}}
+{{- $password = index $existingSecret.data $passwordKey -}}
+{{- else if $hasEmbeddedState -}}
+{{- fail (printf "generated Valkey Secret %s is missing; restore it before upgrading or reinstalling" $secretName) -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.labels" . | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict "helm.sh/resource-policy" "keep")) | nindent 4 }}
+type: Opaque
+data:
+  {{ $passwordKey }}: {{ $password | quote }}
+{{- end -}}

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -84,12 +84,12 @@ spec:
         - --metrics_otel_enable
         - "true"
         - --redis_host
-        - {{ .Values.externalDependencies.valkey.host }}
+        - {{ include "osmo.valkey.host" . }}
         - --redis_port
-        - {{ .Values.externalDependencies.valkey.port | quote }}
+        - {{ include "osmo.valkey.port" . | quote }}
         - --redis_db_number
-        - {{ .Values.externalDependencies.valkey.database | quote }}
-        {{- if .Values.externalDependencies.valkey.tls.enabled }}
+        - {{ include "osmo.valkey.database" . | quote }}
+        {{- if eq (include "osmo.valkey.tlsEnabled" .) "true" }}
         - --redis_tls_enable
         - "true"
         {{- end}}

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1541,7 +1541,7 @@ EOF
     helm_template image-mirror "$charts_copy/osmo" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         --set global.imageRegistry=mirror.example.com \
-        --set global.imagePullSecrets[0]=mirror-secret \
+        --set imagePullSecrets[0].name=mirror-secret \
         >"$TEST_DIRECTORY/osmo-image-mirror.yaml"
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
         "image: mirror.example.com/nvidia/osmo/service:6.3.1"
@@ -1561,20 +1561,50 @@ EOF
         --set-string externalDependencies.valkey.host= \
         --set secrets.valkey.generate=true \
         --set-string secrets.valkey.existingSecret= \
-        --set global.imagePullSecrets[0]=mirror-secret \
+        --set imagePullSecrets[0].name=osmo-mirror-secret \
+        --set valkey.imagePullSecrets[0]=valkey-mirror-secret \
         >"$TEST_DIRECTORY/osmo-embedded-image-pull-secret.yaml"
     resource_document "$TEST_DIRECTORY/osmo-embedded-image-pull-secret.yaml" \
         Deployment embedded-image-pull-secret-osmo-api \
         >"$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml"
     require_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
-        "name: mirror-secret"
+        "name: osmo-mirror-secret"
+    require_not_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
+        "name: valkey-mirror-secret"
     resource_document "$TEST_DIRECTORY/osmo-embedded-image-pull-secret.yaml" \
         Deployment embedded-image-pull-secret-valkey \
         >"$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml"
     require_contains "$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml" \
-        "name: mirror-secret"
+        "name: valkey-mirror-secret"
     require_not_contains "$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml" \
-        "map[name:mirror-secret]"
+        "name: osmo-mirror-secret"
+
+    if helm_template invalid-image-pull-secret-scalar "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set imagePullSecrets[0]=mirror-secret \
+        >"$TEST_DIRECTORY/invalid-image-pull-secret-scalar.out" 2>&1; then
+        fail "expected scalar imagePullSecrets entry to fail schema validation"
+    fi
+    require_schema_path "$TEST_DIRECTORY/invalid-image-pull-secret-scalar.out" \
+        "imagePullSecrets.0"
+
+    if helm_template invalid-image-pull-secret-name "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set imagePullSecrets[0].unexpected=mirror-secret \
+        >"$TEST_DIRECTORY/invalid-image-pull-secret-name.out" 2>&1; then
+        fail "expected imagePullSecrets entry without name to fail schema validation"
+    fi
+    require_schema_path "$TEST_DIRECTORY/invalid-image-pull-secret-name.out" \
+        "imagePullSecrets.0"
+
+    if helm_template invalid-global-image-pull-secret "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set global.imagePullSecrets[0]=legacy-secret \
+        >"$TEST_DIRECTORY/invalid-global-image-pull-secret.out" 2>&1; then
+        fail "expected global.imagePullSecrets to fail schema validation"
+    fi
+    require_schema_path "$TEST_DIRECTORY/invalid-global-image-pull-secret.out" \
+        "global.imagePullSecrets"
 
     helm_template image-component "$charts_copy/osmo" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -271,9 +271,35 @@ require_no_deployment() {
     fi
 }
 
+require_resource() {
+    local file=$1
+    local kind=$2
+    local name=$3
+    local document=$TEST_DIRECTORY/resource.yaml
+    resource_document "$file" "$kind" "$name" >"$document"
+    [[ -s "$document" ]] || fail "expected $kind/$name"
+}
+
+require_no_resource() {
+    local file=$1
+    local kind=$2
+    local name=$3
+    local document=$TEST_DIRECTORY/resource.yaml
+    if resource_document "$file" "$kind" "$name" >"$document" 2>/dev/null; then
+        fail "did not expect $kind/$name"
+    fi
+}
+
 require_clean_osmo_sources() {
-    require_not_contains "$CHARTS_ROOT/osmo/Chart.yaml" "dependencies:"
-    [[ ! -e "$CHARTS_ROOT/osmo/Chart.lock" ]] || fail "osmo must not have a dependency lock"
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "dependencies:"
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "- name: valkey"
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "version: 0.11.0"
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" \
+        "repository: oci://ghcr.io/valkey-io/valkey-helm"
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" \
+        "condition: embeddedDependencies.valkey.enabled"
+    [[ -e "$CHARTS_ROOT/osmo/Chart.lock" ]] || fail "osmo must have a dependency lock"
+    require_contains "$CHARTS_ROOT/osmo/Chart.lock" "version: 0.11.0"
     [[ ! -d "$CHARTS_ROOT/osmo/charts" ]] || fail "osmo must not contain packaged dependencies"
     [[ ! -e "$CHARTS_ROOT/osmo/templates/postgres.yaml" ]] || \
         fail "osmo must not contain an unimplemented embedded PostgreSQL template"
@@ -325,8 +351,9 @@ test_control_umbrella() {
     local rendered="$TEST_DIRECTORY/osmo.yaml"
     mkdir -p "$charts_copy"
     cp -R "$CHARTS_ROOT/osmo" "$charts_copy/osmo"
-    rm -rf "$charts_copy/osmo/charts"
-    rm -f "$charts_copy/osmo/Chart.lock"
+    if ! compgen -G "$charts_copy/osmo/charts/valkey-0.11.0.tgz" >/dev/null; then
+        helm dependency build "$charts_copy/osmo" >/dev/null
+    fi
 
     if ! helm lint "$charts_copy/osmo" >"$TEST_DIRECTORY/osmo-lint.out" 2>&1; then
         cat "$TEST_DIRECTORY/osmo-lint.out" >&2
@@ -335,6 +362,12 @@ test_control_umbrella() {
 
     helm package "$charts_copy/osmo" --destination "$TEST_DIRECTORY" >/dev/null
     tar -tzf "$TEST_DIRECTORY/osmo-0.1.0.tgz" >"$TEST_DIRECTORY/osmo-package.txt"
+    if ! grep -Fq "osmo/charts/valkey/Chart.yaml" \
+        "$TEST_DIRECTORY/osmo-package.txt" && \
+        ! grep -Fq "osmo/charts/valkey-0.11.0.tgz" \
+        "$TEST_DIRECTORY/osmo-package.txt"; then
+        fail "packaged OSMO chart does not contain Valkey 0.11.0"
+    fi
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "osmo/tests/"
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "osmo/migrations/"
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "/migration-job.yaml"
@@ -396,6 +429,13 @@ test_control_umbrella() {
         "name: worker-extension"
     require_no_deployment "$rendered" "postgres"
     require_no_deployment "$rendered" "redis"
+    require_no_deployment "$rendered" "osmo-valkey"
+    require_no_resource "$rendered" StatefulSet "osmo-valkey"
+    require_no_resource "$rendered" Service "osmo-valkey"
+    require_no_resource "$rendered" ServiceAccount "osmo-valkey"
+    require_no_resource "$rendered" NetworkPolicy "osmo-valkey"
+    require_no_resource "$rendered" Secret "osmo-valkey-credentials"
+    require_no_resource "$rendered" PersistentVolumeClaim "osmo-valkey"
     require_no_deployment "$rendered" "localstack-s3"
     require_no_deployment "$rendered" "osmo-backend-listener"
     require_no_deployment "$rendered" "osmo-backend-worker"
@@ -788,6 +828,269 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-api-role-binding.yaml" \
         "app.kubernetes.io/component: api"
 
+    resource_document "$rendered" Deployment osmo-ui \
+        >"$TEST_DIRECTORY/osmo-ui.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-ui.yaml" \
+        "serviceAccountName: default"
+
+    helm_template osmo "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        --set-string commonLabels.owner=platform \
+        --set-string commonAnnotations.owner=platform \
+        >"$TEST_DIRECTORY/osmo-embedded-valkey.yaml"
+
+    require_deployment "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" "osmo-valkey"
+    require_resource "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" Service "osmo-valkey"
+    require_resource "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" \
+        PersistentVolumeClaim "osmo-valkey"
+    require_resource "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" \
+        ServiceAccount "osmo-valkey"
+    require_resource "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" \
+        NetworkPolicy "osmo-valkey"
+    require_resource "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" \
+        Secret "osmo-valkey-credentials"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" Secret \
+        osmo-valkey-credentials >"$TEST_DIRECTORY/osmo-valkey-secret.yaml"
+    require_occurrences "$TEST_DIRECTORY/osmo-valkey-secret.yaml" \
+        "owner: platform" 2
+    require_contains "$TEST_DIRECTORY/osmo-valkey-secret.yaml" \
+        "helm.sh/resource-policy: keep"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" Deployment \
+        osmo-valkey >"$TEST_DIRECTORY/osmo-valkey.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "type: Recreate"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "readinessProbe:"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "livenessProbe:"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "startupProbe:"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "readOnlyRootFilesystem: true"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "allowPrivilegeEscalation: false"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "automountServiceAccountToken: false"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "resources:"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" \
+        PersistentVolumeClaim osmo-valkey >"$TEST_DIRECTORY/osmo-valkey-pvc.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-valkey-pvc.yaml" \
+        '"helm.sh/resource-policy": keep'
+    require_contains "$TEST_DIRECTORY/osmo-valkey-pvc.yaml" "ReadWriteOnce"
+    require_contains "$TEST_DIRECTORY/osmo-valkey-pvc.yaml" "storage: 8Gi"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" ConfigMap \
+        osmo-valkey-config >"$TEST_DIRECTORY/osmo-valkey-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-valkey-config.yaml" "appendonly yes"
+    require_contains "$TEST_DIRECTORY/osmo-valkey-config.yaml" "appendfsync everysec"
+    require_contains "$TEST_DIRECTORY/osmo-valkey-config.yaml" "maxmemory 384mb"
+    require_contains "$TEST_DIRECTORY/osmo-valkey-config.yaml" \
+        "maxmemory-policy noeviction"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" \
+        "secretName: osmo-valkey-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" \
+        "redis-password:"
+
+    local valkey_consumer
+    for valkey_consumer in api worker logger agent delayed-job-monitor; do
+        resource_document "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" Deployment \
+            "osmo-$valkey_consumer" \
+            >"$TEST_DIRECTORY/osmo-$valkey_consumer-valkey.yaml"
+        require_contains "$TEST_DIRECTORY/osmo-$valkey_consumer-valkey.yaml" \
+            "- osmo-valkey"
+        require_contains "$TEST_DIRECTORY/osmo-$valkey_consumer-valkey.yaml" \
+            "name: osmo-valkey-credentials"
+        require_contains "$TEST_DIRECTORY/osmo-$valkey_consumer-valkey.yaml" \
+            "key: redis-password"
+    done
+
+    helm_template osmo "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-review-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        >"$TEST_DIRECTORY/osmo-embedded-valkey-gateway.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-valkey-gateway.yaml" \
+        Deployment osmo-gateway-oauth2-proxy \
+        >"$TEST_DIRECTORY/osmo-embedded-valkey-oauth2-proxy.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-valkey-oauth2-proxy.yaml" \
+        "--redis-connection-url=redis://osmo-valkey:6379/0"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-valkey-oauth2-proxy.yaml" \
+        "name: osmo-valkey-credentials"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-valkey-gateway.yaml" \
+        Deployment osmo-gateway-ratelimit \
+        >"$TEST_DIRECTORY/osmo-embedded-valkey-ratelimit.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-valkey-ratelimit.yaml" \
+        "value: osmo-valkey:6379"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-valkey-ratelimit.yaml" \
+        "name: osmo-valkey-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-valkey-ratelimit.yaml" \
+        'value: "false"'
+
+    helm_template existing-embedded "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set-string secrets.valkey.existingSecret=existing-embedded-valkey \
+        --set-string valkey.auth.usersExistingSecret=existing-embedded-valkey \
+        >"$TEST_DIRECTORY/osmo-existing-embedded-valkey.yaml"
+    require_not_contains "$TEST_DIRECTORY/osmo-existing-embedded-valkey.yaml" \
+        "kind: Secret"
+    require_contains "$TEST_DIRECTORY/osmo-existing-embedded-valkey.yaml" \
+        "secretName: existing-embedded-valkey"
+
+    if helm_template conflicting-embedded "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret=existing-embedded-valkey \
+        >"$TEST_DIRECTORY/conflicting-embedded.out" 2>&1; then
+        fail "expected embedded and external Valkey configuration to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/conflicting-embedded.out" \
+        "externalDependencies.valkey.host must be empty"
+
+    if helm_template missing-embedded-credentials "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set-string secrets.valkey.existingSecret= \
+        >"$TEST_DIRECTORY/missing-embedded-credentials.out" 2>&1; then
+        fail "expected missing embedded Valkey credentials to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/missing-embedded-credentials.out" \
+        "requires generated or existing credentials"
+
+    if helm_template duplicate-embedded-credentials "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret=existing-embedded-valkey \
+        >"$TEST_DIRECTORY/duplicate-embedded-credentials.out" 2>&1; then
+        fail "expected duplicate embedded Valkey credential ownership to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/duplicate-embedded-credentials.out" \
+        "generate and existingSecret are mutually exclusive"
+
+    if helm_template inline-embedded-password "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        --set-string valkey.auth.aclUsers.default.password=plaintext \
+        >"$TEST_DIRECTORY/inline-embedded-password.out" 2>&1; then
+        fail "expected inline embedded Valkey credentials to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/inline-embedded-password.out" \
+        "inline Valkey passwords are not supported"
+
+    if helm_template mismatched-embedded-secret "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set-string secrets.valkey.existingSecret=existing-embedded-valkey \
+        --set-string valkey.auth.usersExistingSecret=other-valkey \
+        >"$TEST_DIRECTORY/mismatched-embedded-secret.out" 2>&1; then
+        fail "expected mismatched embedded Valkey Secret names to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/mismatched-embedded-secret.out" \
+        "must match the effective Valkey Secret"
+
+    if helm_template context-sensitive-embedded-secret "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set-string secrets.valkey.existingSecret=osmo \
+        --set-literal 'valkey.auth.usersExistingSecret={{ .Chart.Name }}' \
+        >"$TEST_DIRECTORY/context-sensitive-embedded-secret.out" 2>&1; then
+        fail "expected context-sensitive embedded Valkey Secret name to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/context-sensitive-embedded-secret.out" \
+        "must not contain templates when using an existing Secret"
+
+    helm_template first-generated-upgrade "$charts_copy/osmo" \
+        --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        >"$TEST_DIRECTORY/first-generated-upgrade.yaml"
+    require_resource "$TEST_DIRECTORY/first-generated-upgrade.yaml" Secret \
+        "first-generated-upgrade-valkey-credentials"
+
+    if helm_template embedded-tls "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        --set valkey.tls.enabled=true \
+        --set valkey.tls.existingSecret=valkey-tls \
+        >"$TEST_DIRECTORY/embedded-tls.out" 2>&1; then
+        fail "expected unsupported embedded Valkey TLS to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-tls.out" \
+        "embedded Valkey TLS is not supported"
+
+    if helm_template embedded-custom-port "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        --set valkey.service.port=6380 \
+        >"$TEST_DIRECTORY/embedded-custom-port.out" 2>&1; then
+        fail "expected unsupported embedded Valkey port to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-custom-port.out" \
+        "embedded Valkey requires service port 6379"
+
+    helm_template replicated-embedded "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        --set valkey.replica.enabled=true \
+        >"$TEST_DIRECTORY/osmo-replicated-valkey.yaml"
+    require_resource "$TEST_DIRECTORY/osmo-replicated-valkey.yaml" StatefulSet \
+        replicated-embedded-valkey
+    require_resource "$TEST_DIRECTORY/osmo-replicated-valkey.yaml" \
+        PodDisruptionBudget replicated-embedded-valkey
+    resource_document "$TEST_DIRECTORY/osmo-replicated-valkey.yaml" StatefulSet \
+        replicated-embedded-valkey \
+        >"$TEST_DIRECTORY/osmo-replicated-valkey-statefulset.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-replicated-valkey-statefulset.yaml" \
+        "replicas: 3"
+    require_contains "$TEST_DIRECTORY/osmo-replicated-valkey-statefulset.yaml" \
+        "whenDeleted: Retain"
+    require_contains "$TEST_DIRECTORY/osmo-replicated-valkey-statefulset.yaml" \
+        "whenScaled: Retain"
+    require_contains "$TEST_DIRECTORY/osmo-replicated-valkey-statefulset.yaml" \
+        "storage: \"8Gi\""
+    resource_document "$TEST_DIRECTORY/osmo-replicated-valkey.yaml" ConfigMap \
+        replicated-embedded-valkey-init-scripts \
+        >"$TEST_DIRECTORY/osmo-replicated-valkey-init.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-replicated-valkey-init.yaml" \
+        "min-replicas-to-write 1"
+
     resource_document "$rendered" Deployment osmo-agent \
         >"$TEST_DIRECTORY/osmo-agent.yaml"
     require_occurrences "$TEST_DIRECTORY/osmo-agent.yaml" "        ports:" 1
@@ -905,6 +1208,7 @@ EOF
     helm_template osmo-tls "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-review-values.yaml" \
         --set externalDependencies.postgresql.tls.enabled=true \
         --set externalDependencies.postgresql.tls.caExistingSecret=postgresql-ca \
         --set externalDependencies.valkey.tls.enabled=true \
@@ -931,6 +1235,26 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-authz-tls.yaml" "/etc/osmo/ca/postgresql"
     require_contains "$TEST_DIRECTORY/osmo-authz-tls.yaml" \
         "--postgres-ssl-mode=verify-full"
+    resource_document "$TEST_DIRECTORY/osmo-tls.yaml" Deployment \
+        osmo-tls-gateway-oauth2-proxy \
+        >"$TEST_DIRECTORY/osmo-oauth2-proxy-tls.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-oauth2-proxy-tls.yaml" \
+        "--redis-connection-url=rediss://external-valkey:6379/0"
+    require_contains "$TEST_DIRECTORY/osmo-oauth2-proxy-tls.yaml" \
+        "name: SSL_CERT_FILE"
+    require_contains "$TEST_DIRECTORY/osmo-oauth2-proxy-tls.yaml" \
+        "/etc/osmo/ca/valkey/ca-bundle.crt"
+    require_contains "$TEST_DIRECTORY/osmo-oauth2-proxy-tls.yaml" \
+        "secretName: valkey-ca"
+    resource_document "$TEST_DIRECTORY/osmo-tls.yaml" Deployment \
+        osmo-tls-gateway-ratelimit \
+        >"$TEST_DIRECTORY/osmo-ratelimit-tls.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-ratelimit-tls.yaml" \
+        "name: SSL_CERT_FILE"
+    require_contains "$TEST_DIRECTORY/osmo-ratelimit-tls.yaml" \
+        "/etc/osmo/ca/valkey/ca-bundle.crt"
+    require_contains "$TEST_DIRECTORY/osmo-ratelimit-tls.yaml" \
+        "secretName: valkey-ca"
 
     helm_template osmo "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -1217,7 +1541,7 @@ EOF
     helm_template image-mirror "$charts_copy/osmo" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         --set global.imageRegistry=mirror.example.com \
-        --set global.imagePullSecrets[0].name=mirror-secret \
+        --set global.imagePullSecrets[0]=mirror-secret \
         >"$TEST_DIRECTORY/osmo-image-mirror.yaml"
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
         "image: mirror.example.com/nvidia/osmo/service:6.3.1"
@@ -1229,6 +1553,28 @@ EOF
         "- mirror.example.com/nvidia/osmo"
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
         "name: mirror-secret"
+
+    helm_template embedded-image-pull-secret "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        --set global.imagePullSecrets[0]=mirror-secret \
+        >"$TEST_DIRECTORY/osmo-embedded-image-pull-secret.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-image-pull-secret.yaml" \
+        Deployment embedded-image-pull-secret-osmo-api \
+        >"$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
+        "name: mirror-secret"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-image-pull-secret.yaml" \
+        Deployment embedded-image-pull-secret-valkey \
+        >"$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml" \
+        "name: mirror-secret"
+    require_not_contains "$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml" \
+        "map[name:mirror-secret]"
 
     helm_template image-component "$charts_copy/osmo" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1221,6 +1221,40 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-review-api.yaml" "path: /health"
     require_not_contains "$TEST_DIRECTORY/osmo-review-api.yaml" "x-osmo-roles"
 
+    helm_template osmo-system-ca "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-review-values.yaml" \
+        --set externalDependencies.valkey.tls.enabled=true \
+        --set configuration.enabled=false \
+        >"$TEST_DIRECTORY/osmo-system-ca.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-system-ca.yaml" Deployment \
+        osmo-system-ca-api >"$TEST_DIRECTORY/osmo-api-system-ca.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-api-system-ca.yaml" \
+        "--redis_tls_enable"
+    require_not_contains "$TEST_DIRECTORY/osmo-api-system-ca.yaml" \
+        "name: SSL_CERT_FILE"
+    require_not_contains "$TEST_DIRECTORY/osmo-api-system-ca.yaml" \
+        "name: valkey-ca"
+    resource_document "$TEST_DIRECTORY/osmo-system-ca.yaml" Deployment \
+        osmo-system-ca-gateway-oauth2-proxy \
+        >"$TEST_DIRECTORY/osmo-oauth2-proxy-system-ca.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-oauth2-proxy-system-ca.yaml" \
+        "--redis-connection-url=rediss://external-valkey:6379/0"
+    require_not_contains "$TEST_DIRECTORY/osmo-oauth2-proxy-system-ca.yaml" \
+        "name: SSL_CERT_FILE"
+    require_not_contains "$TEST_DIRECTORY/osmo-oauth2-proxy-system-ca.yaml" \
+        "name: valkey-ca"
+    resource_document "$TEST_DIRECTORY/osmo-system-ca.yaml" Deployment \
+        osmo-system-ca-gateway-ratelimit \
+        >"$TEST_DIRECTORY/osmo-ratelimit-system-ca.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-ratelimit-system-ca.yaml" \
+        'value: "true"'
+    require_not_contains "$TEST_DIRECTORY/osmo-ratelimit-system-ca.yaml" \
+        "name: SSL_CERT_FILE"
+    require_not_contains "$TEST_DIRECTORY/osmo-ratelimit-system-ca.yaml" \
+        "name: valkey-ca"
+
     helm_template osmo-tls "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -291,15 +291,7 @@ require_no_resource() {
 }
 
 require_clean_osmo_sources() {
-    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "dependencies:"
-    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "- name: valkey"
-    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "version: 0.11.0"
-    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" \
-        "repository: oci://ghcr.io/valkey-io/valkey-helm"
-    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" \
-        "condition: embeddedDependencies.valkey.enabled"
     [[ -e "$CHARTS_ROOT/osmo/Chart.lock" ]] || fail "osmo must have a dependency lock"
-    require_contains "$CHARTS_ROOT/osmo/Chart.lock" "version: 0.11.0"
     [[ ! -d "$CHARTS_ROOT/osmo/charts" ]] || fail "osmo must not contain packaged dependencies"
     [[ ! -e "$CHARTS_ROOT/osmo/templates/postgres.yaml" ]] || \
         fail "osmo must not contain an unimplemented embedded PostgreSQL template"
@@ -871,6 +863,10 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "allowPrivilegeEscalation: false"
     require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "automountServiceAccountToken: false"
     require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "resources:"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "cpu: 500m"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "memory: 1Gi"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "cpu: 1"
+    require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" "memory: 2Gi"
 
     resource_document "$TEST_DIRECTORY/osmo-embedded-valkey.yaml" \
         PersistentVolumeClaim osmo-valkey >"$TEST_DIRECTORY/osmo-valkey-pvc.yaml"
@@ -883,7 +879,7 @@ EOF
         osmo-valkey-config >"$TEST_DIRECTORY/osmo-valkey-config.yaml"
     require_contains "$TEST_DIRECTORY/osmo-valkey-config.yaml" "appendonly yes"
     require_contains "$TEST_DIRECTORY/osmo-valkey-config.yaml" "appendfsync everysec"
-    require_contains "$TEST_DIRECTORY/osmo-valkey-config.yaml" "maxmemory 384mb"
+    require_contains "$TEST_DIRECTORY/osmo-valkey-config.yaml" "maxmemory 1gb"
     require_contains "$TEST_DIRECTORY/osmo-valkey-config.yaml" \
         "maxmemory-policy noeviction"
     require_contains "$TEST_DIRECTORY/osmo-valkey.yaml" \
@@ -938,8 +934,8 @@ EOF
         --set-string secrets.valkey.existingSecret=existing-embedded-valkey \
         --set-string valkey.auth.usersExistingSecret=existing-embedded-valkey \
         >"$TEST_DIRECTORY/osmo-existing-embedded-valkey.yaml"
-    require_not_contains "$TEST_DIRECTORY/osmo-existing-embedded-valkey.yaml" \
-        "kind: Secret"
+    require_no_resource "$TEST_DIRECTORY/osmo-existing-embedded-valkey.yaml" Secret \
+        existing-embedded-valkey-credentials
     require_contains "$TEST_DIRECTORY/osmo-existing-embedded-valkey.yaml" \
         "secretName: existing-embedded-valkey"
 
@@ -1020,17 +1016,16 @@ EOF
     require_contains "$TEST_DIRECTORY/context-sensitive-embedded-secret.out" \
         "must not contain templates when using an existing Secret"
 
-    helm_template first-generated-upgrade "$charts_copy/osmo" \
-        --is-upgrade \
+    helm_template generated-secret-render "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         --set embeddedDependencies.valkey.enabled=true \
         --set-string externalDependencies.valkey.host= \
         --set secrets.valkey.generate=true \
         --set-string secrets.valkey.existingSecret= \
-        >"$TEST_DIRECTORY/first-generated-upgrade.yaml"
-    require_resource "$TEST_DIRECTORY/first-generated-upgrade.yaml" Secret \
-        "first-generated-upgrade-valkey-credentials"
+        >"$TEST_DIRECTORY/generated-secret-render.yaml"
+    require_resource "$TEST_DIRECTORY/generated-secret-render.yaml" Secret \
+        "generated-secret-render-valkey-credentials"
 
     if helm_template embedded-tls "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -1061,6 +1056,20 @@ EOF
     require_contains "$TEST_DIRECTORY/embedded-custom-port.out" \
         "embedded Valkey requires service port 6379"
 
+    if helm_template embedded-external-database "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set externalDependencies.valkey.database=1 \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        >"$TEST_DIRECTORY/embedded-external-database.out" 2>&1; then
+        fail "expected an external Valkey database in embedded mode to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-external-database.out" \
+        "externalDependencies.valkey.database must be 0 when embedded Valkey is enabled"
+
     helm_template replicated-embedded "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
@@ -1074,6 +1083,13 @@ EOF
         replicated-embedded-valkey
     require_resource "$TEST_DIRECTORY/osmo-replicated-valkey.yaml" \
         PodDisruptionBudget replicated-embedded-valkey
+    require_resource "$TEST_DIRECTORY/osmo-replicated-valkey.yaml" Service \
+        replicated-embedded-valkey
+    resource_document "$TEST_DIRECTORY/osmo-replicated-valkey.yaml" Deployment \
+        replicated-embedded-osmo-api \
+        >"$TEST_DIRECTORY/osmo-replicated-valkey-api.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-replicated-valkey-api.yaml" \
+        "- replicated-embedded-valkey"
     resource_document "$TEST_DIRECTORY/osmo-replicated-valkey.yaml" StatefulSet \
         replicated-embedded-valkey \
         >"$TEST_DIRECTORY/osmo-replicated-valkey-statefulset.yaml"
@@ -1540,7 +1556,7 @@ EOF
 
     helm_template image-mirror "$charts_copy/osmo" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set global.imageRegistry=mirror.example.com \
+        --set imageRegistry=mirror.example.com \
         --set imagePullSecrets[0].name=mirror-secret \
         >"$TEST_DIRECTORY/osmo-image-mirror.yaml"
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
@@ -1561,6 +1577,8 @@ EOF
         --set-string externalDependencies.valkey.host= \
         --set secrets.valkey.generate=true \
         --set-string secrets.valkey.existingSecret= \
+        --set imageRegistry=osmo-mirror.example.com \
+        --set valkey.image.registry=valkey-mirror.example.com \
         --set imagePullSecrets[0].name=osmo-mirror-secret \
         --set valkey.imagePullSecrets[0]=valkey-mirror-secret \
         >"$TEST_DIRECTORY/osmo-embedded-image-pull-secret.yaml"
@@ -1569,6 +1587,10 @@ EOF
         >"$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml"
     require_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
         "name: osmo-mirror-secret"
+    require_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
+        "image: osmo-mirror.example.com/nvidia/osmo/service:6.3.1"
+    require_not_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
+        "valkey-mirror.example.com"
     require_not_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
         "name: valkey-mirror-secret"
     resource_document "$TEST_DIRECTORY/osmo-embedded-image-pull-secret.yaml" \
@@ -1576,6 +1598,10 @@ EOF
         >"$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml"
     require_contains "$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml" \
         "name: valkey-mirror-secret"
+    require_contains "$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml" \
+        "image: valkey-mirror.example.com/valkey/valkey:9.1.1"
+    require_not_contains "$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml" \
+        "osmo-mirror.example.com"
     require_not_contains "$TEST_DIRECTORY/osmo-valkey-image-pull-secret.yaml" \
         "name: osmo-mirror-secret"
 
@@ -1596,15 +1622,6 @@ EOF
     fi
     require_schema_path "$TEST_DIRECTORY/invalid-image-pull-secret-name.out" \
         "imagePullSecrets.0"
-
-    if helm_template invalid-global-image-pull-secret "$charts_copy/osmo" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set global.imagePullSecrets[0]=legacy-secret \
-        >"$TEST_DIRECTORY/invalid-global-image-pull-secret.out" 2>&1; then
-        fail "expected global.imagePullSecrets to fail schema validation"
-    fi
-    require_schema_path "$TEST_DIRECTORY/invalid-global-image-pull-secret.out" \
-        "global.imagePullSecrets"
 
     helm_template image-component "$charts_copy/osmo" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -292,7 +292,6 @@ require_no_resource() {
 
 require_clean_osmo_sources() {
     [[ -e "$CHARTS_ROOT/osmo/Chart.lock" ]] || fail "osmo must have a dependency lock"
-    [[ ! -d "$CHARTS_ROOT/osmo/charts" ]] || fail "osmo must not contain packaged dependencies"
     [[ ! -e "$CHARTS_ROOT/osmo/templates/postgres.yaml" ]] || \
         fail "osmo must not contain an unimplemented embedded PostgreSQL template"
     [[ ! -e "$CHARTS_ROOT/osmo/templates/redis.yaml" ]] || \

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -16,7 +16,7 @@
       "type": "object",
       "properties": {
         "postgresql": { "$ref": "#/definitions/enabledBlock" },
-        "valkey": { "$ref": "#/definitions/enabledBlock" },
+        "valkey": { "$ref": "#/definitions/embeddedValkey" },
         "objectStorage": { "$ref": "#/definitions/enabledBlock" },
         "kaiScheduler": { "$ref": "#/definitions/enabledBlock" }
       }
@@ -24,7 +24,7 @@
     "valkey": { "type": "object" },
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
-    "global": { "$ref": "#/definitions/global" },
+    "imageRegistry": { "type": "string" },
     "imagePullSecrets": { "$ref": "#/definitions/imagePullSecrets" },
     "runtimeImage": { "$ref": "#/definitions/runtimeImage" },
     "commonLabels": { "$ref": "#/definitions/stringMap" },
@@ -97,12 +97,20 @@
       }
     }
   },
-  "required": ["planes", "embeddedDependencies", "externalDependencies", "global", "imagePullSecrets", "runtimeImage", "externalUrl", "ingress", "httproute", "monitoring", "secrets", "services", "gateway"],
+  "required": ["planes", "embeddedDependencies", "externalDependencies", "imageRegistry", "imagePullSecrets", "runtimeImage", "externalUrl", "ingress", "httproute", "monitoring", "secrets", "services", "gateway"],
   "definitions": {
     "enabledBlock": {
       "type": "object",
       "properties": { "enabled": { "type": "boolean" } },
       "required": ["enabled"]
+    },
+    "embeddedValkey": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "topologyMigrationAcknowledged": { "type": "boolean" }
+      },
+      "required": ["enabled", "topologyMigrationAcknowledged"]
     },
     "stringMap": {
       "type": "object",
@@ -299,14 +307,6 @@
         },
         "required": ["name"]
       }
-    },
-    "global": {
-      "type": "object",
-      "properties": {
-        "imageRegistry": { "type": "string" },
-        "imagePullSecrets": false
-      },
-      "required": ["imageRegistry"]
     },
     "runtimeImage": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -16,7 +16,7 @@
       "type": "object",
       "properties": {
         "postgresql": { "$ref": "#/definitions/enabledBlock" },
-        "valkey": { "$ref": "#/definitions/embeddedValkey" },
+        "valkey": { "$ref": "#/definitions/enabledBlock" },
         "objectStorage": { "$ref": "#/definitions/enabledBlock" },
         "kaiScheduler": { "$ref": "#/definitions/enabledBlock" }
       }
@@ -103,14 +103,6 @@
       "type": "object",
       "properties": { "enabled": { "type": "boolean" } },
       "required": ["enabled"]
-    },
-    "embeddedValkey": {
-      "type": "object",
-      "properties": {
-        "enabled": { "type": "boolean" },
-        "topologyMigrationAcknowledged": { "type": "boolean" }
-      },
-      "required": ["enabled", "topologyMigrationAcknowledged"]
     },
     "stringMap": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -25,6 +25,7 @@
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "global": { "$ref": "#/definitions/global" },
+    "imagePullSecrets": { "$ref": "#/definitions/imagePullSecrets" },
     "runtimeImage": { "$ref": "#/definitions/runtimeImage" },
     "commonLabels": { "$ref": "#/definitions/stringMap" },
     "commonAnnotations": { "$ref": "#/definitions/stringMap" },
@@ -96,7 +97,7 @@
       }
     }
   },
-  "required": ["planes", "embeddedDependencies", "externalDependencies", "global", "runtimeImage", "externalUrl", "ingress", "httproute", "monitoring", "secrets", "services", "gateway"],
+  "required": ["planes", "embeddedDependencies", "externalDependencies", "global", "imagePullSecrets", "runtimeImage", "externalUrl", "ingress", "httproute", "monitoring", "secrets", "services", "gateway"],
   "definitions": {
     "enabledBlock": {
       "type": "object",
@@ -292,17 +293,20 @@
     "imagePullSecrets": {
       "type": "array",
       "items": {
-        "type": "string",
-        "minLength": 1
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "minLength": 1 }
+        },
+        "required": ["name"]
       }
     },
     "global": {
       "type": "object",
       "properties": {
         "imageRegistry": { "type": "string" },
-        "imagePullSecrets": { "$ref": "#/definitions/imagePullSecrets" }
+        "imagePullSecrets": false
       },
-      "required": ["imageRegistry", "imagePullSecrets"]
+      "required": ["imageRegistry"]
     },
     "runtimeImage": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -21,6 +21,7 @@
         "kaiScheduler": { "$ref": "#/definitions/enabledBlock" }
       }
     },
+    "valkey": { "type": "object" },
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "global": { "$ref": "#/definitions/global" },
@@ -291,9 +292,8 @@
     "imagePullSecrets": {
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": { "name": { "type": "string", "minLength": 1 } },
-        "required": ["name"]
+        "type": "string",
+        "minLength": 1
       }
     },
     "global": {

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -12,10 +12,8 @@ planes:
   compute:
     enabled: false
 
-# Select supporting systems managed by this Helm release.
-# TODO: Allow these switches as their dependency charts are added.
-# They must remain false for now; supply operator-managed services through
-# `externalDependencies` instead.
+# Select supporting systems managed by this Helm release. Embedded Valkey is
+# available; the other switches remain reserved for later chart dependencies.
 embeddedDependencies:
   postgresql:
     enabled: false
@@ -26,9 +24,101 @@ embeddedDependencies:
   kaiScheduler:
     enabled: false
 
-# Connection details for dependencies owned outside this release. These
-# endpoints are required by the control plane because embedded dependencies
-# are not implemented yet.
+# Official Valkey dependency configuration. These defaults provide an
+# authenticated, persistent standalone primary when embedded Valkey is enabled.
+# The dependency also supports fixed-primary replication for read scaling and
+# data redundancy, but it does not provide Sentinel or automatic promotion.
+valkey:
+  image:
+    registry: docker.io
+    repository: valkey/valkey
+    pullPolicy: IfNotPresent
+    tag: "9.1.1"
+  serviceAccount:
+    create: true
+    automount: false
+  podSecurityContext:
+    fsGroup: 1000
+    runAsUser: 1000
+    runAsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+  service:
+    type: ClusterIP
+    port: 6379
+  networkPolicy:
+    ingress:
+    - from:
+      - podSelector: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  initResources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  startupProbe:
+    enabled: true
+  livenessProbe:
+    enabled: true
+  readinessProbe:
+    enabled: true
+  dataStorage:
+    enabled: true
+    requestedSize: 8Gi
+    className: ''
+    accessModes:
+    - ReadWriteOnce
+    keepPvc: true
+  auth:
+    enabled: true
+    usersExistingSecret: '{{ printf "%s-valkey-credentials" .Release.Name | trunc 63 | trimSuffix "-" }}'
+    aclUsers:
+      default:
+        permissions: "~* &* +@all"
+        passwordKey: redis-password
+    aclConfig: ''
+  valkeyConfig: |
+    appendonly yes
+    appendfsync everysec
+    maxmemory 384mb
+    maxmemory-policy noeviction
+  deploymentStrategy: Recreate
+  replica:
+    enabled: false
+    replicas: 2
+    replicationUser: default
+    minReplicasToWrite: 1
+    minReplicasMaxLag: 10
+    persistence:
+      size: 8Gi
+      storageClass: ''
+      accessModes:
+      - ReadWriteOnce
+    persistentVolumeClaimRetentionPolicy:
+      whenDeleted: Retain
+      whenScaled: Retain
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
+
+# Connection details for dependencies owned outside this release. The Valkey
+# endpoint is required only when embedded Valkey is disabled.
 externalDependencies:
   # PostgreSQL stores OSMO control-plane state. Set caExistingSecret when the
   # server certificate is signed by a private CA.
@@ -67,8 +157,8 @@ externalDependencies:
 nameOverride: ''
 fullnameOverride: ''
 
-# Global image registry and pull credentials. A non-empty registry overrides
-# every component and runtime image registry for air-gapped mirrors.
+# Global image registry and pull credential Secret names. A non-empty registry
+# overrides every component and runtime image registry for air-gapped mirrors.
 global:
   imageRegistry: ''
   imagePullSecrets: []
@@ -159,10 +249,9 @@ monitoring:
     relabelings: []
     metricRelabelings: []
 
-# References to operator-owned Kubernetes Secrets. Inline credentials are not
-# accepted.
-# TODO: Implement retained chart-generated credentials for `generate: true`;
-# all `generate` switches must remain false for now.
+# References to Kubernetes Secrets. Inline credentials are not accepted.
+# Generated credentials are supported only for embedded Valkey; every other
+# `generate` switch must remain false.
 secrets:
   # Password used with `externalDependencies.postgresql.username`.
   postgresql:
@@ -170,7 +259,9 @@ secrets:
     existingSecret: ''
     keys:
       password: db-password
-  # Password used for the external Valkey connection.
+  # Password used for the effective Valkey connection. Embedded mode supports
+  # either a retained generated Secret or an existing Secret; external mode
+  # requires an existing Secret.
   valkey:
     generate: false
     existingSecret: ''

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -19,6 +19,7 @@ embeddedDependencies:
     enabled: false
   valkey:
     enabled: false
+    topologyMigrationAcknowledged: false
   objectStorage:
     enabled: false
   kaiScheduler:
@@ -35,11 +36,11 @@ valkey:
       - podSelector: {}
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
-    limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
   initResources:
     requests:
       cpu: 50m
@@ -63,7 +64,7 @@ valkey:
   valkeyConfig: |
     appendonly yes
     appendfsync everysec
-    maxmemory 384mb
+    maxmemory 1gb
     maxmemory-policy noeviction
   deploymentStrategy: Recreate
   replica:
@@ -116,10 +117,9 @@ externalDependencies:
 nameOverride: ''
 fullnameOverride: ''
 
-# A non-empty registry overrides every component and runtime image registry for
-# air-gapped mirrors.
-global:
-  imageRegistry: ''
+# A non-empty registry overrides OSMO-owned component and runtime image
+# registries. Configure dependency registries in their native values blocks.
+imageRegistry: ''
 
 # Pull credential Secret references for OSMO-owned pods. Configure dependency
 # pull credentials in the dependency's native values block.

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -24,58 +24,6 @@ embeddedDependencies:
   kaiScheduler:
     enabled: false
 
-# Official Valkey dependency configuration. These defaults provide an
-# authenticated, persistent standalone primary when embedded Valkey is enabled.
-# The dependency also supports fixed-primary replication for read scaling and
-# data redundancy, but it does not provide Sentinel or automatic promotion.
-valkey:
-  networkPolicy:
-    ingress:
-    - from:
-      - podSelector: {}
-  resources:
-    requests:
-      cpu: 500m
-      memory: 1Gi
-    limits:
-      cpu: 1
-      memory: 2Gi
-  initResources:
-    requests:
-      cpu: 50m
-      memory: 64Mi
-    limits:
-      cpu: 250m
-      memory: 256Mi
-  readinessProbe:
-    enabled: true
-  dataStorage:
-    enabled: true
-    requestedSize: 8Gi
-    keepPvc: true
-  auth:
-    enabled: true
-    usersExistingSecret: '{{ printf "%s-valkey-credentials" .Release.Name | trunc 63 | trimSuffix "-" }}'
-    aclUsers:
-      default:
-        permissions: "~* &* +@all"
-        passwordKey: redis-password
-  valkeyConfig: |
-    appendonly yes
-    appendfsync everysec
-    maxmemory 1gb
-    maxmemory-policy noeviction
-  deploymentStrategy: Recreate
-  replica:
-    minReplicasToWrite: 1
-    persistence:
-      size: 8Gi
-    persistentVolumeClaimRetentionPolicy:
-      whenDeleted: Retain
-      whenScaled: Retain
-  podDisruptionBudget:
-    enabled: true
-
 # Connection details for dependencies owned outside this release. The Valkey
 # endpoint is required only when embedded Valkey is disabled.
 externalDependencies:
@@ -1350,3 +1298,55 @@ configuration:
         default: {}
   backendTests: {}
   groupTemplates: {}
+
+# Official Valkey dependency configuration. These defaults provide an
+# authenticated, persistent standalone primary when embedded Valkey is enabled.
+# The dependency also supports fixed-primary replication for read scaling and
+# data redundancy, but it does not provide Sentinel or automatic promotion.
+valkey:
+  networkPolicy:
+    ingress:
+    - from:
+      - podSelector: {}
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+  initResources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+  readinessProbe:
+    enabled: true
+  dataStorage:
+    enabled: true
+    requestedSize: 8Gi
+    keepPvc: true
+  auth:
+    enabled: true
+    usersExistingSecret: '{{ printf "%s-valkey-credentials" .Release.Name | trunc 63 | trimSuffix "-" }}'
+    aclUsers:
+      default:
+        permissions: "~* &* +@all"
+        passwordKey: redis-password
+  valkeyConfig: |
+    appendonly yes
+    appendfsync everysec
+    maxmemory 1gb
+    maxmemory-policy noeviction
+  deploymentStrategy: Recreate
+  replica:
+    minReplicasToWrite: 1
+    persistence:
+      size: 8Gi
+    persistentVolumeClaimRetentionPolicy:
+      whenDeleted: Retain
+      whenScaled: Retain
+  podDisruptionBudget:
+    enabled: true

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -90,10 +90,10 @@ externalDependencies:
       enabled: false
       caExistingSecret: ''
       caKey: ca.crt
-  # Valkey provides queues, caches, events, and distributed coordination.
-  # When TLS is enabled, caKey must contain a complete trust bundle (including
-  # public/system roots needed by other HTTPS clients), because Python Redis
-  # consumes it through SSL_CERT_FILE.
+  # Valkey provides queues, caches, events, and distributed coordination. TLS
+  # uses the system trust store unless caExistingSecret selects a custom bundle.
+  # When set, caKey must contain the complete trust bundle because clients use
+  # it through SSL_CERT_FILE.
   valkey:
     host: ''
     port: 6379

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -29,6 +29,9 @@ embeddedDependencies:
 # The dependency also supports fixed-primary replication for read scaling and
 # data redundancy, but it does not provide Sentinel or automatic promotion.
 valkey:
+  # Pull credential Secret names for Valkey pods. This dependency-native value
+  # uses strings rather than Kubernetes LocalObjectReference objects.
+  imagePullSecrets: []
   image:
     registry: docker.io
     repository: valkey/valkey
@@ -157,11 +160,14 @@ externalDependencies:
 nameOverride: ''
 fullnameOverride: ''
 
-# Global image registry and pull credential Secret names. A non-empty registry
-# overrides every component and runtime image registry for air-gapped mirrors.
+# A non-empty registry overrides every component and runtime image registry for
+# air-gapped mirrors.
 global:
   imageRegistry: ''
-  imagePullSecrets: []
+
+# Pull credential Secret references for OSMO-owned pods. Configure dependency
+# pull credentials in the dependency's native values block.
+imagePullSecrets: []
 
 # Runtime images referenced by submitted workflows.
 runtimeImage:

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -19,7 +19,6 @@ embeddedDependencies:
     enabled: false
   valkey:
     enabled: false
-    topologyMigrationAcknowledged: false
   objectStorage:
     enabled: false
   kaiScheduler:

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -29,34 +29,6 @@ embeddedDependencies:
 # The dependency also supports fixed-primary replication for read scaling and
 # data redundancy, but it does not provide Sentinel or automatic promotion.
 valkey:
-  # Pull credential Secret names for Valkey pods. This dependency-native value
-  # uses strings rather than Kubernetes LocalObjectReference objects.
-  imagePullSecrets: []
-  image:
-    registry: docker.io
-    repository: valkey/valkey
-    pullPolicy: IfNotPresent
-    tag: "9.1.1"
-  serviceAccount:
-    create: true
-    automount: false
-  podSecurityContext:
-    fsGroup: 1000
-    runAsUser: 1000
-    runAsGroup: 1000
-    seccompProfile:
-      type: RuntimeDefault
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-      - ALL
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsUser: 1000
-  service:
-    type: ClusterIP
-    port: 6379
   networkPolicy:
     ingress:
     - from:
@@ -75,18 +47,11 @@ valkey:
     limits:
       cpu: 250m
       memory: 256Mi
-  startupProbe:
-    enabled: true
-  livenessProbe:
-    enabled: true
   readinessProbe:
     enabled: true
   dataStorage:
     enabled: true
     requestedSize: 8Gi
-    className: ''
-    accessModes:
-    - ReadWriteOnce
     keepPvc: true
   auth:
     enabled: true
@@ -95,7 +60,6 @@ valkey:
       default:
         permissions: "~* &* +@all"
         passwordKey: redis-password
-    aclConfig: ''
   valkeyConfig: |
     appendonly yes
     appendfsync everysec
@@ -103,22 +67,14 @@ valkey:
     maxmemory-policy noeviction
   deploymentStrategy: Recreate
   replica:
-    enabled: false
-    replicas: 2
-    replicationUser: default
     minReplicasToWrite: 1
-    minReplicasMaxLag: 10
     persistence:
       size: 8Gi
-      storageClass: ''
-      accessModes:
-      - ReadWriteOnce
     persistentVolumeClaimRetentionPolicy:
       whenDeleted: Retain
       whenScaled: Retain
   podDisruptionBudget:
     enabled: true
-    maxUnavailable: 1
 
 # Connection details for dependencies owned outside this release. The Valkey
 # endpoint is required only when embedded Valkey is disabled.


### PR DESCRIPTION
## Description
Add optional embedded valkey chart

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional embedded Valkey support for OSMO Helm deployments.
  * Added configurable persistence, TLS, authentication, ACLs, replication, resources, and disruption budgets.
  * Added automatic credential generation and preservation for embedded Valkey.
  * Integrated Valkey TLS support across gateway components.
  * Standardized image pull-secret configuration.

* **Documentation**
  * Documented installation, upgrades, recovery, migration, persistence, and external Valkey configuration.

* **Validation**
  * Added checks for credentials, TLS, ports, storage transitions, replication, and configuration conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->