### PR TITLE
Use standards and conventions in umbrella chart

### DIFF
--- a/deployments/charts/osmo/Chart.yaml
+++ b/deployments/charts/osmo/Chart.yaml
@@ -7,3 +7,13 @@ type: application
 version: 0.1.0
 appVersion: "6.3.1"
 kubeVersion: ">=1.30.0-0"
+home: https://nvidia.github.io/OSMO/main/
+sources:
+- https://github.com/NVIDIA/OSMO
+keywords:
+- osmo
+- workflows
+- robotics
+- physical-ai
+- kubernetes
+icon: https://raw.githubusercontent.com/NVIDIA/OSMO/main/docs/_static/osmo_favicon.png

--- a/deployments/charts/osmo/Chart.yaml
+++ b/deployments/charts/osmo/Chart.yaml
@@ -16,4 +16,4 @@ keywords:
 - robotics
 - physical-ai
 - kubernetes
-icon: https://raw.githubusercontent.com/NVIDIA/OSMO/main/docs/_static/osmo_favicon.png
+icon: https://media.githubusercontent.com/media/NVIDIA/OSMO/main/docs/_static/osmo_favicon.png

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -5,17 +5,16 @@ SPDX-License-Identifier: Apache-2.0
 
 # OSMO Helm Chart
 
-The `osmo` chart deploys the OSMO control-plane services and gateway.
+The `osmo` chart is the unified OSMO deployment entry point.
+
+The chart currently deploys the OSMO control-plane services and gateway.
+Compute-plane workloads and dependencies will be added to this chart in future
+work.
 
 The supported `split-plane-control` profile installs the API, UI, router,
 worker, logger, agent, delayed-job monitor, and standalone OSMO gateway. It
 uses operator-managed PostgreSQL, Valkey, object storage, and Kubernetes
-Secrets. Compute-plane workloads and chart-generated Secrets are outside this
-chart's clean-install boundary.
-
-Install the chart in a dedicated namespace. OSMO Deployments in that namespace
-must use the selectors rendered by this chart because Kubernetes Deployment
-selectors are immutable.
+Secrets.
 
 ## Values layout
 
@@ -42,9 +41,9 @@ registry credentials once through `global.imagePullSecrets`.
 
 Known chart values are schema-validated. Kubernetes pass-through structures
 such as resources, probes, affinity, security contexts, volumes, custom HPA
-metrics and behavior, and PodMonitor TLS/relabeling accept fields supported by
-the target Kubernetes APIs. The `configuration` subtree accepts OSMO
-application configuration.
+metrics and behavior, PodDisruptionBudget specs, and PodMonitor TLS/relabeling
+accept fields supported by the target Kubernetes APIs. The `configuration`
+subtree accepts OSMO application configuration.
 
 ## Control-plane installation
 
@@ -115,7 +114,9 @@ enables `maxUnavailable: 1` with `unhealthyPodEvictionPolicy: AlwaysAllow` for
 replicated API, router, worker, logger, and Envoy workloads. A PDB protects only
 against voluntary disruption; it does not replace replicas, topology spread,
 health probes, or application-level recovery. Overly strict budgets can block
-node drains, so set exactly one of `minAvailable` and `maxUnavailable`.
+node drains, so set exactly one of `minAvailable` and `maxUnavailable`. Native
+PDB spec fields are passed through to Kubernetes, while the chart supplies the
+selector for each component.
 
 ## Pod and ServiceAccount security
 
@@ -156,8 +157,8 @@ installed. The chart creates an OSMO application PodMonitor and, when their
 components are enabled, separate Envoy and OAuth2 Proxy monitors. Configure
 Prometheus discovery through `labels`, metadata through `annotations`, and
 scraping through `interval`, `scrapeTimeout`, `scheme`, `tlsConfig`,
-`honorLabels`, `targetLabels`, `relabelings`, and `metricRelabelings`. The chart
-does not install the Prometheus Operator or its CRDs.
+`honorLabels`, `podTargetLabels`, `relabelings`, and `metricRelabelings`. The
+chart does not install the Prometheus Operator or its CRDs.
 
 ## Existing Secret contract
 

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -28,7 +28,7 @@ labels, and workload selector labels. This grammar keeps generic chart helpers,
 component helpers, gateway helpers, and application-specific helpers distinct.
 
 Chart-owned value names use lower camel case, such as `externalUrl`,
-`externalDependencies`, `imagePullSecrets`, and `gateway.envoy`. The
+`externalDependencies`, `global.imagePullSecrets`, and `gateway.envoy`. The
 `configuration.*` subtree is the exception: it carries OSMO application
 configuration and preserves the application's field spelling. Use the
 currently documented values; the chart does not provide aliases for superseded
@@ -58,14 +58,25 @@ configuration resources that belong to the API use that same derived name.
 - `externalUrl` is the required public OSMO URL used in generated service
   configuration and redirects.
 - `ingress` and `httproute` optionally configure Kubernetes edge resources.
+- `monitoring` configures Prometheus Operator PodMonitors.
 - `secrets` contains typed references to operator-owned Kubernetes Secrets.
 - `configuration` contains shared OSMO domain configuration.
-- `image`, `imagePullSecrets`, `commonLabels`, `commonAnnotations`, and
-  `podDefaults` provide shared workload defaults.
+- `global`, `runtimeImage`, `commonLabels`, `commonAnnotations`, and
+  `podDefaults` provide shared image, metadata, and workload defaults.
 
-Service images inherit the top-level registry, repository prefix, tag, and
-pull policy. A component can override these beneath its own `image` block.
-Maps merge with shared defaults and component lists replace inherited lists.
+Every component image uses `registry`, `repository`, `tag`, `digest`, and
+`pullPolicy`. A non-empty `global.imageRegistry` replaces every component and
+runtime registry, which supports a registry mirror without rewriting
+repositories. A component digest takes precedence over its tag. Workflow
+runtime images use the separate `runtimeImage` repository and tag. Configure
+registry credentials once through `global.imagePullSecrets`.
+
+Chart-owned values are schema-validated and unknown keys fail installation.
+Kubernetes pass-through structures such as resources, probes, affinity,
+security contexts, volumes, custom HPA metrics and behavior, and PodMonitor
+TLS/relabeling remain open to fields supported by the target Kubernetes APIs.
+The `configuration` subtree remains open because it is OSMO application
+configuration rather than a Helm API.
 
 ## Control-plane installation
 
@@ -115,6 +126,70 @@ helm upgrade --install osmo deployments/charts/osmo \
   --wait \
   --timeout 25m
 ```
+
+## Scaling and disruption behavior
+
+Every scalable component has the same `autoscaling` contract. When
+`autoscaling.enabled` is false, its Deployment uses `replicas` and the chart
+does not create an HPA. When it is true, the HPA owns replica count through
+`minReplicas` and `maxReplicas`; optional `behavior` is passed directly to the
+autoscaling/v2 API.
+
+CPU or memory utilization targets require matching non-empty
+`resources.requests.cpu` or `resources.requests.memory`. The chart rejects an
+enabled HPA that Kubernetes could not calculate. The split-plane control
+profile enables autoscaling for the production API, router, worker, logger,
+agent, and Envoy workloads and supplies their required requests.
+
+Each component also has a `podDisruptionBudget` block. General defaults leave
+budgets disabled so local clusters are easy to drain. The production profile
+enables `maxUnavailable: 1` with `unhealthyPodEvictionPolicy: AlwaysAllow` for
+replicated API, router, worker, logger, and Envoy workloads. A PDB protects only
+against voluntary disruption; it does not replace replicas, topology spread,
+health probes, or application-level recovery. Overly strict budgets can block
+node drains, so set exactly one of `minAvailable` and `maxUnavailable`.
+
+## Pod and ServiceAccount security
+
+`podDefaults` supplies shared affinity, scheduling, Pod security context,
+container security context, and termination grace period. Component `pod`
+values override shared maps. The default Pod security context uses
+`seccompProfile.type: RuntimeDefault`; containers drop all Linux capabilities,
+disallow privilege escalation, and run as non-root.
+
+The API, UI, router, worker, logger, agent, delayed-job monitor, and Envoy
+default to `readOnlyRootFilesystem: true`. Their shipped images were validated
+in a live Kind deployment with that setting. The chart mounts ephemeral
+`emptyDir` volumes at `/tmp` where services mint ephemeral TLS material and at
+`/var/run/osmo` where progress probes exchange state. These writable paths are
+chart-owned and remain present when operators append custom
+`extraVolumeMounts` and `pod.extraVolumes`. Optional components that have not
+passed the same live check do not claim this default.
+
+`serviceAccount.automountServiceAccountToken` defaults to false for components
+that do not use the Kubernetes API. It remains true for the API because
+configuration reload reporting reads its ConfigMap and creates Events through
+the chart's Role. The value controls both the Pod and any ServiceAccount the
+component asks the chart to create.
+
+## Metadata precedence
+
+`commonLabels` and `commonAnnotations` apply to all chart-owned resources.
+`podDefaults.labels` and `podDefaults.annotations` add Pod-only metadata, and
+resource or component maps override common metadata. Chart identity labels and
+behavioral annotations such as the Envoy configuration checksum are protected
+and take final precedence so user metadata cannot break selectors or rollout
+triggers.
+
+## Prometheus Operator monitoring
+
+Set `monitoring.podMonitor.enabled: true` when the Prometheus Operator CRDs are
+installed. The chart creates an OSMO application PodMonitor and, when their
+components are enabled, separate Envoy and OAuth2 Proxy monitors. Configure
+Prometheus discovery through `labels`, metadata through `annotations`, and
+scraping through `interval`, `scrapeTimeout`, `scheme`, `tlsConfig`,
+`honorLabels`, `targetLabels`, `relabelings`, and `metricRelabelings`. The chart
+does not install the Prometheus Operator or its CRDs.
 
 ## Existing Secret contract
 

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -15,6 +15,10 @@ uses operator-managed PostgreSQL, Valkey, object storage, and Kubernetes
 Secrets. Compute-plane workloads and chart-generated Secrets are outside this
 chart's clean-install boundary.
 
+Releases installed before this convention cleanup must be uninstalled and
+reinstalled. Do not upgrade those releases in place: this cleanup changes
+Deployment selectors, and Kubernetes treats those selectors as immutable.
+
 ## Chart conventions
 
 Named templates use dotted helper names: `osmo.<area>.<purpose>`. For example,

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -12,8 +12,37 @@ not depend on the legacy `service` chart.
 The supported `split-plane-control` profile installs the API, UI, router,
 worker, logger, agent, delayed-job monitor, and standalone OSMO gateway. It
 uses operator-managed PostgreSQL, Valkey, object storage, and Kubernetes
-Secrets. Compute-plane workloads, embedded dependencies, generated Secrets,
-Gateway API exposure, and Ingress exposure are rejected until implemented.
+Secrets. Compute-plane workloads and chart-generated Secrets are outside this
+chart's clean-install boundary.
+
+## Chart conventions
+
+Named templates use dotted helper names: `osmo.<area>.<purpose>`. For example,
+`osmo.component.fullname`, `osmo.component.labels`, and
+`osmo.component.selectorLabels` derive a component's resource name, metadata
+labels, and workload selector labels. This grammar keeps generic chart helpers,
+component helpers, gateway helpers, and application-specific helpers distinct.
+
+Chart-owned value names use lower camel case, such as `externalUrl`,
+`externalDependencies`, `imagePullSecrets`, and `gateway.envoy`. The
+`configuration.*` subtree is the exception: it carries OSMO application
+configuration and preserves the application's field spelling. Use the
+currently documented values; the chart does not provide aliases for superseded
+value names.
+
+All chart-owned resources use Kubernetes recommended labels. The chart
+protects its identity keys from user-supplied label maps:
+`helm.sh/chart`, `app.kubernetes.io/name`,
+`app.kubernetes.io/instance`, `app.kubernetes.io/managed-by`,
+`app.kubernetes.io/part-of`, `app.kubernetes.io/version`, and the component's
+`app.kubernetes.io/component`. Workload selectors intentionally contain only
+`app.kubernetes.io/name`, `app.kubernetes.io/instance`, and
+`app.kubernetes.io/component`; do not add operational or user labels to a
+selector.
+
+The control-plane API is named `api`, not `service`. Its generated resource and
+DNS name follow the component helper (normally `<release>-osmo-api`), and
+configuration resources that belong to the API use that same derived name.
 
 ## Values layout
 
@@ -22,7 +51,9 @@ Gateway API exposure, and Ingress exposure are rejected until implemented.
 - `externalDependencies` contains typed connection information.
 - `services` configures OSMO application services.
 - `gateway` configures Envoy and gateway-adjacent services.
-- `exposure` describes the public URL and edge ownership.
+- `externalUrl` is the required public OSMO URL used in generated service
+  configuration and redirects.
+- `ingress` and `httproute` optionally configure Kubernetes edge resources.
 - `secrets` contains typed references to operator-owned Kubernetes Secrets.
 - `configuration` contains shared OSMO domain configuration.
 - `image`, `imagePullSecrets`, `commonLabels`, `commonAnnotations`, and
@@ -38,9 +69,7 @@ Create an environment values file containing the external endpoints and
 Secret references:
 
 ```yaml
-exposure:
-  mode: external
-  baseUrl: https://osmo.example.com
+externalUrl: https://osmo.example.com
 
 externalDependencies:
   postgresql:
@@ -104,11 +133,33 @@ bundle through `SSL_CERT_FILE`. The default Valkey key is `ca-bundle.crt`.
 
 ## Exposure
 
-`exposure.mode: external` renders the internal OSMO gateway and no public edge
-resource. The control profile keeps that Service at `ClusterIP`; an
-operator-managed, authenticating proxy is responsible for forwarding HTTP and
-WebSocket traffic to it. Do not expose the profile's gateway directly without
-adding the intended authentication layer. For local verification:
+The gateway Service is the chart's single in-cluster entry point. It has one
+HTTP or HTTPS port, configured by `gateway.envoy.service`, and all edge
+resources target that port. Set `externalUrl` to the public URL clients use;
+the chart does not infer it from a Service, Ingress, or HTTPRoute.
+
+Choose the edge pattern appropriate for the cluster:
+
+1. **Private `ClusterIP` (default).** Keep
+   `gateway.envoy.service.type: ClusterIP` and have an operator-managed,
+   authenticating proxy forward HTTP and WebSocket traffic to the gateway.
+   This is the control profile default.
+2. **Direct `LoadBalancer`.** Set
+   `gateway.envoy.service.type: LoadBalancer`; optionally set its
+   `port`, `nodePort`, `loadBalancerClass`, `loadBalancerSourceRanges`, and
+   `externalTrafficPolicy`. Configure the intended TLS and authentication
+   layers for the public endpoint.
+3. **Ingress.** Set `ingress.enabled: true` and configure at least
+   `ingress.hostname`; optionally configure its class, annotations, paths, and
+   TLS block. The generated Ingress forwards to the gateway Service.
+4. **Gateway API `HTTPRoute`.** Set `httproute.enabled: true`, supply at least
+   one `httproute.parentRefs` entry for a Gateway that already exists, and
+   configure hostnames and rules as needed. The chart creates an HTTPRoute only;
+   it never creates a Gateway or GatewayClass.
+
+Ingress and HTTPRoute can be enabled together when the cluster intentionally
+uses both edge mechanisms. For local verification of the default private
+Service:
 
 ```bash
 kubectl --namespace osmo port-forward service/osmo-gateway 8080:80

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -5,9 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # OSMO Helm Chart
 
-The `osmo` chart is the unified OSMO deployment entry point. This initial
-version directly owns the control-plane service and gateway templates. It does
-not depend on the legacy `service` chart.
+The `osmo` chart deploys the OSMO control-plane services and gateway.
 
 The supported `split-plane-control` profile installs the API, UI, router,
 worker, logger, agent, delayed-job monitor, and standalone OSMO gateway. It
@@ -15,38 +13,9 @@ uses operator-managed PostgreSQL, Valkey, object storage, and Kubernetes
 Secrets. Compute-plane workloads and chart-generated Secrets are outside this
 chart's clean-install boundary.
 
-Releases installed before this convention cleanup must be uninstalled and
-reinstalled. Do not upgrade those releases in place: this cleanup changes
-Deployment selectors, and Kubernetes treats those selectors as immutable.
-
-## Chart conventions
-
-Named templates use dotted helper names: `osmo.<area>.<purpose>`. For example,
-`osmo.component.fullname`, `osmo.component.labels`, and
-`osmo.component.selectorLabels` derive a component's resource name, metadata
-labels, and workload selector labels. This grammar keeps generic chart helpers,
-component helpers, gateway helpers, and application-specific helpers distinct.
-
-Chart-owned value names use lower camel case, such as `externalUrl`,
-`externalDependencies`, `global.imagePullSecrets`, and `gateway.envoy`. The
-`configuration.*` subtree is the exception: it carries OSMO application
-configuration and preserves the application's field spelling. Use the
-currently documented values; the chart does not provide aliases for superseded
-value names.
-
-All chart-owned resources use Kubernetes recommended labels. The chart
-protects its identity keys from user-supplied label maps:
-`helm.sh/chart`, `app.kubernetes.io/name`,
-`app.kubernetes.io/instance`, `app.kubernetes.io/managed-by`,
-`app.kubernetes.io/part-of`, `app.kubernetes.io/version`, and the component's
-`app.kubernetes.io/component`. Workload selectors intentionally contain only
-`app.kubernetes.io/name`, `app.kubernetes.io/instance`, and
-`app.kubernetes.io/component`; do not add operational or user labels to a
-selector.
-
-The control-plane API is named `api`, not `service`. Its generated resource and
-DNS name follow the component helper (normally `<release>-osmo-api`), and
-configuration resources that belong to the API use that same derived name.
+Install the chart in a dedicated namespace. OSMO Deployments in that namespace
+must use the selectors rendered by this chart because Kubernetes Deployment
+selectors are immutable.
 
 ## Values layout
 
@@ -71,12 +40,11 @@ repositories. A component digest takes precedence over its tag. Workflow
 runtime images use the separate `runtimeImage` repository and tag. Configure
 registry credentials once through `global.imagePullSecrets`.
 
-Chart-owned values are schema-validated and unknown keys fail installation.
-Kubernetes pass-through structures such as resources, probes, affinity,
-security contexts, volumes, custom HPA metrics and behavior, and PodMonitor
-TLS/relabeling remain open to fields supported by the target Kubernetes APIs.
-The `configuration` subtree remains open because it is OSMO application
-configuration rather than a Helm API.
+Known chart values are schema-validated. Kubernetes pass-through structures
+such as resources, probes, affinity, security contexts, volumes, custom HPA
+metrics and behavior, and PodMonitor TLS/relabeling accept fields supported by
+the target Kubernetes APIs. The `configuration` subtree accepts OSMO
+application configuration.
 
 ## Control-plane installation
 

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -11,41 +11,7 @@ The chart currently deploys the OSMO control-plane services and gateway.
 Compute-plane workloads and dependencies will be added to this chart in future
 work.
 
-The supported `split-plane-control` profile installs the API, UI, router,
-worker, logger, agent, delayed-job monitor, and standalone OSMO gateway. It
-uses operator-managed PostgreSQL, Valkey, object storage, and Kubernetes
-Secrets.
-
-## Values layout
-
-- `planes` selects the OSMO plane.
-- `embeddedDependencies` selects chart-owned supporting systems.
-- `externalDependencies` contains typed connection information.
-- `services` configures OSMO application services.
-- `gateway` configures Envoy and gateway-adjacent services.
-- `externalUrl` is the required public OSMO URL used in generated service
-  configuration and redirects.
-- `ingress` and `httproute` optionally configure Kubernetes edge resources.
-- `monitoring` configures Prometheus Operator PodMonitors.
-- `secrets` contains typed references to operator-owned Kubernetes Secrets.
-- `configuration` contains shared OSMO domain configuration.
-- `global`, `runtimeImage`, `commonLabels`, `commonAnnotations`, and
-  `podDefaults` provide shared image, metadata, and workload defaults.
-
-Every component image uses `registry`, `repository`, `tag`, `digest`, and
-`pullPolicy`. A non-empty `global.imageRegistry` replaces every component and
-runtime registry, which supports a registry mirror without rewriting
-repositories. A component digest takes precedence over its tag. Workflow
-runtime images use the separate `runtimeImage` repository and tag. Configure
-registry credentials once through `global.imagePullSecrets`.
-
-Known chart values are schema-validated. Kubernetes pass-through structures
-such as resources, probes, affinity, security contexts, volumes, custom HPA
-metrics and behavior, PodDisruptionBudget specs, and PodMonitor TLS/relabeling
-accept fields supported by the target Kubernetes APIs. The `configuration`
-subtree accepts OSMO application configuration.
-
-## Control-plane installation
+## Install the control plane
 
 Create an environment values file containing the external endpoints and
 Secret references:
@@ -94,73 +60,20 @@ helm upgrade --install osmo deployments/charts/osmo \
   --timeout 25m
 ```
 
-## Scaling and disruption behavior
+## Optional configuration
 
-Every scalable component has the same `autoscaling` contract. When
-`autoscaling.enabled` is false, its Deployment uses `replicas` and the chart
-does not create an HPA. When it is true, the HPA owns replica count through
-`minReplicas` and `maxReplicas`; optional `behavior` is passed directly to the
-autoscaling/v2 API.
+- Configure component images and registry credentials under `global`,
+  `runtimeImage`, and each component's `image` block.
+- Configure replicas, autoscaling, resources, disruption budgets, scheduling,
+  security contexts, probes, volumes, and ServiceAccounts under `services`,
+  `gateway`, and `podDefaults`.
+- Enable Prometheus Operator PodMonitors with `monitoring.podMonitor.enabled`.
+- Apply shared resource metadata with `commonLabels` and `commonAnnotations`.
+- Supply OSMO application configuration under `configuration`.
 
-CPU or memory utilization targets require matching non-empty
-`resources.requests.cpu` or `resources.requests.memory`. The chart rejects an
-enabled HPA that Kubernetes could not calculate. The split-plane control
-profile enables autoscaling for the production API, router, worker, logger,
-agent, and Envoy workloads and supplies their required requests.
+See [`values.yaml`](values.yaml) for the complete configuration reference.
 
-Each component also has a `podDisruptionBudget` block. General defaults leave
-budgets disabled so local clusters are easy to drain. The production profile
-enables `maxUnavailable: 1` with `unhealthyPodEvictionPolicy: AlwaysAllow` for
-replicated API, router, worker, logger, and Envoy workloads. A PDB protects only
-against voluntary disruption; it does not replace replicas, topology spread,
-health probes, or application-level recovery. Overly strict budgets can block
-node drains, so set exactly one of `minAvailable` and `maxUnavailable`. Native
-PDB spec fields are passed through to Kubernetes, while the chart supplies the
-selector for each component.
-
-## Pod and ServiceAccount security
-
-`podDefaults` supplies shared affinity, scheduling, Pod security context,
-container security context, and termination grace period. Component `pod`
-values override shared maps. The default Pod security context uses
-`seccompProfile.type: RuntimeDefault`; containers drop all Linux capabilities,
-disallow privilege escalation, and run as non-root.
-
-The API, UI, router, worker, logger, agent, delayed-job monitor, and Envoy
-default to `readOnlyRootFilesystem: true`. Their shipped images were validated
-in a live Kind deployment with that setting. The chart mounts ephemeral
-`emptyDir` volumes at `/tmp` where services mint ephemeral TLS material and at
-`/var/run/osmo` where progress probes exchange state. These writable paths are
-chart-owned and remain present when operators append custom
-`extraVolumeMounts` and `pod.extraVolumes`. Optional components that have not
-passed the same live check do not claim this default.
-
-`serviceAccount.automountServiceAccountToken` defaults to false for components
-that do not use the Kubernetes API. It remains true for the API because
-configuration reload reporting reads its ConfigMap and creates Events through
-the chart's Role. The value controls both the Pod and any ServiceAccount the
-component asks the chart to create.
-
-## Metadata precedence
-
-`commonLabels` and `commonAnnotations` apply to all chart-owned resources.
-`podDefaults.labels` and `podDefaults.annotations` add Pod-only metadata, and
-resource or component maps override common metadata. Chart identity labels and
-behavioral annotations such as the Envoy configuration checksum are protected
-and take final precedence so user metadata cannot break selectors or rollout
-triggers.
-
-## Prometheus Operator monitoring
-
-Set `monitoring.podMonitor.enabled: true` when the Prometheus Operator CRDs are
-installed. The chart creates an OSMO application PodMonitor and, when their
-components are enabled, separate Envoy and OAuth2 Proxy monitors. Configure
-Prometheus discovery through `labels`, metadata through `annotations`, and
-scraping through `interval`, `scrapeTimeout`, `scheme`, `tlsConfig`,
-`honorLabels`, `podTargetLabels`, `relabelings`, and `metricRelabelings`. The
-chart does not install the Prometheus Operator or its CRDs.
-
-## Existing Secret contract
+## Secrets
 
 The same Kubernetes Secret may satisfy several logical blocks, or each block
 may reference a separate Secret. The defaults expect these keys:
@@ -172,42 +85,23 @@ may reference a separate Secret. The defaults expect these keys:
 | `secrets.objectStorage` | `object-storage.yaml` | Workflow data, logs, and apps |
 | `secrets.masterEncryptionKey` | `mek.yaml` | OSMO encryption-key configuration |
 
-The chart only reads operator-owned Secrets. It does not create, mutate, or
-delete them. When PostgreSQL or Valkey uses a private CA, enable TLS in the
-matching `externalDependencies` block and reference the CA Secret there. The
-Valkey `caKey` must hold a complete PEM trust bundle, including the public or
-system roots used by other HTTPS endpoints; OSMO's Python services consume that
-bundle through `SSL_CERT_FILE`. The default Valkey key is `ca-bundle.crt`.
+For PostgreSQL or Valkey private CAs, enable TLS in the corresponding
+`externalDependencies` block and reference the CA Secret there. A Valkey
+`caKey` must contain the complete trust bundle; its default is
+`ca-bundle.crt`.
 
 ## Exposure
 
-The gateway Service is the chart's single in-cluster entry point. It has one
-HTTP or HTTPS port, configured by `gateway.envoy.service`, and all edge
-resources target that port. Set `externalUrl` to the public URL clients use;
-the chart does not infer it from a Service, Ingress, or HTTPRoute.
+Set `externalUrl` to the public URL clients use. The gateway can be exposed in
+one of these ways:
 
-Choose the edge pattern appropriate for the cluster:
+- Keep `gateway.envoy.service.type: ClusterIP` for in-cluster access.
+- Set `gateway.envoy.service.type: LoadBalancer` for a load balancer Service.
+- Set `ingress.enabled: true` and configure `ingress.hostname`.
+- Set `httproute.enabled: true` and configure `httproute.parentRefs` for an
+  existing Gateway.
 
-1. **Private `ClusterIP` (default).** Keep
-   `gateway.envoy.service.type: ClusterIP` and have an operator-managed,
-   authenticating proxy forward HTTP and WebSocket traffic to the gateway.
-   This is the control profile default.
-2. **Direct `LoadBalancer`.** Set
-   `gateway.envoy.service.type: LoadBalancer`; optionally set its
-   `port`, `nodePort`, `loadBalancerClass`, `loadBalancerSourceRanges`, and
-   `externalTrafficPolicy`. Configure the intended TLS and authentication
-   layers for the public endpoint.
-3. **Ingress.** Set `ingress.enabled: true` and configure at least
-   `ingress.hostname`; optionally configure its class, annotations, paths, and
-   TLS block. The generated Ingress forwards to the gateway Service.
-4. **Gateway API `HTTPRoute`.** Set `httproute.enabled: true`, supply at least
-   one `httproute.parentRefs` entry for a Gateway that already exists, and
-   configure hostnames and rules as needed. The chart creates an HTTPRoute only;
-   it never creates a Gateway or GatewayClass.
-
-Ingress and HTTPRoute can be enabled together when the cluster intentionally
-uses both edge mechanisms. For local verification of the default private
-Service:
+For local access to the default ClusterIP Service:
 
 ```bash
 kubectl --namespace osmo port-forward service/osmo-gateway 8080:80

--- a/deployments/charts/osmo/profiles/split-plane-control.yaml
+++ b/deployments/charts/osmo/profiles/split-plane-control.yaml
@@ -54,9 +54,6 @@ services:
       annotations: {}
       maxUnavailable: 1
       unhealthyPodEvictionPolicy: AlwaysAllow
-    monitoring:
-      podMonitor:
-        enabled: false
   router:
     autoscaling:
       enabled: true
@@ -103,6 +100,10 @@ gateway:
   authz:
     enabled: false
   rateLimit:
+    enabled: false
+
+monitoring:
+  podMonitor:
     enabled: false
 
 secrets:

--- a/deployments/charts/osmo/profiles/split-plane-control.yaml
+++ b/deployments/charts/osmo/profiles/split-plane-control.yaml
@@ -35,6 +35,12 @@ services:
       requests:
         cpu: 500m
         memory: 512Mi
+    podDisruptionBudget:
+      enabled: true
+      labels: {}
+      annotations: {}
+      maxUnavailable: 1
+      unhealthyPodEvictionPolicy: AlwaysAllow
   api:
     autoscaling:
       enabled: true
@@ -42,6 +48,12 @@ services:
       requests:
         cpu: 500m
         memory: 512Mi
+    podDisruptionBudget:
+      enabled: true
+      labels: {}
+      annotations: {}
+      maxUnavailable: 1
+      unhealthyPodEvictionPolicy: AlwaysAllow
     monitoring:
       podMonitor:
         enabled: false
@@ -52,9 +64,21 @@ services:
       requests:
         cpu: 200m
         memory: 256Mi
+    podDisruptionBudget:
+      enabled: true
+      labels: {}
+      annotations: {}
+      maxUnavailable: 1
+      unhealthyPodEvictionPolicy: AlwaysAllow
   logger:
     autoscaling:
       enabled: true
+    podDisruptionBudget:
+      enabled: true
+      labels: {}
+      annotations: {}
+      maxUnavailable: 1
+      unhealthyPodEvictionPolicy: AlwaysAllow
   agent:
     autoscaling:
       enabled: true
@@ -64,6 +88,12 @@ gateway:
     enabled: true
     autoscaling:
       enabled: true
+    podDisruptionBudget:
+      enabled: true
+      labels: {}
+      annotations: {}
+      maxUnavailable: 1
+      unhealthyPodEvictionPolicy: AlwaysAllow
     service:
       # Keep the unauthenticated in-cluster gateway behind an operator-managed,
       # authenticating edge rather than provisioning a public load balancer.

--- a/deployments/charts/osmo/profiles/split-plane-control.yaml
+++ b/deployments/charts/osmo/profiles/split-plane-control.yaml
@@ -28,14 +28,42 @@ services:
     enabled: false
   ui:
     enabled: true
+  worker:
+    autoscaling:
+      enabled: true
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
   api:
+    autoscaling:
+      enabled: true
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
     monitoring:
       podMonitor:
         enabled: false
+  router:
+    autoscaling:
+      enabled: true
+    resources:
+      requests:
+        cpu: 200m
+        memory: 256Mi
+  logger:
+    autoscaling:
+      enabled: true
+  agent:
+    autoscaling:
+      enabled: true
 
 gateway:
   envoy:
     enabled: true
+    autoscaling:
+      enabled: true
     service:
       # Keep the unauthenticated in-cluster gateway behind an operator-managed,
       # authenticating edge rather than provisioning a public load balancer.

--- a/deployments/charts/osmo/profiles/split-plane-control.yaml
+++ b/deployments/charts/osmo/profiles/split-plane-control.yaml
@@ -14,13 +14,8 @@ embeddedDependencies:
     enabled: false
   objectStorage:
     enabled: false
-  gateway:
-    enabled: false
   kaiScheduler:
     enabled: false
-
-exposure:
-  mode: external
 
 configuration:
   enabled: true

--- a/deployments/charts/osmo/templates/NOTES.txt
+++ b/deployments/charts/osmo/templates/NOTES.txt
@@ -3,8 +3,18 @@
 
 OSMO control plane installed.
 
-The supported external exposure mode renders no public edge resource. To test
-the gateway locally, run:
+The API component is named {{ include "osmo.api.fullname" . }}. The gateway
+Service has one port and follows gateway.envoy.service.type; Ingress and
+HTTPRoute are optional edge resources.
+
+Configured public URL:
+
+  {{ .Values.externalUrl }}
+
+An HTTPRoute attaches to an existing Gateway named in httproute.parentRefs;
+this chart does not create a Gateway or GatewayClass.
+
+To test a ClusterIP gateway locally, run:
 
   kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "osmo.gateway.fullname" . }} 8080:80
 

--- a/deployments/charts/osmo/templates/NOTES.txt
+++ b/deployments/charts/osmo/templates/NOTES.txt
@@ -16,8 +16,8 @@ this chart does not create a Gateway or GatewayClass.
 
 To test a ClusterIP gateway locally, run:
 
-  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "osmo.gateway.fullname" . }} 8080:80
+  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "osmo.gateway.fullname" . }} 8080:{{ .Values.gateway.envoy.service.port }}
 
 Then query:
 
-  curl http://127.0.0.1:8080/api/version
+  curl {{ ternary "https" "http" .Values.gateway.envoy.ssl.enabled }}://127.0.0.1:8080/api/version

--- a/deployments/charts/osmo/templates/NOTES.txt
+++ b/deployments/charts/osmo/templates/NOTES.txt
@@ -1,23 +1,4 @@
 {{/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 
-OSMO control plane installed.
-
-The API component is named {{ include "osmo.api.fullname" . }}. The gateway
-Service has one port and follows gateway.envoy.service.type; Ingress and
-HTTPRoute are optional edge resources.
-
-Configured public URL:
-
-  {{ .Values.externalUrl }}
-
-An HTTPRoute attaches to an existing Gateway named in httproute.parentRefs;
-this chart does not create a Gateway or GatewayClass.
-
-To test a ClusterIP gateway locally, run:
-
-  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "osmo.gateway.fullname" . }} 8080:{{ .Values.gateway.envoy.service.port }}
-
-Then query:
-
-  curl {{ ternary "https" "http" .Values.gateway.envoy.ssl.enabled }}://127.0.0.1:8080/api/version
+{{ include "osmo.notes" . }}

--- a/deployments/charts/osmo/templates/NOTES.txt
+++ b/deployments/charts/osmo/templates/NOTES.txt
@@ -6,7 +6,7 @@ OSMO control plane installed.
 The supported external exposure mode renders no public edge resource. To test
 the gateway locally, run:
 
-  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "osmo.v1.gateway-name" . }} 8080:80
+  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "osmo.gateway.fullname" . }} 8080:80
 
 Then query:
 

--- a/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
@@ -267,8 +267,8 @@ data:
                 - match:
                     path: /signout
                   redirect:
-                    {{- if .Values.services.api.auth.logout_endpoint }}
-                    path_redirect: "/oauth2/sign_out?rd={{ .Values.services.api.auth.logout_endpoint | urlquery }}"
+                    {{- if .Values.services.api.auth.logoutEndpoint }}
+                    path_redirect: "/oauth2/sign_out?rd={{ .Values.services.api.auth.logoutEndpoint | urlquery }}"
                     {{- else }}
                     path_redirect: "/oauth2/sign_out"
                     {{- end }}
@@ -741,7 +741,7 @@ data:
                           max_interval: 3s
                     claim_to_headers:
                     - claim_name: {{$provider.user_claim}}
-                      header_name: {{$envoy.jwt.user_header}}
+                      header_name: {{$envoy.jwt.userHeader}}
                   {{- end }}
                 rules:
                   {{- if $skipAuthPaths }}

--- a/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
@@ -109,6 +109,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   bootstrap.yaml: |
     admin:

--- a/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
@@ -78,7 +78,7 @@ setting detects this rotation and triggers Envoy to reload.
 {{- fail "services.mcp.scopes entries must not be empty" }}
 {{- end }}
 {{- end }}
-{{- $_ := required "services.mcp.image.name is required when MCP is enabled" $mcp.image.name }}
+{{- $_ := required "services.mcp.image.repository is required when MCP is enabled" $mcp.image.repository }}
 {{- if or (lt (int $mcp.port) 1) (gt (int $mcp.port) 65535) }}
 {{- fail "services.mcp.port must be between 1 and 65535" }}
 {{- end }}

--- a/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
@@ -25,23 +25,23 @@ Kubernetes rotates ConfigMap symlinks atomically.  The watched_directory
 setting detects this rotation and triggers Envoy to reload.
 */}}
 
-{{- define "osmo.v1.gateway-envoy-config" -}}
+{{- define "osmo.gateway.envoyConfig" -}}
 {{- $gw := .Values.gateway }}
 {{- $envoy := $gw.envoy }}
 {{- $mcp := .Values.services.mcp }}
-{{- $serviceHost := $gw.upstreams.service.host | default (include "osmo.v1.apiName" .) }}
-{{- $routerName := include "osmo.v1.componentName" (dict "root" . "suffix" "router") }}
+{{- $serviceHost := $gw.upstreams.api.host | default (include "osmo.api.fullname" .) }}
+{{- $routerName := include "osmo.component.fullname" (dict "root" . "suffix" "router") }}
 {{- $routerHost := $gw.upstreams.router.host | default (printf "%s-headless" $routerName) }}
-{{- $uiHost := $gw.upstreams.ui.host | default (include "osmo.v1.componentName" (dict "root" . "suffix" "ui")) }}
-{{- $agentHost := $gw.upstreams.agent.host | default (include "osmo.v1.componentName" (dict "root" . "suffix" "agent")) }}
-{{- $loggerName := include "osmo.v1.componentName" (dict "root" . "suffix" "logger") }}
+{{- $uiHost := $gw.upstreams.ui.host | default (include "osmo.component.fullname" (dict "root" . "suffix" "ui")) }}
+{{- $agentHost := $gw.upstreams.agent.host | default (include "osmo.component.fullname" (dict "root" . "suffix" "agent")) }}
+{{- $loggerName := include "osmo.component.fullname" (dict "root" . "suffix" "logger") }}
 {{- $loggerHost := $gw.upstreams.logger.host | default (printf "%s-headless" $loggerName) }}
 {{- $mcpEnabled := $mcp.enabled | default false }}
 {{- $mcpPath := "/mcp" }}
 {{- $mcpMetadataPath := "/.well-known/oauth-protected-resource/mcp" }}
 {{- $mcpResourceUrl := "" }}
 {{- $mcpMetadataUrl := "" }}
-{{- $mcpServiceName := include "osmo.v1.componentName" (dict "root" . "suffix" "mcp") }}
+{{- $mcpServiceName := include "osmo.component.fullname" (dict "root" . "suffix" "mcp") }}
 {{- $skipAuthPaths := concat (default (list) $envoy.skipAuthPaths) (default (list) $envoy.extraSkipAuthPaths) }}
 {{- $authnSkipPaths := $skipAuthPaths }}
 {{- if $gw.oauth2Proxy.enabled }}
@@ -57,7 +57,7 @@ setting detects this rotation and triggers Envoy to reload.
 {{- if not $envoy.jwt.providers }}
 {{- fail "services.mcp.enabled requires at least one gateway.envoy.jwt.providers entry" }}
 {{- end }}
-{{- $mcpResourceUrl = include "osmo.v1.mcp-resource-url" . }}
+{{- $mcpResourceUrl = include "osmo.mcp.resourceUrl" . }}
 {{- if not (kindIs "slice" $mcp.authorizationServers) }}
 {{- fail "services.mcp.authorizationServers must be a list" }}
 {{- end }}
@@ -100,13 +100,15 @@ setting detects this rotation and triggers Envoy to reload.
 {{- $mcpBaseUrl := trimSuffix $mcpPath $mcpResourceUrl }}
 {{- $mcpMetadataUrl = printf "%s%s" $mcpBaseUrl $mcpMetadataPath }}
 {{- end }}
-{{- $gwName := include "osmo.v1.gateway-name" . }}
+{{- $gwName := include "osmo.gateway.fullname" . }}
 {{- if $envoy.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $gwName }}-envoy-config
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
 data:
   bootstrap.yaml: |
     admin:
@@ -388,18 +390,18 @@ data:
                     safe_regex:
                       regex: "^/api/workflow/.+/(logs|events|error_logs)$"
                   route:
-                    cluster: osmo-service
+                    cluster: osmo-api
                     timeout: 0s
                     idle_timeout: 60s
                 - match:
                     prefix: /api/
                   route:
-                    cluster: osmo-service
+                    cluster: osmo-api
                     timeout: 60s
                 - match:
                     prefix: /client/
                   route:
-                    cluster: osmo-service
+                    cluster: osmo-api
                     timeout: 60s
                 {{- end }}
 
@@ -855,7 +857,7 @@ data:
   cds.yaml: |
     resources:
     - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster
-      name: osmo-service
+      name: osmo-api
       connect_timeout: 3s
       type: STRICT_DNS
       dns_lookup_family: V4_ONLY
@@ -867,14 +869,14 @@ data:
           max_requests: {{ $envoy.maxRequests }}
       {{- end }}
       load_assignment:
-        cluster_name: osmo-service
+        cluster_name: osmo-api
         endpoints:
         - lb_endpoints:
           - endpoint:
               address:
                 socket_address:
                   address: {{ $serviceHost }}
-                  port_value: {{ $gw.upstreams.service.port }}
+                  port_value: {{ $gw.upstreams.api.port }}
       {{- if $gw.tls.enabled }}
       transport_socket:
         name: envoy.transport_sockets.tls
@@ -1196,7 +1198,7 @@ data:
               address:
                 socket_address:
                   address: {{ $jwksHost }}
-                  port_value: {{ $envoy.internalJwks.port | default $gw.upstreams.service.port }}
+                  port_value: {{ $envoy.internalJwks.port | default $gw.upstreams.api.port }}
       {{- if $gw.tls.enabled }}
       transport_socket:
         name: envoy.transport_sockets.tls

--- a/deployments/charts/osmo/templates/_gateway-helpers.tpl
+++ b/deployments/charts/osmo/templates/_gateway-helpers.tpl
@@ -18,17 +18,15 @@
 Gateway component name prefix. All gateway resources are named
 <prefix>-<component>, e.g. osmo-gateway-envoy.
 */}}
-{{- define "osmo.v1.gateway-name" -}}
-{{- include "osmo.v1.componentName" (dict "root" . "suffix" "gateway") -}}
+{{- define "osmo.gateway.fullname" -}}
+{{- include "osmo.component.fullname" (dict "root" . "suffix" "gateway") -}}
 {{- end }}
 
 {{/*
 Gateway component labels. Pass a dict with "component" and "context" keys.
 */}}
-{{- define "osmo.v1.gateway-component-labels" -}}
-app.kubernetes.io/name: {{ include "osmo.v1.gateway-name" .context }}
-app.kubernetes.io/instance: {{ .context.Release.Name }}
-app.kubernetes.io/component: {{ .component }}
+{{- define "osmo.gateway.componentSelectorLabels" -}}
+{{- include "osmo.component.selectorLabels" (dict "root" .context "component" (printf "gateway-%s" .component)) -}}
 {{- end }}
 
 {{/*
@@ -39,7 +37,7 @@ uvicorn loads tls.crt + tls.key from there (--ssl_keyfile / --ssl_certfile).
 When empty, the Python service mints an ephemeral self-signed cert in
 process at startup (--ssl_self_signed true) — no chart-side cert material.
 */}}
-{{- define "osmo.v1.upstream-tls-args" -}}
+{{- define "osmo.gateway.upstreamTlsArgs" -}}
 {{- if .context.Values.gateway.tls.enabled }}
 {{- if .secretName }}
 - --ssl_keyfile
@@ -58,7 +56,7 @@ TLS volume mount for an upstream container. Only emitted when a Secret
 name is provided — self-signed mode keeps cert material in an in-process
 tempdir, so no mount is needed.
 */}}
-{{- define "osmo.v1.upstream-tls-volume-mount" -}}
+{{- define "osmo.gateway.upstreamTlsVolumeMount" -}}
 {{- if and .context.Values.gateway.tls.enabled .secretName }}
 - name: tls
   mountPath: /etc/osmo/tls
@@ -70,7 +68,7 @@ tempdir, so no mount is needed.
 TLS volume for an upstream pod. Pass dict with "context" and "secretName".
 Only emitted when secretName is non-empty.
 */}}
-{{- define "osmo.v1.upstream-tls-volume" -}}
+{{- define "osmo.gateway.upstreamTlsVolume" -}}
 {{- if and .context.Values.gateway.tls.enabled .secretName }}
 - name: tls
   secret:
@@ -84,9 +82,9 @@ Pass dict with "probe" (the probe value from Values) and "context" ($).
 
 Use:
   livenessProbe:
-  {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" .Values.services.api.livenessProbe "context" .) | nindent 10 }}
+  {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" .Values.services.api.livenessProbe "context" .) | nindent 10 }}
 */}}
-{{- define "osmo.v1.upstream-probe-yaml" -}}
+{{- define "osmo.gateway.upstreamProbeYaml" -}}
 {{- $probe := .probe }}
 {{- if and $probe .context.Values.gateway.tls.enabled (hasKey $probe "httpGet") }}
   {{- $probe = mustMergeOverwrite (deepCopy $probe) (dict "httpGet" (dict "scheme" "HTTPS")) }}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -27,7 +27,7 @@ app.kubernetes.io/name: {{ include "osmo.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-{{- define "osmo.labels" -}}
+{{- define "osmo.metadata.standardLabels" -}}
 {{- $identity := dict
       "helm.sh/chart" (include "osmo.chart" .)
       "app.kubernetes.io/name" (include "osmo.name" .)
@@ -37,6 +37,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion -}}
 {{- $_ := set $identity "app.kubernetes.io/version" .Chart.AppVersion -}}
 {{- end -}}
+{{- toYaml $identity -}}
+{{- end -}}
+
+{{- define "osmo.labels" -}}
+{{- $identity := include "osmo.metadata.standardLabels" . | fromYaml -}}
 {{- toYaml (mergeOverwrite (deepCopy .Values.commonLabels) $identity) -}}
 {{- end -}}
 
@@ -46,10 +51,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- toYaml $labels -}}
 {{- end -}}
 
-{{- define "osmo.component.labels" -}}
-{{- $labels := include "osmo.labels" .root | fromYaml -}}
+{{- define "osmo.component.standardLabels" -}}
+{{- $labels := include "osmo.metadata.standardLabels" .root | fromYaml -}}
 {{- $_ := set $labels "app.kubernetes.io/component" .component -}}
 {{- toYaml $labels -}}
+{{- end -}}
+
+{{- define "osmo.component.labels" -}}
+{{- $labels := deepCopy .root.Values.commonLabels -}}
+{{- $identity := include "osmo.component.standardLabels" . | fromYaml -}}
+{{- toYaml (mergeOverwrite $labels $identity) -}}
 {{- end -}}
 
 {{- define "osmo.component.fullname" -}}
@@ -114,8 +125,19 @@ default
 
 {{- define "osmo.pod.labels" -}}
 {{- $labels := mergeOverwrite (deepCopy .root.Values.commonLabels) .root.Values.podDefaults.labels (dig "pod" "labels" dict .component) -}}
-{{- $identity := include "osmo.component.selectorLabels" (dict "root" .root "component" .componentName) | fromYaml -}}
+{{- $identity := include "osmo.component.standardLabels" (dict "root" .root "component" .componentName) | fromYaml -}}
 {{- toYaml (mergeOverwrite $labels $identity) -}}
+{{- end -}}
+
+{{- define "osmo.pod.topologySpreadConstraints" -}}
+{{- $constraints := list -}}
+{{- $selectorLabels := include "osmo.component.selectorLabels" (dict "root" .root "component" .componentName) | fromYaml -}}
+{{- range .constraints -}}
+{{- $constraint := omit (deepCopy .) "labelSelector" -}}
+{{- $_ := set $constraint "labelSelector" (dict "matchLabels" (deepCopy $selectorLabels)) -}}
+{{- $constraints = append $constraints $constraint -}}
+{{- end -}}
+{{- with $constraints }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
 {{- define "osmo.pod.tolerations" -}}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -154,6 +154,30 @@ default
 {{- with $selector }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
+{{- define "osmo.pod.affinity" -}}
+{{- $affinity := mergeOverwrite (deepCopy .root.Values.podDefaults.affinity) (dig "pod" "affinity" dict .component) -}}
+{{- with $affinity }}{{ toYaml . }}{{- end -}}
+{{- end -}}
+
+{{- define "osmo.pod.securityContext" -}}
+{{- $context := mergeOverwrite (deepCopy .root.Values.podDefaults.podSecurityContext) (dig "pod" "podSecurityContext" dict .component) -}}
+{{- with $context }}{{ toYaml . }}{{- end -}}
+{{- end -}}
+
+{{- define "osmo.container.securityContext" -}}
+{{- $context := mergeOverwrite (deepCopy .root.Values.podDefaults.containerSecurityContext) (dig "pod" "containerSecurityContext" dict .component) -}}
+{{- with $context }}{{ toYaml . }}{{- end -}}
+{{- end -}}
+
+{{- define "osmo.pod.terminationGracePeriodSeconds" -}}
+{{- $pod := dig "pod" dict .component -}}
+{{- if hasKey $pod "terminationGracePeriodSeconds" -}}
+{{- $pod.terminationGracePeriodSeconds -}}
+{{- else -}}
+{{- .root.Values.podDefaults.terminationGracePeriodSeconds -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "osmo.component.extraEnv" -}}
 {{- with .env }}{{ toYaml . }}{{- end -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -1,15 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- define "osmo.v1.name" -}}
+{{- define "osmo.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "osmo.v1.fullname" -}}
+{{- define "osmo.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := include "osmo.v1.name" . -}}
+{{- $name := include "osmo.name" . -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -18,38 +18,51 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.chart" -}}
+{{- define "osmo.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "osmo.v1.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "osmo.v1.name" . }}
+{{- define "osmo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "osmo.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
-{{- define "osmo.v1.labels" -}}
-helm.sh/chart: {{ include "osmo.v1.chart" . }}
-{{ include "osmo.v1.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- with .Values.commonLabels }}
-{{ toYaml . }}
-{{- end }}
+{{- define "osmo.labels" -}}
+{{- $identity := dict
+      "helm.sh/chart" (include "osmo.chart" .)
+      "app.kubernetes.io/name" (include "osmo.name" .)
+      "app.kubernetes.io/instance" .Release.Name
+      "app.kubernetes.io/managed-by" .Release.Service
+      "app.kubernetes.io/part-of" (include "osmo.name" .) -}}
+{{- if .Chart.AppVersion -}}
+{{- $_ := set $identity "app.kubernetes.io/version" .Chart.AppVersion -}}
+{{- end -}}
+{{- toYaml (mergeOverwrite (deepCopy .Values.commonLabels) $identity) -}}
 {{- end -}}
 
-{{- define "osmo.v1.componentName" -}}
+{{- define "osmo.component.selectorLabels" -}}
+{{- $labels := include "osmo.selectorLabels" .root | fromYaml -}}
+{{- $_ := set $labels "app.kubernetes.io/component" .component -}}
+{{- toYaml $labels -}}
+{{- end -}}
+
+{{- define "osmo.component.labels" -}}
+{{- $labels := include "osmo.labels" .root | fromYaml -}}
+{{- $_ := set $labels "app.kubernetes.io/component" .component -}}
+{{- toYaml $labels -}}
+{{- end -}}
+
+{{- define "osmo.component.fullname" -}}
 {{- $root := .root -}}
 {{- $suffix := .suffix -}}
 {{- if eq $suffix "" -}}
-{{- include "osmo.v1.fullname" $root -}}
+{{- include "osmo.fullname" $root -}}
 {{- else -}}
-{{- printf "%s-%s" (include "osmo.v1.fullname" $root) $suffix | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "osmo.fullname" $root) $suffix | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.image" -}}
+{{- define "osmo.component.image" -}}
 {{- $root := .root -}}
 {{- $component := .component -}}
 {{- $registry := $root.Values.image.registry -}}
@@ -59,52 +72,53 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- printf "%s/%s/%s:%s" $registry $prefix $name $tag -}}
 {{- end -}}
 
-{{- define "osmo.v1.imageRepository" -}}
+{{- define "osmo.component.imageRepository" -}}
 {{- printf "%s/%s" .Values.image.registry .Values.image.repositoryPrefix -}}
 {{- end -}}
 
-{{- define "osmo.v1.imageTag" -}}
+{{- define "osmo.component.imageTag" -}}
 {{- .Values.image.tag | default .Chart.AppVersion -}}
 {{- end -}}
 
-{{- define "osmo.v1.hostname" -}}
+{{- define "osmo.hostname" -}}
 {{- $url := trimSuffix "/" .Values.exposure.baseUrl -}}
 {{- $withoutScheme := regexReplaceAll "^https?://" $url "" -}}
 {{- regexReplaceAll "[:/].*$" $withoutScheme "" -}}
 {{- end -}}
 
-{{- define "osmo.v1.imagePullPolicy" -}}
+{{- define "osmo.component.imagePullPolicy" -}}
 {{- .component.image.pullPolicy | default .root.Values.image.pullPolicy -}}
 {{- end -}}
 
-{{- define "osmo.v1.imagePullSecrets" -}}
+{{- define "osmo.component.imagePullSecrets" -}}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml . | nindent 2 }}
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.v1.service-account-name" -}}
+{{- define "osmo.component.serviceAccountName" -}}
 {{- if .component.serviceAccount.name -}}
 {{- .component.serviceAccount.name -}}
 {{- else if .component.serviceAccount.create -}}
-{{- include "osmo.v1.componentName" (dict "root" .root "suffix" .suffix) -}}
+{{- include "osmo.component.fullname" (dict "root" .root "suffix" .suffix) -}}
 {{- else -}}
 default
 {{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.extra-annotations" -}}
+{{- define "osmo.pod.annotations" -}}
 {{- $annotations := mergeOverwrite (deepCopy .root.Values.commonAnnotations) .root.Values.podDefaults.annotations (dig "pod" "annotations" dict .component) -}}
 {{- with $annotations }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.pod-default-labels" -}}
+{{- define "osmo.pod.labels" -}}
 {{- $labels := mergeOverwrite (deepCopy .root.Values.commonLabels) .root.Values.podDefaults.labels (dig "pod" "labels" dict .component) -}}
-{{- with $labels }}{{ toYaml . }}{{- end -}}
+{{- $identity := include "osmo.component.selectorLabels" (dict "root" .root "component" .componentName) | fromYaml -}}
+{{- toYaml (mergeOverwrite $labels $identity) -}}
 {{- end -}}
 
-{{- define "osmo.v1.tolerations" -}}
+{{- define "osmo.pod.tolerations" -}}
 {{- $pod := dig "pod" dict .component -}}
 {{- if hasKey $pod "tolerations" -}}
 {{- toYaml $pod.tolerations -}}
@@ -113,28 +127,28 @@ default
 {{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.node-selector" -}}
+{{- define "osmo.pod.nodeSelector" -}}
 {{- $selector := mergeOverwrite (deepCopy .root.Values.podDefaults.nodeSelector) (dig "pod" "nodeSelector" dict .component) -}}
 {{- with $selector }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.extra-env" -}}
+{{- define "osmo.component.extraEnv" -}}
 {{- with .env }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.extra-volume-mounts" -}}
+{{- define "osmo.component.extraVolumeMounts" -}}
 {{- with (dig "volumeMounts" list .) }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.extra-volumes" -}}
+{{- define "osmo.pod.extraVolumes" -}}
 {{- with (dig "pod" "volumes" list .) }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.extra-sidecars" -}}
+{{- define "osmo.pod.extraSidecars" -}}
 {{- with (dig "pod" "sidecars" list .) }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.extra-configmaps" -}}
+{{- define "osmo.configuration.extraConfigMaps" -}}
 {{- range .Values.configuration.extraConfigMaps }}
 ---
 apiVersion: v1
@@ -143,35 +157,35 @@ metadata:
   name: {{ .name }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "osmo.v1.labels" $ | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" $ "component" "configuration") | nindent 4 }}
 data:
   {{- toYaml .data | nindent 2 }}
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.v1.apiName" -}}
-{{- include "osmo.v1.componentName" (dict "root" . "suffix" "service") -}}
+{{- define "osmo.api.fullname" -}}
+{{- include "osmo.component.fullname" (dict "root" . "suffix" "api") -}}
 {{- end -}}
 
-{{- define "osmo.v1.configmap-args" -}}
+{{- define "osmo.configuration.args" -}}
 {{- if .Values.configuration.enabled }}
 - --config_file
 - /etc/osmo/configs/config.yaml
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.v1.configmap-env" -}}
+{{- define "osmo.configuration.env" -}}
 {{- if .Values.configuration.enabled }}
 - name: POD_NAMESPACE
   valueFrom:
     fieldRef:
       fieldPath: metadata.namespace
 - name: OSMO_CONFIGMAP_NAME
-  value: {{ include "osmo.v1.apiName" . }}-configs
+  value: {{ include "osmo.api.fullname" . }}-config
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.v1.configmap-volume-mounts" -}}
+{{- define "osmo.configuration.volumeMounts" -}}
 {{- if .Values.configuration.enabled }}
 - name: configs
   mountPath: /etc/osmo/configs
@@ -184,11 +198,11 @@ data:
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.v1.configmap-volumes" -}}
+{{- define "osmo.configuration.volumes" -}}
 {{- if .Values.configuration.enabled }}
 - name: configs
   configMap:
-    name: {{ include "osmo.v1.apiName" . }}-configs
+    name: {{ include "osmo.api.fullname" . }}-config
 {{- with .Values.secrets.objectStorage.existingSecret }}
 - name: object-storage-credentials
   secret:
@@ -197,7 +211,7 @@ data:
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.v1.mcp-resource-url" -}}
+{{- define "osmo.mcp.resourceUrl" -}}
 {{- $resourceUrl := required "services.mcp.resourceUrl is required when MCP is enabled" .Values.services.mcp.resourceUrl -}}
 {{- if not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?/mcp$" $resourceUrl) -}}
 {{- fail "services.mcp.resourceUrl must be a valid HTTPS origin followed by the exact /mcp path" -}}
@@ -205,7 +219,7 @@ data:
 {{- $resourceUrl -}}
 {{- end -}}
 
-{{- define "osmo.v1.mek-volume" -}}
+{{- define "osmo.secrets.mekVolume" -}}
 {{- with .Values.secrets.masterEncryptionKey.existingSecret }}
 - name: mek-volume
   secret:
@@ -216,7 +230,7 @@ data:
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.v1.external-ca-volume-mounts" -}}
+{{- define "osmo.externalDependencies.caVolumeMounts" -}}
 {{- if .Values.externalDependencies.postgresql.tls.enabled }}
 - name: postgresql-ca
   mountPath: /etc/osmo/ca/postgresql
@@ -229,7 +243,7 @@ data:
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.v1.external-ca-volumes" -}}
+{{- define "osmo.externalDependencies.caVolumes" -}}
 {{- if .Values.externalDependencies.postgresql.tls.enabled }}
 - name: postgresql-ca
   secret:
@@ -248,7 +262,7 @@ data:
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.v1.connection-secret-env" -}}
+{{- define "osmo.externalDependencies.connectionSecretEnv" -}}
 {{- with .Values.secrets.postgresql.existingSecret }}
 - name: OSMO_POSTGRES_PASSWORD
   valueFrom:

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -83,19 +83,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "osmo.component.image" -}}
 {{- $root := .root -}}
 {{- $component := .component -}}
-{{- $registry := $root.Values.image.registry -}}
-{{- $prefix := $root.Values.image.repositoryPrefix -}}
-{{- $name := required "component image.name is required" $component.image.name -}}
-{{- $tag := $component.image.tag | default $root.Values.image.tag | default $root.Chart.AppVersion -}}
-{{- printf "%s/%s/%s:%s" $registry $prefix $name $tag -}}
+{{- $registry := $root.Values.global.imageRegistry | default $component.image.registry -}}
+{{- $repository := required "component image.repository is required" $component.image.repository -}}
+{{- $base := ternary (printf "%s/%s" $registry $repository) $repository (ne $registry "") -}}
+{{- if $component.image.digest -}}
+{{- printf "%s@%s" $base $component.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $base ($component.image.tag | default $root.Chart.AppVersion) -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "osmo.component.imageRepository" -}}
-{{- printf "%s/%s" .Values.image.registry .Values.image.repositoryPrefix -}}
+{{- $registry := .Values.global.imageRegistry | default .Values.runtimeImage.registry -}}
+{{- ternary (printf "%s/%s" $registry .Values.runtimeImage.repository) .Values.runtimeImage.repository (ne $registry "") -}}
 {{- end -}}
 
 {{- define "osmo.component.imageTag" -}}
-{{- .Values.image.tag | default .Chart.AppVersion -}}
+{{- .Values.runtimeImage.tag | default .Chart.AppVersion -}}
 {{- end -}}
 
 {{- define "osmo.hostname" -}}
@@ -105,11 +109,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "osmo.component.imagePullPolicy" -}}
-{{- .component.image.pullPolicy | default .root.Values.image.pullPolicy -}}
+{{- .component.image.pullPolicy -}}
 {{- end -}}
 
 {{- define "osmo.component.imagePullSecrets" -}}
-{{- with .Values.imagePullSecrets }}
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{ toYaml . | nindent 2 }}
 {{- end }}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -195,11 +195,11 @@ default
 {{- end -}}
 
 {{- define "osmo.component.extraVolumeMounts" -}}
-{{- with (dig "volumeMounts" list .) }}{{ toYaml . }}{{- end -}}
+{{- with (dig "extraVolumeMounts" list .) }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
 {{- define "osmo.pod.extraVolumes" -}}
-{{- with (dig "pod" "volumes" list .) }}{{ toYaml . }}{{- end -}}
+{{- with (dig "pod" "extraVolumes" list .) }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
 {{- define "osmo.pod.extraSidecars" -}}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -63,6 +63,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- toYaml (mergeOverwrite $labels $identity) -}}
 {{- end -}}
 
+{{- define "osmo.metadata.annotations" -}}
+{{- $annotations := deepCopy .root.Values.commonAnnotations -}}
+{{- $annotations = mergeOverwrite $annotations (dig "annotations" dict .) -}}
+{{- $annotations = mergeOverwrite $annotations (dig "protectedAnnotations" dict .) -}}
+{{- with $annotations }}{{ toYaml . }}{{- end -}}
+{{- end -}}
+
 {{- define "osmo.component.fullname" -}}
 {{- $root := .root -}}
 {{- $suffix := .suffix -}}
@@ -120,6 +127,7 @@ default
 
 {{- define "osmo.pod.annotations" -}}
 {{- $annotations := mergeOverwrite (deepCopy .root.Values.commonAnnotations) .root.Values.podDefaults.annotations (dig "pod" "annotations" dict .component) -}}
+{{- $annotations = mergeOverwrite $annotations (dig "protectedAnnotations" dict .) -}}
 {{- with $annotations }}{{ toYaml . }}{{- end -}}
 {{- end -}}
 
@@ -204,6 +212,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "osmo.component.labels" (dict "root" $ "component" "configuration") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" $)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   {{- toYaml .data | nindent 2 }}
 {{- end }}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -81,7 +81,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "osmo.hostname" -}}
-{{- $url := trimSuffix "/" .Values.exposure.baseUrl -}}
+{{- $url := trimSuffix "/" .Values.externalUrl -}}
 {{- $withoutScheme := regexReplaceAll "^https?://" $url "" -}}
 {{- regexReplaceAll "[:/].*$" $withoutScheme "" -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/_notes.tpl
+++ b/deployments/charts/osmo/templates/_notes.tpl
@@ -1,0 +1,34 @@
+{{/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+
+{{- define "osmo.notes" -}}
+OSMO control plane installed.
+
+The API component is named {{ include "osmo.api.fullname" . }}. The gateway
+Service has one port and follows gateway.envoy.service.type; Ingress and
+HTTPRoute are optional edge resources.
+
+Configured public URL:
+
+  {{ .Values.externalUrl }}
+
+An HTTPRoute attaches to an existing Gateway named in httproute.parentRefs;
+this chart does not create a Gateway or GatewayClass.
+
+To test a ClusterIP gateway locally, run:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "osmo.gateway.fullname" . }} 8080:{{ .Values.gateway.envoy.service.port }}
+
+{{- if .Values.gateway.envoy.ssl.enabled }}
+
+For a local-only TLS check, disable certificate verification because the
+gateway certificate normally identifies its public DNS name:
+
+  curl --insecure https://127.0.0.1:8080/api/version
+{{- else }}
+
+Then query:
+
+  curl http://127.0.0.1:8080/api/version
+{{- end }}
+{{- end }}

--- a/deployments/charts/osmo/templates/_notes.tpl
+++ b/deployments/charts/osmo/templates/_notes.tpl
@@ -12,8 +12,10 @@ Configured public URL:
 
   {{ .Values.externalUrl }}
 
+{{ if .Values.httproute.enabled }}
 An HTTPRoute attaches to an existing Gateway named in httproute.parentRefs;
 this chart does not create a Gateway or GatewayClass.
+{{ end }}
 
 To test a ClusterIP gateway locally, run:
 

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -25,6 +25,9 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "agent") | nindent 4 }}
 spec:
+  {{- if not .Values.services.agent.autoscaling.enabled }}
+  replicas: {{ .Values.services.agent.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "agent") | nindent 6 }}
@@ -180,6 +183,7 @@ spec:
 
 ---
 
+{{- if .Values.services.agent.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -194,7 +198,12 @@ spec:
     name: {{ $name }}
   minReplicas: {{ .Values.services.agent.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.services.agent.autoscaling.maxReplicas }}
+  {{- with .Values.services.agent.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
+  {{- if .Values.services.agent.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       name: memory
@@ -202,6 +211,8 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.agent.autoscaling.hpaMemoryTarget }}
+  {{- end }}
+  {{- if .Values.services.agent.autoscaling.hpaCpuTarget }}
   - type: ContainerResource
     containerResource:
       name: cpu
@@ -209,7 +220,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.agent.autoscaling.hpaCpuTarget }}
+  {{- end }}
   {{- with .Values.services.agent.autoscaling.customMetrics }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -28,6 +28,10 @@ spec:
   {{- if not .Values.services.agent.autoscaling.enabled }}
   replicas: {{ .Values.services.agent.replicas }}
   {{- end }}
+  {{- with .Values.services.agent.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "agent") | nindent 6 }}
@@ -38,6 +42,14 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.agent) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.services.agent.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" .Values.services.agent) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" .Values.services.agent) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" .Values.services.agent)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with .Values.services.agent.pod.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
@@ -64,11 +76,7 @@ spec:
         command:
         - agent_service
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 1001
+          {{- include "osmo.container.securityContext" (dict "root" . "component" .Values.services.agent) | nindent 10 }}
         ports:
         - name: metrics
           containerPort: 9464

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -24,6 +24,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "agent") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.services.agent.autoscaling.enabled }}
   replicas: {{ .Values.services.agent.replicas }}
@@ -180,6 +184,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "agent") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: 80
@@ -198,7 +206,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "agent") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
   annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -132,9 +132,11 @@ spec:
         {{- include "osmo.component.extraEnv" .Values.services.agent | nindent 8 }}
         {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
         imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.agent) }}
-        {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.configuration.enabled .Values.services.agent.volumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.agent) .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
-        {{- end }}
+        - name: osmo-runtime-tmp
+          mountPath: /tmp
+        - name: osmo-progress-files
+          mountPath: /var/run/osmo
         {{- if .Values.secrets.masterEncryptionKey.existingSecret}}
         - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
           name: mek-volume
@@ -170,6 +172,10 @@ spec:
 
       {{- include "osmo.pod.extraSidecars" .Values.services.agent | nindent 6 }}
       volumes:
+        - name: osmo-runtime-tmp
+          emptyDir: {}
+        - name: osmo-progress-files
+          emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.agent | nindent 8 }}
         {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -17,24 +17,23 @@
 {{/* Create a copy of the shared sidecar config values */}}
 
 {{- if and .Values.planes.control.enabled .Values.services.agent.enabled }}
-{{- $name := include "osmo.v1.componentName" (dict "root" . "suffix" "agent") }}
+{{- $name := include "osmo.component.fullname" (dict "root" . "suffix" "agent") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "agent") | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ $name }}
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "agent") | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ $name }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" .Values.services.agent) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.agent "componentName" "agent") | nindent 8 }}
       annotations:
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" .Values.services.agent) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.agent) | nindent 8 }}
     spec:
       {{- with .Values.services.agent.pod.hostAliases }}
       hostAliases:
@@ -50,23 +49,23 @@ spec:
         {{- end }}
         labelSelector:
           matchLabels:
-            app: {{ $name }}
+            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "agent") | nindent 12 }}
       {{- end }}
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" .Values.services.agent)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.agent)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" .Values.services.agent) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" .Values.services.agent "root" . "suffix" "agent") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" .Values.services.agent) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" .Values.services.agent "root" . "suffix" "agent") }}
       {{- with .Values.services.agent.pod.initContainers }}
       initContainers:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ $name }}
-        image: {{ include "osmo.v1.image" (dict "root" . "component" .Values.services.agent) }}
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.agent) }}
         command:
         - agent_service
         securityContext:
@@ -89,7 +88,7 @@ spec:
         - --redis_tls_enable
         - "true"
         {{- end}}
-        {{- $serviceHostname := .Values.services.api.hostname | default (include "osmo.v1.hostname" .) }}
+        {{- $serviceHostname := .Values.services.api.hostname | default (include "osmo.hostname" .) }}
         {{- if $serviceHostname }}
         - --service_hostname
         - {{ $serviceHostname }}
@@ -116,16 +115,16 @@ spec:
         - --log_format
         - {{ .Values.logging.logFormat | default "text" }}
         {{- end }}
-        {{- include "osmo.v1.configmap-args" . | nindent 8 }}
+        {{- include "osmo.configuration.args" . | nindent 8 }}
         {{- range $arg := .Values.services.agent.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
-        {{- include "osmo.v1.upstream-tls-args" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
         env:
-        {{- include "osmo.v1.configmap-env" . | nindent 8 }}
-        {{- include "osmo.v1.extra-env" .Values.services.agent | nindent 8 }}
-        {{- include "osmo.v1.connection-secret-env" . | nindent 8 }}
-        imagePullPolicy: {{ include "osmo.v1.imagePullPolicy" (dict "root" . "component" .Values.services.agent) }}
+        {{- include "osmo.configuration.env" . | nindent 8 }}
+        {{- include "osmo.component.extraEnv" .Values.services.agent | nindent 8 }}
+        {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.agent) }}
         {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.configuration.enabled .Values.services.agent.volumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.agent) .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
         {{- end }}
@@ -134,10 +133,10 @@ spec:
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
-        {{- include "osmo.v1.configmap-volume-mounts" . | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volume-mounts" . | nindent 8 }}
-        {{- include "osmo.v1.extra-volume-mounts" .Values.services.agent | nindent 8 }}
-        {{- include "osmo.v1.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
+        {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
+        {{- include "osmo.component.extraVolumeMounts" .Values.services.agent | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
         resources:
         {{- toYaml .Values.services.agent.resources | nindent 10 }}
 
@@ -160,15 +159,15 @@ spec:
         {{- end }}
 
         readinessProbe:
-          {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" .Values.services.agent.readinessProbe "context" .) | nindent 10 }}
+          {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" .Values.services.agent.readinessProbe "context" .) | nindent 10 }}
 
-      {{- include "osmo.v1.extra-sidecars" .Values.services.agent | nindent 6 }}
+      {{- include "osmo.pod.extraSidecars" .Values.services.agent | nindent 6 }}
       volumes:
-        {{- include "osmo.v1.extra-volumes" .Values.services.agent | nindent 8 }}
-        {{- include "osmo.v1.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
-        {{- include "osmo.v1.mek-volume" . | nindent 8 }}
-        {{- include "osmo.v1.configmap-volumes" . | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volumes" . | nindent 8 }}
+        {{- include "osmo.pod.extraVolumes" .Values.services.agent | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
+        {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.configuration.volumes" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 
 ---
 
@@ -177,7 +176,7 @@ kind: Service
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "agent") | nindent 4 }}
 spec:
   ports:
     - port: 80
@@ -185,7 +184,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ $name }}
+    {{- include "osmo.component.selectorLabels" (dict "root" . "component" "agent") | nindent 4 }}
 
 ---
 
@@ -194,7 +193,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "agent") | nindent 4 }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -39,17 +39,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.services.agent.pod.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range .Values.services.agent.pod.topologySpreadConstraints }}
-      - topologyKey: {{.topologyKey }}
-        {{- range $key, $value := . }}
-        {{- if ne $key "topologyKey" }}
-        {{$key}}: {{$value}}
-        {{- end }}
-        {{- end }}
-        labelSelector:
-          matchLabels:
-            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "agent") | nindent 12 }}
+        {{- include "osmo.pod.topologySpreadConstraints" (dict "root" $ "constraints" . "componentName" "agent") | nindent 8 }}
       {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.agent)) }}
       nodeSelector:

--- a/deployments/charts/osmo/templates/api-monitor.yaml
+++ b/deployments/charts/osmo/templates/api-monitor.yaml
@@ -18,21 +18,21 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "osmo.v1.componentName" (dict "root" $root "suffix" "otel-monitor") }}
+  name: {{ include "osmo.component.fullname" (dict "root" $root "suffix" "otel-monitor") }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" $root "component" "monitoring") | nindent 4 }}
 spec:
   podMetricsEndpoints:
   - interval: 15s
     port: metrics
     path: /metrics
   selector:
+    matchLabels:
+      {{- include "osmo.selectorLabels" $root | nindent 6 }}
     matchExpressions:
-    - { key: app,
+    - { key: app.kubernetes.io/component,
         operator: In,
-        values: [{{ include "osmo.v1.componentName" (dict "root" $root "suffix" "agent") }},
-                 {{ include "osmo.v1.apiName" $root }},
-                 {{ include "osmo.v1.componentName" (dict "root" $root "suffix" "worker") }},
-                 {{ include "osmo.v1.componentName" (dict "root" $root "suffix" "logger") }},
-                 {{ include "osmo.v1.componentName" (dict "root" $root "suffix" "delayed-job-monitor") }}]
+        values: [agent, api, worker, logger, delayed-job-monitor]
       }
 {{- end }}
 {{- if and .Values.services.api.monitoring.podMonitor.enabled .Values.gateway.envoy.enabled }}
@@ -40,7 +40,9 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "osmo.v1.componentName" (dict "root" . "suffix" "gateway-envoy-monitor") }}
+  name: {{ include "osmo.component.fullname" (dict "root" . "suffix" "gateway-envoy-monitor") }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "monitoring") | nindent 4 }}
 spec:
   podMetricsEndpoints:
   - interval: 15s
@@ -48,16 +50,16 @@ spec:
     path: /stats/prometheus
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "osmo.v1.gateway-name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: envoy
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "gateway-envoy") | nindent 6 }}
 {{- end }}
 {{- if and .Values.services.api.monitoring.podMonitor.enabled .Values.gateway.oauth2Proxy.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: {{ include "osmo.v1.componentName" (dict "root" . "suffix" "gateway-oauth2-proxy-monitor") }}
+  name: {{ include "osmo.component.fullname" (dict "root" . "suffix" "gateway-oauth2-proxy-monitor") }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "monitoring") | nindent 4 }}
 spec:
   podMetricsEndpoints:
   - interval: 15s
@@ -65,7 +67,5 @@ spec:
     path: /metrics
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "osmo.v1.gateway-name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: oauth2-proxy
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "gateway-oauth2-proxy") | nindent 6 }}
 {{- end }}

--- a/deployments/charts/osmo/templates/api-monitor.yaml
+++ b/deployments/charts/osmo/templates/api-monitor.yaml
@@ -48,8 +48,8 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with $monitor.targetLabels }}
-  targetLabels:
+  {{- with $monitor.podTargetLabels }}
+  podTargetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   podMetricsEndpoints:
@@ -77,8 +77,8 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with $monitor.targetLabels }}
-  targetLabels:
+  {{- with $monitor.podTargetLabels }}
+  podTargetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   podMetricsEndpoints:
@@ -101,8 +101,8 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with $monitor.targetLabels }}
-  targetLabels:
+  {{- with $monitor.podTargetLabels }}
+  podTargetLabels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   podMetricsEndpoints:

--- a/deployments/charts/osmo/templates/api-monitor.yaml
+++ b/deployments/charts/osmo/templates/api-monitor.yaml
@@ -13,19 +13,47 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-{{- if .Values.services.api.monitoring.podMonitor.enabled }}
+{{- define "osmo.monitoring.podMetricsEndpoint" -}}
+interval: {{ .monitor.interval }}
+scrapeTimeout: {{ .monitor.scrapeTimeout }}
+scheme: {{ .monitor.scheme }}
+port: {{ .port }}
+path: {{ .path }}
+honorLabels: {{ .monitor.honorLabels }}
+{{- with .monitor.tlsConfig }}
+tlsConfig:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .monitor.relabelings }}
+relabelings:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .monitor.metricRelabelings }}
+metricRelabelings:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+{{- $monitor := .Values.monitoring.podMonitor -}}
+{{- if $monitor.enabled }}
 {{- $root := . }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "osmo.component.fullname" (dict "root" $root "suffix" "otel-monitor") }}
   labels:
-    {{- include "osmo.component.labels" (dict "root" $root "component" "monitoring") | nindent 4 }}
+    {{- $labels := mergeOverwrite (deepCopy $monitor.labels) (include "osmo.component.labels" (dict "root" $root "component" "monitoring") | fromYaml) }}
+    {{- toYaml $labels | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" $root "annotations" $monitor.annotations)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- with $monitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   podMetricsEndpoints:
-  - interval: 15s
-    port: metrics
-    path: /metrics
+  - {{ include "osmo.monitoring.podMetricsEndpoint" (dict "monitor" $monitor "port" "metrics" "path" "/metrics") | nindent 4 | trim }}
   selector:
     matchLabels:
       {{- include "osmo.selectorLabels" $root | nindent 6 }}
@@ -35,36 +63,50 @@ spec:
         values: [agent, api, worker, logger, delayed-job-monitor]
       }
 {{- end }}
-{{- if and .Values.services.api.monitoring.podMonitor.enabled .Values.gateway.envoy.enabled }}
+{{- if and $monitor.enabled .Values.gateway.envoy.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "osmo.component.fullname" (dict "root" . "suffix" "gateway-envoy-monitor") }}
   labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "monitoring") | nindent 4 }}
+    {{- $labels := mergeOverwrite (deepCopy $monitor.labels) (include "osmo.component.labels" (dict "root" . "component" "monitoring") | fromYaml) }}
+    {{- toYaml $labels | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" . "annotations" $monitor.annotations)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- with $monitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   podMetricsEndpoints:
-  - interval: 15s
-    port: envoy-admin
-    path: /stats/prometheus
+  - {{ include "osmo.monitoring.podMetricsEndpoint" (dict "monitor" $monitor "port" "envoy-admin" "path" "/stats/prometheus") | nindent 4 | trim }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "gateway-envoy") | nindent 6 }}
 {{- end }}
-{{- if and .Values.services.api.monitoring.podMonitor.enabled .Values.gateway.oauth2Proxy.enabled }}
+{{- if and $monitor.enabled .Values.gateway.oauth2Proxy.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ include "osmo.component.fullname" (dict "root" . "suffix" "gateway-oauth2-proxy-monitor") }}
   labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "monitoring") | nindent 4 }}
+    {{- $labels := mergeOverwrite (deepCopy $monitor.labels) (include "osmo.component.labels" (dict "root" . "component" "monitoring") | fromYaml) }}
+    {{- toYaml $labels | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" . "annotations" $monitor.annotations)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
+  {{- with $monitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   podMetricsEndpoints:
-  - interval: 15s
-    port: oauth2-metrics
-    path: /metrics
+  - {{ include "osmo.monitoring.podMetricsEndpoint" (dict "monitor" $monitor "port" "oauth2-metrics" "path" "/metrics") | nindent 4 | trim }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "gateway-oauth2-proxy") | nindent 6 }}

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -25,6 +25,10 @@ spec:
   {{- if not .Values.services.api.autoscaling.enabled }}
   replicas: {{ .Values.services.api.replicas }}
   {{- end }}
+  {{- with .Values.services.api.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "api") | nindent 6 }}
@@ -35,6 +39,14 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.api) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.services.api.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" .Values.services.api) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" .Values.services.api) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" .Values.services.api)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with .Values.services.api.pod.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
@@ -148,11 +160,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.api) }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 1001
+          {{- include "osmo.container.securityContext" (dict "root" . "component" .Values.services.api) | nindent 10 }}
         ports:
         - name: metrics
           containerPort: 9464

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -168,9 +168,9 @@ spec:
         ports:
         - name: metrics
           containerPort: 9464
-        {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.configuration.enabled .Values.services.api.volumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.api) .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
-        {{- end }}
+        - name: osmo-runtime-tmp
+          mountPath: /tmp
         {{- if .Values.secrets.masterEncryptionKey.existingSecret}}
         - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
           name: mek-volume
@@ -199,6 +199,8 @@ spec:
 
       {{- include "osmo.pod.extraSidecars" .Values.services.api | nindent 6 }}
       volumes:
+        - name: osmo-runtime-tmp
+          emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.api | nindent 8 }}
         {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.api) | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -22,6 +22,9 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
 spec:
+  {{- if not .Values.services.api.autoscaling.enabled }}
+  replicas: {{ .Values.services.api.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "api") | nindent 6 }}
@@ -208,6 +211,7 @@ spec:
 
 ---
 
+{{- if .Values.services.api.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -222,7 +226,12 @@ spec:
     name: {{ $name }}
   minReplicas: {{ .Values.services.api.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.services.api.autoscaling.maxReplicas }}
+  {{- with .Values.services.api.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
+  {{- if .Values.services.api.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       name: memory
@@ -230,6 +239,8 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.api.autoscaling.hpaMemoryTarget }}
+  {{- end }}
+  {{- if .Values.services.api.autoscaling.hpaCpuTarget }}
   - type: ContainerResource
     containerResource:
       name: cpu
@@ -237,7 +248,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.api.autoscaling.hpaCpuTarget }}
+  {{- end }}
   {{- with .Values.services.api.autoscaling.customMetrics }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -14,24 +14,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 {{- if and .Values.planes.control.enabled .Values.services.api.enabled }}
-{{- $name := include "osmo.v1.componentName" (dict "root" . "suffix" "service") }}
+{{- $name := include "osmo.api.fullname" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ $name }}
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "api") | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ $name }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" .Values.services.api) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.api "componentName" "api") | nindent 8 }}
       annotations:
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" .Values.services.api) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.api) | nindent 8 }}
     spec:
       {{- with .Values.services.api.pod.hostAliases }}
       hostAliases:
@@ -47,23 +46,23 @@ spec:
         {{- end }}
         labelSelector:
           matchLabels:
-            app: {{ $name }}
+            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "api") | nindent 12 }}
       {{- end }}
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" .Values.services.api)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.api)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" .Values.services.api) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" .Values.services.api "root" . "suffix" "service") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" .Values.services.api) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" .Values.services.api "root" . "suffix" "api") }}
       {{- with .Values.services.api.pod.initContainers }}
       initContainers:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ $name }}
-        image: {{ include "osmo.v1.image" (dict "root" . "component" .Values.services.api) }}
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.api) }}
         command:
         - service
         args:
@@ -109,7 +108,7 @@ spec:
         - --logout_endpoint
         - {{ .Values.services.api.auth.logout_endpoint }}
         {{- end }}
-        {{- $serviceHostname := .Values.services.api.hostname | default (include "osmo.v1.hostname" .) }}
+        {{- $serviceHostname := .Values.services.api.hostname | default (include "osmo.hostname" .) }}
         {{- if $serviceHostname }}
         - --service_hostname
         - {{ $serviceHostname }}
@@ -119,9 +118,9 @@ spec:
         - {{ .Values.services.api.clientInstallUrl }}
         {{- end }}
         - --osmo_image_location
-        - {{ include "osmo.v1.imageRepository" . }}
+        - {{ include "osmo.component.imageRepository" . }}
         - --osmo_image_tag
-        - {{ include "osmo.v1.imageTag" . | quote }}
+        - {{ include "osmo.component.imageTag" . | quote }}
         {{- if .Values.logging.enabled }}
         - --log_level
         - {{ .Values.logging.logLevel }}
@@ -134,17 +133,17 @@ spec:
         - --default_admin_username
         - {{ .Values.secrets.defaultAdmin.username | quote }}
         {{- end }}
-        {{- include "osmo.v1.configmap-args" . | nindent 8 }}
+        {{- include "osmo.configuration.args" . | nindent 8 }}
         {{- range $arg := .Values.services.api.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
-        {{- include "osmo.v1.upstream-tls-args" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.service) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.api) | nindent 8 }}
         env:
         - name: OSMO_DISABLE_TASK_METRICS
           value: {{ .Values.services.api.disableTaskMetrics | quote }}
-        {{- include "osmo.v1.configmap-env" . | nindent 8 }}
-        {{- include "osmo.v1.extra-env" .Values.services.api | nindent 8 }}
-        {{- include "osmo.v1.connection-secret-env" . | nindent 8 }}
+        {{- include "osmo.configuration.env" . | nindent 8 }}
+        {{- include "osmo.component.extraEnv" .Values.services.api | nindent 8 }}
+        {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
         {{- if .Values.secrets.defaultAdmin.existingSecret }}
         - name: OSMO_DEFAULT_ADMIN_PASSWORD
           valueFrom:
@@ -152,7 +151,7 @@ spec:
               name: {{ .Values.secrets.defaultAdmin.existingSecret }}
               key: {{ .Values.secrets.defaultAdmin.keys.password }}
         {{- end }}
-        imagePullPolicy: {{ include "osmo.v1.imagePullPolicy" (dict "root" . "component" .Values.services.api) }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.api) }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -162,7 +161,7 @@ spec:
         ports:
         - name: metrics
           containerPort: 9464
-        {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.configuration.enabled .Values.services.api.volumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.service) .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
+        {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.configuration.enabled .Values.services.api.volumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.api) .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
         {{- end }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret}}
@@ -170,34 +169,34 @@ spec:
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
-        {{- include "osmo.v1.configmap-volume-mounts" . | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volume-mounts" . | nindent 8 }}
-        {{- include "osmo.v1.extra-volume-mounts" .Values.services.api | nindent 8 }}
-        {{- include "osmo.v1.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.service) | nindent 8 }}
+        {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
+        {{- include "osmo.component.extraVolumeMounts" .Values.services.api | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.api) | nindent 8 }}
         resources:
         {{- toYaml .Values.services.api.resources | nindent 10 }}
 
         # Any failure to return the version api means the service is in a bad state
         livenessProbe:
-        {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" .Values.services.api.livenessProbe "context" .) | nindent 10 }}
+        {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" .Values.services.api.livenessProbe "context" .) | nindent 10 }}
 
 
         # Probe spec comes from values.yaml; the helper overlays
         # `scheme: HTTPS` when gateway.tls.enabled is true.
         startupProbe:
-          {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" .Values.services.api.startupProbe "context" .) | nindent 10 }}
+          {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" .Values.services.api.startupProbe "context" .) | nindent 10 }}
 
         # Readiness must not require privileged request headers.
         readinessProbe:
-          {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" .Values.services.api.readinessProbe "context" .) | nindent 10 }}
+          {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" .Values.services.api.readinessProbe "context" .) | nindent 10 }}
 
-      {{- include "osmo.v1.extra-sidecars" .Values.services.api | nindent 6 }}
+      {{- include "osmo.pod.extraSidecars" .Values.services.api | nindent 6 }}
       volumes:
-        {{- include "osmo.v1.extra-volumes" .Values.services.api | nindent 8 }}
-        {{- include "osmo.v1.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.service) | nindent 8 }}
-        {{- include "osmo.v1.mek-volume" . | nindent 8 }}
-        {{- include "osmo.v1.configmap-volumes" . | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volumes" . | nindent 8 }}
+        {{- include "osmo.pod.extraVolumes" .Values.services.api | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.api) | nindent 8 }}
+        {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.configuration.volumes" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 ---
 
 apiVersion: v1
@@ -205,7 +204,7 @@ kind: Service
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
 spec:
   ports:
     - port: 80
@@ -213,7 +212,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ $name }}
+    {{- include "osmo.component.selectorLabels" (dict "root" . "component" "api") | nindent 4 }}
 
 ---
 
@@ -222,7 +221,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -36,17 +36,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.services.api.pod.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range .Values.services.api.pod.topologySpreadConstraints }}
-      - topologyKey: {{.topologyKey }}
-        {{- range $key, $value := . }}
-        {{- if ne $key "topologyKey" }}
-        {{$key}}: {{$value}}
-        {{- end }}
-        {{- end }}
-        labelSelector:
-          matchLabels:
-            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "api") | nindent 12 }}
+        {{- include "osmo.pod.topologySpreadConstraints" (dict "root" $ "constraints" . "componentName" "api") | nindent 8 }}
       {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.api)) }}
       nodeSelector:

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -21,6 +21,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.services.api.autoscaling.enabled }}
   replicas: {{ .Values.services.api.replicas }}
@@ -208,6 +212,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: 80
@@ -226,7 +234,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
   annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -96,17 +96,17 @@ spec:
         {{- end }}
         {{- if .Values.services.api.auth.enabled }}
         - --device_endpoint
-        - {{ .Values.services.api.auth.device_endpoint }}
+        - {{ .Values.services.api.auth.deviceEndpoint }}
         - --device_client_id
-        - {{ .Values.services.api.auth.device_client_id }}
+        - {{ .Values.services.api.auth.deviceClientId }}
         - --browser_endpoint
-        - {{ .Values.services.api.auth.browser_endpoint }}
+        - {{ .Values.services.api.auth.browserEndpoint }}
         - --browser_client_id
-        - {{ .Values.services.api.auth.browser_client_id }}
+        - {{ .Values.services.api.auth.browserClientId }}
         - --token_endpoint
-        - {{ .Values.services.api.auth.token_endpoint }}
+        - {{ .Values.services.api.auth.tokenEndpoint }}
         - --logout_endpoint
-        - {{ .Values.services.api.auth.logout_endpoint }}
+        - {{ .Values.services.api.auth.logoutEndpoint }}
         {{- end }}
         {{- $serviceHostname := .Values.services.api.hostname | default (include "osmo.hostname" .) }}
         {{- if $serviceHostname }}

--- a/deployments/charts/osmo/templates/configs.yaml
+++ b/deployments/charts/osmo/templates/configs.yaml
@@ -27,11 +27,11 @@ metadata:
 data:
   config.yaml: |
     {{- $cfg := .Values.configuration }}
-    {{- if or $cfg.service .Values.exposure.baseUrl }}
+    {{- if or $cfg.service .Values.externalUrl }}
     service:
       {{- $service := deepCopy ($cfg.service | default dict) }}
-      {{- if .Values.exposure.baseUrl }}
-      {{- $_ := set $service "service_base_url" .Values.exposure.baseUrl }}
+      {{- if .Values.externalUrl }}
+      {{- $_ := set $service "service_base_url" .Values.externalUrl }}
       {{- end }}
       {{- toYaml $service | nindent 6 }}
     {{- end }}

--- a/deployments/charts/osmo/templates/configs.yaml
+++ b/deployments/charts/osmo/templates/configs.yaml
@@ -20,9 +20,9 @@ metadata:
   name: {{ include "osmo.api.fullname" . }}-config
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
-  {{- with .Values.configuration.extraAnnotations }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" . "annotations" .Values.configuration.extraAnnotations)) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 data:
   config.yaml: |

--- a/deployments/charts/osmo/templates/configs.yaml
+++ b/deployments/charts/osmo/templates/configs.yaml
@@ -17,9 +17,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "osmo.v1.apiName" . }}-configs
+  name: {{ include "osmo.api.fullname" . }}-config
   labels:
-    app: {{ include "osmo.v1.apiName" . }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
   {{- with .Values.configuration.extraAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -14,41 +14,40 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 {{- if and .Values.planes.control.enabled .Values.services.delayedJobMonitor.enabled }}
-{{- $name := include "osmo.v1.componentName" (dict "root" . "suffix" "delayed-job-monitor") }}
+{{- $name := include "osmo.component.fullname" (dict "root" . "suffix" "delayed-job-monitor") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "delayed-job-monitor") | nindent 4 }}
 spec:
   replicas: {{ .Values.services.delayedJobMonitor.replicas }}
   selector:
     matchLabels:
-      app: {{ $name }}
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "delayed-job-monitor") | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ $name }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.delayedJobMonitor "componentName" "delayed-job-monitor") | nindent 8 }}
       annotations:
-      {{- include "osmo.v1.extra-annotations" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
+      {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
     spec:
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" .Values.services.delayedJobMonitor)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.delayedJobMonitor)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" .Values.services.delayedJobMonitor "root" . "suffix" "delayed-job-monitor") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" .Values.services.delayedJobMonitor "root" . "suffix" "delayed-job-monitor") }}
       {{- with .Values.services.delayedJobMonitor.pod.initContainers }}
       initContainers:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ $name }}
-        image: {{ include "osmo.v1.image" (dict "root" . "component" .Values.services.delayedJobMonitor) }}
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.delayedJobMonitor) }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -60,7 +59,7 @@ spec:
           containerPort: 9464
         command:
         - delayed_job_monitor
-        imagePullPolicy: {{ include "osmo.v1.imagePullPolicy" (dict "root" . "component" .Values.services.delayedJobMonitor) }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.delayedJobMonitor) }}
         args:
         - --metrics_otel_collector_component
         - {{ $name }}
@@ -103,8 +102,8 @@ spec:
         - {{ $arg | quote }}
         {{- end }}
         env:
-        {{- include "osmo.v1.extra-env" .Values.services.delayedJobMonitor | nindent 8 }}
-        {{- include "osmo.v1.connection-secret-env" . | nindent 8 }}
+        {{- include "osmo.component.extraEnv" .Values.services.delayedJobMonitor | nindent 8 }}
+        {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
         resources:
         {{- toYaml .Values.services.delayedJobMonitor.resources | nindent 10 }}
 
@@ -116,8 +115,8 @@ spec:
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
-        {{- include "osmo.v1.extra-volume-mounts" .Values.services.delayedJobMonitor | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volume-mounts" . | nindent 8 }}
+        {{- include "osmo.component.extraVolumeMounts" .Values.services.delayedJobMonitor | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
 
         # Restart if no progress for 300 seconds
         livenessProbe:
@@ -135,9 +134,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
 
-      {{- include "osmo.v1.extra-sidecars" .Values.services.delayedJobMonitor | nindent 6 }}
+      {{- include "osmo.pod.extraSidecars" .Values.services.delayedJobMonitor | nindent 6 }}
       volumes:
-        {{- include "osmo.v1.extra-volumes" .Values.services.delayedJobMonitor | nindent 8 }}
-        {{- include "osmo.v1.mek-volume" . | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volumes" . | nindent 8 }}
+        {{- include "osmo.pod.extraVolumes" .Values.services.delayedJobMonitor | nindent 8 }}
+        {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 {{- end }}

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -21,6 +21,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "delayed-job-monitor") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.services.delayedJobMonitor.replicas }}
   {{- with .Values.services.delayedJobMonitor.deploymentStrategy }}

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -23,6 +23,10 @@ metadata:
     {{- include "osmo.component.labels" (dict "root" . "component" "delayed-job-monitor") | nindent 4 }}
 spec:
   replicas: {{ .Values.services.delayedJobMonitor.replicas }}
+  {{- with .Values.services.delayedJobMonitor.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "delayed-job-monitor") | nindent 6 }}
@@ -33,6 +37,14 @@ spec:
       annotations:
       {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.services.delayedJobMonitor.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" .Values.services.delayedJobMonitor) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" .Values.services.delayedJobMonitor)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.delayedJobMonitor)) }}
       nodeSelector:
         {{- . | nindent 8 }}
@@ -49,11 +61,7 @@ spec:
       - name: {{ $name }}
         image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.delayedJobMonitor) }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 1001
+          {{- include "osmo.container.securityContext" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 10 }}
         ports:
         - name: metrics
           containerPort: 9464

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -119,9 +119,9 @@ spec:
         resources:
         {{- toYaml .Values.services.delayedJobMonitor.resources | nindent 10 }}
 
-        {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.services.delayedJobMonitor.volumeMounts .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
-        {{- end }}
+        - name: osmo-progress-files
+          mountPath: /var/run/osmo
         {{- if .Values.secrets.masterEncryptionKey.existingSecret}}
         - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
           name: mek-volume
@@ -148,6 +148,8 @@ spec:
 
       {{- include "osmo.pod.extraSidecars" .Values.services.delayedJobMonitor | nindent 6 }}
       volumes:
+        - name: osmo-progress-files
+          emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.delayedJobMonitor | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}

--- a/deployments/charts/osmo/templates/extra-configmaps.yaml
+++ b/deployments/charts/osmo/templates/extra-configmaps.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 #
 # SPDX-License-Identifier: Apache-2.0
-{{- include "osmo.v1.extra-configmaps" . }}
+{{- include "osmo.configuration.extraConfigMaps" . }}

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -36,6 +36,9 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | nindent 4 }}
 spec:
+  {{- if not $gw.envoy.autoscaling.enabled }}
+  replicas: {{ $gw.envoy.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "envoy" "context" .) | nindent 6 }}
@@ -172,6 +175,7 @@ spec:
 
 ---
 
+{{- if $gw.envoy.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -185,7 +189,12 @@ spec:
     name: {{ $gwName }}-envoy
   minReplicas: {{ $gw.envoy.autoscaling.minReplicas }}
   maxReplicas: {{ $gw.envoy.autoscaling.maxReplicas }}
+  {{- with $gw.envoy.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
+  {{- if $gw.envoy.autoscaling.hpaCpuTarget }}
   - type: ContainerResource
     containerResource:
       name: cpu
@@ -193,6 +202,8 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $gw.envoy.autoscaling.hpaCpuTarget }}
+  {{- end }}
+  {{- if $gw.envoy.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       name: memory
@@ -200,9 +211,11 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $gw.envoy.autoscaling.hpaMemoryTarget }}
+  {{- end }}
   {{- with $gw.envoy.autoscaling.customMetrics }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}
 
 {{- end }}{{/* end envoy.enabled */}}
 
@@ -219,6 +232,9 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-oauth2-proxy") | nindent 4 }}
 spec:
+  {{- if not $gw.oauth2Proxy.autoscaling.enabled }}
+  replicas: {{ $gw.oauth2Proxy.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "oauth2-proxy" "context" .) | nindent 6 }}
@@ -356,6 +372,7 @@ spec:
 
 ---
 
+{{- if $gw.oauth2Proxy.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -369,7 +386,12 @@ spec:
     name: {{ $gwName }}-oauth2-proxy
   minReplicas: {{ $gw.oauth2Proxy.autoscaling.minReplicas }}
   maxReplicas: {{ $gw.oauth2Proxy.autoscaling.maxReplicas }}
+  {{- with $gw.oauth2Proxy.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
+  {{- if $gw.oauth2Proxy.autoscaling.hpaCpuTarget }}
   - type: ContainerResource
     containerResource:
       name: cpu
@@ -377,6 +399,8 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $gw.oauth2Proxy.autoscaling.hpaCpuTarget }}
+  {{- end }}
+  {{- if $gw.oauth2Proxy.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       name: memory
@@ -384,9 +408,11 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $gw.oauth2Proxy.autoscaling.hpaMemoryTarget }}
+  {{- end }}
   {{- with $gw.oauth2Proxy.autoscaling.customMetrics }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}
 
 ---
@@ -402,6 +428,9 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-authz") | nindent 4 }}
 spec:
+  {{- if not $gw.authz.autoscaling.enabled }}
+  replicas: {{ $gw.authz.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "authz" "context" .) | nindent 6 }}
@@ -500,6 +529,7 @@ spec:
 
 ---
 
+{{- if $gw.authz.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -513,7 +543,12 @@ spec:
     name: {{ $gwName }}-authz
   minReplicas: {{ $gw.authz.autoscaling.minReplicas }}
   maxReplicas: {{ $gw.authz.autoscaling.maxReplicas }}
+  {{- with $gw.authz.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
+  {{- if $gw.authz.autoscaling.hpaCpuTarget }}
   - type: ContainerResource
     containerResource:
       name: cpu
@@ -521,6 +556,8 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $gw.authz.autoscaling.hpaCpuTarget }}
+  {{- end }}
+  {{- if $gw.authz.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       name: memory
@@ -528,9 +565,11 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ $gw.authz.autoscaling.hpaMemoryTarget }}
+  {{- end }}
   {{- with $gw.authz.autoscaling.customMetrics }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}
 
 ---

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -108,7 +108,7 @@ spec:
             mountPath: /etc/ssl/envoy-certs
             readOnly: true
           {{- end }}
-          {{- with $gw.envoy.volumeMounts }}
+          {{- with $gw.envoy.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         resources:
@@ -142,7 +142,7 @@ spec:
           secret:
             secretName: {{ $gw.envoy.ssl.secretName | default "envoy-ssl-cert" }}
         {{- end }}
-        {{- with $gw.envoy.pod.volumes }}
+        {{- with $gw.envoy.pod.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
 
@@ -366,7 +366,7 @@ spec:
             mountPath: /etc/oauth2-proxy
             readOnly: true
           {{- end }}
-          {{- with $gw.oauth2Proxy.volumeMounts }}
+          {{- with $gw.oauth2Proxy.extraVolumeMounts }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
       volumes:
@@ -380,7 +380,7 @@ spec:
             - key: {{ $gw.oauth2Proxy.cookieSecretKey | default "cookie_secret" }}
               path: cookie-secret
         {{- end }}
-        {{- with $gw.oauth2Proxy.pod.volumes }}
+        {{- with $gw.oauth2Proxy.pod.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
 
@@ -536,14 +536,14 @@ spec:
         env:
           {{- include "osmo.component.extraEnv" $gw.authz | nindent 10 }}
           {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 10 }}
-        {{- if or .Values.configuration.enabled $gw.authz.volumeMounts .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
+        {{- if or .Values.configuration.enabled $gw.authz.extraVolumeMounts .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
           {{- if .Values.configuration.enabled }}
           - name: configs
             mountPath: /etc/osmo/configs
             readOnly: true
           {{- end }}
-          {{- with $gw.authz.volumeMounts }}
+          {{- with $gw.authz.extraVolumeMounts }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 10 }}
@@ -564,7 +564,7 @@ spec:
           configMap:
             name: {{ include "osmo.api.fullname" . }}-config
         {{- end }}
-        {{- with $gw.authz.pod.volumes }}
+        {{- with $gw.authz.pod.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
@@ -762,7 +762,7 @@ spec:
         volumeMounts:
         - name: ratelimit-config
           mountPath: /data/ratelimit/config
-        {{- with $gw.rateLimit.volumeMounts }}
+        {{- with $gw.rateLimit.extraVolumeMounts }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         livenessProbe:
@@ -778,7 +778,7 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-      {{- with $gw.rateLimit.pod.volumes }}
+      {{- with $gw.rateLimit.pod.extraVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
 

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -134,85 +134,42 @@ spec:
 {{/* ================================================================ */}}
 {{/* Envoy Service                                                    */}}
 {{/*                                                                  */}}
-{{/* Service type controls external access:                           */}}
-{{/*   LoadBalancer (default) — NLB for direct external access        */}}
-{{/*   ClusterIP — use with gateway.envoy.ingress for shared ALB      */}}
+{{/* Service type controls external access.                           */}}
 {{/* ================================================================ */}}
+{{- $service := $gw.envoy.service }}
+{{- $serviceLabels := mergeOverwrite (deepCopy $service.labels) (include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | fromYaml) }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ $gwName }}
   labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | nindent 4 }}
-  {{- with $gw.envoy.service.annotations }}
+    {{- toYaml $serviceLabels | nindent 4 }}
+  {{- with $service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ $gw.envoy.service.type | default "LoadBalancer" }}
+  type: {{ $service.type }}
+  {{- if and (eq $service.type "LoadBalancer") $service.loadBalancerClass }}
+  loadBalancerClass: {{ $service.loadBalancerClass }}
+  {{- end }}
+  {{- if and (eq $service.type "LoadBalancer") $service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml $service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if or (eq $service.type "LoadBalancer") (eq $service.type "NodePort") }}
+  externalTrafficPolicy: {{ $service.externalTrafficPolicy }}
+  {{- end }}
   ports:
-    - port: 80
-      targetPort: envoy-http
-      protocol: TCP
-      name: http
-      {{- if $gw.envoy.service.nodePort }}
-      nodePort: {{ $gw.envoy.service.nodePort }}
-      {{- end }}
-    {{- if $gw.envoy.service.httpsPort }}
-    - port: {{ $gw.envoy.service.httpsPort }}
-      targetPort: envoy-http
-      protocol: TCP
-      name: https
+  - name: {{ ternary "https" "http" $gw.envoy.ssl.enabled }}
+    port: {{ $service.port }}
+    targetPort: envoy-http
+    protocol: TCP
+    {{- if and $service.nodePort (or (eq $service.type "LoadBalancer") (eq $service.type "NodePort")) }}
+    nodePort: {{ $service.nodePort }}
     {{- end }}
   selector:
     {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "envoy" "context" .) | nindent 4 }}
-
-{{- if $gw.envoy.ingress.enabled }}
----
-
-{{/* ================================================================ */}}
-{{/* Envoy Ingress — use when multiple namespaces share a single      */}}
-{{/* load balancer (e.g. ALB with group.name). Set service type to    */}}
-{{/* ClusterIP and enable this to route external traffic via ALB.      */}}
-{{/* ================================================================ */}}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {{ $gwName }}
-  labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | nindent 4 }}
-  annotations:
-    {{- if $gw.envoy.ingress.albAnnotations.enabled }}
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/group.name: {{ $gw.envoy.ingress.albAnnotations.groupName | default "osmo" }}
-    alb.ingress.kubernetes.io/group.order: {{ $gw.envoy.ingress.albAnnotations.groupOrder | default "10" | quote }}
-    alb.ingress.kubernetes.io/certificate-arn: {{ $gw.envoy.ingress.albAnnotations.sslCertArn }}
-    alb.ingress.kubernetes.io/backend-protocol: {{ ternary "HTTPS" "HTTP" $gw.envoy.ssl.enabled }}
-    alb.ingress.kubernetes.io/healthcheck-path: /api/version
-    {{- end }}
-    {{- range $k, $v := $gw.envoy.ingress.annotations }}
-    {{ $k }}: {{ $v | quote }}
-    {{- end }}
-spec:
-  ingressClassName: {{ $gw.envoy.ingress.ingressClass }}
-  rules:
-  - host: {{ $envoyHostname }}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ $gwName }}
-            port:
-              number: 80
-  {{- if $gw.envoy.ingress.sslEnabled }}
-  tls:
-  - hosts:
-    - {{ $envoyHostname }}
-    secretName: {{ $gw.envoy.ingress.sslSecret | default "osmo-tls" }}
-  {{- end }}
-{{- end }}
 
 ---
 

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -39,6 +39,10 @@ spec:
   {{- if not $gw.envoy.autoscaling.enabled }}
   replicas: {{ $gw.envoy.replicas }}
   {{- end }}
+  {{- with $gw.envoy.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "envoy" "context" .) | nindent 6 }}
@@ -50,6 +54,14 @@ spec:
         checksum/envoy-config: {{ include "osmo.gateway.envoyConfig" . | sha256sum }}
         {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.envoy) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ $gw.envoy.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" $gw.envoy) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" $gw.envoy) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" $gw.envoy)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $gw.envoy)) }}
       nodeSelector:
         {{- . | nindent 8 }}
@@ -61,7 +73,7 @@ spec:
       containers:
       - name: envoy
         securityContext:
-          {{- toYaml $gw.envoy.pod.containerSecurityContext | nindent 10 }}
+          {{- include "osmo.container.securityContext" (dict "root" . "component" $gw.envoy) | nindent 10 }}
         image: "{{ $gw.envoy.image.repository }}"
         imagePullPolicy: {{ $gw.envoy.image.pullPolicy }}
         args:
@@ -235,6 +247,10 @@ spec:
   {{- if not $gw.oauth2Proxy.autoscaling.enabled }}
   replicas: {{ $gw.oauth2Proxy.replicas }}
   {{- end }}
+  {{- with $gw.oauth2Proxy.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "oauth2-proxy" "context" .) | nindent 6 }}
@@ -245,6 +261,14 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.oauth2Proxy) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ $gw.oauth2Proxy.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" $gw.oauth2Proxy) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" $gw.oauth2Proxy) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" $gw.oauth2Proxy)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $gw.oauth2Proxy)) }}
       nodeSelector:
         {{- . | nindent 8 }}
@@ -258,7 +282,7 @@ spec:
         image: "{{ $gw.oauth2Proxy.image.repository }}"
         imagePullPolicy: {{ $gw.oauth2Proxy.image.pullPolicy }}
         securityContext:
-          {{- toYaml $gw.oauth2Proxy.pod.containerSecurityContext | nindent 10 }}
+          {{- include "osmo.container.securityContext" (dict "root" . "component" $gw.oauth2Proxy) | nindent 10 }}
         args:
           {{- if $gw.oauth2Proxy.useKubernetesSecrets }}
           - --client-secret-file=/etc/oauth2-proxy/client-secret
@@ -431,6 +455,10 @@ spec:
   {{- if not $gw.authz.autoscaling.enabled }}
   replicas: {{ $gw.authz.replicas }}
   {{- end }}
+  {{- with $gw.authz.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "authz" "context" .) | nindent 6 }}
@@ -441,6 +469,14 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.authz) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ $gw.authz.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" $gw.authz) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" $gw.authz) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" $gw.authz)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $gw.authz)) }}
       nodeSelector:
         {{- . | nindent 8 }}
@@ -452,7 +488,7 @@ spec:
       containers:
       - name: authz
         securityContext:
-          {{- toYaml $gw.authz.pod.containerSecurityContext | nindent 10 }}
+          {{- include "osmo.container.securityContext" (dict "root" . "component" $gw.authz) | nindent 10 }}
         image: {{ include "osmo.component.image" (dict "root" . "component" $gw.authz) }}
         imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" $gw.authz) }}
         args:
@@ -600,6 +636,10 @@ metadata:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-ratelimit") | nindent 4 }}
 spec:
   replicas: {{ $gw.rateLimit.replicas }}
+  {{- with $gw.rateLimit.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "ratelimit" "context" .) | nindent 6 }}
@@ -611,6 +651,14 @@ spec:
         checksum/ratelimit-config: {{ $gw.rateLimit.config | toYaml | sha256sum }}
         {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.rateLimit) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ $gw.rateLimit.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" $gw.rateLimit) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" $gw.rateLimit) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" $gw.rateLimit)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $gw.rateLimit)) }}
       nodeSelector:
         {{- . | nindent 8 }}
@@ -624,7 +672,7 @@ spec:
         image: "{{ $gw.rateLimit.image.repository }}"
         imagePullPolicy: "{{ $gw.rateLimit.image.pullPolicy }}"
         securityContext:
-          {{- toYaml $gw.rateLimit.pod.containerSecurityContext | nindent 10 }}
+          {{- include "osmo.container.securityContext" (dict "root" . "component" $gw.rateLimit) | nindent 10 }}
         {{- /* The default 875d418c image does not define an ENTRYPOINT. */}}
         command:
           {{- toYaml ($gw.rateLimit.command | default (list "/bin/ratelimit")) | nindent 10 }}

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -312,10 +312,10 @@ spec:
           - --set-xauthrequest=true
           - --set-authorization-header=true
           - --pass-access-token={{ $gw.oauth2Proxy.passAccessToken }}
-          {{- $redisHost := $.Values.externalDependencies.valkey.host }}
+          {{- $valkey := $.Values.externalDependencies.valkey }}
           {{- if $gw.oauth2Proxy.redisSessionStore }}
           - --session-store-type=redis
-          - --redis-connection-url={{ if $gw.oauth2Proxy.redis.tlsEnabled }}rediss{{ else }}redis{{ end }}://{{ $redisHost }}:{{ $gw.oauth2Proxy.redis.port | default 6379 }}/{{ $gw.oauth2Proxy.redis.dbNumber | default 0 }}
+          - --redis-connection-url={{ if $valkey.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ $valkey.host }}:{{ $valkey.port }}/{{ $valkey.database }}
           {{- end }}
           - --upstream=static://200
           - --redirect-url=https://{{ $envoyHostname }}/oauth2/callback
@@ -656,7 +656,7 @@ spec:
               name: {{ .Values.secrets.valkey.existingSecret }}
               key: {{ .Values.secrets.valkey.keys.password }}
         - name: REDIS_TLS
-          value: {{ dig "redis" "tlsEnabled" true $gw.rateLimit | quote }}
+          value: {{ .Values.externalDependencies.valkey.tls.enabled | quote }}
         - name: USE_STATSD
           value: "false"
         - name: RUNTIME_ROOT

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -15,13 +15,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- $gw := .Values.gateway }}
-{{- $gwName := include "osmo.v1.gateway-name" . }}
-{{- $envoyHostname := $gw.envoy.hostname | default (include "osmo.v1.hostname" .) }}
+{{- $gwName := include "osmo.gateway.fullname" . }}
+{{- $envoyHostname := $gw.envoy.hostname | default (include "osmo.hostname" .) }}
 
 {{/* ================================================================ */}}
 {{/* Envoy ConfigMap (dynamic LDS/CDS)                                */}}
 {{/* ================================================================ */}}
-{{- include "osmo.v1.gateway-envoy-config" . }}
+{{- include "osmo.gateway.envoyConfig" . }}
 
 ---
 
@@ -34,27 +34,28 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $gwName }}-envoy
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "osmo.v1.gateway-component-labels" (dict "component" "envoy" "context" .) | nindent 6 }}
+      {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "envoy" "context" .) | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "osmo.v1.gateway-component-labels" (dict "component" "envoy" "context" .) | nindent 8 }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" $gw.envoy) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" $gw.envoy "componentName" "gateway-envoy") | nindent 8 }}
       annotations:
-        checksum/envoy-config: {{ include "osmo.v1.gateway-envoy-config" . | sha256sum }}
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" $gw.envoy) | nindent 8 }}
+        checksum/envoy-config: {{ include "osmo.gateway.envoyConfig" . | sha256sum }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.envoy) | nindent 8 }}
     spec:
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" $gw.envoy)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $gw.envoy)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" $gw.envoy) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" $gw.envoy "root" . "suffix" "gateway-envoy") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" $gw.envoy) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" $gw.envoy "root" . "suffix" "gateway-envoy") }}
       containers:
       - name: envoy
         securityContext:
@@ -141,6 +142,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $gwName }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | nindent 4 }}
   {{- with $gw.envoy.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -162,7 +165,7 @@ spec:
       name: https
     {{- end }}
   selector:
-    {{- include "osmo.v1.gateway-component-labels" (dict "component" "envoy" "context" .) | nindent 4 }}
+    {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "envoy" "context" .) | nindent 4 }}
 
 {{- if $gw.envoy.ingress.enabled }}
 ---
@@ -176,6 +179,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $gwName }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | nindent 4 }}
   annotations:
     {{- if $gw.envoy.ingress.albAnnotations.enabled }}
     alb.ingress.kubernetes.io/target-type: ip
@@ -215,6 +220,8 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $gwName }}-envoy
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -253,26 +260,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $gwName }}-oauth2-proxy
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-oauth2-proxy") | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "osmo.v1.gateway-component-labels" (dict "component" "oauth2-proxy" "context" .) | nindent 6 }}
+      {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "oauth2-proxy" "context" .) | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "osmo.v1.gateway-component-labels" (dict "component" "oauth2-proxy" "context" .) | nindent 8 }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" $gw.oauth2Proxy) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" $gw.oauth2Proxy "componentName" "gateway-oauth2-proxy") | nindent 8 }}
       annotations:
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" $gw.oauth2Proxy) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.oauth2Proxy) | nindent 8 }}
     spec:
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" $gw.oauth2Proxy)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $gw.oauth2Proxy)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" $gw.oauth2Proxy) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" $gw.oauth2Proxy "root" . "suffix" "gateway-oauth2-proxy") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" $gw.oauth2Proxy) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" $gw.oauth2Proxy "root" . "suffix" "gateway-oauth2-proxy") }}
       containers:
       - name: oauth2-proxy
         image: "{{ $gw.oauth2Proxy.image.repository }}"
@@ -326,7 +334,7 @@ spec:
                 name: {{ .Values.secrets.valkey.existingSecret }}
                 key: {{ .Values.secrets.valkey.keys.password }}
           {{- end }}
-          {{- include "osmo.v1.extra-env" $gw.oauth2Proxy | nindent 10 }}
+          {{- include "osmo.component.extraEnv" $gw.oauth2Proxy | nindent 10 }}
         {{- end }}
         ports:
         - name: http
@@ -375,6 +383,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $gwName }}-oauth2-proxy
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-oauth2-proxy") | nindent 4 }}
 spec:
   ports:
     - port: {{ $gw.oauth2Proxy.httpPort }}
@@ -386,7 +396,7 @@ spec:
       protocol: TCP
       name: metrics
   selector:
-    {{- include "osmo.v1.gateway-component-labels" (dict "component" "oauth2-proxy" "context" .) | nindent 4 }}
+    {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "oauth2-proxy" "context" .) | nindent 4 }}
 
 ---
 
@@ -394,6 +404,8 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $gwName }}-oauth2-proxy
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-oauth2-proxy") | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -431,32 +443,33 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $gwName }}-authz
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-authz") | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "osmo.v1.gateway-component-labels" (dict "component" "authz" "context" .) | nindent 6 }}
+      {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "authz" "context" .) | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "osmo.v1.gateway-component-labels" (dict "component" "authz" "context" .) | nindent 8 }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" $gw.authz) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" $gw.authz "componentName" "gateway-authz") | nindent 8 }}
       annotations:
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" $gw.authz) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.authz) | nindent 8 }}
     spec:
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" $gw.authz)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $gw.authz)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" $gw.authz) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" $gw.authz "root" . "suffix" "gateway-authz") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" $gw.authz) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" $gw.authz "root" . "suffix" "gateway-authz") }}
       containers:
       - name: authz
         securityContext:
           {{- toYaml $gw.authz.pod.containerSecurityContext | nindent 10 }}
-        image: {{ include "osmo.v1.image" (dict "root" . "component" $gw.authz) }}
-        imagePullPolicy: {{ include "osmo.v1.imagePullPolicy" (dict "root" . "component" $gw.authz) }}
+        image: {{ include "osmo.component.image" (dict "root" . "component" $gw.authz) }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" $gw.authz) }}
         args:
           - "--grpc-port={{ $gw.authz.grpcPort }}"
           {{- if .Values.configuration.enabled }}
@@ -477,8 +490,8 @@ spec:
           - "--log-format={{ . }}"
           {{- end }}
         env:
-          {{- include "osmo.v1.extra-env" $gw.authz | nindent 10 }}
-          {{- include "osmo.v1.connection-secret-env" . | nindent 10 }}
+          {{- include "osmo.component.extraEnv" $gw.authz | nindent 10 }}
+          {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 10 }}
         {{- if or .Values.configuration.enabled $gw.authz.volumeMounts .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
           {{- if .Values.configuration.enabled }}
@@ -489,7 +502,7 @@ spec:
           {{- with $gw.authz.volumeMounts }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- include "osmo.v1.external-ca-volume-mounts" . | nindent 10 }}
+          {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 10 }}
         {{- end }}
         {{- with $gw.authz.livenessProbe }}
         livenessProbe:
@@ -505,12 +518,12 @@ spec:
         {{- if .Values.configuration.enabled }}
         - name: configs
           configMap:
-            name: {{ include "osmo.v1.apiName" . }}-configs
+            name: {{ include "osmo.api.fullname" . }}-config
         {{- end }}
         {{- with $gw.authz.pod.volumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- include "osmo.v1.external-ca-volumes" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 
 ---
 
@@ -518,6 +531,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $gwName }}-authz
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-authz") | nindent 4 }}
 spec:
   ports:
     - port: {{ $gw.authz.grpcPort }}
@@ -525,7 +540,7 @@ spec:
       protocol: TCP
       name: grpc
   selector:
-    {{- include "osmo.v1.gateway-component-labels" (dict "component" "authz" "context" .) | nindent 4 }}
+    {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "authz" "context" .) | nindent 4 }}
 
 ---
 
@@ -533,6 +548,8 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $gwName }}-authz
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-authz") | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -570,6 +587,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $gwName }}-ratelimit-config
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
 data:
   config.yaml: |
     domain: {{ $gw.rateLimit.config.domain | default "ratelimit" }}
@@ -582,28 +601,29 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $gwName }}-ratelimit
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-ratelimit") | nindent 4 }}
 spec:
   replicas: {{ $gw.rateLimit.replicas }}
   selector:
     matchLabels:
-      {{- include "osmo.v1.gateway-component-labels" (dict "component" "ratelimit" "context" .) | nindent 6 }}
+      {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "ratelimit" "context" .) | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "osmo.v1.gateway-component-labels" (dict "component" "ratelimit" "context" .) | nindent 8 }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" $gw.rateLimit) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" $gw.rateLimit "componentName" "gateway-ratelimit") | nindent 8 }}
       annotations:
         checksum/ratelimit-config: {{ $gw.rateLimit.config | toYaml | sha256sum }}
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" $gw.rateLimit) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.rateLimit) | nindent 8 }}
     spec:
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" $gw.rateLimit)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $gw.rateLimit)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" $gw.rateLimit) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" $gw.rateLimit "root" . "suffix" "gateway-ratelimit") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" $gw.rateLimit) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" $gw.rateLimit "root" . "suffix" "gateway-ratelimit") }}
       containers:
       - name: ratelimit
         image: "{{ $gw.rateLimit.image.repository }}"
@@ -651,7 +671,7 @@ spec:
           value: "::"
         - name: GRPC_HOST
           value: "::"
-        {{- include "osmo.v1.extra-env" $gw.rateLimit | nindent 8 }}
+        {{- include "osmo.component.extraEnv" $gw.rateLimit | nindent 8 }}
         ports:
         - name: grpc
           containerPort: {{ $gw.rateLimit.grpcPort }}
@@ -686,6 +706,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $gwName }}-ratelimit
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "gateway-ratelimit") | nindent 4 }}
 spec:
   ports:
     - port: {{ $gw.rateLimit.grpcPort }}
@@ -697,7 +719,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "osmo.v1.gateway-component-labels" (dict "component" "ratelimit" "context" .) | nindent 4 }}
+    {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "ratelimit" "context" .) | nindent 4 }}
 {{- end }}
 
 ---
@@ -706,17 +728,19 @@ spec:
 {{/* Network Policies                                                 */}}
 {{/* ================================================================ */}}
 {{- if $gw.networkPolicies.enabled }}
-{{- $envoyLabels := (include "osmo.v1.gateway-component-labels" (dict "component" "envoy" "context" .) | fromYaml) }}
+{{- $envoyLabels := (include "osmo.gateway.componentSelectorLabels" (dict "component" "envoy" "context" .) | fromYaml) }}
 {{- range $gw.networkPolicies.upstreams }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ $gwName }}-allow-envoy-to-{{ .name }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" $ "component" .component) | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ include "osmo.v1.componentName" (dict "root" $ "suffix" .component) }}
+      {{- include "osmo.component.selectorLabels" (dict "root" $ "component" .component) | nindent 6 }}
   policyTypes:
   - Ingress
   ingress:

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -77,8 +77,8 @@ spec:
       - name: envoy
         securityContext:
           {{- include "osmo.container.securityContext" (dict "root" . "component" $gw.envoy) | nindent 10 }}
-        image: "{{ $gw.envoy.image.repository }}"
-        imagePullPolicy: {{ $gw.envoy.image.pullPolicy }}
+        image: "{{ include "osmo.component.image" (dict "root" . "component" $gw.envoy) }}"
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" $gw.envoy) }}
         args:
           - -c
           - /var/config/bootstrap.yaml
@@ -290,8 +290,8 @@ spec:
       serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" $gw.oauth2Proxy "root" . "suffix" "gateway-oauth2-proxy") }}
       containers:
       - name: oauth2-proxy
-        image: "{{ $gw.oauth2Proxy.image.repository }}"
-        imagePullPolicy: {{ $gw.oauth2Proxy.image.pullPolicy }}
+        image: "{{ include "osmo.component.image" (dict "root" . "component" $gw.oauth2Proxy) }}"
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" $gw.oauth2Proxy) }}
         securityContext:
           {{- include "osmo.container.securityContext" (dict "root" . "component" $gw.oauth2Proxy) | nindent 10 }}
         args:
@@ -708,8 +708,8 @@ spec:
       serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" $gw.rateLimit "root" . "suffix" "gateway-ratelimit") }}
       containers:
       - name: ratelimit
-        image: "{{ $gw.rateLimit.image.repository }}"
-        imagePullPolicy: "{{ $gw.rateLimit.image.pullPolicy }}"
+        image: "{{ include "osmo.component.image" (dict "root" . "component" $gw.rateLimit) }}"
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" $gw.rateLimit) }}
         securityContext:
           {{- include "osmo.container.securityContext" (dict "root" . "component" $gw.rateLimit) | nindent 10 }}
         {{- /* The default 875d418c image does not define an ENTRYPOINT. */}}

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -16,7 +16,6 @@
 
 {{- $gw := .Values.gateway }}
 {{- $gwName := include "osmo.gateway.fullname" . }}
-{{- $envoyHostname := $gw.envoy.hostname | default (include "osmo.hostname" .) }}
 
 {{/* ================================================================ */}}
 {{/* Envoy ConfigMap (dynamic LDS/CDS)                                */}}
@@ -275,7 +274,7 @@ spec:
           - --redis-connection-url={{ if $valkey.tls.enabled }}rediss{{ else }}redis{{ end }}://{{ $valkey.host }}:{{ $valkey.port }}/{{ $valkey.database }}
           {{- end }}
           - --upstream=static://200
-          - --redirect-url=https://{{ $envoyHostname }}/oauth2/callback
+          - --redirect-url={{ trimSuffix "/" $.Values.externalUrl }}/oauth2/callback
           - --silence-ping-logging=true
           - --skip-provider-button=true
           - --api-route=/api/.+

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -35,6 +35,10 @@ metadata:
   name: {{ $gwName }}-envoy
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not $gw.envoy.autoscaling.enabled }}
   replicas: {{ $gw.envoy.replicas }}
@@ -51,8 +55,7 @@ spec:
       labels:
         {{- include "osmo.pod.labels" (dict "root" . "component" $gw.envoy "componentName" "gateway-envoy") | nindent 8 }}
       annotations:
-        checksum/envoy-config: {{ include "osmo.gateway.envoyConfig" . | sha256sum }}
-        {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.envoy) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.envoy "protectedAnnotations" (dict "checksum/envoy-config" (include "osmo.gateway.envoyConfig" . | sha256sum))) | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ $gw.envoy.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -158,9 +161,9 @@ metadata:
   name: {{ $gwName }}
   labels:
     {{- toYaml $serviceLabels | nindent 4 }}
-  {{- with $service.annotations }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" . "annotations" $service.annotations)) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ $service.type }}
@@ -194,6 +197,10 @@ metadata:
   name: {{ $gwName }}-envoy
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -243,6 +250,10 @@ metadata:
   name: {{ $gwName }}-oauth2-proxy
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-oauth2-proxy") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not $gw.oauth2Proxy.autoscaling.enabled }}
   replicas: {{ $gw.oauth2Proxy.replicas }}
@@ -381,6 +392,10 @@ metadata:
   name: {{ $gwName }}-oauth2-proxy
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-oauth2-proxy") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: {{ $gw.oauth2Proxy.httpPort }}
@@ -403,6 +418,10 @@ metadata:
   name: {{ $gwName }}-oauth2-proxy
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-oauth2-proxy") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -451,6 +470,10 @@ metadata:
   name: {{ $gwName }}-authz
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-authz") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not $gw.authz.autoscaling.enabled }}
   replicas: {{ $gw.authz.replicas }}
@@ -554,6 +577,10 @@ metadata:
   name: {{ $gwName }}-authz
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-authz") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: {{ $gw.authz.grpcPort }}
@@ -572,6 +599,10 @@ metadata:
   name: {{ $gwName }}-authz
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-authz") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -620,6 +651,10 @@ metadata:
   name: {{ $gwName }}-ratelimit-config
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   config.yaml: |
     domain: {{ $gw.rateLimit.config.domain | default "ratelimit" }}
@@ -634,6 +669,10 @@ metadata:
   name: {{ $gwName }}-ratelimit
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-ratelimit") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ $gw.rateLimit.replicas }}
   {{- with $gw.rateLimit.deploymentStrategy }}
@@ -751,6 +790,10 @@ metadata:
   name: {{ $gwName }}-ratelimit
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "gateway-ratelimit") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: {{ $gw.rateLimit.grpcPort }}
@@ -780,6 +823,10 @@ metadata:
   name: {{ $gwName }}-allow-envoy-to-{{ .name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" $ "component" .component) | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" $)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:

--- a/deployments/charts/osmo/templates/httproute.yaml
+++ b/deployments/charts/osmo/templates/httproute.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.httproute.enabled }}
+{{- $route := .Values.httproute }}
+{{- $identityLabels := include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | fromYaml }}
+{{- $labels := mergeOverwrite (deepCopy $route.labels) $identityLabels }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "osmo.gateway.fullname" . }}
+  labels:
+    {{- toYaml $labels | nindent 4 }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+    {{- toYaml $route.parentRefs | nindent 4 }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+  {{- range $rule := $route.rules }}
+  - {{- $routeRule := omit $rule "backendRefs" }}
+    {{- with $routeRule }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    backendRefs:
+    - name: {{ include "osmo.gateway.fullname" $ }}
+      port: {{ $.Values.gateway.envoy.service.port }}
+  {{- end }}
+{{- end }}

--- a/deployments/charts/osmo/templates/httproute.yaml
+++ b/deployments/charts/osmo/templates/httproute.yaml
@@ -11,9 +11,9 @@ metadata:
   name: {{ include "osmo.gateway.fullname" . }}
   labels:
     {{- toYaml $labels | nindent 4 }}
-  {{- with $route.annotations }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" . "annotations" $route.annotations)) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
   parentRefs:

--- a/deployments/charts/osmo/templates/ingress.yaml
+++ b/deployments/charts/osmo/templates/ingress.yaml
@@ -12,9 +12,9 @@ metadata:
   name: {{ $gatewayName }}
   labels:
     {{- toYaml $labels | nindent 4 }}
-  {{- with $ingress.annotations }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" . "annotations" $ingress.annotations)) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
   {{- with $ingress.ingressClassName }}

--- a/deployments/charts/osmo/templates/ingress.yaml
+++ b/deployments/charts/osmo/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
   tls:
   {{- if $ingress.tls.enabled }}
   - hosts:
-    - {{ $ingress.hostname }}
+    - {{ $ingress.hostname | quote }}
     {{- with $ingress.tls.secretName }}
     secretName: {{ . }}
     {{- end }}
@@ -34,7 +34,7 @@ spec:
   {{- end }}
   {{- end }}
   rules:
-  - host: {{ $ingress.hostname }}
+  - host: {{ $ingress.hostname | quote }}
     http:
       paths:
       - path: {{ $ingress.path }}
@@ -48,7 +48,7 @@ spec:
         {{- toYaml . | nindent 6 }}
       {{- end }}
   {{- range $extraHost := $ingress.extraHosts }}
-  - host: {{ $extraHost.name }}
+  - host: {{ $extraHost.name | quote }}
     http:
       paths:
       - path: {{ $extraHost.path | default $ingress.path }}

--- a/deployments/charts/osmo/templates/ingress.yaml
+++ b/deployments/charts/osmo/templates/ingress.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.ingress.enabled }}
+{{- $ingress := .Values.ingress }}
+{{- $gatewayName := include "osmo.gateway.fullname" . }}
+{{- $identityLabels := include "osmo.component.labels" (dict "root" . "component" "gateway-envoy") | fromYaml }}
+{{- $labels := mergeOverwrite (deepCopy $ingress.labels) $identityLabels }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $gatewayName }}
+  labels:
+    {{- toYaml $labels | nindent 4 }}
+  {{- with $ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $ingress.ingressClassName }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if or $ingress.tls.enabled $ingress.extraTls }}
+  tls:
+  {{- if $ingress.tls.enabled }}
+  - hosts:
+    - {{ $ingress.hostname }}
+    {{- with $ingress.tls.secretName }}
+    secretName: {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- with $ingress.extraTls }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- end }}
+  rules:
+  - host: {{ $ingress.hostname }}
+    http:
+      paths:
+      - path: {{ $ingress.path }}
+        pathType: {{ $ingress.pathType }}
+        backend:
+          service:
+            name: {{ $gatewayName }}
+            port:
+              number: {{ $.Values.gateway.envoy.service.port }}
+      {{- with $ingress.extraPaths }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+  {{- range $extraHost := $ingress.extraHosts }}
+  - host: {{ $extraHost.name }}
+    http:
+      paths:
+      - path: {{ $extraHost.path | default $ingress.path }}
+        pathType: {{ $extraHost.pathType | default $ingress.pathType }}
+        backend:
+          service:
+            name: {{ $gatewayName }}
+            port:
+              number: {{ $.Values.gateway.envoy.service.port }}
+  {{- end }}
+  {{- with $ingress.extraRules }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -39,17 +39,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.services.logger.pod.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range .Values.services.logger.pod.topologySpreadConstraints }}
-      - topologyKey: {{.topologyKey }}
-        {{- range $key, $value := . }}
-        {{- if ne $key "topologyKey" }}
-        {{$key}}: {{$value}}
-        {{- end }}
-        {{- end }}
-        labelSelector:
-          matchLabels:
-            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "logger") | nindent 12 }}
+        {{- include "osmo.pod.topologySpreadConstraints" (dict "root" $ "constraints" . "componentName" "logger") | nindent 8 }}
       {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.logger)) }}
       nodeSelector:

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -28,6 +28,10 @@ spec:
   {{- if not .Values.services.logger.autoscaling.enabled }}
   replicas: {{ .Values.services.logger.replicas }}
   {{- end }}
+  {{- with .Values.services.logger.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "logger") | nindent 6 }}
@@ -38,6 +42,14 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.logger) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.services.logger.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" .Values.services.logger) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" .Values.services.logger) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" .Values.services.logger)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with .Values.services.logger.pod.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
@@ -62,11 +74,7 @@ spec:
       - name: {{ $name }}
         image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.logger) }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 1001
+          {{- include "osmo.container.securityContext" (dict "root" . "component" .Values.services.logger) | nindent 10 }}
         ports:
         - name: metrics
           containerPort: 9464

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -24,6 +24,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "logger") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.services.logger.autoscaling.enabled }}
   replicas: {{ .Values.services.logger.replicas }}
@@ -185,6 +189,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "logger") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: 80
@@ -202,6 +210,10 @@ metadata:
   name: {{ $name }}-headless
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "logger") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   ports:
@@ -221,7 +233,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "logger") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
   annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -127,9 +127,11 @@ spec:
         {{- include "osmo.component.extraEnv" .Values.services.logger | nindent 8 }}
         {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
         imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.logger) }}
-        {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.configuration.enabled .Values.services.logger.volumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.logger) .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
-        {{- end }}
+        - name: osmo-runtime-tmp
+          mountPath: /tmp
+        - name: osmo-progress-files
+          mountPath: /var/run/osmo
         {{- if .Values.secrets.masterEncryptionKey.existingSecret}}
         - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
           name: mek-volume
@@ -175,6 +177,10 @@ spec:
 
       {{- include "osmo.pod.extraSidecars" .Values.services.logger | nindent 6 }}
       volumes:
+        - name: osmo-runtime-tmp
+          emptyDir: {}
+        - name: osmo-progress-files
+          emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.logger | nindent 8 }}
         {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -17,24 +17,23 @@
 {{/* Create a copy of the shared sidecar config values */}}
 
 {{- if and .Values.planes.control.enabled .Values.services.logger.enabled }}
-{{- $name := include "osmo.v1.componentName" (dict "root" . "suffix" "logger") }}
+{{- $name := include "osmo.component.fullname" (dict "root" . "suffix" "logger") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "logger") | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ $name }}
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "logger") | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ $name }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" .Values.services.logger) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.logger "componentName" "logger") | nindent 8 }}
       annotations:
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" .Values.services.logger) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.logger) | nindent 8 }}
     spec:
       {{- with .Values.services.logger.pod.hostAliases }}
       hostAliases:
@@ -50,23 +49,23 @@ spec:
         {{- end }}
         labelSelector:
           matchLabels:
-            app: {{ $name }}
+            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "logger") | nindent 12 }}
       {{- end }}
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" .Values.services.logger)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.logger)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" .Values.services.logger) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" .Values.services.logger "root" . "suffix" "logger") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" .Values.services.logger) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" .Values.services.logger "root" . "suffix" "logger") }}
       {{- with .Values.services.logger.pod.initContainers }}
       initContainers:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ $name }}
-        image: {{ include "osmo.v1.image" (dict "root" . "component" .Values.services.logger) }}
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.logger) }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -111,16 +110,16 @@ spec:
         - --log_format
         - {{ .Values.logging.logFormat | default "text" }}
         {{- end }}
-        {{- include "osmo.v1.configmap-args" . | nindent 8 }}
+        {{- include "osmo.configuration.args" . | nindent 8 }}
         {{- range $arg := .Values.services.logger.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
-        {{- include "osmo.v1.upstream-tls-args" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
         env:
-        {{- include "osmo.v1.configmap-env" . | nindent 8 }}
-        {{- include "osmo.v1.extra-env" .Values.services.logger | nindent 8 }}
-        {{- include "osmo.v1.connection-secret-env" . | nindent 8 }}
-        imagePullPolicy: {{ include "osmo.v1.imagePullPolicy" (dict "root" . "component" .Values.services.logger) }}
+        {{- include "osmo.configuration.env" . | nindent 8 }}
+        {{- include "osmo.component.extraEnv" .Values.services.logger | nindent 8 }}
+        {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.logger) }}
         {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.configuration.enabled .Values.services.logger.volumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.logger) .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
         {{- end }}
@@ -129,10 +128,10 @@ spec:
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
-        {{- include "osmo.v1.configmap-volume-mounts" . | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volume-mounts" . | nindent 8 }}
-        {{- include "osmo.v1.extra-volume-mounts" .Values.services.logger | nindent 8 }}
-        {{- include "osmo.v1.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
+        {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
+        {{- include "osmo.component.extraVolumeMounts" .Values.services.logger | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
         resources:
         {{- toYaml .Values.services.logger.resources | nindent 10 }}
 
@@ -167,13 +166,13 @@ spec:
           timeoutSeconds: 20
 
 
-      {{- include "osmo.v1.extra-sidecars" .Values.services.logger | nindent 6 }}
+      {{- include "osmo.pod.extraSidecars" .Values.services.logger | nindent 6 }}
       volumes:
-        {{- include "osmo.v1.extra-volumes" .Values.services.logger | nindent 8 }}
-        {{- include "osmo.v1.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
-        {{- include "osmo.v1.mek-volume" . | nindent 8 }}
-        {{- include "osmo.v1.configmap-volumes" . | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volumes" . | nindent 8 }}
+        {{- include "osmo.pod.extraVolumes" .Values.services.logger | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
+        {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.configuration.volumes" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 
 ---
 
@@ -182,7 +181,7 @@ kind: Service
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "logger") | nindent 4 }}
 spec:
   ports:
     - port: 80
@@ -190,7 +189,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ $name }}
+    {{- include "osmo.component.selectorLabels" (dict "root" . "component" "logger") | nindent 4 }}
 
 ---
 
@@ -199,7 +198,7 @@ kind: Service
 metadata:
   name: {{ $name }}-headless
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "logger") | nindent 4 }}
 spec:
   clusterIP: None
   ports:
@@ -208,7 +207,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ $name }}
+    {{- include "osmo.component.selectorLabels" (dict "root" . "component" "logger") | nindent 4 }}
 
 ---
 
@@ -217,7 +216,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "logger") | nindent 4 }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -25,6 +25,9 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "logger") | nindent 4 }}
 spec:
+  {{- if not .Values.services.logger.autoscaling.enabled }}
+  replicas: {{ .Values.services.logger.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "logger") | nindent 6 }}
@@ -203,6 +206,7 @@ spec:
 
 ---
 
+{{- if .Values.services.logger.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -217,7 +221,12 @@ spec:
     name: {{ $name }}
   minReplicas: {{ .Values.services.logger.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.services.logger.autoscaling.maxReplicas }}
+  {{- with .Values.services.logger.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
+  {{- if .Values.services.logger.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       name: memory
@@ -225,6 +234,8 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.logger.autoscaling.hpaMemoryTarget }}
+  {{- end }}
+  {{- if .Values.services.logger.autoscaling.hpaCpuTarget }}
   - type: ContainerResource
     containerResource:
       name: cpu
@@ -232,7 +243,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.logger.autoscaling.hpaCpuTarget }}
+  {{- end }}
   {{- with .Values.services.logger.autoscaling.customMetrics }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deployments/charts/osmo/templates/mcp-service.yaml
+++ b/deployments/charts/osmo/templates/mcp-service.yaml
@@ -16,8 +16,8 @@
 
 {{- if and .Values.planes.control.enabled .Values.services.mcp.enabled }}
 {{- $mcp := .Values.services.mcp }}
-{{- $name := include "osmo.v1.componentName" (dict "root" . "suffix" "mcp") }}
-{{- $mcpResourceUrl := include "osmo.v1.mcp-resource-url" . }}
+{{- $name := include "osmo.component.fullname" (dict "root" . "suffix" "mcp") }}
+{{- $mcpResourceUrl := include "osmo.mcp.resourceUrl" . }}
 {{- $gatewayUrl := trimSuffix "/mcp" $mcpResourceUrl }}
 {{- $requestTimeoutSeconds := toString $mcp.requestTimeoutSeconds }}
 {{- $reservedEnvNames := list "OSMO_MCP_HOST" "OSMO_MCP_PORT" "OSMO_GATEWAY_URL" "OSMO_MCP_REQUEST_TIMEOUT_SECONDS" }}
@@ -31,40 +31,37 @@ kind: Deployment
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
-    app.kubernetes.io/component: mcp
+    {{- include "osmo.component.labels" (dict "root" . "component" "mcp") | nindent 4 }}
 spec:
   replicas: {{ $mcp.replicas }}
   selector:
     matchLabels:
-      app: {{ $name }}
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "mcp") | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ $name }}
-        app.kubernetes.io/component: mcp
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" $mcp) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" $mcp "componentName" "mcp") | nindent 8 }}
       annotations:
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" $mcp) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" $mcp) | nindent 8 }}
     spec:
       automountServiceAccountToken: false
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" $mcp)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $mcp)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" $mcp) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" $mcp "root" . "suffix" "mcp") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" $mcp) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" $mcp "root" . "suffix" "mcp") }}
       containers:
       - name: {{ $name }}
-        image: {{ include "osmo.v1.image" (dict "root" . "component" $mcp) }}
-        imagePullPolicy: {{ include "osmo.v1.imagePullPolicy" (dict "root" . "component" $mcp) }}
+        image: {{ include "osmo.component.image" (dict "root" . "component" $mcp) }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" $mcp) }}
         command:
         - mcp
         {{- if .Values.gateway.tls.enabled }}
         args:
-        {{- include "osmo.v1.upstream-tls-args" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 8 }}
         {{- end }}
         securityContext:
           {{- toYaml $mcp.pod.containerSecurityContext | nindent 10 }}
@@ -88,17 +85,17 @@ spec:
           {{- toYaml $mcp.resources | nindent 10 }}
         {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
         volumeMounts:
-        {{- include "osmo.v1.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 8 }}
         {{- end }}
         livenessProbe:
-          {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" $mcp.livenessProbe "context" .) | nindent 10 }}
+          {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" $mcp.livenessProbe "context" .) | nindent 10 }}
         readinessProbe:
-          {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" $mcp.readinessProbe "context" .) | nindent 10 }}
+          {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" $mcp.readinessProbe "context" .) | nindent 10 }}
         startupProbe:
-          {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" $mcp.startupProbe "context" .) | nindent 10 }}
+          {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" $mcp.startupProbe "context" .) | nindent 10 }}
       {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
       volumes:
-      {{- include "osmo.v1.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 6 }}
+      {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 6 }}
       {{- end }}
 
 ---
@@ -108,8 +105,7 @@ kind: Service
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
-    app.kubernetes.io/component: mcp
+    {{- include "osmo.component.labels" (dict "root" . "component" "mcp") | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
@@ -118,7 +114,7 @@ spec:
     targetPort: http
     protocol: TCP
   selector:
-    app: {{ $name }}
+    {{- include "osmo.component.selectorLabels" (dict "root" . "component" "mcp") | nindent 4 }}
 
 ---
 
@@ -126,17 +122,19 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ $name }}-allow-gateway-envoy
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "mcp") | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app: {{ $name }}
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "mcp") | nindent 6 }}
   policyTypes:
   - Ingress
   ingress:
   - from:
     - podSelector:
         matchLabels:
-          {{- include "osmo.v1.gateway-component-labels" (dict "component" "envoy" "context" .) | nindent 10 }}
+          {{- include "osmo.gateway.componentSelectorLabels" (dict "component" "envoy" "context" .) | nindent 10 }}
     ports:
     - port: {{ $mcp.port }}
       protocol: TCP

--- a/deployments/charts/osmo/templates/mcp-service.yaml
+++ b/deployments/charts/osmo/templates/mcp-service.yaml
@@ -32,6 +32,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "mcp") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ $mcp.replicas }}
   {{- with $mcp.deploymentStrategy }}
@@ -117,6 +121,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "mcp") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:
@@ -135,6 +143,10 @@ metadata:
   name: {{ $name }}-allow-gateway-envoy
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "mcp") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   podSelector:
     matchLabels:

--- a/deployments/charts/osmo/templates/mcp-service.yaml
+++ b/deployments/charts/osmo/templates/mcp-service.yaml
@@ -34,6 +34,10 @@ metadata:
     {{- include "osmo.component.labels" (dict "root" . "component" "mcp") | nindent 4 }}
 spec:
   replicas: {{ $mcp.replicas }}
+  {{- with $mcp.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "mcp") | nindent 6 }}
@@ -44,7 +48,14 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" $mcp) | nindent 8 }}
     spec:
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ $mcp.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" $mcp) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" $mcp) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" $mcp)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" $mcp)) }}
       nodeSelector:
         {{- . | nindent 8 }}
@@ -64,7 +75,7 @@ spec:
         {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 8 }}
         {{- end }}
         securityContext:
-          {{- toYaml $mcp.pod.containerSecurityContext | nindent 10 }}
+          {{- include "osmo.container.securityContext" (dict "root" . "component" $mcp) | nindent 10 }}
         ports:
         - name: http
           containerPort: {{ $mcp.port }}

--- a/deployments/charts/osmo/templates/poddisruptionbudgets.yaml
+++ b/deployments/charts/osmo/templates/poddisruptionbudgets.yaml
@@ -30,17 +30,12 @@ metadata:
     {{- . | nindent 4 }}
   {{- end }}
 spec:
+  {{- $spec := omit $pdb "enabled" "labels" "annotations" "selector" }}
+  {{- with $spec }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" $root "component" $item.componentName) | nindent 6 }}
-  {{- if hasKey $pdb "minAvailable" }}
-  minAvailable: {{ get $pdb "minAvailable" }}
-  {{- end }}
-  {{- if hasKey $pdb "maxUnavailable" }}
-  maxUnavailable: {{ get $pdb "maxUnavailable" }}
-  {{- end }}
-  {{- with (dig "unhealthyPodEvictionPolicy" "" $pdb) }}
-  unhealthyPodEvictionPolicy: {{ . }}
-  {{- end }}
 {{- end }}
 {{- end }}

--- a/deployments/charts/osmo/templates/poddisruptionbudgets.yaml
+++ b/deployments/charts/osmo/templates/poddisruptionbudgets.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+{{- $root := . -}}
+{{- $components := list
+  (dict "suffix" "api" "componentName" "api" "component" .Values.services.api)
+  (dict "suffix" "ui" "componentName" "ui" "component" .Values.services.ui)
+  (dict "suffix" "router" "componentName" "router" "component" .Values.services.router)
+  (dict "suffix" "worker" "componentName" "worker" "component" .Values.services.worker)
+  (dict "suffix" "logger" "componentName" "logger" "component" .Values.services.logger)
+  (dict "suffix" "agent" "componentName" "agent" "component" .Values.services.agent)
+  (dict "suffix" "delayed-job-monitor" "componentName" "delayed-job-monitor" "component" .Values.services.delayedJobMonitor)
+  (dict "suffix" "mcp" "componentName" "mcp" "component" .Values.services.mcp)
+  (dict "suffix" "gateway-envoy" "componentName" "gateway-envoy" "component" .Values.gateway.envoy)
+  (dict "suffix" "gateway-oauth2-proxy" "componentName" "gateway-oauth2-proxy" "component" .Values.gateway.oauth2Proxy)
+  (dict "suffix" "gateway-authz" "componentName" "gateway-authz" "component" .Values.gateway.authz)
+  (dict "suffix" "gateway-ratelimit" "componentName" "gateway-ratelimit" "component" .Values.gateway.rateLimit) -}}
+{{- range $item := $components -}}
+{{- $pdb := dig "podDisruptionBudget" dict $item.component -}}
+{{- if and $item.component.enabled (dig "enabled" false $pdb) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "osmo.component.fullname" (dict "root" $root "suffix" $item.suffix) }}
+  labels:
+    {{- $labels := mergeOverwrite (deepCopy (dig "labels" dict $pdb)) (include "osmo.component.labels" (dict "root" $root "component" $item.componentName) | fromYaml) }}
+    {{- toYaml $labels | nindent 4 }}
+  {{- with (dig "annotations" dict $pdb) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "osmo.component.selectorLabels" (dict "root" $root "component" $item.componentName) | nindent 6 }}
+  {{- if hasKey $pdb "minAvailable" }}
+  minAvailable: {{ get $pdb "minAvailable" }}
+  {{- end }}
+  {{- if hasKey $pdb "maxUnavailable" }}
+  maxUnavailable: {{ get $pdb "maxUnavailable" }}
+  {{- end }}
+  {{- with (dig "unhealthyPodEvictionPolicy" "" $pdb) }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/deployments/charts/osmo/templates/poddisruptionbudgets.yaml
+++ b/deployments/charts/osmo/templates/poddisruptionbudgets.yaml
@@ -25,9 +25,9 @@ metadata:
   labels:
     {{- $labels := mergeOverwrite (deepCopy (dig "labels" dict $pdb)) (include "osmo.component.labels" (dict "root" $root "component" $item.componentName) | fromYaml) }}
     {{- toYaml $labels | nindent 4 }}
-  {{- with (dig "annotations" dict $pdb) }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" $root "annotations" (dig "annotations" dict $pdb))) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/deployments/charts/osmo/templates/rbac-configs.yaml
+++ b/deployments/charts/osmo/templates/rbac-configs.yaml
@@ -24,7 +24,7 @@ kind: Role
 metadata:
   name: {{ $apiName }}-configmap-events
   labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
 rules:
 # Emit Events on reload failures/recoveries.
 - apiGroups: [""]
@@ -44,7 +44,7 @@ kind: RoleBinding
 metadata:
   name: {{ $apiName }}-configmap-events
   labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deployments/charts/osmo/templates/rbac-configs.yaml
+++ b/deployments/charts/osmo/templates/rbac-configs.yaml
@@ -25,6 +25,10 @@ metadata:
   name: {{ $apiName }}-configmap-events
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 rules:
 # Emit Events on reload failures/recoveries.
 - apiGroups: [""]
@@ -45,6 +49,10 @@ metadata:
   name: {{ $apiName }}-configmap-events
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "api") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deployments/charts/osmo/templates/rbac-configs.yaml
+++ b/deployments/charts/osmo/templates/rbac-configs.yaml
@@ -14,29 +14,29 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Grants the osmo service the minimum RBAC needed to emit K8s Events
-# on the osmo-configs ConfigMap. Operators see these in the ArgoCD UI,
+# Grants the osmo API the minimum RBAC needed to emit K8s Events
+# on the osmo-api-config ConfigMap. Operators see these in the ArgoCD UI,
 # `kubectl describe configmap`, and `kubectl get events`.
 {{- if .Values.configuration.enabled }}
-{{- $apiName := include "osmo.v1.apiName" . }}
+{{- $apiName := include "osmo.api.fullname" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ $apiName }}-configmap-events
   labels:
-    app: {{ $apiName }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
 rules:
 # Emit Events on reload failures/recoveries.
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "get", "patch"]
-# Read the osmo-configs ConfigMap to fetch its UID. `kubectl describe
+# Read the osmo-api-config ConfigMap to fetch its UID. `kubectl describe
 # configmap` filters associated events by involvedObject.uid, so without
 # this the events wouldn't appear in that view (though they'd still be
 # visible in `kubectl get events --field-selector` and the ArgoCD UI).
 - apiGroups: [""]
   resources: ["configmaps"]
-  resourceNames: ["{{ $apiName }}-configs"]
+  resourceNames: ["{{ $apiName }}-config"]
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -44,12 +44,12 @@ kind: RoleBinding
 metadata:
   name: {{ $apiName }}-configmap-events
   labels:
-    app: {{ $apiName }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "configuration") | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ $apiName }}-configmap-events
 subjects:
 - kind: ServiceAccount
-  name: {{ include "osmo.v1.service-account-name" (dict "component" .Values.services.api "root" . "suffix" "service") }}
+  name: {{ include "osmo.component.serviceAccountName" (dict "component" .Values.services.api "root" . "suffix" "api") }}
 {{- end }}

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -15,25 +15,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.planes.control.enabled .Values.services.router.enabled }}
-{{- $name := include "osmo.v1.componentName" (dict "root" . "suffix" "router") }}
+{{- $name := include "osmo.component.fullname" (dict "root" . "suffix" "router") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "router") | nindent 4 }}
 spec:
   replicas: {{ .Values.services.router.autoscaling.minReplicas }}
   selector:
     matchLabels:
-      app: {{ $name }}
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "router") | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ $name }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" .Values.services.router) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.router "componentName" "router") | nindent 8 }}
       annotations:
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" .Values.services.router) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.router) | nindent 8 }}
     spec:
       {{- with .Values.services.router.pod.hostAliases }}
       hostAliases:
@@ -50,28 +49,28 @@ spec:
         {{- end }}
         labelSelector:
           matchLabels:
-            app: {{ $name }}
+            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "router") | nindent 12 }}
       {{- end }}
       {{- end }}
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" .Values.services.router)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.router)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" .Values.services.router) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" .Values.services.router "root" . "suffix" "router") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" .Values.services.router) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" .Values.services.router "root" . "suffix" "router") }}
       {{- with .Values.services.router.pod.initContainers }}
       initContainers:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ $name }}
-        image: {{ include "osmo.v1.image" (dict "root" . "component" .Values.services.router) }}
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.router) }}
         command:
         - router
         args:
-        {{- $routerHostname := .Values.services.router.hostname | default (include "osmo.v1.hostname" .) }}
+        {{- $routerHostname := .Values.services.router.hostname | default (include "osmo.hostname" .) }}
         {{- if $routerHostname }}
         - --hostname
         - {{ $routerHostname }}
@@ -106,9 +105,9 @@ spec:
         - {{ . }}
         {{- end }}
         {{- end }}
-        {{- include "osmo.v1.upstream-tls-args" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
         env:
-        {{- include "osmo.v1.connection-secret-env" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
         {{- with .Values.services.router.env }}
         {{- range . }}
         - name: {{ .name }}
@@ -120,7 +119,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- end }}
-        imagePullPolicy: {{ include "osmo.v1.imagePullPolicy" (dict "root" . "component" .Values.services.router) }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.router) }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -148,37 +147,37 @@ spec:
         {{- with .Values.services.router.volumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- include "osmo.v1.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volume-mounts" . | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
         {{- end }}
         resources:
         {{- toYaml .Values.services.router.resources | nindent 10 }}
 
         {{- with .Values.services.router.livenessProbe }}
         livenessProbe:
-          {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" . "context" $) | nindent 10 }}
+          {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" . "context" $) | nindent 10 }}
         {{- end }}
 
         {{- with .Values.services.router.startupProbe }}
         startupProbe:
-          {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" . "context" $) | nindent 10 }}
+          {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" . "context" $) | nindent 10 }}
         {{- end }}
 
         {{- with .Values.services.router.readinessProbe }}
         readinessProbe:
-          {{- include "osmo.v1.upstream-probe-yaml" (dict "probe" . "context" $) | nindent 10 }}
+          {{- include "osmo.gateway.upstreamProbeYaml" (dict "probe" . "context" $) | nindent 10 }}
         {{- end }}
 
       {{- with .Values.services.router.pod.sidecars }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
-        {{- include "osmo.v1.mek-volume" . | nindent 8 }}
+        {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
         {{- with .Values.services.router.pod.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- include "osmo.v1.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volumes" . | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 
 ---
 
@@ -187,7 +186,7 @@ kind: Service
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "router") | nindent 4 }}
 spec:
   ports:
     - port: 80
@@ -195,7 +194,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ $name }}
+    {{- include "osmo.component.selectorLabels" (dict "root" . "component" "router") | nindent 4 }}
 
 ---
 
@@ -204,7 +203,7 @@ kind: Service
 metadata:
   name: {{ $name }}-headless
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "router") | nindent 4 }}
 spec:
   clusterIP: None
   ports:
@@ -213,7 +212,7 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: {{ $name }}
+    {{- include "osmo.component.selectorLabels" (dict "root" . "component" "router") | nindent 4 }}
 
 ---
 
@@ -222,7 +221,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "router") | nindent 4 }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -237,7 +237,7 @@ spec:
       container: {{ $name }}
       target:
         type: Utilization
-        averageUtilization: {{ .Values.services.router.autoscaling.memoryTarget }}
+        averageUtilization: {{ .Values.services.router.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       name: cpu

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -141,19 +141,19 @@ spec:
           protocol: {{ .protocol | default "TCP" }}
         {{- end }}
         {{- end }}
-        {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.services.router.volumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.router) .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
+        - name: osmo-runtime-tmp
+          mountPath: /tmp
         {{- if .Values.secrets.masterEncryptionKey.existingSecret}}
         - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
-        {{- with .Values.services.router.volumeMounts }}
+        {{- with .Values.services.router.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
-        {{- end }}
         resources:
         {{- toYaml .Values.services.router.resources | nindent 10 }}
 
@@ -176,8 +176,10 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
+        - name: osmo-runtime-tmp
+          emptyDir: {}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
-        {{- with .Values.services.router.pod.volumes }}
+        {{- with .Values.services.router.pod.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -23,7 +23,9 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "router") | nindent 4 }}
 spec:
-  replicas: {{ .Values.services.router.autoscaling.minReplicas }}
+  {{- if not .Values.services.router.autoscaling.enabled }}
+  replicas: {{ .Values.services.router.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "router") | nindent 6 }}
@@ -206,6 +208,7 @@ spec:
 
 ---
 
+{{- if .Values.services.router.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -220,7 +223,12 @@ spec:
     name: {{ $name }}
   minReplicas: {{ .Values.services.router.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.services.router.autoscaling.maxReplicas }}
+  {{- with .Values.services.router.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
+  {{- if .Values.services.router.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       name: memory
@@ -228,6 +236,8 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.router.autoscaling.hpaMemoryTarget }}
+  {{- end }}
+  {{- if .Values.services.router.autoscaling.hpaCpuTarget }}
   - type: ContainerResource
     containerResource:
       name: cpu
@@ -235,7 +245,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.router.autoscaling.hpaCpuTarget }}
+  {{- end }}
   {{- with .Values.services.router.autoscaling.customMetrics }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -22,6 +22,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "router") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.services.router.autoscaling.enabled }}
   replicas: {{ .Values.services.router.replicas }}
@@ -187,6 +191,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "router") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - port: 80
@@ -204,6 +212,10 @@ metadata:
   name: {{ $name }}-headless
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "router") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   clusterIP: None
   ports:
@@ -223,7 +235,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "router") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
   annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -40,17 +40,7 @@ spec:
       {{- end }}
       {{- with .Values.services.router.pod.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range . }}
-      - topologyKey: {{.topologyKey }}
-        {{- range $key, $value := . }}
-        {{- if ne $key "topologyKey" }}
-        {{$key}}: {{$value}}
-        {{- end }}
-        {{- end }}
-        labelSelector:
-          matchLabels:
-            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "router") | nindent 12 }}
-      {{- end }}
+        {{- include "osmo.pod.topologySpreadConstraints" (dict "root" $ "constraints" . "componentName" "router") | nindent 8 }}
       {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.router)) }}
       nodeSelector:

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -26,6 +26,10 @@ spec:
   {{- if not .Values.services.router.autoscaling.enabled }}
   replicas: {{ .Values.services.router.replicas }}
   {{- end }}
+  {{- with .Values.services.router.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "router") | nindent 6 }}
@@ -36,6 +40,14 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.router) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.services.router.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" .Values.services.router) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" .Values.services.router) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" .Values.services.router)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with .Values.services.router.pod.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}
@@ -113,11 +125,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.router) }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 1001
+          {{- include "osmo.container.securityContext" (dict "root" . "component" .Values.services.router) | nindent 10 }}
         ports:
         - name: http
           containerPort: 8000

--- a/deployments/charts/osmo/templates/service-account.yaml
+++ b/deployments/charts/osmo/templates/service-account.yaml
@@ -42,5 +42,6 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ $component.serviceAccount.automountServiceAccountToken }}
 {{- end }}
 {{- end }}

--- a/deployments/charts/osmo/templates/service-account.yaml
+++ b/deployments/charts/osmo/templates/service-account.yaml
@@ -38,9 +38,9 @@ metadata:
   name: {{ include "osmo.component.serviceAccountName" (dict "component" $component "root" $root "suffix" $item.suffix) }}
   labels:
     {{- include "osmo.component.labels" (dict "root" $root "component" $item.suffix) | nindent 4 }}
-  {{- with $component.serviceAccount.annotations }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" $root "annotations" $component.serviceAccount.annotations)) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ $component.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/deployments/charts/osmo/templates/service-account.yaml
+++ b/deployments/charts/osmo/templates/service-account.yaml
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 {{- $root := . }}
 {{- $components := list
-  (dict "suffix" "service" "component" .Values.services.api)
+  (dict "suffix" "api" "component" .Values.services.api)
   (dict "suffix" "ui" "component" .Values.services.ui)
   (dict "suffix" "router" "component" .Values.services.router)
   (dict "suffix" "worker" "component" .Values.services.worker)
@@ -35,9 +35,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "osmo.v1.service-account-name" (dict "component" $component "root" $root "suffix" $item.suffix) }}
+  name: {{ include "osmo.component.serviceAccountName" (dict "component" $component "root" $root "suffix" $item.suffix) }}
   labels:
-    {{- include "osmo.v1.labels" $root | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" $root "component" $item.suffix) | nindent 4 }}
   {{- with $component.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deployments/charts/osmo/templates/ui-service.yaml
+++ b/deployments/charts/osmo/templates/ui-service.yaml
@@ -21,6 +21,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "ui") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.services.ui.autoscaling.enabled }}
   replicas: {{ .Values.services.ui.replicas }}
@@ -248,9 +252,9 @@ metadata:
   labels:
     {{- $serviceLabels := mergeOverwrite (deepCopy .Values.services.ui.service.labels) (include "osmo.component.labels" (dict "root" . "component" "ui") | fromYaml) }}
     {{- toYaml $serviceLabels | nindent 4 }}
-  {{- with .Values.services.ui.service.annotations }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" . "annotations" .Values.services.ui.service.annotations)) }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.services.ui.service.type }}
@@ -281,7 +285,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "ui") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
   annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/osmo/templates/ui-service.yaml
+++ b/deployments/charts/osmo/templates/ui-service.yaml
@@ -22,7 +22,9 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "ui") | nindent 4 }}
 spec:
-  replicas: {{ if .Values.services.ui.autoscaling.enabled }}{{ .Values.services.ui.autoscaling.minReplicas }}{{ else }}{{ .Values.services.ui.replicas }}{{ end }}
+  {{- if not .Values.services.ui.autoscaling.enabled }}
+  replicas: {{ .Values.services.ui.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "ui") | nindent 6 }}
@@ -279,14 +281,29 @@ spec:
     name: {{ $name }}
   minReplicas: {{ .Values.services.ui.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.services.ui.autoscaling.maxReplicas }}
+  {{- with .Values.services.ui.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
+  {{- if .Values.services.ui.autoscaling.hpaCpuTarget }}
+  - type: ContainerResource
+    containerResource:
+      container: {{ $name }}
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.services.ui.autoscaling.hpaCpuTarget }}
+  {{- end }}
+  {{- if .Values.services.ui.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       container: {{ $name }}
       name: memory
       target:
         type: Utilization
-        averageUtilization: {{ .Values.services.ui.autoscaling.hpaTarget }}
+        averageUtilization: {{ .Values.services.ui.autoscaling.hpaMemoryTarget }}
+  {{- end }}
   {{- with .Values.services.ui.autoscaling.customMetrics }}
   {{- toYaml . | nindent 2 }}
   {{- end }}

--- a/deployments/charts/osmo/templates/ui-service.yaml
+++ b/deployments/charts/osmo/templates/ui-service.yaml
@@ -113,10 +113,10 @@ spec:
         imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.ui) }}
         securityContext:
           {{- include "osmo.container.securityContext" (dict "root" . "component" .Values.services.ui) | nindent 10 }}
-        {{- if .Values.services.ui.volumeMounts }}
+        {{- if .Values.services.ui.extraVolumeMounts }}
         volumeMounts:
         {{- end }}
-        {{- with .Values.services.ui.volumeMounts }}
+        {{- with .Values.services.ui.extraVolumeMounts }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         resources:
@@ -239,7 +239,7 @@ spec:
         {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
-        {{- with .Values.services.ui.pod.volumes }}
+        {{- with .Values.services.ui.pod.extraVolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
 

--- a/deployments/charts/osmo/templates/ui-service.yaml
+++ b/deployments/charts/osmo/templates/ui-service.yaml
@@ -25,6 +25,10 @@ spec:
   {{- if not .Values.services.ui.autoscaling.enabled }}
   replicas: {{ .Values.services.ui.replicas }}
   {{- end }}
+  {{- with .Values.services.ui.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "ui") | nindent 6 }}
@@ -35,6 +39,14 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.ui) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.services.ui.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" .Values.services.ui) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" .Values.services.ui) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" .Values.services.ui)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       hostAliases:
         {{ toYaml .Values.services.ui.pod.hostAliases | nindent 8}}
       {{- with .Values.services.ui.pod.topologySpreadConstraints }}
@@ -96,11 +108,7 @@ spec:
         {{- end }}
         imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.ui) }}
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 1000
+          {{- include "osmo.container.securityContext" (dict "root" . "component" .Values.services.ui) | nindent 10 }}
         {{- if .Values.services.ui.volumeMounts }}
         volumeMounts:
         {{- end }}

--- a/deployments/charts/osmo/templates/ui-service.yaml
+++ b/deployments/charts/osmo/templates/ui-service.yaml
@@ -35,17 +35,9 @@ spec:
     spec:
       hostAliases:
         {{ toYaml .Values.services.ui.pod.hostAliases | nindent 8}}
+      {{- with .Values.services.ui.pod.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range .Values.services.ui.pod.topologySpreadConstraints }}
-      - topologyKey: {{.topologyKey }}
-        {{- range $key, $value := . }}
-        {{- if ne $key "topologyKey" }}
-        {{$key}}: {{$value}}
-        {{- end }}
-        {{- end }}
-        labelSelector:
-          matchLabels:
-            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "ui") | nindent 12 }}
+        {{- include "osmo.pod.topologySpreadConstraints" (dict "root" $ "constraints" . "componentName" "ui") | nindent 8 }}
       {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.ui)) }}
       nodeSelector:
@@ -76,7 +68,7 @@ spec:
         - name: NODE_OPTIONS
           value: '--max-http-header-size={{ mul .Values.services.ui.maxHttpHeaderSizeKb 1024 }}'
         - name: NEXT_PUBLIC_OSMO_API_HOSTNAME
-          value: {{ .Values.services.ui.apiHostname | default (printf "%s:80" (include "osmo.gateway.fullname" .)) | quote }}
+          value: {{ .Values.services.ui.apiHostname | default (printf "%s:%v" (include "osmo.gateway.fullname" .) .Values.gateway.envoy.service.port) | quote }}
         - name: NEXT_PUBLIC_OSMO_PORT_FORWARD_ENABLED
           value: {{ .Values.services.ui.portForwardEnabled | quote }}
         - name: NEXT_PUBLIC_OSMO_SSL_ENABLED

--- a/deployments/charts/osmo/templates/ui-service.yaml
+++ b/deployments/charts/osmo/templates/ui-service.yaml
@@ -14,26 +14,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 {{- if and .Values.planes.control.enabled .Values.services.ui.enabled }}
-{{- $name := include "osmo.v1.componentName" (dict "root" . "suffix" "ui") }}
+{{- $name := include "osmo.component.fullname" (dict "root" . "suffix" "ui") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
-    {{- include "osmo.v1.labels" . | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "ui") | nindent 4 }}
 spec:
   replicas: {{ if .Values.services.ui.autoscaling.enabled }}{{ .Values.services.ui.autoscaling.minReplicas }}{{ else }}{{ .Values.services.ui.replicas }}{{ end }}
   selector:
     matchLabels:
-      app: {{ $name }}
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "ui") | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ $name }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" .Values.services.ui) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.ui "componentName" "ui") | nindent 8 }}
       annotations:
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" .Values.services.ui) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.ui) | nindent 8 }}
     spec:
       hostAliases:
         {{ toYaml .Values.services.ui.pod.hostAliases | nindent 8}}
@@ -47,23 +45,23 @@ spec:
         {{- end }}
         labelSelector:
           matchLabels:
-            app: {{ $name }}
+            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "ui") | nindent 12 }}
       {{- end }}
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" .Values.services.ui)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.ui)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" .Values.services.ui) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" .Values.services.ui) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.services.ui.pod.initContainers }}
       initContainers:
         {{- toYaml .Values.services.ui.pod.initContainers | nindent 6 }}
       {{- end }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" .Values.services.ui "root" . "suffix" "ui") }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" .Values.services.ui "root" . "suffix" "ui") }}
       containers:
       - name: {{ $name }}
-        image: {{ include "osmo.v1.image" (dict "root" . "component" .Values.services.ui) }}
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.ui) }}
         {{- with .Values.services.ui.command }}
         command:
           {{- toYaml . | nindent 10 }}
@@ -78,7 +76,7 @@ spec:
         - name: NODE_OPTIONS
           value: '--max-http-header-size={{ mul .Values.services.ui.maxHttpHeaderSizeKb 1024 }}'
         - name: NEXT_PUBLIC_OSMO_API_HOSTNAME
-          value: {{ .Values.services.ui.apiHostname | default (printf "%s:80" (include "osmo.v1.gateway-name" .)) | quote }}
+          value: {{ .Values.services.ui.apiHostname | default (printf "%s:80" (include "osmo.gateway.fullname" .)) | quote }}
         - name: NEXT_PUBLIC_OSMO_PORT_FORWARD_ENABLED
           value: {{ .Values.services.ui.portForwardEnabled | quote }}
         - name: NEXT_PUBLIC_OSMO_SSL_ENABLED
@@ -102,7 +100,7 @@ spec:
         envFrom:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        imagePullPolicy: {{ include "osmo.v1.imagePullPolicy" (dict "root" . "component" .Values.services.ui) }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.ui) }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -246,11 +244,8 @@ kind: Service
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
-    {{- include "osmo.v1.labels" . | nindent 4 }}
-    {{- with .Values.services.ui.service.labels }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- $serviceLabels := mergeOverwrite (deepCopy .Values.services.ui.service.labels) (include "osmo.component.labels" (dict "root" . "component" "ui") | fromYaml) }}
+    {{- toYaml $serviceLabels | nindent 4 }}
   {{- with .Values.services.ui.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -274,10 +269,7 @@ spec:
       {{- end }}
     {{- end }}
   selector:
-    app: {{ $name }}
-    {{- with .Values.services.ui.service.selector }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+    {{- include "osmo.component.selectorLabels" (dict "root" . "component" "ui") | nindent 4 }}
 
 {{- if .Values.services.ui.autoscaling.enabled }}
 ---
@@ -286,8 +278,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
-    {{- include "osmo.v1.labels" . | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "ui") | nindent 4 }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -58,6 +58,30 @@
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- $pdbComponents := list
+  (dict "path" "services.mcp" "component" .Values.services.mcp)
+  (dict "path" "services.ui" "component" .Values.services.ui)
+  (dict "path" "services.delayedJobMonitor" "component" .Values.services.delayedJobMonitor)
+  (dict "path" "services.worker" "component" .Values.services.worker)
+  (dict "path" "services.api" "component" .Values.services.api)
+  (dict "path" "services.router" "component" .Values.services.router)
+  (dict "path" "services.logger" "component" .Values.services.logger)
+  (dict "path" "services.agent" "component" .Values.services.agent)
+  (dict "path" "gateway.envoy" "component" .Values.gateway.envoy)
+  (dict "path" "gateway.oauth2Proxy" "component" .Values.gateway.oauth2Proxy)
+  (dict "path" "gateway.authz" "component" .Values.gateway.authz)
+  (dict "path" "gateway.rateLimit" "component" .Values.gateway.rateLimit) -}}
+{{- range $item := $pdbComponents -}}
+{{- $pdb := dig "podDisruptionBudget" dict $item.component -}}
+{{- if dig "enabled" false $pdb -}}
+{{- if and (hasKey $pdb "minAvailable") (hasKey $pdb "maxUnavailable") -}}
+{{- fail (printf "%s.podDisruptionBudget cannot set both minAvailable and maxUnavailable" $item.path) -}}
+{{- end -}}
+{{- if and (not (hasKey $pdb "minAvailable")) (not (hasKey $pdb "maxUnavailable")) -}}
+{{- fail (printf "%s.podDisruptionBudget requires minAvailable or maxUnavailable when enabled" $item.path) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- if hasKey .Values "controlPlane" -}}
 {{- fail "controlPlane is not a supported value; configure services and gateway directly" -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -15,17 +15,17 @@
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
 {{- fail "embeddedDependencies.objectStorage.enabled: embedded object storage is not implemented" -}}
 {{- end -}}
-{{- if .Values.embeddedDependencies.gateway.enabled -}}
-{{- fail "embeddedDependencies.gateway.enabled: embedded Gateway API controller is not implemented" -}}
-{{- end -}}
 {{- if .Values.embeddedDependencies.kaiScheduler.enabled -}}
 {{- fail "embeddedDependencies.kaiScheduler.enabled: embedded KAI Scheduler is not implemented" -}}
 {{- end -}}
-{{- if ne .Values.exposure.mode "external" -}}
-{{- fail "exposure.mode: only external exposure is implemented" -}}
+{{- if not .Values.externalUrl -}}
+{{- fail "externalUrl is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.exposure.baseUrl -}}
-{{- fail "exposure.baseUrl is required for the control plane" -}}
+{{- if and .Values.ingress.enabled (not .Values.ingress.hostname) -}}
+{{- fail "ingress.hostname is required when ingress.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.httproute.enabled (eq (len .Values.httproute.parentRefs) 0) -}}
+{{- fail "httproute.parentRefs requires at least one entry when httproute.enabled=true" -}}
 {{- end -}}
 {{- if or .Values.secrets.postgresql.generate .Values.secrets.valkey.generate .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
 {{- fail "secrets: generated Secrets are not implemented; configure existingSecret" -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -21,6 +21,12 @@
 {{- if not .Values.externalUrl -}}
 {{- fail "externalUrl is required for the control plane" -}}
 {{- end -}}
+{{- if and .Values.ingress.enabled (not .Values.gateway.envoy.enabled) -}}
+{{- fail "ingress.enabled=true requires gateway.envoy.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.httproute.enabled (not .Values.gateway.envoy.enabled) -}}
+{{- fail "httproute.enabled=true requires gateway.envoy.enabled=true" -}}
+{{- end -}}
 {{- if and .Values.ingress.enabled (not .Values.ingress.hostname) -}}
 {{- fail "ingress.hostname is required when ingress.enabled=true" -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -36,6 +36,28 @@
 {{- if or .Values.secrets.postgresql.generate .Values.secrets.valkey.generate .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
 {{- fail "secrets: generated Secrets are not implemented; configure existingSecret" -}}
 {{- end -}}
+{{- $autoscaledComponents := list
+  (dict "path" "services.ui" "component" .Values.services.ui)
+  (dict "path" "services.worker" "component" .Values.services.worker)
+  (dict "path" "services.api" "component" .Values.services.api)
+  (dict "path" "services.router" "component" .Values.services.router)
+  (dict "path" "services.logger" "component" .Values.services.logger)
+  (dict "path" "services.agent" "component" .Values.services.agent)
+  (dict "path" "gateway.envoy" "component" .Values.gateway.envoy)
+  (dict "path" "gateway.oauth2Proxy" "component" .Values.gateway.oauth2Proxy)
+  (dict "path" "gateway.authz" "component" .Values.gateway.authz) -}}
+{{- range $item := $autoscaledComponents -}}
+{{- $component := $item.component -}}
+{{- if and $component.enabled $component.autoscaling.enabled -}}
+{{- $requests := dig "requests" dict $component.resources -}}
+{{- if and $component.autoscaling.hpaCpuTarget (not (get $requests "cpu")) -}}
+{{- fail (printf "%s autoscaling CPU target requires resources.requests.cpu" $item.path) -}}
+{{- end -}}
+{{- if and $component.autoscaling.hpaMemoryTarget (not (get $requests "memory")) -}}
+{{- fail (printf "%s autoscaling memory target requires resources.requests.memory" $item.path) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- if hasKey .Values "controlPlane" -}}
 {{- fail "controlPlane is not a supported value; configure services and gateway directly" -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -25,6 +25,10 @@ spec:
   {{- if not .Values.services.worker.autoscaling.enabled }}
   replicas: {{ .Values.services.worker.replicas }}
   {{- end }}
+  {{- with .Values.services.worker.deploymentStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "worker") | nindent 6 }}
@@ -35,6 +39,14 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
     spec:
+      automountServiceAccountToken: {{ .Values.services.worker.serviceAccount.automountServiceAccountToken }}
+      securityContext:
+        {{- include "osmo.pod.securityContext" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
+      terminationGracePeriodSeconds: {{ include "osmo.pod.terminationGracePeriodSeconds" (dict "root" . "component" .Values.services.worker) }}
+      {{- with (include "osmo.pod.affinity" (dict "root" . "component" .Values.services.worker)) }}
+      affinity:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with .Values.services.worker.pod.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- include "osmo.pod.topologySpreadConstraints" (dict "root" $ "constraints" . "componentName" "worker") | nindent 8 }}
@@ -57,11 +69,7 @@ spec:
         command:
         - "worker"
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          runAsNonRoot: true
-          runAsUser: 1001
+          {{- include "osmo.container.securityContext" (dict "root" . "component" .Values.services.worker) | nindent 10 }}
         ports:
         - name: metrics
           containerPort: 9464

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -14,24 +14,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 {{- if and .Values.planes.control.enabled .Values.services.worker.enabled }}
-{{- $name := include "osmo.v1.componentName" (dict "root" . "suffix" "worker") }}
+{{- $name := include "osmo.component.fullname" (dict "root" . "suffix" "worker") }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "worker") | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      app: {{ $name }}
+      {{- include "osmo.component.selectorLabels" (dict "root" . "component" "worker") | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ $name }}
-        {{- include "osmo.v1.pod-default-labels" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
+        {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.worker "componentName" "worker") | nindent 8 }}
       annotations:
-        {{- include "osmo.v1.extra-annotations" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
     spec:
       topologySpreadConstraints:
       {{- range .Values.services.worker.pod.topologySpreadConstraints }}
@@ -43,23 +42,23 @@ spec:
         {{- end }}
         labelSelector:
           matchLabels:
-            app: {{ $name }}
+            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "worker") | nindent 12 }}
       {{- end }}
-      {{- with (include "osmo.v1.node-selector" (dict "root" . "component" .Values.services.worker)) }}
+      {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.worker)) }}
       nodeSelector:
         {{- . | nindent 8 }}
       {{- end }}
       tolerations:
-        {{- include "osmo.v1.tolerations" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
-      {{- include "osmo.v1.imagePullSecrets" . | nindent 6 }}
-      serviceAccountName: {{ include "osmo.v1.service-account-name" (dict "component" .Values.services.worker "root" . "suffix" "worker") }}
+        {{- include "osmo.pod.tolerations" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "osmo.component.serviceAccountName" (dict "component" .Values.services.worker "root" . "suffix" "worker") }}
       {{- with .Values.services.worker.pod.initContainers }}
       initContainers:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ $name }}
-        image: {{ include "osmo.v1.image" (dict "root" . "component" .Values.services.worker) }}
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.worker) }}
         command:
         - "worker"
         securityContext:
@@ -71,7 +70,7 @@ spec:
         ports:
         - name: metrics
           containerPort: 9464
-        imagePullPolicy: {{ include "osmo.v1.imagePullPolicy" (dict "root" . "component" .Values.services.worker) }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.worker) }}
         args:
         - --metrics_otel_collector_component
         - {{ $name }}
@@ -109,14 +108,14 @@ spec:
         - --log_format
         - {{ .Values.logging.logFormat | default "text" }}
         {{- end }}
-        {{- include "osmo.v1.configmap-args" . | nindent 8 }}
+        {{- include "osmo.configuration.args" . | nindent 8 }}
         {{- range $arg := .Values.services.worker.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
         env:
-        {{- include "osmo.v1.configmap-env" . | nindent 8 }}
-        {{- include "osmo.v1.extra-env" .Values.services.worker | nindent 8 }}
-        {{- include "osmo.v1.connection-secret-env" . | nindent 8 }}
+        {{- include "osmo.configuration.env" . | nindent 8 }}
+        {{- include "osmo.component.extraEnv" .Values.services.worker | nindent 8 }}
+        {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
         {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.configuration.enabled .Values.services.worker.volumeMounts .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
         {{- end }}
@@ -125,9 +124,9 @@ spec:
           name: mek-volume
           subPath: mek.yaml
         {{- end }}
-        {{- include "osmo.v1.configmap-volume-mounts" . | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volume-mounts" . | nindent 8 }}
-        {{- include "osmo.v1.extra-volume-mounts" .Values.services.worker | nindent 8 }}
+        {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
+        {{- include "osmo.component.extraVolumeMounts" .Values.services.worker | nindent 8 }}
         resources:
         {{- toYaml .Values.services.worker.resources | nindent 10 }}
 
@@ -148,12 +147,12 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
 
-      {{- include "osmo.v1.extra-sidecars" .Values.services.worker | nindent 6 }}
+      {{- include "osmo.pod.extraSidecars" .Values.services.worker | nindent 6 }}
       volumes:
-        {{- include "osmo.v1.extra-volumes" .Values.services.worker | nindent 8 }}
-        {{- include "osmo.v1.mek-volume" . | nindent 8 }}
-        {{- include "osmo.v1.configmap-volumes" . | nindent 8 }}
-        {{- include "osmo.v1.external-ca-volumes" . | nindent 8 }}
+        {{- include "osmo.pod.extraVolumes" .Values.services.worker | nindent 8 }}
+        {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.configuration.volumes" . | nindent 8 }}
+        {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 
 ---
 
@@ -162,7 +161,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $name }}
   labels:
-    app: {{ $name }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "worker") | nindent 4 }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -21,6 +21,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "worker") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.services.worker.autoscaling.enabled }}
   replicas: {{ .Values.services.worker.replicas }}
@@ -166,7 +170,10 @@ metadata:
   name: {{ $name }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "worker") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
   annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -22,6 +22,9 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "worker") | nindent 4 }}
 spec:
+  {{- if not .Values.services.worker.autoscaling.enabled }}
+  replicas: {{ .Values.services.worker.replicas }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "osmo.component.selectorLabels" (dict "root" . "component" "worker") | nindent 6 }}
@@ -148,6 +151,7 @@ spec:
 
 ---
 
+{{- if .Values.services.worker.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -162,7 +166,12 @@ spec:
     name: {{ $name }}
   minReplicas: {{ .Values.services.worker.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.services.worker.autoscaling.maxReplicas }}
+  {{- with .Values.services.worker.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   metrics:
+  {{- if .Values.services.worker.autoscaling.hpaMemoryTarget }}
   - type: ContainerResource
     containerResource:
       name: memory
@@ -170,6 +179,8 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.worker.autoscaling.hpaMemoryTarget }}
+  {{- end }}
+  {{- if .Values.services.worker.autoscaling.hpaCpuTarget }}
   - type: ContainerResource
     containerResource:
       name: cpu
@@ -177,7 +188,9 @@ spec:
       target:
         type: Utilization
         averageUtilization: {{ .Values.services.worker.autoscaling.hpaCpuTarget }}
+  {{- end }}
   {{- with .Values.services.worker.autoscaling.customMetrics }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -32,17 +32,9 @@ spec:
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
     spec:
+      {{- with .Values.services.worker.pod.topologySpreadConstraints }}
       topologySpreadConstraints:
-      {{- range .Values.services.worker.pod.topologySpreadConstraints }}
-      - topologyKey: {{.topologyKey }}
-        {{- range $key, $value := . }}
-        {{- if ne $key "topologyKey" }}
-        {{$key}}: {{$value}}
-        {{- end }}
-        {{- end }}
-        labelSelector:
-          matchLabels:
-            {{- include "osmo.component.selectorLabels" (dict "root" $ "component" "worker") | nindent 12 }}
+        {{- include "osmo.pod.topologySpreadConstraints" (dict "root" $ "constraints" . "componentName" "worker") | nindent 8 }}
       {{- end }}
       {{- with (include "osmo.pod.nodeSelector" (dict "root" . "component" .Values.services.worker)) }}
       nodeSelector:

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -123,9 +123,9 @@ spec:
         {{- include "osmo.configuration.env" . | nindent 8 }}
         {{- include "osmo.component.extraEnv" .Values.services.worker | nindent 8 }}
         {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
-        {{- if or .Values.secrets.masterEncryptionKey.existingSecret .Values.configuration.enabled .Values.services.worker.volumeMounts .Values.externalDependencies.postgresql.tls.enabled .Values.externalDependencies.valkey.tls.enabled }}
         volumeMounts:
-        {{- end }}
+        - name: osmo-progress-files
+          mountPath: /var/run/osmo
         {{- if .Values.secrets.masterEncryptionKey.existingSecret}}
         - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
           name: mek-volume
@@ -156,6 +156,8 @@ spec:
 
       {{- include "osmo.pod.extraSidecars" .Values.services.worker | nindent 6 }}
       volumes:
+        - name: osmo-progress-files
+          emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.worker | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
         {{- include "osmo.configuration.volumes" . | nindent 8 }}

--- a/deployments/charts/osmo/tests/control-external-values.yaml
+++ b/deployments/charts/osmo/tests/control-external-values.yaml
@@ -34,6 +34,6 @@ secrets:
 services:
   api:
     image:
-      name: service
+      repository: nvidia/osmo/service
   mcp:
     enabled: false

--- a/deployments/charts/osmo/tests/control-external-values.yaml
+++ b/deployments/charts/osmo/tests/control-external-values.yaml
@@ -1,9 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-exposure:
-  mode: external
-  baseUrl: http://osmo-gateway
+externalUrl: http://osmo-gateway
 
 externalDependencies:
   postgresql:

--- a/deployments/charts/osmo/tests/control-hostile-metadata-values.yaml
+++ b/deployments/charts/osmo/tests/control-hostile-metadata-values.yaml
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+commonLabels:
+  helm.sh/chart: wrong-common
+  app.kubernetes.io/name: wrong-common
+  app.kubernetes.io/instance: wrong-common
+  app.kubernetes.io/version: wrong-common
+  app.kubernetes.io/managed-by: wrong-common
+  app.kubernetes.io/part-of: wrong-common
+  app.kubernetes.io/component: wrong-common
+  example.com/common-label: preserved
+  example.com/precedence: common
+
+podDefaults:
+  labels:
+    helm.sh/chart: wrong-pod-default
+    app.kubernetes.io/name: wrong-pod-default
+    app.kubernetes.io/instance: wrong-pod-default
+    app.kubernetes.io/version: wrong-pod-default
+    app.kubernetes.io/managed-by: wrong-pod-default
+    app.kubernetes.io/part-of: wrong-pod-default
+    app.kubernetes.io/component: wrong-pod-default
+    example.com/pod-default-label: preserved
+    example.com/precedence: pod-default
+
+services:
+  api:
+    pod:
+      labels:
+        helm.sh/chart: wrong-component
+        app.kubernetes.io/name: wrong-component
+        app.kubernetes.io/instance: wrong-component
+        app.kubernetes.io/version: wrong-component
+        app.kubernetes.io/managed-by: wrong-component
+        app.kubernetes.io/part-of: wrong-component
+        app.kubernetes.io/component: wrong-component
+        example.com/component-label: preserved
+        example.com/precedence: component
+      topologySpreadConstraints:
+      - maxSkew: 2
+        minDomains: 2
+        topologyKey: topology.example.com/api
+        whenUnsatisfiable: DoNotSchedule
+        matchLabelKeys:
+        - pod-template-hash
+        labelSelector:
+          matchLabels:
+            user.example.com/selector: hostile-api
+          matchExpressions:
+          - key: user.example.com/expression
+            operator: Exists
+  ui:
+    pod:
+      topologySpreadConstraints:
+      - maxSkew: 2
+        minDomains: 2
+        topologyKey: topology.example.com/ui
+        whenUnsatisfiable: DoNotSchedule
+        matchLabelKeys:
+        - pod-template-hash
+        labelSelector:
+          matchLabels:
+            user.example.com/selector: hostile-ui
+          matchExpressions:
+          - key: user.example.com/expression
+            operator: Exists
+  router:
+    pod:
+      topologySpreadConstraints:
+      - maxSkew: 2
+        minDomains: 2
+        topologyKey: topology.example.com/router
+        whenUnsatisfiable: DoNotSchedule
+        matchLabelKeys:
+        - pod-template-hash
+        labelSelector:
+          matchLabels:
+            user.example.com/selector: hostile-router
+          matchExpressions:
+          - key: user.example.com/expression
+            operator: Exists
+  worker:
+    pod:
+      topologySpreadConstraints:
+      - maxSkew: 2
+        minDomains: 2
+        topologyKey: topology.example.com/worker
+        whenUnsatisfiable: DoNotSchedule
+        matchLabelKeys:
+        - pod-template-hash
+        labelSelector:
+          matchLabels:
+            user.example.com/selector: hostile-worker
+          matchExpressions:
+          - key: user.example.com/expression
+            operator: Exists
+  logger:
+    pod:
+      topologySpreadConstraints:
+      - maxSkew: 2
+        minDomains: 2
+        topologyKey: topology.example.com/logger
+        whenUnsatisfiable: DoNotSchedule
+        matchLabelKeys:
+        - pod-template-hash
+        labelSelector:
+          matchLabels:
+            user.example.com/selector: hostile-logger
+          matchExpressions:
+          - key: user.example.com/expression
+            operator: Exists
+  agent:
+    pod:
+      topologySpreadConstraints:
+      - maxSkew: 2
+        minDomains: 2
+        topologyKey: topology.example.com/agent
+        whenUnsatisfiable: DoNotSchedule
+        matchLabelKeys:
+        - pod-template-hash
+        labelSelector:
+          matchLabels:
+            user.example.com/selector: hostile-agent
+          matchExpressions:
+          - key: user.example.com/expression
+            operator: Exists

--- a/deployments/charts/osmo/tests/control-monitoring-values.yaml
+++ b/deployments/charts/osmo/tests/control-monitoring-values.yaml
@@ -33,7 +33,7 @@ monitoring:
     tlsConfig:
       insecureSkipVerify: true
     honorLabels: true
-    targetLabels:
+    podTargetLabels:
     - app.kubernetes.io/component
     relabelings:
     - action: replace

--- a/deployments/charts/osmo/tests/control-monitoring-values.yaml
+++ b/deployments/charts/osmo/tests/control-monitoring-values.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+commonAnnotations:
+  platform.example.com/owner: common
+  checksum/envoy-config: wrong
+
+podDefaults:
+  annotations:
+    platform.example.com/owner: pod
+
+ingress:
+  enabled: true
+  hostname: osmo.example.com
+  annotations:
+    platform.example.com/owner: edge
+
+httproute:
+  enabled: true
+  parentRefs:
+  - name: shared-gateway
+
+monitoring:
+  podMonitor:
+    enabled: true
+    labels:
+      prometheus: platform
+    annotations:
+      platform.example.com/owner: monitor
+    interval: 99s
+    scrapeTimeout: 88s
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+    honorLabels: true
+    targetLabels:
+    - app.kubernetes.io/component
+    relabelings:
+    - action: replace
+      targetLabel: cluster
+      replacement: osmo-test
+    metricRelabelings:
+    - action: drop
+      sourceLabels:
+      - __name__
+      regex: unwanted_metric

--- a/deployments/charts/osmo/tests/control-review-values.yaml
+++ b/deployments/charts/osmo/tests/control-review-values.yaml
@@ -9,11 +9,12 @@ externalDependencies:
     tls:
       enabled: false
 
+monitoring:
+  podMonitor:
+    enabled: true
+
 services:
-  api:
-    monitoring:
-      podMonitor:
-        enabled: true
+  api: {}
   ui:
     docsBaseUrl: "*docs"
     cliInstallScriptUrl: "&install"

--- a/deployments/charts/osmo/tests/control-review-values.yaml
+++ b/deployments/charts/osmo/tests/control-review-values.yaml
@@ -4,6 +4,11 @@
 configuration:
   service: null
 
+externalDependencies:
+  valkey:
+    tls:
+      enabled: false
+
 services:
   api:
     monitoring:
@@ -63,7 +68,5 @@ gateway:
     enabled: true
   rateLimit:
     enabled: true
-    redis:
-      tlsEnabled: false
   networkPolicies:
     enabled: true

--- a/deployments/charts/osmo/tests/control-review-values.yaml
+++ b/deployments/charts/osmo/tests/control-review-values.yaml
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+externalUrl: https://osmo.example.com
+
 configuration:
   service: null
 

--- a/deployments/charts/osmo/tests/control-review-values.yaml
+++ b/deployments/charts/osmo/tests/control-review-values.yaml
@@ -50,15 +50,6 @@ gateway:
     ssl:
       enabled: true
       secretName: gateway-tls
-    ingress:
-      enabled: true
-      sslEnabled: true
-      albAnnotations:
-        enabled: true
-        groupName: osmo
-        groupOrder: "10"
-        # Synthetic test-only ARN used to verify ALB annotation rendering.
-        sslCertArn: arn:aws:acm:us-east-1:123456789012:certificate/test
   oauth2Proxy:
     enabled: true
     useKubernetesSecrets: true
@@ -70,3 +61,12 @@ gateway:
     enabled: true
   networkPolicies:
     enabled: true
+
+ingress:
+  enabled: true
+  hostname: osmo.example.com
+  annotations:
+    alb.ingress.kubernetes.io/backend-protocol: HTTPS
+  tls:
+    enabled: true
+    secretName: osmo-ingress-tls

--- a/deployments/charts/osmo/tests/control-volume-extension-values.yaml
+++ b/deployments/charts/osmo/tests/control-volume-extension-values.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+  api:
+    extraVolumeMounts:
+    - name: api-extension
+      mountPath: /var/lib/osmo-extension
+    pod:
+      extraVolumes:
+      - name: api-extension
+        emptyDir: {}
+  worker:
+    extraVolumeMounts:
+    - name: worker-extension
+      mountPath: /var/lib/osmo-worker-extension
+    pod:
+      extraVolumes:
+      - name: worker-extension
+        emptyDir: {}

--- a/deployments/charts/osmo/tests/control-workload-policy-values.yaml
+++ b/deployments/charts/osmo/tests/control-workload-policy-values.yaml
@@ -46,6 +46,11 @@ services:
         policy.example.com/reason: api-availability
       maxUnavailable: 1
       unhealthyPodEvictionPolicy: AlwaysAllow
+      # Simulates a native PDB spec field added after this chart release.
+      futureSpecField: forwarded
+      selector:
+        matchLabels:
+          user-supplied-selector: ignored
   worker:
     podDisruptionBudget:
       enabled: true

--- a/deployments/charts/osmo/tests/control-workload-policy-values.yaml
+++ b/deployments/charts/osmo/tests/control-workload-policy-values.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+podDefaults:
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 50
+        preference:
+          matchExpressions:
+          - key: workload-class
+            operator: In
+            values:
+            - osmo
+  podSecurityContext:
+    fsGroup: 2000
+  containerSecurityContext:
+    runAsUser: 1234
+  terminationGracePeriodSeconds: 45
+
+services:
+  api:
+    deploymentStrategy:
+      type: Recreate
+    pod:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 75
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  workload-tier: api
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
+        runAsUser: 4321
+      podSecurityContext:
+        runAsGroup: 2001
+      terminationGracePeriodSeconds: 75
+    podDisruptionBudget:
+      enabled: true
+      labels:
+        policy-owner: platform
+      annotations:
+        policy.example.com/reason: api-availability
+      maxUnavailable: 1
+      unhealthyPodEvictionPolicy: AlwaysAllow
+  worker:
+    podDisruptionBudget:
+      enabled: true
+      labels: {}
+      annotations: {}
+      minAvailable: 1
+      unhealthyPodEvictionPolicy: IfHealthyBudget

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -144,7 +144,8 @@ test_control_umbrella() {
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         >"$rendered"
 
-    require_deployment "$rendered" "osmo-service"
+    require_deployment "$rendered" "osmo-api"
+    require_no_deployment "$rendered" "osmo-service"
     require_deployment "$rendered" "osmo-worker"
     require_deployment "$rendered" "osmo-router"
     require_deployment "$rendered" "osmo-logger"
@@ -171,6 +172,23 @@ test_control_umbrella() {
     require_not_contains "$rendered" "vault.hashicorp.com"
     require_not_contains "$rendered" "labels_config:"
     require_not_contains "$rendered" "OSMO_SCHEMA_VERSION"
+    require_contains "$rendered" "app.kubernetes.io/name: osmo"
+    require_contains "$rendered" "app.kubernetes.io/component: api"
+
+    helm_template osmo "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string 'commonLabels.app\.kubernetes\.io/name=wrong' \
+        --set-string 'podDefaults.labels.app\.kubernetes\.io/component=wrong' \
+        >"$TEST_DIRECTORY/osmo-hostile-labels.yaml"
+    require_deployment "$TEST_DIRECTORY/osmo-hostile-labels.yaml" "osmo-api"
+    resource_document "$TEST_DIRECTORY/osmo-hostile-labels.yaml" Deployment osmo-api \
+        >"$TEST_DIRECTORY/osmo-api-hostile-labels.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-api-hostile-labels.yaml" \
+        "app.kubernetes.io/name: osmo"
+    require_contains "$TEST_DIRECTORY/osmo-api-hostile-labels.yaml" \
+        "app.kubernetes.io/component: api"
+    require_not_contains "$TEST_DIRECTORY/osmo-api-hostile-labels.yaml" "wrong"
 
     resource_document "$rendered" Deployment osmo-agent \
         >"$TEST_DIRECTORY/osmo-agent.yaml"
@@ -224,7 +242,7 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/osmo-review.yaml" \
         'value: "review-release-osmo-gateway:80"'
     require_contains "$TEST_DIRECTORY/osmo-review.yaml" \
-        "address: review-release-osmo-service"
+        "address: review-release-osmo-api"
     require_contains "$TEST_DIRECTORY/osmo-review.yaml" \
         "address: review-release-osmo-router-headless"
     require_contains "$TEST_DIRECTORY/osmo-review.yaml" \
@@ -240,10 +258,10 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/osmo-review.yaml" \
         "name: review-release-osmo-gateway-oauth2-proxy-monitor"
     resource_document "$TEST_DIRECTORY/osmo-review.yaml" NetworkPolicy \
-        review-release-osmo-gateway-allow-envoy-to-service \
+        review-release-osmo-gateway-allow-envoy-to-api \
         >"$TEST_DIRECTORY/osmo-review-service-network-policy.yaml"
     require_contains "$TEST_DIRECTORY/osmo-review-service-network-policy.yaml" \
-        "app: review-release-osmo-service"
+        "app.kubernetes.io/component: api"
     resource_document "$TEST_DIRECTORY/osmo-review.yaml" Deployment \
         review-release-osmo-gateway-oauth2-proxy \
         >"$TEST_DIRECTORY/osmo-review-oauth2-proxy.yaml"
@@ -275,7 +293,7 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/osmo-review-ingress.yaml" \
         "alb.ingress.kubernetes.io/backend-protocol: HTTPS"
     resource_document "$TEST_DIRECTORY/osmo-review.yaml" Deployment \
-        review-release-osmo-service >"$TEST_DIRECTORY/osmo-review-api.yaml"
+        review-release-osmo-api >"$TEST_DIRECTORY/osmo-review-api.yaml"
     require_contains "$TEST_DIRECTORY/osmo-review-api.yaml" "path: /health"
     require_not_contains "$TEST_DIRECTORY/osmo-review-api.yaml" "x-osmo-roles"
 

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -808,6 +808,63 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-overrides.yaml" "kubernetes.io/os: linux"
     require_no_deployment "$TEST_DIRECTORY/osmo-overrides.yaml" "osmo-logger"
 
+    helm_template scaling-disabled "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.api.autoscaling.enabled=false \
+        --set services.api.replicas=4 \
+        >"$TEST_DIRECTORY/osmo-scaling-disabled.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-scaling-disabled.yaml" Deployment \
+        scaling-disabled-osmo-api \
+        >"$TEST_DIRECTORY/osmo-scaling-disabled-api.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-scaling-disabled-api.yaml" \
+        "replicas: 4"
+    resource_document "$TEST_DIRECTORY/osmo-scaling-disabled.yaml" \
+        HorizontalPodAutoscaler scaling-disabled-osmo-api \
+        >"$TEST_DIRECTORY/osmo-scaling-disabled-api-hpa.yaml"
+    require_line_count "$TEST_DIRECTORY/osmo-scaling-disabled-api-hpa.yaml" 0
+
+    helm_template scaling-enabled "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.api.autoscaling.enabled=true \
+        --set services.api.autoscaling.behavior.scaleDown.stabilizationWindowSeconds=300 \
+        >"$TEST_DIRECTORY/osmo-scaling-enabled.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-scaling-enabled.yaml" \
+        HorizontalPodAutoscaler scaling-enabled-osmo-api \
+        >"$TEST_DIRECTORY/osmo-scaling-enabled-api-hpa.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-scaling-enabled-api-hpa.yaml" \
+        "stabilizationWindowSeconds: 300"
+    resource_document "$TEST_DIRECTORY/osmo-scaling-enabled.yaml" Deployment \
+        scaling-enabled-osmo-api \
+        >"$TEST_DIRECTORY/osmo-scaling-enabled-api.yaml"
+    require_not_contains "$TEST_DIRECTORY/osmo-scaling-enabled-api.yaml" \
+        "replicas:"
+
+    if helm_template scaling-without-cpu-request "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.api.autoscaling.enabled=true \
+        --set services.api.resources.requests.memory=256Mi \
+        --set-string services.api.resources.requests.cpu= \
+        >"$TEST_DIRECTORY/scaling-without-cpu-request.out" 2>&1; then
+        fail "expected API CPU autoscaling without a CPU request to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/scaling-without-cpu-request.out" \
+        "services.api autoscaling CPU target requires resources.requests.cpu"
+
+    if helm_template scaling-without-memory-request "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.worker.autoscaling.enabled=true \
+        --set services.worker.resources.requests.cpu=100m \
+        --set-string services.worker.resources.requests.memory= \
+        >"$TEST_DIRECTORY/scaling-without-memory-request.out" 2>&1; then
+        fail "expected worker memory autoscaling without a memory request to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/scaling-without-memory-request.out" \
+        "services.worker autoscaling memory target requires resources.requests.memory"
+
     if helm_template unsupported-compute "$charts_copy/osmo" \
         --set planes.compute.enabled=true \
         >"$TEST_DIRECTORY/unsupported-compute.out" 2>&1; then

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -51,6 +51,15 @@ require_occurrences() {
         fail "expected '$expected' $count times in $file, found $actual"
 }
 
+require_line_count() {
+    local file=$1
+    local expected=$2
+    local actual
+    actual=$(awk 'END { print NR }' "$file")
+    [[ "$actual" -eq "$expected" ]] || \
+        fail "expected $expected lines in $file, found $actual"
+}
+
 require_no_grep_matches() {
     local output_file=$1
     local failure_message=$2
@@ -84,8 +93,57 @@ resource_document() {
     local name=$3
     awk -v kind="$kind" -v name="$name" '
         BEGIN { RS = "---" }
-        $0 ~ ("\nkind: " kind "\n") && $0 ~ ("\n  name: " name "\n") { print }
+        {
+            line_count = split($0, lines, "\n")
+            for (i = 1; i <= line_count - 2; i++) {
+                if (lines[i] == "kind: " kind &&
+                    lines[i + 1] == "metadata:" &&
+                    lines[i + 2] == "  name: " name) {
+                    print
+                    next
+                }
+            }
+        }
     ' "$file"
+}
+
+pod_template_labels() {
+    awk '
+        /^  template:$/ { in_template = 1; next }
+        in_template && /^    metadata:$/ { in_metadata = 1; next }
+        in_metadata && /^      labels:$/ { in_labels = 1; next }
+        in_labels && /^        [^ ]/ {
+            sub(/^        /, "")
+            print
+            next
+        }
+        in_labels { exit }
+    ' "$1"
+}
+
+deployment_selector_labels() {
+    awk '
+        /^  selector:$/ { in_selector = 1; next }
+        in_selector && /^    matchLabels:$/ { in_labels = 1; next }
+        in_labels && /^      [^ ]/ {
+            sub(/^      /, "")
+            print
+            next
+        }
+        in_labels { exit }
+    ' "$1"
+}
+
+topology_spread_constraints() {
+    awk '
+        /^      topologySpreadConstraints:$/ {
+            in_constraints = 1
+            print
+            next
+        }
+        in_constraints && /^      [[:alnum:]]/ { exit }
+        in_constraints { print }
+    ' "$1"
 }
 
 require_deployment() {
@@ -361,6 +419,34 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/osmo-node-port-service.yaml" "port: 8080"
     require_contains "$TEST_DIRECTORY/osmo-node-port-service.yaml" \
         "nodePort: 30080"
+    resource_document "$TEST_DIRECTORY/osmo-node-port.yaml" Deployment \
+        node-port-release-osmo-ui >"$TEST_DIRECTORY/osmo-node-port-ui.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-node-port-ui.yaml" \
+        'value: "node-port-release-osmo-gateway:8080"'
+
+    helm_template external-url-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string externalUrl=https://osmo.example.com:8443/osmo/ \
+        --set gateway.oauth2Proxy.enabled=true \
+        >"$TEST_DIRECTORY/osmo-external-url.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-external-url.yaml" Deployment \
+        external-url-release-osmo-gateway-oauth2-proxy \
+        >"$TEST_DIRECTORY/osmo-external-url-oauth2-proxy.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-external-url-oauth2-proxy.yaml" \
+        "- --redirect-url=https://osmo.example.com:8443/osmo/oauth2/callback"
+
+    helm_template external-http-url-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string externalUrl=http://osmo.example.com:65535/base/ \
+        --set gateway.oauth2Proxy.enabled=true \
+        >"$TEST_DIRECTORY/osmo-external-http-url.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-external-http-url.yaml" Deployment \
+        external-http-url-release-osmo-gateway-oauth2-proxy \
+        >"$TEST_DIRECTORY/osmo-external-http-url-oauth2-proxy.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-external-http-url-oauth2-proxy.yaml" \
+        "- --redirect-url=http://osmo.example.com:65535/base/oauth2/callback"
 
     helm_template values-api "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -404,22 +490,149 @@ gateway.envoy.jwt.user_header=x-osmo-user|user_header
 gateway.oauth2Proxy.redis.tlsEnabled=false|oauth2Proxy
 gateway.rateLimit.redis.tlsEnabled=false|rateLimit
 services.ui.service.selector.component=ui|selector
+gateway.upstreams.service.host=legacy-api|service
+gateway.upstreams.api.enabled=false|enabled
+gateway.upstreams.api.unknown=true|unknown
+gateway.networkPolicies.unknown=true|unknown
+gateway.networkPolicies.upstreams[0].component=service|component
+gateway.tls.unknown=true|unknown
+gateway.tls.upstreamCerts.service=legacy-api-tls|service
+EOF
+
+
+    local invalid_gateway_value
+    local invalid_gateway_property
+    while IFS='|' read -r invalid_gateway_value invalid_gateway_property; do
+        if helm_template invalid-gateway-values "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set-string "$invalid_gateway_value" \
+            >"$TEST_DIRECTORY/invalid-gateway-values.out" 2>&1; then
+            fail "expected invalid $invalid_gateway_value to fail schema validation"
+        fi
+        require_contains "$TEST_DIRECTORY/invalid-gateway-values.out" \
+            "$invalid_gateway_property"
+    done <<'EOF'
+gateway.upstreams.api.port=not-a-port|port
+gateway.networkPolicies.enabled=not-a-boolean|enabled
+gateway.tls.enabled=not-a-boolean|enabled
+gateway.tls.upstreamCerts.api[0]=invalid|api
 EOF
 
     helm_template osmo "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set-string 'commonLabels.app\.kubernetes\.io/name=wrong' \
-        --set-string 'podDefaults.labels.app\.kubernetes\.io/component=wrong' \
+        -f "$CHARTS_ROOT/osmo/tests/control-hostile-metadata-values.yaml" \
         >"$TEST_DIRECTORY/osmo-hostile-labels.yaml"
     require_deployment "$TEST_DIRECTORY/osmo-hostile-labels.yaml" "osmo-api"
     resource_document "$TEST_DIRECTORY/osmo-hostile-labels.yaml" Deployment osmo-api \
         >"$TEST_DIRECTORY/osmo-api-hostile-labels.yaml"
-    require_contains "$TEST_DIRECTORY/osmo-api-hostile-labels.yaml" \
+    pod_template_labels "$TEST_DIRECTORY/osmo-api-hostile-labels.yaml" \
+        >"$TEST_DIRECTORY/osmo-api-pod-labels.yaml"
+    deployment_selector_labels "$TEST_DIRECTORY/osmo-api-hostile-labels.yaml" \
+        >"$TEST_DIRECTORY/osmo-api-selector-labels.yaml"
+    require_line_count "$TEST_DIRECTORY/osmo-api-selector-labels.yaml" 3
+    require_contains "$TEST_DIRECTORY/osmo-api-selector-labels.yaml" \
         "app.kubernetes.io/name: osmo"
-    require_contains "$TEST_DIRECTORY/osmo-api-hostile-labels.yaml" \
+    require_contains "$TEST_DIRECTORY/osmo-api-selector-labels.yaml" \
+        "app.kubernetes.io/instance: osmo"
+    require_contains "$TEST_DIRECTORY/osmo-api-selector-labels.yaml" \
         "app.kubernetes.io/component: api"
-    require_not_contains "$TEST_DIRECTORY/osmo-api-hostile-labels.yaml" "wrong"
+    require_occurrences "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "helm.sh/chart:" 1
+    require_occurrences "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/name:" 1
+    require_occurrences "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/instance:" 1
+    require_occurrences "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/version:" 1
+    require_occurrences "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/managed-by:" 1
+    require_occurrences "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/part-of:" 1
+    require_occurrences "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/component:" 1
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "helm.sh/chart: osmo-0.1.0"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/name: osmo"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/instance: osmo"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/version: 6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/managed-by: Helm"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/part-of: osmo"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "app.kubernetes.io/component: api"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "example.com/common-label: preserved"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "example.com/pod-default-label: preserved"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "example.com/component-label: preserved"
+    require_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" \
+        "example.com/precedence: component"
+    require_not_contains "$TEST_DIRECTORY/osmo-api-pod-labels.yaml" "wrong-"
+
+    local topology_component
+    for topology_component in api ui router worker logger agent; do
+        resource_document "$TEST_DIRECTORY/osmo-hostile-labels.yaml" Deployment \
+            "osmo-$topology_component" \
+            >"$TEST_DIRECTORY/osmo-$topology_component-hostile-topology.yaml"
+        topology_spread_constraints \
+            "$TEST_DIRECTORY/osmo-$topology_component-hostile-topology.yaml" \
+            >"$TEST_DIRECTORY/osmo-$topology_component-topology.yaml"
+        require_occurrences \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "labelSelector:" 1
+        require_occurrences \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "app.kubernetes.io/name: osmo" 1
+        require_occurrences \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "app.kubernetes.io/instance: osmo" 1
+        require_occurrences \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "app.kubernetes.io/component: $topology_component" 1
+        require_contains \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "matchLabelKeys:"
+        require_contains \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "- pod-template-hash"
+        require_contains \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "maxSkew: 2"
+        require_contains \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "minDomains: 2"
+        require_contains \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "topologyKey: topology.example.com/$topology_component"
+        require_contains \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "whenUnsatisfiable: DoNotSchedule"
+        require_not_contains \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "user.example.com/selector"
+        require_not_contains \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "user.example.com/expression"
+        require_not_contains \
+            "$TEST_DIRECTORY/osmo-$topology_component-topology.yaml" \
+            "helm.sh/chart"
+    done
+
+    resource_document "$rendered" Role osmo-api-configmap-events \
+        >"$TEST_DIRECTORY/osmo-api-role.yaml"
+    resource_document "$rendered" RoleBinding osmo-api-configmap-events \
+        >"$TEST_DIRECTORY/osmo-api-role-binding.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-api-role.yaml" \
+        "app.kubernetes.io/component: api"
+    require_contains "$TEST_DIRECTORY/osmo-api-role-binding.yaml" \
+        "app.kubernetes.io/component: api"
 
     resource_document "$rendered" Deployment osmo-agent \
         >"$TEST_DIRECTORY/osmo-agent.yaml"
@@ -724,6 +937,58 @@ EOF
     require_contains "$TEST_DIRECTORY/invalid-httproute.out" \
         "httproute.parentRefs requires at least one entry when httproute.enabled=true"
 
+    if helm_template dangling-ingress "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.envoy.enabled=false \
+        --set ingress.enabled=true \
+        --set ingress.hostname=osmo.example.com \
+        >"$TEST_DIRECTORY/dangling-ingress.out" 2>&1; then
+        fail "expected ingress.enabled=true with Envoy disabled to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/dangling-ingress.out" \
+        "ingress.enabled=true requires gateway.envoy.enabled=true"
+
+    if helm_template dangling-httproute "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.envoy.enabled=false \
+        --set httproute.enabled=true \
+        --set httproute.parentRefs[0].name=shared-gateway \
+        >"$TEST_DIRECTORY/dangling-httproute.out" 2>&1; then
+        fail "expected httproute.enabled=true with Envoy disabled to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/dangling-httproute.out" \
+        "httproute.enabled=true requires gateway.envoy.enabled=true"
+
+    local invalid_external_url
+    for invalid_external_url in \
+        " " \
+        " https://osmo.example.com" \
+        "osmo.example.com" \
+        "ftp://osmo.example.com" \
+        "https:///missing-host" \
+        "https://osmo.example.com/bad path" \
+        "https://osmo.example.com/foo\"bar" \
+        "https://osmo.example.com/<bad>" \
+        "https://osmo.example.com/{bad}" \
+        "https://osmo.example.com/%ZZ" \
+        "https://osmo.example.com/foo|bar" \
+        "https://osmo.example.com/foo\\\\bar" \
+        "https://osmo.example.com:65536/base" \
+        "https://osmo.example.com?next=/base" \
+        "https://osmo.example.com#base" \
+        "https://[2001:db8::1]:8443/osmo/"; do
+        if helm_template invalid-external-url "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set-string "externalUrl=$invalid_external_url" \
+            >"$TEST_DIRECTORY/invalid-external-url.out" 2>&1; then
+            fail "expected invalid externalUrl '$invalid_external_url' to fail"
+        fi
+        require_contains "$TEST_DIRECTORY/invalid-external-url.out" "externalUrl"
+    done
+
     local required_value
     local expected_message
     while IFS='|' read -r required_value expected_message; do
@@ -741,6 +1006,18 @@ externalDependencies.objectStorage.buckets.workflows|buckets.workflows is requir
 externalDependencies.objectStorage.buckets.logs|buckets.logs is required
 externalDependencies.objectStorage.buckets.apps|buckets.apps is required
 EOF
+
+    helm install notes-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --dry-run=client \
+        --set gateway.envoy.service.port=8443 \
+        --set gateway.envoy.ssl.enabled=true \
+        >"$TEST_DIRECTORY/osmo-notes.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-notes.yaml" \
+        "service/notes-release-osmo-gateway 8080:8443"
+    require_contains "$TEST_DIRECTORY/osmo-notes.yaml" \
+        "curl https://127.0.0.1:8080/api/version"
 
     if helm_template unknown-root "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -221,6 +221,11 @@ test_control_umbrella() {
     rm -rf "$charts_copy/osmo/charts"
     rm -f "$charts_copy/osmo/Chart.lock"
 
+    if ! helm lint "$charts_copy/osmo" >"$TEST_DIRECTORY/osmo-lint.out" 2>&1; then
+        cat "$TEST_DIRECTORY/osmo-lint.out" >&2
+        fail "expected chart defaults to pass helm lint"
+    fi
+
     helm package "$charts_copy/osmo" --destination "$TEST_DIRECTORY" >/dev/null
     tar -tzf "$TEST_DIRECTORY/osmo-0.1.0.tgz" >"$TEST_DIRECTORY/osmo-package.txt"
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "osmo/tests/"

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -33,6 +33,20 @@ require_contains() {
     grep -Fq -- "$expected" "$file" || fail "expected '$expected' in $file"
 }
 
+require_schema_path() {
+    local file=$1
+    local expected=$2
+    awk -v expected="$expected" '
+        {
+            gsub(/\//, ".")
+            if (index($0, expected) > 0) {
+                found = 1
+            }
+        }
+        END { exit !found }
+    ' "$file" || fail "expected schema path '$expected' in $file"
+}
+
 require_not_contains() {
     local file=$1
     local unexpected=$2
@@ -79,16 +93,52 @@ resource_document() {
     local kind=$2
     local name=$3
     awk -v kind="$kind" -v name="$name" '
-        BEGIN { RS = "---" }
+        function reset_document() {
+            document = ""
+            document_kind = ""
+            document_name = ""
+            in_metadata = 0
+        }
+        function finish_document() {
+            if (document_kind == kind && document_name == name) {
+                printf "%s", document
+                found = 1
+            }
+        }
+        BEGIN {
+            found = 0
+            reset_document()
+        }
+        /^---[[:space:]]*$/ {
+            finish_document()
+            reset_document()
+            next
+        }
         {
-            line_count = split($0, lines, "\n")
-            for (i = 1; i <= line_count - 2; i++) {
-                if (lines[i] == "kind: " kind &&
-                    lines[i + 1] == "metadata:" &&
-                    lines[i + 2] == "  name: " name) {
-                    print
-                    next
-                }
+            document = document $0 ORS
+        }
+        /^kind: / {
+            document_kind = $0
+            sub(/^kind: /, "", document_kind)
+            next
+        }
+        /^metadata:$/ {
+            in_metadata = 1
+            next
+        }
+        in_metadata && /^  name: / && document_name == "" {
+            document_name = $0
+            sub(/^  name: /, "", document_name)
+            next
+        }
+        in_metadata && /^[^ ]/ {
+            in_metadata = 0
+        }
+        END {
+            finish_document()
+            if (!found) {
+                print "resource not found: " kind "/" name > "/dev/stderr"
+                exit 1
             }
         }
     ' "$file"
@@ -151,39 +201,59 @@ require_resource_metadata_annotation() {
     local file=$1
     local annotation_key=$2
     awk -v annotation_key="$annotation_key" '
-        BEGIN { RS = "---"; missing = 0 }
-        {
+        function reset_document() {
             kind = ""
             name = ""
             in_metadata = 0
             in_annotations = 0
             found = 0
-            line_count = split($0, lines, "\n")
-            for (i = 1; i <= line_count; i++) {
-                if (lines[i] ~ /^kind: /) {
-                    kind = lines[i]
-                    sub(/^kind: /, "", kind)
-                } else if (lines[i] == "metadata:") {
-                    in_metadata = 1
-                    in_annotations = 0
-                } else if (in_metadata && lines[i] ~ /^  name: / && name == "") {
-                    name = lines[i]
-                    sub(/^  name: /, "", name)
-                } else if (in_metadata && lines[i] == "  annotations:") {
-                    in_annotations = 1
-                } else if (in_annotations && index(lines[i], "    " annotation_key ":") == 1) {
-                    found = 1
-                } else if (in_metadata && lines[i] ~ /^[^ ]/) {
-                    in_metadata = 0
-                    in_annotations = 0
-                }
-            }
+        }
+        function finish_document() {
             if (kind != "" && !found) {
                 print "missing " annotation_key " on " kind "/" name > "/dev/stderr"
                 missing = 1
             }
         }
-        END { exit missing }
+        BEGIN {
+            missing = 0
+            reset_document()
+        }
+        /^---[[:space:]]*$/ {
+            finish_document()
+            reset_document()
+            next
+        }
+        /^kind: / {
+            kind = $0
+            sub(/^kind: /, "", kind)
+            next
+        }
+        /^metadata:$/ {
+            in_metadata = 1
+            in_annotations = 0
+            next
+        }
+        in_metadata && /^  name: / && name == "" {
+            name = $0
+            sub(/^  name: /, "", name)
+            next
+        }
+        in_metadata && /^  annotations:$/ {
+            in_annotations = 1
+            next
+        }
+        in_annotations && index($0, "    " annotation_key ":") == 1 {
+            found = 1
+            next
+        }
+        in_metadata && /^[^ ]/ {
+            in_metadata = 0
+            in_annotations = 0
+        }
+        END {
+            finish_document()
+            exit missing
+        }
     ' "$file" || fail "expected every rendered resource to have annotation $annotation_key"
 }
 
@@ -211,6 +281,43 @@ require_clean_osmo_sources() {
         fail "osmo must not contain an unimplemented embedded Valkey template"
     [[ ! -e "$CHARTS_ROOT/osmo/templates/localstack-s3.yaml" ]] || \
         fail "osmo must not contain an unimplemented embedded object-storage template"
+}
+
+test_yaml_helpers() {
+    local fixture="$TEST_DIRECTORY/yaml-helper-fixture.yaml"
+    cat >"$fixture" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    certificate-data
+    -----END CERTIFICATE-----
+metadata:
+  name: certificate-config
+  annotations:
+    test.osmo.nvidia.com/required: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: annotated-service
+  annotations:
+    test.osmo.nvidia.com/required: "true"
+EOF
+
+    require_resource_metadata_annotation "$fixture" \
+        "test.osmo.nvidia.com/required"
+
+    resource_document "$fixture" ConfigMap certificate-config \
+        >"$TEST_DIRECTORY/certificate-config.yaml"
+    require_contains "$TEST_DIRECTORY/certificate-config.yaml" \
+        "certificate-data"
+
+    if resource_document "$fixture" Secret missing-secret \
+        >"$TEST_DIRECTORY/missing-resource.yaml" 2>/dev/null; then
+        fail "expected absent resource extraction to fail"
+    fi
 }
 
 test_control_umbrella() {
@@ -557,13 +664,13 @@ test_control_umbrella() {
             >"$TEST_DIRECTORY/invalid-gateway-values.out" 2>&1; then
             fail "expected invalid $invalid_gateway_value to fail schema validation"
         fi
-        require_contains "$TEST_DIRECTORY/invalid-gateway-values.out" \
+        require_schema_path "$TEST_DIRECTORY/invalid-gateway-values.out" \
             "$invalid_gateway_property"
     done <<'EOF'
-gateway.upstreams.api.port=not-a-port|port
-gateway.networkPolicies.enabled=not-a-boolean|enabled
-gateway.tls.enabled=not-a-boolean|enabled
-gateway.tls.upstreamCerts.api[0]=invalid|api
+gateway.upstreams.api.port=not-a-port|gateway.upstreams.api.port
+gateway.networkPolicies.enabled=not-a-boolean|gateway.networkPolicies.enabled
+gateway.tls.enabled=not-a-boolean|gateway.tls.enabled
+gateway.tls.upstreamCerts.api[0]=invalid|gateway.tls.upstreamCerts.api
 EOF
 
     helm_template osmo "$charts_copy/osmo" \
@@ -698,6 +805,11 @@ EOF
         >"$TEST_DIRECTORY/osmo-review.yaml"
     require_contains "$TEST_DIRECTORY/osmo-review.yaml" 'value: "*docs"'
     require_contains "$TEST_DIRECTORY/osmo-review.yaml" 'value: "&install"'
+    resource_document "$TEST_DIRECTORY/osmo-review.yaml" ConfigMap \
+        review-release-osmo-api-config \
+        >"$TEST_DIRECTORY/osmo-review-api-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-review-api-config.yaml" \
+        "service_base_url: https://osmo.example.com"
     resource_document "$TEST_DIRECTORY/osmo-review.yaml" Deployment \
         review-release-osmo-worker >"$TEST_DIRECTORY/osmo-review-worker.yaml"
     require_contains "$TEST_DIRECTORY/osmo-review-worker.yaml" \
@@ -867,10 +979,11 @@ EOF
         >"$TEST_DIRECTORY/osmo-scaling-disabled-api.yaml"
     require_contains "$TEST_DIRECTORY/osmo-scaling-disabled-api.yaml" \
         "replicas: 4"
-    resource_document "$TEST_DIRECTORY/osmo-scaling-disabled.yaml" \
+    if resource_document "$TEST_DIRECTORY/osmo-scaling-disabled.yaml" \
         HorizontalPodAutoscaler scaling-disabled-osmo-api \
-        >"$TEST_DIRECTORY/osmo-scaling-disabled-api-hpa.yaml"
-    require_line_count "$TEST_DIRECTORY/osmo-scaling-disabled-api-hpa.yaml" 0
+        >"$TEST_DIRECTORY/osmo-scaling-disabled-api-hpa.yaml" 2>/dev/null; then
+        fail "did not expect HorizontalPodAutoscaler/scaling-disabled-osmo-api"
+    fi
 
     helm_template scaling-enabled "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -1233,13 +1346,13 @@ EOF
             >"$TEST_DIRECTORY/invalid-gateway-service.out" 2>&1; then
             fail "expected invalid $invalid_service_value to fail schema validation"
         fi
-        require_contains "$TEST_DIRECTORY/invalid-gateway-service.out" \
+        require_schema_path "$TEST_DIRECTORY/invalid-gateway-service.out" \
             "$invalid_service_property"
     done <<'EOF'
-gateway.envoy.service.type=ExternalName|type
-gateway.envoy.service.port=0|port
-gateway.envoy.service.nodePort=65536|nodePort
-gateway.envoy.service.externalTrafficPolicy=Nearest|externalTrafficPolicy
+gateway.envoy.service.type=ExternalName|gateway.envoy.service.type
+gateway.envoy.service.port=0|gateway.envoy.service.port
+gateway.envoy.service.nodePort=65536|gateway.envoy.service.nodePort
+gateway.envoy.service.externalTrafficPolicy=Nearest|gateway.envoy.service.externalTrafficPolicy
 EOF
 
     if helm_template invalid-ingress "$charts_copy/osmo" \
@@ -1332,22 +1445,47 @@ externalDependencies.objectStorage.buckets.logs|buckets.logs is required
 externalDependencies.objectStorage.buckets.apps|buckets.apps is required
 EOF
 
-    helm install notes-release "$charts_copy/osmo" \
+    cat >"$charts_copy/osmo/templates/test-notes.yaml" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rendered-notes
+data:
+  notes: |-
+{{ include "osmo.notes" . | indent 4 }}
+EOF
+    helm_template notes-release "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --dry-run=client \
         --set gateway.envoy.service.port=8443 \
         --set gateway.envoy.ssl.enabled=true \
         >"$TEST_DIRECTORY/osmo-notes.yaml"
-    require_contains "$TEST_DIRECTORY/osmo-notes.yaml" \
+    resource_document "$TEST_DIRECTORY/osmo-notes.yaml" ConfigMap rendered-notes \
+        >"$TEST_DIRECTORY/osmo-notes-configmap.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-notes-configmap.yaml" \
         "service/notes-release-osmo-gateway 8080:8443"
-    require_contains "$TEST_DIRECTORY/osmo-notes.yaml" \
-        "curl https://127.0.0.1:8080/api/version"
+    require_contains "$TEST_DIRECTORY/osmo-notes-configmap.yaml" \
+        "local-only TLS check"
+    require_contains "$TEST_DIRECTORY/osmo-notes-configmap.yaml" \
+        "curl --insecure https://127.0.0.1:8080/api/version"
+
+    helm_template notes-http-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.envoy.ssl.enabled=false \
+        >"$TEST_DIRECTORY/osmo-http-notes.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-http-notes.yaml" ConfigMap rendered-notes \
+        >"$TEST_DIRECTORY/osmo-http-notes-configmap.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-http-notes-configmap.yaml" \
+        "curl http://127.0.0.1:8080/api/version"
+    require_not_contains "$TEST_DIRECTORY/osmo-http-notes-configmap.yaml" \
+        "--insecure"
 
 }
 
 case "$MODE" in
     osmo|all)
+        test_yaml_helpers
         require_clean_osmo_sources
         test_control_umbrella
         ;;

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -175,6 +175,171 @@ test_control_umbrella() {
     require_not_contains "$rendered" "OSMO_SCHEMA_VERSION"
     require_contains "$rendered" "app.kubernetes.io/name: osmo"
     require_contains "$rendered" "app.kubernetes.io/component: api"
+    resource_document "$rendered" Service osmo-gateway \
+        >"$TEST_DIRECTORY/osmo-gateway-service.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-gateway-service.yaml" "type: ClusterIP"
+    require_occurrences "$TEST_DIRECTORY/osmo-gateway-service.yaml" \
+        "targetPort: envoy-http" 1
+    require_not_contains "$rendered" "kind: Ingress"
+    require_not_contains "$rendered" "kind: HTTPRoute"
+
+    helm_template ingress-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set ingress.enabled=true \
+        --set ingress.ingressClassName=nginx \
+        --set ingress.hostname=osmo.example.com \
+        --set ingress.tls.enabled=true \
+        --set ingress.tls.secretName=osmo-ingress-tls \
+        --set ingress.extraHosts[0].name=extra.example.com \
+        --set ingress.extraHosts[0].path=/extra \
+        --set ingress.extraPaths[0].path=/custom \
+        --set ingress.extraPaths[0].pathType=Exact \
+        --set ingress.extraPaths[0].backend.service.name=custom-service \
+        --set ingress.extraPaths[0].backend.service.port.number=8080 \
+        --set ingress.extraRules[0].host=rule.example.com \
+        --set ingress.extraRules[0].http.paths[0].path=/rule \
+        --set ingress.extraRules[0].http.paths[0].pathType=Prefix \
+        --set ingress.extraRules[0].http.paths[0].backend.service.name=rule-service \
+        --set ingress.extraRules[0].http.paths[0].backend.service.port.number=8081 \
+        --set ingress.extraTls[0].hosts[0]=extra.example.com \
+        --set ingress.extraTls[0].secretName=extra-tls \
+        --set-string 'ingress.labels.app\.kubernetes\.io/name=wrong' \
+        --set-string 'ingress.labels.app\.kubernetes\.io/component=wrong' \
+        >"$TEST_DIRECTORY/osmo-ingress.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-ingress.yaml" Ingress \
+        ingress-release-osmo-gateway >"$TEST_DIRECTORY/osmo-ingress-resource.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "ingressClassName: nginx"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "host: osmo.example.com"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "name: ingress-release-osmo-gateway"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" "number: 80"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "secretName: osmo-ingress-tls"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "host: extra.example.com"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" "path: /extra"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" "path: /custom"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "name: custom-service"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "host: rule.example.com"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" "name: rule-service"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "secretName: extra-tls"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "app.kubernetes.io/name: osmo"
+    require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
+        "app.kubernetes.io/component: gateway-envoy"
+    require_not_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" "wrong"
+    require_occurrences "$TEST_DIRECTORY/osmo-ingress.yaml" "kind: Ingress" 1
+    require_not_contains "$TEST_DIRECTORY/osmo-ingress.yaml" "kind: HTTPRoute"
+
+    helm_template route-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set httproute.enabled=true \
+        --set httproute.parentRefs[0].name=shared-gateway \
+        --set httproute.parentRefs[0].namespace=ingress-system \
+        --set httproute.parentRefs[0].sectionName=https \
+        --set httproute.hostnames[0]=osmo.example.com \
+        --set httproute.rules[0].matches[0].path.type=PathPrefix \
+        --set httproute.rules[0].matches[0].path.value=/ \
+        --set httproute.rules[0].backendRefs[0].name=wrong-backend \
+        --set httproute.rules[0].backendRefs[0].port=9999 \
+        --set-string 'httproute.labels.app\.kubernetes\.io/name=wrong' \
+        --set-string 'httproute.labels.app\.kubernetes\.io/component=wrong' \
+        >"$TEST_DIRECTORY/osmo-httproute.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-httproute.yaml" HTTPRoute \
+        route-release-osmo-gateway >"$TEST_DIRECTORY/osmo-httproute-resource.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" \
+        "apiVersion: gateway.networking.k8s.io/v1"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" \
+        "name: shared-gateway"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" \
+        "namespace: ingress-system"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" \
+        "sectionName: https"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" \
+        "- osmo.example.com"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" \
+        "type: PathPrefix"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" "value: /"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" \
+        "name: route-release-osmo-gateway"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" "port: 80"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" \
+        "app.kubernetes.io/name: osmo"
+    require_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" \
+        "app.kubernetes.io/component: gateway-envoy"
+    require_not_contains "$TEST_DIRECTORY/osmo-httproute-resource.yaml" "wrong"
+    require_occurrences "$TEST_DIRECTORY/osmo-httproute.yaml" "kind: HTTPRoute" 1
+    require_not_contains "$TEST_DIRECTORY/osmo-httproute.yaml" "kind: Ingress"
+    require_not_contains "$TEST_DIRECTORY/osmo-httproute.yaml" "kind: GatewayClass"
+    require_not_contains "$TEST_DIRECTORY/osmo-httproute.yaml" "kind: Gateway"
+    require_not_contains "$TEST_DIRECTORY/osmo-httproute.yaml" "kind: GRPCRoute"
+
+    helm_template combined-edge-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set ingress.enabled=true \
+        --set ingress.hostname=osmo.example.com \
+        --set httproute.enabled=true \
+        --set httproute.parentRefs[0].name=shared-gateway \
+        >"$TEST_DIRECTORY/osmo-combined-edge.yaml"
+    require_occurrences "$TEST_DIRECTORY/osmo-combined-edge.yaml" \
+        "kind: Ingress" 1
+    require_occurrences "$TEST_DIRECTORY/osmo-combined-edge.yaml" \
+        "kind: HTTPRoute" 1
+
+    helm_template load-balancer-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.envoy.service.type=LoadBalancer \
+        --set gateway.envoy.service.port=443 \
+        --set gateway.envoy.service.nodePort=30443 \
+        --set gateway.envoy.service.loadBalancerClass=example.com/lb \
+        --set gateway.envoy.service.loadBalancerSourceRanges[0]=192.0.2.0/24 \
+        --set gateway.envoy.ssl.enabled=true \
+        >"$TEST_DIRECTORY/osmo-load-balancer.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-load-balancer.yaml" Service \
+        load-balancer-release-osmo-gateway \
+        >"$TEST_DIRECTORY/osmo-load-balancer-service.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-load-balancer-service.yaml" \
+        "type: LoadBalancer"
+    require_contains "$TEST_DIRECTORY/osmo-load-balancer-service.yaml" \
+        "loadBalancerClass: example.com/lb"
+    require_contains "$TEST_DIRECTORY/osmo-load-balancer-service.yaml" \
+        "- 192.0.2.0/24"
+    require_contains "$TEST_DIRECTORY/osmo-load-balancer-service.yaml" \
+        "externalTrafficPolicy: Cluster"
+    require_contains "$TEST_DIRECTORY/osmo-load-balancer-service.yaml" "name: https"
+    require_contains "$TEST_DIRECTORY/osmo-load-balancer-service.yaml" "port: 443"
+    require_contains "$TEST_DIRECTORY/osmo-load-balancer-service.yaml" \
+        "nodePort: 30443"
+    require_occurrences "$TEST_DIRECTORY/osmo-load-balancer-service.yaml" \
+        "targetPort: envoy-http" 1
+    require_not_contains "$TEST_DIRECTORY/osmo-load-balancer.yaml" "kind: Ingress"
+    require_not_contains "$TEST_DIRECTORY/osmo-load-balancer.yaml" "kind: HTTPRoute"
+
+    helm_template node-port-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.envoy.service.type=NodePort \
+        --set gateway.envoy.service.port=8080 \
+        --set gateway.envoy.service.nodePort=30080 \
+        --set gateway.envoy.service.externalTrafficPolicy=Local \
+        >"$TEST_DIRECTORY/osmo-node-port.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-node-port.yaml" Service \
+        node-port-release-osmo-gateway >"$TEST_DIRECTORY/osmo-node-port-service.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-node-port-service.yaml" "type: NodePort"
+    require_contains "$TEST_DIRECTORY/osmo-node-port-service.yaml" \
+        "externalTrafficPolicy: Local"
+    require_contains "$TEST_DIRECTORY/osmo-node-port-service.yaml" "port: 8080"
+    require_contains "$TEST_DIRECTORY/osmo-node-port-service.yaml" \
+        "nodePort: 30080"
 
     helm_template values-api "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -427,15 +592,25 @@ EOF
     require_contains "$TEST_DIRECTORY/unsupported-embedded.out" \
         "embedded PostgreSQL is not implemented"
 
-    if helm_template unsupported-exposure "$charts_copy/osmo" \
-        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set exposure.mode=gateway \
-        >"$TEST_DIRECTORY/unsupported-exposure.out" 2>&1; then
-        fail "expected exposure.mode=gateway to fail"
-    fi
-    require_contains "$TEST_DIRECTORY/unsupported-exposure.out" \
-        "only external exposure is implemented"
+    local legacy_exposure_value
+    local legacy_exposure_property
+    while IFS='|' read -r legacy_exposure_value legacy_exposure_property; do
+        if helm_template legacy-exposure "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set "$legacy_exposure_value" \
+            >"$TEST_DIRECTORY/legacy-exposure.out" 2>&1; then
+            fail "expected legacy $legacy_exposure_value to fail schema validation"
+        fi
+        require_contains "$TEST_DIRECTORY/legacy-exposure.out" \
+            "$legacy_exposure_property"
+    done <<'EOF'
+exposure.mode=external|exposure
+exposure.baseUrl=https://osmo.example.com|exposure
+embeddedDependencies.gateway.enabled=false|gateway
+gateway.envoy.ingress.enabled=false|'not' failed
+gateway.envoy.service.httpsPort=443|httpsPort
+EOF
 
     if helm_template unsupported-generated-secret "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -488,6 +663,46 @@ EOF
         "requestTimeoutSeconds"
     require_contains "$TEST_DIRECTORY/invalid-mcp-timeout.out" "60"
 
+    local invalid_service_value
+    local invalid_service_property
+    while IFS='|' read -r invalid_service_value invalid_service_property; do
+        if helm_template invalid-gateway-service "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set "$invalid_service_value" \
+            >"$TEST_DIRECTORY/invalid-gateway-service.out" 2>&1; then
+            fail "expected invalid $invalid_service_value to fail schema validation"
+        fi
+        require_contains "$TEST_DIRECTORY/invalid-gateway-service.out" \
+            "$invalid_service_property"
+    done <<'EOF'
+gateway.envoy.service.type=ExternalName|type
+gateway.envoy.service.port=0|port
+gateway.envoy.service.nodePort=65536|nodePort
+gateway.envoy.service.externalTrafficPolicy=Nearest|externalTrafficPolicy
+gateway.envoy.service.loadBalancerIP=192.0.2.1|loadBalancerIP
+EOF
+
+    if helm_template invalid-ingress "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set ingress.enabled=true \
+        >"$TEST_DIRECTORY/invalid-ingress.out" 2>&1; then
+        fail "expected ingress.enabled=true without hostname to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/invalid-ingress.out" \
+        "ingress.hostname is required when ingress.enabled=true"
+
+    if helm_template invalid-httproute "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set httproute.enabled=true \
+        >"$TEST_DIRECTORY/invalid-httproute.out" 2>&1; then
+        fail "expected httproute.enabled=true without parentRefs to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/invalid-httproute.out" \
+        "httproute.parentRefs requires at least one entry when httproute.enabled=true"
+
     local required_value
     local expected_message
     while IFS='|' read -r required_value expected_message; do
@@ -500,7 +715,7 @@ EOF
         fi
         require_contains "$TEST_DIRECTORY/missing-required.out" "$expected_message"
     done <<'EOF'
-exposure.baseUrl|exposure.baseUrl is required
+externalUrl|externalUrl is required
 externalDependencies.objectStorage.buckets.workflows|buckets.workflows is required
 externalDependencies.objectStorage.buckets.logs|buckets.logs is required
 externalDependencies.objectStorage.buckets.apps|buckets.apps is required

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -242,6 +242,46 @@ test_control_umbrella() {
     require_deployment "$rendered" "osmo-delayed-job-monitor"
     require_deployment "$rendered" "osmo-ui"
     require_deployment "$rendered" "osmo-gateway-envoy"
+    local hardened_component
+    for hardened_component in \
+        api worker router logger agent delayed-job-monitor ui gateway-envoy; do
+        resource_document "$rendered" Deployment "osmo-$hardened_component" \
+            >"$TEST_DIRECTORY/osmo-$hardened_component.yaml"
+        require_contains "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
+            "readOnlyRootFilesystem: true"
+    done
+    for hardened_component in api router logger agent; do
+        require_contains "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
+            "mountPath: /tmp"
+        require_contains "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
+            "name: osmo-runtime-tmp"
+    done
+    for hardened_component in worker logger agent delayed-job-monitor; do
+        require_contains "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
+            "mountPath: /var/run/osmo"
+        require_contains "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
+            "name: osmo-progress-files"
+    done
+
+    helm_template protected-writable-volumes "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-volume-extension-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-protected-writable-volumes.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-protected-writable-volumes.yaml" \
+        Deployment protected-writable-volumes-osmo-api \
+        >"$TEST_DIRECTORY/osmo-protected-api-volumes.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-protected-api-volumes.yaml" \
+        "name: osmo-runtime-tmp"
+    require_contains "$TEST_DIRECTORY/osmo-protected-api-volumes.yaml" \
+        "name: api-extension"
+    resource_document "$TEST_DIRECTORY/osmo-protected-writable-volumes.yaml" \
+        Deployment protected-writable-volumes-osmo-worker \
+        >"$TEST_DIRECTORY/osmo-protected-worker-volumes.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-protected-worker-volumes.yaml" \
+        "name: osmo-progress-files"
+    require_contains "$TEST_DIRECTORY/osmo-protected-worker-volumes.yaml" \
+        "name: worker-extension"
     require_no_deployment "$rendered" "postgres"
     require_no_deployment "$rendered" "redis"
     require_no_deployment "$rendered" "localstack-s3"
@@ -791,6 +831,12 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-tls.yaml" "/etc/osmo/ca/valkey/ca-bundle.crt"
     require_contains "$TEST_DIRECTORY/osmo-tls.yaml" "key: ca-bundle.crt"
     resource_document "$TEST_DIRECTORY/osmo-tls.yaml" Deployment \
+        osmo-tls-router >"$TEST_DIRECTORY/osmo-router-tls.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-router-tls.yaml" \
+        "/etc/osmo/ca/postgresql/ca.crt"
+    require_contains "$TEST_DIRECTORY/osmo-router-tls.yaml" \
+        "/etc/osmo/ca/valkey/ca-bundle.crt"
+    resource_document "$TEST_DIRECTORY/osmo-tls.yaml" Deployment \
         osmo-tls-gateway-authz >"$TEST_DIRECTORY/osmo-authz-tls.yaml"
     require_contains "$TEST_DIRECTORY/osmo-authz-tls.yaml" "secretName: postgresql-ca"
     require_contains "$TEST_DIRECTORY/osmo-authz-tls.yaml" "/etc/osmo/ca/postgresql"
@@ -1184,7 +1230,7 @@ EOF
 exposure.mode=external|exposure
 exposure.baseUrl=https://osmo.example.com|exposure
 embeddedDependencies.gateway.enabled=false|gateway
-gateway.envoy.ingress.enabled=false|'not' failed
+gateway.envoy.ingress.enabled=false|ingress
 gateway.envoy.service.httpsPort=443|httpsPort
 EOF
 
@@ -1378,6 +1424,44 @@ EOF
         fail "expected legacy per-service fields to fail schema validation"
     fi
     require_contains "$TEST_DIRECTORY/legacy-component.out" "worker"
+
+    local wrong_component_value
+    for wrong_component_value in \
+        services.api.httpPort=1234 \
+        services.ui.grpcPort=1234 \
+        services.router.cookieName=wrong \
+        services.worker.httpPort=1234 \
+        services.logger.clientId=wrong \
+        services.agent.service.type=ClusterIP \
+        services.delayedJobMonitor.autoscaling.enabled=true \
+        services.mcp.hostname=wrong \
+        gateway.envoy.grpcPort=1234 \
+        gateway.oauth2Proxy.jwt.userHeader=wrong \
+        gateway.authz.cookieName=wrong \
+        gateway.rateLimit.autoscaling.enabled=true; do
+        if helm_template wrong-component "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set "$wrong_component_value" \
+            >"$TEST_DIRECTORY/wrong-component.out" 2>&1; then
+            fail "expected wrong-component value $wrong_component_value to fail"
+        fi
+    done
+
+    local unsupported_pod_value
+    for unsupported_pod_value in \
+        podDefaults.hostAliases[0].ip=127.0.0.1 \
+        services.delayedJobMonitor.pod.topologySpreadConstraints[0].topologyKey=zone \
+        services.mcp.pod.extraVolumes[0].name=ignored \
+        gateway.envoy.pod.topologySpreadConstraints[0].topologyKey=zone; do
+        if helm_template unsupported-pod "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set "$unsupported_pod_value" \
+            >"$TEST_DIRECTORY/unsupported-pod.out" 2>&1; then
+            fail "expected unsupported pod value $unsupported_pod_value to fail"
+        fi
+    done
 }
 
 case "$MODE" in

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -865,6 +865,102 @@ EOF
     require_contains "$TEST_DIRECTORY/scaling-without-memory-request.out" \
         "services.worker autoscaling memory target requires resources.requests.memory"
 
+    helm_template workload-policy "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-workload-policy-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-workload-policy.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-workload-policy.yaml" Deployment \
+        workload-policy-osmo-api \
+        >"$TEST_DIRECTORY/osmo-workload-policy-api.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "type: Recreate"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "terminationGracePeriodSeconds: 75"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "seccompProfile:"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "type: RuntimeDefault"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "fsGroup: 2000"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "runAsGroup: 2001"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "readOnlyRootFilesystem: true"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "runAsUser: 4321"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "nodeAffinity:"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "podAntiAffinity:"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api.yaml" \
+        "automountServiceAccountToken: true"
+    resource_document "$TEST_DIRECTORY/osmo-workload-policy.yaml" ServiceAccount \
+        workload-policy-osmo-api \
+        >"$TEST_DIRECTORY/osmo-workload-policy-api-service-account.yaml"
+    require_contains \
+        "$TEST_DIRECTORY/osmo-workload-policy-api-service-account.yaml" \
+        "automountServiceAccountToken: true"
+
+    resource_document "$TEST_DIRECTORY/osmo-workload-policy.yaml" Deployment \
+        workload-policy-osmo-worker \
+        >"$TEST_DIRECTORY/osmo-workload-policy-worker.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-worker.yaml" \
+        "terminationGracePeriodSeconds: 45"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-worker.yaml" \
+        "runAsUser: 1234"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-worker.yaml" \
+        "automountServiceAccountToken: false"
+
+    resource_document "$TEST_DIRECTORY/osmo-workload-policy.yaml" Deployment \
+        workload-policy-osmo-ui \
+        >"$TEST_DIRECTORY/osmo-workload-policy-ui.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-ui.yaml" \
+        "serviceAccountName: default"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-ui.yaml" \
+        "automountServiceAccountToken: false"
+    require_occurrences "$TEST_DIRECTORY/osmo-workload-policy.yaml" \
+        "type: RuntimeDefault" 10
+
+    resource_document "$TEST_DIRECTORY/osmo-workload-policy.yaml" \
+        PodDisruptionBudget workload-policy-osmo-api \
+        >"$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "maxUnavailable: 1"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "unhealthyPodEvictionPolicy: AlwaysAllow"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "policy-owner: platform"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "policy.example.com/reason: api-availability"
+    require_occurrences "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "app.kubernetes.io/managed-by:" 1
+    require_occurrences "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "app.kubernetes.io/component: api" 2
+    require_occurrences "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "app.kubernetes.io/instance: workload-policy" 2
+    require_occurrences "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "app.kubernetes.io/name: osmo" 2
+
+    resource_document "$TEST_DIRECTORY/osmo-workload-policy.yaml" \
+        PodDisruptionBudget workload-policy-osmo-worker \
+        >"$TEST_DIRECTORY/osmo-workload-policy-worker-pdb.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-worker-pdb.yaml" \
+        "minAvailable: 1"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-worker-pdb.yaml" \
+        "unhealthyPodEvictionPolicy: IfHealthyBudget"
+
+    if helm_template invalid-pdb "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.api.podDisruptionBudget.enabled=true \
+        --set services.api.podDisruptionBudget.minAvailable=1 \
+        --set services.api.podDisruptionBudget.maxUnavailable=1 \
+        >"$TEST_DIRECTORY/invalid-pdb.out" 2>&1; then
+        fail "expected a PDB with both availability fields to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/invalid-pdb.out" \
+        "services.api.podDisruptionBudget cannot set both minAvailable and maxUnavailable"
+
     if helm_template unsupported-compute "$charts_copy/osmo" \
         --set planes.compute.enabled=true \
         >"$TEST_DIRECTORY/unsupported-compute.out" 2>&1; then

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -212,14 +212,14 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
         "ingressClassName: nginx"
     require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
-        "host: osmo.example.com"
+        'host: "osmo.example.com"'
     require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
         "name: ingress-release-osmo-gateway"
     require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" "number: 80"
     require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
         "secretName: osmo-ingress-tls"
     require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
-        "host: extra.example.com"
+        'host: "extra.example.com"'
     require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" "path: /extra"
     require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" "path: /custom"
     require_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" \
@@ -236,6 +236,27 @@ test_control_umbrella() {
     require_not_contains "$TEST_DIRECTORY/osmo-ingress-resource.yaml" "wrong"
     require_occurrences "$TEST_DIRECTORY/osmo-ingress.yaml" "kind: Ingress" 1
     require_not_contains "$TEST_DIRECTORY/osmo-ingress.yaml" "kind: HTTPRoute"
+
+    helm_template wildcard-ingress-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set ingress.enabled=true \
+        --set-string 'ingress.hostname=*.example.com' \
+        --set ingress.tls.enabled=true \
+        --set ingress.tls.secretName=wildcard-ingress-tls \
+        --set-string 'ingress.extraHosts[0].name=*.extra.example.com' \
+        --set-string 'ingress.extraTls[0].hosts[0]=*.tls.example.com' \
+        --set ingress.extraTls[0].secretName=wildcard-extra-tls \
+        >"$TEST_DIRECTORY/osmo-wildcard-ingress.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-wildcard-ingress.yaml" Ingress \
+        wildcard-ingress-release-osmo-gateway \
+        >"$TEST_DIRECTORY/osmo-wildcard-ingress-resource.yaml"
+    require_occurrences "$TEST_DIRECTORY/osmo-wildcard-ingress-resource.yaml" \
+        '"*.example.com"' 2
+    require_contains "$TEST_DIRECTORY/osmo-wildcard-ingress-resource.yaml" \
+        '"*.extra.example.com"'
+    require_contains "$TEST_DIRECTORY/osmo-wildcard-ingress-resource.yaml" \
+        "'*.tls.example.com'"
 
     helm_template route-release "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -121,6 +121,20 @@ pod_template_labels() {
     ' "$1"
 }
 
+pod_template_annotations() {
+    awk '
+        /^  template:$/ { in_template = 1; next }
+        in_template && /^    metadata:$/ { in_metadata = 1; next }
+        in_metadata && /^      annotations:$/ { in_annotations = 1; next }
+        in_annotations && /^        [^ ]/ {
+            sub(/^        /, "")
+            print
+            next
+        }
+        in_annotations { exit }
+    ' "$1"
+}
+
 deployment_selector_labels() {
     awk '
         /^  selector:$/ { in_selector = 1; next }
@@ -144,6 +158,46 @@ topology_spread_constraints() {
         in_constraints && /^      [[:alnum:]]/ { exit }
         in_constraints { print }
     ' "$1"
+}
+
+require_resource_metadata_annotation() {
+    local file=$1
+    local annotation_key=$2
+    awk -v annotation_key="$annotation_key" '
+        BEGIN { RS = "---"; missing = 0 }
+        {
+            kind = ""
+            name = ""
+            in_metadata = 0
+            in_annotations = 0
+            found = 0
+            line_count = split($0, lines, "\n")
+            for (i = 1; i <= line_count; i++) {
+                if (lines[i] ~ /^kind: /) {
+                    kind = lines[i]
+                    sub(/^kind: /, "", kind)
+                } else if (lines[i] == "metadata:") {
+                    in_metadata = 1
+                    in_annotations = 0
+                } else if (in_metadata && lines[i] ~ /^  name: / && name == "") {
+                    name = lines[i]
+                    sub(/^  name: /, "", name)
+                } else if (in_metadata && lines[i] == "  annotations:") {
+                    in_annotations = 1
+                } else if (in_annotations && index(lines[i], "    " annotation_key ":") == 1) {
+                    found = 1
+                } else if (in_metadata && lines[i] ~ /^[^ ]/) {
+                    in_metadata = 0
+                    in_annotations = 0
+                }
+            }
+            if (kind != "" && !found) {
+                print "missing " annotation_key " on " kind "/" name > "/dev/stderr"
+                missing = 1
+            }
+        }
+        END { exit missing }
+    ' "$file" || fail "expected every rendered resource to have annotation $annotation_key"
 }
 
 require_deployment() {
@@ -948,6 +1002,80 @@ EOF
         "minAvailable: 1"
     require_contains "$TEST_DIRECTORY/osmo-workload-policy-worker-pdb.yaml" \
         "unhealthyPodEvictionPolicy: IfHealthyBudget"
+
+    helm_template monitoring "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-monitoring-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-monitoring.yaml"
+    require_resource_metadata_annotation "$TEST_DIRECTORY/osmo-monitoring.yaml" \
+        "platform.example.com/owner"
+    resource_document "$TEST_DIRECTORY/osmo-monitoring.yaml" PodMonitor \
+        monitoring-osmo-otel-monitor \
+        >"$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "prometheus: platform"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "platform.example.com/owner: monitor"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "interval: 99s"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "scrapeTimeout: 88s"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "scheme: https"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "insecureSkipVerify: true"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "honorLabels: true"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "targetLabels:"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "targetLabel: cluster"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "replacement: osmo-test"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "regex: unwanted_metric"
+
+    resource_document "$TEST_DIRECTORY/osmo-monitoring.yaml" Ingress \
+        monitoring-osmo-gateway \
+        >"$TEST_DIRECTORY/osmo-monitoring-ingress.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-ingress.yaml" \
+        "platform.example.com/owner: edge"
+    resource_document "$TEST_DIRECTORY/osmo-monitoring.yaml" Deployment \
+        monitoring-osmo-api \
+        >"$TEST_DIRECTORY/osmo-monitoring-api.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-api.yaml" \
+        "platform.example.com/owner: common"
+    require_contains "$TEST_DIRECTORY/osmo-monitoring-api.yaml" \
+        "platform.example.com/owner: pod"
+    resource_document "$TEST_DIRECTORY/osmo-monitoring.yaml" Deployment \
+        monitoring-osmo-gateway-envoy \
+        >"$TEST_DIRECTORY/osmo-monitoring-envoy.yaml"
+    pod_template_annotations "$TEST_DIRECTORY/osmo-monitoring-envoy.yaml" \
+        >"$TEST_DIRECTORY/osmo-monitoring-envoy-pod-annotations.yaml"
+    require_occurrences \
+        "$TEST_DIRECTORY/osmo-monitoring-envoy-pod-annotations.yaml" \
+        "checksum/envoy-config:" 1
+    require_not_contains \
+        "$TEST_DIRECTORY/osmo-monitoring-envoy-pod-annotations.yaml" \
+        "checksum/envoy-config: wrong"
+
+    helm_template monitoring-defaults "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-monitoring-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-monitoring-defaults.yaml"
+    require_resource_metadata_annotation \
+        "$TEST_DIRECTORY/osmo-monitoring-defaults.yaml" \
+        "platform.example.com/owner"
+
+    helm_template monitoring-mcp "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-mcp-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-monitoring-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-monitoring-mcp.yaml"
+    require_resource_metadata_annotation \
+        "$TEST_DIRECTORY/osmo-monitoring-mcp.yaml" \
+        "platform.example.com/owner"
 
     if helm_template invalid-pdb "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -60,19 +60,6 @@ require_line_count() {
         fail "expected $expected lines in $file, found $actual"
 }
 
-require_no_grep_matches() {
-    local output_file=$1
-    local failure_message=$2
-    shift 2
-    if grep -ERn -- "$@" >"$output_file"; then
-        cat "$output_file" >&2
-        fail "$failure_message"
-    else
-        local status=$?
-        [[ "$status" -eq 1 ]] || fail "grep failed with status $status"
-    fi
-}
-
 deployment_names() {
     awk '
         /^kind: Deployment$/ { deployment = 1; metadata = 0; next }
@@ -215,17 +202,6 @@ require_no_deployment() {
 }
 
 require_clean_osmo_sources() {
-    require_no_grep_matches "$TEST_DIRECTORY/legacy-template-values.out" \
-        "osmo templates still reference legacy values" \
-        '\.Values\.(global|controlPlane|components|services\.(configFile|configs|defaultAdmin|localstackS3|postgres|redis))' \
-        "$CHARTS_ROOT/osmo/templates"
-    require_no_grep_matches "$TEST_DIRECTORY/legacy-external-values.out" \
-        "osmo templates still reference the legacy external values block" \
-        '\.Values\.external([^[:alnum:]_]|$)' "$CHARTS_ROOT/osmo/templates"
-    require_no_grep_matches "$TEST_DIRECTORY/legacy-default-values.out" \
-        "osmo defaults still expose legacy values" \
-        '^(global|controlPlane|components):|^    (imageName|imageTag|imagePullPolicy|serviceAccountName):' \
-        "$CHARTS_ROOT/osmo/values.yaml"
     require_not_contains "$CHARTS_ROOT/osmo/Chart.yaml" "dependencies:"
     [[ ! -e "$CHARTS_ROOT/osmo/Chart.lock" ]] || fail "osmo must not have a dependency lock"
     [[ ! -d "$CHARTS_ROOT/osmo/charts" ]] || fail "osmo must not contain packaged dependencies"
@@ -774,6 +750,8 @@ EOF
         "name: REDIS_AUTH"
     require_contains "$TEST_DIRECTORY/osmo-review-ratelimit.yaml" \
         'value: "false"'
+    require_contains "$TEST_DIRECTORY/osmo-review-ratelimit.yaml" \
+        'image: "docker.io/envoyproxy/ratelimit:875d418c"'
     helm_template authz-database "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
@@ -844,6 +822,8 @@ EOF
         "issuer: https://issuer.example.com"
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
         "uri: https://issuer.example.com/.well-known/jwks.json"
+    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
+        "image: nvcr.io/nvidia/osmo/mcp-self-hosted:6.3.1"
     require_occurrences "$TEST_DIRECTORY/osmo-mcp.yaml" \
         "kubernetes.io/os: linux" 10
 
@@ -852,7 +832,7 @@ EOF
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         --set commonLabels.team=platform \
         --set-string 'podDefaults.nodeSelector.kubernetes\.io/os=linux' \
-        --set services.worker.image.name=custom-worker \
+        --set services.worker.image.repository=nvidia/osmo/custom-worker \
         --set services.worker.image.tag=test-tag \
         --set services.logger.enabled=false \
         >"$TEST_DIRECTORY/osmo-overrides.yaml"
@@ -1076,6 +1056,87 @@ EOF
     require_resource_metadata_annotation \
         "$TEST_DIRECTORY/osmo-monitoring-mcp.yaml" \
         "platform.example.com/owner"
+
+    helm_template image-defaults "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-image-defaults.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        "image: nvcr.io/nvidia/osmo/service:6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        "image: nvcr.io/nvidia/osmo/web-ui:6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        "image: nvcr.io/nvidia/osmo/worker:6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        "image: nvcr.io/nvidia/osmo/router:6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        "image: nvcr.io/nvidia/osmo/logger:6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        "image: nvcr.io/nvidia/osmo/agent:6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        "image: nvcr.io/nvidia/osmo/delayed-job-monitor:6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        "image: nvcr.io/nvidia/osmo/authz-sidecar:6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        'image: "docker.io/envoyproxy/envoy:v1.38.1"'
+    require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
+        'image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"'
+
+    helm_template image-mirror "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set global.imageRegistry=mirror.example.com \
+        --set global.imagePullSecrets[0].name=mirror-secret \
+        >"$TEST_DIRECTORY/osmo-image-mirror.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
+        "image: mirror.example.com/nvidia/osmo/service:6.3.1"
+    require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
+        'image: "mirror.example.com/envoyproxy/envoy:v1.38.1"'
+    require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
+        'image: "mirror.example.com/oauth2-proxy/oauth2-proxy:v7.14.2"'
+    require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
+        "- mirror.example.com/nvidia/osmo"
+    require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
+        "name: mirror-secret"
+
+    helm_template image-component "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.worker.image.registry=registry.example.com \
+        --set services.worker.image.repository=custom/team/worker \
+        --set services.worker.image.tag=v2 \
+        >"$TEST_DIRECTORY/osmo-image-component.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-image-component.yaml" \
+        "image: registry.example.com/custom/team/worker:v2"
+
+    helm_template image-digest "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.worker.image.tag=ignored \
+        --set-string services.worker.image.digest=sha256:0123456789abcdef \
+        >"$TEST_DIRECTORY/osmo-image-digest.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-image-digest.yaml" \
+        "image: nvcr.io/nvidia/osmo/worker@sha256:0123456789abcdef"
+    require_not_contains "$TEST_DIRECTORY/osmo-image-digest.yaml" \
+        "worker:ignored"
+
+    local unknown_nested_value
+    while IFS= read -r unknown_nested_value; do
+        if helm_template unknown-nested "$charts_copy/osmo" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set "$unknown_nested_value" \
+            >"$TEST_DIRECTORY/unknown-nested.out" 2>&1; then
+            fail "expected unknown chart-owned value $unknown_nested_value to fail"
+        fi
+        require_contains "$TEST_DIRECTORY/unknown-nested.out" "typo"
+    done <<'EOF'
+services.worker.typo=true
+services.worker.image.typo=true
+services.worker.serviceAccount.typo=true
+services.worker.podDisruptionBudget.typo=true
+services.worker.pod.typo=true
+monitoring.podMonitor.typo=true
+gateway.envoy.internalJwks.typo=true
+gateway.authz.postgres.typo=true
+gateway.rateLimit.config.typo=true
+secrets.valkey.typo=true
+EOF
 
     if helm_template invalid-pdb "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -176,6 +176,50 @@ test_control_umbrella() {
     require_contains "$rendered" "app.kubernetes.io/name: osmo"
     require_contains "$rendered" "app.kubernetes.io/component: api"
 
+    helm_template values-api "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.api.auth.enabled=true \
+        --set services.api.auth.deviceEndpoint=https://idp.example.com/device \
+        --set services.api.auth.deviceClientId=device-client \
+        --set services.api.auth.browserEndpoint=https://idp.example.com/authorize \
+        --set services.api.auth.browserClientId=browser-client \
+        --set services.api.auth.tokenEndpoint=https://idp.example.com/token \
+        --set services.api.auth.logoutEndpoint=https://idp.example.com/logout \
+        >"$TEST_DIRECTORY/osmo-values-api.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-values-api.yaml" Deployment values-api-osmo-api \
+        >"$TEST_DIRECTORY/osmo-values-api-deployment.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-values-api-deployment.yaml" \
+        "https://idp.example.com/device"
+    require_contains "$TEST_DIRECTORY/osmo-values-api-deployment.yaml" "device-client"
+    require_contains "$TEST_DIRECTORY/osmo-values-api-deployment.yaml" \
+        "https://idp.example.com/authorize"
+    require_contains "$TEST_DIRECTORY/osmo-values-api-deployment.yaml" "browser-client"
+    require_contains "$TEST_DIRECTORY/osmo-values-api-deployment.yaml" \
+        "https://idp.example.com/token"
+    require_contains "$TEST_DIRECTORY/osmo-values-api-deployment.yaml" \
+        "https://idp.example.com/logout"
+
+    local legacy_value
+    local legacy_property
+    while IFS='|' read -r legacy_value legacy_property; do
+        if helm_template legacy-chart-values "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set "$legacy_value" \
+            >"$TEST_DIRECTORY/legacy-chart-values.out" 2>&1; then
+            fail "expected legacy $legacy_value to fail schema validation"
+        fi
+        require_contains "$TEST_DIRECTORY/legacy-chart-values.out" "$legacy_property"
+    done <<'EOF'
+services.api.auth.device_endpoint=https://idp.example.com/device|device_endpoint
+services.router.autoscaling.memoryTarget=80|memoryTarget
+gateway.envoy.jwt.user_header=x-osmo-user|user_header
+gateway.oauth2Proxy.redis.tlsEnabled=false|oauth2Proxy
+gateway.rateLimit.redis.tlsEnabled=false|rateLimit
+services.ui.service.selector.component=ui|selector
+EOF
+
     helm_template osmo "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -146,6 +146,7 @@ test_control_umbrella() {
 
     require_deployment "$rendered" "osmo-api"
     require_no_deployment "$rendered" "osmo-service"
+    require_not_contains "$rendered" "name: osmo-service"
     require_deployment "$rendered" "osmo-worker"
     require_deployment "$rendered" "osmo-router"
     require_deployment "$rendered" "osmo-logger"

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -547,34 +547,6 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/osmo-values-api-deployment.yaml" \
         "https://idp.example.com/logout"
 
-    local legacy_value
-    local legacy_property
-    while IFS='|' read -r legacy_value legacy_property; do
-        if helm_template legacy-chart-values "$charts_copy/osmo" \
-            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-            --set "$legacy_value" \
-            >"$TEST_DIRECTORY/legacy-chart-values.out" 2>&1; then
-            fail "expected legacy $legacy_value to fail schema validation"
-        fi
-        require_contains "$TEST_DIRECTORY/legacy-chart-values.out" "$legacy_property"
-    done <<'EOF'
-services.api.auth.device_endpoint=https://idp.example.com/device|device_endpoint
-services.router.autoscaling.memoryTarget=80|memoryTarget
-gateway.envoy.jwt.user_header=x-osmo-user|user_header
-gateway.oauth2Proxy.redis.tlsEnabled=false|oauth2Proxy
-gateway.rateLimit.redis.tlsEnabled=false|rateLimit
-services.ui.service.selector.component=ui|selector
-gateway.upstreams.service.host=legacy-api|service
-gateway.upstreams.api.enabled=false|enabled
-gateway.upstreams.api.unknown=true|unknown
-gateway.networkPolicies.unknown=true|unknown
-gateway.networkPolicies.upstreams[0].component=service|component
-gateway.tls.unknown=true|unknown
-gateway.tls.upstreamCerts.service=legacy-api-tls|service
-EOF
-
-
     local invalid_gateway_value
     local invalid_gateway_property
     while IFS='|' read -r invalid_gateway_value invalid_gateway_property; do
@@ -847,15 +819,6 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-authz-tls.yaml" "/etc/osmo/ca/postgresql"
     require_contains "$TEST_DIRECTORY/osmo-authz-tls.yaml" \
         "--postgres-ssl-mode=verify-full"
-
-    if helm_template unsupported-migration "$charts_copy/osmo" \
-        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set services.migration.enabled=true \
-        >"$TEST_DIRECTORY/unsupported-migration.out" 2>&1; then
-        fail "expected services.migration to fail schema validation"
-    fi
-    require_contains "$TEST_DIRECTORY/unsupported-migration.out" "migration"
 
     helm_template osmo "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -1167,27 +1130,20 @@ EOF
     require_not_contains "$TEST_DIRECTORY/osmo-image-digest.yaml" \
         "worker:ignored"
 
-    local unknown_nested_value
-    while IFS= read -r unknown_nested_value; do
-        if helm_template unknown-nested "$charts_copy/osmo" \
-            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-            --set "$unknown_nested_value" \
-            >"$TEST_DIRECTORY/unknown-nested.out" 2>&1; then
-            fail "expected unknown chart-owned value $unknown_nested_value to fail"
-        fi
-        require_contains "$TEST_DIRECTORY/unknown-nested.out" "typo"
-    done <<'EOF'
-services.worker.typo=true
-services.worker.image.typo=true
-services.worker.serviceAccount.typo=true
-services.worker.podDisruptionBudget.typo=true
-services.worker.pod.typo=true
-monitoring.podMonitor.typo=true
-gateway.envoy.internalJwks.typo=true
-gateway.authz.postgres.typo=true
-gateway.rateLimit.config.typo=true
-secrets.valkey.typo=true
-EOF
+    helm_template unknown-root "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set unsupportedRoot.enabled=true \
+        >"$TEST_DIRECTORY/unknown-root.yaml"
+    require_deployment "$TEST_DIRECTORY/unknown-root.yaml" "unknown-root-osmo-api"
+
+    helm_template unknown-nested "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.worker.typo=true \
+        --set services.worker.image.typo=true \
+        --set gateway.envoy.service.loadBalancerIP=192.0.2.1 \
+        >"$TEST_DIRECTORY/unknown-nested.yaml"
+    require_deployment "$TEST_DIRECTORY/unknown-nested.yaml" \
+        "unknown-nested-osmo-worker"
 
     if helm_template invalid-pdb "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -1219,26 +1175,6 @@ EOF
     require_contains "$TEST_DIRECTORY/unsupported-embedded.out" \
         "embedded PostgreSQL is not implemented"
 
-    local legacy_exposure_value
-    local legacy_exposure_property
-    while IFS='|' read -r legacy_exposure_value legacy_exposure_property; do
-        if helm_template legacy-exposure "$charts_copy/osmo" \
-            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-            --set "$legacy_exposure_value" \
-            >"$TEST_DIRECTORY/legacy-exposure.out" 2>&1; then
-            fail "expected legacy $legacy_exposure_value to fail schema validation"
-        fi
-        require_contains "$TEST_DIRECTORY/legacy-exposure.out" \
-            "$legacy_exposure_property"
-    done <<'EOF'
-exposure.mode=external|exposure
-exposure.baseUrl=https://osmo.example.com|exposure
-embeddedDependencies.gateway.enabled=false|gateway
-gateway.envoy.ingress.enabled=false|ingress
-gateway.envoy.service.httpsPort=443|httpsPort
-EOF
-
     if helm_template unsupported-generated-secret "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
@@ -1258,15 +1194,6 @@ EOF
     fi
     require_contains "$TEST_DIRECTORY/unsupported-legacy-values.out" \
         "controlPlane"
-
-    if helm_template unsupported-legacy-external "$charts_copy/osmo" \
-        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set external.postgresql.host=legacy-postgresql \
-        >"$TEST_DIRECTORY/unsupported-legacy-external.out" 2>&1; then
-        fail "expected legacy external values to fail schema validation"
-    fi
-    require_contains "$TEST_DIRECTORY/unsupported-legacy-external.out" "external"
 
     if helm_template invalid-replicas "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -1307,7 +1234,6 @@ gateway.envoy.service.type=ExternalName|type
 gateway.envoy.service.port=0|port
 gateway.envoy.service.nodePort=65536|nodePort
 gateway.envoy.service.externalTrafficPolicy=Nearest|externalTrafficPolicy
-gateway.envoy.service.loadBalancerIP=192.0.2.1|loadBalancerIP
 EOF
 
     if helm_template invalid-ingress "$charts_copy/osmo" \
@@ -1412,61 +1338,6 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-notes.yaml" \
         "curl https://127.0.0.1:8080/api/version"
 
-    if helm_template unknown-root "$charts_copy/osmo" \
-        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set unsupportedRoot.enabled=true \
-        >"$TEST_DIRECTORY/unknown-root.out" 2>&1; then
-        fail "expected an unknown top-level value to fail schema validation"
-    fi
-    require_contains "$TEST_DIRECTORY/unknown-root.out" "unsupportedRoot"
-
-    if helm_template legacy-component "$charts_copy/osmo" \
-        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set services.worker.imageName=legacy-worker \
-        >"$TEST_DIRECTORY/legacy-component.out" 2>&1; then
-        fail "expected legacy per-service fields to fail schema validation"
-    fi
-    require_contains "$TEST_DIRECTORY/legacy-component.out" "worker"
-
-    local wrong_component_value
-    for wrong_component_value in \
-        services.api.httpPort=1234 \
-        services.ui.grpcPort=1234 \
-        services.router.cookieName=wrong \
-        services.worker.httpPort=1234 \
-        services.logger.clientId=wrong \
-        services.agent.service.type=ClusterIP \
-        services.delayedJobMonitor.autoscaling.enabled=true \
-        services.mcp.hostname=wrong \
-        gateway.envoy.grpcPort=1234 \
-        gateway.oauth2Proxy.jwt.userHeader=wrong \
-        gateway.authz.cookieName=wrong \
-        gateway.rateLimit.autoscaling.enabled=true; do
-        if helm_template wrong-component "$charts_copy/osmo" \
-            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-            --set "$wrong_component_value" \
-            >"$TEST_DIRECTORY/wrong-component.out" 2>&1; then
-            fail "expected wrong-component value $wrong_component_value to fail"
-        fi
-    done
-
-    local unsupported_pod_value
-    for unsupported_pod_value in \
-        podDefaults.hostAliases[0].ip=127.0.0.1 \
-        services.delayedJobMonitor.pod.topologySpreadConstraints[0].topologyKey=zone \
-        services.mcp.pod.extraVolumes[0].name=ignored \
-        gateway.envoy.pod.topologySpreadConstraints[0].topologyKey=zone; do
-        if helm_template unsupported-pod "$charts_copy/osmo" \
-            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-            --set "$unsupported_pod_value" \
-            >"$TEST_DIRECTORY/unsupported-pod.out" 2>&1; then
-            fail "expected unsupported pod value $unsupported_pod_value to fail"
-        fi
-    done
 }
 
 case "$MODE" in

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -977,6 +977,10 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
         "unhealthyPodEvictionPolicy: AlwaysAllow"
     require_contains "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "futureSpecField: forwarded"
+    require_not_contains "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
+        "user-supplied-selector"
+    require_contains "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
         "policy-owner: platform"
     require_contains "$TEST_DIRECTORY/osmo-workload-policy-api-pdb.yaml" \
         "policy.example.com/reason: api-availability"
@@ -1022,7 +1026,9 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
         "honorLabels: true"
     require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
-        "targetLabels:"
+        "podTargetLabels:"
+    require_occurrences "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
+        "  targetLabels:" 0
     require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \
         "targetLabel: cluster"
     require_contains "$TEST_DIRECTORY/osmo-monitoring-pod-monitor.yaml" \

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -3,11 +3,9 @@
   "$comment": "SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. SPDX-License-Identifier: Apache-2.0",
   "title": "OSMO Helm chart values",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "planes": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "control": { "$ref": "#/definitions/enabledBlock" },
         "compute": { "$ref": "#/definitions/enabledBlock" }
@@ -16,7 +14,6 @@
     },
     "embeddedDependencies": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "postgresql": { "$ref": "#/definitions/enabledBlock" },
         "valkey": { "$ref": "#/definitions/enabledBlock" },
@@ -33,7 +30,6 @@
     "podDefaults": { "$ref": "#/definitions/podDefaults" },
     "logging": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "logLevel": { "type": "string" },
@@ -56,7 +52,6 @@
     "monitoring": { "$ref": "#/definitions/monitoring" },
     "externalDependencies": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "postgresql": { "$ref": "#/definitions/databaseConnection" },
         "valkey": { "$ref": "#/definitions/valkeyConnection" },
@@ -65,7 +60,6 @@
     },
     "secrets": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "postgresql": { "$ref": "#/definitions/secretReference" },
         "valkey": { "$ref": "#/definitions/secretReference" },
@@ -77,7 +71,6 @@
     "configuration": { "type": "object" },
     "services": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "api": { "$ref": "#/definitions/apiComponent" },
         "ui": { "$ref": "#/definitions/uiComponent" },
@@ -91,7 +84,6 @@
     },
     "gateway": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "envoy": { "$ref": "#/definitions/gatewayEnvoyComponent" },
         "oauth2Proxy": { "$ref": "#/definitions/gatewayOauth2ProxyComponent" },
@@ -107,7 +99,6 @@
   "definitions": {
     "enabledBlock": {
       "type": "object",
-      "additionalProperties": false,
       "properties": { "enabled": { "type": "boolean" } },
       "required": ["enabled"]
     },
@@ -117,7 +108,6 @@
     },
     "gatewayApiUpstream": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "host": { "type": "string" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
@@ -126,7 +116,6 @@
     },
     "gatewayOptionalUpstream": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "host": { "type": "string" },
@@ -136,7 +125,6 @@
     },
     "gatewayUpstreams": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "api": { "$ref": "#/definitions/gatewayApiUpstream" },
         "router": { "$ref": "#/definitions/gatewayOptionalUpstream" },
@@ -148,7 +136,6 @@
     },
     "gatewayNetworkPolicyUpstream": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "component": {
@@ -161,7 +148,6 @@
     },
     "gatewayNetworkPolicies": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "upstreams": {
@@ -173,7 +159,6 @@
     },
     "gatewayUpstreamCerts": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "api": { "type": "string" },
         "router": { "type": "string" },
@@ -185,7 +170,6 @@
     },
     "gatewayTls": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "upstreamCerts": { "$ref": "#/definitions/gatewayUpstreamCerts" },
@@ -195,7 +179,6 @@
     },
     "podMonitor": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "labels": { "$ref": "#/definitions/stringMap" },
@@ -213,7 +196,6 @@
     },
     "monitoring": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "podMonitor": { "$ref": "#/definitions/podMonitor" }
       },
@@ -221,7 +203,6 @@
     },
     "ingressTls": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "secretName": { "type": "string" }
@@ -230,7 +211,6 @@
     },
     "ingress": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "labels": { "$ref": "#/definitions/stringMap" },
@@ -244,7 +224,6 @@
           "type": "array",
           "items": {
             "type": "object",
-            "additionalProperties": false,
             "properties": {
               "name": { "type": "string", "minLength": 1 },
               "path": { "type": "string", "minLength": 1 },
@@ -261,7 +240,6 @@
     },
     "httpRouteParentRef": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "group": { "type": "string" },
         "kind": { "type": "string" },
@@ -273,7 +251,6 @@
     },
     "httpRoute": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "labels": { "$ref": "#/definitions/stringMap" },
@@ -296,7 +273,6 @@
     },
     "gatewayService": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
@@ -316,14 +292,12 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
         "properties": { "name": { "type": "string", "minLength": 1 } },
         "required": ["name"]
       }
     },
     "global": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "imageRegistry": { "type": "string" },
         "imagePullSecrets": { "$ref": "#/definitions/imagePullSecrets" }
@@ -332,7 +306,6 @@
     },
     "runtimeImage": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "registry": { "type": "string" },
         "repository": { "type": "string", "minLength": 1 },
@@ -342,7 +315,6 @@
     },
     "componentImage": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "registry": { "type": "string" },
         "repository": { "type": "string", "minLength": 1 },
@@ -354,7 +326,6 @@
     },
     "podSettings": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "labels": { "$ref": "#/definitions/stringMap" },
         "annotations": { "$ref": "#/definitions/stringMap" },
@@ -373,7 +344,6 @@
     },
     "podDefaults": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "labels": { "$ref": "#/definitions/stringMap" },
         "annotations": { "$ref": "#/definitions/stringMap" },
@@ -387,7 +357,6 @@
     },
     "podSettingsWithoutHostAliases": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "labels": { "$ref": "#/definitions/stringMap" },
         "annotations": { "$ref": "#/definitions/stringMap" },
@@ -405,7 +374,6 @@
     },
     "podSettingsWithoutTopologyOrHosts": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "labels": { "$ref": "#/definitions/stringMap" },
         "annotations": { "$ref": "#/definitions/stringMap" },
@@ -422,7 +390,6 @@
     },
     "podSettingsWithVolumes": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "labels": { "$ref": "#/definitions/stringMap" },
         "annotations": { "$ref": "#/definitions/stringMap" },
@@ -437,7 +404,6 @@
     },
     "podSettingsSchedulingOnly": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "labels": { "$ref": "#/definitions/stringMap" },
         "annotations": { "$ref": "#/definitions/stringMap" },
@@ -451,7 +417,6 @@
     },
     "gatewayDefaultIdentity": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "user": { "type": "string" },
         "roles": { "type": "string" },
@@ -461,7 +426,6 @@
     },
     "gatewaySsl": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "secretName": { "type": "string" }
@@ -470,13 +434,11 @@
     },
     "gatewayIdp": {
       "type": "object",
-      "additionalProperties": false,
       "properties": { "host": { "type": "string" } },
       "required": ["host"]
     },
     "gatewayInternalJwks": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "cluster": { "type": "string" },
@@ -492,7 +454,6 @@
     },
     "gatewayRouteCookie": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "ttl": { "type": "string", "minLength": 1 }
@@ -501,7 +462,6 @@
     },
     "gatewayRouterRoute": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "prefix": { "type": "string", "minLength": 1 },
         "timeout": { "type": "string", "minLength": 1 },
@@ -511,7 +471,6 @@
     },
     "oauthSecretPaths": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "clientSecret": { "type": "string", "minLength": 1 },
         "cookieSecret": { "type": "string", "minLength": 1 }
@@ -520,7 +479,6 @@
     },
     "authzPostgres": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "maxConns": { "type": "integer", "minimum": 1 },
         "minConns": { "type": "integer", "minimum": 0 },
@@ -530,7 +488,6 @@
     },
     "authzCache": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "ttl": { "type": "integer", "minimum": 1 },
         "maxSize": { "type": "integer", "minimum": 1 }
@@ -539,7 +496,6 @@
     },
     "rateLimitConfig": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "domain": { "type": "string", "minLength": 1 },
         "descriptors": { "type": "array" }
@@ -548,7 +504,6 @@
     },
     "apiAuth": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "deviceEndpoint": { "type": "string" },
@@ -561,7 +516,6 @@
     },
     "autoscaling": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "minReplicas": { "type": "integer", "minimum": 0 },
@@ -575,7 +529,6 @@
     },
     "serviceAccount": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "name": { "type": "string" },
         "create": { "type": "boolean" },
@@ -586,7 +539,6 @@
     },
     "podDisruptionBudget": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "labels": { "$ref": "#/definitions/stringMap" },
@@ -612,7 +564,6 @@
     },
     "envoyJwt": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "userHeader": { "type": "string" },
         "providers": { "type": "array" }
@@ -620,7 +571,6 @@
     },
     "uiService": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "type": { "type": "string" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
@@ -633,7 +583,6 @@
     },
     "apiComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -658,7 +607,6 @@
     },
     "uiComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -690,7 +638,6 @@
     },
     "workerComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -709,7 +656,6 @@
     },
     "routerComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -733,7 +679,6 @@
     },
     "loggerComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -753,7 +698,6 @@
     },
     "agentComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -774,7 +718,6 @@
     },
     "delayedJobMonitorComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -792,7 +735,6 @@
     },
     "gatewayEnvoyComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -829,7 +771,6 @@
     },
     "gatewayOauth2ProxyComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -865,7 +806,6 @@
     },
     "gatewayAuthzComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -887,7 +827,6 @@
     },
     "gatewayRateLimitComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -908,7 +847,6 @@
     },
     "mcpComponent": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -932,7 +870,6 @@
     },
     "tlsConnection": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "caExistingSecret": { "type": "string" },
@@ -941,7 +878,6 @@
     },
     "databaseConnection": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "host": { "type": "string" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
@@ -952,7 +888,6 @@
     },
     "valkeyConnection": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "host": { "type": "string" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
@@ -962,13 +897,11 @@
     },
     "objectStorageConnection": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "endpoint": { "type": "string" },
         "region": { "type": "string" },
         "buckets": {
           "type": "object",
-          "additionalProperties": false,
           "properties": {
             "workflows": { "type": "string" },
             "logs": { "type": "string" },
@@ -979,7 +912,6 @@
     },
     "secretReference": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "generate": { "type": "boolean" },
         "existingSecret": { "type": "string" },

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -26,16 +26,8 @@
     },
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
-    "image": { "$ref": "#/definitions/globalImage" },
-    "imagePullSecrets": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": { "name": { "type": "string", "minLength": 1 } },
-        "required": ["name"]
-      }
-    },
+    "global": { "$ref": "#/definitions/global" },
+    "runtimeImage": { "$ref": "#/definitions/runtimeImage" },
     "commonLabels": { "$ref": "#/definitions/stringMap" },
     "commonAnnotations": { "$ref": "#/definitions/stringMap" },
     "podDefaults": { "$ref": "#/definitions/podSettings" },
@@ -111,7 +103,7 @@
       }
     }
   },
-  "required": ["planes", "embeddedDependencies", "externalDependencies", "image", "externalUrl", "ingress", "httproute", "monitoring", "secrets", "services", "gateway"],
+  "required": ["planes", "embeddedDependencies", "externalDependencies", "global", "runtimeImage", "externalUrl", "ingress", "httproute", "monitoring", "secrets", "services", "gateway"],
   "definitions": {
     "enabledBlock": {
       "type": "object",
@@ -320,28 +312,49 @@
       },
       "required": ["type", "port", "nodePort", "labels", "annotations", "loadBalancerClass", "loadBalancerSourceRanges", "externalTrafficPolicy"]
     },
-    "globalImage": {
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": { "name": { "type": "string", "minLength": 1 } },
+        "required": ["name"]
+      }
+    },
+    "global": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "registry": { "type": "string", "minLength": 1 },
-        "repositoryPrefix": { "type": "string", "minLength": 1 },
-        "tag": { "type": "string" },
-        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+        "imageRegistry": { "type": "string" },
+        "imagePullSecrets": { "$ref": "#/definitions/imagePullSecrets" }
       },
-      "required": ["registry", "repositoryPrefix", "pullPolicy"]
+      "required": ["imageRegistry", "imagePullSecrets"]
+    },
+    "runtimeImage": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "registry": { "type": "string" },
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" }
+      },
+      "required": ["registry", "repository", "tag"]
     },
     "componentImage": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
+        "registry": { "type": "string" },
+        "repository": { "type": "string", "minLength": 1 },
         "tag": { "type": "string" },
-        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
-        "repository": { "type": "string", "minLength": 1 }
-      }
+        "digest": { "type": "string", "pattern": "^$|^sha256:[A-Fa-f0-9]{16,}$" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      },
+      "required": ["registry", "repository", "tag", "digest", "pullPolicy"]
     },
     "podSettings": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "labels": { "$ref": "#/definitions/stringMap" },
         "annotations": { "$ref": "#/definitions/stringMap" },
@@ -360,6 +373,7 @@
     },
     "serviceComponent": {
       "type": "object",
+      "additionalProperties": false,
       "not": {
         "anyOf": [
           { "required": ["imageName"] },
@@ -392,8 +406,171 @@
         "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
         "env": { "type": "array" },
         "extraArgs": { "type": "array" },
-        "resources": { "type": "object" }
+        "resources": { "type": "object" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "resourceUrl": { "type": "string" },
+        "requestTimeoutSeconds": { "type": "integer", "minimum": 1 },
+        "authorizationServers": { "type": "array" },
+        "scopes": { "type": "array" },
+        "allowedOrigins": { "type": "array" },
+        "apiHostname": { "type": "string" },
+        "portForwardEnabled": { "type": "boolean" },
+        "nextjsSslEnabled": { "type": "boolean" },
+        "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "maxHttpHeaderSizeKb": { "type": "integer", "minimum": 1 },
+        "command": { "type": "array" },
+        "args": { "type": "array" },
+        "docsBaseUrl": { "type": "string" },
+        "cliInstallScriptUrl": { "type": "string" },
+        "service": { "type": "object" },
+        "extraPorts": { "type": "array" },
+        "envFrom": { "type": "array" },
+        "volumeMounts": { "type": "array" },
+        "hostname": { "type": "string" },
+        "clientInstallUrl": { "type": "string" },
+        "disableTaskMetrics": { "type": "boolean" },
+        "auth": { "type": "object" },
+        "webserverEnabled": { "type": "boolean" },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "startupProbe": { "type": "object" },
+        "envoy": { "type": "object" },
+        "logLevel": { "type": "string" },
+        "listenerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "maxHeadersSizeKb": { "type": "integer", "minimum": 1 },
+        "blockedIPs": { "type": "array" },
+        "defaultIdentity": { "$ref": "#/definitions/gatewayDefaultIdentity" },
+        "ssl": { "$ref": "#/definitions/gatewaySsl" },
+        "idp": { "$ref": "#/definitions/gatewayIdp" },
+        "internalJwks": { "$ref": "#/definitions/gatewayInternalJwks" },
+        "jwt": { "$ref": "#/definitions/envoyJwt" },
+        "skipAuthPaths": { "type": "array" },
+        "extraSkipAuthPaths": { "type": "array" },
+        "routerRoute": { "$ref": "#/definitions/gatewayRouterRoute" },
+        "serviceRoutes": { "type": "array" },
+        "extraRoutes": { "type": "array" },
+        "extraClusters": { "type": "array" },
+        "maxRequests": { "type": "integer", "minimum": 1 },
+        "httpPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "metricsPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "provider": { "type": "string" },
+        "oidcIssuerUrl": { "type": "string" },
+        "clientId": { "type": "string" },
+        "cookieName": { "type": "string" },
+        "cookieSecure": { "type": "boolean" },
+        "cookieDomain": { "type": "string" },
+        "cookieExpire": { "type": "string" },
+        "cookieRefresh": { "type": "string" },
+        "scope": { "type": "string" },
+        "passAccessToken": { "type": "boolean" },
+        "redisSessionStore": { "type": "boolean" },
+        "useKubernetesSecrets": { "type": "boolean" },
+        "secretName": { "type": "string" },
+        "clientSecretKey": { "type": "string" },
+        "cookieSecretKey": { "type": "string" },
+        "secretPaths": { "$ref": "#/definitions/oauthSecretPaths" },
+        "grpcPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "postgres": { "$ref": "#/definitions/authzPostgres" },
+        "cache": { "$ref": "#/definitions/authzCache" },
+        "config": { "$ref": "#/definitions/rateLimitConfig" }
       }
+    },
+    "gatewayDefaultIdentity": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "user": { "type": "string" },
+        "roles": { "type": "string" },
+        "allowedPools": { "type": "string" }
+      },
+      "required": ["user", "roles", "allowedPools"]
+    },
+    "gatewaySsl": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "secretName": { "type": "string" }
+      },
+      "required": ["enabled", "secretName"]
+    },
+    "gatewayIdp": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": { "host": { "type": "string" } },
+      "required": ["host"]
+    },
+    "gatewayInternalJwks": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "cluster": { "type": "string" },
+        "host": { "type": "string" },
+        "port": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "integer", "minimum": 1, "maximum": 65535 }
+          ]
+        }
+      },
+      "required": ["enabled", "cluster", "host", "port"]
+    },
+    "gatewayRouteCookie": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "ttl": { "type": "string", "minLength": 1 }
+      },
+      "required": ["name", "ttl"]
+    },
+    "gatewayRouterRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "prefix": { "type": "string", "minLength": 1 },
+        "timeout": { "type": "string", "minLength": 1 },
+        "cookie": { "$ref": "#/definitions/gatewayRouteCookie" }
+      },
+      "required": ["prefix", "timeout", "cookie"]
+    },
+    "oauthSecretPaths": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "clientSecret": { "type": "string", "minLength": 1 },
+        "cookieSecret": { "type": "string", "minLength": 1 }
+      },
+      "required": ["clientSecret", "cookieSecret"]
+    },
+    "authzPostgres": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxConns": { "type": "integer", "minimum": 1 },
+        "minConns": { "type": "integer", "minimum": 0 },
+        "maxConnLifetimeMin": { "type": "integer", "minimum": 1 }
+      },
+      "required": ["maxConns", "minConns", "maxConnLifetimeMin"]
+    },
+    "authzCache": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ttl": { "type": "integer", "minimum": 1 },
+        "maxSize": { "type": "integer", "minimum": 1 }
+      },
+      "required": ["ttl", "maxSize"]
+    },
+    "rateLimitConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "domain": { "type": "string", "minLength": 1 },
+        "descriptors": { "type": "array" }
+      },
+      "required": ["domain", "descriptors"]
     },
     "apiAuth": {
       "type": "object",
@@ -600,13 +777,15 @@
     },
     "secretReference": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "generate": { "type": "boolean" },
         "existingSecret": { "type": "string" },
-        "keys": { "type": "object" },
+        "keys": { "$ref": "#/definitions/stringMap" },
         "mountPath": { "type": "string" },
         "username": { "type": "string" }
-      }
+      },
+      "required": ["generate", "existingSecret", "keys"]
     }
   }
 }

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -30,7 +30,7 @@
     "runtimeImage": { "$ref": "#/definitions/runtimeImage" },
     "commonLabels": { "$ref": "#/definitions/stringMap" },
     "commonAnnotations": { "$ref": "#/definitions/stringMap" },
-    "podDefaults": { "$ref": "#/definitions/podSettings" },
+    "podDefaults": { "$ref": "#/definitions/podDefaults" },
     "logging": {
       "type": "object",
       "additionalProperties": false,
@@ -81,11 +81,11 @@
       "properties": {
         "api": { "$ref": "#/definitions/apiComponent" },
         "ui": { "$ref": "#/definitions/uiComponent" },
-        "router": { "$ref": "#/definitions/autoscaledServiceComponent" },
-        "worker": { "$ref": "#/definitions/autoscaledServiceComponent" },
-        "logger": { "$ref": "#/definitions/autoscaledServiceComponent" },
-        "agent": { "$ref": "#/definitions/autoscaledServiceComponent" },
-        "delayedJobMonitor": { "$ref": "#/definitions/serviceComponent" },
+        "router": { "$ref": "#/definitions/routerComponent" },
+        "worker": { "$ref": "#/definitions/workerComponent" },
+        "logger": { "$ref": "#/definitions/loggerComponent" },
+        "agent": { "$ref": "#/definitions/agentComponent" },
+        "delayedJobMonitor": { "$ref": "#/definitions/delayedJobMonitorComponent" },
         "mcp": { "$ref": "#/definitions/mcpComponent" }
       }
     },
@@ -95,7 +95,7 @@
       "properties": {
         "envoy": { "$ref": "#/definitions/gatewayEnvoyComponent" },
         "oauth2Proxy": { "$ref": "#/definitions/gatewayOauth2ProxyComponent" },
-        "authz": { "$ref": "#/definitions/autoscaledServiceComponent" },
+        "authz": { "$ref": "#/definitions/gatewayAuthzComponent" },
         "rateLimit": { "$ref": "#/definitions/gatewayRateLimitComponent" },
         "upstreams": { "$ref": "#/definitions/gatewayUpstreams" },
         "networkPolicies": { "$ref": "#/definitions/gatewayNetworkPolicies" },
@@ -366,113 +366,87 @@
         "topologySpreadConstraints": { "type": "array" },
         "hostAliases": { "type": "array" },
         "initContainers": { "type": "array" },
-        "volumes": { "type": "array" },
+        "extraVolumes": { "type": "array" },
         "sidecars": { "type": "array" },
         "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 }
       }
     },
-    "serviceComponent": {
+    "podDefaults": {
       "type": "object",
       "additionalProperties": false,
-      "not": {
-        "anyOf": [
-          { "required": ["imageName"] },
-          { "required": ["imageTag"] },
-          { "required": ["imagePullPolicy"] },
-          { "required": ["serviceName"] },
-          { "required": ["serviceAccountName"] },
-          { "required": ["scaling"] },
-          { "required": ["nodeSelector"] },
-          { "required": ["tolerations"] },
-          { "required": ["extraPodLabels"] },
-          { "required": ["extraPodAnnotations"] },
-          { "required": ["extraEnv"] },
-          { "required": ["extraEnvs"] },
-          { "required": ["extraVolumeMounts"] },
-          { "required": ["extraVolumes"] },
-          { "required": ["extraSidecars"] },
-          { "required": ["extraContainers"] },
-          { "required": ["initContainers"] }
-        ]
-      },
       "properties": {
-        "enabled": { "type": "boolean" },
-        "replicas": { "type": "integer", "minimum": 0 },
-        "image": { "$ref": "#/definitions/componentImage" },
-        "pod": { "$ref": "#/definitions/podSettings" },
-        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
-        "autoscaling": { "$ref": "#/definitions/autoscaling" },
-        "deploymentStrategy": { "type": "object" },
-        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
-        "env": { "type": "array" },
-        "extraArgs": { "type": "array" },
-        "resources": { "type": "object" },
-        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
-        "resourceUrl": { "type": "string" },
-        "requestTimeoutSeconds": { "type": "integer", "minimum": 1 },
-        "authorizationServers": { "type": "array" },
-        "scopes": { "type": "array" },
-        "allowedOrigins": { "type": "array" },
-        "apiHostname": { "type": "string" },
-        "portForwardEnabled": { "type": "boolean" },
-        "nextjsSslEnabled": { "type": "boolean" },
-        "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
-        "maxHttpHeaderSizeKb": { "type": "integer", "minimum": 1 },
-        "command": { "type": "array" },
-        "args": { "type": "array" },
-        "docsBaseUrl": { "type": "string" },
-        "cliInstallScriptUrl": { "type": "string" },
-        "service": { "type": "object" },
-        "extraPorts": { "type": "array" },
-        "envFrom": { "type": "array" },
-        "volumeMounts": { "type": "array" },
-        "hostname": { "type": "string" },
-        "clientInstallUrl": { "type": "string" },
-        "disableTaskMetrics": { "type": "boolean" },
-        "auth": { "type": "object" },
-        "webserverEnabled": { "type": "boolean" },
-        "livenessProbe": { "type": "object" },
-        "readinessProbe": { "type": "object" },
-        "startupProbe": { "type": "object" },
-        "envoy": { "type": "object" },
-        "logLevel": { "type": "string" },
-        "listenerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
-        "maxHeadersSizeKb": { "type": "integer", "minimum": 1 },
-        "blockedIPs": { "type": "array" },
-        "defaultIdentity": { "$ref": "#/definitions/gatewayDefaultIdentity" },
-        "ssl": { "$ref": "#/definitions/gatewaySsl" },
-        "idp": { "$ref": "#/definitions/gatewayIdp" },
-        "internalJwks": { "$ref": "#/definitions/gatewayInternalJwks" },
-        "jwt": { "$ref": "#/definitions/envoyJwt" },
-        "skipAuthPaths": { "type": "array" },
-        "extraSkipAuthPaths": { "type": "array" },
-        "routerRoute": { "$ref": "#/definitions/gatewayRouterRoute" },
-        "serviceRoutes": { "type": "array" },
-        "extraRoutes": { "type": "array" },
-        "extraClusters": { "type": "array" },
-        "maxRequests": { "type": "integer", "minimum": 1 },
-        "httpPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
-        "metricsPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
-        "provider": { "type": "string" },
-        "oidcIssuerUrl": { "type": "string" },
-        "clientId": { "type": "string" },
-        "cookieName": { "type": "string" },
-        "cookieSecure": { "type": "boolean" },
-        "cookieDomain": { "type": "string" },
-        "cookieExpire": { "type": "string" },
-        "cookieRefresh": { "type": "string" },
-        "scope": { "type": "string" },
-        "passAccessToken": { "type": "boolean" },
-        "redisSessionStore": { "type": "boolean" },
-        "useKubernetesSecrets": { "type": "boolean" },
-        "secretName": { "type": "string" },
-        "clientSecretKey": { "type": "string" },
-        "cookieSecretKey": { "type": "string" },
-        "secretPaths": { "$ref": "#/definitions/oauthSecretPaths" },
-        "grpcPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
-        "postgres": { "$ref": "#/definitions/authzPostgres" },
-        "cache": { "$ref": "#/definitions/authzCache" },
-        "config": { "$ref": "#/definitions/rateLimitConfig" }
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "nodeSelector": { "$ref": "#/definitions/stringMap" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" },
+        "podSecurityContext": { "type": "object" },
+        "containerSecurityContext": { "type": "object" },
+        "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "podSettingsWithoutHostAliases": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "nodeSelector": { "$ref": "#/definitions/stringMap" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" },
+        "podSecurityContext": { "type": "object" },
+        "containerSecurityContext": { "type": "object" },
+        "topologySpreadConstraints": { "type": "array" },
+        "initContainers": { "type": "array" },
+        "extraVolumes": { "type": "array" },
+        "sidecars": { "type": "array" },
+        "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "podSettingsWithoutTopologyOrHosts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "nodeSelector": { "$ref": "#/definitions/stringMap" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" },
+        "podSecurityContext": { "type": "object" },
+        "containerSecurityContext": { "type": "object" },
+        "initContainers": { "type": "array" },
+        "extraVolumes": { "type": "array" },
+        "sidecars": { "type": "array" },
+        "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "podSettingsWithVolumes": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "nodeSelector": { "$ref": "#/definitions/stringMap" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" },
+        "podSecurityContext": { "type": "object" },
+        "containerSecurityContext": { "type": "object" },
+        "extraVolumes": { "type": "array" },
+        "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "podSettingsSchedulingOnly": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "nodeSelector": { "$ref": "#/definitions/stringMap" },
+        "tolerations": { "type": "array" },
+        "affinity": { "type": "object" },
+        "podSecurityContext": { "type": "object" },
+        "containerSecurityContext": { "type": "object" },
+        "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 }
       }
     },
     "gatewayDefaultIdentity": {
@@ -657,76 +631,304 @@
         "extraPorts": { "type": "array" }
       }
     },
-    "autoscaledServiceComponent": {
-      "allOf": [
-        { "$ref": "#/definitions/serviceComponent" },
-        {
-          "properties": {
-            "autoscaling": { "$ref": "#/definitions/autoscaling" }
-          }
-        }
-      ]
-    },
     "apiComponent": {
-      "allOf": [
-        { "$ref": "#/definitions/autoscaledServiceComponent" },
-        {
-          "properties": {
-            "auth": { "$ref": "#/definitions/apiAuth" }
-          }
-        }
-      ]
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "hostname": { "type": "string" },
+        "clientInstallUrl": { "type": "string" },
+        "disableTaskMetrics": { "type": "boolean" },
+        "auth": { "$ref": "#/definitions/apiAuth" },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "startupProbe": { "type": "object" },
+        "resources": { "type": "object" },
+        "extraArgs": { "type": "array" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "env": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettings" },
+        "deploymentStrategy": { "type": "object" }
+      }
     },
     "uiComponent": {
-      "allOf": [
-        { "$ref": "#/definitions/serviceComponent" },
-        {
-          "properties": {
-            "service": { "$ref": "#/definitions/uiService" }
-          }
-        }
-      ]
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "apiHostname": { "type": "string" },
+        "portForwardEnabled": { "type": "boolean" },
+        "nextjsSslEnabled": { "type": "boolean" },
+        "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "maxHttpHeaderSizeKb": { "type": "integer", "minimum": 1 },
+        "command": { "type": "array" },
+        "args": { "type": "array" },
+        "docsBaseUrl": { "type": "string" },
+        "cliInstallScriptUrl": { "type": "string" },
+        "service": { "$ref": "#/definitions/uiService" },
+        "resources": { "type": "object" },
+        "extraPorts": { "type": "array" },
+        "envFrom": { "type": "array" },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "startupProbe": { "type": "object" },
+        "env": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettings" },
+        "deploymentStrategy": { "type": "object" }
+      }
     },
-    "gatewayComponent": {
-      "allOf": [{ "$ref": "#/definitions/serviceComponent" }]
+    "workerComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "startupProbe": { "type": "object" },
+        "resources": { "type": "object" },
+        "extraArgs": { "type": "array" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "env": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettingsWithoutHostAliases" },
+        "deploymentStrategy": { "type": "object" }
+      }
+    },
+    "routerComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "hostname": { "type": "string" },
+        "webserverEnabled": { "type": "boolean" },
+        "extraArgs": { "type": "array" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "extraPorts": { "type": "array" },
+        "resources": { "type": "object" },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "startupProbe": { "type": "object" },
+        "env": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettings" },
+        "deploymentStrategy": { "type": "object" }
+      }
+    },
+    "loggerComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "startupProbe": { "type": "object" },
+        "resources": { "type": "object" },
+        "extraArgs": { "type": "array" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "envoy": { "type": "object" },
+        "env": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettings" },
+        "deploymentStrategy": { "type": "object" }
+      }
+    },
+    "agentComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "startupProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "resources": { "type": "object" },
+        "extraArgs": { "type": "array" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "envoy": { "type": "object" },
+        "env": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettings" },
+        "deploymentStrategy": { "type": "object" }
+      }
+    },
+    "delayedJobMonitorComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "startupProbe": { "type": "object" },
+        "resources": { "type": "object" },
+        "extraArgs": { "type": "array" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "env": { "type": "array" },
+        "extraVolumeMounts": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettingsWithoutTopologyOrHosts" },
+        "deploymentStrategy": { "type": "object" }
+      }
     },
     "gatewayEnvoyComponent": {
-      "allOf": [
-        { "$ref": "#/definitions/autoscaledServiceComponent" },
-        {
-          "not": { "required": ["ingress"] },
-          "properties": {
-            "service": { "$ref": "#/definitions/gatewayService" },
-            "jwt": { "$ref": "#/definitions/envoyJwt" }
-          }
-        }
-      ]
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "logLevel": { "type": "string" },
+        "listenerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "maxHeadersSizeKb": { "type": "integer", "minimum": 1 },
+        "blockedIPs": { "type": "array" },
+        "hostname": { "type": "string" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "defaultIdentity": { "$ref": "#/definitions/gatewayDefaultIdentity" },
+        "service": { "$ref": "#/definitions/gatewayService" },
+        "ssl": { "$ref": "#/definitions/gatewaySsl" },
+        "resources": { "type": "object" },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "startupProbe": { "type": "object" },
+        "idp": { "$ref": "#/definitions/gatewayIdp" },
+        "internalJwks": { "$ref": "#/definitions/gatewayInternalJwks" },
+        "jwt": { "$ref": "#/definitions/envoyJwt" },
+        "skipAuthPaths": { "type": "array" },
+        "extraSkipAuthPaths": { "type": "array" },
+        "routerRoute": { "$ref": "#/definitions/gatewayRouterRoute" },
+        "serviceRoutes": { "type": "array" },
+        "extraRoutes": { "type": "array" },
+        "extraClusters": { "type": "array" },
+        "maxRequests": { "type": "integer", "minimum": 1 },
+        "extraVolumeMounts": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettingsWithVolumes" },
+        "deploymentStrategy": { "type": "object" }
+      }
     },
     "gatewayOauth2ProxyComponent": {
-      "allOf": [
-        { "$ref": "#/definitions/autoscaledServiceComponent" },
-        { "not": { "required": ["redis"] } }
-      ]
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "httpPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "metricsPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "provider": { "type": "string" },
+        "oidcIssuerUrl": { "type": "string" },
+        "clientId": { "type": "string" },
+        "cookieName": { "type": "string" },
+        "cookieSecure": { "type": "boolean" },
+        "cookieDomain": { "type": "string" },
+        "cookieExpire": { "type": "string" },
+        "cookieRefresh": { "type": "string" },
+        "scope": { "type": "string" },
+        "passAccessToken": { "type": "boolean" },
+        "redisSessionStore": { "type": "boolean" },
+        "useKubernetesSecrets": { "type": "boolean" },
+        "secretName": { "type": "string" },
+        "clientSecretKey": { "type": "string" },
+        "cookieSecretKey": { "type": "string" },
+        "secretPaths": { "$ref": "#/definitions/oauthSecretPaths" },
+        "extraArgs": { "type": "array" },
+        "resources": { "type": "object" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "extraVolumeMounts": { "type": "array" },
+        "env": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettingsWithVolumes" },
+        "deploymentStrategy": { "type": "object" }
+      }
+    },
+    "gatewayAuthzComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "grpcPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "postgres": { "$ref": "#/definitions/authzPostgres" },
+        "cache": { "$ref": "#/definitions/authzCache" },
+        "resources": { "type": "object" },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "extraVolumeMounts": { "type": "array" },
+        "env": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettingsWithVolumes" },
+        "deploymentStrategy": { "type": "object" }
+      }
     },
     "gatewayRateLimitComponent": {
-      "allOf": [
-        { "$ref": "#/definitions/gatewayComponent" },
-        { "not": { "required": ["redis"] } }
-      ]
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "grpcPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "httpPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "config": { "$ref": "#/definitions/rateLimitConfig" },
+        "resources": { "type": "object" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "extraVolumeMounts": { "type": "array" },
+        "env": { "type": "array" },
+        "command": { "type": "array" },
+        "args": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettingsWithVolumes" },
+        "deploymentStrategy": { "type": "object" }
+      }
     },
     "mcpComponent": {
-      "allOf": [
-        { "$ref": "#/definitions/serviceComponent" },
-        {
-          "properties": {
-            "requestTimeoutSeconds": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 60
-            }
-          }
-        }
-      ]
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "replicas": { "type": "integer", "minimum": 0 },
+        "image": { "$ref": "#/definitions/componentImage" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "resourceUrl": { "type": "string" },
+        "requestTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 60 },
+        "authorizationServers": { "type": "array" },
+        "scopes": { "type": "array" },
+        "allowedOrigins": { "type": "array" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
+        "resources": { "type": "object" },
+        "livenessProbe": { "type": "object" },
+        "readinessProbe": { "type": "object" },
+        "startupProbe": { "type": "object" },
+        "env": { "type": "array" },
+        "pod": { "$ref": "#/definitions/podSettingsSchedulingOnly" },
+        "deploymentStrategy": { "type": "object" }
+      }
     },
     "tlsConnection": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -310,7 +310,7 @@
         },
         "externalTrafficPolicy": { "type": "string", "enum": ["Cluster", "Local"] }
       },
-      "required": ["type", "port", "nodePort", "labels", "annotations", "loadBalancerClass", "loadBalancerSourceRanges", "externalTrafficPolicy"]
+      "required": ["type", "port", "labels", "annotations", "loadBalancerClass", "loadBalancerSourceRanges", "externalTrafficPolicy"]
     },
     "imagePullSecrets": {
       "type": "array",
@@ -571,7 +571,7 @@
         "customMetrics": { "type": "array" },
         "behavior": { "type": "object" }
       },
-      "required": ["enabled", "minReplicas", "maxReplicas", "hpaMemoryTarget", "hpaCpuTarget", "customMetrics", "behavior"]
+      "required": ["enabled", "minReplicas", "maxReplicas", "hpaCpuTarget", "customMetrics", "behavior"]
     },
     "serviceAccount": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -327,7 +327,8 @@
         "hostAliases": { "type": "array" },
         "initContainers": { "type": "array" },
         "volumes": { "type": "array" },
-        "sidecars": { "type": "array" }
+        "sidecars": { "type": "array" },
+        "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 }
       }
     },
     "serviceComponent": {
@@ -358,8 +359,10 @@
         "replicas": { "type": "integer", "minimum": 0 },
         "image": { "$ref": "#/definitions/componentImage" },
         "pod": { "$ref": "#/definitions/podSettings" },
-        "serviceAccount": { "type": "object" },
+        "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
         "autoscaling": { "$ref": "#/definitions/autoscaling" },
+        "deploymentStrategy": { "type": "object" },
+        "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
         "env": { "type": "array" },
         "extraArgs": { "type": "array" },
         "resources": { "type": "object" }
@@ -391,6 +394,43 @@
         "behavior": { "type": "object" }
       },
       "required": ["enabled", "minReplicas", "maxReplicas", "hpaMemoryTarget", "hpaCpuTarget", "customMetrics", "behavior"]
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "create": { "type": "boolean" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "automountServiceAccountToken": { "type": "boolean" }
+      },
+      "required": ["name", "create", "annotations", "automountServiceAccountToken"]
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "minAvailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^(?:100|[1-9]?[0-9])%$" }
+          ]
+        },
+        "maxUnavailable": {
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^(?:100|[1-9]?[0-9])%$" }
+          ]
+        },
+        "unhealthyPodEvictionPolicy": {
+          "type": "string",
+          "enum": ["IfHealthyBudget", "AlwaysAllow"]
+        }
+      },
+      "required": ["enabled", "labels", "annotations", "unhealthyPodEvictionPolicy"]
     },
     "envoyJwt": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -49,7 +49,16 @@
         "logFormat": { "type": "string", "enum": ["text", "json"] }
       }
     },
-    "externalUrl": { "type": "string" },
+    "externalUrl": {
+      "type": "string",
+      "anyOf": [
+        { "maxLength": 0 },
+        {
+          "format": "uri",
+          "pattern": "^https?://[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?(?::(?:[1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))?(?:/(?:[A-Za-z0-9._~!$&'()*+,;=:@-]|%[0-9A-Fa-f]{2})*)*$"
+        }
+      ]
+    },
     "ingress": { "$ref": "#/definitions/ingress" },
     "httproute": { "$ref": "#/definitions/httpRoute" },
     "externalDependencies": {
@@ -95,9 +104,9 @@
         "oauth2Proxy": { "$ref": "#/definitions/gatewayOauth2ProxyComponent" },
         "authz": { "$ref": "#/definitions/autoscaledServiceComponent" },
         "rateLimit": { "$ref": "#/definitions/gatewayRateLimitComponent" },
-        "upstreams": { "type": "object" },
-        "networkPolicies": { "type": "object" },
-        "tls": { "type": "object" }
+        "upstreams": { "$ref": "#/definitions/gatewayUpstreams" },
+        "networkPolicies": { "$ref": "#/definitions/gatewayNetworkPolicies" },
+        "tls": { "$ref": "#/definitions/gatewayTls" }
       }
     }
   },
@@ -112,6 +121,84 @@
     "stringMap": {
       "type": "object",
       "additionalProperties": { "type": "string" }
+    },
+    "gatewayApiUpstream": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "host": { "type": "string" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      },
+      "required": ["host", "port"]
+    },
+    "gatewayOptionalUpstream": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "host": { "type": "string" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      },
+      "required": ["enabled", "host", "port"]
+    },
+    "gatewayUpstreams": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "api": { "$ref": "#/definitions/gatewayApiUpstream" },
+        "router": { "$ref": "#/definitions/gatewayOptionalUpstream" },
+        "ui": { "$ref": "#/definitions/gatewayOptionalUpstream" },
+        "agent": { "$ref": "#/definitions/gatewayOptionalUpstream" },
+        "logger": { "$ref": "#/definitions/gatewayOptionalUpstream" }
+      },
+      "required": ["api", "router", "ui", "agent", "logger"]
+    },
+    "gatewayNetworkPolicyUpstream": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "component": {
+          "type": "string",
+          "enum": ["api", "router", "ui", "agent", "logger", "mcp"]
+        },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      },
+      "required": ["name", "component"]
+    },
+    "gatewayNetworkPolicies": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "upstreams": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/gatewayNetworkPolicyUpstream" }
+        }
+      },
+      "required": ["enabled", "upstreams"]
+    },
+    "gatewayUpstreamCerts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "api": { "type": "string" },
+        "router": { "type": "string" },
+        "agent": { "type": "string" },
+        "logger": { "type": "string" },
+        "mcp": { "type": "string" }
+      },
+      "required": ["api", "router", "agent", "logger", "mcp"]
+    },
+    "gatewayTls": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "upstreamCerts": { "$ref": "#/definitions/gatewayUpstreamCerts" },
+        "caSecret": { "type": "string" }
+      },
+      "required": ["enabled", "upstreamCerts", "caSecret"]
     },
     "ingressTls": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -61,6 +61,7 @@
     },
     "ingress": { "$ref": "#/definitions/ingress" },
     "httproute": { "$ref": "#/definitions/httpRoute" },
+    "monitoring": { "$ref": "#/definitions/monitoring" },
     "externalDependencies": {
       "type": "object",
       "additionalProperties": false,
@@ -110,7 +111,7 @@
       }
     }
   },
-  "required": ["planes", "embeddedDependencies", "externalDependencies", "image", "externalUrl", "ingress", "httproute", "secrets", "services", "gateway"],
+  "required": ["planes", "embeddedDependencies", "externalDependencies", "image", "externalUrl", "ingress", "httproute", "monitoring", "secrets", "services", "gateway"],
   "definitions": {
     "enabledBlock": {
       "type": "object",
@@ -199,6 +200,32 @@
         "caSecret": { "type": "string" }
       },
       "required": ["enabled", "upstreamCerts", "caSecret"]
+    },
+    "podMonitor": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "interval": { "type": "string", "minLength": 1 },
+        "scrapeTimeout": { "type": "string", "minLength": 1 },
+        "scheme": { "type": "string", "enum": ["http", "https"] },
+        "tlsConfig": { "type": "object" },
+        "honorLabels": { "type": "boolean" },
+        "targetLabels": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "relabelings": { "type": "array", "items": { "type": "object" } },
+        "metricRelabelings": { "type": "array", "items": { "type": "object" } }
+      },
+      "required": ["enabled", "labels", "annotations", "interval", "scrapeTimeout", "scheme", "tlsConfig", "honorLabels", "targetLabels", "relabelings", "metricRelabelings"]
+    },
+    "monitoring": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "podMonitor": { "$ref": "#/definitions/podMonitor" }
+      },
+      "required": ["podMonitor"]
     },
     "ingressTls": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -84,12 +84,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "api": { "$ref": "#/definitions/serviceComponent" },
-        "ui": { "$ref": "#/definitions/serviceComponent" },
-        "router": { "$ref": "#/definitions/serviceComponent" },
-        "worker": { "$ref": "#/definitions/serviceComponent" },
-        "logger": { "$ref": "#/definitions/serviceComponent" },
-        "agent": { "$ref": "#/definitions/serviceComponent" },
+        "api": { "$ref": "#/definitions/apiComponent" },
+        "ui": { "$ref": "#/definitions/uiComponent" },
+        "router": { "$ref": "#/definitions/autoscaledServiceComponent" },
+        "worker": { "$ref": "#/definitions/autoscaledServiceComponent" },
+        "logger": { "$ref": "#/definitions/autoscaledServiceComponent" },
+        "agent": { "$ref": "#/definitions/autoscaledServiceComponent" },
         "delayedJobMonitor": { "$ref": "#/definitions/serviceComponent" },
         "mcp": { "$ref": "#/definitions/mcpComponent" }
       }
@@ -98,10 +98,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "envoy": { "$ref": "#/definitions/gatewayComponent" },
-        "oauth2Proxy": { "$ref": "#/definitions/gatewayComponent" },
-        "authz": { "$ref": "#/definitions/gatewayComponent" },
-        "rateLimit": { "$ref": "#/definitions/gatewayComponent" },
+        "envoy": { "$ref": "#/definitions/gatewayEnvoyComponent" },
+        "oauth2Proxy": { "$ref": "#/definitions/gatewayOauth2ProxyComponent" },
+        "authz": { "$ref": "#/definitions/autoscaledServiceComponent" },
+        "rateLimit": { "$ref": "#/definitions/gatewayRateLimitComponent" },
         "upstreams": { "type": "object" },
         "networkPolicies": { "type": "object" },
         "tls": { "type": "object" }
@@ -192,8 +192,105 @@
         "resources": { "type": "object" }
       }
     },
+    "apiAuth": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "deviceEndpoint": { "type": "string" },
+        "deviceClientId": { "type": "string" },
+        "browserEndpoint": { "type": "string" },
+        "browserClientId": { "type": "string" },
+        "tokenEndpoint": { "type": "string" },
+        "logoutEndpoint": { "type": "string" }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "minReplicas": { "type": "integer", "minimum": 0 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "hpaMemoryTarget": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "hpaCpuTarget": { "type": "integer", "minimum": 1, "maximum": 100 },
+        "customMetrics": { "type": "array" }
+      }
+    },
+    "envoyJwt": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "userHeader": { "type": "string" },
+        "providers": { "type": "array" }
+      }
+    },
+    "uiService": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "portName": { "type": "string" },
+        "protocol": { "type": "string" },
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "extraPorts": { "type": "array" }
+      }
+    },
+    "autoscaledServiceComponent": {
+      "allOf": [
+        { "$ref": "#/definitions/serviceComponent" },
+        {
+          "properties": {
+            "autoscaling": { "$ref": "#/definitions/autoscaling" }
+          }
+        }
+      ]
+    },
+    "apiComponent": {
+      "allOf": [
+        { "$ref": "#/definitions/autoscaledServiceComponent" },
+        {
+          "properties": {
+            "auth": { "$ref": "#/definitions/apiAuth" }
+          }
+        }
+      ]
+    },
+    "uiComponent": {
+      "allOf": [
+        { "$ref": "#/definitions/serviceComponent" },
+        {
+          "properties": {
+            "service": { "$ref": "#/definitions/uiService" }
+          }
+        }
+      ]
+    },
     "gatewayComponent": {
       "allOf": [{ "$ref": "#/definitions/serviceComponent" }]
+    },
+    "gatewayEnvoyComponent": {
+      "allOf": [
+        { "$ref": "#/definitions/autoscaledServiceComponent" },
+        {
+          "properties": {
+            "jwt": { "$ref": "#/definitions/envoyJwt" }
+          }
+        }
+      ]
+    },
+    "gatewayOauth2ProxyComponent": {
+      "allOf": [
+        { "$ref": "#/definitions/autoscaledServiceComponent" },
+        { "not": { "required": ["redis"] } }
+      ]
+    },
+    "gatewayRateLimitComponent": {
+      "allOf": [
+        { "$ref": "#/definitions/gatewayComponent" },
+        { "not": { "required": ["redis"] } }
+      ]
     },
     "mcpComponent": {
       "allOf": [

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -21,7 +21,6 @@
         "postgresql": { "$ref": "#/definitions/enabledBlock" },
         "valkey": { "$ref": "#/definitions/enabledBlock" },
         "objectStorage": { "$ref": "#/definitions/enabledBlock" },
-        "gateway": { "$ref": "#/definitions/enabledBlock" },
         "kaiScheduler": { "$ref": "#/definitions/enabledBlock" }
       }
     },
@@ -50,15 +49,9 @@
         "logFormat": { "type": "string", "enum": ["text", "json"] }
       }
     },
-    "exposure": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "mode": { "type": "string", "enum": ["external", "gateway", "ingress"] },
-        "baseUrl": { "type": "string" }
-      },
-      "required": ["mode"]
-    },
+    "externalUrl": { "type": "string" },
+    "ingress": { "$ref": "#/definitions/ingress" },
+    "httproute": { "$ref": "#/definitions/httpRoute" },
     "externalDependencies": {
       "type": "object",
       "additionalProperties": false,
@@ -108,7 +101,7 @@
       }
     }
   },
-  "required": ["planes", "embeddedDependencies", "externalDependencies", "image", "exposure", "secrets", "services", "gateway"],
+  "required": ["planes", "embeddedDependencies", "externalDependencies", "image", "externalUrl", "ingress", "httproute", "secrets", "services", "gateway"],
   "definitions": {
     "enabledBlock": {
       "type": "object",
@@ -119,6 +112,99 @@
     "stringMap": {
       "type": "object",
       "additionalProperties": { "type": "string" }
+    },
+    "ingressTls": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "secretName": { "type": "string" }
+      },
+      "required": ["enabled", "secretName"]
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "ingressClassName": { "type": "string" },
+        "hostname": { "type": "string" },
+        "path": { "type": "string", "minLength": 1 },
+        "pathType": { "type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"] },
+        "tls": { "$ref": "#/definitions/ingressTls" },
+        "extraHosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "path": { "type": "string", "minLength": 1 },
+              "pathType": { "type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"] }
+            },
+            "required": ["name"]
+          }
+        },
+        "extraPaths": { "type": "array", "items": { "type": "object" } },
+        "extraRules": { "type": "array", "items": { "type": "object" } },
+        "extraTls": { "type": "array", "items": { "type": "object" } }
+      },
+      "required": ["enabled", "labels", "annotations", "ingressClassName", "hostname", "path", "pathType", "tls", "extraHosts", "extraPaths", "extraRules", "extraTls"]
+    },
+    "httpRouteParentRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "group": { "type": "string" },
+        "kind": { "type": "string" },
+        "namespace": { "type": "string" },
+        "name": { "type": "string", "minLength": 1 },
+        "sectionName": { "type": "string" }
+      },
+      "required": ["name"]
+    },
+    "httpRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "parentRefs": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/httpRouteParentRef" }
+        },
+        "hostnames": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "rules": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "object" }
+        }
+      },
+      "required": ["enabled", "labels", "annotations", "parentRefs", "hostnames", "rules"]
+    },
+    "gatewayService": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "nodePort": { "type": ["integer", "null"], "minimum": 1, "maximum": 65535 },
+        "labels": { "$ref": "#/definitions/stringMap" },
+        "annotations": { "$ref": "#/definitions/stringMap" },
+        "loadBalancerClass": { "type": "string" },
+        "loadBalancerSourceRanges": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "externalTrafficPolicy": { "type": "string", "enum": ["Cluster", "Local"] }
+      },
+      "required": ["type", "port", "nodePort", "labels", "annotations", "loadBalancerClass", "loadBalancerSourceRanges", "externalTrafficPolicy"]
     },
     "globalImage": {
       "type": "object",
@@ -274,7 +360,9 @@
       "allOf": [
         { "$ref": "#/definitions/autoscaledServiceComponent" },
         {
+          "not": { "required": ["ingress"] },
           "properties": {
+            "service": { "$ref": "#/definitions/gatewayService" },
             "jwt": { "$ref": "#/definitions/envoyJwt" }
           }
         }

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -359,7 +359,7 @@
         "image": { "$ref": "#/definitions/componentImage" },
         "pod": { "$ref": "#/definitions/podSettings" },
         "serviceAccount": { "type": "object" },
-        "autoscaling": { "type": "object" },
+        "autoscaling": { "$ref": "#/definitions/autoscaling" },
         "env": { "type": "array" },
         "extraArgs": { "type": "array" },
         "resources": { "type": "object" }
@@ -382,12 +382,15 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": { "type": "boolean" },
         "minReplicas": { "type": "integer", "minimum": 0 },
         "maxReplicas": { "type": "integer", "minimum": 1 },
-        "hpaMemoryTarget": { "type": "integer", "minimum": 1, "maximum": 100 },
-        "hpaCpuTarget": { "type": "integer", "minimum": 1, "maximum": 100 },
-        "customMetrics": { "type": "array" }
-      }
+        "hpaMemoryTarget": { "type": ["integer", "null"], "minimum": 1, "maximum": 100 },
+        "hpaCpuTarget": { "type": ["integer", "null"], "minimum": 1, "maximum": 100 },
+        "customMetrics": { "type": "array" },
+        "behavior": { "type": "object" }
+      },
+      "required": ["enabled", "minReplicas", "maxReplicas", "hpaMemoryTarget", "hpaCpuTarget", "customMetrics", "behavior"]
     },
     "envoyJwt": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -188,11 +188,11 @@
         "scheme": { "type": "string", "enum": ["http", "https"] },
         "tlsConfig": { "type": "object" },
         "honorLabels": { "type": "boolean" },
-        "targetLabels": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "podTargetLabels": { "type": "array", "items": { "type": "string", "minLength": 1 } },
         "relabelings": { "type": "array", "items": { "type": "object" } },
         "metricRelabelings": { "type": "array", "items": { "type": "object" } }
       },
-      "required": ["enabled", "labels", "annotations", "interval", "scrapeTimeout", "scheme", "tlsConfig", "honorLabels", "targetLabels", "relabelings", "metricRelabelings"]
+      "required": ["enabled", "labels", "annotations", "interval", "scrapeTimeout", "scheme", "tlsConfig", "honorLabels", "podTargetLabels", "relabelings", "metricRelabelings"]
     },
     "monitoring": {
       "type": "object",

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -89,7 +89,9 @@ podDefaults:
   tolerations: []
   # TODO: Apply these shared pod-policy fields to every OSMO workload.
   affinity: {}
-  podSecurityContext: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
   containerSecurityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -97,6 +99,7 @@ podDefaults:
       - ALL
     runAsNonRoot: true
     runAsUser: 1001
+  terminationGracePeriodSeconds: 30
 
 # Shared Python service logging settings.
 logging:
@@ -202,6 +205,12 @@ services:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     resources:
       requests:
         cpu: 100m
@@ -259,9 +268,15 @@ services:
     nextjsSslEnabled: false
     containerPort: 8000
     serviceAccount:
-      name: osmo
+      name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     maxHttpHeaderSizeKb: 128
     command: []
     args: []
@@ -313,6 +328,8 @@ services:
       labels: {}
       annotations: {}
       nodeSelector: {}
+      containerSecurityContext:
+        runAsUser: 1000
       topologySpreadConstraints:
       - topologyKey: kubernetes.io/hostname
         maxSkew: 1
@@ -347,6 +364,12 @@ services:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     volumeMounts:
     - name: progress-files
       mountPath: /var/run/osmo
@@ -391,6 +414,12 @@ services:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     env: []
     replicas: 2
     pod:
@@ -469,6 +498,12 @@ services:
       name: ''
       create: true
       annotations: {}
+      automountServiceAccountToken: true
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     env: []
     replicas: 3
     pod:
@@ -504,6 +539,12 @@ services:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     extraPorts: []
     resources: {}
     livenessProbe:
@@ -579,6 +620,12 @@ services:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     envoy: {}
     env: []
     replicas: 3
@@ -637,6 +684,12 @@ services:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     envoy: {}
     env: []
     replicas: 1
@@ -677,6 +730,12 @@ gateway:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     defaultIdentity:
       user: ''
       roles: ''
@@ -834,6 +893,12 @@ gateway:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     volumeMounts: []
     env: []
     replicas: 1
@@ -898,6 +963,12 @@ gateway:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     volumeMounts: []
     env: []
     replicas: 1
@@ -936,6 +1007,12 @@ gateway:
       name: ''
       create: false
       annotations: {}
+      automountServiceAccountToken: false
+    podDisruptionBudget:
+      enabled: false
+      labels: {}
+      annotations: {}
+      unhealthyPodEvictionPolicy: IfHealthyBudget
     volumeMounts: []
     env: []
     pod:

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -262,7 +262,6 @@ services:
       labels: {}
       annotations: {}
       extraPorts: []
-      selector: {}
     resources: {}
     extraPorts: []
     envFrom: []
@@ -409,12 +408,12 @@ services:
     disableTaskMetrics: false
     auth:
       enabled: false
-      device_endpoint: ''
-      device_client_id: ''
-      browser_endpoint: ''
-      browser_client_id: ''
-      token_endpoint: ''
-      logout_endpoint: ''
+      deviceEndpoint: ''
+      deviceClientId: ''
+      browserEndpoint: ''
+      browserClientId: ''
+      tokenEndpoint: ''
+      logoutEndpoint: ''
     livenessProbe:
       httpGet:
         port: 8000
@@ -464,7 +463,7 @@ services:
     autoscaling:
       minReplicas: 3
       maxReplicas: 5
-      memoryTarget: 80
+      hpaMemoryTarget: 80
       hpaCpuTarget: 80
       customMetrics: []
     image:
@@ -705,7 +704,7 @@ gateway:
       host: ''
       port: ''
     jwt:
-      user_header: x-osmo-user
+      userHeader: x-osmo-user
       providers: []
     skipAuthPaths:
     - /api/version
@@ -800,10 +799,6 @@ gateway:
       clientSecret: /etc/oauth2-proxy/client-secret
       cookieSecret: /etc/oauth2-proxy/cookie-secret
     extraArgs: []
-    redis:
-      port: 6379
-      tlsEnabled: true
-      dbNumber: 0
     resources:
       requests:
         cpu: 50m
@@ -901,9 +896,6 @@ gateway:
       pullPolicy: IfNotPresent
     grpcPort: 8091
     httpPort: 8090
-    redis:
-      port: 6379
-      tlsEnabled: true
     config:
       domain: ratelimit
       descriptors: []

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -143,6 +143,21 @@ httproute:
         type: PathPrefix
         value: /
 
+# Optional Prometheus Operator PodMonitors for OSMO metrics endpoints.
+monitoring:
+  podMonitor:
+    enabled: false
+    labels: {}
+    annotations: {}
+    interval: 30s
+    scrapeTimeout: 10s
+    scheme: http
+    tlsConfig: {}
+    honorLabels: false
+    targetLabels: []
+    relabelings: []
+    metricRelabelings: []
+
 # References to operator-owned Kubernetes Secrets. Inline credentials are not
 # accepted.
 # TODO: Implement retained chart-generated credentials for `generate: true`;
@@ -438,13 +453,6 @@ services:
   # Main OSMO REST API and control-plane service.
   api:
     enabled: true
-    monitoring:
-      podMonitor:
-        enabled: false
-        interval: 30s
-        scrapeTimeout: 10s
-        scheme: http
-        tlsConfig: {}
     autoscaling:
       enabled: false
       minReplicas: 3

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -65,7 +65,7 @@ externalDependencies:
       apps: ''
 
 # Override the names Helm derives from the chart and release. Leave empty for
-# conventional names such as `osmo-service` and `osmo-gateway`.
+# conventional names such as `osmo-api` and `osmo-gateway`.
 nameOverride: ''
 fullnameOverride: ''
 
@@ -701,7 +701,7 @@ gateway:
       host: ''
     internalJwks:
       enabled: true
-      cluster: osmo-service-jwks
+      cluster: osmo-api-jwks
       host: ''
       port: ''
     jwt:
@@ -745,7 +745,7 @@ gateway:
   # Internal destinations used by Envoy routes. Empty hosts resolve to this
   # release's Services; set a host only to route outside the release.
   upstreams:
-    service:
+    api:
       enabled: true
       host: ''
       port: 80
@@ -938,8 +938,8 @@ gateway:
     # Release-relative component suffixes prevent policies from selecting pods
     # owned by another OSMO release in the same namespace.
     upstreams:
-    - name: service
-      component: service
+    - name: api
+      component: api
       port: 8000
     - name: router
       component: router
@@ -954,7 +954,7 @@ gateway:
   tls:
     enabled: true
     upstreamCerts:
-      service: ''
+      api: ''
       router: ''
       agent: ''
       logger: ''

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -253,7 +253,7 @@ services:
       name: web-ui
       tag: ''
       pullPolicy: Always
-    # Leave empty to use this release's gateway Service and port 80.
+    # Leave empty to use this release's gateway Service and configured port.
     apiHostname: ''
     portForwardEnabled: false
     nextjsSslEnabled: false
@@ -755,7 +755,6 @@ gateway:
   # release's Services; set a host only to route outside the release.
   upstreams:
     api:
-      enabled: true
       host: ''
       port: 80
     router:

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -23,8 +23,6 @@ embeddedDependencies:
     enabled: false
   objectStorage:
     enabled: false
-  gateway:
-    enabled: false
   kaiScheduler:
     enabled: false
 
@@ -107,19 +105,40 @@ logging:
   k8sLogLevel: WARNING
   logFormat: text
 
-# Describe how clients reach the release.
-#
-# Supported mode values are `external`, `gateway`, and `ingress`. Only
-# `external` is implemented today: the chart creates the internal
-# `osmo-gateway` Service but expects an operator-managed proxy, load balancer,
-# or port-forward to expose it.
-# TODO: Implement Kubernetes edge resources for `gateway` and `ingress` modes;
-# those modes currently fail validation.
-exposure:
-  mode: external
-  # Public OSMO URL used in generated service configuration. Include the
-  # scheme, for example `https://osmo.example.com`.
-  baseUrl: ''
+# Public OSMO URL used in generated service configuration and redirects.
+# Include the scheme, for example `https://osmo.example.com`.
+externalUrl: ''
+
+# Optional Kubernetes Ingress for the OSMO gateway Service.
+ingress:
+  enabled: false
+  labels: {}
+  annotations: {}
+  ingressClassName: ''
+  hostname: ''
+  path: /
+  pathType: Prefix
+  tls:
+    enabled: false
+    secretName: ''
+  extraHosts: []
+  extraPaths: []
+  extraRules: []
+  extraTls: []
+
+# Optional Gateway API HTTPRoute. Parent references must target a Gateway
+# managed outside this chart.
+httproute:
+  enabled: false
+  labels: {}
+  annotations: {}
+  parentRefs: []
+  hostnames: []
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
 
 # References to operator-owned Kubernetes Secrets. Inline credentials are not
 # accepted.
@@ -620,8 +639,8 @@ services:
       initContainers: []
 
 # Internal API gateway and optional gateway-adjacent services. This block is
-# independent of `exposure.mode`: `gateway.envoy` routes traffic inside the
-# release even when an external edge owns the public URL.
+# independent of the Kubernetes edge mechanism: `gateway.envoy` routes traffic
+# inside the release even when an external edge owns the public URL.
 gateway:
   # Envoy proxy that provides the single in-cluster OSMO entry point.
   envoy:
@@ -649,23 +668,14 @@ gateway:
       roles: ''
       allowedPools: ''
     service:
-      type: LoadBalancer
-      httpsPort: 443
+      type: ClusterIP
+      port: 80
       nodePort: null
+      labels: {}
       annotations: {}
-    # TODO: Remove this legacy enabled switch and derive Ingress rendering from
-    # top-level exposure.mode when ingress exposure is implemented.
-    ingress:
-      enabled: false
-      ingressClass: alb
-      albAnnotations:
-        enabled: false
-        groupName: osmo
-        groupOrder: '10'
-        sslCertArn: ''
-      sslEnabled: false
-      sslSecret: osmo-tls
-      annotations: {}
+      loadBalancerClass: ''
+      loadBalancerSourceRanges: []
+      externalTrafficPolicy: Cluster
     ssl:
       enabled: false
       secretName: envoy-ssl-cert

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -155,7 +155,7 @@ monitoring:
     scheme: http
     tlsConfig: {}
     honorLabels: false
-    targetLabels: []
+    podTargetLabels: []
     relabelings: []
     metricRelabelings: []
 

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -89,7 +89,6 @@ podDefaults:
   annotations: {}
   nodeSelector: {}
   tolerations: []
-  # TODO: Apply these shared pod-policy fields to every OSMO workload.
   affinity: {}
   podSecurityContext:
     seccompProfile:
@@ -345,11 +344,13 @@ services:
       timeoutSeconds: 3
       periodSeconds: 5
     env: []
+    extraVolumeMounts: []
     pod:
       labels: {}
       annotations: {}
       nodeSelector: {}
       containerSecurityContext:
+        readOnlyRootFilesystem: true
         runAsUser: 1000
       topologySpreadConstraints:
       - topologyKey: kubernetes.io/hostname
@@ -360,6 +361,7 @@ services:
         whenUnsatisfiable: ScheduleAnyway
       hostAliases: []
       initContainers: []
+      extraVolumes: []
 
   # Promotes scheduled Redis jobs when their delay expires.
   delayedJobMonitor:
@@ -393,18 +395,16 @@ services:
       labels: {}
       annotations: {}
       unhealthyPodEvictionPolicy: IfHealthyBudget
-    volumeMounts:
-    - name: progress-files
-      mountPath: /var/run/osmo
+    extraVolumeMounts: []
     env: []
     pod:
       labels: {}
       annotations: {}
       nodeSelector: {}
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
       initContainers: []
-      volumes:
-      - name: progress-files
-        emptyDir: {}
+      extraVolumes: []
 
   # Executes asynchronous control-plane jobs from the Valkey queue.
   worker:
@@ -447,10 +447,13 @@ services:
       unhealthyPodEvictionPolicy: IfHealthyBudget
     env: []
     replicas: 2
+    extraVolumeMounts: []
     pod:
       labels: {}
       annotations: {}
       nodeSelector: {}
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
       topologySpreadConstraints:
       - topologyKey: kubernetes.io/hostname
         maxSkew: 1
@@ -459,6 +462,7 @@ services:
         maxSkew: 1
         whenUnsatisfiable: ScheduleAnyway
       initContainers: []
+      extraVolumes: []
 
   # Main OSMO REST API and control-plane service.
   api:
@@ -526,16 +530,20 @@ services:
       unhealthyPodEvictionPolicy: IfHealthyBudget
     env: []
     replicas: 3
+    extraVolumeMounts: []
     pod:
       labels: {}
       annotations: {}
       nodeSelector: {}
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
       topologySpreadConstraints:
       - topologyKey: topology.kubernetes.io/zone
         maxSkew: 1
         whenUnsatisfiable: ScheduleAnyway
       hostAliases: []
       initContainers: []
+      extraVolumes: []
 
   # Routes sticky HTTP and WebSocket sessions to connected backends.
   router:
@@ -593,16 +601,20 @@ services:
       timeoutSeconds: 30
     env: []
     replicas: 3
+    extraVolumeMounts: []
     pod:
       labels: {}
       annotations: {}
       nodeSelector: {}
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
       topologySpreadConstraints:
       - topologyKey: topology.kubernetes.io/zone
         maxSkew: 1
         whenUnsatisfiable: ScheduleAnyway
       hostAliases: []
       initContainers: []
+      extraVolumes: []
 
   # Receives workflow logs and task metrics from runtime containers.
   logger:
@@ -653,15 +665,19 @@ services:
     envoy: {}
     env: []
     replicas: 3
+    extraVolumeMounts: []
     pod:
       labels: {}
       annotations: {}
       nodeSelector: {}
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
       topologySpreadConstraints:
       - topologyKey: topology.kubernetes.io/zone
         maxSkew: 1
         whenUnsatisfiable: ScheduleAnyway
       initContainers: []
+      extraVolumes: []
 
   # Receives backend-cluster events and heartbeat streams.
   agent:
@@ -719,15 +735,19 @@ services:
     envoy: {}
     env: []
     replicas: 1
+    extraVolumeMounts: []
     pod:
       labels: {}
       annotations: {}
       nodeSelector: {}
+      containerSecurityContext:
+        readOnlyRootFilesystem: true
       topologySpreadConstraints:
       - topologyKey: topology.kubernetes.io/zone
         maxSkew: 1
         whenUnsatisfiable: ScheduleAnyway
       initContainers: []
+      extraVolumes: []
 
 # Internal API gateway and optional gateway-adjacent services. This block is
 # independent of the Kubernetes edge mechanism: `gateway.envoy` routes traffic
@@ -838,7 +858,7 @@ gateway:
     extraRoutes: []
     extraClusters: []
     maxRequests: 100
-    volumeMounts: []
+    extraVolumeMounts: []
     replicas: 2
     pod:
       nodeSelector: {}
@@ -847,9 +867,10 @@ gateway:
         capabilities:
           drop:
           - ALL
+        readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsUser: 1001
-      volumes: []
+      extraVolumes: []
       labels: {}
       annotations: {}
 
@@ -931,7 +952,7 @@ gateway:
       labels: {}
       annotations: {}
       unhealthyPodEvictionPolicy: IfHealthyBudget
-    volumeMounts: []
+    extraVolumeMounts: []
     env: []
     replicas: 1
     pod:
@@ -944,7 +965,7 @@ gateway:
           - ALL
         runAsNonRoot: true
         runAsUser: 1001
-      volumes: []
+      extraVolumes: []
       labels: {}
 
   # Optional external-authorization service backed by OSMO role policies.
@@ -1003,7 +1024,7 @@ gateway:
       labels: {}
       annotations: {}
       unhealthyPodEvictionPolicy: IfHealthyBudget
-    volumeMounts: []
+    extraVolumeMounts: []
     env: []
     replicas: 1
     pod:
@@ -1016,7 +1037,7 @@ gateway:
           - ALL
         runAsNonRoot: true
         runAsUser: 10001
-      volumes: []
+      extraVolumes: []
       labels: {}
 
   # Optional Envoy-compatible global rate-limit service backed by Valkey.
@@ -1050,7 +1071,7 @@ gateway:
       labels: {}
       annotations: {}
       unhealthyPodEvictionPolicy: IfHealthyBudget
-    volumeMounts: []
+    extraVolumeMounts: []
     env: []
     pod:
       annotations: {}
@@ -1062,7 +1083,7 @@ gateway:
           - ALL
         runAsNonRoot: true
         runAsUser: 1001
-      volumes: []
+      extraVolumes: []
       labels: {}
 
   # Optional ingress policies limiting gateway traffic to known upstream pods.

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -67,15 +67,17 @@ externalDependencies:
 nameOverride: ''
 fullnameOverride: ''
 
-# Shared defaults for OSMO-owned images. A service can override these values in
-# its own `image` block; an empty service tag inherits `image.tag`, which in
-# turn defaults to Chart.appVersion.
-image:
+# Global image registry and pull credentials. A non-empty registry overrides
+# every component and runtime image registry for air-gapped mirrors.
+global:
+  imageRegistry: ''
+  imagePullSecrets: []
+
+# Runtime images referenced by submitted workflows.
+runtimeImage:
   registry: nvcr.io
-  repositoryPrefix: nvidia/osmo
+  repository: nvidia/osmo
   tag: ''
-  pullPolicy: IfNotPresent
-imagePullSecrets: []
 
 # Metadata and scheduling defaults shared by OSMO-owned workloads. Labels,
 # annotations, and node selectors merge with service-specific pod values;
@@ -207,9 +209,11 @@ services:
     enabled: false
     replicas: 1
     image:
-      name: mcp-self-hosted
+      registry: nvcr.io
+      repository: nvidia/osmo/mcp-self-hosted
       tag: ''
-      pullPolicy: Always
+      digest: ''
+      pullPolicy: IfNotPresent
     port: 8000
     resourceUrl: ''
     requestTimeoutSeconds: 10
@@ -274,9 +278,11 @@ services:
     enabled: true
     replicas: 1
     image:
-      name: web-ui
+      registry: nvcr.io
+      repository: nvidia/osmo/web-ui
       tag: ''
-      pullPolicy: Always
+      digest: ''
+      pullPolicy: IfNotPresent
     # Leave empty to use this release's gateway Service and configured port.
     apiHostname: ''
     portForwardEnabled: false
@@ -360,9 +366,11 @@ services:
     enabled: true
     replicas: 1
     image:
-      name: delayed-job-monitor
+      registry: nvcr.io
+      repository: nvidia/osmo/delayed-job-monitor
       tag: ''
-      pullPolicy: Always
+      digest: ''
+      pullPolicy: IfNotPresent
     startupProbe:
       exec:
         command:
@@ -410,9 +418,11 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      name: worker
+      registry: nvcr.io
+      repository: nvidia/osmo/worker
       tag: ''
-      pullPolicy: Always
+      digest: ''
+      pullPolicy: IfNotPresent
     startupProbe:
       exec:
         command:
@@ -462,9 +472,11 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      name: service
+      registry: nvcr.io
+      repository: nvidia/osmo/service
       tag: ''
-      pullPolicy: Always
+      digest: ''
+      pullPolicy: IfNotPresent
     hostname: ''
     clientInstallUrl: https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/install.sh
     disableTaskMetrics: false
@@ -537,9 +549,11 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      name: router
+      registry: nvcr.io
+      repository: nvidia/osmo/router
       tag: ''
-      pullPolicy: Always
+      digest: ''
+      pullPolicy: IfNotPresent
     hostname: ''
     webserverEnabled: false
     extraArgs: []
@@ -602,9 +616,11 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      name: logger
+      registry: nvcr.io
+      repository: nvidia/osmo/logger
       tag: ''
-      pullPolicy: Always
+      digest: ''
+      pullPolicy: IfNotPresent
     startupProbe:
       exec:
         command:
@@ -659,9 +675,11 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      name: agent
+      registry: nvcr.io
+      repository: nvidia/osmo/agent
       tag: ''
-      pullPolicy: Always
+      digest: ''
+      pullPolicy: IfNotPresent
     startupProbe:
       exec:
         command:
@@ -727,7 +745,10 @@ gateway:
       customMetrics: []
       behavior: {}
     image:
-      repository: envoyproxy/envoy:v1.38.1
+      registry: docker.io
+      repository: envoyproxy/envoy
+      tag: v1.38.1
+      digest: ''
       pullPolicy: IfNotPresent
     logLevel: info
     listenerPort: 8080
@@ -868,7 +889,10 @@ gateway:
       customMetrics: []
       behavior: {}
     image:
-      repository: quay.io/oauth2-proxy/oauth2-proxy:v7.14.2
+      registry: quay.io
+      repository: oauth2-proxy/oauth2-proxy
+      tag: v7.14.2
+      digest: ''
       pullPolicy: IfNotPresent
     httpPort: 4180
     metricsPort: 44180
@@ -935,9 +959,11 @@ gateway:
       customMetrics: []
       behavior: {}
     image:
-      name: authz-sidecar
+      registry: nvcr.io
+      repository: nvidia/osmo/authz-sidecar
       tag: ''
-      pullPolicy: Always
+      digest: ''
+      pullPolicy: IfNotPresent
     grpcPort: 50052
     postgres:
       maxConns: 10
@@ -998,7 +1024,10 @@ gateway:
     enabled: false
     replicas: 1
     image:
-      repository: envoyproxy/ratelimit:875d418c
+      registry: docker.io
+      repository: envoyproxy/ratelimit
+      tag: 875d418c
+      digest: ''
       pullPolicy: IfNotPresent
     grpcPort: 8091
     httpPort: 8090

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -271,8 +271,10 @@ services:
       enabled: false
       minReplicas: 1
       maxReplicas: 3
-      hpaTarget: 85
+      hpaCpuTarget: 85
+      hpaMemoryTarget: null
       customMetrics: []
+      behavior: {}
     service:
       type: ''
       port: 80
@@ -362,11 +364,13 @@ services:
   worker:
     enabled: true
     autoscaling:
+      enabled: false
       minReplicas: 2
       maxReplicas: 10
       hpaMemoryTarget: 80
       hpaCpuTarget: 80
       customMetrics: []
+      behavior: {}
     image:
       name: worker
       tag: ''
@@ -413,11 +417,13 @@ services:
         scheme: http
         tlsConfig: {}
     autoscaling:
+      enabled: false
       minReplicas: 3
       maxReplicas: 9
       hpaMemoryTarget: 80
       hpaCpuTarget: 80
       customMetrics: []
+      behavior: {}
     image:
       name: service
       tag: ''
@@ -480,11 +486,13 @@ services:
   router:
     enabled: true
     autoscaling:
+      enabled: false
       minReplicas: 3
       maxReplicas: 5
       hpaMemoryTarget: 80
       hpaCpuTarget: 80
       customMetrics: []
+      behavior: {}
     image:
       name: router
       tag: ''
@@ -537,11 +545,13 @@ services:
   logger:
     enabled: true
     autoscaling:
+      enabled: false
       minReplicas: 3
       maxReplicas: 9
       hpaMemoryTarget: 80
       hpaCpuTarget: 80
       customMetrics: []
+      behavior: {}
     image:
       name: logger
       tag: ''
@@ -586,11 +596,13 @@ services:
   agent:
     enabled: true
     autoscaling:
+      enabled: false
       minReplicas: 1
       maxReplicas: 9
       hpaMemoryTarget: 80
       hpaCpuTarget: 80
       customMetrics: []
+      behavior: {}
     image:
       name: agent
       tag: ''
@@ -646,11 +658,13 @@ gateway:
   envoy:
     enabled: true
     autoscaling:
+      enabled: false
       minReplicas: 2
       maxReplicas: 6
       hpaCpuTarget: 80
       hpaMemoryTarget: 80
       customMetrics: []
+      behavior: {}
     image:
       repository: envoyproxy/envoy:v1.38.1
       pullPolicy: IfNotPresent
@@ -779,11 +793,13 @@ gateway:
   oauth2Proxy:
     enabled: true
     autoscaling:
+      enabled: false
       minReplicas: 1
       maxReplicas: 3
       hpaCpuTarget: 80
       hpaMemoryTarget: 80
       customMetrics: []
+      behavior: {}
     image:
       repository: quay.io/oauth2-proxy/oauth2-proxy:v7.14.2
       pullPolicy: IfNotPresent
@@ -838,11 +854,13 @@ gateway:
   authz:
     enabled: true
     autoscaling:
+      enabled: false
       minReplicas: 1
       maxReplicas: 3
       hpaCpuTarget: 80
       hpaMemoryTarget: 80
       customMetrics: []
+      behavior: {}
     image:
       name: authz-sidecar
       tag: ''


### PR DESCRIPTION
## Description
- Standardizes Helm values, helpers, labels, annotations, and Kubernetes resource names.
- Adds conventional Ingress, HTTPRoute, and configurable gateway Service exposure.
- Adds consistent autoscaling, disruption-budget, security, scheduling, image, and monitoring controls.
- Strengthens validation for documented values.
- Improves chart documentation, production profile guidance, tests, and chart metadata.

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added configurable Kubernetes Ingress and Gateway API HTTPRoute support.
  * Added autoscaling, PodDisruptionBudgets, security settings, workload policies, and Prometheus monitoring.
  * Added configurable images, volumes, scheduling, and gateway service options.
* **Bug Fixes**
  * Added validation for external URLs, routing prerequisites, autoscaling resources, and disruption budgets.
* **Documentation**
  * Expanded installation, exposure, gateway, monitoring, and local HTTPS guidance.
* **Refactor**
  * Replaced legacy exposure settings with `externalUrl` and standardized component naming, labels, and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->