### PR TITLE
Add typed Secret handling to the unified OSMO chart

### DIFF
--- a/bzl/py.bzl
+++ b/bzl/py.bzl
@@ -120,7 +120,22 @@ def _osmo_python_wrapper_script(
         bin_name,
         main,
         runfiles_dir,
+        module = None,
         python_interpreter = "/usr/bin/python3"):
+
+    if (main == None) == (module == None):
+        fail("osmo_python_wrapper requires exactly one of main or module")
+
+    if module:
+        execution = 'os.execv("{python_interpreter}", ["{python_interpreter}", "-m", "{module}"] + sys.argv[1:])'.format(
+            python_interpreter = python_interpreter,
+            module = module,
+        )
+    else:
+        execution = 'os.execv("{python_interpreter}", ["{python_interpreter}", local_main_dir + "{main}"] + sys.argv[1:])'.format(
+            python_interpreter = python_interpreter,
+            main = main,
+        )
     native.genrule(
         name = name,
         outs = [bin_name],
@@ -151,14 +166,14 @@ pythonpath.extend(site_packages)
 # Set PYTHONPATH
 os.environ["PYTHONPATH"] = ":".join(pythonpath)
 
-# Execute target script directly with system Python
-os.execv("{python_interpreter}", ["{python_interpreter}", local_main_dir + "{main}"] + sys.argv[1:])
+# Execute the target with system Python.
+{execution}
 EOF
             chmod +x $@
         """.format(
             python_interpreter = python_interpreter,
             runfiles_dir = runfiles_dir,
-            main = main,
+            execution = execution,
         ),
     )
 
@@ -169,6 +184,7 @@ def osmo_python_wrapper(
         bin_name,
         main,
         runfiles_dir,
+        module = None,
         package_dir = "/usr/bin",
         python_interpreter = "/usr/bin/python3",
         include_progress_check = False):
@@ -179,6 +195,7 @@ def osmo_python_wrapper(
             bin_name = bin_name,
             main = main,
             runfiles_dir = runfiles_dir,
+            module = module,
             python_interpreter = python_interpreter,
         ),
     ]

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -591,6 +591,9 @@ may reference a separate Secret. The defaults expect these keys:
 | `secrets.objectStorage` | `object-storage.yaml` | Workflow data, logs, and apps |
 | `secrets.masterEncryptionKey` | `mek.yaml` | OSMO encryption-key configuration |
 | `secrets.backendApiTokens.credentials[]` | `token`, optional `previous-token` | Backend authentication |
+| `secrets.defaultAdmin` | `password` | Optional administrator bootstrap |
+| `secrets.oauthClientSecret` | `client_secret` | OAuth2 proxy client authentication |
+| `secrets.oauthCookieSecret` | `cookie_secret` | OAuth2 proxy sessions |
 
 Generated backend-token and MEK Secrets are intentionally retained because
 replacing either can disconnect the compute plane or make encrypted database
@@ -710,6 +713,60 @@ use the image's system trust store. For a private CA, set `caExistingSecret` and
 `caKey` in the same block. The selected key must contain the complete trust
 bundle because clients use it through `SSL_CERT_FILE`. PostgreSQL private CAs
 are also configured in its `externalDependencies` TLS block.
+
+Secret references may share one Kubernetes Secret or use separate Secrets.
+After rotating an external Secret, change its `rolloutNonce` to restart
+consumers.
+
+### OAuth credentials
+
+OAuth client credentials are always operator-owned. The client and cookie may
+share a Secret:
+
+```yaml
+secrets:
+  oauthClientSecret:
+    existingSecret: oauth2-proxy-secrets
+    keys:
+      value: client_secret
+  oauthCookieSecret:
+    existingSecret: oauth2-proxy-secrets
+    keys:
+      value: cookie_secret
+```
+
+For direct-Helm development only, set
+`secrets.oauthCookieSecret.generate: true` and clear its `existingSecret`.
+Production and GitOps installations must use an existing Secret because
+generated values are stored in Helm release state.
+
+Cookie rotation invalidates browser sessions and must not leave replicas using
+different keys. Suspend the OAuth2 Proxy HPA, scale its Deployment to zero and
+verify no matching nonterminal pods remain; then replace the Secret, update
+`rolloutNonce`, complete the rollout, and restore autoscaling.
+
+For upgrades from legacy OAuth values, move `secretName`, `clientSecretKey`, and
+`cookieSecretKey` to the blocks above and remove `useKubernetesSecrets` and
+`secretPaths`. Also remove unsupported `mountPath` fields from typed Secret
+blocks; Helm schema errors identify any remaining legacy fields.
+
+## Internal gateway TLS
+
+`gateway.tls` protects internal Envoy-to-service traffic, not public ingress.
+
+| Mode | Configuration |
+| --- | --- |
+| Development | `gateway.tls.generated.enabled: true` |
+| Production | Set `generated.enabled: false`, `caSecret`, and every `upstreamCerts` Secret |
+
+- Rotate leaves by changing `gateway.tls.generated.leafRotationNonce`.
+- For CA rotation, freeze consumer HPAs and use one unique rotation ID through `prepare`, `activate`,
+  `retire`, then `stable`. Wait after every phase. Before `retire`, verify every live leaf and consumer uses the activated CA.
+  Unfreeze HPAs only after `stable` completes.
+- On the first upgrade from process-local TLS, set
+  `gateway.tls.generated.bootstrap.allowInitialGeneration=true` once, verify the
+  retained Secrets, then set it back to `false`. Never use this flag to replace
+  a missing retained CA; restore the original Secret instead.
 
 ## Exposure
 

--- a/deployments/charts/osmo/profiles/quickstart.yaml
+++ b/deployments/charts/osmo/profiles/quickstart.yaml
@@ -41,8 +41,12 @@ secrets:
       managedSecret:
         name: osmo-backend-token
   masterEncryptionKey:
-    generate: true
-    existingSecret: ''
+    managementMode: osmo
+    existingSecret:
+      name: osmo-master-encryption-key
+      key: mek.yaml
+    bootstrap:
+      enabled: true
 
 services:
   ui:

--- a/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
@@ -27,6 +27,7 @@ setting detects this rotation and triggers Envoy to reload.
 
 {{- define "osmo.gateway.envoyConfig" -}}
 {{- $gw := .Values.gateway }}
+{{- $tlsCaSecret := include "osmo.gateway.tlsTrustSecretName" . }}
 {{- $envoy := $gw.envoy }}
 {{- $mcp := .Values.services.mcp }}
 {{- $serviceHost := $gw.upstreams.api.host | default (include "osmo.api.fullname" .) }}
@@ -148,7 +149,7 @@ data:
           filename: /etc/ssl/envoy-certs/tls.key
   {{- end }}
 
-  {{- if and $gw.tls.enabled $gw.tls.caSecret }}
+  {{- if and $gw.tls.enabled $tlsCaSecret }}
   sds_upstream_ca.yaml: |
     resources:
     - "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret
@@ -895,15 +896,7 @@ data:
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
-            {{- if $gw.tls.caSecret }}
-            validation_context_sds_secret_config:
-              name: upstream_ca
-              sds_config:
-                path_config_source:
-                  path: /var/config/sds_upstream_ca.yaml
-                  watched_directory:
-                    path: /var/config
-            {{- end }}
+            {{- include "osmo.gateway.upstreamValidationContext" (dict "host" $serviceHost) | nindent 12 }}
       {{- end }}
 
     {{- if $gw.upstreams.router.enabled }}
@@ -938,15 +931,7 @@ data:
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
-            {{- if $gw.tls.caSecret }}
-            validation_context_sds_secret_config:
-              name: upstream_ca
-              sds_config:
-                path_config_source:
-                  path: /var/config/sds_upstream_ca.yaml
-                  watched_directory:
-                    path: /var/config
-            {{- end }}
+            {{- include "osmo.gateway.upstreamValidationContext" (dict "host" $routerHost) | nindent 12 }}
       {{- end }}
     {{- end }}
 
@@ -1002,15 +987,7 @@ data:
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
-            {{- if $gw.tls.caSecret }}
-            validation_context_sds_secret_config:
-              name: upstream_ca
-              sds_config:
-                path_config_source:
-                  path: /var/config/sds_upstream_ca.yaml
-                  watched_directory:
-                    path: /var/config
-            {{- end }}
+            {{- include "osmo.gateway.upstreamValidationContext" (dict "host" $agentHost) | nindent 12 }}
       {{- end }}
     {{- end }}
 
@@ -1044,15 +1021,7 @@ data:
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
-            {{- if $gw.tls.caSecret }}
-            validation_context_sds_secret_config:
-              name: upstream_ca
-              sds_config:
-                path_config_source:
-                  path: /var/config/sds_upstream_ca.yaml
-                  watched_directory:
-                    path: /var/config
-            {{- end }}
+            {{- include "osmo.gateway.upstreamValidationContext" (dict "host" $loggerHost) | nindent 12 }}
       {{- end }}
     {{- end }}
 
@@ -1088,15 +1057,7 @@ data:
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
-            {{- if $gw.tls.caSecret }}
-            validation_context_sds_secret_config:
-              name: upstream_ca
-              sds_config:
-                path_config_source:
-                  path: /var/config/sds_upstream_ca.yaml
-                  watched_directory:
-                    path: /var/config
-            {{- end }}
+            {{- include "osmo.gateway.upstreamValidationContext" (dict "host" $mcpServiceName) | nindent 12 }}
       {{- end }}
     {{- end }}
 
@@ -1217,7 +1178,7 @@ data:
             tls_params:
               tls_minimum_protocol_version: TLSv1_2
               tls_maximum_protocol_version: TLSv1_3
-            {{- if $gw.tls.caSecret }}
+            {{- if $tlsCaSecret }}
             validation_context_sds_secret_config:
               name: upstream_ca
               sds_config:

--- a/deployments/charts/osmo/templates/_gateway-helpers.tpl
+++ b/deployments/charts/osmo/templates/_gateway-helpers.tpl
@@ -29,52 +29,108 @@ Gateway component labels. Pass a dict with "component" and "context" keys.
 {{- include "osmo.component.selectorLabels" (dict "root" .context "component" (printf "gateway-%s" .component)) -}}
 {{- end }}
 
+{{/* Fill only TLS fields absent from pre-stable-Secret release values. */}}
+{{- define "osmo.gateway.tlsNormalize" -}}
+{{- $tls := .Values.gateway.tls -}}
+{{- if not (hasKey $tls "rolloutNonce") -}}{{- $_ := set $tls "rolloutNonce" "" -}}{{- end -}}
+{{- if not (hasKey $tls "generated") -}}{{- $_ := set $tls "generated" (dict) -}}{{- end -}}
+{{- $generated := $tls.generated -}}
+{{- if kindIs "map" $generated -}}
+{{- if not (hasKey $generated "enabled") -}}{{- $_ := set $generated "enabled" true -}}{{- end -}}
+{{- if not (hasKey $generated "bootstrap") -}}{{- $_ := set $generated "bootstrap" (dict) -}}{{- end -}}
+{{- if kindIs "map" $generated.bootstrap -}}
+{{- if not (hasKey $generated.bootstrap "image") -}}{{- $_ := set $generated.bootstrap "image" "" -}}{{- end -}}
+{{- if not (hasKey $generated.bootstrap "imagePullPolicy") -}}{{- $_ := set $generated.bootstrap "imagePullPolicy" "IfNotPresent" -}}{{- end -}}
+{{- if not (hasKey $generated.bootstrap "allowInitialGeneration") -}}{{- $_ := set $generated.bootstrap "allowInitialGeneration" false -}}{{- end -}}
+{{- end -}}
+{{- if not (hasKey $generated "leafRotationNonce") -}}{{- $_ := set $generated "leafRotationNonce" "" -}}{{- end -}}
+{{- if not (hasKey $generated "caRotation") -}}{{- $_ := set $generated "caRotation" (dict) -}}{{- end -}}
+{{- if kindIs "map" $generated.caRotation -}}
+{{- if not (hasKey $generated.caRotation "id") -}}{{- $_ := set $generated.caRotation "id" "" -}}{{- end -}}
+{{- if not (hasKey $generated.caRotation "phase") -}}{{- $_ := set $generated.caRotation "phase" "stable" -}}{{- end -}}
+{{- if not (hasKey $generated.caRotation "freezeHpas") -}}{{- $_ := set $generated.caRotation "freezeHpas" false -}}{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Per-upstream TLS args. Pass a dict with "context" and "secretName".
 
-When secretName is non-empty, that Secret is mounted at /etc/osmo/tls and
-uvicorn loads tls.crt + tls.key from there (--ssl_keyfile / --ssl_certfile).
-When empty, the Python service mints an ephemeral self-signed cert in
-process at startup (--ssl_self_signed true) — no chart-side cert material.
+The chart always mounts a stable Kubernetes Secret when internal TLS is on.
 */}}
 {{- define "osmo.gateway.upstreamTlsArgs" -}}
+{{- include "osmo.gateway.tlsNormalize" .context -}}
 {{- if .context.Values.gateway.tls.enabled }}
-{{- if .secretName }}
 - --ssl_keyfile
 - /etc/osmo/tls/tls.key
 - --ssl_certfile
 - /etc/osmo/tls/tls.crt
-{{- else }}
-- --ssl_self_signed
-- "true"
-{{- end }}
 {{- end }}
 {{- end }}
 
-{{/*
-TLS volume mount for an upstream container. Only emitted when a Secret
-name is provided — self-signed mode keeps cert material in an in-process
-tempdir, so no mount is needed.
-*/}}
+{{/* TLS volume mount for an upstream container. */}}
 {{- define "osmo.gateway.upstreamTlsVolumeMount" -}}
-{{- if and .context.Values.gateway.tls.enabled .secretName }}
+{{- include "osmo.gateway.tlsNormalize" .context -}}
+{{- if .context.Values.gateway.tls.enabled }}
 - name: tls
   mountPath: /etc/osmo/tls
   readOnly: true
 {{- end }}
 {{- end }}
 
-{{/*
-TLS volume for an upstream pod. Pass dict with "context" and "secretName".
-Only emitted when secretName is non-empty.
-*/}}
+{{/* TLS volume for an upstream pod. Pass dict with "context" and "secretName". */}}
 {{- define "osmo.gateway.upstreamTlsVolume" -}}
-{{- if and .context.Values.gateway.tls.enabled .secretName }}
+{{- include "osmo.gateway.tlsNormalize" .context -}}
+{{- if .context.Values.gateway.tls.enabled }}
 - name: tls
   secret:
-    secretName: {{ .secretName }}
+    secretName: {{ required "internal TLS Secret name is required" .secretName | quote }}
 {{- end }}
 {{- end }}
+
+{{- define "osmo.gateway.tlsLeafSecretName" -}}
+{{- include "osmo.gateway.tlsNormalize" .root -}}
+{{- if .root.Values.gateway.tls.generated.enabled -}}
+{{- printf "%s-internal-tls-%s" (include "osmo.fullname" .root) .component | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- required (printf "gateway.tls.upstreamCerts.%s is required when generated TLS is disabled" .component) (index .root.Values.gateway.tls.upstreamCerts .component) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.gateway.tlsTrustSecretName" -}}
+{{- include "osmo.gateway.tlsNormalize" . -}}
+{{- if .Values.gateway.tls.generated.enabled -}}
+{{- printf "%s-internal-tls-trust" (include "osmo.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- required "gateway.tls.caSecret is required when generated TLS is disabled" .Values.gateway.tls.caSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.gateway.tlsCaSecretName" -}}
+{{- printf "%s-internal-tls-ca" (include "osmo.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "osmo.gateway.tlsRolloutAnnotations" -}}
+{{- include "osmo.gateway.tlsNormalize" . -}}
+checksum/internal-tls-rotation: {{ dict "external" .Values.gateway.tls.rolloutNonce "leaf" .Values.gateway.tls.generated.leafRotationNonce "ca" .Values.gateway.tls.generated.caRotation | toJson | sha256sum | quote }}
+checksum/internal-tls-ca-phase: {{ printf "%s:%s" .Values.gateway.tls.generated.caRotation.id .Values.gateway.tls.generated.caRotation.phase | quote }}
+{{- end -}}
+
+{{- define "osmo.gateway.upstreamValidationContext" -}}
+combined_validation_context:
+  default_validation_context:
+    match_typed_subject_alt_names:
+    - san_type: DNS
+      matcher:
+        exact: {{ .host | quote }}
+  validation_context_sds_secret_config:
+    name: upstream_ca
+    sds_config:
+      path_config_source:
+        path: /var/config/sds_upstream_ca.yaml
+        watched_directory:
+          path: /var/config
+{{- end -}}
 
 {{/*
 Render a probe block, injecting `scheme: HTTPS` into httpGet when TLS is on.

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -379,7 +379,10 @@ data:
 {{- with (include "osmo.objectStorage.secretName" .) }}
 - name: object-storage-credentials
   secret:
-    secretName: {{ . }}
+    secretName: {{ . | quote }}
+    items:
+    - key: {{ $.Values.secrets.objectStorage.keys.credentials | quote }}
+      path: {{ $.Values.secrets.objectStorage.keys.credentials | quote }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -403,8 +406,8 @@ data:
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.secrets.mekFile" -}}/opt/osmo/mek/mek.yaml{{- end -}}
 {{- define "osmo.secrets.mekMountPath" -}}/opt/osmo/mek{{- end -}}
+{{- define "osmo.secrets.mekFile" -}}{{ include "osmo.secrets.mekMountPath" . }}/mek.yaml{{- end -}}
 
 {{- define "osmo.secrets.mekRolloutAnnotation" -}}
 {{- with .Values.secrets.masterEncryptionKey.rotation.rolloutRevision }}
@@ -528,6 +531,15 @@ osmo.nvidia.com/mek-rollout: {{ . | quote }}
 {{- end -}}
 {{- end -}}
 
+{{/* Effective OAuth cookie Secret. */}}
+{{- define "osmo.oauthCookie.secretName" -}}
+{{- if .Values.secrets.oauthCookieSecret.generate -}}
+{{- printf "%s-oauth-cookie" (include "osmo.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- required "secrets.oauthCookieSecret.existingSecret is required" .Values.secrets.oauthCookieSecret.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "osmo.postgresql.host" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}
 {{- printf "%s-rw" (include "osmo.postgresql.clusterName" .) -}}
@@ -587,6 +599,13 @@ disable
   .Values.embeddedDependencies.postgresql.enabled
   .Values.externalDependencies.postgresql.tls.enabled
   (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "osmo.secrets.rolloutAnnotations" -}}
+osmo.nvidia.com/postgresql-secret-rollout: {{ .Values.secrets.postgresql.rolloutNonce | quote }}
+osmo.nvidia.com/valkey-secret-rollout: {{ .Values.secrets.valkey.rolloutNonce | quote }}
+osmo.nvidia.com/object-storage-secret-rollout: {{ .Values.secrets.objectStorage.rolloutNonce | quote }}
+{{- include "osmo.secrets.mekRolloutAnnotation" . }}
 {{- end -}}
 
 {{- define "osmo.externalDependencies.caVolumeMounts" -}}

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -46,7 +46,8 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.agent "componentName" "agent") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.agent) | nindent 8 }}
-        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
+        {{- include "osmo.gateway.tlsRolloutAnnotations" . | nindent 8 }}
+        {{- include "osmo.secrets.rolloutAnnotations" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.agent.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -128,7 +129,7 @@ spec:
         {{- range $arg := .Values.services.agent.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
-        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "agent"))) | nindent 8 }}
         env:
         {{- include "osmo.configuration.extraEnv" . | nindent 8 }}
         {{- include "osmo.component.extraEnv" .Values.services.agent | nindent 8 }}
@@ -147,7 +148,7 @@ spec:
         {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
         {{- include "osmo.component.extraVolumeMounts" .Values.services.agent | nindent 8 }}
-        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "agent"))) | nindent 8 }}
         resources:
         {{- toYaml .Values.services.agent.resources | nindent 10 }}
 
@@ -181,7 +182,7 @@ spec:
         - name: osmo-progress-files
           emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.agent | nindent 8 }}
-        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "agent"))) | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
         {{- include "osmo.configuration.volumes" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
@@ -226,7 +227,7 @@ spec:
     kind: Deployment
     name: {{ $name }}
   minReplicas: {{ .Values.services.agent.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.services.agent.autoscaling.maxReplicas }}
+  maxReplicas: {{ ternary .Values.services.agent.autoscaling.minReplicas .Values.services.agent.autoscaling.maxReplicas .Values.gateway.tls.generated.caRotation.freezeHpas }}
   {{- with .Values.services.agent.autoscaling.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -47,7 +47,9 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.api "componentName" "api") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.api "protectedAnnotations" $protectedPodAnnotations) | nindent 8 }}
-        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
+        {{- include "osmo.gateway.tlsRolloutAnnotations" . | nindent 8 }}
+        {{- include "osmo.secrets.rolloutAnnotations" . | nindent 8 }}
+        osmo.nvidia.com/default-admin-secret-rollout: {{ .Values.secrets.defaultAdmin.rolloutNonce | quote }}
     spec:
       automountServiceAccountToken: {{ .Values.services.api.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -158,7 +160,7 @@ spec:
         {{- range $arg := .Values.services.api.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
-        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.api) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "api"))) | nindent 8 }}
         env:
         - name: OSMO_DISABLE_TASK_METRICS
           value: {{ .Values.services.api.disableTaskMetrics | quote }}
@@ -196,7 +198,7 @@ spec:
         {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
         {{- include "osmo.component.extraVolumeMounts" .Values.services.api | nindent 8 }}
-        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.api) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "api"))) | nindent 8 }}
         resources:
         {{- toYaml .Values.services.api.resources | nindent 10 }}
 
@@ -218,7 +220,7 @@ spec:
         - name: osmo-runtime-tmp
           emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.api | nindent 8 }}
-        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.api) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "api"))) | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
         {{- include "osmo.configuration.volumes" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
@@ -269,7 +271,7 @@ spec:
     kind: Deployment
     name: {{ $name }}
   minReplicas: {{ .Values.services.api.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.services.api.autoscaling.maxReplicas }}
+  maxReplicas: {{ ternary .Values.services.api.autoscaling.minReplicas .Values.services.api.autoscaling.maxReplicas .Values.gateway.tls.generated.caRotation.freezeHpas }}
   {{- with .Values.services.api.autoscaling.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -41,7 +41,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.delayedJobMonitor "componentName" "delayed-job-monitor") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
-        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
+        {{- include "osmo.secrets.rolloutAnnotations" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.delayedJobMonitor.serviceAccount.automountServiceAccountToken }}
       securityContext:

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -57,6 +57,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" $gw.envoy "componentName" "gateway-envoy") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.envoy "protectedAnnotations" (dict "checksum/envoy-config" (include "osmo.gateway.envoyConfig" . | sha256sum))) | nindent 8 }}
+        {{- include "osmo.gateway.tlsRolloutAnnotations" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ $gw.envoy.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -111,7 +112,7 @@ spec:
           - mountPath: /var/config
             name: envoy-config
             readOnly: true
-          {{- if and $gw.tls.enabled $gw.tls.caSecret }}
+          {{- if $gw.tls.enabled }}
           - name: gateway-tls-ca
             mountPath: /etc/gateway-tls
             readOnly: true
@@ -143,10 +144,10 @@ spec:
         - name: envoy-config
           configMap:
             name: {{ $gwName }}-envoy-config
-        {{- if and $gw.tls.enabled $gw.tls.caSecret }}
+        {{- if $gw.tls.enabled }}
         - name: gateway-tls-ca
           secret:
-            secretName: {{ $gw.tls.caSecret }}
+            secretName: {{ include "osmo.gateway.tlsTrustSecretName" . | quote }}
             items:
             - key: ca.crt
               path: ca.crt
@@ -221,7 +222,7 @@ spec:
     kind: Deployment
     name: {{ $gwName }}-envoy
   minReplicas: {{ $gw.envoy.autoscaling.minReplicas }}
-  maxReplicas: {{ $gw.envoy.autoscaling.maxReplicas }}
+  maxReplicas: {{ ternary $gw.envoy.autoscaling.minReplicas $gw.envoy.autoscaling.maxReplicas $gw.tls.generated.caRotation.freezeHpas }}
   {{- with $gw.envoy.autoscaling.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}
@@ -285,6 +286,9 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" $gw.oauth2Proxy "componentName" "gateway-oauth2-proxy") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.oauth2Proxy) | nindent 8 }}
+        osmo.nvidia.com/valkey-secret-rollout: {{ .Values.secrets.valkey.rolloutNonce | quote }}
+        osmo.nvidia.com/oauth-client-secret-rollout: {{ .Values.secrets.oauthClientSecret.rolloutNonce | quote }}
+        osmo.nvidia.com/oauth-cookie-secret-rollout: {{ .Values.secrets.oauthCookieSecret.rolloutNonce | quote }}
     spec:
       automountServiceAccountToken: {{ $gw.oauth2Proxy.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -321,12 +325,8 @@ spec:
         securityContext:
           {{- include "osmo.container.securityContext" (dict "root" . "component" $gw.oauth2Proxy) | nindent 10 }}
         args:
-          {{- if $gw.oauth2Proxy.useKubernetesSecrets }}
           - --client-secret-file=/etc/oauth2-proxy/client-secret
           - --cookie-secret-file=/etc/oauth2-proxy/cookie-secret
-          {{- else }}
-          - --config={{ $gw.oauth2Proxy.secretPaths.cookieSecret }}
-          {{- end }}
           - --http-address=0.0.0.0:{{ $gw.oauth2Proxy.httpPort }}
           - --metrics-address=0.0.0.0:{{ $gw.oauth2Proxy.metricsPort }}
           - --reverse-proxy=true
@@ -391,11 +391,14 @@ spec:
         resources:
           {{- toYaml $gw.oauth2Proxy.resources | nindent 10 }}
         volumeMounts:
-          {{- if $gw.oauth2Proxy.useKubernetesSecrets }}
-          - name: oauth2-proxy-secrets
-            mountPath: /etc/oauth2-proxy
+          - name: oauth-client-secret
+            mountPath: /etc/oauth2-proxy/client-secret
+            subPath: client-secret
             readOnly: true
-          {{- end }}
+          - name: oauth-cookie-secret
+            mountPath: /etc/oauth2-proxy/cookie-secret
+            subPath: cookie-secret
+            readOnly: true
           {{- if and $gw.oauth2Proxy.redisSessionStore (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") }}
           - name: valkey-ca
             mountPath: /etc/osmo/ca/valkey
@@ -406,16 +409,18 @@ spec:
           {{- end }}
       {{- include "osmo.pod.extraContainers" $gw.oauth2Proxy | nindent 6 }}
       volumes:
-        {{- if $gw.oauth2Proxy.useKubernetesSecrets }}
-        - name: oauth2-proxy-secrets
+        - name: oauth-client-secret
           secret:
-            secretName: {{ $gw.oauth2Proxy.secretName | default "oauth2-proxy-secrets" }}
+            secretName: {{ .Values.secrets.oauthClientSecret.existingSecret | quote }}
             items:
-            - key: {{ $gw.oauth2Proxy.clientSecretKey | default "client_secret" }}
+            - key: {{ .Values.secrets.oauthClientSecret.keys.value | quote }}
               path: client-secret
-            - key: {{ $gw.oauth2Proxy.cookieSecretKey | default "cookie_secret" }}
+        - name: oauth-cookie-secret
+          secret:
+            secretName: {{ include "osmo.oauthCookie.secretName" . | quote }}
+            items:
+            - key: {{ .Values.secrets.oauthCookieSecret.keys.value | quote }}
               path: cookie-secret
-        {{- end }}
         {{- if and $gw.oauth2Proxy.redisSessionStore (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") }}
         - name: valkey-ca
           secret:
@@ -535,6 +540,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" $gw.authz "componentName" "gateway-authz") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.authz) | nindent 8 }}
+        osmo.nvidia.com/postgresql-secret-rollout: {{ .Values.secrets.postgresql.rolloutNonce | quote }}
     spec:
       automountServiceAccountToken: {{ $gw.authz.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -746,6 +752,7 @@ spec:
       annotations:
         checksum/ratelimit-config: {{ $gw.rateLimit.config | toYaml | sha256sum }}
         {{- include "osmo.pod.annotations" (dict "root" . "component" $gw.rateLimit) | nindent 8 }}
+        osmo.nvidia.com/valkey-secret-rollout: {{ .Values.secrets.valkey.rolloutNonce | quote }}
     spec:
       automountServiceAccountToken: {{ $gw.rateLimit.serviceAccount.automountServiceAccountToken }}
       securityContext:

--- a/deployments/charts/osmo/templates/internal-tls-bootstrap.yaml
+++ b/deployments/charts/osmo/templates/internal-tls-bootstrap.yaml
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- include "osmo.gateway.tlsNormalize" . }}
+{{- $tls := .Values.gateway.tls }}
+{{- if and .Values.planes.control.enabled $tls.enabled $tls.generated.enabled }}
+{{- $bootstrapImage := $tls.generated.bootstrap.image | default (include "osmo.component.image" (dict "root" . "component" .Values.services.api)) }}
+{{- $bootstrapName := printf "%s-internal-tls-bootstrap" (include "osmo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $caSecret := include "osmo.gateway.tlsCaSecretName" . }}
+{{- $trustSecret := include "osmo.gateway.tlsTrustSecretName" . }}
+{{- $routerName := include "osmo.component.fullname" (dict "root" . "suffix" "router") }}
+{{- $loggerName := include "osmo.component.fullname" (dict "root" . "suffix" "logger") }}
+{{- $leaves := list
+      (dict "component" "api" "dns" (.Values.gateway.upstreams.api.host | default (include "osmo.api.fullname" .)))
+      (dict "component" "router" "dns" (.Values.gateway.upstreams.router.host | default (printf "%s-headless" $routerName)))
+      (dict "component" "agent" "dns" (.Values.gateway.upstreams.agent.host | default (include "osmo.component.fullname" (dict "root" . "suffix" "agent"))))
+      (dict "component" "logger" "dns" (.Values.gateway.upstreams.logger.host | default (printf "%s-headless" $loggerName))) -}}
+{{- if .Values.services.mcp.enabled }}
+{{- $leaves = append $leaves (dict "component" "mcp" "dns" (include "osmo.component.fullname" (dict "root" . "suffix" "mcp"))) -}}
+{{- end }}
+{{- $consumers := list
+      (include "osmo.api.fullname" .)
+      $routerName
+      (include "osmo.component.fullname" (dict "root" . "suffix" "agent"))
+      $loggerName
+      (printf "%s-envoy" (include "osmo.gateway.fullname" .)) -}}
+{{- if .Values.services.mcp.enabled }}
+{{- $consumers = append $consumers (include "osmo.component.fullname" (dict "root" . "suffix" "mcp")) -}}
+{{- end }}
+{{- $secretNames := list $caSecret $trustSecret -}}
+{{- range $leaf := $leaves }}
+{{- $secretName := include "osmo.gateway.tlsLeafSecretName" (dict "root" $ "component" $leaf.component) -}}
+{{- $secretNames = append $secretNames $secretName -}}
+{{- end }}
+{{- range $secretName := $secretNames }}
+{{- if not (lookup "v1" "Secret" $.Release.Namespace $secretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName | quote }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: osmo-internal-tls-bootstrap
+    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" $) | nindent 4 }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-30"
+    helm.sh/resource-policy: keep
+type: "Opaque"
+---
+{{- end }}
+{{- end }}
+apiVersion: v1
+kind: List
+metadata:
+  name: {{ $bootstrapName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" .) | nindent 4 }}
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-29"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
+items:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: {{ $bootstrapName }}
+    namespace: {{ .Release.Namespace }}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: {{ $bootstrapName }}
+    namespace: {{ .Release.Namespace }}
+  rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+    {{- range $secretName := $secretNames }}
+    - {{ $secretName | quote }}
+    {{- end }}
+    verbs: ["get", "update"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames:
+    {{- range $consumer := $consumers }}
+    - {{ $consumer | quote }}
+    {{- end }}
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["list"]
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: {{ $bootstrapName }}
+    namespace: {{ .Release.Namespace }}
+  subjects:
+  - kind: ServiceAccount
+    name: {{ $bootstrapName }}
+    namespace: {{ .Release.Namespace }}
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: {{ $bootstrapName }}
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: {{ $bootstrapName }}
+    namespace: {{ .Release.Namespace }}
+  spec:
+    activeDeadlineSeconds: 300
+    backoffLimit: 0
+    ttlSecondsAfterFinished: 300
+    template:
+      metadata:
+        labels:
+          {{- include "osmo.component.standardLabels" (dict "root" . "component" "internal-tls-bootstrap") | nindent 10 }}
+      spec:
+        restartPolicy: Never
+        serviceAccountName: {{ $bootstrapName }}
+        {{- include "osmo.component.imagePullSecrets" . | nindent 8 }}
+        nodeSelector:
+          {{- toYaml .Values.podDefaults.nodeSelector | nindent 10 }}
+        tolerations:
+          {{- toYaml .Values.podDefaults.tolerations | nindent 10 }}
+        containers:
+        - name: internal-tls-bootstrap
+          image: {{ $bootstrapImage | quote }}
+          imagePullPolicy: {{ $tls.generated.bootstrap.imagePullPolicy | quote }}
+          command: ["internal-tls-bootstrap"]
+          args:
+          - --namespace
+          - {{ .Release.Namespace | quote }}
+          - --release-name
+          - {{ .Release.Name | quote }}
+          - --ca-secret
+          - {{ $caSecret | quote }}
+          - --trust-secret
+          - {{ $trustSecret | quote }}
+          - --leaf-rotation-nonce
+          - {{ $tls.generated.leafRotationNonce | quote }}
+          - --ca-rotation-id
+          - {{ $tls.generated.caRotation.id | quote }}
+          - --ca-rotation-phase
+          - {{ $tls.generated.caRotation.phase | quote }}
+          {{- range $leaf := $leaves }}
+          - --leaf
+          - {{ printf "%s=%s" (include "osmo.gateway.tlsLeafSecretName" (dict "root" $ "component" $leaf.component)) $leaf.dns | quote }}
+          {{- end }}
+          {{- range $consumer := $consumers }}
+          - --consumer-deployment
+          - {{ $consumer | quote }}
+          {{- end }}
+          {{- if and .Release.IsUpgrade (not $tls.generated.bootstrap.allowInitialGeneration) }}
+          - --fail-if-missing
+          {{- end }}
+          env:
+          - name: HOME
+            value: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+          - name: bootstrap-tmp
+            mountPath: /tmp
+        volumes:
+        - name: bootstrap-tmp
+          emptyDir: {}
+{{- end }}

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -46,7 +46,8 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.logger "componentName" "logger") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.logger) | nindent 8 }}
-        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
+        {{- include "osmo.gateway.tlsRolloutAnnotations" . | nindent 8 }}
+        {{- include "osmo.secrets.rolloutAnnotations" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.logger.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -123,7 +124,7 @@ spec:
         {{- range $arg := .Values.services.logger.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
-        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "logger"))) | nindent 8 }}
         env:
         {{- include "osmo.configuration.extraEnv" . | nindent 8 }}
         {{- include "osmo.component.extraEnv" .Values.services.logger | nindent 8 }}
@@ -142,7 +143,7 @@ spec:
         {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
         {{- include "osmo.component.extraVolumeMounts" .Values.services.logger | nindent 8 }}
-        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "logger"))) | nindent 8 }}
         resources:
         {{- toYaml .Values.services.logger.resources | nindent 10 }}
 
@@ -184,7 +185,7 @@ spec:
         - name: osmo-progress-files
           emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.logger | nindent 8 }}
-        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "logger"))) | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
         {{- include "osmo.configuration.volumes" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
@@ -251,7 +252,7 @@ spec:
     kind: Deployment
     name: {{ $name }}
   minReplicas: {{ .Values.services.logger.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.services.logger.autoscaling.maxReplicas }}
+  maxReplicas: {{ ternary .Values.services.logger.autoscaling.minReplicas .Values.services.logger.autoscaling.maxReplicas .Values.gateway.tls.generated.caRotation.freezeHpas }}
   {{- with .Values.services.logger.autoscaling.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}

--- a/deployments/charts/osmo/templates/mcp-service.yaml
+++ b/deployments/charts/osmo/templates/mcp-service.yaml
@@ -52,6 +52,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" $mcp "componentName" "mcp") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" $mcp) | nindent 8 }}
+        {{- include "osmo.gateway.tlsRolloutAnnotations" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ $mcp.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -81,7 +82,7 @@ spec:
         - mcp
         {{- if .Values.gateway.tls.enabled }}
         args:
-        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "mcp"))) | nindent 8 }}
         {{- end }}
         securityContext:
           {{- include "osmo.container.securityContext" (dict "root" . "component" $mcp) | nindent 10 }}
@@ -103,9 +104,9 @@ spec:
         {{- end }}
         resources:
           {{- toYaml $mcp.resources | nindent 10 }}
-        {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
+        {{- if .Values.gateway.tls.enabled }}
         volumeMounts:
-        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "mcp"))) | nindent 8 }}
         {{- end }}
         {{- with (include "osmo.gateway.upstreamProbeYaml" (dict "probe" $mcp.livenessProbe "context" .)) }}
         livenessProbe:
@@ -120,9 +121,9 @@ spec:
           {{- . | nindent 10 }}
         {{- end }}
       {{- include "osmo.pod.extraContainers" $mcp | nindent 6 }}
-      {{- if or (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp) $mcp.pod.extraVolumes }}
+      {{- if or .Values.gateway.tls.enabled $mcp.pod.extraVolumes }}
       volumes:
-      {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 6 }}
+      {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "mcp"))) | nindent 6 }}
       {{- include "osmo.pod.extraVolumes" $mcp | nindent 6 }}
       {{- end }}
 

--- a/deployments/charts/osmo/templates/oauth-cookie-secret.yaml
+++ b/deployments/charts/osmo/templates/oauth-cookie-secret.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{ if and .Values.planes.control.enabled .Values.secrets.oauthCookieSecret.generate }}
+{{- $secretName := include "osmo.oauthCookie.secretName" . -}}
+{{- $secretKey := .Values.secrets.oauthCookieSecret.keys.value -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $cookieData := "" -}}
+{{- if $existing -}}
+{{- $labels := default dict $existing.metadata.labels -}}
+{{- $annotations := default dict $existing.metadata.annotations -}}
+{{- if or
+      (ne (get $labels "app.kubernetes.io/managed-by") "Helm")
+      (ne (get $labels "app.kubernetes.io/instance") .Release.Name)
+      (ne (get $annotations "meta.helm.sh/release-name") .Release.Name)
+      (ne (get $annotations "meta.helm.sh/release-namespace") .Release.Namespace) -}}
+{{- fail (printf "generated OAuth cookie Secret %s is not owned by this release" $secretName) -}}
+{{- end -}}
+{{- if ne $existing.type "Opaque" -}}
+{{- fail (printf "generated OAuth cookie Secret %s has an invalid type" $secretName) -}}
+{{- end -}}
+{{- $cookieData = required (printf "generated OAuth cookie Secret %s is missing key %s" $secretName $secretKey) (get (default dict $existing.data) $secretKey) -}}
+{{- $mountedCookie := b64dec $cookieData -}}
+{{- $standardCookie := replace "_" "/" (replace "-" "+" $mountedCookie) -}}
+{{- if or (not (regexMatch "^[A-Za-z0-9_-]{43}=$" $mountedCookie)) (ne (len (b64dec $standardCookie)) 32) -}}
+{{- fail (printf "generated OAuth cookie Secret %s key %s is invalid" $secretName $secretKey) -}}
+{{- end -}}
+{{- else -}}
+{{- if .Release.IsUpgrade -}}
+{{- fail (printf "generated OAuth cookie Secret %s is missing during upgrade; restore it" $secretName) -}}
+{{- end -}}
+{{- $mountedCookie := randBytes 32 | replace "+" "-" | replace "/" "_" -}}
+{{- $cookieData = b64enc $mountedCookie -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.labels" . | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" .) | nindent 4 }}
+    meta.helm.sh/release-name: {{ .Release.Name | quote }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace | quote }}
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  {{ $secretKey | quote }}: {{ $cookieData | quote }}
+{{- end }}

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -44,7 +44,8 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.router "componentName" "router") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.router) | nindent 8 }}
-        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
+        {{- include "osmo.gateway.tlsRolloutAnnotations" . | nindent 8 }}
+        {{- include "osmo.secrets.rolloutAnnotations" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.router.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -112,7 +113,7 @@ spec:
         - {{ . }}
         {{- end }}
         {{- end }}
-        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsArgs" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "router"))) | nindent 8 }}
         env:
         {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
         {{- with .Values.services.router.extraEnv }}
@@ -151,7 +152,7 @@ spec:
         {{- with .Values.services.router.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "router"))) | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
         resources:
         {{- toYaml .Values.services.router.resources | nindent 10 }}
@@ -181,7 +182,7 @@ spec:
         {{- with .Values.services.router.pod.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
+        {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "router"))) | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 
 ---
@@ -246,7 +247,7 @@ spec:
     kind: Deployment
     name: {{ $name }}
   minReplicas: {{ .Values.services.router.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.services.router.autoscaling.maxReplicas }}
+  maxReplicas: {{ ternary .Values.services.router.autoscaling.minReplicas .Values.services.router.autoscaling.maxReplicas .Values.gateway.tls.generated.caRotation.freezeHpas }}
   {{- with .Values.services.router.autoscaling.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -1,5 +1,6 @@
 {{/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- include "osmo.gateway.tlsNormalize" . }}
 {{- if and (not .Values.planes.control.enabled) (not .Values.planes.compute.enabled) -}}
 {{- fail "at least one of planes.control.enabled or planes.compute.enabled must be true" -}}
 {{- end -}}
@@ -313,8 +314,22 @@
 {{- if and .Values.httproute.enabled (eq (len .Values.httproute.parentRefs) 0) -}}
 {{- fail "httproute.parentRefs requires at least one entry when httproute.enabled=true" -}}
 {{- end -}}
+{{- if and .Values.gateway.tls.enabled .Values.gateway.tls.generated.enabled -}}
+{{- if or .Values.gateway.tls.caSecret .Values.gateway.tls.upstreamCerts.api .Values.gateway.tls.upstreamCerts.router .Values.gateway.tls.upstreamCerts.agent .Values.gateway.tls.upstreamCerts.logger .Values.gateway.tls.upstreamCerts.mcp -}}
+{{- fail "gateway.tls.generated.enabled cannot be combined with caSecret or upstreamCerts" -}}
+{{- end -}}
+{{- if and (ne .Values.gateway.tls.generated.caRotation.phase "stable") (not .Values.gateway.tls.generated.caRotation.id) -}}
+{{- fail "gateway.tls.generated.caRotation.id is required outside the stable phase" -}}
+{{- end -}}
+{{- if and (ne .Values.gateway.tls.generated.caRotation.phase "stable") (not .Values.gateway.tls.generated.caRotation.freezeHpas) -}}
+{{- fail "gateway.tls.generated.caRotation.freezeHpas must be true during CA rotation" -}}
+{{- end -}}
+{{- end -}}
 {{- if .Values.secrets.defaultAdmin.generate -}}
-{{- fail "secrets.defaultAdmin.generate is not implemented; configure existingSecret" -}}
+{{- fail "secrets: generated Secrets are not implemented; configure existingSecret" -}}
+{{- end -}}
+{{- if and .Values.secrets.oauthCookieSecret.generate .Values.secrets.oauthCookieSecret.existingSecret -}}
+{{- fail "secrets.oauthCookieSecret.generate and existingSecret are mutually exclusive" -}}
 {{- end -}}
 {{- $autoscaledComponents := list
   (dict "path" "services.ui" "component" .Values.services.ui)
@@ -368,6 +383,9 @@
 {{- if hasKey .Values "components" -}}
 {{- fail "components is not a supported value; configure services and gateway" -}}
 {{- end -}}
+{{- if or (hasKey .Values.gateway.oauth2Proxy "useKubernetesSecrets") (hasKey .Values.gateway.oauth2Proxy "secretName") (hasKey .Values.gateway.oauth2Proxy "clientSecretKey") (hasKey .Values.gateway.oauth2Proxy "cookieSecretKey") (hasKey .Values.gateway.oauth2Proxy "secretPaths") -}}
+{{- fail "gateway.oauth2Proxy legacy Secret values are not supported; configure secrets.oauthClientSecret and secrets.oauthCookieSecret" -}}
+{{- end -}}
 {{- if and (not .Values.embeddedDependencies.postgresql.enabled) (not .Values.externalDependencies.postgresql.host) -}}
 {{- fail "externalDependencies.postgresql.host is required for the control plane" -}}
 {{- end -}}
@@ -400,6 +418,12 @@
 {{- end -}}
 {{- if not .Values.secrets.masterEncryptionKey.existingSecret.key -}}
 {{- fail "secrets.masterEncryptionKey.existingSecret.key is required for the control plane" -}}
+{{- end -}}
+{{- if and .Values.gateway.oauth2Proxy.enabled (not .Values.secrets.oauthClientSecret.existingSecret) -}}
+{{- fail "secrets.oauthClientSecret.existingSecret is required when the OAuth2 proxy is enabled" -}}
+{{- end -}}
+{{- if and .Values.gateway.oauth2Proxy.enabled (not .Values.secrets.oauthCookieSecret.generate) (not .Values.secrets.oauthCookieSecret.existingSecret) -}}
+{{- fail "secrets.oauthCookieSecret requires generate=true or existingSecret when the OAuth2 proxy is enabled" -}}
 {{- end -}}
 {{- if and (not .Values.embeddedDependencies.postgresql.enabled) .Values.externalDependencies.postgresql.tls.enabled (not .Values.externalDependencies.postgresql.tls.caExistingSecret) -}}
 {{- fail "externalDependencies.postgresql.tls.caExistingSecret is required when TLS is enabled" -}}

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -43,7 +43,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.worker "componentName" "worker") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
-        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
+        {{- include "osmo.secrets.rolloutAnnotations" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.worker.serviceAccount.automountServiceAccountToken }}
       securityContext:

--- a/deployments/charts/osmo/tests/control-review-values.yaml
+++ b/deployments/charts/osmo/tests/control-review-values.yaml
@@ -58,7 +58,6 @@ gateway:
       secretName: gateway-tls
   oauth2Proxy:
     enabled: true
-    useKubernetesSecrets: true
     oidcIssuerUrl: https://issuer.example.com
     clientId: osmo
   authz:
@@ -76,3 +75,9 @@ ingress:
   tls:
     enabled: true
     secretName: osmo-ingress-tls
+
+secrets:
+  oauthClientSecret:
+    existingSecret: oauth-client
+  oauthCookieSecret:
+    existingSecret: oauth-cookie

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -679,7 +679,7 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/quickstart-rustfs-pvc.yaml" "storage: 1Gi"
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
         "osmo-backend-token-bootstrap"
-    require_resource "$TEST_DIRECTORY/quickstart.yaml" Job "osmo-mek-bootstrap"
+    require_contains "$TEST_DIRECTORY/quickstart.yaml" 'name: "osmo-mek-bootstrap-'
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
         "osmo-object-storage-bootstrap"
     resource_document "$TEST_DIRECTORY/quickstart.yaml" Service \
@@ -1105,6 +1105,236 @@ test_control_umbrella() {
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         >"$rendered"
 
+    resource_document "$rendered" List osmo-internal-tls-bootstrap \
+        >"$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml" \
+        'command: ["internal-tls-bootstrap"]'
+    require_contains "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml" \
+        'verbs: ["get", "update"]'
+    require_contains "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml" \
+        'resourceNames:'
+    require_contains "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml" \
+        'activeDeadlineSeconds: 300'
+    require_contains "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml" \
+        'ttlSecondsAfterFinished: 300'
+    require_contains "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml" \
+        'nodeSelector:'
+    require_contains "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml" \
+        'tolerations:'
+    require_contains "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml" \
+        'seccompProfile:'
+    require_contains "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml" \
+        'helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed'
+    require_contains "$CHARTS_ROOT/osmo/README.md" \
+        'one unique rotation ID through `prepare`, `activate`'
+    require_contains "$CHARTS_ROOT/osmo/README.md" \
+        '`retire`, then `stable`'
+    require_contains "$CHARTS_ROOT/osmo/README.md" \
+        'every live leaf and consumer uses the activated CA'
+    require_contains "$CHARTS_ROOT/osmo/README.md" \
+        'gateway.tls.generated.bootstrap.allowInitialGeneration=true'
+    require_contains "$CHARTS_ROOT/osmo/README.md" \
+        'Suspend the OAuth2 Proxy HPA'
+    if [[ $(grep -c -- '--consumer-deployment' \
+            "$TEST_DIRECTORY/osmo-internal-tls-bootstrap.yaml") -ne 5 ]]; then
+        fail 'generated TLS hook does not verify every consumer Deployment'
+    fi
+    require_not_contains "$rendered" '--ssl_self_signed'
+    local tls_placeholder
+    for tls_placeholder in \
+        osmo-internal-tls-ca osmo-internal-tls-trust \
+        osmo-internal-tls-api osmo-internal-tls-router \
+        osmo-internal-tls-agent osmo-internal-tls-logger; do
+        resource_document "$rendered" Secret "$tls_placeholder" \
+            >"$TEST_DIRECTORY/$tls_placeholder.yaml"
+        if grep -Eq '^(data|stringData):' \
+                "$TEST_DIRECTORY/$tls_placeholder.yaml"; then
+            fail "generated TLS placeholder $tls_placeholder owns generated data"
+        fi
+        require_contains "$TEST_DIRECTORY/$tls_placeholder.yaml" \
+            'type: "Opaque"'
+    done
+    helm_template tlsmcp "$charts_copy/osmo" --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set services.mcp.enabled=true \
+        --set gateway.authz.enabled=true \
+        --set-string services.mcp.resourceUrl=https://osmo.example.com/mcp \
+        --set-string 'services.mcp.authorizationServers[0]=https://login.example.com' \
+        --set-string 'services.mcp.scopes[0]=mcp.read' \
+        --set-string 'gateway.envoy.jwt.providers[0].issuer=https://login.example.com' \
+        --set-string 'gateway.envoy.jwt.providers[0].audience=https://osmo.example.com/mcp' \
+        --set-string 'gateway.envoy.jwt.providers[0].jwks_uri=https://login.example.com/keys' \
+        --set-string 'gateway.envoy.jwt.providers[0].cluster=osmo-api' \
+        >"$TEST_DIRECTORY/osmo-tls-mcp-upgrade.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-tls-mcp-upgrade.yaml" Secret \
+        tlsmcp-osmo-internal-tls-mcp \
+        >"$TEST_DIRECTORY/osmo-tls-mcp-upgrade-placeholder.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-tls-mcp-upgrade-placeholder.yaml" \
+        'helm.sh/hook: pre-install,pre-upgrade'
+    require_contains "$TEST_DIRECTORY/osmo-tls-mcp-upgrade-placeholder.yaml" \
+        'type: "Opaque"'
+    if grep -Eq '^(data|stringData):' \
+            "$TEST_DIRECTORY/osmo-tls-mcp-upgrade-placeholder.yaml"; then
+        fail 'offline GitOps TLS placeholder owns generated data'
+    fi
+
+    local legacy_reuse_chart="$TEST_DIRECTORY/osmo-legacy-reuse"
+    cp -R "$charts_copy/osmo" "$legacy_reuse_chart"
+    awk '
+        BEGIN { skip = 0 }
+        skip && /^    [[:alnum:]][[:alnum:]_-]*:/ { skip = 0 }
+        /^    generated:$/ { skip = 1; next }
+        !skip { print }
+    ' "$charts_copy/osmo/values.yaml" >"$legacy_reuse_chart/values.yaml"
+    helm_template legacy-reuse "$legacy_reuse_chart" --is-upgrade \
+        -f "$legacy_reuse_chart/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.tls.generated.bootstrap.allowInitialGeneration=true \
+        >"$TEST_DIRECTORY/osmo-legacy-reuse.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-legacy-reuse.yaml" List \
+        legacy-reuse-osmo-internal-tls-bootstrap \
+        >"$TEST_DIRECTORY/osmo-legacy-reuse-bootstrap.yaml"
+    require_not_contains "$TEST_DIRECTORY/osmo-legacy-reuse-bootstrap.yaml" \
+        '--fail-if-missing'
+    local upstream_identity
+    for upstream_identity in \
+            osmo-api osmo-router-headless osmo-agent osmo-logger-headless; do
+        require_contains "$rendered" 'match_typed_subject_alt_names:'
+        require_contains "$rendered" "exact: \"$upstream_identity\""
+    done
+
+    helm_template existingtls "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.tls.generated.enabled=false \
+        --set gateway.tls.caSecret=operator-trust \
+        --set gateway.tls.upstreamCerts.api=operator-api-tls \
+        --set gateway.tls.upstreamCerts.router=operator-router-tls \
+        --set gateway.tls.upstreamCerts.agent=operator-agent-tls \
+        --set gateway.tls.upstreamCerts.logger=operator-logger-tls \
+        >"$TEST_DIRECTORY/osmo-existing-internal-tls.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-existing-internal-tls.yaml" \
+        'secretName: "operator-trust"'
+    require_contains "$TEST_DIRECTORY/osmo-existing-internal-tls.yaml" \
+        'secretName: "operator-api-tls"'
+    if resource_document "$TEST_DIRECTORY/osmo-existing-internal-tls.yaml" \
+            List existingtls-osmo-internal-tls-bootstrap >/dev/null 2>&1; then
+        fail 'existing internal TLS mode rendered a Secret mutator'
+    fi
+
+    if helm_template mixed-internal-tls "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.tls.caSecret=operator-trust \
+        >"$TEST_DIRECTORY/mixed-internal-tls.out" 2>&1; then
+        fail 'expected mixed generated and existing internal TLS to fail'
+    fi
+    require_contains "$TEST_DIRECTORY/mixed-internal-tls.out" \
+        'cannot be combined with caSecret or upstreamCerts'
+
+    if helm_template missing-ca-rotation-id "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.tls.generated.caRotation.phase=prepare \
+        >"$TEST_DIRECTORY/missing-ca-rotation-id.out" 2>&1; then
+        fail 'expected generated CA prepare without a rotation id to fail'
+    fi
+    require_contains "$TEST_DIRECTORY/missing-ca-rotation-id.out" \
+        'caRotation.id is required'
+
+    if helm_template unfrozen-ca-rotation "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string gateway.tls.generated.caRotation.id=ca-test \
+        --set gateway.tls.generated.caRotation.phase=prepare \
+        >"$TEST_DIRECTORY/unfrozen-ca-rotation.out" 2>&1; then
+        fail 'expected CA prepare without frozen consumer HPAs to fail'
+    fi
+    require_contains "$TEST_DIRECTORY/unfrozen-ca-rotation.out" \
+        'freezeHpas must be true'
+
+    helm_template osmo "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string gateway.tls.generated.caRotation.id=ca-test \
+        --set gateway.tls.generated.caRotation.phase=prepare \
+        --set gateway.tls.generated.caRotation.freezeHpas=true \
+        >"$TEST_DIRECTORY/frozen-ca-rotation.yaml"
+    local hpa hpa_document minimum maximum
+    for hpa in osmo-api osmo-router osmo-agent osmo-logger osmo-gateway-envoy; do
+        hpa_document=$(resource_document \
+            "$TEST_DIRECTORY/frozen-ca-rotation.yaml" \
+            HorizontalPodAutoscaler "$hpa")
+        minimum=$(awk '$1 == "minReplicas:" { print $2 }' <<<"$hpa_document")
+        maximum=$(awk '$1 == "maxReplicas:" { print $2 }' <<<"$hpa_document")
+        if [[ -z "$minimum" || "$minimum" != "$maximum" ]]; then
+            fail "CA rotation did not freeze HorizontalPodAutoscaler/$hpa"
+        fi
+    done
+
+    helm_template generated-oauth-cookie "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.oauth2Proxy.enabled=true \
+        --set secrets.oauthClientSecret.existingSecret=operator-oauth-client \
+        --set secrets.oauthCookieSecret.generate=true \
+        --set-string secrets.oauthCookieSecret.existingSecret= \
+        >"$TEST_DIRECTORY/generated-oauth-cookie.yaml"
+    resource_document "$TEST_DIRECTORY/generated-oauth-cookie.yaml" Secret \
+        generated-oauth-cookie-osmo-oauth-cookie \
+        >"$TEST_DIRECTORY/generated-oauth-cookie-secret.yaml"
+    require_contains "$TEST_DIRECTORY/generated-oauth-cookie-secret.yaml" \
+        'helm.sh/resource-policy: keep'
+    require_contains "$TEST_DIRECTORY/generated-oauth-cookie-secret.yaml" \
+        'meta.helm.sh/release-name: "generated-oauth-cookie"'
+    require_contains "$TEST_DIRECTORY/generated-oauth-cookie-secret.yaml" \
+        'meta.helm.sh/release-namespace: "default"'
+    require_contains "$TEST_DIRECTORY/generated-oauth-cookie-secret.yaml" \
+        'app.kubernetes.io/managed-by: Helm'
+    require_contains "$TEST_DIRECTORY/generated-oauth-cookie-secret.yaml" \
+        '"cookie_secret":'
+    require_not_contains "$TEST_DIRECTORY/generated-oauth-cookie.yaml" \
+        'oauth-cookie-bootstrap'
+    local generated_cookie_data mounted_cookie raw_cookie_length
+    generated_cookie_data=$(awk '$1 == "\"cookie_secret\":" {
+        gsub(/\"/, "", $2); print $2
+    }' "$TEST_DIRECTORY/generated-oauth-cookie-secret.yaml")
+    mounted_cookie=$(printf '%s' "$generated_cookie_data" | base64 -d)
+    if [[ ! "$mounted_cookie" =~ ^[A-Za-z0-9_-]{43}=$ ]]; then
+        fail 'generated OAuth cookie is not canonical URL-safe base64'
+    fi
+    raw_cookie_length=$(printf '%s' "$mounted_cookie" | tr '_-' '/+' \
+        | base64 -d | wc -c | tr -d ' ')
+    if [[ "$raw_cookie_length" -ne 32 ]]; then
+        fail 'generated OAuth cookie does not contain 32 random bytes'
+    fi
+
+    if helm_template mixed-oauth-cookie "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.oauthCookieSecret.generate=true \
+        --set secrets.oauthCookieSecret.existingSecret=operator-cookie \
+        >"$TEST_DIRECTORY/mixed-oauth-cookie.out" 2>&1; then
+        fail 'expected mixed generated/existing OAuth cookie mode to fail'
+    fi
+    require_contains "$TEST_DIRECTORY/mixed-oauth-cookie.out" \
+        'secrets.oauthCookieSecret.generate and existingSecret are mutually exclusive'
+
+    if helm_template missing-generated-oauth-cookie "$charts_copy/osmo" \
+        --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.oauth2Proxy.enabled=true \
+        --set secrets.oauthClientSecret.existingSecret=operator-oauth-client \
+        --set secrets.oauthCookieSecret.generate=true \
+        --set-string secrets.oauthCookieSecret.existingSecret= \
+        >"$TEST_DIRECTORY/missing-generated-oauth-cookie.out" 2>&1; then
+        fail 'expected a missing generated OAuth cookie on upgrade to fail'
+    fi
+    require_contains "$TEST_DIRECTORY/missing-generated-oauth-cookie.out" \
+        'is missing during upgrade; restore it'
+
     require_deployment "$rendered" "osmo-api"
     resource_document "$rendered" Deployment osmo-api \
         >"$TEST_DIRECTORY/osmo-api-external-postgresql.yaml"
@@ -1238,7 +1468,7 @@ invalid-name|--set secrets.backendApiTokens.credentials[0].name=INVALID --set se
 duplicate-name|--set secrets.backendApiTokens.credentials[0].name=duplicate --set secrets.backendApiTokens.credentials[0].existingSecret.name=token-one --set secrets.backendApiTokens.credentials[1].name=duplicate --set secrets.backendApiTokens.credentials[1].existingSecret.name=token-two|duplicate backend API token credential name "duplicate"
 missing-source|--set secrets.backendApiTokens.credentials[0].name=default|backend API token credential "default" must configure exactly one of existingSecret or managedSecret
 conflicting-source|--set secrets.backendApiTokens.credentials[0].name=default --set secrets.backendApiTokens.credentials[0].existingSecret.name=token-one --set secrets.backendApiTokens.credentials[0].managedSecret.name=token-two|backend API token credential "default" must configure exactly one of existingSecret or managedSecret
-legacy-source|--set secrets.backendApiTokens.credentials[0].name=legacy --set secrets.backendApiTokens.credentials[0].secretName=osmo-legacy-backend-token|backend API token credential "legacy" must configure exactly one of existingSecret or managedSecret
+legacy-source|--set secrets.backendApiTokens.credentials[0].name=legacy --set secrets.backendApiTokens.credentials[0].secretName=osmo-legacy-backend-token|secretName
 duplicate-secret|--set secrets.backendApiTokens.credentials[0].name=one --set secrets.backendApiTokens.credentials[0].existingSecret.name=shared-token --set secrets.backendApiTokens.credentials[1].name=two --set secrets.backendApiTokens.credentials[1].managedSecret.name=shared-token|duplicate backend API token Secret name "shared-token"
 invalid-secret|--set secrets.backendApiTokens.credentials[0].name=default --set secrets.backendApiTokens.credentials[0].existingSecret.name=INVALID_SECRET|invalid backend API token Secret name "INVALID_SECRET"
 EOF
@@ -1329,7 +1559,8 @@ EOF
     require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'command: ["mek-lifecycle"]'
     require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" '- "bootstrap"'
     require_not_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'kind: Lease'
-    require_not_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'kind: Secret'
+    require_no_resource "$TEST_DIRECTORY/mek-bootstrap.yaml" Secret \
+        external-master-encryption-key-secret
     require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'verbs: ["create"]'
     require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'runAsUser: 1001'
     helm_template bootstrap-osmo "$charts_copy/osmo" \
@@ -1510,6 +1741,24 @@ EOF
     fi
     require_schema_path "$TEST_DIRECTORY/invalid-mek-bootstrap.out" \
         "secrets.masterEncryptionKey.bootstrap.imagePullPolicy"
+    require_contains "$rendered" 'key: "object-storage.yaml"'
+    if awk '
+        /^---[[:space:]]*$/ { secret = 0; secret_data = 0 }
+        /^kind: Secret$/ { secret = 1 }
+        secret && /^(data|stringData):$/ { secret_data = 1; next }
+        secret_data && /^  [^ ]+:/ {
+            value = $0
+            sub(/^  [^:]+:[[:space:]]*/, "", value)
+            if (value != "\"\"" && value != "\047\047") {
+                found = 1
+            }
+            next
+        }
+        secret_data && /^[^ ]/ { secret_data = 0 }
+        END { exit !found }
+    ' "$rendered"; then
+        fail 'Helm rendered non-empty Secret material into release state'
+    fi
     require_contains "$rendered" "https://s3.external.example.com"
     resource_document "$rendered" ConfigMap osmo-api-config \
         >"$TEST_DIRECTORY/osmo-external-object-storage-config.yaml"
@@ -1730,6 +1979,8 @@ EOF
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         --set-string externalUrl=https://osmo.example.com:8443/osmo/ \
         --set gateway.oauth2Proxy.enabled=true \
+        --set secrets.oauthClientSecret.existingSecret=oauth-client \
+        --set secrets.oauthCookieSecret.existingSecret=oauth-cookie \
         >"$TEST_DIRECTORY/osmo-external-url.yaml"
     resource_document "$TEST_DIRECTORY/osmo-external-url.yaml" Deployment \
         external-url-release-osmo-gateway-oauth2-proxy \
@@ -1742,6 +1993,8 @@ EOF
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         --set-string externalUrl=http://osmo.example.com:65535/base/ \
         --set gateway.oauth2Proxy.enabled=true \
+        --set secrets.oauthClientSecret.existingSecret=oauth-client \
+        --set secrets.oauthCookieSecret.existingSecret=oauth-cookie \
         >"$TEST_DIRECTORY/osmo-external-http-url.yaml"
     resource_document "$TEST_DIRECTORY/osmo-external-http-url.yaml" Deployment \
         external-http-url-release-osmo-gateway-oauth2-proxy \
@@ -1942,9 +2195,6 @@ EOF
         embedded-object-storage-osmo-object-storage-bootstrap
     require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" Job \
         embedded-object-storage-osmo-object-storage-bootstrap
-    require_occurrences "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
-        "kind: Secret" 1
-
     resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
         Secret osmo-rustfs-credentials \
         >"$TEST_DIRECTORY/osmo-rustfs-secret.yaml"
@@ -2122,7 +2372,7 @@ EOF
             >"$TEST_DIRECTORY/osmo-$object_storage_consumer-object-storage.yaml"
         require_contains \
             "$TEST_DIRECTORY/osmo-$object_storage_consumer-object-storage.yaml" \
-            "secretName: osmo-rustfs-credentials"
+            'secretName: "osmo-rustfs-credentials"'
         require_contains \
             "$TEST_DIRECTORY/osmo-$object_storage_consumer-object-storage.yaml" \
             "mountPath: /etc/osmo/secrets/osmo-rustfs-credentials"
@@ -2327,6 +2577,20 @@ EOF
     require_contains "$TEST_DIRECTORY/duplicate-object-storage-credentials.out" \
         "generate and existingSecret are mutually exclusive"
 
+    if helm_template invalid-empty-object-storage-credentials-key \
+        "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set-string secrets.objectStorage.keys.credentials= \
+        >"$TEST_DIRECTORY/invalid-empty-object-storage-credentials-key.out" \
+        2>&1; then
+        fail "expected an empty object-storage credentials key to fail"
+    fi
+    require_schema_path \
+        "$TEST_DIRECTORY/invalid-empty-object-storage-credentials-key.out" \
+        "secrets.objectStorage.keys.credentials"
+
     local invalid_object_storage_credentials_key
     local invalid_object_storage_credentials_key_message
     while IFS='|' read -r invalid_object_storage_credentials_key \
@@ -2345,7 +2609,6 @@ EOF
             "$TEST_DIRECTORY/invalid-object-storage-credentials-key.out" \
             "$invalid_object_storage_credentials_key_message"
     done <<'EOF'
-secrets.objectStorage.keys.credentials=|must be a non-empty valid Kubernetes Secret data key
 secrets.objectStorage.keys.credentials=object/storage.yaml|must be a non-empty valid Kubernetes Secret data key
 secrets.objectStorage.keys.credentials=RUSTFS_ACCESS_KEY|must not use a reserved RustFS key name
 secrets.objectStorage.keys.credentials=RUSTFS_SECRET_KEY|must not use a reserved RustFS key name
@@ -3124,6 +3387,44 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-embedded-dev.yaml" \
         "number: 0"
 
+    helm_template secret-rollout "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.postgresql.rolloutNonce=postgres-v2 \
+        --set secrets.valkey.rolloutNonce=valkey-v2 \
+        --set secrets.objectStorage.rolloutNonce=storage-v2 \
+        --set secrets.defaultAdmin.rolloutNonce=admin-v2 \
+        >"$TEST_DIRECTORY/osmo-secret-rollout.yaml"
+    require_occurrences "$TEST_DIRECTORY/osmo-secret-rollout.yaml" \
+        'osmo.nvidia.com/postgresql-secret-rollout: "postgres-v2"' 6
+    require_occurrences "$TEST_DIRECTORY/osmo-secret-rollout.yaml" \
+        'osmo.nvidia.com/valkey-secret-rollout: "valkey-v2"' 6
+    require_occurrences "$TEST_DIRECTORY/osmo-secret-rollout.yaml" \
+        'osmo.nvidia.com/object-storage-secret-rollout: "storage-v2"' 6
+    require_occurrences "$TEST_DIRECTORY/osmo-secret-rollout.yaml" \
+        'osmo.nvidia.com/default-admin-secret-rollout: "admin-v2"' 1
+    require_not_contains "$TEST_DIRECTORY/osmo-secret-rollout.yaml" \
+        "osmo.nvidia.com/mek-secret-rollout"
+
+    helm_template oauth-secret-rollout "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.oauth2Proxy.enabled=true \
+        --set secrets.oauthClientSecret.existingSecret=oauth-client \
+        --set secrets.oauthClientSecret.rolloutNonce=client-v2 \
+        --set secrets.oauthCookieSecret.existingSecret=oauth-cookie \
+        --set secrets.oauthCookieSecret.rolloutNonce=cookie-v2 \
+        >"$TEST_DIRECTORY/osmo-oauth-secret-rollout.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-oauth-secret-rollout.yaml" Deployment \
+        oauth-secret-rollout-osmo-gateway-oauth2-proxy \
+        >"$TEST_DIRECTORY/osmo-oauth-secret-rollout-deployment.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-oauth-secret-rollout-deployment.yaml" \
+        'osmo.nvidia.com/oauth-client-secret-rollout: "client-v2"'
+    require_contains "$TEST_DIRECTORY/osmo-oauth-secret-rollout-deployment.yaml" \
+        'osmo.nvidia.com/oauth-cookie-secret-rollout: "cookie-v2"'
+    require_not_contains "$TEST_DIRECTORY/osmo-oauth-secret-rollout-deployment.yaml" \
+        "osmo.nvidia.com/mek-secret-rollout"
+
     resource_document "$rendered" Deployment osmo-agent \
         >"$TEST_DIRECTORY/osmo-agent.yaml"
     require_occurrences "$TEST_DIRECTORY/osmo-agent.yaml" "        ports:" 1
@@ -3208,6 +3509,41 @@ EOF
         "name: OAUTH2_PROXY_REDIS_PASSWORD"
     require_contains "$TEST_DIRECTORY/osmo-review-oauth2-proxy.yaml" \
         "key: redis-password"
+    require_contains "$TEST_DIRECTORY/osmo-review-oauth2-proxy.yaml" \
+        'secretName: "oauth-client"'
+    require_contains "$TEST_DIRECTORY/osmo-review-oauth2-proxy.yaml" \
+        'secretName: "oauth-cookie"'
+    require_contains "$TEST_DIRECTORY/osmo-review-oauth2-proxy.yaml" \
+        'key: "client_secret"'
+    require_contains "$TEST_DIRECTORY/osmo-review-oauth2-proxy.yaml" \
+        'key: "cookie_secret"'
+    require_contains "$TEST_DIRECTORY/osmo-review-oauth2-proxy.yaml" \
+        "mountPath: /etc/oauth2-proxy/client-secret"
+    require_contains "$TEST_DIRECTORY/osmo-review-oauth2-proxy.yaml" \
+        "mountPath: /etc/oauth2-proxy/cookie-secret"
+
+    helm_template quoted-secret-scalars "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.oauth2Proxy.enabled=true \
+        --set-string secrets.objectStorage.keys.credentials=null \
+        --set-string secrets.oauthClientSecret.existingSecret=true \
+        --set-string secrets.oauthClientSecret.keys.value=false \
+        --set-string secrets.oauthCookieSecret.existingSecret=null \
+        --set-string secrets.oauthCookieSecret.keys.value=true \
+        >"$TEST_DIRECTORY/osmo-quoted-secret-scalars.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-quoted-secret-scalars.yaml" \
+        'secretName: "true"'
+    require_contains "$TEST_DIRECTORY/osmo-quoted-secret-scalars.yaml" \
+        'secretName: "null"'
+    require_contains "$TEST_DIRECTORY/osmo-quoted-secret-scalars.yaml" \
+        'key: "false"'
+    require_contains "$TEST_DIRECTORY/osmo-quoted-secret-scalars.yaml" \
+        'key: "true"'
+    require_contains "$TEST_DIRECTORY/osmo-quoted-secret-scalars.yaml" \
+        'key: "null"'
+    require_contains "$TEST_DIRECTORY/osmo-quoted-secret-scalars.yaml" \
+        'path: "null"'
     resource_document "$TEST_DIRECTORY/osmo-review.yaml" Deployment \
         review-release-osmo-gateway-ratelimit \
         >"$TEST_DIRECTORY/osmo-review-ratelimit.yaml"
@@ -3342,7 +3678,7 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
         "image: nvcr.io/nvidia/osmo/mcp-self-hosted:6.3.1"
     require_occurrences "$TEST_DIRECTORY/osmo-mcp.yaml" \
-        "kubernetes.io/os: linux" 10
+        "kubernetes.io/os: linux" 11
 
     helm_template osmo "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -3420,6 +3756,8 @@ EOF
     helm_template workload-policy "$charts_copy/osmo" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-workload-policy-values.yaml" \
+        --set secrets.oauthClientSecret.existingSecret=oauth-client \
+        --set secrets.oauthCookieSecret.existingSecret=oauth-cookie \
         >"$TEST_DIRECTORY/osmo-workload-policy.yaml"
     resource_document "$TEST_DIRECTORY/osmo-workload-policy.yaml" Deployment \
         workload-policy-osmo-api \
@@ -3471,7 +3809,7 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-workload-policy-ui.yaml" \
         "automountServiceAccountToken: false"
     require_occurrences "$TEST_DIRECTORY/osmo-workload-policy.yaml" \
-        "type: RuntimeDefault" 10
+        "type: RuntimeDefault" 11
 
     resource_document "$TEST_DIRECTORY/osmo-workload-policy.yaml" \
         PodDisruptionBudget workload-policy-osmo-api \
@@ -3583,6 +3921,8 @@ EOF
 
     helm_template image-defaults "$charts_copy/osmo" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.oauthClientSecret.existingSecret=oauth-client \
+        --set secrets.oauthCookieSecret.existingSecret=oauth-cookie \
         >"$TEST_DIRECTORY/osmo-image-defaults.yaml"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
         "image: nvcr.io/nvidia/osmo/service:6.3.1"
@@ -3607,6 +3947,8 @@ EOF
 
     helm_template image-mirror "$charts_copy/osmo" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.oauthClientSecret.existingSecret=oauth-client \
+        --set secrets.oauthCookieSecret.existingSecret=oauth-cookie \
         --set imageRegistry=mirror.example.com \
         --set imagePullSecrets[0].name=mirror-secret \
         >"$TEST_DIRECTORY/osmo-image-mirror.yaml"
@@ -3889,6 +4231,47 @@ EOF
     fi
     require_contains "$TEST_DIRECTORY/invalid-postgresql-instances.out" "instances"
     require_contains "$TEST_DIRECTORY/invalid-postgresql-instances.out" "integer"
+
+    if helm_template unsupported-generated-oauth-secret "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.oauthClientSecret.generate=true \
+        >"$TEST_DIRECTORY/unsupported-generated-oauth-secret.out" 2>&1; then
+        fail "expected secrets.oauthClientSecret.generate=true to fail"
+    fi
+    require_schema_path "$TEST_DIRECTORY/unsupported-generated-oauth-secret.out" \
+        "secrets.oauthClientSecret"
+
+    if helm_template missing-oauth-client-secret "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.oauth2Proxy.enabled=true \
+        --set-string secrets.oauthClientSecret.existingSecret= \
+        --set-string secrets.oauthCookieSecret.existingSecret= \
+        >"$TEST_DIRECTORY/missing-oauth-client-secret.out" 2>&1; then
+        fail "expected an enabled OAuth2 proxy without credential Secrets to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/missing-oauth-client-secret.out" \
+        "secrets.oauthClientSecret.existingSecret is required when the OAuth2 proxy is enabled"
+
+    if helm_template legacy-oauth-secret-values "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set gateway.oauth2Proxy.secretName=legacy-oauth \
+        >"$TEST_DIRECTORY/legacy-oauth-secret-values.out" 2>&1; then
+        fail "expected legacy OAuth Secret values to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/legacy-oauth-secret-values.out" \
+        "gateway.oauth2Proxy legacy Secret values are not supported"
+
+    if helm_template untyped-postgresql-secret "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string secrets.postgresql.inlinePassword=do-not-render \
+        >"$TEST_DIRECTORY/untyped-postgresql-secret.out" 2>&1; then
+        fail "expected an inline PostgreSQL password field to fail schema validation"
+    fi
+    require_not_contains "$TEST_DIRECTORY/untyped-postgresql-secret.out" "do-not-render"
 
     if helm_template unsupported-legacy-values "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -67,11 +67,13 @@
       "type": "object",
       "properties": {
         "postgresql": { "$ref": "#/definitions/postgresqlSecretReference" },
-        "valkey": { "$ref": "#/definitions/secretReference" },
-        "objectStorage": { "$ref": "#/definitions/secretReference" },
+        "valkey": { "$ref": "#/definitions/passwordSecretReference" },
+        "objectStorage": { "$ref": "#/definitions/objectStorageSecretReference" },
         "backendApiTokens": { "$ref": "#/definitions/backendApiTokens" },
         "masterEncryptionKey": { "$ref": "#/definitions/masterEncryptionKeyReference" },
-        "defaultAdmin": { "$ref": "#/definitions/secretReference" }
+        "defaultAdmin": { "$ref": "#/definitions/adminSecretReference" },
+        "oauthClientSecret": { "$ref": "#/definitions/existingValueSecretReference" },
+        "oauthCookieSecret": { "$ref": "#/definitions/generatedValueSecretReference" }
       }
     },
     "configuration": { "type": "object" },
@@ -429,8 +431,42 @@
     },
     "gatewayTls": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
+        "rolloutNonce": { "type": "string" },
+        "generated": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "bootstrap": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "image": { "type": "string" },
+                "imagePullPolicy": {
+                  "type": "string",
+                  "enum": ["Always", "IfNotPresent", "Never"]
+                },
+                "allowInitialGeneration": { "type": "boolean" }
+              }
+            },
+            "leafRotationNonce": { "type": "string" },
+            "caRotation": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "id": { "type": "string" },
+                "freezeHpas": { "type": "boolean" },
+                "phase": {
+                  "type": "string",
+                  "enum": ["stable", "prepare", "activate", "retire"]
+                }
+              }
+            }
+          }
+        },
         "upstreamCerts": { "$ref": "#/definitions/gatewayUpstreamCerts" },
         "caSecret": { "type": "string" }
       },
@@ -717,14 +753,6 @@
         "cookie": { "$ref": "#/definitions/gatewayRouteCookie" }
       },
       "required": ["prefix", "timeout", "cookie"]
-    },
-    "oauthSecretPaths": {
-      "type": "object",
-      "properties": {
-        "clientSecret": { "type": "string", "minLength": 1 },
-        "cookieSecret": { "type": "string", "minLength": 1 }
-      },
-      "required": ["clientSecret", "cookieSecret"]
     },
     "authzPostgres": {
       "type": "object",
@@ -1050,11 +1078,6 @@
         "scope": { "type": "string" },
         "passAccessToken": { "type": "boolean" },
         "redisSessionStore": { "type": "boolean" },
-        "useKubernetesSecrets": { "type": "boolean" },
-        "secretName": { "type": "string" },
-        "clientSecretKey": { "type": "string" },
-        "cookieSecretKey": { "type": "string" },
-        "secretPaths": { "$ref": "#/definitions/oauthSecretPaths" },
         "extraArgs": { "type": "array" },
         "resources": { "type": "object" },
         "service": { "$ref": "#/definitions/serviceMetadata" },
@@ -1175,51 +1198,6 @@
         }
       }
     },
-    "secretReference": {
-      "type": "object",
-      "properties": {
-        "generate": { "type": "boolean" },
-        "existingSecret": { "type": "string" },
-        "keys": { "$ref": "#/definitions/stringMap" },
-        "mountPath": { "type": "string" },
-        "username": { "type": "string" }
-      },
-      "required": ["generate", "existingSecret", "keys"]
-    },
-    "backendApiTokens": {
-      "type": "object",
-      "properties": {
-        "enabled": { "type": "boolean" },
-        "bootstrap": {
-          "type": "object",
-          "properties": {
-            "image": { "$ref": "#/definitions/componentImage" }
-          },
-          "required": ["image"]
-        },
-        "rolloutNonce": { "type": "string" },
-        "credentials": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "name": { "type": "string", "minLength": 1 },
-              "existingSecret": { "$ref": "#/definitions/backendApiTokenSecretSource" },
-              "managedSecret": { "$ref": "#/definitions/backendApiTokenSecretSource" }
-            },
-            "required": ["name"]
-          }
-        }
-      },
-      "required": ["enabled", "bootstrap", "rolloutNonce", "credentials"]
-    },
-    "backendApiTokenSecretSource": {
-      "type": "object",
-      "properties": {
-        "name": { "type": "string" }
-      },
-      "required": ["name"]
-    },
     "masterEncryptionKeyReference": {
       "type": "object",
       "additionalProperties": false,
@@ -1269,16 +1247,137 @@
     },
     "postgresqlSecretReference": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "existingSecret": { "type": "string" },
+        "rolloutNonce": { "type": "string" },
         "keys": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "username": { "type": "string", "minLength": 1 },
             "password": { "type": "string", "minLength": 1 }
+          },
+          "required": ["username", "password"]
+        }
+      },
+      "required": ["existingSecret", "rolloutNonce", "keys"]
+    },
+    "backendApiTokens": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "bootstrap": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "image": { "$ref": "#/definitions/componentImage" }
+          },
+          "required": ["image"]
+        },
+        "rolloutNonce": { "type": "string" },
+        "credentials": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "existingSecret": { "$ref": "#/definitions/backendApiTokenSecretSource" },
+              "managedSecret": { "$ref": "#/definitions/backendApiTokenSecretSource" }
+            },
+            "required": ["name"]
           }
         }
-      }
+      },
+      "required": ["enabled", "bootstrap", "rolloutNonce", "credentials"]
+    },
+    "backendApiTokenSecretSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": { "name": { "type": "string", "minLength": 1 } },
+      "required": ["name"]
+    },
+    "passwordSecretReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "generate": { "type": "boolean" },
+        "existingSecret": { "type": "string" },
+        "rolloutNonce": { "type": "string" },
+        "keys": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": { "password": { "type": "string", "minLength": 1 } },
+          "required": ["password"]
+        }
+      },
+      "required": ["generate", "existingSecret", "rolloutNonce", "keys"]
+    },
+    "existingValueSecretReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingSecret": { "type": "string" },
+        "rolloutNonce": { "type": "string" },
+        "keys": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": { "value": { "type": "string", "minLength": 1 } },
+          "required": ["value"]
+        }
+      },
+      "required": ["existingSecret", "rolloutNonce", "keys"]
+    },
+    "generatedValueSecretReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "generate": { "type": "boolean" },
+        "existingSecret": { "type": "string" },
+        "rolloutNonce": { "type": "string" },
+        "keys": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": { "value": { "type": "string", "minLength": 1 } },
+          "required": ["value"]
+        }
+      },
+      "required": ["existingSecret", "rolloutNonce", "keys"]
+    },
+    "objectStorageSecretReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "generate": { "type": "boolean" },
+        "existingSecret": { "type": "string" },
+        "rolloutNonce": { "type": "string" },
+        "keys": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": { "credentials": { "type": "string", "minLength": 1 } },
+          "required": ["credentials"]
+        }
+      },
+      "required": ["generate", "existingSecret", "rolloutNonce", "keys"]
+    },
+    "adminSecretReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "generate": { "type": "boolean" },
+        "existingSecret": { "type": "string" },
+        "rolloutNonce": { "type": "string" },
+        "username": { "type": "string", "minLength": 1 },
+        "keys": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": { "password": { "type": "string", "minLength": 1 } },
+          "required": ["password"]
+        }
+      },
+      "required": ["generate", "existingSecret", "rolloutNonce", "username", "keys"]
     }
   }
 }

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -239,6 +239,7 @@ secrets:
   # postgresql.cluster.initdb.secret.name.
   postgresql:
     existingSecret: ''
+    rolloutNonce: ''
     keys:
       username: username
       password: db-password
@@ -248,12 +249,14 @@ secrets:
   valkey:
     generate: false
     existingSecret: ''
+    rolloutNonce: ''
     keys:
       password: redis-password
   # Storage SDK configuration file mounted for all three object-storage uses.
   objectStorage:
     generate: false
     existingSecret: ''
+    rolloutNonce: ''
     keys:
       credentials: object-storage.yaml
   # Backend compute-plane authentication. Each credential selects exactly one
@@ -308,9 +311,25 @@ secrets:
   defaultAdmin:
     generate: false
     existingSecret: ''
+    rolloutNonce: ''
     username: admin
     keys:
       password: password
+  # OAuth client Secret consumed only when the OAuth2 proxy is enabled.
+  oauthClientSecret:
+    existingSecret: oauth2-proxy-secrets
+    rolloutNonce: ''
+    keys:
+      value: client_secret
+  # OAuth cookie encryption Secret. This may be owned and rotated separately
+  # from the OAuth client Secret.
+  oauthCookieSecret:
+    # Helm generation is for direct-Helm development/test installs only.
+    generate: false
+    existingSecret: oauth2-proxy-secrets
+    rolloutNonce: ''
+    keys:
+      value: cookie_secret
 
 
 # Directly owned OSMO services and workload components. Each component owns its
@@ -545,7 +564,6 @@ services:
       automountServiceAccountToken: true
       hostAliases: []
     extraRoles: []
-
   # Optional Model Context Protocol endpoint exposed through the gateway.
   mcp:
     enabled: false
@@ -1307,8 +1325,8 @@ gateway:
       host: ''
       port: 8000
 
-  # Optional OIDC login/session proxy. The split-plane control profile keeps
-  # it disabled unless an identity provider and existing Secret are supplied.
+  # Optional OIDC login/session proxy. Enable it only after configuring an
+  # identity provider and the required existing Secrets.
   oauth2Proxy:
     enabled: true
     autoscaling:
@@ -1338,13 +1356,6 @@ gateway:
     scope: openid email profile
     passAccessToken: false
     redisSessionStore: true
-    useKubernetesSecrets: false
-    secretName: oauth2-proxy-secrets
-    clientSecretKey: client_secret
-    cookieSecretKey: cookie_secret
-    secretPaths:
-      clientSecret: /etc/oauth2-proxy/client-secret
-      cookieSecret: /etc/oauth2-proxy/cookie-secret
     extraArgs: []
     resources:
       requests:
@@ -1540,11 +1551,27 @@ gateway:
       component: ui
       port: 8000
 
-  # TLS for traffic from Envoy to OSMO upstream services. Existing Secret
-  # names provide fixed certificates; empty entries use each service's
-  # chart-managed self-signed mode. This does not configure public edge TLS.
+  # TLS for traffic from Envoy to OSMO upstream services. Development mode
+  # generates stable Kubernetes Secrets; production uses operator-provided or
+  # cert-manager-owned existing Secrets. This does not configure edge TLS.
   tls:
     enabled: true
+    # Non-secret rollout trigger after operator-owned TLS Secrets change.
+    rolloutNonce: ''
+    generated:
+      enabled: true
+      bootstrap:
+        # Empty uses the OSMO API service image.
+        image: ''
+        imagePullPolicy: IfNotPresent
+        # One-time gate for the first upgrade from process-local TLS.
+        allowInitialGeneration: false
+      leafRotationNonce: ''
+      caRotation:
+        id: ''
+        phase: stable
+        # Set in a stable preflight upgrade and keep true through retirement.
+        freezeHpas: false
     upstreamCerts:
       api: ''
       router: ''

--- a/src/service/core/BUILD
+++ b/src/service/core/BUILD
@@ -56,6 +56,7 @@ osmo_py_library(
         "//src/service/logger:ctrl_websocket",
         "//src/utils:ssl_init",
         "//src/utils/progress_check:progress_check_lib",
+        "//src/utils:internal_tls_bootstrap_lib",
     ],
     data = [
         "//src/lib/utils:version.yaml",
@@ -100,6 +101,7 @@ filegroup(
         ":service_layer_packages",
         ":service_wrapper",
         ":mek_lifecycle_wrapper",
+        "//src/utils:internal_tls_bootstrap_wrapper_public",
     ],
 )
 

--- a/src/service/core/auth/backend_secret_auth.py
+++ b/src/service/core/auth/backend_secret_auth.py
@@ -15,6 +15,7 @@ from src.utils.job import task as task_lib
 
 BACKEND_ROLE: Final = 'osmo-backend'
 _CREDENTIAL_NAME_PATTERN: Final = re.compile(r'^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$')
+_TOKEN_PATTERN: Final = re.compile(r'^[A-Za-z0-9_-]+$')
 _CURRENT_TOKEN_KEY: Final = 'token'
 _PREVIOUS_TOKEN_KEY: Final = 'previous-token'
 logger = logging.getLogger(__name__)
@@ -254,6 +255,9 @@ class BackendSecretAuthenticator:
         if len(token) not in task_lib.VALID_TOKEN_LENGTHS:
             raise BackendTokenConfigurationError(
                 f'Backend credential {credential_name} key {token_key} has invalid length')
+        if not _TOKEN_PATTERN.fullmatch(token):
+            raise BackendTokenConfigurationError(
+                f'Backend credential {credential_name} key {token_key} has invalid format')
         return token
 
 

--- a/src/service/core/auth/tests/test_backend_secret_auth.py
+++ b/src/service/core/auth/tests/test_backend_secret_auth.py
@@ -99,6 +99,20 @@ class BackendSecretAuthenticatorTest(unittest.TestCase):
         self.assertIsNone(authenticator.authenticate(self._new_token()))
         self.assertIn('invalid length', '\n'.join(logs.output))
 
+    def test_ignores_invalid_token_characters_without_logging_value(self) -> None:
+        invalid_token = ('a' * 42) + '!'
+        self._write_credential('default', invalid_token)
+        authenticator = backend_secret_auth.BackendSecretAuthenticator(
+            str(self.token_directory))
+
+        with self.assertLogs(backend_secret_auth.logger, level='WARNING') as logs:
+            authenticator.validate()
+
+        joined_logs = '\n'.join(logs.output)
+        self.assertIsNone(authenticator.authenticate(invalid_token))
+        self.assertIn('invalid format', joined_logs)
+        self.assertNotIn(invalid_token, joined_logs)
+
     def test_ignores_credential_with_duplicate_values(self) -> None:
         token = self._new_token()
         self._write_credential('default', token, token)

--- a/src/utils/BUILD
+++ b/src/utils/BUILD
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bzl:py.bzl", "osmo_py_library")
+load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library", "osmo_python_wrapper")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
@@ -112,6 +112,37 @@ osmo_py_library(
         requirement("kubernetes"),
         requirement("truststore"),
     ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "internal_tls_bootstrap_lib",
+    srcs = ["internal_tls_bootstrap.py"],
+    deps = [
+        requirement("cryptography"),
+        requirement("kubernetes"),
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_binary(
+    name = "internal_tls_bootstrap_binary",
+    main = "internal_tls_bootstrap.py",
+    srcs = ["internal_tls_bootstrap.py"],
+    deps = [":internal_tls_bootstrap_lib"],
+)
+
+osmo_python_wrapper(
+    name = "internal_tls_bootstrap_wrapper",
+    bin_name = "internal-tls-bootstrap",
+    main = None,
+    module = "src.utils.internal_tls_bootstrap",
+    runfiles_dir = "/src/service/core/service_binary.runfiles",
+)
+
+alias(
+    name = "internal_tls_bootstrap_wrapper_public",
+    actual = ":internal_tls_bootstrap_wrapper",
     visibility = ["//visibility:public"],
 )
 

--- a/src/utils/internal_tls_bootstrap.py
+++ b/src/utils/internal_tls_bootstrap.py
@@ -1,0 +1,767 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import argparse
+import base64
+import dataclasses
+import datetime
+import sys
+from typing import Iterable
+
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+from kubernetes import client as kubernetes_client  # type: ignore
+from kubernetes import config as kubernetes_config  # type: ignore
+from kubernetes.client import exceptions as kubernetes_exceptions  # type: ignore
+
+_MANAGED_BY = 'osmo-internal-tls-bootstrap'
+_MANAGED_BY_LABEL = 'app.kubernetes.io/managed-by'
+_INSTANCE_LABEL = 'app.kubernetes.io/instance'
+
+
+class BootstrapError(RuntimeError):
+    """An actionable generated-TLS contract violation."""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class LeafSpec:
+    secret_name: str
+    dns_name: str
+
+
+@dataclasses.dataclass(slots=True)
+class KeyPair:
+    certificate: bytes
+    private_key: bytes
+
+
+def _active_pod(pod: kubernetes_client.V1Pod) -> bool:
+    metadata = pod.metadata
+    phase = pod.status.phase if pod.status else None
+    return (
+        (metadata is None or metadata.deletion_timestamp is None)
+        and phase not in {'Succeeded', 'Failed'}
+    )
+
+
+def verify_rollout(
+    core_api: kubernetes_client.CoreV1Api,
+    apps_api: kubernetes_client.AppsV1Api,
+    autoscaling_api: kubernetes_client.AutoscalingV2Api,
+    *,
+    namespace: str,
+    deployment_names: Iterable[str],
+    allowed_annotations: set[str] | None,
+    allowed_annotation_suffixes: set[str] | None = None,
+    require_complete: bool = True,
+) -> None:
+    """Prove every TLS consumer is on one complete, HPA-frozen rollout."""
+    names = set(deployment_names)
+    try:
+        hpas = autoscaling_api.list_namespaced_horizontal_pod_autoscaler(
+            namespace=namespace
+        ).items
+        for hpa in hpas:
+            target = getattr(getattr(hpa, 'spec', None), 'scale_target_ref', None)
+            if (
+                getattr(target, 'kind', None) == 'Deployment'
+                and getattr(target, 'name', None) in names
+                and getattr(hpa.spec, 'min_replicas', None)
+                != getattr(hpa.spec, 'max_replicas', None)
+            ):
+                raise BootstrapError(
+                    'Internal TLS CA rotation requires every consumer HPA to be frozen'
+                )
+
+        for name in names:
+            deployment = apps_api.read_namespaced_deployment(
+                name=name,
+                namespace=namespace,
+            )
+            metadata = deployment.metadata
+            spec = deployment.spec
+            status = deployment.status
+            desired = spec.replicas if spec.replicas is not None else 1
+            counts = (
+                status.replicas,
+                status.updated_replicas,
+                status.ready_replicas,
+                status.available_replicas,
+            )
+            if require_complete and (
+                status.observed_generation != metadata.generation
+                or any((count or 0) != desired for count in counts)
+                or (status.unavailable_replicas or 0) != 0
+            ):
+                raise BootstrapError(
+                    'Internal TLS CA rotation requires a complete consumer rollout'
+                )
+            match_labels = getattr(spec.selector, 'match_labels', None) or {}
+            if not match_labels:
+                raise BootstrapError('Internal TLS consumer selector is invalid')
+            selector = ','.join(
+                f'{key}={value}' for key, value in sorted(match_labels.items())
+            )
+            pods = core_api.list_namespaced_pod(
+                namespace=namespace,
+                label_selector=selector,
+            ).items
+            active_pods = [pod for pod in pods if _active_pod(pod)]
+            if require_complete and len(active_pods) != desired:
+                raise BootstrapError(
+                    'Internal TLS CA rotation found mixed consumer pod generations'
+                )
+            if not active_pods:
+                raise BootstrapError(
+                    'Internal TLS CA rotation found no active consumer pods'
+                )
+            observed_annotations = {
+                (getattr(pod.metadata, 'annotations', None) or {}).get(
+                    'checksum/internal-tls-ca-phase'
+                )
+                for pod in active_pods
+            }
+            if allowed_annotations and any(
+                value not in allowed_annotations
+                and not (
+                    value
+                    and allowed_annotation_suffixes
+                    and any(
+                        value.endswith(suffix)
+                        for suffix in allowed_annotation_suffixes
+                    )
+                )
+                for value in observed_annotations
+            ):
+                raise BootstrapError(
+                    'Internal TLS CA rotation found a consumer on the wrong phase'
+                )
+    except kubernetes_exceptions.ApiException as error:
+        raise BootstrapError('Unable to verify internal TLS consumer rollout') from error
+
+
+def _read_rotation_state(
+    api: kubernetes_client.CoreV1Api,
+    *,
+    namespace: str,
+    release_name: str,
+    ca_secret_name: str,
+) -> tuple[str, str]:
+    secret = _read_secret(api, namespace, ca_secret_name)
+    _require_owned(secret, release_name)
+    try:
+        rotation_id = (_decode_secret_data(secret, 'rotation-id') or b'').decode(
+            'utf-8'
+        )
+        phase = (_decode_secret_data(secret, 'rotation-phase') or b'stable').decode(
+            'utf-8'
+        )
+    except UnicodeDecodeError as error:
+        raise BootstrapError('Generated TLS CA rotation metadata is invalid') from error
+    if phase not in {'stable', 'prepare', 'activate', 'retire'}:
+        raise BootstrapError('Generated TLS CA rotation metadata is invalid')
+    return rotation_id, phase
+
+
+def verify_transition_rollout(
+    core_api: kubernetes_client.CoreV1Api,
+    apps_api: kubernetes_client.AppsV1Api,
+    autoscaling_api: kubernetes_client.AutoscalingV2Api,
+    *,
+    namespace: str,
+    release_name: str,
+    ca_secret_name: str,
+    deployment_names: Iterable[str],
+    requested_rotation_id: str,
+    requested_phase: str,
+) -> None:
+    """Gate a new phase strictly, but let an already-applied phase converge."""
+    stored_rotation_id, stored_phase = _read_rotation_state(
+        core_api,
+        namespace=namespace,
+        release_name=release_name,
+        ca_secret_name=ca_secret_name,
+    )
+    predecessor = {
+        'prepare': 'stable',
+        'activate': 'prepare',
+        'retire': 'activate',
+    }[requested_phase]
+    target_annotation = f'{requested_rotation_id}:{requested_phase}'
+    if stored_phase == requested_phase and stored_rotation_id == requested_rotation_id:
+        predecessor_annotation = f'{requested_rotation_id}:{predecessor}'
+        allowed_annotations = {target_annotation, predecessor_annotation}
+        verify_rollout(
+            core_api,
+            apps_api,
+            autoscaling_api,
+            namespace=namespace,
+            deployment_names=deployment_names,
+            allowed_annotations=allowed_annotations,
+            allowed_annotation_suffixes=(
+                {':stable'} if requested_phase == 'prepare' else None
+            ),
+            require_complete=False,
+        )
+        return
+    if stored_phase != predecessor:
+        raise BootstrapError(
+            f'CA {requested_phase} requires the durable {predecessor} phase'
+        )
+    if requested_phase != 'prepare' and stored_rotation_id != requested_rotation_id:
+        raise BootstrapError(
+            f'CA {requested_phase} requires the matching rotation id'
+        )
+    verify_rollout(
+        core_api,
+        apps_api,
+        autoscaling_api,
+        namespace=namespace,
+        deployment_names=deployment_names,
+        allowed_annotations={f'{stored_rotation_id}:{stored_phase}'},
+    )
+
+
+def _decode_secret_data(
+    secret: kubernetes_client.V1Secret,
+    key: str,
+) -> bytes | None:
+    encoded = secret.data or {}
+    value = encoded.get(key)
+    if not value:
+        return None
+    try:
+        return base64.b64decode(value, validate=True)
+    except ValueError as error:
+        raise BootstrapError(f'Generated TLS Secret has invalid key {key}') from error
+
+
+def _encode_secret_data(values: dict[str, bytes]) -> dict[str, str]:
+    return {
+        key: base64.b64encode(value).decode('ascii')
+        for key, value in values.items()
+    }
+
+
+def _read_secret(
+    api: kubernetes_client.CoreV1Api,
+    namespace: str,
+    name: str,
+) -> kubernetes_client.V1Secret:
+    try:
+        return api.read_namespaced_secret(name=name, namespace=namespace)
+    except kubernetes_exceptions.ApiException as error:
+        if error.status == 404:
+            raise BootstrapError(
+                f'Generated TLS Secret {name} is missing; restore the retained Secret'
+            ) from error
+        raise BootstrapError(f'Unable to read generated TLS Secret {name}') from error
+
+
+def _require_owned(
+    secret: kubernetes_client.V1Secret,
+    release_name: str,
+) -> None:
+    metadata = secret.metadata
+    labels = metadata.labels if metadata and metadata.labels else {}
+    if (
+        labels.get(_MANAGED_BY_LABEL) != _MANAGED_BY
+        or labels.get(_INSTANCE_LABEL) != release_name
+    ):
+        name = metadata.name if metadata and metadata.name else '<unknown>'
+        raise BootstrapError(
+            f'Generated TLS Secret {name} is not owned by release {release_name}'
+        )
+
+
+def _replace_secret(
+    api: kubernetes_client.CoreV1Api,
+    namespace: str,
+    secret: kubernetes_client.V1Secret,
+    secret_type: str,
+    values: dict[str, bytes],
+) -> None:
+    metadata = secret.metadata
+    name = metadata.name if metadata else None
+    if not name:
+        raise BootstrapError('Generated TLS Secret is missing metadata.name')
+    if not metadata or not metadata.resource_version:
+        raise BootstrapError(
+            f'Generated TLS Secret {name} is missing metadata.resourceVersion'
+        )
+    if secret.type != secret_type:
+        raise BootstrapError(
+            f'Generated TLS Secret {name} has immutable type {secret.type!r}; '
+            f'expected {secret_type!r}'
+        )
+    try:
+        # A merge patch cannot remove keys omitted from ``data``.  Replacing the
+        # complete Secret with its observed resourceVersion both deletes stale
+        # rotation keys and makes concurrent writers fail with a CAS conflict.
+        replacement = kubernetes_client.V1Secret(
+            api_version=secret.api_version or 'v1',
+            kind=secret.kind or 'Secret',
+            metadata=kubernetes_client.V1ObjectMeta(
+                name=name,
+                namespace=metadata.namespace or namespace,
+                resource_version=metadata.resource_version,
+                labels=metadata.labels,
+                annotations=metadata.annotations,
+                finalizers=metadata.finalizers,
+                owner_references=metadata.owner_references,
+            ),
+            data=_encode_secret_data(values),
+            immutable=secret.immutable,
+            type=secret_type,
+        )
+        api.replace_namespaced_secret(
+            name=name,
+            namespace=namespace,
+            body=replacement,
+        )
+    except kubernetes_exceptions.ApiException as error:
+        status = error.status if error.status is not None else 'unknown'
+        reason = error.reason or 'API error'
+        raise BootstrapError(
+            f'Unable to update generated TLS Secret {name}: '
+            f'Kubernetes API {status} {reason}'
+        ) from error
+
+
+def _serialize_key(private_key: rsa.RSAPrivateKey) -> bytes:
+    return private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def _generate_ca(now: datetime.datetime) -> KeyPair:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=3072)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'OSMO internal CA')])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=825))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(private_key, hashes.SHA256())
+    )
+    return KeyPair(
+        certificate.public_bytes(serialization.Encoding.PEM),
+        _serialize_key(private_key),
+    )
+
+
+def _load_key_pair(certificate: bytes | None, private_key: bytes | None) -> KeyPair:
+    if not certificate or not private_key:
+        raise BootstrapError('Generated TLS certificate and private key are required')
+    try:
+        loaded_certificate = x509.load_pem_x509_certificate(certificate)
+        loaded_private_key = serialization.load_pem_private_key(
+            private_key,
+            password=None,
+        )
+    except ValueError as error:
+        raise BootstrapError('Generated TLS certificate or key is invalid') from error
+    if not isinstance(loaded_private_key, rsa.RSAPrivateKey):
+        raise BootstrapError('Generated TLS private key must be RSA')
+    certificate_public_key = loaded_certificate.public_key()
+    if not isinstance(certificate_public_key, rsa.RSAPublicKey):
+        raise BootstrapError('Generated TLS certificate key must be RSA')
+    if (
+        certificate_public_key.public_numbers()
+        != loaded_private_key.public_key().public_numbers()
+    ):
+        raise BootstrapError('Generated TLS certificate and private key do not match')
+    return KeyPair(certificate, private_key)
+
+
+def _load_ca(
+    certificate: bytes | None,
+    private_key: bytes | None,
+    now: datetime.datetime,
+    *,
+    validate_time: bool = True,
+) -> KeyPair:
+    pair = _load_key_pair(certificate, private_key)
+    loaded_certificate = x509.load_pem_x509_certificate(pair.certificate)
+    public_key = loaded_certificate.public_key()
+    if not isinstance(public_key, rsa.RSAPublicKey):
+        raise BootstrapError('Generated TLS CA certificate key must be RSA')
+    signature_hash_algorithm = loaded_certificate.signature_hash_algorithm
+    if signature_hash_algorithm is None:
+        raise BootstrapError('Generated TLS CA certificate signature is unsupported')
+    try:
+        constraints = loaded_certificate.extensions.get_extension_for_class(
+            x509.BasicConstraints
+        ).value
+        if not constraints.ca or loaded_certificate.issuer != loaded_certificate.subject:
+            raise BootstrapError('Generated TLS CA certificate is not a self-signed CA')
+        public_key.verify(
+            loaded_certificate.signature,
+            loaded_certificate.tbs_certificate_bytes,
+            padding.PKCS1v15(),
+            signature_hash_algorithm,
+        )
+    except (InvalidSignature, x509.ExtensionNotFound) as error:
+        raise BootstrapError('Generated TLS CA certificate is not a self-signed CA') from error
+    if validate_time and not (
+        loaded_certificate.not_valid_before_utc <= now
+        < loaded_certificate.not_valid_after_utc
+    ):
+        raise BootstrapError('Generated TLS CA certificate is not currently valid')
+    return pair
+
+
+def _leaf_matches_contract(
+    certificate: bytes | None,
+    private_key: bytes | None,
+    ca: KeyPair,
+    dns_name: str,
+    namespace: str,
+    now: datetime.datetime,
+) -> bool:
+    try:
+        pair = _load_key_pair(certificate, private_key)
+        leaf_certificate = x509.load_pem_x509_certificate(pair.certificate)
+        ca_certificate = x509.load_pem_x509_certificate(ca.certificate)
+        ca_public_key = ca_certificate.public_key()
+        if not isinstance(ca_public_key, rsa.RSAPublicKey):
+            return False
+        signature_hash_algorithm = leaf_certificate.signature_hash_algorithm
+        if signature_hash_algorithm is None:
+            return False
+        ca_public_key.verify(
+            leaf_certificate.signature,
+            leaf_certificate.tbs_certificate_bytes,
+            padding.PKCS1v15(),
+            signature_hash_algorithm,
+        )
+        expected_names = {
+            dns_name,
+            f'{dns_name}.{namespace}',
+            f'{dns_name}.{namespace}.svc',
+        }
+        actual_names = set(
+            leaf_certificate.extensions.get_extension_for_class(
+                x509.SubjectAlternativeName
+            ).value.get_values_for_type(x509.DNSName)
+        )
+        minimum_expiry = now + datetime.timedelta(days=30)
+        return (
+            leaf_certificate.issuer == ca_certificate.subject
+            and leaf_certificate.not_valid_before_utc <= now
+            and leaf_certificate.not_valid_after_utc > minimum_expiry
+            and actual_names == expected_names
+        )
+    except (BootstrapError, InvalidSignature, ValueError, x509.ExtensionNotFound):
+        return False
+
+
+def _generate_leaf(
+    ca: KeyPair,
+    dns_name: str,
+    namespace: str,
+    now: datetime.datetime,
+) -> KeyPair:
+    ca_certificate = x509.load_pem_x509_certificate(ca.certificate)
+    ca_private_key = serialization.load_pem_private_key(ca.private_key, password=None)
+    if not isinstance(ca_private_key, rsa.RSAPrivateKey):
+        raise BootstrapError('Generated TLS CA private key must be RSA')
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, dns_name)])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_certificate.subject)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=397))
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName(dns_name),
+                    x509.DNSName(f'{dns_name}.{namespace}'),
+                    x509.DNSName(f'{dns_name}.{namespace}.svc'),
+                ]
+            ),
+            critical=False,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+            critical=False,
+        )
+        .sign(ca_private_key, hashes.SHA256())
+    )
+    return KeyPair(
+        certificate.public_bytes(serialization.Encoding.PEM),
+        _serialize_key(private_key),
+    )
+
+
+def reconcile(
+    api: kubernetes_client.CoreV1Api,
+    *,
+    namespace: str,
+    release_name: str,
+    ca_secret_name: str,
+    trust_secret_name: str,
+    leaf_specs: list[LeafSpec],
+    leaf_rotation_nonce: str,
+    ca_rotation_id: str,
+    ca_rotation_phase: str,
+    fail_if_missing: bool,
+    now: datetime.datetime,
+    rollout_verified: bool = False,
+) -> None:
+    if ca_rotation_phase != 'stable' and not rollout_verified:
+        raise BootstrapError(
+            'Internal TLS CA rotation requires verified consumer rollout state'
+        )
+    ca_secret = _read_secret(api, namespace, ca_secret_name)
+    _require_owned(ca_secret, release_name)
+    current_certificate = _decode_secret_data(ca_secret, 'ca.crt')
+    current_private_key = _decode_secret_data(ca_secret, 'ca.key')
+    if not current_certificate or not current_private_key:
+        if fail_if_missing:
+            raise BootstrapError(
+                f'Generated TLS CA Secret {ca_secret_name} is incomplete; restore it'
+            )
+        current = _generate_ca(now)
+    else:
+        current = _load_ca(current_certificate, current_private_key, now)
+
+    pending_certificate = _decode_secret_data(ca_secret, 'pending-ca.crt')
+    pending_private_key = _decode_secret_data(ca_secret, 'pending-ca.key')
+    previous_certificate = _decode_secret_data(ca_secret, 'previous-ca.crt')
+    previous_private_key = _decode_secret_data(ca_secret, 'previous-ca.key')
+    try:
+        rotation_id = (_decode_secret_data(ca_secret, 'rotation-id') or b'').decode(
+            'utf-8'
+        )
+    except UnicodeDecodeError as error:
+        raise BootstrapError('Generated TLS CA rotation metadata is invalid') from error
+    pending = (
+        _load_ca(pending_certificate, pending_private_key, now)
+        if pending_certificate or pending_private_key
+        else None
+    )
+    previous = (
+        _load_ca(
+            previous_certificate,
+            previous_private_key,
+            now,
+            validate_time=False,
+        )
+        if previous_certificate or previous_private_key
+        else None
+    )
+    force_leaf_rotation = False
+
+    if ca_rotation_phase == 'stable':
+        if pending or previous:
+            raise BootstrapError(
+                'CA rotation is incomplete; use prepare, activate, or retire with its rotation id'
+            )
+    elif ca_rotation_phase == 'prepare':
+        if previous:
+            raise BootstrapError('Retire the previous CA before preparing another')
+        if pending and rotation_id != ca_rotation_id:
+            raise BootstrapError('A different pending CA rotation already exists')
+        pending = pending or _generate_ca(now)
+        rotation_id = ca_rotation_id
+    elif ca_rotation_phase == 'activate':
+        if rotation_id != ca_rotation_id:
+            raise BootstrapError('CA activate requires the matching prepared rotation')
+        if not previous:
+            if not pending:
+                raise BootstrapError('CA activate requires the matching prepared rotation')
+            previous = current
+            current = pending
+            pending = None
+            force_leaf_rotation = True
+    elif ca_rotation_phase == 'retire':
+        if rotation_id != ca_rotation_id:
+            raise BootstrapError('CA retire requires the active rotation id')
+        if pending:
+            raise BootstrapError('CA retire requires the prepared CA to be activated first')
+        for leaf_spec in leaf_specs:
+            leaf_secret = _read_secret(api, namespace, leaf_spec.secret_name)
+            _require_owned(leaf_secret, release_name)
+            if not _leaf_matches_contract(
+                _decode_secret_data(leaf_secret, 'tls.crt'),
+                _decode_secret_data(leaf_secret, 'tls.key'),
+                current,
+                leaf_spec.dns_name,
+                namespace,
+                now,
+            ):
+                raise BootstrapError(
+                    'CA retire requires every leaf Secret to use the active CA'
+                )
+        previous = None
+    else:
+        raise BootstrapError(f'Unsupported CA rotation phase {ca_rotation_phase}')
+
+    ca_values = {
+        'ca.crt': current.certificate,
+        'ca.key': current.private_key,
+        'rotation-id': rotation_id.encode('utf-8'),
+        'rotation-phase': ca_rotation_phase.encode('utf-8'),
+    }
+    if pending:
+        ca_values['pending-ca.crt'] = pending.certificate
+        ca_values['pending-ca.key'] = pending.private_key
+    if previous:
+        ca_values['previous-ca.crt'] = previous.certificate
+        ca_values['previous-ca.key'] = previous.private_key
+    _replace_secret(api, namespace, ca_secret, 'Opaque', ca_values)
+
+    trust_secret = _read_secret(api, namespace, trust_secret_name)
+    _require_owned(trust_secret, release_name)
+    trust_bundle = current.certificate
+    if pending:
+        trust_bundle += pending.certificate
+    elif previous:
+        trust_bundle += previous.certificate
+    _replace_secret(
+        api,
+        namespace,
+        trust_secret,
+        'Opaque',
+        {'ca.crt': trust_bundle},
+    )
+
+    for leaf_spec in leaf_specs:
+        leaf_secret = _read_secret(api, namespace, leaf_spec.secret_name)
+        _require_owned(leaf_secret, release_name)
+        existing_nonce = _decode_secret_data(leaf_secret, 'rotation-nonce')
+        certificate = _decode_secret_data(leaf_secret, 'tls.crt')
+        private_key = _decode_secret_data(leaf_secret, 'tls.key')
+        valid_key_pair = _leaf_matches_contract(
+            certificate,
+            private_key,
+            current,
+            leaf_spec.dns_name,
+            namespace,
+            now,
+        )
+        if (
+            force_leaf_rotation
+            or existing_nonce != leaf_rotation_nonce.encode('utf-8')
+            or not valid_key_pair
+        ):
+            leaf = _generate_leaf(current, leaf_spec.dns_name, namespace, now)
+            _replace_secret(
+                api,
+                namespace,
+                leaf_secret,
+                'Opaque',
+                {
+                    'tls.crt': leaf.certificate,
+                    'tls.key': leaf.private_key,
+                    'rotation-nonce': leaf_rotation_nonce.encode('utf-8'),
+                },
+            )
+
+
+def _parse_leaf(value: str) -> LeafSpec:
+    secret_name, separator, dns_name = value.partition('=')
+    if not separator or not secret_name or not dns_name:
+        raise argparse.ArgumentTypeError('leaf must be SECRET_NAME=DNS_NAME')
+    return LeafSpec(secret_name, dns_name)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--namespace', required=True)
+    parser.add_argument('--release-name', required=True)
+    parser.add_argument('--ca-secret', required=True)
+    parser.add_argument('--trust-secret', required=True)
+    parser.add_argument('--leaf', action='append', type=_parse_leaf, required=True)
+    parser.add_argument('--consumer-deployment', action='append', required=True)
+    parser.add_argument('--leaf-rotation-nonce', default='')
+    parser.add_argument('--ca-rotation-id', default='')
+    parser.add_argument(
+        '--ca-rotation-phase',
+        choices=('stable', 'prepare', 'activate', 'retire'),
+        default='stable',
+    )
+    parser.add_argument('--fail-if-missing', action='store_true')
+    arguments = parser.parse_args()
+    try:
+        kubernetes_config.load_incluster_config()
+        core_api = kubernetes_client.CoreV1Api()
+        rollout_verified = False
+        if arguments.ca_rotation_phase != 'stable':
+            verify_transition_rollout(
+                core_api,
+                kubernetes_client.AppsV1Api(),
+                kubernetes_client.AutoscalingV2Api(),
+                namespace=arguments.namespace,
+                release_name=arguments.release_name,
+                ca_secret_name=arguments.ca_secret,
+                deployment_names=arguments.consumer_deployment,
+                requested_rotation_id=arguments.ca_rotation_id,
+                requested_phase=arguments.ca_rotation_phase,
+            )
+            rollout_verified = True
+        reconcile(
+            core_api,
+            namespace=arguments.namespace,
+            release_name=arguments.release_name,
+            ca_secret_name=arguments.ca_secret,
+            trust_secret_name=arguments.trust_secret,
+            leaf_specs=arguments.leaf,
+            leaf_rotation_nonce=arguments.leaf_rotation_nonce,
+            ca_rotation_id=arguments.ca_rotation_id,
+            ca_rotation_phase=arguments.ca_rotation_phase,
+            fail_if_missing=arguments.fail_if_missing,
+            now=datetime.datetime.now(datetime.UTC),
+            rollout_verified=rollout_verified,
+        )
+    except BootstrapError as error:
+        print(f'ERROR {error}', file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/utils/tests/BUILD
+++ b/src/utils/tests/BUILD
@@ -54,3 +54,13 @@ osmo_py_test(
         requirement("truststore"),
     ]
 )
+
+osmo_py_test(
+    name = "test_internal_tls_bootstrap",
+    srcs = ["test_internal_tls_bootstrap.py"],
+    deps = [
+        "//src/utils:internal_tls_bootstrap_lib",
+        requirement("cryptography"),
+        requirement("kubernetes"),
+    ],
+)

--- a/src/utils/tests/test_internal_tls_bootstrap.py
+++ b/src/utils/tests/test_internal_tls_bootstrap.py
@@ -1,0 +1,571 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import base64
+import copy
+import datetime
+from types import SimpleNamespace
+import unittest
+from unittest import mock
+
+from cryptography import x509
+from kubernetes import client as kubernetes_client  # type: ignore
+from kubernetes.client import exceptions as kubernetes_exceptions  # type: ignore
+
+from src.utils import internal_tls_bootstrap
+
+
+class FakeCoreApi:
+    """Minimal in-memory CoreV1Api used by the reconciler tests."""
+
+    def __init__(self) -> None:
+        self.secrets: dict[str, kubernetes_client.V1Secret] = {}
+        self.fail_next_replace: set[str] = set()
+
+    def add_placeholder(
+        self,
+        name: str,
+        release_name: str = 'test',
+        secret_type: str = 'Opaque',
+    ) -> None:
+        data = (
+            {'tls.crt': '', 'tls.key': ''}
+            if secret_type == 'kubernetes.io/tls'
+            else {}
+        )
+        self.secrets[name] = kubernetes_client.V1Secret(
+            metadata=kubernetes_client.V1ObjectMeta(
+                name=name,
+                namespace='osmo',
+                resource_version='1',
+                labels={
+                    'app.kubernetes.io/managed-by': (
+                        'osmo-internal-tls-bootstrap'
+                    ),
+                    'app.kubernetes.io/instance': release_name,
+                },
+            ),
+            data=data,
+            type=secret_type,
+        )
+
+    def read_namespaced_secret(
+        self,
+        name: str,
+        namespace: str,
+    ) -> kubernetes_client.V1Secret:
+        del namespace
+        return copy.deepcopy(self.secrets[name])
+
+    def replace_namespaced_secret(
+        self,
+        name: str,
+        namespace: str,
+        body: kubernetes_client.V1Secret,
+    ) -> kubernetes_client.V1Secret:
+        del namespace
+        if name in self.fail_next_replace:
+            self.fail_next_replace.remove(name)
+            raise kubernetes_exceptions.ApiException(status=503, reason='Unavailable')
+        current = self.secrets[name]
+        if body.metadata.resource_version != current.metadata.resource_version:
+            raise kubernetes_exceptions.ApiException(status=409, reason='Conflict')
+        replacement = copy.deepcopy(body)
+        replacement.metadata.resource_version = str(
+            int(current.metadata.resource_version) + 1
+        )
+        self.secrets[name] = replacement
+        return copy.deepcopy(replacement)
+
+
+class InternalTlsBootstrapTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.api = FakeCoreApi()
+        for name in ('ca', 'trust', 'leaf'):
+            self.api.add_placeholder(name)
+        self.now = datetime.datetime(2026, 8, 18, tzinfo=datetime.UTC)
+
+    def reconcile(
+        self,
+        phase: str = 'stable',
+        rotation_id: str = '',
+        fail_if_missing: bool = False,
+    ) -> None:
+        internal_tls_bootstrap.reconcile(
+            self.api,  # type: ignore[arg-type]
+            namespace='osmo',
+            release_name='test',
+            ca_secret_name='ca',
+            trust_secret_name='trust',
+            leaf_specs=[internal_tls_bootstrap.LeafSpec('leaf', 'osmo-api')],
+            leaf_rotation_nonce='leaf-v1',
+            ca_rotation_id=rotation_id,
+            ca_rotation_phase=phase,
+            fail_if_missing=fail_if_missing,
+            now=self.now,
+            rollout_verified=phase != 'stable',
+        )
+
+    def secret_value(self, secret_name: str, key: str) -> bytes:
+        secret = self.api.secrets[secret_name]
+        self.assertIsNotNone(secret.data)
+        encoded = secret.data[key]  # type: ignore[index]
+        return base64.b64decode(encoded)
+
+    def test_write_failure_reports_sanitized_api_status(self) -> None:
+        with mock.patch.object(
+            self.api,
+            'replace_namespaced_secret',
+            side_effect=kubernetes_exceptions.ApiException(
+                status=403,
+                reason='Forbidden',
+            ),
+        ), self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            r'ca: Kubernetes API 403 Forbidden',
+        ):
+            self.reconcile()
+
+    def test_rejects_leaf_placeholder_with_non_opaque_type(self) -> None:
+        self.api.secrets['leaf'].type = 'kubernetes.io/tls'
+
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            r"leaf has immutable type 'kubernetes.io/tls'; expected 'Opaque'",
+        ):
+            self.reconcile()
+
+    def test_initial_bootstrap_generates_stable_ca_trust_and_leaf(self) -> None:
+        self.reconcile()
+        initial_ca = self.secret_value('ca', 'ca.crt')
+        initial_leaf = self.secret_value('leaf', 'tls.crt')
+
+        self.reconcile()
+
+        self.assertEqual(self.secret_value('ca', 'ca.crt'), initial_ca)
+        self.assertEqual(self.secret_value('trust', 'ca.crt'), initial_ca)
+        self.assertEqual(self.secret_value('leaf', 'tls.crt'), initial_leaf)
+        certificate = x509.load_pem_x509_certificate(initial_leaf)
+        alternative_names = certificate.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
+        ).value.get_values_for_type(x509.DNSName)
+        self.assertEqual(
+            alternative_names,
+            ['osmo-api', 'osmo-api.osmo', 'osmo-api.osmo.svc'],
+        )
+        self.assertEqual(getattr(self.api.secrets['leaf'], 'type'), 'Opaque')
+
+    def test_ca_rotation_preserves_dual_trust_across_prepare_activate(self) -> None:
+        self.reconcile()
+        original_ca = self.secret_value('ca', 'ca.crt')
+        original_leaf = self.secret_value('leaf', 'tls.crt')
+
+        self.reconcile('prepare', 'ca-2026-09')
+        self.reconcile('prepare', 'ca-2026-09')
+        prepared_bundle = x509.load_pem_x509_certificates(
+            self.secret_value('trust', 'ca.crt')
+        )
+        self.assertEqual(len(prepared_bundle), 2)
+        self.assertEqual(self.secret_value('leaf', 'tls.crt'), original_leaf)
+
+        self.reconcile('activate', 'ca-2026-09')
+        self.assertNotIn('pending-ca.crt', getattr(self.api.secrets['ca'], 'data'))
+        self.reconcile('activate', 'ca-2026-09')
+        activated_bundle = x509.load_pem_x509_certificates(
+            self.secret_value('trust', 'ca.crt')
+        )
+        self.assertEqual(len(activated_bundle), 2)
+        self.assertNotEqual(self.secret_value('ca', 'ca.crt'), original_ca)
+        self.assertNotEqual(self.secret_value('leaf', 'tls.crt'), original_leaf)
+
+        self.reconcile('retire', 'ca-2026-09')
+        retired_bundle = x509.load_pem_x509_certificates(
+            self.secret_value('trust', 'ca.crt')
+        )
+        self.assertEqual(len(retired_bundle), 1)
+        self.assertNotIn('previous-ca.crt', getattr(self.api.secrets['ca'], 'data'))
+
+        # The retained Helm value remains safe on later upgrades.
+        self.reconcile('retire', 'ca-2026-09')
+
+    def test_activate_retry_after_partial_write_preserves_dual_trust(self) -> None:
+        self.reconcile()
+        original_ca = self.secret_value('ca', 'ca.crt')
+        self.reconcile('prepare', 'ca-2026-09')
+        self.api.fail_next_replace.add('trust')
+
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            r'trust: Kubernetes API 503 Unavailable',
+        ):
+            self.reconcile('activate', 'ca-2026-09')
+
+        self.reconcile('activate', 'ca-2026-09')
+        bundle = x509.load_pem_x509_certificates(
+            self.secret_value('trust', 'ca.crt')
+        )
+        self.assertEqual(len(bundle), 2)
+        self.assertIn(original_ca, self.secret_value('trust', 'ca.crt'))
+        self.assertNotIn('pending-ca.crt', getattr(self.api.secrets['ca'], 'data'))
+
+    def test_concurrent_secret_update_is_rejected_by_resource_version_cas(self) -> None:
+        self.reconcile()
+        stale_ca = self.api.read_namespaced_secret('ca', 'osmo')
+        self.api.secrets['ca'].metadata.resource_version = '99'
+
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            r'ca: Kubernetes API 409 Conflict',
+        ):
+            internal_tls_bootstrap._replace_secret(  # pylint: disable=protected-access
+                self.api,  # type: ignore[arg-type]
+                'osmo',
+                stale_ca,
+                'Opaque',
+                {'ca.crt': b'not-written'},
+            )
+
+    def test_ca_rotation_cannot_retire_a_prepared_ca(self) -> None:
+        self.reconcile()
+        self.reconcile('prepare', 'ca-2026-09')
+
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'activated first',
+        ):
+            self.reconcile('retire', 'ca-2026-09')
+
+    def test_ca_rotation_cannot_retire_with_an_old_leaf(self) -> None:
+        self.reconcile()
+        old_leaf_data = dict(getattr(self.api.secrets['leaf'], 'data'))
+        self.reconcile('prepare', 'ca-2026-09')
+        self.reconcile('activate', 'ca-2026-09')
+        setattr(self.api.secrets['leaf'], 'data', old_leaf_data)
+
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'every leaf Secret to use the active CA',
+        ):
+            self.reconcile('retire', 'ca-2026-09')
+
+        trust_bundle = x509.load_pem_x509_certificates(
+            self.secret_value('trust', 'ca.crt')
+        )
+        self.assertEqual(len(trust_bundle), 2)
+
+    def test_upgrade_never_regenerates_a_missing_ca(self) -> None:
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'incomplete; restore it',
+        ):
+            self.reconcile(fail_if_missing=True)
+
+    def test_replaces_leaf_that_is_not_signed_by_the_retained_ca(self) -> None:
+        self.reconcile()
+        rogue_ca = internal_tls_bootstrap._generate_ca(self.now)  # pylint: disable=protected-access
+        rogue_leaf = internal_tls_bootstrap._generate_leaf(  # pylint: disable=protected-access
+            rogue_ca,
+            'osmo-api',
+            'osmo',
+            self.now,
+        )
+        leaf_secret = self.api.secrets['leaf']
+        setattr(
+            leaf_secret,
+            'data',
+            internal_tls_bootstrap._encode_secret_data(  # pylint: disable=protected-access
+                {
+                    'tls.crt': rogue_leaf.certificate,
+                    'tls.key': rogue_leaf.private_key,
+                    'rotation-nonce': b'leaf-v1',
+                }
+            ),
+        )
+
+        self.reconcile(fail_if_missing=True)
+
+        self.assertNotEqual(self.secret_value('leaf', 'tls.crt'), rogue_leaf.certificate)
+
+    def test_replaces_leaf_with_the_wrong_dns_identity(self) -> None:
+        self.reconcile()
+        ca = internal_tls_bootstrap.KeyPair(
+            self.secret_value('ca', 'ca.crt'),
+            self.secret_value('ca', 'ca.key'),
+        )
+        wrong_leaf = internal_tls_bootstrap._generate_leaf(  # pylint: disable=protected-access
+            ca,
+            'wrong-service',
+            'osmo',
+            self.now,
+        )
+        leaf_secret = self.api.secrets['leaf']
+        setattr(
+            leaf_secret,
+            'data',
+            internal_tls_bootstrap._encode_secret_data(  # pylint: disable=protected-access
+                {
+                    'tls.crt': wrong_leaf.certificate,
+                    'tls.key': wrong_leaf.private_key,
+                    'rotation-nonce': b'leaf-v1',
+                }
+            ),
+        )
+
+        self.reconcile(fail_if_missing=True)
+
+        self.assertNotEqual(self.secret_value('leaf', 'tls.crt'), wrong_leaf.certificate)
+
+    def test_refuses_secret_owned_by_another_release(self) -> None:
+        self.api.add_placeholder('ca', release_name='other')
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'not owned by release test',
+        ):
+            self.reconcile()
+
+    def test_rotation_requires_durable_rollout_proof(self) -> None:
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'requires verified consumer rollout state',
+        ):
+            internal_tls_bootstrap.reconcile(
+                self.api,  # type: ignore[arg-type]
+                namespace='osmo',
+                release_name='test',
+                ca_secret_name='ca',
+                trust_secret_name='trust',
+                leaf_specs=[internal_tls_bootstrap.LeafSpec('leaf', 'osmo-api')],
+                leaf_rotation_nonce='leaf-v1',
+                ca_rotation_id='ca-2026-09',
+                ca_rotation_phase='prepare',
+                fail_if_missing=False,
+                now=self.now,
+            )
+
+
+class RolloutVerificationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.annotation = 'ca-2026-09:prepare'
+        self.deployment = SimpleNamespace(
+            metadata=SimpleNamespace(generation=3),
+            spec=SimpleNamespace(
+                replicas=2,
+                selector=SimpleNamespace(match_labels={'app': 'api'}),
+            ),
+            status=SimpleNamespace(
+                observed_generation=3,
+                replicas=2,
+                updated_replicas=2,
+                ready_replicas=2,
+                available_replicas=2,
+                unavailable_replicas=0,
+            ),
+        )
+        self.pods = [
+            SimpleNamespace(
+                metadata=SimpleNamespace(
+                    annotations={
+                        'checksum/internal-tls-ca-phase': self.annotation
+                    },
+                    deletion_timestamp=None,
+                ),
+                status=SimpleNamespace(phase='Running'),
+            )
+            for _ in range(2)
+        ]
+
+    def verify(self, *, hpas: list[object] | None = None) -> None:
+        core_api = SimpleNamespace(
+            list_namespaced_pod=lambda **_kwargs: SimpleNamespace(items=self.pods)
+        )
+        apps_api = SimpleNamespace(
+            read_namespaced_deployment=lambda **_kwargs: self.deployment
+        )
+        autoscaling_api = SimpleNamespace(
+            list_namespaced_horizontal_pod_autoscaler=lambda **_kwargs: (
+                SimpleNamespace(items=hpas or [])
+            )
+        )
+        internal_tls_bootstrap.verify_rollout(
+            core_api,  # type: ignore[arg-type]
+            apps_api,  # type: ignore[arg-type]
+            autoscaling_api,  # type: ignore[arg-type]
+            namespace='osmo',
+            deployment_names=['osmo-api'],
+            allowed_annotations={self.annotation},
+        )
+
+    def test_accepts_one_complete_frozen_generation(self) -> None:
+        self.verify()
+
+    def test_rejects_a_partial_rollout(self) -> None:
+        self.deployment.status.updated_replicas = 1
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'complete consumer rollout',
+        ):
+            self.verify()
+
+    def test_rejects_an_unfrozen_hpa(self) -> None:
+        hpa = SimpleNamespace(
+            spec=SimpleNamespace(
+                scale_target_ref=SimpleNamespace(kind='Deployment', name='osmo-api'),
+                min_replicas=1,
+                max_replicas=3,
+            )
+        )
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'HPA to be frozen',
+        ):
+            self.verify(hpas=[hpa])
+
+    def test_rejects_a_pod_from_the_wrong_phase(self) -> None:
+        self.pods[0].metadata.annotations[
+            'checksum/internal-tls-ca-phase'
+        ] = 'ca-2026-09:stable'
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'wrong phase',
+        ):
+            self.verify()
+
+    def verify_transition(
+        self,
+        *,
+        stored_phase: str,
+        pod_annotations: list[str],
+        requested_phase: str = 'activate',
+    ) -> None:
+        encoded = internal_tls_bootstrap._encode_secret_data(  # pylint: disable=protected-access
+            {
+                'rotation-id': b'ca-2026-09',
+                'rotation-phase': stored_phase.encode('utf-8'),
+            }
+        )
+        secret = SimpleNamespace(
+            metadata=SimpleNamespace(
+                name='ca',
+                labels={
+                    'app.kubernetes.io/managed-by': (
+                        'osmo-internal-tls-bootstrap'
+                    ),
+                    'app.kubernetes.io/instance': 'test',
+                },
+            ),
+            data=encoded,
+        )
+        pods = [
+            SimpleNamespace(
+                metadata=SimpleNamespace(
+                    annotations={'checksum/internal-tls-ca-phase': annotation},
+                    deletion_timestamp=None,
+                ),
+                status=SimpleNamespace(phase='Running'),
+            )
+            for annotation in pod_annotations
+        ]
+        core_api = SimpleNamespace(
+            read_namespaced_secret=lambda **_kwargs: secret,
+            list_namespaced_pod=lambda **_kwargs: SimpleNamespace(items=pods),
+        )
+        apps_api = SimpleNamespace(
+            read_namespaced_deployment=lambda **_kwargs: self.deployment
+        )
+        autoscaling_api = SimpleNamespace(
+            list_namespaced_horizontal_pod_autoscaler=lambda **_kwargs: (
+                SimpleNamespace(items=[])
+            )
+        )
+        internal_tls_bootstrap.verify_transition_rollout(
+            core_api,  # type: ignore[arg-type]
+            apps_api,  # type: ignore[arg-type]
+            autoscaling_api,  # type: ignore[arg-type]
+            namespace='osmo',
+            release_name='test',
+            ca_secret_name='ca',
+            deployment_names=['osmo-api'],
+            requested_rotation_id='ca-2026-09',
+            requested_phase=requested_phase,
+        )
+
+    def test_transition_accepts_complete_predecessor_generation(self) -> None:
+        self.verify_transition(
+            stored_phase='prepare',
+            pod_annotations=['ca-2026-09:prepare'] * 2,
+        )
+
+    def test_transition_retry_accepts_only_predecessor_and_target_pods(self) -> None:
+        self.deployment.status.updated_replicas = 1
+        self.deployment.status.ready_replicas = 1
+        self.deployment.status.available_replicas = 1
+        self.deployment.status.unavailable_replicas = 1
+        self.verify_transition(
+            stored_phase='activate',
+            pod_annotations=[
+                'ca-2026-09:prepare',
+                'ca-2026-09:activate',
+            ],
+        )
+
+    def test_transition_retry_accepts_completed_target_generation(self) -> None:
+        self.verify_transition(
+            stored_phase='activate',
+            pod_annotations=['ca-2026-09:activate'] * 2,
+        )
+
+    def test_retire_retry_accepts_partial_target_generation(self) -> None:
+        self.deployment.status.updated_replicas = 1
+        self.deployment.status.ready_replicas = 1
+        self.deployment.status.available_replicas = 1
+        self.deployment.status.unavailable_replicas = 1
+        self.verify_transition(
+            stored_phase='retire',
+            requested_phase='retire',
+            pod_annotations=[
+                'ca-2026-09:activate',
+                'ca-2026-09:retire',
+            ],
+        )
+
+    def test_transition_retry_rejects_unrelated_mixed_generation(self) -> None:
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'wrong phase',
+        ):
+            self.verify_transition(
+                stored_phase='activate',
+                pod_annotations=[
+                    'ca-2026-09:prepare',
+                    'other:retire',
+                ],
+            )
+
+    def test_transition_rejects_skipped_durable_phase(self) -> None:
+        with self.assertRaisesRegex(
+            internal_tls_bootstrap.BootstrapError,
+            'requires the durable prepare phase',
+        ):
+            self.verify_transition(
+                stored_phase='stable',
+                pod_annotations=['ca-2026-09:stable'] * 2,
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/smoke/BUILD
+++ b/test/smoke/BUILD
@@ -56,3 +56,12 @@ oetf_smoke_test(
     tags = ["database", "kind"],
     timeout = "long",
 )
+
+oetf_smoke_test(
+    name = "oauth-cookie-kind",
+    src = "oauth_cookie_kind.py",
+    data = ["//deployments/charts:osmo"],
+    extra_deps = [requirement("cryptography")],
+    size = "medium",
+    tags = ["auth", "kind"],
+)

--- a/test/smoke/oauth_cookie_kind.py
+++ b/test/smoke/oauth_cookie_kind.py
@@ -1,0 +1,407 @@
+"""KIND coverage for the unified chart's generated OAuth cookie Secret."""
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from cryptography import x509
+
+from test.oetf.smoke_fixture import SmokeFixture
+
+
+class OauthCookieKind(SmokeFixture):
+    """Exercise Helm lookup, retention, and old-release compatibility."""
+
+    @staticmethod
+    def _run(command, expected_success=True):
+        result = subprocess.run(
+            command, check=False, capture_output=True, text=True, timeout=180)
+        if (result.returncode == 0) != expected_success:
+            command_text = " ".join(command)
+            raise RuntimeError(
+                f"{command_text} exited {result.returncode}: "
+                f"{result.stderr.strip()}")
+        return result
+
+    @staticmethod
+    def _chart_path():
+        return os.path.join(
+            os.environ["TEST_SRCDIR"], os.environ["TEST_WORKSPACE"],
+            "deployments", "charts", "osmo")
+
+    def test_generated_oauth_cookie_helm_lifecycle(self):
+        suffix = secrets.token_hex(4)
+        namespace = f"oauth-cookie-{suffix}"
+        release = f"oauth-cookie-{suffix}"
+        legacy_release = f"oauth-existing-{suffix}"
+        chart = self._chart_path()
+        profile = os.path.join(chart, "profiles", "split-plane-control.yaml")
+        external = os.path.join(chart, "tests", "control-external-values.yaml")
+        generated_secret = f"{release}-osmo-oauth-cookie"
+
+        def kubectl(*args, expected_success=True):
+            return self._run(
+                ["kubectl", "--namespace", namespace, *args], expected_success)
+
+        def helm_apply(target_release, *extra, reuse_values=False,
+                       expected_success=True, chart_path=None):
+            command = [
+                "helm", "upgrade", target_release, chart_path or chart,
+                "--namespace", namespace, "--no-hooks",
+            ]
+            if reuse_values:
+                command.append("--reuse-values")
+            else:
+                command.extend([
+                    "--install", "-f", profile, "-f", external,
+                    "--set", "gateway.oauth2Proxy.enabled=true",
+                    "--set",
+                    "secrets.oauthClientSecret.existingSecret=operator-oauth-client",
+                ])
+            command.extend(extra)
+            return self._run(command, expected_success)
+
+        def secret():
+            return json.loads(kubectl(
+                "get", "secret", generated_secret, "-o", "json").stdout)
+
+        self.addCleanup(
+            subprocess.run,
+            ["kubectl", "delete", "namespace", namespace,
+             "--ignore-not-found=true", "--wait=true", "--timeout=45s"],
+            check=False, capture_output=True, text=True)
+        self._run(["kubectl", "create", "namespace", namespace])
+
+        helm_apply(
+            release,
+            "--set", "secrets.oauthCookieSecret.generate=true",
+            "--set-string", "secrets.oauthCookieSecret.existingSecret=")
+        initial = secret()
+        initial_uid = initial["metadata"]["uid"]
+        initial_data = initial["data"]["cookie_secret"]
+        mounted = base64.b64decode(initial_data).decode("ascii")
+        self.assertRegex(mounted, re.compile(r"^[A-Za-z0-9_-]{43}=$"))
+        self.assertEqual(32, len(base64.urlsafe_b64decode(mounted)))
+
+        helm_apply(release, reuse_values=True)
+        upgraded = secret()
+        self.assertEqual(initial_uid, upgraded["metadata"]["uid"])
+        self.assertEqual(initial_data, upgraded["data"]["cookie_secret"])
+
+        self._run(["helm", "uninstall", release, "--namespace", namespace])
+        retained = secret()
+        self.assertEqual(initial_uid, retained["metadata"]["uid"])
+        self.assertEqual(initial_data, retained["data"]["cookie_secret"])
+        helm_apply(
+            release,
+            "--set", "secrets.oauthCookieSecret.generate=true",
+            "--set-string", "secrets.oauthCookieSecret.existingSecret=")
+        reinstalled = secret()
+        self.assertEqual(initial_uid, reinstalled["metadata"]["uid"])
+        self.assertEqual(initial_data, reinstalled["data"]["cookie_secret"])
+
+        kubectl(
+            "label", "secret", generated_secret,
+            "app.kubernetes.io/instance=another-release", "--overwrite")
+        foreign = helm_apply(release, reuse_values=True, expected_success=False)
+        self.assertIn("is not owned by this release", foreign.stderr)
+        kubectl(
+            "label", "secret", generated_secret,
+            f"app.kubernetes.io/instance={release}", "--overwrite")
+
+        kubectl(
+            "annotate", "secret", generated_secret,
+            "meta.helm.sh/release-name=another-release", "--overwrite")
+        foreign_annotation = helm_apply(
+            release, reuse_values=True, expected_success=False)
+        self.assertIn("is not owned by this release", foreign_annotation.stderr)
+        kubectl(
+            "annotate", "secret", generated_secret,
+            f"meta.helm.sh/release-name={release}", "--overwrite")
+
+        kubectl(
+            "patch", "secret", generated_secret, "--type=merge",
+            "--patch", json.dumps({"type": "example.com/foreign"}))
+        invalid_type = helm_apply(
+            release, reuse_values=True, expected_success=False)
+        self.assertIn("has an invalid type", invalid_type.stderr)
+        kubectl(
+            "patch", "secret", generated_secret, "--type=merge",
+            "--patch", json.dumps({"type": "Opaque"}))
+
+        sentinel = base64.b64encode(b"OAUTH-COOKIE-DO-NOT-LOG").decode("ascii")
+        kubectl(
+            "patch", "secret", generated_secret, "--type=merge",
+            "--patch", json.dumps({"data": {"cookie_secret": sentinel}}))
+        malformed = helm_apply(release, reuse_values=True, expected_success=False)
+        self.assertIn("key cookie_secret is invalid", malformed.stderr)
+        self.assertNotIn(sentinel, malformed.stderr)
+
+        kubectl("delete", "secret", generated_secret)
+        missing = helm_apply(release, reuse_values=True, expected_success=False)
+        self.assertIn("is missing during upgrade; restore it", missing.stderr)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            legacy_chart = os.path.join(temporary_directory, "osmo")
+            shutil.copytree(chart, legacy_chart)
+            values_path = Path(legacy_chart, "values.yaml")
+            legacy_values, replacements = re.subn(
+                r"(  oauthCookieSecret:\n(?:    #[^\n]*\n)*)"
+                r"    generate: false\n",
+                r"\1", values_path.read_text(encoding="utf-8"), count=1)
+            self.assertEqual(1, replacements)
+            values_path.write_text(legacy_values, encoding="utf-8")
+            helm_apply(
+                legacy_release,
+                "--set", "secrets.oauthCookieSecret.existingSecret=operator-cookie",
+                chart_path=legacy_chart)
+            stored = json.loads(self._run([
+                "helm", "get", "values", legacy_release,
+                "--namespace", namespace, "-o", "json",
+            ]).stdout)
+            self.assertNotIn("generate", stored["secrets"]["oauthCookieSecret"])
+        helm_apply(legacy_release, reuse_values=True)
+        oauth_deployment = json.loads(kubectl(
+            "get", "deployment",
+            f"{legacy_release}-osmo-gateway-oauth2-proxy",
+            "-o", "json").stdout)
+        cookie_volume = next(
+            volume for volume in oauth_deployment["spec"]["template"]["spec"]["volumes"]
+            if volume["name"] == "oauth-cookie-secret")
+        self.assertEqual(
+            "operator-cookie", cookie_volume["secret"]["secretName"])
+
+    def test_unified_generated_and_existing_secret_modes(self):
+        """Install the unified chart in both supported OAuth/TLS modes."""
+        suffix = secrets.token_hex(4)
+        generated_namespace = f"secret-generated-{suffix}"
+        existing_namespace = f"secret-existing-{suffix}"
+        generated_release = f"secret-generated-{suffix}"
+        existing_release = f"secret-existing-{suffix}"
+        chart = self._chart_path()
+        profile = os.path.join(chart, "profiles", "split-plane-control.yaml")
+        external = os.path.join(chart, "tests", "control-external-values.yaml")
+        osmo_namespace = os.environ.get("OSMO_NAMESPACE", "osmo")
+
+        deployments = json.loads(self._run([
+            "kubectl", "--namespace", osmo_namespace,
+            "get", "deployments", "-o", "json",
+        ]).stdout)["items"]
+        service_images = [
+            container["image"]
+            for deployment in deployments
+            for container in deployment["spec"]["template"]["spec"]["containers"]
+            if container.get("command") == ["service"]
+        ]
+        self.assertEqual(1, len(service_images))
+        bootstrap_image = service_images[0]
+
+        for namespace in (generated_namespace, existing_namespace):
+            self.addCleanup(
+                subprocess.run,
+                ["kubectl", "delete", "namespace", namespace,
+                 "--ignore-not-found=true", "--wait=true", "--timeout=45s"],
+                check=False, capture_output=True, text=True)
+            self._run(["kubectl", "create", "namespace", namespace])
+
+        generated_client = f"{generated_release}-oauth-client"
+        self._run([
+            "kubectl", "--namespace", generated_namespace,
+            "create", "secret", "generic", generated_client,
+            "--from-literal=client_secret=generated-mode-client",
+        ])
+        self._run([
+            "helm", "install", generated_release, chart,
+            "--namespace", generated_namespace,
+            "-f", profile, "-f", external,
+            "--set", "gateway.oauth2Proxy.enabled=true",
+            "--set-string",
+            f"secrets.oauthClientSecret.existingSecret={generated_client}",
+            "--set", "secrets.oauthCookieSecret.generate=true",
+            "--set-string", "secrets.oauthCookieSecret.existingSecret=",
+            "--set", "gateway.tls.enabled=true",
+            "--set", "gateway.tls.generated.enabled=true",
+            "--set-string",
+            f"gateway.tls.generated.bootstrap.image={bootstrap_image}",
+            "--set", "gateway.tls.generated.bootstrap.imagePullPolicy=IfNotPresent",
+            "--timeout", "5m",
+        ])
+        generated_status = json.loads(self._run([
+            "helm", "status", generated_release,
+            "--namespace", generated_namespace, "-o", "json",
+        ]).stdout)
+        self.assertEqual("deployed", generated_status["info"]["status"])
+
+        generated_prefix = f"{generated_release}-osmo"
+        ca_secret = json.loads(self._run([
+            "kubectl", "--namespace", generated_namespace,
+            "get", "secret", f"{generated_prefix}-internal-tls-ca",
+            "-o", "json",
+        ]).stdout)
+        ca_certificate = x509.load_pem_x509_certificate(
+            base64.b64decode(ca_secret["data"]["ca.crt"]))
+        self.assertEqual(ca_certificate.subject, ca_certificate.issuer)
+        self.assertTrue(ca_secret["data"]["ca.key"])
+
+        trust_secret = json.loads(self._run([
+            "kubectl", "--namespace", generated_namespace,
+            "get", "secret", f"{generated_prefix}-internal-tls-trust",
+            "-o", "json",
+        ]).stdout)
+        self.assertEqual(
+            ca_secret["data"]["ca.crt"], trust_secret["data"]["ca.crt"])
+        for component in ("api", "router", "agent", "logger"):
+            leaf_secret = json.loads(self._run([
+                "kubectl", "--namespace", generated_namespace,
+                "get", "secret", f"{generated_prefix}-internal-tls-{component}",
+                "-o", "json",
+            ]).stdout)
+            leaf_certificate = x509.load_pem_x509_certificate(
+                base64.b64decode(leaf_secret["data"]["tls.crt"]))
+            self.assertEqual(ca_certificate.subject, leaf_certificate.issuer)
+            self.assertTrue(leaf_secret["data"]["tls.key"])
+
+        generated_cookie = json.loads(self._run([
+            "kubectl", "--namespace", generated_namespace,
+            "get", "secret", f"{generated_prefix}-oauth-cookie", "-o", "json",
+        ]).stdout)
+        mounted_cookie = base64.b64decode(
+            generated_cookie["data"]["cookie_secret"]).decode("ascii")
+        self.assertRegex(mounted_cookie, re.compile(r"^[A-Za-z0-9_-]{43}=$"))
+        self.assertEqual(32, len(base64.urlsafe_b64decode(mounted_cookie)))
+
+        generated_api = json.loads(self._run([
+            "kubectl", "--namespace", generated_namespace,
+            "get", "deployment", f"{generated_prefix}-api", "-o", "json",
+        ]).stdout)
+        generated_api_secrets = {
+            volume["secret"]["secretName"]
+            for volume in generated_api["spec"]["template"]["spec"]["volumes"]
+            if "secret" in volume
+        }
+        self.assertIn(
+            f"{generated_prefix}-internal-tls-api", generated_api_secrets)
+        generated_oauth = json.loads(self._run([
+            "kubectl", "--namespace", generated_namespace,
+            "get", "deployment", f"{generated_prefix}-gateway-oauth2-proxy",
+            "-o", "json",
+        ]).stdout)
+        generated_oauth_secrets = {
+            volume["secret"]["secretName"]
+            for volume in generated_oauth["spec"]["template"]["spec"]["volumes"]
+            if "secret" in volume
+        }
+        self.assertIn(generated_client, generated_oauth_secrets)
+        self.assertIn(f"{generated_prefix}-oauth-cookie", generated_oauth_secrets)
+        missing_generated_rbac = self._run([
+            "kubectl", "--namespace", generated_namespace,
+            "get", "rolebinding", f"{generated_prefix}-internal-tls-bootstrap",
+        ], expected_success=False)
+        self.assertIn("NotFound", missing_generated_rbac.stderr)
+
+        existing_client = f"{existing_release}-oauth-client"
+        existing_cookie = f"{existing_release}-oauth-cookie"
+        existing_trust = f"{existing_release}-tls-trust"
+        existing_leaves = {
+            component: f"{existing_release}-tls-{component}"
+            for component in ("api", "router", "agent", "logger")
+        }
+        operator_secrets = {
+            existing_client: ["--from-literal=client_secret=existing-mode-client"],
+            existing_cookie: [
+                "--from-literal=cookie_secret="
+                + base64.urlsafe_b64encode(secrets.token_bytes(32)).decode("ascii")
+            ],
+            existing_trust: ["--from-literal=ca.crt=operator-ca"],
+        }
+        for leaf_name in existing_leaves.values():
+            operator_secrets[leaf_name] = [
+                "--from-literal=tls.crt=operator-certificate",
+                "--from-literal=tls.key=operator-private-key",
+            ]
+        before = {}
+        for secret_name, literal_args in operator_secrets.items():
+            self._run([
+                "kubectl", "--namespace", existing_namespace,
+                "create", "secret", "generic", secret_name, *literal_args,
+            ])
+            before[secret_name] = json.loads(self._run([
+                "kubectl", "--namespace", existing_namespace,
+                "get", "secret", secret_name, "-o", "json",
+            ]).stdout)
+
+        existing_command = [
+            "helm", "install", existing_release, chart,
+            "--namespace", existing_namespace,
+            "-f", profile, "-f", external,
+            "--set", "gateway.oauth2Proxy.enabled=true",
+            "--set-string",
+            f"secrets.oauthClientSecret.existingSecret={existing_client}",
+            "--set", "secrets.oauthCookieSecret.generate=false",
+            "--set-string",
+            f"secrets.oauthCookieSecret.existingSecret={existing_cookie}",
+            "--set", "gateway.tls.enabled=true",
+            "--set", "gateway.tls.generated.enabled=false",
+            "--set-string", f"gateway.tls.caSecret={existing_trust}",
+        ]
+        for component, secret_name in existing_leaves.items():
+            existing_command.extend([
+                "--set-string",
+                f"gateway.tls.upstreamCerts.{component}={secret_name}",
+            ])
+        existing_command.extend(["--timeout", "5m"])
+        self._run(existing_command)
+
+        existing_status = json.loads(self._run([
+            "helm", "status", existing_release,
+            "--namespace", existing_namespace, "-o", "json",
+        ]).stdout)
+        self.assertEqual("deployed", existing_status["info"]["status"])
+        for secret_name, original in before.items():
+            observed = json.loads(self._run([
+                "kubectl", "--namespace", existing_namespace,
+                "get", "secret", secret_name, "-o", "json",
+            ]).stdout)
+            self.assertEqual(original["metadata"]["uid"], observed["metadata"]["uid"])
+            self.assertEqual(original["data"], observed["data"])
+
+        existing_prefix = f"{existing_release}-osmo"
+        existing_api = json.loads(self._run([
+            "kubectl", "--namespace", existing_namespace,
+            "get", "deployment", f"{existing_prefix}-api", "-o", "json",
+        ]).stdout)
+        existing_api_secrets = {
+            volume["secret"]["secretName"]
+            for volume in existing_api["spec"]["template"]["spec"]["volumes"]
+            if "secret" in volume
+        }
+        self.assertIn(existing_leaves["api"], existing_api_secrets)
+        existing_envoy = json.loads(self._run([
+            "kubectl", "--namespace", existing_namespace,
+            "get", "deployment", f"{existing_prefix}-gateway-envoy", "-o", "json",
+        ]).stdout)
+        existing_envoy_secrets = {
+            volume["secret"]["secretName"]
+            for volume in existing_envoy["spec"]["template"]["spec"]["volumes"]
+            if "secret" in volume
+        }
+        self.assertIn(existing_trust, existing_envoy_secrets)
+        unexpected_ca = self._run([
+            "kubectl", "--namespace", existing_namespace,
+            "get", "secret", f"{existing_prefix}-internal-tls-ca",
+        ], expected_success=False)
+        self.assertIn("NotFound", unexpected_ca.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Issue #None

Implements the remaining Kubernetes-native Secret handling tracked by OSMO-6590,
OSMO-6594, and OSMO-6596 on top of the MEK lifecycle delivered in #1307.
This PR is scoped to the unified `deployments/charts/osmo` chart; the legacy
`deployments/charts/service` chart is unchanged.

- adds typed existing-Secret contracts and rollout controls for PostgreSQL,
  Valkey, object-storage, backend API token, and OAuth credentials
- preserves operator-owned and development-managed backend API token modes
  without rendering token material into Helm values or manifests
- keeps OAuth client credentials operator-owned and supports either an existing
  OAuth2 Proxy cookie Secret or optional Helm generation for direct-Helm
  development/test installs
- replaces process-local internal certificates with stable Kubernetes Secrets
  and supports generated development PKI or operator-provided production PKI
- makes generated PKI rotation resourceVersion-CAS protected, uses data-less
  Opaque placeholders that are safe under offline GitOps reconciliation, and
  removes privileged bootstrap RBAC after successful or failed hooks
- provides an explicit one-upgrade gate and value normalization for the first
  stable-TLS upgrade of the unified chart
- validates Secret names, keys, types, and mutually exclusive modes with
  redaction-safe errors and chart-owned mount paths
- documents coordinated cookie, leaf-certificate, and dual-trust CA rotation

Production and GitOps deployments use operator-owned existing Secrets. This PR
does not add MEK database tables, triggers, or lifecycle DDL; MEK rollout remains
the Kubernetes Lease and pod cohort mechanism from #1307.

## Validation

- `bash deployments/charts/osmo/tests/test_osmo_charts.sh osmo`
- `bazel test //src/utils/tests:test_internal_tls_bootstrap //src/service/core/auth/tests:test_backend_secret_auth`
- `bazel test //test/smoke:oauth-cookie-kind-pylint`
- `bazel build //test/smoke:oauth-cookie-kind //src/service/core:service_image_layers`
- `git diff --check origin/main`
- verified no diff under `deployments/charts/service`, `deployments/scripts`,
  `test/oetf`, or `src/service/mcp`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
