### PR TITLE
testbot: let Slack unfurl the PR link into a GitHub card

### DIFF
--- a/src/scripts/testbot/create_pr.py
+++ b/src/scripts/testbot/create_pr.py
@@ -475,21 +475,17 @@ def _build_slack_review_payload(
     pr_url: str,
     pr_title: str,
 ) -> dict[str, Any]:
-    """Build a brief Slack Block Kit payload asking reviewers to review."""
+    """Build a brief Slack payload asking reviewers to review."""
     message = _build_slack_review_text(pr_url, pr_title)
 
+    # Plain text, no blocks: Slack only unfurls links in `text`, and messages
+    # posted by a bot need unfurl_links set explicitly. That lets the GitHub
+    # Slack app render the PR preview card under the message.
     return {
         "channel": _resolve_slack_channel(channel),
         "text": message,
-        "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": message,
-                },
-            },
-        ],
+        "unfurl_links": True,
+        "unfurl_media": True,
     }
 
 

--- a/src/scripts/testbot/tests/test_create_pr.py
+++ b/src/scripts/testbot/tests/test_create_pr.py
@@ -309,7 +309,19 @@ class TestSlackReviewRequest(unittest.TestCase):
         )
         self.assertEqual(payload["channel"], "C0A8RJ738KZ")
         self.assertEqual(payload["text"], expected)
-        self.assertEqual(payload["blocks"][0]["text"]["text"], expected)
+
+    def test_build_slack_review_payload_enables_unfurl(self):
+        payload = _build_slack_review_payload(
+            channel="#osmo-slack-test",
+            pr_url="https://github.com/NVIDIA/OSMO/pull/123",
+            pr_title="[testbot] Add tests for foo.py",
+        )
+
+        # The GitHub Slack app only renders the PR card when Slack unfurls the
+        # link, which it will not do for a bot message carrying Block Kit blocks.
+        self.assertTrue(payload["unfurl_links"])
+        self.assertTrue(payload["unfurl_media"])
+        self.assertNotIn("blocks", payload)
 
     @patch("src.scripts.testbot.create_pr.urllib.request.urlopen")
     def test_post_slack_review_request_posts_payload(self, mock_urlopen):


### PR DESCRIPTION
## Description

The testbot review request posts as plain text with no PR preview card.

Two things in the payload prevented it:

1. Slack unfurls links from a message's `text` field, not from links inside Block Kit `blocks`.
2. Messages posted by a bot do not unfurl unless `unfurl_links` is set explicitly.

The `blocks` array duplicated `text` verbatim, so dropping it changes nothing about how the message reads. With unfurling enabled the GitHub app renders the card under the message.

### Verification

`bazel test //src/scripts/testbot:all //src/scripts/testbot/tests:all` — 19 targets pass, including the `-pylint` siblings. Added a test asserting the payload enables unfurling and carries no `blocks`.

The rendered card can only be confirmed once this runs with the testbot bot token, since posting as a user unfurls regardless and would not exercise the bot path.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Slack review notifications now use plain-text messages with link and media previews enabled.
  * Notifications no longer use Block Kit formatting, providing a simpler message presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->