### PR TITLE
Replace localstack with ministack

### DIFF
--- a/src/tests/common/storage/s3.py
+++ b/src/tests/common/storage/s3.py
@@ -28,9 +28,7 @@ from src.tests.common.core import network, utils
 
 logger = logging.getLogger(__name__)
 
-# TODO: Switch the localstack image
-#   https://blog.localstack.cloud/localstack-for-aws-release-2026-03-0/
-S3_IMAGE = f'{utils.DOCKER_HUB_REGISTRY}/localstack/localstack:s3-community-archive'
+S3_IMAGE = f'{utils.DOCKER_HUB_REGISTRY}/ministackorg/ministack:1.4.16'
 S3_NAME = f's3-{labels.SESSION_ID}'
 S3_PORT = 4566
 S3_REGION = 'us-east-1'


### PR DESCRIPTION
Swaps the S3 test container image from `localstack/localstack:s3-community-archive` to `ministackorg/ministack:1.4.16`, resolving the existing `TODO: Switch the localstack image`. ministack is an open-source (MIT) AWS emulator that serves the S3 API on the same port (4566) and works under the existing `LocalStackContainer` fixture with no other changes.

Disclosure: I maintain ministack.

Verified locally by reproducing this file's Testcontainers usage against ministack — the `NetworkAwareLocalStackContainer` start-override pattern, `with_services('s3')`, and `get_client('s3')`, then `create_bucket`, `put_object`/`get_object`, and `list_buckets` on `test-bucket` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated S3 test environments to use the maintained MiniStack container image.
  * Improved test reliability by replacing the archived LocalStack S3 Community image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->