### PR TITLE
testbot: target 3 files per run instead of 1

### DIFF
--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -25,18 +25,18 @@ on:
     inputs:
       max_targets:
         description: 'Max files to target'
-        default: '1'
+        default: '3'
       max_uncovered:
         description: 'Max uncovered lines per target (0 = no cap)'
         default: '500'
       max_turns:
         description: 'Max Claude Code agent turns'
-        # Matches the schedule-trigger fallback below. Large picks
-        # (e.g., utils/job/jobs.py at 500 uncovered lines) need the
-        # extra headroom — runs/26536045087 hit max_turns at 101/100
-        # after Claude's 200K context window auto-compacted, wiping
-        # most of the exploration state mid-run.
-        default: '200'
+        # Matches the schedule-trigger fallback below. Scales with
+        # max_targets — the generator runs the full read/write/verify
+        # loop per target, and runs/26536045087 hit max_turns at 101/100
+        # on a single target after Claude's context auto-compacted,
+        # wiping most of the exploration state mid-run.
+        default: '400'
       timeout_minutes:
         description: 'Workflow timeout in minutes'
         default: '60'
@@ -211,7 +211,7 @@ jobs:
         run: |
           PYTHONPATH=. python src/scripts/testbot/select_targets_agent.py \
             --shortlist "$RUNNER_TEMP/shortlist.json" \
-            --max-targets ${{ inputs.max_targets || '1' }} \
+            --max-targets ${{ inputs.max_targets || '3' }} \
             --output "$RUNNER_TEMP/targets.txt" \
             --meta-output "$RUNNER_TEMP/targets_meta.json"
           echo "::group::Selected targets"
@@ -315,7 +315,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
           ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/bedrock-claude-opus-5' }}
-          MAX_TURNS: ${{ inputs.max_turns || '200' }}
+          MAX_TURNS: ${{ inputs.max_turns || '400' }}
           DISABLE_PROMPT_CACHING: "1"  # NVIDIA gateway rejects cache_control.ephemeral.scope
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"  # NVIDIA gateway rejects context_management
 

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -63,9 +63,9 @@ Claude Code is sandboxed: it can only read files, edit test files, and run test/
 
 ```bash
 gh workflow run testbot.yaml --ref <branch> \
-  -f max_targets=1 \
+  -f max_targets=3 \
   -f max_uncovered=500 \
-  -f max_turns=100 \
+  -f max_turns=400 \
   -f model=aws/anthropic/bedrock-claude-opus-5
 ```
 
@@ -105,10 +105,10 @@ Then post a new `/testbot` comment with clearer instructions.
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `max_targets` | `1` | Files to target per run |
+| `max_targets` | `3` | Files to target per run |
 | `max_uncovered` | `500` | Uncovered lines cap per target (0 = no cap) |
-| `max_turns` | `100` | Claude Code agent turns |
-| `timeout_minutes` | `30` | Workflow timeout |
+| `max_turns` | `400` | Claude Code agent turns |
+| `timeout_minutes` | `60` | Workflow timeout |
 | `model` | `aws/anthropic/bedrock-claude-opus-5` | LLM model on API gateway |
 | `dry_run` | `false` | Generate without creating PR |
 


### PR DESCRIPTION
## Description

Testbot PRs have been consistently small in scope — every recent one covers exactly **one** source file:

| PR | Files | Added | Target |
|----|-------|-------|--------|
| #1288 | 2 | +553 | copying.py |
| #1283 | 2 | +652 | downloading.py |
| #1280 | 2 | +634 | streaming.py |
| #1278 | 2 | +1193 | workflow.py |
| #1273 | 1 | +522 | common.py |

(The second changed file is the `BUILD` entry, not a second target.)

### Changes

- `max_targets` **1 → 3**, on both the dispatch input default and the schedule-path fallback. Nothing hardcodes the count — `SELECT_TARGETS_PROMPT.md` already renders `pick at most {max_targets}` and the generator prompt already loops per target — so this is a pure parameter change.
- `max_turns` **200 → 400**. The generator runs the full read/write/verify/coverage loop per target, and a single target has already exhausted the limit once (runs/26536045087, 101/100, after context auto-compaction).
- README table refreshed: it documented `max_turns=100` and `timeout_minutes=30` against the workflow's actual 200 and 60.

### Deliberately unchanged

- **`max_uncovered` stays 500.** It is a *per-target* cap (`_cap_ranges` is applied inside the per-file loop in `parse_coverage_entries`, with `remaining` reset per file), and recent targets carried only 35–231 uncovered lines. Raising it would change nothing; `max_targets` is the binding constraint. The per-PR ceiling still rises 500 → 1500 as a side effect of targeting 3 files.
- **Schedule and `timeout_minutes`.** Note the workflow is hourly with `concurrency.cancel-in-progress: true`, so a run is cancelled when the next hourly trigger fires — the effective wall-clock ceiling is ~60 min regardless of `timeout_minutes`. If 3-target runs start getting cancelled mid-generation, the fix is to slow the cron rather than raise the timeout.

### Verification

`bazel test //src/scripts/testbot:all //src/scripts/testbot/tests:all` — 19 targets pass, including `-pylint` siblings. Workflow YAML parses with the expected defaults.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the default number of files processed per test generation run from 1 to 3.
  * Increased the default agent turn limit from 200 to 400.
  * Extended the default run timeout from 30 to 60 minutes.
  * Updated guidance to reflect the expanded processing limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->