### PR TITLE
testbot: bigger PRs, Slack PR card, trimmed coverage report

### DIFF
--- a/.github/workflows/testbot.yaml
+++ b/.github/workflows/testbot.yaml
@@ -25,18 +25,18 @@ on:
     inputs:
       max_targets:
         description: 'Max files to target'
-        default: '1'
+        default: '3'
       max_uncovered:
         description: 'Max uncovered lines per target (0 = no cap)'
         default: '500'
       max_turns:
         description: 'Max Claude Code agent turns'
-        # Matches the schedule-trigger fallback below. Large picks
-        # (e.g., utils/job/jobs.py at 500 uncovered lines) need the
-        # extra headroom — runs/26536045087 hit max_turns at 101/100
-        # after Claude's 200K context window auto-compacted, wiping
-        # most of the exploration state mid-run.
-        default: '200'
+        # Matches the schedule-trigger fallback below. Scales with
+        # max_targets — the generator runs the full read/write/verify
+        # loop per target, and runs/26536045087 hit max_turns at 101/100
+        # on a single target after Claude's context auto-compacted,
+        # wiping most of the exploration state mid-run.
+        default: '400'
       timeout_minutes:
         description: 'Workflow timeout in minutes'
         default: '60'
@@ -211,7 +211,7 @@ jobs:
         run: |
           PYTHONPATH=. python src/scripts/testbot/select_targets_agent.py \
             --shortlist "$RUNNER_TEMP/shortlist.json" \
-            --max-targets ${{ inputs.max_targets || '1' }} \
+            --max-targets ${{ inputs.max_targets || '3' }} \
             --output "$RUNNER_TEMP/targets.txt" \
             --meta-output "$RUNNER_TEMP/targets_meta.json"
           echo "::group::Selected targets"
@@ -315,7 +315,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.NVIDIA_NIM_KEY }}
           ANTHROPIC_BASE_URL: https://inference-api.nvidia.com
           ANTHROPIC_MODEL: ${{ inputs.model || 'aws/anthropic/bedrock-claude-opus-5' }}
-          MAX_TURNS: ${{ inputs.max_turns || '200' }}
+          MAX_TURNS: ${{ inputs.max_turns || '400' }}
           DISABLE_PROMPT_CACHING: "1"  # NVIDIA gateway rejects cache_control.ephemeral.scope
           CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"  # NVIDIA gateway rejects context_management
 

--- a/src/scripts/testbot/README.md
+++ b/src/scripts/testbot/README.md
@@ -63,9 +63,9 @@ Claude Code is sandboxed: it can only read files, edit test files, and run test/
 
 ```bash
 gh workflow run testbot.yaml --ref <branch> \
-  -f max_targets=1 \
+  -f max_targets=3 \
   -f max_uncovered=500 \
-  -f max_turns=100 \
+  -f max_turns=400 \
   -f model=aws/anthropic/bedrock-claude-opus-5
 ```
 
@@ -105,10 +105,10 @@ Then post a new `/testbot` comment with clearer instructions.
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `max_targets` | `1` | Files to target per run |
+| `max_targets` | `3` | Files to target per run |
 | `max_uncovered` | `500` | Uncovered lines cap per target (0 = no cap) |
-| `max_turns` | `100` | Claude Code agent turns |
-| `timeout_minutes` | `30` | Workflow timeout |
+| `max_turns` | `400` | Claude Code agent turns |
+| `timeout_minutes` | `60` | Workflow timeout |
 | `model` | `aws/anthropic/bedrock-claude-opus-5` | LLM model on API gateway |
 | `dry_run` | `false` | Generate without creating PR |
 

--- a/src/scripts/testbot/create_pr.py
+++ b/src/scripts/testbot/create_pr.py
@@ -475,21 +475,17 @@ def _build_slack_review_payload(
     pr_url: str,
     pr_title: str,
 ) -> dict[str, Any]:
-    """Build a brief Slack Block Kit payload asking reviewers to review."""
+    """Build a brief Slack payload asking reviewers to review."""
     message = _build_slack_review_text(pr_url, pr_title)
 
+    # Plain text, no blocks: Slack only unfurls links in `text`, and messages
+    # posted by a bot need unfurl_links set explicitly. That lets the GitHub
+    # Slack app render the PR preview card under the message.
     return {
         "channel": _resolve_slack_channel(channel),
         "text": message,
-        "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": message,
-                },
-            },
-        ],
+        "unfurl_links": True,
+        "unfurl_media": True,
     }
 
 

--- a/src/scripts/testbot/tests/test_create_pr.py
+++ b/src/scripts/testbot/tests/test_create_pr.py
@@ -309,7 +309,19 @@ class TestSlackReviewRequest(unittest.TestCase):
         )
         self.assertEqual(payload["channel"], "C0A8RJ738KZ")
         self.assertEqual(payload["text"], expected)
-        self.assertEqual(payload["blocks"][0]["text"]["text"], expected)
+
+    def test_build_slack_review_payload_enables_unfurl(self):
+        payload = _build_slack_review_payload(
+            channel="#osmo-slack-test",
+            pr_url="https://github.com/NVIDIA/OSMO/pull/123",
+            pr_title="[testbot] Add tests for foo.py",
+        )
+
+        # The GitHub Slack app only renders the PR card when Slack unfurls the
+        # link, which it will not do for a bot message carrying Block Kit blocks.
+        self.assertTrue(payload["unfurl_links"])
+        self.assertTrue(payload["unfurl_media"])
+        self.assertNotIn("blocks", payload)
 
     @patch("src.scripts.testbot.create_pr.urllib.request.urlopen")
     def test_post_slack_review_request_posts_payload(self, mock_urlopen):

--- a/src/scripts/testbot/tests/test_verify_coverage.py
+++ b/src/scripts/testbot/tests/test_verify_coverage.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from src.scripts.testbot.verify_coverage import (
     DEFAULT_TARGET_THRESHOLD,
+    MAX_REPORTED_RANGES,
     RANGE_HIT_FRACTION,
     RangeResult,
     TargetReport,
@@ -328,6 +329,47 @@ class TestRenderMarkdown(unittest.TestCase):
         )
         md = render_markdown([report])
         self.assertIn("⚠️", md)
+
+    def test_fully_covered_target_lists_no_ranges(self):
+        # A checklist of all-✅ entries is noise; the summary line already
+        # carries the number a reviewer acts on.
+        report = TargetReport(
+            file_path="src/lib/foo.py",
+            listed_lines=4,
+            hit_lines=4,
+            ranges=[RangeResult(1, 2, 2, 2), RangeResult(5, 6, 2, 2)],
+            lcov_seen=True,
+        )
+        md = render_markdown([report])
+        self.assertNotIn("still uncovered", md)
+        self.assertNotIn("lines 1-2", md)
+
+    def test_names_still_uncovered_ranges(self):
+        report = TargetReport(
+            file_path="src/lib/foo.py",
+            listed_lines=4,
+            hit_lines=2,
+            ranges=[RangeResult(1, 2, 2, 2), RangeResult(5, 6, 0, 2)],
+            lcov_seen=True,
+        )
+        md = render_markdown([report])
+        self.assertIn("still uncovered: lines 5-6", md)
+        self.assertNotIn("lines 1-2", md)
+
+    def test_still_uncovered_ranges_are_capped(self):
+        misses = [RangeResult(n, n, 0, 1) for n in range(1, 15)]
+        report = TargetReport(
+            file_path="src/lib/foo.py",
+            listed_lines=14,
+            hit_lines=0,
+            ranges=misses,
+            lcov_seen=True,
+        )
+        md = render_markdown([report])
+        overflow = len(misses) - MAX_REPORTED_RANGES
+        self.assertIn(f"and {overflow} more", md)
+        self.assertIn("line 1,", md)
+        self.assertNotIn("line 14", md)
 
     def test_lcov_miss_marker(self):
         report = TargetReport(

--- a/src/scripts/testbot/verify_coverage.py
+++ b/src/scripts/testbot/verify_coverage.py
@@ -48,6 +48,10 @@ RANGE_HIT_FRACTION = 0.5
 # generator iterates until it clears this bar (or runs out of turns).
 DEFAULT_TARGET_THRESHOLD = 0.70
 
+# Cap on still-uncovered ranges named in the Markdown report. Enough to act
+# on; past that the list is noise and the JSON sidecar has the full set.
+MAX_REPORTED_RANGES = 8
+
 
 @dataclasses.dataclass(frozen=True)
 class RangeResult:
@@ -249,8 +253,10 @@ def render_markdown(reports: list[TargetReport]) -> str:
     """Render a Markdown coverage-gain section for the PR body.
 
     Mirrors the picker-rationale block format already used by
-    ``create_pr.py``: one heading, one row per target, then a per-range
-    checklist. The numbers come from the same JSON the LLM consumed during
+    ``create_pr.py``: one heading and one row per target. Only the ranges
+    still missing coverage are named — a per-range checklist of mostly-✅
+    entries ran to dozens of lines and buried the number that matters.
+    The numbers come from the same JSON the LLM consumed during
     iteration, so the PR description and the generator's view agree.
     """
     if not reports:
@@ -269,18 +275,16 @@ def render_markdown(reports: list[TargetReport]) -> str:
             f"{report.hit_lines}/{report.listed_lines} listed lines hit "
             f"({pct:.0f}%){note}"
         )
-        if not report.ranges:
-            lines.append("")
-            continue
-        for r in report.ranges:
-            span = (
-                f"line {r.start}" if r.start == r.end
-                else f"lines {r.start}-{r.end}"
+        still = report.still_uncovered_ranges()
+        if still:
+            shown = ", ".join(
+                f"line {start}" if start == end else f"lines {start}-{end}"
+                for start, end in still[:MAX_REPORTED_RANGES]
             )
-            check = "✅" if r.covered else "❌"
-            lines.append(
-                f"  - {check} {span} — {r.hit_lines}/{r.total_lines} hit"
-            )
+            overflow = len(still) - MAX_REPORTED_RANGES
+            if overflow > 0:
+                shown += f", and {overflow} more"
+            lines.append(f"  - still uncovered: {shown}")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 


### PR DESCRIPTION
## Description

Three testbot improvements.

### 1. Target 3 files per run instead of 1

- `max_targets` **1 → 3**, on both the dispatch input default and the schedule-path fallback. Nothing hardcodes the count: `SELECT_TARGETS_PROMPT.md` renders `pick at most {max_targets}` and the generator prompt already loops per target.
- `max_turns` **200 → 400**. The generator runs the full read/write/verify/coverage loop per target, and a single target has already exhausted the limit once (runs/26536045087, 101/100, after context auto-compaction).
- `max_uncovered` stays **500**. It is a *per-target* cap (`_cap_ranges` runs inside the per-file loop, `remaining` reset per file), and recent targets carried only 35–231 uncovered lines — so it is not the binding constraint. The per-PR ceiling still rises 500 → 1500 as a consequence of targeting 3 files.
- README table refreshed; it documented `max_turns=100` / `timeout_minutes=30` against the workflow's actual 200 / 60.

Schedule and `timeout_minutes` deliberately unchanged. Note the workflow is hourly with `concurrency.cancel-in-progress: true`, so a run is cancelled when the next hourly trigger fires — the effective ceiling is ~60 min regardless of `timeout_minutes`. If 3-target runs start getting cancelled mid-generation, the fix is slowing the cron rather than raising the timeout.

### 2. Let Slack unfurl the PR link into a GitHub card

The review request posted as plain text with no preview card. 

Two things in the payload prevented it: Slack unfurls links from a message's `text`, not from links inside Block Kit `blocks`; and bot-posted messages do not unfurl unless `unfurl_links` is set. The `blocks` array duplicated `text` verbatim, so dropping it changes nothing about how the message reads.

### 3. Drop the per-range checklist from the PR body

The coverage report listed every targeted range as its own bullet with a ✅/❌ and hit count — 35 bullets on #1253, all ✅, under a summary line that already said 61/61.

Now: the per-target summary line, plus only the ranges still missing coverage, capped at `MAX_REPORTED_RANGES` with an "and N more" tail. The JSON sidecar keeps full per-range detail for the generator's self-iteration loop, which is what actually consumes it.

```
## Coverage gain on listed uncovered ranges

✅ **`src/lib/data/storage/uploading.py`** — 61/61 listed lines hit (100%)

⚠️ **`src/lib/foo.py`** — 8/40 listed lines hit (20%)
  - still uncovered: lines 10-11, lines 12-13, ..., and 7 more
```

### Verification

`bazel test //src/scripts/testbot:all //src/scripts/testbot/tests:all` — 19 targets pass, including every `-pylint` sibling. Workflow YAML parses with the expected defaults. Added tests covering the Slack payload's unfurl flags and the three report-rendering cases (fully covered, partially covered, capped overflow).

The Slack card itself can only be confirmed once this runs with the testbot bot token, since posting as a user unfurls regardless and would not exercise the bot path.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test generation workflows now support up to 3 targets and 400 agent turns by default.
  * Coverage reports show only remaining under-covered ranges and summarize additional ranges beyond the first 8.
  * Slack review notifications now use clearer plain-text formatting with link and media previews enabled.

* **Documentation**
  * Updated test-generation guidance and workflow timeout documentation to reflect the expanded limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->