### PR TITLE
Use FastMCP OIDCProxy for MCP authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ bash deployments/charts/service/tests/render-tests.sh
 | `service/agent/` | Backend cluster integration via WebSocket. Receives node/pod/event/heartbeat streams from K8s clusters. |
 | `service/logger/` | Receives structured logs from osmo-ctrl containers. Persists task metrics to PostgreSQL. Distributed barriers via Redis. |
 | `service/delayed_job_monitor/` | Polls Redis for scheduled jobs, promotes to main queue when ready. |
-| `service/mcp/` | Serves the stateless Streamable HTTP MCP endpoint for external OSMO clients. |
+| `service/mcp/` | Serves the Streamable HTTP MCP endpoint and optionally attaches FastMCP's built-in OIDC proxy for endpoint-only client authentication. |
 
 ### Deployment Charts (`deployments/charts/`)
 

--- a/bzl/mypy/BUILD
+++ b/bzl/mypy/BUILD
@@ -35,6 +35,7 @@ mypy_cli(
     deps =[
         app_requirement("certifi"),
         app_requirement("fastapi"),
+        app_requirement("fastmcp-slim"),
         app_requirement("jinja2"),
         app_requirement("lark"),
         app_requirement("mcp"),
@@ -43,6 +44,7 @@ mypy_cli(
         app_requirement("mypy-boto3-sts"),
         app_requirement("opentelemetry-sdk"),
         app_requirement("pydantic"),
+        app_requirement("py-key-value-aio"),
         app_requirement("pyjwt"),
         app_requirement("shtab"),
         app_requirement("slack_sdk"),

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -106,6 +106,7 @@ destination, but it cannot validate external DNS.
 | `services.mcp.extraVolumes` | Additional MCP pod volumes. | `[]` |
 | `services.mcp.oidcProxy.enabled` | Enable FastMCP's built-in OIDC proxy inside the existing MCP process. It advertises CIMD and retains DCR as a compatibility fallback. | `false` |
 | `services.mcp.oidcProxy.scope` | Full delegated scope URI advertised to MCP clients and requested upstream, normally `<resourceUrl>/access_as_user`. | `""` |
+| `services.mcp.oidcProxy.trustedHttpsRedirectOrigins` | Exact HTTPS origins allowed for pre-registered web-client redirects; native clients use loopback redirects. | `[]` |
 | `services.mcp.oidcProxy.oidc.configUrl` | Upstream OIDC discovery URL. | `""` |
 | `services.mcp.oidcProxy.oidc.clientId` | Administrator-managed confidential OIDC application client ID. | `""` |
 | `services.mcp.oidcProxy.oidc.clientSecretFile` | Mounted file containing the upstream OIDC client secret. | `/etc/osmo/mcp-auth/client-secret` |
@@ -114,6 +115,9 @@ destination, but it cannot validate external DNS.
 | `services.mcp.oidcProxy.oidc.accessTokenJwksUrl` | HTTPS JWKS URL used to verify upstream API access tokens. | `""` |
 | `services.mcp.oidcProxy.oidc.accessTokenRequiredScope` | Short scope value required in the upstream access token's `scp` claim. | `access_as_user` |
 | `services.mcp.oidcProxy.redis` | Redis connection used by FastMCP for registrations, authorization state, and encrypted upstream tokens; blank host/port inherit `services.redis`. | See `values.yaml` |
+| `services.mcp.oidcProxy.accessTokenTtlSeconds` | Lifetime of proxy access tokens, from 60 through 3600 seconds. | `600` |
+| `services.mcp.oidcProxy.refreshTokenTtlSeconds` | Lifetime of proxy refresh tokens, from 300 through 604800 seconds. | `28800` |
+| `services.mcp.oidcProxy.upstreamTimeoutSeconds` | Timeout for upstream OIDC requests, from 1 through 60 seconds. | `10` |
 | `services.mcp.oidcProxy.existingSecret` | Optional existing Secret holding the OIDC client secret and Redis password. The chart references it but never creates credential material. | See `values.yaml` |
 
 The in-process proxy follows OSMO's OIDC profile: a full delegated scope URI is requested
@@ -124,6 +128,12 @@ CIMD-capable clients identify themselves with a hosted metadata document;
 older clients can use FastMCP's `/register` DCR endpoint. Both paths use
 authorization-code flow with PKCE and end in the same OSMO Gateway and semantic
 RBAC checks.
+
+Before production exposure, add route-specific rate limits at the trusted
+ingress for the public authorization, callback, registration, and token
+endpoints. The chart does not choose a default shared bucket because one caller
+could otherwise exhaust it and block every user's login; deployments must
+select both the client-IP trust boundary and suitable limits.
 
 FastMCP deterministically derives its proxy-token signing key and the encrypted
 Redis-store key from the upstream OIDC client secret. Rotating that client

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -75,10 +75,11 @@ OSMO services write logs to standard streams for collection by the platform log 
 ### Self-hosted MCP service
 
 The optional MCP workload exposes predefined OSMO operations to compatible
-native or desktop MCP clients. The Gateway authenticates and authorizes every
-`/mcp` request, and the MCP service relays the unchanged caller bearer through
-the same Gateway for each mapped OSMO API request. The second Gateway pass
-applies the API-specific action; `mcp:Access` alone grants no API permission.
+native or desktop MCP clients. In direct-provider mode, the Gateway validates
+the bearer on `/mcp`. With `oidcProxy.enabled`, FastMCP validates its own proxy
+token and relays the verified upstream access token through the same Gateway
+for each mapped OSMO API request. That API request still passes the deployment's
+normal identity-provider validation and semantic RBAC.
 
 `services.mcp.resourceUrl` is the single source of truth for the public MCP
 resource and the outbound Gateway origin. It must be an externally reachable
@@ -95,17 +96,42 @@ destination, but it cannot validate external DNS.
 | `services.mcp.imageName` | MCP image repository name. | `mcp` |
 | `services.mcp.imageTag` | Per-MCP image tag override; falls back to `global.osmoImageTag` when empty. | `""` |
 | `services.mcp.resourceUrl` | Canonical public HTTPS MCP URL ending in exact `/mcp`; also determines the fixed outbound Gateway origin. | `""` |
-| `services.mcp.authorizationServers` | OAuth/OIDC issuer identifiers advertised in protected-resource metadata. At least one is required when enabled. | `[]` |
-| `services.mcp.scopes` | OAuth scopes advertised in protected-resource metadata. | `[]` |
+| `services.mcp.authorizationServers` | OAuth/OIDC issuers advertised in direct-provider mode; ignored when `oidcProxy.enabled` is true. | `[]` |
+| `services.mcp.scopes` | OAuth scopes advertised in direct-provider mode; ignored when `oidcProxy.enabled` is true. | `[]` |
 | `services.mcp.allowedOrigins` | Exact browser origins permitted on `/mcp`; native clients normally omit `Origin`. | `[]` |
 | `services.mcp.requestTimeoutSeconds` | Total timeout for each MCP-initiated Gateway request, from 1 through 60 seconds. | `10` |
-| `services.mcp.replicas` | Number of stateless MCP replicas. | `1` |
+| `services.mcp.replicas` | Number of MCP replicas. Must remain `1` with `oidcProxy.enabled` because FastMCP 3.4.7 refresh serialization is process-local. | `1` |
 | `services.mcp.extraEnv` | Additional non-managed environment variables. It cannot override MCP host, port, Gateway origin, or request timeout. | `[]` |
+| `services.mcp.extraVolumeMounts` | Additional MCP container volume mounts, including Vault-injected credential files. | `[]` |
+| `services.mcp.extraVolumes` | Additional MCP pod volumes. | `[]` |
+| `services.mcp.oidcProxy.enabled` | Enable FastMCP's built-in OIDC proxy inside the existing MCP process. It advertises CIMD and retains DCR as a compatibility fallback. | `false` |
+| `services.mcp.oidcProxy.scope` | Full delegated scope URI advertised to MCP clients and requested upstream, normally `<resourceUrl>/access_as_user`. | `""` |
+| `services.mcp.oidcProxy.oidc.configUrl` | Upstream OIDC discovery URL. | `""` |
+| `services.mcp.oidcProxy.oidc.clientId` | Administrator-managed confidential OIDC application client ID. | `""` |
+| `services.mcp.oidcProxy.oidc.clientSecretFile` | Mounted file containing the upstream OIDC client secret. | `/etc/osmo/mcp-auth/client-secret` |
+| `services.mcp.oidcProxy.oidc.accessTokenIssuer` | Exact issuer required on upstream API access tokens. | `""` |
+| `services.mcp.oidcProxy.oidc.accessTokenAudience` | Exact OSMO MCP resource audience required on upstream API access tokens; must equal `resourceUrl`. | `""` |
+| `services.mcp.oidcProxy.oidc.accessTokenJwksUrl` | HTTPS JWKS URL used to verify upstream API access tokens. | `""` |
+| `services.mcp.oidcProxy.oidc.accessTokenRequiredScope` | Short scope value required in the upstream access token's `scp` claim. | `access_as_user` |
+| `services.mcp.oidcProxy.redis` | Redis connection used by FastMCP for registrations, authorization state, and encrypted upstream tokens; blank host/port inherit `services.redis`. | See `values.yaml` |
+| `services.mcp.oidcProxy.signingJwksFile` | Private single-key HS256 JWKS mounted only in the MCP pod. | `/etc/osmo/mcp-auth/signing-jwks.json` |
+| `services.mcp.oidcProxy.existingSecret` | Optional existing Secret holding the OIDC client secret, signing JWKS, and Redis password. The chart references it but never creates credential material. | See `values.yaml` |
+
+The in-process proxy follows OSMO's OIDC profile: a full delegated scope URI is requested
+from the upstream provider while its short suffix is enforced in the verified
+API access token. Register the single stable upstream redirect URI
+`<resourceUrl origin>/auth/callback`. MCP clients still configure only `resourceUrl`.
+CIMD-capable clients identify themselves with a hosted metadata document;
+older clients can use FastMCP's `/register` DCR endpoint. Both paths use
+authorization-code flow with PKCE and end in the same OSMO Gateway and semantic
+RBAC checks.
 
 Enabling MCP always renders an ingress NetworkPolicy whose allow rule selects
 only this release's Gateway Envoy pods, even when
 `gateway.networkPolicies.enabled` is false for other upstreams. This is
-required because MCP trusts the identity context created by Gateway.
+required because direct-provider mode trusts the identity context created by
+Gateway, while OIDC-proxy mode accepts traffic only through the same public
+Gateway boundary.
 NetworkPolicies require enforcement by the cluster CNI and are additive, so
 operators must also ensure no other policy grants MCP ingress. The pod does
 not mount a service-account token, and the chart creates no MCP credential

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -114,8 +114,7 @@ destination, but it cannot validate external DNS.
 | `services.mcp.oidcProxy.oidc.accessTokenJwksUrl` | HTTPS JWKS URL used to verify upstream API access tokens. | `""` |
 | `services.mcp.oidcProxy.oidc.accessTokenRequiredScope` | Short scope value required in the upstream access token's `scp` claim. | `access_as_user` |
 | `services.mcp.oidcProxy.redis` | Redis connection used by FastMCP for registrations, authorization state, and encrypted upstream tokens; blank host/port inherit `services.redis`. | See `values.yaml` |
-| `services.mcp.oidcProxy.signingJwksFile` | Private single-key HS256 JWKS mounted only in the MCP pod. | `/etc/osmo/mcp-auth/signing-jwks.json` |
-| `services.mcp.oidcProxy.existingSecret` | Optional existing Secret holding the OIDC client secret, signing JWKS, and Redis password. The chart references it but never creates credential material. | See `values.yaml` |
+| `services.mcp.oidcProxy.existingSecret` | Optional existing Secret holding the OIDC client secret and Redis password. The chart references it but never creates credential material. | See `values.yaml` |
 
 The in-process proxy follows OSMO's OIDC profile: a full delegated scope URI is requested
 from the upstream provider while its short suffix is enforced in the verified
@@ -125,6 +124,12 @@ CIMD-capable clients identify themselves with a hosted metadata document;
 older clients can use FastMCP's `/register` DCR endpoint. Both paths use
 authorization-code flow with PKCE and end in the same OSMO Gateway and semantic
 RBAC checks.
+
+FastMCP deterministically derives its proxy-token signing key and the encrypted
+Redis-store key from the upstream OIDC client secret. Rotating that client
+secret therefore invalidates existing proxy tokens; encrypted entries from the
+old key are treated as cache misses, so clients must sign in again after a
+rotation.
 
 Enabling MCP always renders an ingress NetworkPolicy whose allow rule selects
 only this release's Gateway Envoy pods, even when

--- a/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
+++ b/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Synthetic values used only to validate FastMCP's in-process OIDC proxy.
+services:
+  mcp:
+    enabled: true
+    resourceUrl: https://osmo.example.com/mcp
+    allowedOrigins:
+    - http://localhost:6274
+    oidcProxy:
+      enabled: true
+      scope: https://osmo.example.com/mcp/access_as_user
+      trustedHttpsRedirectOrigins:
+      - https://trusted-client.example.com
+      oidc:
+        configUrl: https://login.example.com/example-tenant/v2.0/.well-known/openid-configuration
+        clientId: example-mcp-proxy-client
+        accessTokenIssuer: https://sts.example.com/example-tenant/
+        accessTokenAudience: https://osmo.example.com/mcp
+        accessTokenJwksUrl: https://login.example.com/example-tenant/discovery/v2.0/keys
+        accessTokenRequiredScope: access_as_user
+      redis:
+        serviceName: proxy-redis.example.internal
+        port: 6380
+        dbNumber: 14
+        tlsEnabled: true
+        passwordFile: /etc/osmo/mcp-auth/redis-password
+        keyPrefix: test:mcp-auth
+      existingSecret:
+        name: mcp-oidc-proxy-secrets
+
+gateway:
+  networkPolicies:
+    enabled: false
+  envoy:
+    jwt:
+      providers:
+      - issuer: https://sts.example.com/example-tenant/
+        audience: https://osmo.example.com/mcp
+        jwks_uri: https://login.example.com/example-tenant/discovery/v2.0/keys
+        cluster: idp
+        user_claim: preferred_username

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -273,6 +273,51 @@ expect_render_failure "$PROXY_VALUES_FILE" \
   --set 'services.mcp.oidcProxy.redis.port=0'
 
 expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy Redis database below range' \
+  'services.mcp.oidcProxy.redis.dbNumber must be between 0 and 15' \
+  --set 'services.mcp.oidcProxy.redis.dbNumber=-1'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy Redis database above range' \
+  'services.mcp.oidcProxy.redis.dbNumber must be between 0 and 15' \
+  --set 'services.mcp.oidcProxy.redis.dbNumber=16'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'invalid OIDC proxy Redis key prefix' \
+  'services.mcp.oidcProxy.redis.keyPrefix contains unsupported characters' \
+  --set 'services.mcp.oidcProxy.redis.keyPrefix=invalid/prefix'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy access-token TTL below range' \
+  'services.mcp.oidcProxy.accessTokenTtlSeconds must be between 60 and 3600' \
+  --set 'services.mcp.oidcProxy.accessTokenTtlSeconds=59'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy access-token TTL above range' \
+  'services.mcp.oidcProxy.accessTokenTtlSeconds must be between 60 and 3600' \
+  --set 'services.mcp.oidcProxy.accessTokenTtlSeconds=3601'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy refresh-token TTL below range' \
+  'services.mcp.oidcProxy.refreshTokenTtlSeconds must be between 300 and 604800' \
+  --set 'services.mcp.oidcProxy.refreshTokenTtlSeconds=299'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy refresh-token TTL above range' \
+  'services.mcp.oidcProxy.refreshTokenTtlSeconds must be between 300 and 604800' \
+  --set 'services.mcp.oidcProxy.refreshTokenTtlSeconds=604801'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy upstream timeout below range' \
+  'services.mcp.oidcProxy.upstreamTimeoutSeconds must be between 1 and 60' \
+  --set 'services.mcp.oidcProxy.upstreamTimeoutSeconds=0'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy upstream timeout above range' \
+  'services.mcp.oidcProxy.upstreamTimeoutSeconds must be between 1 and 60' \
+  --set 'services.mcp.oidcProxy.upstreamTimeoutSeconds=61'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
   'OIDC access-token audience mismatch' \
   'services.mcp.oidcProxy.oidc.accessTokenAudience must equal services.mcp.resourceUrl' \
   --set 'services.mcp.oidcProxy.oidc.accessTokenAudience=https://other.example.com/mcp'
@@ -281,6 +326,16 @@ expect_render_failure "$PROXY_VALUES_FILE" \
   'OIDC full scope mismatch' \
   'services.mcp.oidcProxy.scope must equal services.mcp.resourceUrl followed by oidc.accessTokenRequiredScope' \
   --set 'services.mcp.oidcProxy.scope=https://other.example.com/access_as_user'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'relative OIDC client-secret path' \
+  'services.mcp.oidcProxy.oidc.clientSecretFile must be an absolute path' \
+  --set 'services.mcp.oidcProxy.oidc.clientSecretFile=client-secret'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'relative Redis password path' \
+  'services.mcp.oidcProxy.redis.passwordFile must be an absolute path' \
+  --set 'services.mcp.oidcProxy.redis.passwordFile=redis-password'
 
 expect_render_failure "$PROXY_VALUES_FILE" \
   'OIDC client-secret path outside the existing Secret mount' \

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -238,8 +238,12 @@ assert_route_contains "$PROXY_RENDERED_MANIFEST" osmo-mcp 'envoy.filters.http.jw
 assert_route_contains "$PROXY_RENDERED_MANIFEST" osmo-mcp 'envoy.filters.http.ext_authz:'
 assert_file_omits "$PROXY_RENDERED_MANIFEST" '\"authorization_servers\"'
 
-if grep -A12 -B2 -F 'kind: Secret' "$PROXY_MCP_MANIFEST" | \
-    grep -i -F 'mcp' >/dev/null; then
+if awk -v secret_name='mcp-oidc-proxy-secrets' '
+    $0 == "kind: Secret" { in_secret = 1; next }
+    $0 == "---" { in_secret = 0 }
+    in_secret && $1 == "name:" && $2 == secret_name { found = 1 }
+    END { exit !found }
+  ' "$PROXY_RENDERED_MANIFEST"; then
   fail 'OIDC proxy mode rendered credential material into a Secret'
 fi
 
@@ -277,6 +281,16 @@ expect_render_failure "$PROXY_VALUES_FILE" \
   'OIDC full scope mismatch' \
   'services.mcp.oidcProxy.scope must equal services.mcp.resourceUrl followed by oidc.accessTokenRequiredScope' \
   --set 'services.mcp.oidcProxy.scope=https://other.example.com/access_as_user'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC client-secret path outside the existing Secret mount' \
+  'services.mcp.oidcProxy.oidc.clientSecretFile must be <existingSecret.mountPath>/client-secret' \
+  --set 'services.mcp.oidcProxy.oidc.clientSecretFile=/other/client-secret'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'Redis password path outside the existing Secret mount' \
+  'services.mcp.oidcProxy.redis.passwordFile must be <existingSecret.mountPath>/redis-password' \
+  --set 'services.mcp.oidcProxy.redis.passwordFile=/other/redis-password'
 
 expect_render_failure "$PROXY_VALUES_FILE" \
   'untrusted redirect origin with a path' \

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -103,6 +103,9 @@ assert_rendered '\"authorization_servers\":[\"https://issuer.example.com\"]'
 assert_rendered '\"bearer_methods_supported\":[\"header\"]'
 assert_rendered '\"resource\":\"https://osmo.example.com/mcp\"'
 assert_rendered '\"scopes_supported\":[\"mcp:Access\"]'
+assert_rendered 'local safe_roles = {}'
+assert_rendered "not string.find(role, '[,%c]')"
+assert_rendered "table.concat(safe_roles, ',')"
 assert_env_value 'OSMO_GATEWAY_URL' 'https://osmo.example.com'
 assert_env_value 'OSMO_MCP_REQUEST_TIMEOUT_SECONDS' '10'
 

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -175,7 +175,6 @@ for expected in \
     'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE' \
     'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL' \
     'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE' \
-    'name: OSMO_MCP_AUTH_SIGNING_JWKS_FILE' \
     'name: OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS' \
     'secretName: mcp-oidc-proxy-secrets'; do
   assert_file_contains "$PROXY_MCP_MANIFEST" "$expected"
@@ -228,6 +227,8 @@ for forbidden in \
     '- mcp-auth' \
     'local_jwks:' \
     'mcp-oauth-signing-jwks' \
+    'OSMO_MCP_AUTH_SIGNING_JWKS_FILE' \
+    'signing-jwks.json' \
     'upstream_claims' \
     'meta.verified_jwt.token_use'; do
   assert_file_omits "$PROXY_RENDERED_MANIFEST" "$forbidden"

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -20,44 +20,80 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 CHART_DIR="$(dirname -- "$SCRIPT_DIR")"
 VALUES_FILE="$SCRIPT_DIR/mcp-values.yaml"
+PROXY_VALUES_FILE="$SCRIPT_DIR/mcp-oidc-proxy-values.yaml"
 RENDERED_MANIFEST="$(mktemp)"
 MCP_MANIFEST="$(mktemp)"
 DISABLED_MANIFEST="$(mktemp)"
-trap 'rm -f "$RENDERED_MANIFEST" "$MCP_MANIFEST" "$DISABLED_MANIFEST"' EXIT
+PROXY_RENDERED_MANIFEST="$(mktemp)"
+PROXY_MCP_MANIFEST="$(mktemp)"
+trap 'rm -f "$RENDERED_MANIFEST" "$MCP_MANIFEST" "$DISABLED_MANIFEST" \
+  "$PROXY_RENDERED_MANIFEST" "$PROXY_MCP_MANIFEST"' EXIT
 
 fail() {
   echo "MCP chart validation failed: $*" >&2
   exit 1
 }
 
-assert_rendered() {
-  local expected="$1"
-  grep -F -- "$expected" "$RENDERED_MANIFEST" >/dev/null || \
-    fail "rendered manifest is missing: $expected"
+assert_file_contains() {
+  local file="$1"
+  local expected="$2"
+  grep -F -- "$expected" "$file" >/dev/null || \
+    fail "$(basename "$file") is missing: $expected"
 }
 
-assert_mcp_rendered() {
-  local expected="$1"
-  grep -F -- "$expected" "$MCP_MANIFEST" >/dev/null || \
-    fail "rendered MCP manifest is missing: $expected"
+assert_file_omits() {
+  local file="$1"
+  local forbidden="$2"
+  if grep -F -- "$forbidden" "$file" >/dev/null; then
+    fail "$(basename "$file") unexpectedly contains: $forbidden"
+  fi
 }
 
 assert_env_value() {
-  local name="$1"
-  local value="$2"
-  grep -A1 -F -- "name: $name" "$MCP_MANIFEST" | \
+  local file="$1"
+  local name="$2"
+  local value="$3"
+  grep -A1 -F -- "name: $name" "$file" | \
     grep -F -- "value: \"$value\"" >/dev/null || \
     fail "managed environment variable $name does not equal $value"
 }
 
+assert_route_contains() {
+  local file="$1"
+  local route="$2"
+  local expected="$3"
+  awk -v marker="                - name: $route" '
+    $0 == marker { found = 1 }
+    found && $0 != marker && index($0, "                - ") == 1 { exit }
+    found { print }
+  ' "$file" | \
+    grep -F -- "$expected" >/dev/null || \
+    fail "Gateway route $route is missing: $expected"
+}
+
+assert_route_omits() {
+  local file="$1"
+  local route="$2"
+  local forbidden="$3"
+  if awk -v marker="                - name: $route" '
+      $0 == marker { found = 1 }
+      found && $0 != marker && index($0, "                - ") == 1 { exit }
+      found { print }
+    ' "$file" | \
+      grep -F -- "$forbidden" >/dev/null; then
+    fail "Gateway route $route unexpectedly contains: $forbidden"
+  fi
+}
+
 expect_render_failure() {
-  local description="$1"
-  local expected_error="$2"
-  shift 2
+  local values_file="$1"
+  local description="$2"
+  local expected_error="$3"
+  shift 3
 
   local output
   if output=$(helm template mcp-validation "$CHART_DIR" \
-      --values "$VALUES_FILE" "$@" 2>&1); then
+      --values "$values_file" "$@" 2>&1); then
     fail "$description unexpectedly rendered successfully"
   fi
   case "$output" in
@@ -67,87 +103,188 @@ expect_render_failure() {
 }
 
 helm lint "$CHART_DIR" --values "$VALUES_FILE"
+helm lint "$CHART_DIR" --values "$PROXY_VALUES_FILE"
 helm template mcp-disabled "$CHART_DIR" >"$DISABLED_MANIFEST"
 helm template mcp-validation "$CHART_DIR" \
   --values "$VALUES_FILE" >"$RENDERED_MANIFEST"
 helm template mcp-validation "$CHART_DIR" \
   --values "$VALUES_FILE" \
   --show-only templates/mcp-service.yaml >"$MCP_MANIFEST"
+helm template mcp-proxy-validation "$CHART_DIR" \
+  --values "$PROXY_VALUES_FILE" >"$PROXY_RENDERED_MANIFEST"
+helm template mcp-proxy-validation "$CHART_DIR" \
+  --values "$PROXY_VALUES_FILE" \
+  --show-only templates/mcp-service.yaml >"$PROXY_MCP_MANIFEST"
 
 for forbidden in \
     'name: osmo-mcp' \
     'cluster: osmo-mcp' \
     'path: /mcp' \
     'path: /.well-known/oauth-protected-resource/mcp'; do
-  if grep -F -- "$forbidden" "$DISABLED_MANIFEST" >/dev/null; then
-    fail "disabled mode rendered MCP configuration: $forbidden"
-  fi
+  assert_file_omits "$DISABLED_MANIFEST" "$forbidden"
 done
 
-assert_mcp_rendered 'kind: Deployment'
-assert_mcp_rendered 'kind: Service'
-assert_mcp_rendered 'name: osmo-mcp'
-assert_mcp_rendered 'image: nvcr.io/nvidia/osmo/mcp:latest'
-assert_mcp_rendered 'name: OSMO_GATEWAY_URL'
-assert_mcp_rendered 'name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS'
-assert_mcp_rendered 'kind: NetworkPolicy'
-assert_mcp_rendered 'name: osmo-mcp-allow-gateway-envoy'
-assert_mcp_rendered 'app.kubernetes.io/component: envoy'
-assert_mcp_rendered 'livenessProbe:'
-assert_mcp_rendered 'readinessProbe:'
-assert_mcp_rendered 'startupProbe:'
-assert_mcp_rendered 'automountServiceAccountToken: false'
-assert_rendered 'path: /mcp'
-assert_rendered 'path: /.well-known/oauth-protected-resource/mcp'
-assert_rendered '\"authorization_servers\":[\"https://issuer.example.com\"]'
-assert_rendered '\"bearer_methods_supported\":[\"header\"]'
-assert_rendered '\"resource\":\"https://osmo.example.com/mcp\"'
-assert_rendered '\"scopes_supported\":[\"mcp:Access\"]'
-assert_rendered 'local safe_roles = {}'
-assert_rendered "not string.find(role, '[,%c]')"
-assert_rendered "table.concat(safe_roles, ',')"
-assert_env_value 'OSMO_GATEWAY_URL' 'https://osmo.example.com'
-assert_env_value 'OSMO_MCP_REQUEST_TIMEOUT_SECONDS' '10'
+for forbidden in \
+    'path: /.well-known/oauth-authorization-server' \
+    'path: /authorize' \
+    'path: /auth/callback' \
+    'path: /register' \
+    'path: /token' \
+    'path: /consent'; do
+  assert_file_omits "$RENDERED_MANIFEST" "$forbidden"
+done
 
-if grep -A12 -B2 -F 'kind: Secret' "$MCP_MANIFEST" | \
+for expected in \
+    'kind: Deployment' \
+    'kind: Service' \
+    'name: osmo-mcp' \
+    'image: nvcr.io/nvidia/osmo/mcp:latest' \
+    'name: OSMO_GATEWAY_URL' \
+    'name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS' \
+    'name: OSMO_MCP_AUTH_ENABLED' \
+    'kind: NetworkPolicy' \
+    'name: osmo-mcp-allow-gateway-envoy' \
+    'app.kubernetes.io/component: envoy' \
+    'automountServiceAccountToken: false'; do
+  assert_file_contains "$MCP_MANIFEST" "$expected"
+done
+assert_file_contains "$RENDERED_MANIFEST" 'path: /mcp'
+assert_file_contains "$RENDERED_MANIFEST" 'path: /.well-known/oauth-protected-resource/mcp'
+assert_file_contains "$RENDERED_MANIFEST" '\"authorization_servers\":[\"https://issuer.example.com\"]'
+assert_file_contains "$RENDERED_MANIFEST" '\"resource\":\"https://osmo.example.com/mcp\"'
+assert_file_contains "$RENDERED_MANIFEST" '\"scopes_supported\":[\"mcp:Access\"]'
+assert_file_contains "$RENDERED_MANIFEST" 'local safe_roles = {}'
+assert_file_contains "$RENDERED_MANIFEST" "not string.find(role, '[,%c]')"
+assert_file_contains "$RENDERED_MANIFEST" "table.concat(safe_roles, ',')"
+assert_env_value "$MCP_MANIFEST" OSMO_GATEWAY_URL https://osmo.example.com
+assert_env_value "$MCP_MANIFEST" OSMO_MCP_REQUEST_TIMEOUT_SECONDS 10
+assert_env_value "$MCP_MANIFEST" OSMO_MCP_AUTH_ENABLED false
+assert_route_omits "$RENDERED_MANIFEST" osmo-mcp 'typed_per_filter_config:'
+
+for expected in \
+    'name: OSMO_MCP_AUTH_ISSUER_URL' \
+    'name: OSMO_MCP_AUTH_RESOURCE_URL' \
+    'name: OSMO_MCP_AUTH_SCOPE' \
+    'name: OSMO_MCP_AUTH_REDIS_URL' \
+    'name: OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS' \
+    'name: OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS' \
+    'name: OSMO_MCP_AUTH_OIDC_CONFIG_URL' \
+    'name: OSMO_MCP_AUTH_OIDC_CLIENT_ID' \
+    'name: OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE' \
+    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER' \
+    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE' \
+    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL' \
+    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE' \
+    'name: OSMO_MCP_AUTH_SIGNING_JWKS_FILE' \
+    'name: OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS' \
+    'secretName: mcp-oidc-proxy-secrets'; do
+  assert_file_contains "$PROXY_MCP_MANIFEST" "$expected"
+done
+
+for route in \
+    mcp-protected-resource-metadata \
+    mcp-oauth-authorization-server-metadata \
+    mcp-oauth-authorize-get \
+    mcp-oauth-authorize-post \
+    mcp-oauth-oidc-callback \
+    mcp-oauth-register \
+    mcp-oauth-token \
+    mcp-oauth-consent-get \
+    mcp-oauth-consent-post \
+    mcp-oauth-authorization-server-metadata-options \
+    mcp-oauth-authorize-options \
+    mcp-oauth-oidc-callback-options \
+    mcp-oauth-register-options \
+    mcp-oauth-token-options \
+    mcp-oauth-consent-options; do
+  assert_route_contains "$PROXY_RENDERED_MANIFEST" "$route" 'cluster: osmo-mcp'
+  assert_route_contains "$PROXY_RENDERED_MANIFEST" "$route" 'envoy.filters.http.jwt_authn:'
+  assert_route_contains "$PROXY_RENDERED_MANIFEST" "$route" 'envoy.filters.http.ext_authz:'
+done
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_ENABLED true
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_ISSUER_URL https://osmo.example.com
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_RESOURCE_URL https://osmo.example.com/mcp
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_SCOPE https://osmo.example.com/mcp/access_as_user
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_REDIS_URL rediss://proxy-redis.example.internal:6380/14
+
+for expected in \
+    'path: /.well-known/oauth-authorization-server' \
+    'path: /authorize' \
+    'path: /auth/callback' \
+    'path: /register' \
+    'path: /token' \
+    'path: /consent' \
+    'name: mcp-protected-resource-metadata' \
+    'name: osmo-mcp' \
+    'cluster: osmo-mcp' \
+    'path: "%PATH(NQ:ORIG_OR_PATH)%"'; do
+  assert_file_contains "$PROXY_RENDERED_MANIFEST" "$expected"
+done
+
+for forbidden in \
+    'name: osmo-mcp-oauth' \
+    'cluster: osmo-mcp-oauth' \
+    'app.kubernetes.io/component: mcp-oauth-broker' \
+    '- mcp-auth' \
+    'local_jwks:' \
+    'mcp-oauth-signing-jwks' \
+    'upstream_claims' \
+    'meta.verified_jwt.token_use'; do
+  assert_file_omits "$PROXY_RENDERED_MANIFEST" "$forbidden"
+done
+
+assert_route_contains "$PROXY_RENDERED_MANIFEST" osmo-mcp 'envoy.filters.http.jwt_authn:'
+assert_route_contains "$PROXY_RENDERED_MANIFEST" osmo-mcp 'envoy.filters.http.ext_authz:'
+assert_file_omits "$PROXY_RENDERED_MANIFEST" '\"authorization_servers\"'
+
+if grep -A12 -B2 -F 'kind: Secret' "$PROXY_MCP_MANIFEST" | \
     grep -i -F 'mcp' >/dev/null; then
-  fail 'enabled mode rendered an MCP credential Secret'
-fi
-if grep -E 'OSMO_MCP_(TOKEN|CREDENTIAL|SECRET)' \
-    "$MCP_MANIFEST" >/dev/null; then
-  fail 'enabled mode rendered an MCP credential environment variable'
+  fail 'OIDC proxy mode rendered credential material into a Secret'
 fi
 
-expect_render_failure \
+expect_render_failure "$VALUES_FILE" \
   'encoded alternate Gateway origin' \
   'services.mcp.resourceUrl must be a valid HTTPS origin' \
   --set 'services.mcp.resourceUrl=https://osmo.example.com%40evil.example.com/mcp'
 
-expect_render_failure \
-  'non-integer timeout' \
-  'services.mcp.requestTimeoutSeconds must be between 1 and 60' \
-  --set 'services.mcp.requestTimeoutSeconds=true'
-
-expect_render_failure \
+expect_render_failure "$VALUES_FILE" \
   'managed Gateway URL override' \
   'services.mcp.extraEnv must not override managed variable OSMO_GATEWAY_URL' \
-  --set-json \
-  'services.mcp.extraEnv=[{"name":"OSMO_GATEWAY_URL","value":"https://evil.example.com"}]'
+  --set-json 'services.mcp.extraEnv=[{"name":"OSMO_GATEWAY_URL","value":"https://evil.example.com"}]'
 
-expect_render_failure \
-  'MCP authentication bypass' \
-  'overlaps a protected MCP path' \
-  --set 'gateway.envoy.extraSkipAuthPaths[0]=/mcp'
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy without MCP' \
+  'services.mcp.oidcProxy.enabled requires services.mcp.enabled=true' \
+  --set 'services.mcp.enabled=false'
 
-expect_render_failure \
-  'query-prefixed MCP authentication bypass' \
-  'overlaps a protected MCP path' \
-  --set-string 'gateway.envoy.extraSkipAuthPaths[0]=/mcp?bypass=true'
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy with multiple replicas' \
+  'services.mcp.replicas must be 1 when services.mcp.oidcProxy.enabled=true' \
+  --set 'services.mcp.replicas=2'
 
-expect_render_failure \
-  'query-prefixed MCP metadata authentication bypass' \
-  'overlaps a protected MCP path' \
-  --set-string \
-  'gateway.envoy.extraSkipAuthPaths[0]=/.well-known/oauth-protected-resource/mcp?bypass=true'
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'invalid OIDC proxy Redis port' \
+  'services.mcp.oidcProxy.redis.port must be between 1 and 65535' \
+  --set 'services.mcp.oidcProxy.redis.port=0'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC access-token audience mismatch' \
+  'services.mcp.oidcProxy.oidc.accessTokenAudience must equal services.mcp.resourceUrl' \
+  --set 'services.mcp.oidcProxy.oidc.accessTokenAudience=https://other.example.com/mcp'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC full scope mismatch' \
+  'services.mcp.oidcProxy.scope must equal services.mcp.resourceUrl followed by oidc.accessTokenRequiredScope' \
+  --set 'services.mcp.oidcProxy.scope=https://other.example.com/access_as_user'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'untrusted redirect origin with a path' \
+  'trustedHttpsRedirectOrigins entries must be exact HTTPS origins' \
+  --set 'services.mcp.oidcProxy.trustedHttpsRedirectOrigins[0]=https://trusted.example.com/callback'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'managed OIDC proxy issuer override' \
+  'services.mcp.extraEnv must not override managed variable OSMO_MCP_AUTH_ISSUER_URL' \
+  --set-json 'services.mcp.extraEnv=[{"name":"OSMO_MCP_AUTH_ISSUER_URL","value":"https://evil.example.com"}]'
 
 echo 'MCP chart validation passed'

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -777,7 +777,13 @@ data:
                       end
                       local roles = meta.verified_jwt.roles
                       if (roles ~= nil and type(roles) == 'table') then
-                        request_handle:headers():replace('x-osmo-roles', table.concat(roles, ','))
+                        local safe_roles = {}
+                        for _, role in ipairs(roles) do
+                          if (type(role) == 'string' and #role <= 256 and not string.find(role, '[,%c]')) then
+                            table.insert(safe_roles, role)
+                          end
+                        end
+                        request_handle:headers():replace('x-osmo-roles', table.concat(safe_roles, ','))
                       end
                       if (meta.verified_jwt.osmo_token_name ~= nil) then
                         request_handle:headers():replace('x-osmo-token-name', tostring(meta.verified_jwt.osmo_token_name))

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -30,10 +30,35 @@ setting detects this rotation and triggers Envoy to reload.
 {{- $envoy := $gw.envoy }}
 {{- $mcp := .Values.services.mcp }}
 {{- $mcpEnabled := $mcp.enabled | default false }}
+{{- $mcpOidcProxy := $mcp.oidcProxy }}
+{{- if and ($mcpOidcProxy.enabled | default false) (not $mcpEnabled) }}
+{{- fail "services.mcp.oidcProxy.enabled requires services.mcp.enabled=true" }}
+{{- end }}
+{{- $mcpOidcProxyEnabled := and $mcpEnabled ($mcpOidcProxy.enabled | default false) }}
 {{- $mcpPath := "/mcp" }}
 {{- $mcpMetadataPath := "/.well-known/oauth-protected-resource/mcp" }}
+{{- $mcpOidcProxyRoutes := list
+      (dict "name" "mcp-oauth-authorization-server-metadata" "path" "/.well-known/oauth-authorization-server" "pathRegex" "^/[.]well-known/oauth-authorization-server([?].*)?$" "method" "GET")
+      (dict "name" "mcp-oauth-authorize-get" "path" "/authorize" "pathRegex" "^/authorize([?].*)?$" "method" "GET")
+      (dict "name" "mcp-oauth-authorize-post" "path" "/authorize" "pathRegex" "^/authorize([?].*)?$" "method" "POST")
+      (dict "name" "mcp-oauth-oidc-callback" "path" "/auth/callback" "pathRegex" "^/auth/callback([?].*)?$" "method" "GET" "timeout" "45s")
+      (dict "name" "mcp-oauth-register" "path" "/register" "pathRegex" "^/register([?].*)?$" "method" "POST")
+      (dict "name" "mcp-oauth-token" "path" "/token" "pathRegex" "^/token([?].*)?$" "method" "POST" "timeout" "45s")
+      (dict "name" "mcp-oauth-consent-get" "path" "/consent" "pathRegex" "^/consent([?].*)?$" "method" "GET")
+      (dict "name" "mcp-oauth-consent-post" "path" "/consent" "pathRegex" "^/consent([?].*)?$" "method" "POST")
+    }}
+{{- $mcpOidcProxyOptionRoutes := list
+      (dict "name" "mcp-oauth-authorization-server-metadata-options" "path" "/.well-known/oauth-authorization-server" "pathRegex" "^/[.]well-known/oauth-authorization-server([?].*)?$")
+      (dict "name" "mcp-oauth-authorize-options" "path" "/authorize" "pathRegex" "^/authorize([?].*)?$")
+      (dict "name" "mcp-oauth-oidc-callback-options" "path" "/auth/callback" "pathRegex" "^/auth/callback([?].*)?$" "timeout" "45s")
+      (dict "name" "mcp-oauth-register-options" "path" "/register" "pathRegex" "^/register([?].*)?$")
+      (dict "name" "mcp-oauth-token-options" "path" "/token" "pathRegex" "^/token([?].*)?$")
+      (dict "name" "mcp-oauth-consent-options" "path" "/consent" "pathRegex" "^/consent([?].*)?$")
+    }}
 {{- $mcpResourceUrl := "" }}
 {{- $mcpMetadataUrl := "" }}
+{{- $mcpAuthorizationServers := $mcp.authorizationServers }}
+{{- $mcpScopes := $mcp.scopes }}
 {{- $skipAuthPaths := concat (default (list) $envoy.skipAuthPaths) (default (list) $envoy.extraSkipAuthPaths) }}
 {{- $authnSkipPaths := $skipAuthPaths }}
 {{- if $gw.oauth2Proxy.enabled }}
@@ -46,10 +71,8 @@ setting detects this rotation and triggers Envoy to reload.
 {{- if not $gw.authz.enabled }}
 {{- fail "services.mcp.enabled requires gateway.authz.enabled=true" }}
 {{- end }}
-{{- if not $envoy.jwt.providers }}
-{{- fail "services.mcp.enabled requires at least one gateway.envoy.jwt.providers entry" }}
-{{- end }}
 {{- $mcpResourceUrl = include "osmo.mcp-resource-url" . }}
+{{- if not $mcpOidcProxyEnabled }}
 {{- if not (kindIs "slice" $mcp.authorizationServers) }}
 {{- fail "services.mcp.authorizationServers must be a list" }}
 {{- end }}
@@ -70,6 +93,10 @@ setting detects this rotation and triggers Envoy to reload.
 {{- fail "services.mcp.scopes entries must not be empty" }}
 {{- end }}
 {{- end }}
+{{- end }}
+{{- if not $envoy.jwt.providers }}
+{{- fail "services.mcp.enabled requires at least one gateway.envoy.jwt.providers entry" }}
+{{- end }}
 {{- $mcpServiceName := required "services.mcp.serviceName is required when MCP is enabled" $mcp.serviceName }}
 {{- $mcpImageName := required "services.mcp.imageName is required when MCP is enabled" $mcp.imageName }}
 {{- if or (lt (int $mcp.port) 1) (gt (int $mcp.port) 65535) }}
@@ -86,7 +113,15 @@ setting detects this rotation and triggers Envoy to reload.
 {{- range $skipPath := $skipAuthPaths }}
 {{- $overlapsMcpPath := or (hasPrefix $skipPath $mcpPath) (hasPrefix $mcpPath $skipPath) }}
 {{- $overlapsMcpMetadataPath := or (hasPrefix $skipPath $mcpMetadataPath) (hasPrefix $mcpMetadataPath $skipPath) }}
-{{- if or $overlapsMcpPath $overlapsMcpMetadataPath }}
+{{- $overlapsMcpOidcProxyPath := false }}
+{{- if $mcpOidcProxyEnabled }}
+{{- range $route := $mcpOidcProxyRoutes }}
+{{- if or (hasPrefix $skipPath $route.path) (hasPrefix $route.path $skipPath) }}
+{{- $overlapsMcpOidcProxyPath = true }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if or $overlapsMcpPath $overlapsMcpMetadataPath $overlapsMcpOidcProxyPath }}
 {{- fail (printf "gateway auth bypass prefix %q overlaps a protected MCP path" $skipPath) }}
 {{- end }}
 {{- end }}
@@ -171,7 +206,9 @@ data:
                   json_format:
                     start_time: "%START_TIME%"
                     method: "%REQ(:METHOD)%"
-                    path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                    # Never persist query parameters. OAuth callbacks carry
+                    # short-lived authorization codes and state in the query.
+                    path: "%PATH(NQ:ORIG_OR_PATH)%"
                     protocol: "%PROTOCOL%"
                     response_code: "%RESPONSE_CODE%"
                     response_code_details: "%RESPONSE_CODE_DETAILS%"
@@ -285,9 +322,8 @@ data:
                 {{- end }}
 
                 {{- if $mcpEnabled }}
-                # RFC 9728 metadata is the only public MCP route. Keep the
-                # method and path exact so no neighboring path or write method
-                # inherits the authentication bypass.
+                # Keep the public protected-resource route exact so no
+                # neighboring path or write method inherits the bypass.
                 - name: mcp-protected-resource-metadata
                   match:
                     path: {{ $mcpMetadataPath }}
@@ -295,10 +331,16 @@ data:
                     - name: ":method"
                       string_match:
                         exact: GET
+                  {{- if $mcpOidcProxyEnabled }}
+                  route:
+                    cluster: osmo-mcp
+                    timeout: 15s
+                  {{- else }}
                   direct_response:
                     status: 200
                     body:
-                      inline_string: {{ dict "resource" $mcpResourceUrl "authorization_servers" $mcp.authorizationServers "bearer_methods_supported" (list "header") "scopes_supported" $mcp.scopes | toJson | quote }}
+                      inline_string: {{ dict "resource" $mcpResourceUrl "authorization_servers" $mcpAuthorizationServers "bearer_methods_supported" (list "header") "scopes_supported" $mcpScopes | toJson | quote }}
+                  {{- end }}
                   response_headers_to_add:
                   - header:
                       key: content-type
@@ -318,15 +360,67 @@ data:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
                       disabled: true
 
-                # Streamable HTTP uses the same exact endpoint for its
-                # supported methods. Authentication and semantic authorization
-                # remain enabled on this route.
+                {{- if $mcpOidcProxyEnabled }}
+                # FastMCP owns this complete public OAuth surface in the same
+                # process as /mcp. Every route remains method/path exact.
+                {{- range $route := $mcpOidcProxyRoutes }}
+                - name: {{ $route.name }}
+                  match:
+                    path: {{ $route.path }}
+                    headers:
+                    - name: ":method"
+                      string_match:
+                        exact: {{ $route.method }}
+                  route:
+                    cluster: osmo-mcp
+                    timeout: {{ default "15s" $route.timeout }}
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+                {{- end }}
+                {{- range $route := $mcpOidcProxyOptionRoutes }}
+                - name: {{ $route.name }}
+                  match:
+                    path: {{ $route.path }}
+                    headers:
+                    - name: ":method"
+                      string_match:
+                        exact: OPTIONS
+                  route:
+                    cluster: osmo-mcp
+                    timeout: {{ default "15s" $route.timeout }}
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+                {{- end }}
+                {{- end }}
+
+                # In direct mode Gateway validates and authorizes /mcp. With
+                # the in-process proxy enabled, FastMCP validates its own token
+                # and relays the verified upstream token to protected /api.
                 - name: osmo-mcp
                   match:
                     path: {{ $mcpPath }}
                   route:
                     cluster: osmo-mcp
                     timeout: 0s
+                  {{- if $mcpOidcProxyEnabled }}
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+                  {{- end }}
                 {{- end }}
 
                 {{- if $gw.upstreams.router.enabled }}
@@ -651,6 +745,54 @@ data:
                                       header_name: ":method"
                                   value_match:
                                     exact: "GET"
+                          {{- if $mcpOidcProxyEnabled }}
+                          # Skip the browser-session proxy only for the exact
+                          # method/path pairs owned by FastMCP's OIDC proxy.
+                          {{- range $route := $mcpOidcProxyRoutes }}
+                          - and_matcher:
+                              predicate:
+                              - single_predicate:
+                                  input:
+                                    name: request-headers
+                                    typed_config:
+                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                      header_name: ":path"
+                                  value_match:
+                                    safe_regex:
+                                      google_re2: {}
+                                      regex: {{ $route.pathRegex | quote }}
+                              - single_predicate:
+                                  input:
+                                    name: request-headers
+                                    typed_config:
+                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                      header_name: ":method"
+                                  value_match:
+                                    exact: {{ $route.method | quote }}
+                          {{- end }}
+                          {{- range $route := $mcpOidcProxyOptionRoutes }}
+                          - and_matcher:
+                              predicate:
+                              - single_predicate:
+                                  input:
+                                    name: request-headers
+                                    typed_config:
+                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                      header_name: ":path"
+                                  value_match:
+                                    safe_regex:
+                                      google_re2: {}
+                                      regex: {{ $route.pathRegex | quote }}
+                              - single_predicate:
+                                  input:
+                                    name: request-headers
+                                    typed_config:
+                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                      header_name: ":method"
+                                  value_match:
+                                    exact: "OPTIONS"
+                          {{- end }}
+                          {{- end }}
                           {{- end }}
                           {{- if $authnSkipPaths }}
                           - single_predicate:

--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -135,6 +135,13 @@
 {{- fail "services.mcp.oidcProxy.existingSecret.mountPath must be an absolute path" }}
 {{- end }}
 {{- $clientSecretKey := required "services.mcp.oidcProxy.existingSecret.clientSecretKey is required" $oidcProxy.existingSecret.clientSecretKey }}
+{{- $normalizedMountPath := trimSuffix "/" $mountPath }}
+{{- if ne $oidcClientSecretFile (printf "%s/client-secret" $normalizedMountPath) }}
+{{- fail "services.mcp.oidcProxy.oidc.clientSecretFile must be <existingSecret.mountPath>/client-secret" }}
+{{- end }}
+{{- if and $oidcProxy.redis.passwordFile (ne $oidcProxy.redis.passwordFile (printf "%s/redis-password" $normalizedMountPath)) }}
+{{- fail "services.mcp.oidcProxy.redis.passwordFile must be <existingSecret.mountPath>/redis-password" }}
+{{- end }}
 {{- if and $oidcProxy.redis.passwordFile (not $oidcProxy.existingSecret.redisPasswordKey) }}
 {{- fail "services.mcp.oidcProxy.existingSecret.redisPasswordKey is required when redis.passwordFile is configured" }}
 {{- end }}

--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -16,6 +16,8 @@
 
 {{- if .Values.services.mcp.enabled }}
 {{- $mcp := .Values.services.mcp }}
+{{- $oidcProxy := $mcp.oidcProxy }}
+{{- $oidcProxyEnabled := $oidcProxy.enabled | default false }}
 {{- $imageTag := $mcp.imageTag | default .Values.global.osmoImageTag }}
 {{- $mcpResourceUrl := include "osmo.mcp-resource-url" . }}
 {{- $gatewayUrl := trimSuffix "/mcp" $mcpResourceUrl }}
@@ -23,7 +25,156 @@
 {{- if not (regexMatch "^([1-9]|[1-5][0-9]|60)$" $requestTimeoutSeconds) }}
 {{- fail "services.mcp.requestTimeoutSeconds must be between 1 and 60" }}
 {{- end }}
-{{- $reservedEnvNames := list "OSMO_MCP_HOST" "OSMO_MCP_PORT" "OSMO_GATEWAY_URL" "OSMO_MCP_REQUEST_TIMEOUT_SECONDS" }}
+{{- $scope := "" }}
+{{- $oidcConfigUrl := "" }}
+{{- $oidcClientId := "" }}
+{{- $oidcClientSecretFile := "" }}
+{{- $oidcAccessTokenIssuer := "" }}
+{{- $oidcAccessTokenAudience := "" }}
+{{- $oidcAccessTokenJwksUrl := "" }}
+{{- $oidcAccessTokenRequiredScope := "" }}
+{{- $signingJwksFile := "" }}
+{{- $redisKeyPrefix := "" }}
+{{- $redisUrl := "" }}
+{{- if $oidcProxyEnabled }}
+{{- if ne (int $mcp.replicas) 1 }}
+{{- fail "services.mcp.replicas must be 1 when services.mcp.oidcProxy.enabled=true" }}
+{{- end }}
+{{- if not (kindIs "slice" $oidcProxy.trustedHttpsRedirectOrigins) }}
+{{- fail "services.mcp.oidcProxy.trustedHttpsRedirectOrigins must be a list" }}
+{{- end }}
+{{- range $origin := $oidcProxy.trustedHttpsRedirectOrigins }}
+{{- if or (not (kindIs "string" $origin)) (not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?$" $origin)) }}
+{{- fail "services.mcp.oidcProxy.trustedHttpsRedirectOrigins entries must be exact HTTPS origins" }}
+{{- end }}
+{{- $originPortSuffix := regexFind ":[0-9]+$" $origin }}
+{{- if $originPortSuffix }}
+{{- $originPort := trimPrefix ":" $originPortSuffix | int }}
+{{- if or (lt $originPort 1) (gt $originPort 65535) }}
+{{- fail "services.mcp.oidcProxy.trustedHttpsRedirectOrigins ports must be between 1 and 65535" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- $scope = required "services.mcp.oidcProxy.scope is required when the OIDC proxy is enabled" $oidcProxy.scope }}
+{{- $oidcConfigUrl = required "services.mcp.oidcProxy.oidc.configUrl is required when the OIDC proxy is enabled" $oidcProxy.oidc.configUrl }}
+{{- $oidcClientId = required "services.mcp.oidcProxy.oidc.clientId is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientId }}
+{{- $oidcClientSecretFile = required "services.mcp.oidcProxy.oidc.clientSecretFile is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientSecretFile }}
+{{- $oidcAccessTokenIssuer = required "services.mcp.oidcProxy.oidc.accessTokenIssuer is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenIssuer }}
+{{- $oidcAccessTokenAudience = required "services.mcp.oidcProxy.oidc.accessTokenAudience is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenAudience }}
+{{- $oidcAccessTokenJwksUrl = required "services.mcp.oidcProxy.oidc.accessTokenJwksUrl is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenJwksUrl }}
+{{- $oidcAccessTokenRequiredScope = required "services.mcp.oidcProxy.oidc.accessTokenRequiredScope is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenRequiredScope }}
+{{- if not (regexMatch "^[A-Za-z0-9:._~-]{1,128}$" $oidcAccessTokenRequiredScope) }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenRequiredScope must be one non-empty scope" }}
+{{- end }}
+{{- if or (gt (len $oidcAccessTokenAudience) 2048) (not (regexMatch "^[^[:space:][:cntrl:]]+$" $oidcAccessTokenAudience)) }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenAudience must be one non-empty value without whitespace or control characters" }}
+{{- end }}
+{{- if ne $oidcAccessTokenAudience $mcpResourceUrl }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenAudience must equal services.mcp.resourceUrl" }}
+{{- end }}
+{{- if ne $scope (printf "%s/%s" $mcpResourceUrl $oidcAccessTokenRequiredScope) }}
+{{- fail "services.mcp.oidcProxy.scope must equal services.mcp.resourceUrl followed by oidc.accessTokenRequiredScope" }}
+{{- end }}
+{{- $oidcHttpsUrlPattern := "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?(/[A-Za-z0-9._~%!$&'()*+,;=:@/-]*)?$" }}
+{{- if not (regexMatch $oidcHttpsUrlPattern $oidcConfigUrl) }}
+{{- fail "services.mcp.oidcProxy.oidc.configUrl must be an absolute HTTPS URL without query or fragment" }}
+{{- end }}
+{{- if not (regexMatch $oidcHttpsUrlPattern $oidcAccessTokenIssuer) }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenIssuer must be an absolute HTTPS issuer without query or fragment" }}
+{{- end }}
+{{- if not (regexMatch $oidcHttpsUrlPattern $oidcAccessTokenJwksUrl) }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenJwksUrl must be an absolute HTTPS URL without query or fragment" }}
+{{- end }}
+{{- range $name, $url := dict "configUrl" $oidcConfigUrl "accessTokenIssuer" $oidcAccessTokenIssuer "accessTokenJwksUrl" $oidcAccessTokenJwksUrl }}
+{{- $portMatch := regexFind ":[0-9]+(/|$)" $url }}
+{{- if $portMatch }}
+{{- $urlPort := trimSuffix "/" (trimPrefix ":" $portMatch) | int }}
+{{- if or (lt $urlPort 1) (gt $urlPort 65535) }}
+{{- fail (printf "services.mcp.oidcProxy.oidc.%s port must be between 1 and 65535" $name) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- $signingJwksFile = required "services.mcp.oidcProxy.signingJwksFile is required when the OIDC proxy is enabled" $oidcProxy.signingJwksFile }}
+{{- if not (hasPrefix "/" $oidcClientSecretFile) }}
+{{- fail "services.mcp.oidcProxy.oidc.clientSecretFile must be an absolute path" }}
+{{- end }}
+{{- if not (hasPrefix "/" $signingJwksFile) }}
+{{- fail "services.mcp.oidcProxy.signingJwksFile must be an absolute path" }}
+{{- end }}
+{{- $redisHost := $oidcProxy.redis.serviceName | default .Values.services.redis.serviceName | required "services.mcp.oidcProxy.redis.serviceName or services.redis.serviceName is required" }}
+{{- $redisPort := .Values.services.redis.port }}
+{{- if not (kindIs "invalid" $oidcProxy.redis.port) }}
+{{- $redisPort = $oidcProxy.redis.port }}
+{{- end }}
+{{- if or (lt (int $redisPort) 1) (gt (int $redisPort) 65535) }}
+{{- fail "services.mcp.oidcProxy.redis.port must be between 1 and 65535" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.redis.dbNumber) 0) (gt (int $oidcProxy.redis.dbNumber) 15) }}
+{{- fail "services.mcp.oidcProxy.redis.dbNumber must be between 0 and 15" }}
+{{- end }}
+{{- $redisKeyPrefix = required "services.mcp.oidcProxy.redis.keyPrefix is required" $oidcProxy.redis.keyPrefix }}
+{{- if not (regexMatch "^[A-Za-z0-9:._~-]{1,128}$" $redisKeyPrefix) }}
+{{- fail "services.mcp.oidcProxy.redis.keyPrefix contains unsupported characters" }}
+{{- end }}
+{{- if and $oidcProxy.redis.passwordFile (not (hasPrefix "/" $oidcProxy.redis.passwordFile)) }}
+{{- fail "services.mcp.oidcProxy.redis.passwordFile must be an absolute path" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.redis.connectTimeoutSeconds) 1) (gt (int $oidcProxy.redis.connectTimeoutSeconds) 30) }}
+{{- fail "services.mcp.oidcProxy.redis.connectTimeoutSeconds must be between 1 and 30" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.redis.operationTimeoutSeconds) 1) (gt (int $oidcProxy.redis.operationTimeoutSeconds) 30) }}
+{{- fail "services.mcp.oidcProxy.redis.operationTimeoutSeconds must be between 1 and 30" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.accessTokenTtlSeconds) 60) (gt (int $oidcProxy.accessTokenTtlSeconds) 3600) }}
+{{- fail "services.mcp.oidcProxy.accessTokenTtlSeconds must be between 60 and 3600" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.refreshTokenTtlSeconds) 300) (gt (int $oidcProxy.refreshTokenTtlSeconds) 604800) }}
+{{- fail "services.mcp.oidcProxy.refreshTokenTtlSeconds must be between 300 and 604800" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.upstreamTimeoutSeconds) 1) (gt (int $oidcProxy.upstreamTimeoutSeconds) 60) }}
+{{- fail "services.mcp.oidcProxy.upstreamTimeoutSeconds must be between 1 and 60" }}
+{{- end }}
+{{- if $oidcProxy.existingSecret.name }}
+{{- $mountPath := required "services.mcp.oidcProxy.existingSecret.mountPath is required when an existing Secret is configured" $oidcProxy.existingSecret.mountPath }}
+{{- if not (hasPrefix "/" $mountPath) }}
+{{- fail "services.mcp.oidcProxy.existingSecret.mountPath must be an absolute path" }}
+{{- end }}
+{{- $clientSecretKey := required "services.mcp.oidcProxy.existingSecret.clientSecretKey is required" $oidcProxy.existingSecret.clientSecretKey }}
+{{- $signingKey := required "services.mcp.oidcProxy.existingSecret.signingJwksKey is required" $oidcProxy.existingSecret.signingJwksKey }}
+{{- if and $oidcProxy.redis.passwordFile (not $oidcProxy.existingSecret.redisPasswordKey) }}
+{{- fail "services.mcp.oidcProxy.existingSecret.redisPasswordKey is required when redis.passwordFile is configured" }}
+{{- end }}
+{{- end }}
+{{- $redisScheme := ternary "rediss" "redis" $oidcProxy.redis.tlsEnabled }}
+{{- $redisUrl = printf "%s://%s:%v/%v" $redisScheme $redisHost $redisPort $oidcProxy.redis.dbNumber }}
+{{- end }}
+{{- $reservedEnvNames := list
+      "OSMO_MCP_HOST"
+      "OSMO_MCP_PORT"
+      "OSMO_GATEWAY_URL"
+      "OSMO_MCP_REQUEST_TIMEOUT_SECONDS"
+      "OSMO_MCP_AUTH_ENABLED"
+      "OSMO_MCP_AUTH_ISSUER_URL"
+      "OSMO_MCP_AUTH_RESOURCE_URL"
+      "OSMO_MCP_AUTH_SCOPE"
+      "OSMO_MCP_AUTH_TRUSTED_HTTPS_REDIRECT_ORIGINS"
+      "OSMO_MCP_AUTH_REDIS_URL"
+      "OSMO_MCP_AUTH_REDIS_PASSWORD_FILE"
+      "OSMO_MCP_AUTH_REDIS_KEY_PREFIX"
+      "OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS"
+      "OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS"
+      "OSMO_MCP_AUTH_OIDC_CONFIG_URL"
+      "OSMO_MCP_AUTH_OIDC_CLIENT_ID"
+      "OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE"
+      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER"
+      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE"
+      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL"
+      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE"
+      "OSMO_MCP_AUTH_SIGNING_JWKS_FILE"
+      "OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS"
+      "OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS"
+      "OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS"
+    }}
 {{- range $env := $mcp.extraEnv }}
 {{- if has (toString (default "" $env.name)) $reservedEnvNames }}
 {{- fail (printf "services.mcp.extraEnv must not override managed variable %s" $env.name) }}
@@ -93,14 +244,70 @@ spec:
           value: {{ $gatewayUrl | quote }}
         - name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS
           value: {{ $requestTimeoutSeconds | quote }}
+        - name: OSMO_MCP_AUTH_ENABLED
+          value: {{ $oidcProxyEnabled | quote }}
+        {{- if $oidcProxyEnabled }}
+        - name: OSMO_MCP_AUTH_ISSUER_URL
+          value: {{ $gatewayUrl | quote }}
+        - name: OSMO_MCP_AUTH_RESOURCE_URL
+          value: {{ $mcpResourceUrl | quote }}
+        - name: OSMO_MCP_AUTH_SCOPE
+          value: {{ $scope | quote }}
+        - name: OSMO_MCP_AUTH_TRUSTED_HTTPS_REDIRECT_ORIGINS
+          value: {{ join "," $oidcProxy.trustedHttpsRedirectOrigins | quote }}
+        - name: OSMO_MCP_AUTH_REDIS_URL
+          value: {{ $redisUrl | quote }}
+        {{- if $oidcProxy.redis.passwordFile }}
+        - name: OSMO_MCP_AUTH_REDIS_PASSWORD_FILE
+          value: {{ $oidcProxy.redis.passwordFile | quote }}
+        {{- end }}
+        - name: OSMO_MCP_AUTH_REDIS_KEY_PREFIX
+          value: {{ $redisKeyPrefix | quote }}
+        - name: OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS
+          value: {{ $oidcProxy.redis.connectTimeoutSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS
+          value: {{ $oidcProxy.redis.operationTimeoutSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_CONFIG_URL
+          value: {{ $oidcConfigUrl | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_CLIENT_ID
+          value: {{ $oidcClientId | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE
+          value: {{ $oidcClientSecretFile | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER
+          value: {{ $oidcAccessTokenIssuer | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE
+          value: {{ $oidcAccessTokenAudience | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL
+          value: {{ $oidcAccessTokenJwksUrl | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE
+          value: {{ $oidcAccessTokenRequiredScope | quote }}
+        - name: OSMO_MCP_AUTH_SIGNING_JWKS_FILE
+          value: {{ $signingJwksFile | quote }}
+        - name: OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS
+          value: {{ $oidcProxy.accessTokenTtlSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS
+          value: {{ $oidcProxy.refreshTokenTtlSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS
+          value: {{ $oidcProxy.upstreamTimeoutSeconds | int | quote }}
+        {{- end }}
         {{- with $mcp.extraEnv }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         resources:
           {{- toYaml $mcp.resources | nindent 10 }}
-        {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
+        {{- if or (and $oidcProxyEnabled $oidcProxy.existingSecret.name) $mcp.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp) }}
         volumeMounts:
+        {{- if and $oidcProxyEnabled $oidcProxy.existingSecret.name }}
+        - name: mcp-auth-secrets
+          mountPath: {{ $oidcProxy.existingSecret.mountPath }}
+          readOnly: true
+        {{- end }}
+        {{- with $mcp.extraVolumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
         {{- include "osmo.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 8 }}
+        {{- end }}
         {{- end }}
         livenessProbe:
           {{- include "osmo.upstream-probe-yaml" (dict "probe" $mcp.livenessProbe "context" .) | nindent 10 }}
@@ -108,9 +315,28 @@ spec:
           {{- include "osmo.upstream-probe-yaml" (dict "probe" $mcp.readinessProbe "context" .) | nindent 10 }}
         startupProbe:
           {{- include "osmo.upstream-probe-yaml" (dict "probe" $mcp.startupProbe "context" .) | nindent 10 }}
-      {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
+      {{- if or (and $oidcProxyEnabled $oidcProxy.existingSecret.name) $mcp.extraVolumes (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp) }}
       volumes:
+      {{- if and $oidcProxyEnabled $oidcProxy.existingSecret.name }}
+      - name: mcp-auth-secrets
+        secret:
+          secretName: {{ $oidcProxy.existingSecret.name }}
+          items:
+          - key: {{ $oidcProxy.existingSecret.clientSecretKey }}
+            path: client-secret
+          - key: {{ $oidcProxy.existingSecret.signingJwksKey }}
+            path: signing-jwks.json
+          {{- if $oidcProxy.redis.passwordFile }}
+          - key: {{ $oidcProxy.existingSecret.redisPasswordKey }}
+            path: redis-password
+          {{- end }}
+      {{- end }}
+      {{- with $mcp.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
       {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 6 }}
+      {{- end }}
       {{- end }}
 
 ---

--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -33,7 +33,6 @@
 {{- $oidcAccessTokenAudience := "" }}
 {{- $oidcAccessTokenJwksUrl := "" }}
 {{- $oidcAccessTokenRequiredScope := "" }}
-{{- $signingJwksFile := "" }}
 {{- $redisKeyPrefix := "" }}
 {{- $redisUrl := "" }}
 {{- if $oidcProxyEnabled }}
@@ -94,12 +93,8 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- $signingJwksFile = required "services.mcp.oidcProxy.signingJwksFile is required when the OIDC proxy is enabled" $oidcProxy.signingJwksFile }}
 {{- if not (hasPrefix "/" $oidcClientSecretFile) }}
 {{- fail "services.mcp.oidcProxy.oidc.clientSecretFile must be an absolute path" }}
-{{- end }}
-{{- if not (hasPrefix "/" $signingJwksFile) }}
-{{- fail "services.mcp.oidcProxy.signingJwksFile must be an absolute path" }}
 {{- end }}
 {{- $redisHost := $oidcProxy.redis.serviceName | default .Values.services.redis.serviceName | required "services.mcp.oidcProxy.redis.serviceName or services.redis.serviceName is required" }}
 {{- $redisPort := .Values.services.redis.port }}
@@ -140,7 +135,6 @@
 {{- fail "services.mcp.oidcProxy.existingSecret.mountPath must be an absolute path" }}
 {{- end }}
 {{- $clientSecretKey := required "services.mcp.oidcProxy.existingSecret.clientSecretKey is required" $oidcProxy.existingSecret.clientSecretKey }}
-{{- $signingKey := required "services.mcp.oidcProxy.existingSecret.signingJwksKey is required" $oidcProxy.existingSecret.signingJwksKey }}
 {{- if and $oidcProxy.redis.passwordFile (not $oidcProxy.existingSecret.redisPasswordKey) }}
 {{- fail "services.mcp.oidcProxy.existingSecret.redisPasswordKey is required when redis.passwordFile is configured" }}
 {{- end }}
@@ -170,7 +164,6 @@
       "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE"
       "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL"
       "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE"
-      "OSMO_MCP_AUTH_SIGNING_JWKS_FILE"
       "OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS"
       "OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS"
       "OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS"
@@ -281,8 +274,6 @@ spec:
           value: {{ $oidcAccessTokenJwksUrl | quote }}
         - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE
           value: {{ $oidcAccessTokenRequiredScope | quote }}
-        - name: OSMO_MCP_AUTH_SIGNING_JWKS_FILE
-          value: {{ $signingJwksFile | quote }}
         - name: OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS
           value: {{ $oidcProxy.accessTokenTtlSeconds | int | quote }}
         - name: OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS
@@ -324,8 +315,6 @@ spec:
           items:
           - key: {{ $oidcProxy.existingSecret.clientSecretKey }}
             path: client-secret
-          - key: {{ $oidcProxy.existingSecret.signingJwksKey }}
-            path: signing-jwks.json
           {{- if $oidcProxy.redis.passwordFile }}
           - key: {{ $oidcProxy.existingSecret.redisPasswordKey }}
             path: redis-password

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -116,11 +116,12 @@ services:
   mcp:
     ## Enable the MCP workload and its gateway routes. Disabled by default.
     ## When enabled, the chart always renders an ingress NetworkPolicy for
-    ## MCP because only Gateway-authenticated requests may reach the service.
+    ## MCP because only this deployment's Gateway may reach the service.
     ##
     enabled: false
 
-    ## Number of MCP replicas.
+    ## Number of MCP replicas. Keep this at 1 while oidcProxy is enabled;
+    ## FastMCP 3.4.7 serializes refreshes within one process.
     ##
     replicas: 1
 
@@ -166,6 +167,68 @@ services:
     ##
     allowedOrigins: []
 
+    ## Built-in FastMCP OIDC proxy for endpoint-only client setup. This runs
+    ## inside the existing MCP process and publishes OAuth metadata, CIMD/DCR,
+    ## PKCE, callback, and token endpoints on the same public origin. The MCP
+    ## process validates its proxy token, then relays the verified upstream
+    ## identity-provider access token to the OSMO Gateway for normal RBAC.
+    ##
+    oidcProxy:
+      enabled: false
+
+      ## Full delegated scope URI advertised to MCP clients and requested from
+      ## the upstream provider, normally <resourceUrl>/access_as_user.
+      ##
+      scope: ""
+
+      ## Public HTTPS redirect origins allowed for pre-registered web clients.
+      ## Native clients use dynamically allocated loopback redirects.
+      ##
+      trustedHttpsRedirectOrigins: []
+
+      ## Upstream OpenID Connect provider. Register the fixed redirect URL
+      ## <resourceUrl origin>/auth/callback on this confidential application.
+      ##
+      oidc:
+        configUrl: ""
+        clientId: ""
+        clientSecretFile: /etc/osmo/mcp-auth/client-secret
+        accessTokenIssuer: ""
+        accessTokenAudience: ""
+        accessTokenJwksUrl: ""
+        accessTokenRequiredScope: access_as_user
+
+      ## Redis stores proxy registrations, authorization state, and encrypted
+      ## upstream tokens. Empty serviceName/port inherit services.redis.
+      ##
+      redis:
+        serviceName: ""
+        port: null
+        dbNumber: 0
+        tlsEnabled: true
+        passwordFile: ""
+        keyPrefix: osmo:mcp-fastmcp
+        connectTimeoutSeconds: 3
+        operationTimeoutSeconds: 5
+
+      ## Private single-key HS256 JWKS used only by the MCP process.
+      ##
+      signingJwksFile: /etc/osmo/mcp-auth/signing-jwks.json
+
+      accessTokenTtlSeconds: 600
+      refreshTokenTtlSeconds: 28800
+      upstreamTimeoutSeconds: 10
+
+      ## Optionally mount all proxy credentials from an existing Secret.
+      ## Leave name empty when Vault injection or extra volumes provide them.
+      ##
+      existingSecret:
+        name: ""
+        mountPath: /etc/osmo/mcp-auth
+        clientSecretKey: client-secret
+        signingJwksKey: signing-jwks
+        redisPasswordKey: redis-password
+
     ## Additional pod labels and annotations.
     ##
     extraPodLabels: {}
@@ -174,6 +237,12 @@ services:
     ## Additional environment variables for the MCP container.
     ##
     extraEnv: []
+
+    ## Additional volume mounts and volumes for the MCP container and pod.
+    ## These can provide Vault-injected OIDC proxy credentials.
+    ##
+    extraVolumeMounts: []
+    extraVolumes: []
 
     ## Service account name. Empty uses global.serviceAccountName.
     ##

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -211,10 +211,6 @@ services:
         connectTimeoutSeconds: 3
         operationTimeoutSeconds: 5
 
-      ## Private single-key HS256 JWKS used only by the MCP process.
-      ##
-      signingJwksFile: /etc/osmo/mcp-auth/signing-jwks.json
-
       accessTokenTtlSeconds: 600
       refreshTokenTtlSeconds: 28800
       upstreamTimeoutSeconds: 10
@@ -226,7 +222,6 @@ services:
         name: ""
         mountPath: /etc/osmo/mcp-auth
         clientSecretKey: client-secret
-        signingJwksKey: signing-jwks
         redisPasswordKey: redis-password
 
     ## Additional pod labels and annotations.

--- a/src/locked_requirements.txt
+++ b/src/locked_requirements.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=locked_requirements.txt ./requirements.txt
 #
+aiofile==3.12.3 \
+    --hash=sha256:5c1bcc9e929c50834608e8cc1a4cc1d7503eb60c15a535b779fd39e2f372c017 \
+    --hash=sha256:caa6aa746b5e47e2165f7abd741b6415e49cf4d44fddc0f61844612cc3924d41
+    # via py-key-value-aio
 aiofiles==25.1.0 \
     --hash=sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2 \
     --hash=sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695
@@ -34,6 +38,7 @@ anyio==4.12.1 \
     # via
     #   httpx
     #   mcp
+    #   py-key-value-aio
     #   sse-starlette
     #   starlette
     #   watchfiles
@@ -47,6 +52,10 @@ attrs==26.1.0 \
     # via
     #   jsonschema
     #   referencing
+authlib==1.7.2 \
+    --hash=sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231 \
+    --hash=sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f
+    # via -r requirements.txt
 azure-core==1.38.2 \
     --hash=sha256:074806c75cf239ea284a33a66827695ef7aeddac0b4e19dda266a93e4665ead9 \
     --hash=sha256:67562857cb979217e48dc60980243b61ea115b77326fa93d83b729e7ff0482e7
@@ -61,6 +70,10 @@ azure-storage-blob==12.26.0 \
     --hash=sha256:5dd7d7824224f7de00bfeb032753601c982655173061e242f13be6e26d78d71f \
     --hash=sha256:8c5631b8b22b4f53ec5fff2f3bededf34cfef111e2af613ad42c9e6de00a77fe
     # via -r requirements.txt
+beartype==0.22.9 \
+    --hash=sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f \
+    --hash=sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2
+    # via py-key-value-aio
 boto3==1.38.0 \
     --hash=sha256:8b6544eca17e31d1bfd538e5d152b96a68d6c92950352a0cd9679f89d217d53a \
     --hash=sha256:96898facb164b47859d40a4271007824a0a791c3811a7079ce52459d753d4474
@@ -72,6 +85,45 @@ botocore==1.38.0 \
     #   -r requirements.txt
     #   boto3
     #   s3transfer
+cachetools==7.1.7 \
+    --hash=sha256:a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50 \
+    --hash=sha256:ef98ef375ad188819ef2f9b3645e3987f4b8c5b7550e436ad998c2de78296df0
+    # via py-key-value-aio
+caio==0.12.2 \
+    --hash=sha256:07942d3b5999127ecb96256c38d5dbf49ed2864c087ed2a80b783901d0aa3ba1 \
+    --hash=sha256:0ad8d8f9f5ea47aee81aead563fe3aca5bb54c3fc21b62bd830eaf369eb04060 \
+    --hash=sha256:0b85f94819058a8f21c3dca26c5f006a0f003b8700483a326ec86d569d2bd1a3 \
+    --hash=sha256:107e56554c179749de9440e1b5e5a19813572eebf3166e9dc3e5228b16966beb \
+    --hash=sha256:121f4de82e2a875aff468ef2af7491fbecfffe9e71b507f5073fe2a156bb78df \
+    --hash=sha256:15af6eb10d7705a92ee8143d8a4d89c2886ecb6b65ce1161d3dad1adb9b3cbec \
+    --hash=sha256:1b04358ef65bd03d9c34d7b028efb422593b07485da82d6c5439f8c5dea35668 \
+    --hash=sha256:2097cc0d19fa95e8d55aad770597bb0f76e4f70ed48278c965aa7c5b0b8c3bf5 \
+    --hash=sha256:2122dccbd1959b922543fc9f8a9d2af47bd5b59190d1ece2445d3d1b4d1be45f \
+    --hash=sha256:391a7cc1dbfc5885d7d54406c9a7a4ec19d514d526e67d240d32734eebde378e \
+    --hash=sha256:40ebea9ebe3a3a66ae85fa00d4112d163654a33c82dcf9b26a99f7d30de13317 \
+    --hash=sha256:51bb86c0abce55d0b3467ba6671e95cd96356044e5abd58651ad0645cf37084b \
+    --hash=sha256:5233e797c9fe2b541914b1bc2e2df82677e2206b537e44e252188f3c2cbb0ea9 \
+    --hash=sha256:5d658212d585b8814b9caf766d8090acac05f01abfa2875d57fdc4a7e2af032e \
+    --hash=sha256:6003ec389a68d5ec8f089df82b2dc8915293dd630a4d11322d7e3455045981fd \
+    --hash=sha256:78e3ccafc98e009fcb00a97ad441585551e52c0ae7ecc50427a3ccd9b11502fd \
+    --hash=sha256:8054cba5e7ee623bea34946e2b59eb7c7c2be8872d0a5d12215d6ff564938d5f \
+    --hash=sha256:87a67c0dccc60e432888bd532ec504b66e124a5d8b391aab894583b55abd39ea \
+    --hash=sha256:a294091062831970b702f10a7fb119c1b55a49db7b843deeb8939550531189ea \
+    --hash=sha256:a2a7f0fa3b49f219f09705717c73a618eecbb3d697701e20abb4771d17e2bbcf \
+    --hash=sha256:a60459e42c680068a2a5286f15f54ccd887af34ad9ed1be1f0a7747ad6bd8820 \
+    --hash=sha256:a682783aef6eff8bc47cd5dd262081d7f746b8d3db1957c70a04017598a048d9 \
+    --hash=sha256:a857d06308dc4428b760f9430350b3847f4c62ad0e79e635215f7cc97f7adcc9 \
+    --hash=sha256:adc7785e61ff7cf372318f67ec65617eaa06975e20da177522665dca8be6ea5d \
+    --hash=sha256:af0c75b43f0cde52c758c000b797188e6d62579c4914173ca7afca382a47993d \
+    --hash=sha256:bd94522714af3fd806093bdd10f3175f1c42c5ee72dda975b8b35b55c3400147 \
+    --hash=sha256:c3922302878d17d6860ebe6b5e4dcc6821f7a9d162474a774b8534fedea80236 \
+    --hash=sha256:e0ba5f8c0dc7035c05817ca1399dd7d6121ea55c363a079c334a151a75094322 \
+    --hash=sha256:e1253743841b0864bfd6827e496fea4591bb3999ec1c003e57de65370e2d9031 \
+    --hash=sha256:e33295963f5a4787355b8bfd754b4f0e7ac5d535138860748c1eb833ca10d620 \
+    --hash=sha256:e97f960ab7c84aaa7520367bf597222db4229054bc7aae70344cb7da7b19b6f1 \
+    --hash=sha256:eee9376d0e2af25b6defc5bce39f6efa90521c803aaf12eba931bd898a397cfc \
+    --hash=sha256:f2355db8917f5a0f3638bf332fe0d87549c80e978fca01db84a8a14b9df56a05
+    # via aiofile
 certifi==2026.2.25 \
     --hash=sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa \
     --hash=sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7
@@ -337,18 +389,41 @@ cryptography==48.0.1 \
     --hash=sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46
     # via
     #   -r requirements.txt
+    #   authlib
     #   azure-identity
     #   azure-storage-blob
+    #   joserfc
     #   jwcrypto
     #   msal
+    #   py-key-value-aio
     #   pyjwt
+dnspython==2.8.0 \
+    --hash=sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af \
+    --hash=sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f
+    # via email-validator
 durationpy==0.10 \
     --hash=sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba \
     --hash=sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286
     # via kubernetes
+email-validator==2.3.0 \
+    --hash=sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4 \
+    --hash=sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426
+    # via pydantic
+exceptiongroup==1.3.1 \
+    --hash=sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219 \
+    --hash=sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598
+    # via fastmcp-slim
 fastapi==0.137.2 \
     --hash=sha256:791d36261e916a98b25ac85ee591bc3db159394070f6d3d096d94fb378f60ce2 \
     --hash=sha256:b9d893bebc97dcfbdcb1917e88a292d062844ea19445a5fa4f7eb28c4baea9e3
+    # via -r requirements.txt
+fastmcp-slim[mcp]==3.4.7 \
+    --hash=sha256:06b32a358320a7dc2b2ee040ba89ea55ddc20763dff2949f384f7974b13b5d8f \
+    --hash=sha256:6c931a0089705f3f2935428ef9b2bc74ad94140adc64aab84d116d103e694b3a
+    # via -r requirements.txt
+griffelib==2.1.0 \
+    --hash=sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813 \
+    --hash=sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00
     # via -r requirements.txt
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -409,7 +484,9 @@ httptools==0.7.1 \
 httpx==0.28.1 \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
-    # via mcp
+    # via
+    #   fastmcp-slim
+    #   mcp
 httpx-sse==0.4.3 \
     --hash=sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc \
     --hash=sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d
@@ -420,6 +497,7 @@ idna==3.16 \
     # via
     #   -r requirements.txt
     #   anyio
+    #   email-validator
     #   httpx
     #   requests
 ijson==3.4.0 \
@@ -527,6 +605,16 @@ jmespath==1.1.0 \
     # via
     #   boto3
     #   botocore
+joserfc==1.7.4 \
+    --hash=sha256:32d46c2cd5e3203c13e87a6c61333cab310b1ba80cd54b4c4f386a848a122463 \
+    --hash=sha256:b3bc561672ae541b17a9237053b48a03dacddd92d68047b3ecdfb4b5714a88ed
+    # via
+    #   -r requirements.txt
+    #   authlib
+jsonref==1.1.0 \
+    --hash=sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552 \
+    --hash=sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9
+    # via -r requirements.txt
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -557,6 +645,10 @@ macholib==1.16.3 \
     # via
     #   -r requirements.txt
     #   pyinstaller
+markdown-it-py==4.2.0 \
+    --hash=sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49 \
+    --hash=sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
+    # via rich
 markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
@@ -651,7 +743,13 @@ markupsafe==3.0.3 \
 mcp==1.28.1 \
     --hash=sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df \
     --hash=sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   fastmcp-slim
+mdurl==0.1.2 \
+    --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
+    --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
+    # via markdown-it-py
 msal==1.35.0 \
     --hash=sha256:76ab7513dbdac88d76abdc6a50110f082b7ed3ff1080aca938c53fc88bc75b51 \
     --hash=sha256:baf268172d2b736e5d409689424d2f321b4142cab231b4b96594c86762e7e01d
@@ -682,6 +780,7 @@ opentelemetry-api==1.39.1 \
     --hash=sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950 \
     --hash=sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c
     # via
+    #   fastmcp-slim
     #   opentelemetry-exporter-prometheus
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
@@ -730,10 +829,15 @@ packaging==26.0 \
     --hash=sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4 \
     --hash=sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
     # via
+    #   -r requirements.txt
     #   kombu
     #   opentelemetry-instrumentation
     #   pyinstaller
     #   pyinstaller-hooks-contrib
+platformdirs==4.11.2 \
+    --hash=sha256:3a2ae5fca3520a01ab1be8b45613537f52ddf5b5f6f53d88233892dfbf0cd82d \
+    --hash=sha256:7f89089b6ea71bda7962953edcf784b2e2d9d285b40ad88be2bb75c6e9d82ab4
+    # via fastmcp-slim
 prometheus-client==0.24.1 \
     --hash=sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055 \
     --hash=sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9
@@ -807,16 +911,21 @@ psycopg2-binary==2.9.11 \
     --hash=sha256:fa0f693d3c68ae925966f0b14b8edda71696608039f4ed61b1fe9ffa468d16db \
     --hash=sha256:fcf21be3ce5f5659daefd2b3b3b6e4727b028221ddc94e6c1523425579664747
     # via -r requirements.txt
+py-key-value-aio[filetree,memory,redis,wrappers-encryption]==0.4.5 \
+    --hash=sha256:ab862adbcb8c72547d1c57821f22cbbb71ab86509039c96f36e914e0336c8dd7 \
+    --hash=sha256:c6563a2c6abe5da5e20f4f9e875c2a9b425a2244a54fadbf46cf140a9eea45d7
+    # via -r requirements.txt
 pycparser==3.0 \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \
     --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
     # via cffi
-pydantic==2.12.5 \
+pydantic[email]==2.12.5 \
     --hash=sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49 \
     --hash=sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d
     # via
     #   -r requirements.txt
     #   fastapi
+    #   fastmcp-slim
     #   mcp
     #   pydantic-settings
 pydantic-core==2.41.5 \
@@ -947,7 +1056,12 @@ pydantic-settings==2.9.1 \
     --hash=sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268
     # via
     #   -r requirements.txt
+    #   fastmcp-slim
     #   mcp
+pygments==2.20.0 \
+    --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
+    --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+    # via rich
 pyinstaller==6.19.0 \
     --hash=sha256:1ec54ef967996ca61dacba676227e2b23219878ccce5ee9d6f3aada7b8ed8abf \
     --hash=sha256:3c5c251054fe4cfaa04c34a363dcfbf811545438cb7198304cd444756bc2edd2 \
@@ -983,12 +1097,15 @@ python-dotenv==1.2.2 \
     --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
     --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
     # via
+    #   fastmcp-slim
     #   pydantic-settings
     #   uvicorn
 python-multipart==0.0.32 \
     --hash=sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e \
     --hash=sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23
-    # via mcp
+    # via
+    #   -r requirements.txt
+    #   mcp
 pytz==2023.3 \
     --hash=sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588 \
     --hash=sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb
@@ -1074,7 +1191,9 @@ pyyaml==6.0.3 \
 redis==7.4.0 \
     --hash=sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad \
     --hash=sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   py-key-value-aio
 referencing==0.37.0 \
     --hash=sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231 \
     --hash=sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8
@@ -1094,6 +1213,10 @@ requests-oauthlib==2.0.0 \
     --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
     --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
     # via kubernetes
+rich==15.0.0 \
+    --hash=sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb \
+    --hash=sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36
+    # via fastmcp-slim
 rpds-py==2026.5.1 \
     --hash=sha256:01d17b29c0c23d82b1f4751147ec49cf451f1fc2554eb9ef5f957e55d2656ead \
     --hash=sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a \
@@ -1255,6 +1378,7 @@ starlette==1.3.1 \
     --hash=sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6
     # via
     #   fastapi
+    #   fastmcp-slim
     #   mcp
     #   sse-starlette
 texttable==1.6.4 \
@@ -1281,11 +1405,13 @@ typing-extensions==4.15.0 \
     #   azure-identity
     #   azure-storage-blob
     #   fastapi
+    #   fastmcp-slim
     #   jwcrypto
     #   mcp
     #   opentelemetry-api
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
+    #   py-key-value-aio
     #   pydantic
     #   pydantic-core
     #   typing-inspection
@@ -1301,6 +1427,10 @@ tzdata==2026.1 \
     --hash=sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9 \
     --hash=sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98
     # via kombu
+uncalled-for==0.4.0 \
+    --hash=sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd \
+    --hash=sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af
+    # via -r requirements.txt
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -45,6 +45,19 @@ h11==0.16.0
 # Model Context Protocol
 mcp>=1.27,<2
 
+# Endpoint-only MCP OAuth. FastMCP's OIDCProxy is used as a focused OAuth proxy;
+# these explicit server-import dependencies avoid upgrading OSMO's existing
+# Uvicorn/WebSocket runtime through the broad `server` extra.
+fastmcp-slim[mcp]==3.4.7
+authlib>=1.6.11
+griffelib>=2.0.0
+jsonref>=1.1.0
+joserfc>=1.1.0
+packaging>=24.0
+py-key-value-aio[filetree,memory,redis,wrappers-encryption]>=0.4.4,<0.5.0
+python-multipart>=0.0.26
+uncalled-for>=0.2.0
+
 # JWT
 pyjwt==2.13.0
 

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -23,11 +23,57 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
 load("@osmo_constants//:constants.bzl", "BASE_IMAGE_URL", "IMAGE_TAG")
 
 osmo_py_library(
+    name = "fastmcp_runtime",
+    deps = [
+        requirement("authlib"),
+        requirement("cryptography"),
+        requirement("fastmcp-slim"),
+        requirement("griffelib"),
+        requirement("httpx"),
+        requirement("joserfc"),
+        requirement("jsonref"),
+        requirement("mcp"),
+        requirement("packaging"),
+        requirement("py-key-value-aio"),
+        requirement("pydantic"),
+        requirement("python-multipart"),
+        requirement("redis"),
+        requirement("starlette"),
+        requirement("uncalled-for"),
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "request_context",
     srcs = ["request_context.py"],
     deps = [
+        ":fastmcp_runtime",
         requirement("starlette"),
         "//src/lib/utils:login",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
+    name = "auth",
+    srcs = ["auth.py"],
+    deps = [
+        requirement("authlib"),
+        requirement("cryptography"),
+        ":fastmcp_runtime",
+        requirement("griffelib"),
+        requirement("httpx"),
+        requirement("joserfc"),
+        requirement("jsonref"),
+        requirement("mcp"),
+        requirement("packaging"),
+        requirement("py-key-value-aio"),
+        requirement("pydantic"),
+        requirement("python-multipart"),
+        requirement("redis"),
+        requirement("starlette"),
+        requirement("uncalled-for"),
     ],
     visibility = ["//visibility:public"],
 )
@@ -66,7 +112,7 @@ osmo_py_library(
     name = "tool_errors",
     srcs = ["tool_errors.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
     ],
     visibility = ["//visibility:public"],
 )
@@ -94,7 +140,7 @@ osmo_py_library(
     name = "tool_requests",
     srcs = ["tool_requests.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         requirement("pydantic"),
         requirement("starlette"),
         ":gateway",
@@ -109,7 +155,7 @@ osmo_py_library(
     name = "access_scope",
     srcs = ["access_scope.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         ":tool_requests",
         ":tool_validation",
     ],
@@ -196,7 +242,7 @@ osmo_py_library(
     name = "profile_tools",
     srcs = ["profile.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         requirement("pydantic"),
         ":access_scope",
         ":tool_errors",
@@ -210,7 +256,7 @@ osmo_py_library(
     name = "health_tools",
     srcs = ["health.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         requirement("pydantic"),
         ":access_scope",
     ],
@@ -221,7 +267,7 @@ osmo_py_library(
     name = "pool_tools",
     srcs = ["pools.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         ":access_scope",
         ":pool_models",
         ":tool_errors",
@@ -235,7 +281,7 @@ osmo_py_library(
     name = "resource_tools",
     srcs = ["resources.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         requirement("pydantic"),
         ":access_scope",
         ":resource_models",
@@ -251,7 +297,7 @@ osmo_py_library(
     name = "workflow_tools",
     srcs = ["workflows.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         ":access_scope",
         ":gateway",
         ":tool_errors",
@@ -267,7 +313,7 @@ osmo_py_library(
     name = "workflow_submission",
     srcs = ["workflow_submission.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         ":access_scope",
         ":gateway",
         ":tool_errors",
@@ -285,7 +331,7 @@ osmo_py_library(
     name = "workflow_action_tools",
     srcs = ["workflow_actions.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         ":gateway",
         ":tool_errors",
         ":tool_requests",
@@ -302,7 +348,7 @@ osmo_py_library(
     name = "app_tools",
     srcs = ["apps.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         ":app_models",
         ":tool_errors",
         ":tool_requests",
@@ -315,7 +361,7 @@ osmo_py_library(
     name = "app_action_tools",
     srcs = ["app_actions.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         requirement("pydantic"),
         ":app_action_models",
         ":app_models",
@@ -331,7 +377,7 @@ osmo_py_library(
     name = "app_submission_tools",
     srcs = ["app_submission.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         ":app_action_models",
         ":app_models",
         ":app_tools",
@@ -348,7 +394,7 @@ osmo_py_library(
     name = "credential_tools",
     srcs = ["credentials.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         requirement("pydantic"),
         ":tool_errors",
         ":tool_requests",
@@ -360,7 +406,7 @@ osmo_py_library(
     name = "credential_action_tools",
     srcs = ["credential_actions.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         ":credential_action_models",
         ":tool_errors",
         ":tool_requests",
@@ -373,6 +419,7 @@ osmo_py_library(
     name = "tool_registry",
     srcs = ["tool_registry.py"],
     deps = [
+        ":fastmcp_runtime",
         requirement("mcp"),
         ":app_action_tools",
         ":app_submission_tools",
@@ -393,7 +440,7 @@ osmo_py_library(
     name = "protocol",
     srcs = ["protocol.py"],
     deps = [
-        requirement("mcp"),
+        ":fastmcp_runtime",
         requirement("pydantic"),
         ":request_context",
         ":telemetry",
@@ -407,10 +454,11 @@ osmo_py_library(
     srcs = ["server.py"],
     deps = [
         requirement("httpx"),
-        requirement("mcp"),
+        ":fastmcp_runtime",
         requirement("pydantic"),
         requirement("starlette"),
         requirement("uvicorn"),
+        ":auth",
         ":gateway",
         ":protocol",
         ":request_body",

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -18,26 +18,47 @@
 
 # OSMO MCP service
 
-The self-hosted MCP service is a stateless, thin adapter over predefined OSMO
-REST APIs. It does not authenticate users itself. The deployment contract
-requires every MCP request and every resulting API request to pass through the
-same deployment's Gateway.
+The self-hosted MCP service is a thin adapter over predefined OSMO REST APIs.
+Every MCP request and every resulting API request enters through the same
+deployment's Gateway. Authentication can remain at the Gateway or run inside
+the existing MCP process through FastMCP's built-in `OIDCProxy`.
+
+OSMO can expose MCP authentication in either of two deployment modes:
+
+- **Direct identity-provider mode** retains the existing behavior. The Gateway
+  advertises the configured identity provider, and clients may need an OAuth
+  client ID, scopes, and callback configuration supplied by the deployment
+  administrator.
+- **OIDC proxy mode** passes an `OIDCProxy` as the existing FastMCP server's
+  `auth` argument. A client configures only `/mcp`, discovers FastMCP's OAuth
+  endpoints, and completes the deployment identity-provider login in a browser.
+  FastMCP supports Client ID Metadata Documents (CIMD) and retains Dynamic
+  Client Registration (DCR) for older clients. It authenticates MCP access but
+  does not replace OSMO's API-specific authorization.
+
+OIDC proxy mode is feature-gated by `services.mcp.oidcProxy.enabled` and
+disabled by default. No second executable, process, Service, or Deployment is
+created.
 
 ## Request flow and trust boundary
 
 ```text
-MCP client
-  -> Gateway (token validation + mcp:Access)
-  -> MCP (request-local token reference + fixed tool mapping)
-  -> same Gateway (second token validation + API-specific action)
-  -> OSMO API
+Direct mode:
+  MCP client -> Gateway JWT + mcp:Access -> MCP
+             -> same Gateway JWT + API action -> OSMO API
+
+OIDC proxy mode:
+  MCP client -> Gateway routing -> FastMCP OIDCProxy -> MCP
+             -> same Gateway with verified upstream token + API action
+             -> OSMO API
 ```
 
-The Gateway supplies one `Authorization: Bearer ...` header and trusted
-`x-osmo-user` identity to the MCP request. The MCP middleware validates the
-forwarded context, removes those headers from the downstream ASGI scope, and
-holds the exact authorization value only in request-local context. A tool must
-pass those credentials explicitly to `GatewayClient`; the shared HTTP client
+In direct mode, Gateway supplies the validated bearer and trusted user identity;
+the request-context middleware strips those headers from the downstream ASGI
+scope and retains one request-local credential. In OIDC proxy mode, FastMCP
+validates its resource token and `get_access_token()` exposes the verified
+upstream identity-provider bearer to the active tool request. A tool passes the
+selected credential explicitly to `GatewayClient`; the shared HTTP client
 contains no caller credentials.
 
 The relay boundary has these invariants:
@@ -49,14 +70,17 @@ The relay boundary has these invariants:
   by each tool and values are encoded from bounded typed inputs. Unknown tool
   arguments, alternate URLs, embedded queries or fragments, redirects, and
   path traversal fail closed.
-- The unchanged authorization value and optional request ID are the only
-  caller-derived headers forwarded on the second Gateway pass. MCP does not
+- The direct-mode bearer or OIDC proxy's verified upstream bearer, plus an
+  optional request ID, are the only caller-derived values forwarded on the
+  second Gateway pass. MCP does not
   copy `x-osmo-*`, cookies, proxy headers, or other inbound request headers.
   Request IDs that reuse a meaningful bearer-token substring are rejected
   before forwarding or telemetry.
-- MCP does not exchange, refresh, modify, cache, persist, log, or return the
-  bearer token. It clears request context and upstream cookies on completion,
-  failure, timeout, or cancellation.
+- The tool adapter does not independently exchange, refresh, modify, cache,
+  persist, log, or return bearer tokens. In OIDC proxy mode, FastMCP alone owns
+  upstream exchange, refresh, and encrypted Redis state. Tool request context
+  and upstream cookies are cleared on completion, failure, timeout, or
+  cancellation.
 - Tool arguments are rejected before execution if they contain the active
   authorization value or bearer token, preventing credential reflection into
   dynamic path or query values.
@@ -95,8 +119,150 @@ The relay boundary has these invariants:
   to a generic error without reflecting exception text.
 
 The Gateway, MCP process, receiving OSMO APIs, and applicable middleware are
-inside the bearer-token handling boundary. None of them may log or persist the
-authorization value.
+inside the bearer-token handling boundary. None may log the authorization
+value. The only intentional persistence is FastMCP's encrypted upstream-token
+state in Redis while OIDC proxy mode is enabled.
+
+## Endpoint-only OAuth
+
+When OIDC proxy mode is enabled, the public flow is:
+
+```text
+MCP client
+  -> Gateway /mcp (401 with protected-resource metadata)
+  -> FastMCP OAuth discovery in the existing MCP process
+  -> CIMD client identity, or DCR registration as a compatibility fallback
+  -> deployment identity provider login in the user's browser
+  -> FastMCP authorization-code exchange with PKCE
+  -> Gateway routes the FastMCP resource token to /mcp
+  -> FastMCP validates it and exposes the verified upstream access token
+  -> Gateway validates that upstream token on each /api tool request
+```
+
+The client still performs an interactive browser login, but it does not need a
+deployment-specific client ID, scope list, callback URL, or callback port. For
+example, a fresh Codex profile requires only:
+
+```bash
+codex mcp add osmo --url https://<osmo-host>/mcp
+codex mcp login osmo
+```
+
+Clients that support OAuth discovery, CIMD, and PKCE S256 use their HTTPS
+metadata-document URL as a stable client ID. DCR-capable clients without CIMD
+support can use the same endpoint-only flow through `/register`. A DCR record
+is stored in OSMO; neither approach creates an application in the upstream
+identity provider. The deployment owns one administrator-managed confidential
+upstream OIDC application and one stable `/auth/callback` redirect URL.
+
+FastMCP's OIDC proxy owns CIMD, DCR fallback, PKCE, consent, upstream OIDC
+exchange, refresh, proxy-token issuance, and encrypted state. OSMO supplies a
+built-in `JWTVerifier` for the upstream API token's RS256 signature, issuer,
+audience, and short `access_as_user` `scp` value. The full delegated scope URI
+is advertised to clients with `update_default_scopes()` and requested upstream
+alongside `openid profile email offline_access`.
+
+Gateway does not validate FastMCP's private proxy token. In this mode it routes
+the exact `/mcp`, metadata, authorization, callback, registration, token, and
+consent paths to the existing `osmo-mcp` cluster with Gateway JWT and ext-authz
+disabled only on those routes. FastMCP authenticates `/mcp`; each tool then
+relays the verified upstream access token to `/api`, where the existing Gateway
+identity-provider validation, OSMO roles, API actions, and pool scope still
+apply. The private FastMCP signing key is never mounted into Gateway.
+
+### Deployment prerequisites
+
+Before enabling OIDC proxy mode, an administrator must provide:
+
+- one confidential OIDC application in the deployment identity provider, with
+  the exact `https://<osmo-host>/auth/callback` redirect registered;
+- its client ID and client secret through the deployment's secret manager;
+- the full delegated `<resource-url>/access_as_user` scope on that application;
+- OIDC discovery plus explicit issuer, audience, JWKS URL, and short
+  `access_as_user` scope requirements for upstream API access-token validation;
+- one private 256-bit HS256 key as a single-key JWKS mounted only in the MCP
+  pod; this symmetric key must never be exposed publicly;
+- a shared Redis namespace for FastMCP's encrypted clients, authorization
+  transactions, upstream tokens, and refresh state;
+- an exact public MCP resource URL; the OAuth issuer is its origin; and
+- an existing Gateway identity-provider JWT provider and role mapping for the
+  verified upstream token relayed to `/api`.
+
+The public protocol surface is deliberately narrow:
+
+```text
+GET  /.well-known/oauth-protected-resource/mcp
+GET  /.well-known/oauth-authorization-server
+GET  /authorize
+POST /authorize
+GET  /auth/callback
+POST /register
+POST /token
+GET  /consent
+POST /consent
+```
+
+Only these exact OAuth paths and methods bypass the normal Gateway JWT and OSMO
+authorization filters. In OIDC proxy mode, exact `/mcp` also bypasses those
+Gateway filters because FastMCP authenticates it in-process. Neighboring paths
+remain protected. All resulting `/api` calls use normal Gateway authentication
+and authorization.
+
+A minimal values overlay selects OIDC proxy mode and its upstream provider;
+credentials remain file-mounted secrets:
+
+```yaml
+services:
+  mcp:
+    resourceUrl: https://<osmo-host>/mcp
+    replicas: 1
+    oidcProxy:
+      enabled: true
+      scope: https://<osmo-host>/mcp/access_as_user
+      oidc:
+        configUrl: https://login.microsoftonline.com/<tenant-id>/v2.0/.well-known/openid-configuration
+        clientId: <oidc-application-client-id>
+        clientSecretFile: /etc/osmo/mcp-auth/client-secret
+        accessTokenIssuer: https://sts.windows.net/<tenant-id>/
+        accessTokenAudience: https://<osmo-host>/mcp
+        accessTokenJwksUrl: https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys
+        accessTokenRequiredScope: access_as_user
+      signingJwksFile: /etc/osmo/mcp-auth/signing-jwks.json
+      redis:
+        dbNumber: <dedicated-database-number>
+        keyPrefix: osmo:mcp-fastmcp
+```
+
+Do not place the upstream client secret, signing key, access token, refresh
+token, authorization code, or user session in Helm values, Git, or logs. The
+existing `/usr/bin/mcp` process loads `OIDCProxy` and the
+file-mounted secrets directly. Startup fails if required configuration or key
+material is missing; health probes report process health and do not perform an
+upstream OIDC or Redis transaction. Operators should
+monitor CIMD metadata-fetch failures, registration, authorization, callback,
+token, refresh, consent, Redis, and upstream identity-provider outcomes without
+logging credential or identity payloads. CIMD fetches are outbound requests to
+client-controlled URLs; retain FastMCP's validation and SSRF protections and do
+not add an unrestricted custom metadata-fetch path.
+
+### Rollout and rollback
+
+The feature gate updates the existing MCP Deployment, adds exact Gateway
+routes, and lets FastMCP serve protected-resource metadata in one rollout. Use
+it first on a dev instance and run discovery, DCR fallback, CIMD, login,
+access-token expiry, refresh, restart recovery, and key-rotation tests from
+clean client profiles. Confirm CIMD through
+`client_id_metadata_document_supported: true` in authorization-server metadata
+and DCR fallback through `registration_endpoint`. Keep `services.mcp.replicas`
+at `1` while using FastMCP 3.4.7 because refresh serialization is process-local.
+
+After changing an Entra app-role assignment, users should log out and
+authenticate again so the next token definitely contains the updated role set.
+
+To roll back, disable `services.mcp.oidcProxy.enabled`, restore the direct-mode
+`authorizationServers` and `scopes` values, and redeploy. Existing proxy tokens
+will no longer authenticate, so clients must log in again through the direct
+provider. The MCP tool catalog and API-specific authorization do not change.
 
 ## Available tools
 
@@ -205,6 +371,11 @@ projection, and handlers in the matching domain module. `tool_registry.py` is
 the single source of registration metadata used by both the server and
 catalog.
 
+Optional authentication lives in `auth.py`. It constructs FastMCP's built-in
+`OIDCProxy`, upstream `JWTVerifier`, encrypted Redis store, and signing key, then
+passes the provider as the `auth` argument to the same `OSMOFastMCP` instance.
+OSMO does not implement OAuth endpoints or run a second auth service.
+
 Do not import the CLI runtime. Extract only pure public helpers when behavior
 genuinely needs to match another OSMO surface.
 
@@ -234,17 +405,22 @@ Keep each new tool a narrow adapter:
 ## Local validation
 
 ```bash
-bazel test --test_output=errors //src/service/mcp/...
+bazel test --test_output=errors \
+  //src/service/mcp/...
 bazel build \
   //src/service/mcp:mcp_binary \
   //test/smoke:mcp-checks
+bazel build \
+  --platforms=//bzl/platforms:linux_x86_64 \
+  //src/service/mcp:mcp_image_x86_64
 bazel test //test/smoke:mcp-checks-pylint
 bash deployments/charts/service/ci/validate-mcp-chart.sh
 ```
 
-The chart validation covers MCP-disabled and MCP-enabled renders, the derived
-Gateway origin, OAuth metadata, probes, ingress isolation, absence of MCP
-credential material, and expected configuration failures.
+The chart validation covers MCP-disabled, direct-provider, and in-process OIDC
+proxy renders; the derived Gateway origin; exact OAuth routing; the `/mcp`
+filter boundary; secret mounts; ingress isolation; and expected configuration
+failures.
 
 ## Deployment validation
 

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -168,7 +168,8 @@ consent paths to the existing `osmo-mcp` cluster with Gateway JWT and ext-authz
 disabled only on those routes. FastMCP authenticates `/mcp`; each tool then
 relays the verified upstream access token to `/api`, where the existing Gateway
 identity-provider validation, OSMO roles, API actions, and pool scope still
-apply. The private FastMCP signing key is never mounted into Gateway.
+apply. FastMCP derives its private proxy-token signing key from the upstream
+OIDC client secret; no proxy signing key is mounted into Gateway.
 
 ### Deployment prerequisites
 
@@ -180,8 +181,6 @@ Before enabling OIDC proxy mode, an administrator must provide:
 - the full delegated `<resource-url>/access_as_user` scope on that application;
 - OIDC discovery plus explicit issuer, audience, JWKS URL, and short
   `access_as_user` scope requirements for upstream API access-token validation;
-- one private 256-bit HS256 key as a single-key JWKS mounted only in the MCP
-  pod; this symmetric key must never be exposed publicly;
 - a shared Redis namespace for FastMCP's encrypted clients, authorization
   transactions, upstream tokens, and refresh state;
 - an exact public MCP resource URL; the OAuth issuer is its origin; and
@@ -227,14 +226,13 @@ services:
         accessTokenAudience: https://<osmo-host>/mcp
         accessTokenJwksUrl: https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys
         accessTokenRequiredScope: access_as_user
-      signingJwksFile: /etc/osmo/mcp-auth/signing-jwks.json
       redis:
         dbNumber: <dedicated-database-number>
         keyPrefix: osmo:mcp-fastmcp
 ```
 
-Do not place the upstream client secret, signing key, access token, refresh
-token, authorization code, or user session in Helm values, Git, or logs. The
+Do not place the upstream client secret, access token, refresh token,
+authorization code, or user session in Helm values, Git, or logs. The
 existing `/usr/bin/mcp` process loads `OIDCProxy` and the
 file-mounted secrets directly. Startup fails if required configuration or key
 material is missing; health probes report process health and do not perform an
@@ -244,6 +242,13 @@ token, refresh, consent, Redis, and upstream identity-provider outcomes without
 logging credential or identity payloads. CIMD fetches are outbound requests to
 client-controlled URLs; retain FastMCP's validation and SSRF protections and do
 not add an unrestricted custom metadata-fetch path.
+
+FastMCP deterministically derives the proxy-token signing key from the upstream
+OIDC client secret. OSMO mirrors FastMCP's derivation for the encrypted Redis
+store, so all replicas and restarts using the same client secret share stable
+keys. Rotating the client secret invalidates outstanding proxy tokens; encrypted
+entries from the old key are treated as cache misses, so clients must sign in
+again after the rotation.
 
 ### Rollout and rollback
 
@@ -372,8 +377,9 @@ the single source of registration metadata used by both the server and
 catalog.
 
 Optional authentication lives in `auth.py`. It constructs FastMCP's built-in
-`OIDCProxy`, upstream `JWTVerifier`, encrypted Redis store, and signing key, then
-passes the provider as the `auth` argument to the same `OSMOFastMCP` instance.
+`OIDCProxy`, upstream `JWTVerifier`, and encrypted Redis store, then passes the
+provider as the `auth` argument to the same `OSMOFastMCP` instance. FastMCP
+derives its signing key from the existing upstream OIDC client secret.
 OSMO does not implement OAuth endpoints or run a second auth service.
 
 Do not import the CLI runtime. Extract only pure public helpers when behavior

--- a/src/service/mcp/access_scope.py
+++ b/src/service/mcp/access_scope.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 
 from src.service.mcp import tool_requests, tool_validation
 

--- a/src/service/mcp/app_actions.py
+++ b/src/service/mcp/app_actions.py
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 import pydantic
 
 from src.service.mcp import apps, tool_errors, tool_requests, tool_validation

--- a/src/service/mcp/app_submission.py
+++ b/src/service/mcp/app_submission.py
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 
 from src.service.mcp import (
     apps,

--- a/src/service/mcp/apps.py
+++ b/src/service/mcp/apps.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import dataclasses
 import re
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 
 from src.service.mcp import tool_requests, tool_validation
 from src.service.mcp.app_models import (

--- a/src/service/mcp/auth.py
+++ b/src/service/mcp/auth.py
@@ -16,14 +16,12 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import base64
 import dataclasses
-import hashlib
-import json
-from typing import Any, cast
+from typing import cast
 from urllib import parse
 
 from cryptography.fernet import Fernet
+from fastmcp.server.auth.jwt_issuer import derive_jwt_key
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
 import httpx
@@ -42,7 +40,7 @@ class MCPAuthConfig(pydantic.BaseModel):
 
     model_config = pydantic.ConfigDict(hide_input_in_errors=True)
 
-    enabled: bool = pydantic.Field(
+    auth_enabled: bool = pydantic.Field(
         default=False,
         json_schema_extra={'env': 'OSMO_MCP_AUTH_ENABLED'},
     )
@@ -54,7 +52,7 @@ class MCPAuthConfig(pydantic.BaseModel):
         default=None,
         json_schema_extra={'env': 'OSMO_MCP_AUTH_RESOURCE_URL'},
     )
-    scope: str | None = pydantic.Field(
+    auth_scope: str | None = pydantic.Field(
         default=None,
         json_schema_extra={'env': 'OSMO_MCP_AUTH_SCOPE'},
     )
@@ -102,10 +100,6 @@ class MCPAuthConfig(pydantic.BaseModel):
             'env': 'OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE',
         },
     )
-    signing_jwks_file: str | None = pydantic.Field(
-        default=None,
-        json_schema_extra={'env': 'OSMO_MCP_AUTH_SIGNING_JWKS_FILE'},
-    )
     trusted_https_redirect_origins: str = pydantic.Field(
         default='',
         json_schema_extra={
@@ -144,15 +138,15 @@ class MCPAuthConfig(pydantic.BaseModel):
     )
 
     @pydantic.model_validator(mode='after')
-    def _validate_enabled_config(self) -> 'MCPAuthConfig':
-        if not self.enabled:
+    def _validate_auth_config(self) -> 'MCPAuthConfig':
+        if not self.auth_enabled:
             return self
         required = {
             name: getattr(self, name)
             for name in (
                 'issuer_url',
                 'resource_url',
-                'scope',
+                'auth_scope',
                 'redis_url',
                 'oidc_config_url',
                 'oidc_client_id',
@@ -160,7 +154,6 @@ class MCPAuthConfig(pydantic.BaseModel):
                 'oidc_access_token_jwks_url',
                 'oidc_access_token_issuer',
                 'oidc_access_token_audience',
-                'signing_jwks_file',
             )
         }
         missing = sorted(name for name, value in required.items() if not value)
@@ -171,16 +164,18 @@ class MCPAuthConfig(pydantic.BaseModel):
 
         issuer = _https_url(cast(str, self.issuer_url), root_only=True)
         resource = _https_url(cast(str, self.resource_url))
-        scope = _https_url(cast(str, self.scope))
+        scope = _https_url(cast(str, self.auth_scope))
         if resource != f'{issuer}/mcp':
             raise ValueError('resource_url must be issuer_url followed by /mcp')
         if scope != f'{resource}/{self.oidc_access_token_required_scope}':
-            raise ValueError('scope must be resource_url followed by the token scope')
+            raise ValueError(
+                'auth_scope must be resource_url followed by the token scope'
+            )
         if self.oidc_access_token_audience != resource:
             raise ValueError('oidc_access_token_audience must match resource_url')
         self.issuer_url = issuer
         self.resource_url = resource
-        self.scope = scope
+        self.auth_scope = scope
         self.oidc_config_url = _https_url(cast(str, self.oidc_config_url))
         self.oidc_access_token_jwks_url = _https_url(
             cast(str, self.oidc_access_token_jwks_url)
@@ -222,19 +217,25 @@ class MCPAuthRuntime:
     """Resources owned by FastMCP's built-in OIDC proxy."""
 
     provider: OIDCProxy
-    redis_client: Any
+    redis_client: redis_asyncio.Redis
     http_client: httpx.AsyncClient
 
     async def aclose(self) -> None:
-        await self.http_client.aclose()
-        await cast(Any, self.redis_client).aclose()
+        try:
+            await self.http_client.aclose()
+        finally:
+            await self.redis_client.aclose()
 
 
 def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
     """Configure FastMCP's OIDCProxy; no OSMO OAuth endpoints are implemented."""
-    if not config.enabled:
+    if not config.auth_enabled:
         raise ValueError('MCP auth is disabled')
 
+    client_secret = _read_required_secret(
+        cast(str, config.oidc_client_secret_file),
+        'OIDC client secret',
+    )
     redis_client = redis_asyncio.Redis.from_url(
         cast(str, config.redis_url),
         password=_read_optional_secret(config.redis_password_file),
@@ -246,10 +247,10 @@ def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
         key_value=RedisStore(client=redis_client),
         prefix=config.redis_key_prefix,
     )
-    signing_key = _read_signing_jwks(cast(str, config.signing_jwks_file))
     encrypted_store: AsyncKeyValue = FernetEncryptionWrapper(
         key_value=namespaced_store,
-        fernet=Fernet(base64.urlsafe_b64encode(_storage_key(signing_key))),
+        fernet=Fernet(_storage_encryption_key(client_secret)),
+        raise_on_decryption_error=False,
     )
     http_client = httpx.AsyncClient(
         timeout=config.upstream_timeout_seconds,
@@ -263,15 +264,12 @@ def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
         required_scopes=[config.oidc_access_token_required_scope],
         http_client=http_client,
     )
-    requested_scope = cast(str, config.scope)
+    requested_scope = cast(str, config.auth_scope)
     upstream_scope = ' '.join((requested_scope, *_UPSTREAM_OIDC_SCOPES))
     provider = OIDCProxy(
         config_url=cast(str, config.oidc_config_url),
         client_id=cast(str, config.oidc_client_id),
-        client_secret=_read_required_secret(
-            cast(str, config.oidc_client_secret_file),
-            'OIDC client secret',
-        ),
+        client_secret=client_secret,
         token_verifier=verifier,
         base_url=cast(str, config.issuer_url),
         resource_base_url=cast(str, config.issuer_url),
@@ -279,7 +277,6 @@ def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
         redirect_path='/auth/callback',
         allowed_client_redirect_uris=config.allowed_client_redirect_uris,
         client_storage=encrypted_store,
-        jwt_signing_key=signing_key,
         token_endpoint_auth_method='client_secret_post',
         require_authorization_consent=True,
         forward_resource=False,
@@ -296,29 +293,16 @@ def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
     return MCPAuthRuntime(provider, redis_client, http_client)
 
 
-def _read_signing_jwks(path: str) -> bytes:
-    with open(path, encoding='utf-8') as jwks_file:
-        document = json.load(jwks_file)
-    keys = document.get('keys') if isinstance(document, dict) else None
-    if not isinstance(keys, list) or len(keys) != 1 or not isinstance(keys[0], dict):
-        raise ValueError('FastMCP signing JWKS must contain exactly one key')
-    key = keys[0]
-    encoded = key.get('k')
-    if key.get('kty') != 'oct' or not isinstance(encoded, str):
-        raise ValueError('FastMCP signing key must be one symmetric JWK')
-    if key.get('alg') not in {None, 'HS256'} or key.get('use') not in {None, 'sig'}:
-        raise ValueError('FastMCP signing key must be an HS256 signing key')
-    try:
-        decoded = base64.urlsafe_b64decode(encoded + '=' * (-len(encoded) % 4))
-    except (TypeError, ValueError) as error:
-        raise ValueError('FastMCP signing key must be base64url') from error
-    if len(decoded) != 32:
-        raise ValueError('FastMCP signing key must contain exactly 256 bits')
-    return decoded
-
-
-def _storage_key(signing_key: bytes) -> bytes:
-    return hashlib.sha256(b'osmo-fastmcp-storage-v1\0' + signing_key).digest()
+def _storage_encryption_key(client_secret: str) -> bytes:
+    """Mirror FastMCP's default signing and storage key derivation."""
+    signing_key = derive_jwt_key(
+        high_entropy_material=client_secret,
+        salt='fastmcp-jwt-signing-key',
+    )
+    return derive_jwt_key(
+        high_entropy_material=signing_key.decode('ascii'),
+        salt='fastmcp-storage-encryption-key',
+    )
 
 
 def _read_required_secret(path: str, name: str) -> str:
@@ -341,7 +325,7 @@ def _https_url(
 ) -> str:
     parsed = parse.urlsplit(value)
     try:
-        parsed.port
+        _ = parsed.port
     except ValueError as error:
         raise ValueError('OAuth URL contains an invalid port') from error
     if (

--- a/src/service/mcp/auth.py
+++ b/src/service/mcp/auth.py
@@ -1,0 +1,359 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import base64
+import dataclasses
+import hashlib
+import json
+from typing import Any, cast
+from urllib import parse
+
+from cryptography.fernet import Fernet
+from fastmcp.server.auth.oidc_proxy import OIDCProxy
+from fastmcp.server.auth.providers.jwt import JWTVerifier
+import httpx
+from key_value.aio.protocols import AsyncKeyValue
+from key_value.aio.stores.redis import RedisStore
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+from key_value.aio.wrappers.prefix_collections import PrefixCollectionsWrapper
+import pydantic
+from redis import asyncio as redis_asyncio
+
+_UPSTREAM_OIDC_SCOPES = ('openid', 'profile', 'email', 'offline_access')
+
+
+class MCPAuthConfig(pydantic.BaseModel):
+    """Optional OIDC settings loaded by the existing MCP process."""
+
+    model_config = pydantic.ConfigDict(hide_input_in_errors=True)
+
+    enabled: bool = pydantic.Field(
+        default=False,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_ENABLED'},
+    )
+    issuer_url: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_ISSUER_URL'},
+    )
+    resource_url: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_RESOURCE_URL'},
+    )
+    scope: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_SCOPE'},
+    )
+    redis_url: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_REDIS_URL'},
+    )
+    redis_password_file: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_REDIS_PASSWORD_FILE'},
+    )
+    redis_key_prefix: str = pydantic.Field(
+        default='osmo:mcp-fastmcp',
+        pattern=r'^[A-Za-z0-9:._~-]{1,128}$',
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_REDIS_KEY_PREFIX'},
+    )
+    oidc_config_url: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_CONFIG_URL'},
+    )
+    oidc_client_id: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_CLIENT_ID'},
+    )
+    oidc_client_secret_file: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE'},
+    )
+    oidc_access_token_jwks_url: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL'},
+    )
+    oidc_access_token_issuer: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER'},
+    )
+    oidc_access_token_audience: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE'},
+    )
+    oidc_access_token_required_scope: str = pydantic.Field(
+        default='access_as_user',
+        pattern=r'^[A-Za-z0-9:._~-]{1,128}$',
+        json_schema_extra={
+            'env': 'OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE',
+        },
+    )
+    signing_jwks_file: str | None = pydantic.Field(
+        default=None,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_SIGNING_JWKS_FILE'},
+    )
+    trusted_https_redirect_origins: str = pydantic.Field(
+        default='',
+        json_schema_extra={
+            'env': 'OSMO_MCP_AUTH_TRUSTED_HTTPS_REDIRECT_ORIGINS',
+        },
+    )
+    access_token_ttl_seconds: int = pydantic.Field(
+        default=600,
+        ge=60,
+        le=3600,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS'},
+    )
+    refresh_token_ttl_seconds: int = pydantic.Field(
+        default=28800,
+        ge=300,
+        le=604800,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS'},
+    )
+    upstream_timeout_seconds: int = pydantic.Field(
+        default=10,
+        ge=1,
+        le=60,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS'},
+    )
+    redis_connect_timeout_seconds: int = pydantic.Field(
+        default=3,
+        ge=1,
+        le=30,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS'},
+    )
+    redis_operation_timeout_seconds: int = pydantic.Field(
+        default=5,
+        ge=1,
+        le=30,
+        json_schema_extra={'env': 'OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS'},
+    )
+
+    @pydantic.model_validator(mode='after')
+    def _validate_enabled_config(self) -> 'MCPAuthConfig':
+        if not self.enabled:
+            return self
+        required = {
+            name: getattr(self, name)
+            for name in (
+                'issuer_url',
+                'resource_url',
+                'scope',
+                'redis_url',
+                'oidc_config_url',
+                'oidc_client_id',
+                'oidc_client_secret_file',
+                'oidc_access_token_jwks_url',
+                'oidc_access_token_issuer',
+                'oidc_access_token_audience',
+                'signing_jwks_file',
+            )
+        }
+        missing = sorted(name for name, value in required.items() if not value)
+        if missing:
+            raise ValueError(
+                'Enabled MCP auth is missing: ' + ', '.join(missing)
+            )
+
+        issuer = _https_url(cast(str, self.issuer_url), root_only=True)
+        resource = _https_url(cast(str, self.resource_url))
+        scope = _https_url(cast(str, self.scope))
+        if resource != f'{issuer}/mcp':
+            raise ValueError('resource_url must be issuer_url followed by /mcp')
+        if scope != f'{resource}/{self.oidc_access_token_required_scope}':
+            raise ValueError('scope must be resource_url followed by the token scope')
+        if self.oidc_access_token_audience != resource:
+            raise ValueError('oidc_access_token_audience must match resource_url')
+        self.issuer_url = issuer
+        self.resource_url = resource
+        self.scope = scope
+        self.oidc_config_url = _https_url(cast(str, self.oidc_config_url))
+        self.oidc_access_token_jwks_url = _https_url(
+            cast(str, self.oidc_access_token_jwks_url)
+        )
+        self.oidc_access_token_issuer = _https_url(
+            cast(str, self.oidc_access_token_issuer),
+            preserve_trailing_slash=True,
+        )
+        redis_url = parse.urlsplit(cast(str, self.redis_url))
+        if redis_url.scheme not in {'redis', 'rediss'} or not redis_url.hostname:
+            raise ValueError('redis_url must be an absolute Redis URL')
+        if redis_url.password is not None:
+            raise ValueError('Redis password must be provided through its file')
+        for origin in self.trusted_redirect_origins:
+            if _https_url(origin, root_only=True) != origin:
+                raise ValueError('trusted redirect origins must be normalized')
+        return self
+
+    @property
+    def trusted_redirect_origins(self) -> tuple[str, ...]:
+        return tuple(
+            item.strip().rstrip('/')
+            for item in self.trusted_https_redirect_origins.split(',')
+            if item.strip()
+        )
+
+    @property
+    def allowed_client_redirect_uris(self) -> list[str]:
+        return [
+            'http://localhost:*',
+            'http://127.0.0.1:*',
+            'http://[::1]:*',
+            *self.trusted_redirect_origins,
+        ]
+
+
+@dataclasses.dataclass(slots=True)
+class MCPAuthRuntime:
+    """Resources owned by FastMCP's built-in OIDC proxy."""
+
+    provider: OIDCProxy
+    redis_client: Any
+    http_client: httpx.AsyncClient
+
+    async def aclose(self) -> None:
+        await self.http_client.aclose()
+        await cast(Any, self.redis_client).aclose()
+
+
+def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
+    """Configure FastMCP's OIDCProxy; no OSMO OAuth endpoints are implemented."""
+    if not config.enabled:
+        raise ValueError('MCP auth is disabled')
+
+    redis_client = redis_asyncio.Redis.from_url(
+        cast(str, config.redis_url),
+        password=_read_optional_secret(config.redis_password_file),
+        socket_connect_timeout=config.redis_connect_timeout_seconds,
+        socket_timeout=config.redis_operation_timeout_seconds,
+        decode_responses=True,
+    )
+    namespaced_store = PrefixCollectionsWrapper(
+        key_value=RedisStore(client=redis_client),
+        prefix=config.redis_key_prefix,
+    )
+    signing_key = _read_signing_jwks(cast(str, config.signing_jwks_file))
+    encrypted_store: AsyncKeyValue = FernetEncryptionWrapper(
+        key_value=namespaced_store,
+        fernet=Fernet(base64.urlsafe_b64encode(_storage_key(signing_key))),
+    )
+    http_client = httpx.AsyncClient(
+        timeout=config.upstream_timeout_seconds,
+        follow_redirects=False,
+    )
+    verifier = JWTVerifier(
+        jwks_uri=cast(str, config.oidc_access_token_jwks_url),
+        issuer=cast(str, config.oidc_access_token_issuer),
+        audience=cast(str, config.oidc_access_token_audience),
+        algorithm='RS256',
+        required_scopes=[config.oidc_access_token_required_scope],
+        http_client=http_client,
+    )
+    requested_scope = cast(str, config.scope)
+    upstream_scope = ' '.join((requested_scope, *_UPSTREAM_OIDC_SCOPES))
+    provider = OIDCProxy(
+        config_url=cast(str, config.oidc_config_url),
+        client_id=cast(str, config.oidc_client_id),
+        client_secret=_read_required_secret(
+            cast(str, config.oidc_client_secret_file),
+            'OIDC client secret',
+        ),
+        token_verifier=verifier,
+        base_url=cast(str, config.issuer_url),
+        resource_base_url=cast(str, config.issuer_url),
+        issuer_url=cast(str, config.issuer_url),
+        redirect_path='/auth/callback',
+        allowed_client_redirect_uris=config.allowed_client_redirect_uris,
+        client_storage=encrypted_store,
+        jwt_signing_key=signing_key,
+        token_endpoint_auth_method='client_secret_post',
+        require_authorization_consent=True,
+        forward_resource=False,
+        extra_authorize_params={'scope': upstream_scope},
+        fallback_refresh_token_expiry_seconds=config.refresh_token_ttl_seconds,
+        fastmcp_access_token_expiry_seconds=config.access_token_ttl_seconds,
+        token_expiry_threshold_seconds=30,
+        timeout_seconds=config.upstream_timeout_seconds,
+        enable_cimd=True,
+    )
+    # Entra returns the short `scp` claim that the verifier enforces, while MCP
+    # clients must discover and request the full API scope URI.
+    provider.update_default_scopes([requested_scope])
+    return MCPAuthRuntime(provider, redis_client, http_client)
+
+
+def _read_signing_jwks(path: str) -> bytes:
+    with open(path, encoding='utf-8') as jwks_file:
+        document = json.load(jwks_file)
+    keys = document.get('keys') if isinstance(document, dict) else None
+    if not isinstance(keys, list) or len(keys) != 1 or not isinstance(keys[0], dict):
+        raise ValueError('FastMCP signing JWKS must contain exactly one key')
+    key = keys[0]
+    encoded = key.get('k')
+    if key.get('kty') != 'oct' or not isinstance(encoded, str):
+        raise ValueError('FastMCP signing key must be one symmetric JWK')
+    if key.get('alg') not in {None, 'HS256'} or key.get('use') not in {None, 'sig'}:
+        raise ValueError('FastMCP signing key must be an HS256 signing key')
+    try:
+        decoded = base64.urlsafe_b64decode(encoded + '=' * (-len(encoded) % 4))
+    except (TypeError, ValueError) as error:
+        raise ValueError('FastMCP signing key must be base64url') from error
+    if len(decoded) != 32:
+        raise ValueError('FastMCP signing key must contain exactly 256 bits')
+    return decoded
+
+
+def _storage_key(signing_key: bytes) -> bytes:
+    return hashlib.sha256(b'osmo-fastmcp-storage-v1\0' + signing_key).digest()
+
+
+def _read_required_secret(path: str, name: str) -> str:
+    with open(path, encoding='utf-8') as secret_file:
+        value = secret_file.read().strip()
+    if not value:
+        raise ValueError(f'{name} file must not be empty')
+    return value
+
+
+def _read_optional_secret(path: str | None) -> str | None:
+    return _read_required_secret(path, 'Redis password') if path else None
+
+
+def _https_url(
+    value: str,
+    *,
+    root_only: bool = False,
+    preserve_trailing_slash: bool = False,
+) -> str:
+    parsed = parse.urlsplit(value)
+    try:
+        parsed.port
+    except ValueError as error:
+        raise ValueError('OAuth URL contains an invalid port') from error
+    if (
+        parsed.scheme != 'https'
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError('OAuth URLs must be absolute HTTPS URLs')
+    path = parsed.path if preserve_trailing_slash else parsed.path.rstrip('/')
+    if root_only and path:
+        raise ValueError('OAuth issuer and redirect origins must be origins')
+    return parse.urlunsplit((parsed.scheme, parsed.netloc, path, '', ''))

--- a/src/service/mcp/credential_actions.py
+++ b/src/service/mcp/credential_actions.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import re
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 
 from src.service.mcp import tool_errors, tool_requests, tool_validation
 from src.service.mcp.credential_action_models import (

--- a/src/service/mcp/credentials.py
+++ b/src/service/mcp/credentials.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 from collections.abc import Mapping
 from typing import Annotated
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 import pydantic
 
 from src.service.mcp import tool_requests

--- a/src/service/mcp/health.py
+++ b/src/service/mcp/health.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 from typing import Literal
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 import pydantic
 
 from src.service.mcp import access_scope

--- a/src/service/mcp/pools.py
+++ b/src/service/mcp/pools.py
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 
 from src.service.mcp import access_scope, tool_requests, tool_validation
 from src.service.mcp.pool_models import (

--- a/src/service/mcp/profile.py
+++ b/src/service/mcp/profile.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import datetime
 from typing import Annotated, Literal
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 import pydantic
 
 from src.service.mcp import (

--- a/src/service/mcp/protocol.py
+++ b/src/service/mcp/protocol.py
@@ -21,10 +21,8 @@ import json
 import time
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
-from mcp.server.fastmcp.exceptions import ToolError
-from mcp.types import ContentBlock
-from mcp.types import Tool as MCPTool
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError, ValidationError
 import pydantic
 
 from src.service.mcp import request_context, telemetry, tool_errors
@@ -36,17 +34,35 @@ _MAX_SERIALIZED_TOOL_RESULT_BYTES = 512 * 1024
 class OSMOFastMCP(FastMCP):
     """FastMCP server with fail-closed, non-reflective tool validation."""
 
-    async def list_tools(self) -> list[MCPTool]:
-        tools = await super().list_tools()
-        for tool in tools:
-            tool.inputSchema['additionalProperties'] = False
-        return tools
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # MCP SDK schema validation reflects rejected input values in its error
+        # text. Let FunctionTool validate inside call_tool so this boundary can
+        # replace all validation detail with a fixed public message.
+        kwargs['strict_input_validation'] = False
+        kwargs.setdefault('mask_error_details', True)
+        super().__init__(*args, **kwargs)
 
     async def call_tool(
         self,
         name: str,
-        arguments: dict[str, Any],
-    ) -> Sequence[ContentBlock] | dict[str, Any]:
+        arguments: dict[str, Any] | None = None,
+        *,
+        version: Any = None,
+        run_middleware: bool = True,
+        task_meta: Any = None,
+    ) -> Any:
+        if run_middleware:
+            # FastMCP middleware re-enters self.call_tool(..., False). Run the
+            # OSMO boundary only on that inner invocation to avoid duplicate
+            # telemetry and credential checks.
+            return await super().call_tool(
+                name,
+                arguments,
+                version=version,
+                run_middleware=True,
+                task_meta=task_meta,
+            )
+
         start_time = time.monotonic()
         telemetry_tool_name = 'unknown'
         request_id: str | None = None
@@ -55,9 +71,12 @@ class OSMOFastMCP(FastMCP):
             request_id = (
                 request_context.get_request_credentials().request_id
             )
+            arguments = arguments or {}
             tools_by_name = {
                 tool.name: tool
-                for tool in await super().list_tools()
+                for tool in await super().list_tools(
+                    run_middleware=False,
+                )
             }
             tool = tools_by_name.get(name)
             if tool is None:
@@ -65,7 +84,7 @@ class OSMOFastMCP(FastMCP):
                 raise tool_errors.PublicToolError('Unknown MCP tool.')
             telemetry_tool_name = tool.name
 
-            allowed_arguments = set(tool.inputSchema.get('properties', {}))
+            allowed_arguments = set(tool.parameters.get('properties', {}))
             if not arguments.keys() <= allowed_arguments:
                 outcome = 'validation_error'
                 raise tool_errors.PublicToolError(
@@ -82,7 +101,18 @@ class OSMOFastMCP(FastMCP):
                         'MCP tool arguments are invalid.'
                     )
                 try:
-                    result = await super().call_tool(name, arguments)
+                    result = await super().call_tool(
+                        name,
+                        arguments,
+                        version=version,
+                        run_middleware=False,
+                        task_meta=task_meta,
+                    )
+                except ValidationError:
+                    outcome = 'validation_error'
+                    raise tool_errors.PublicToolError(
+                        'MCP tool validation failed.'
+                    ) from None
                 except ToolError as error:
                     if isinstance(error.__cause__, pydantic.ValidationError):
                         outcome = 'validation_error'

--- a/src/service/mcp/request_context.py
+++ b/src/service/mcp/request_context.py
@@ -24,6 +24,8 @@ import contextvars
 import dataclasses
 import re
 
+from fastmcp.server.auth import AccessToken
+from fastmcp.server.dependencies import get_access_token, get_http_request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
@@ -126,11 +128,28 @@ class RequestContextMiddleware:
 
 def get_request_credentials() -> RequestCredentials:
     """Return credentials for the active MCP request."""
+    access_token = get_access_token()
+    if access_token is not None:
+        return _credentials_from_access_token(access_token)
+
     request_state = _request_state.get()
-    if request_state is None or request_state.credentials is None:
-        raise RequestContextUnavailable(
-            'MCP request credentials are unavailable.')
-    return request_state.credentials
+    if request_state is not None and request_state.credentials is not None:
+        return request_state.credentials
+
+    # Direct mode is retained for deployments where the Gateway authenticates
+    # /mcp before forwarding it to this process. Read the untouched ASGI header
+    # list so duplicate security-sensitive headers still fail closed.
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        request = None
+    if request is not None:
+        credentials = _parse_credentials(request.scope.get('headers', []))
+        if credentials is not None:
+            return credentials
+
+    raise RequestContextUnavailable(
+        'MCP request credentials are unavailable.')
 
 
 def get_active_tool_name() -> str | None:
@@ -153,9 +172,12 @@ def track_request_task() -> Iterator[RequestCredentials]:
     """Cancel the current tool task when its owning MCP request ends."""
     request_state = _request_state.get()
     current_task = asyncio.current_task()
+    if request_state is None:
+        # FastMCP owns request-task cancellation in the integrated auth mode.
+        yield get_request_credentials()
+        return
     if (
-        request_state is None
-        or request_state.credentials is None
+        request_state.credentials is None
         or current_task is None
     ):
         raise RequestContextUnavailable(
@@ -167,6 +189,60 @@ def track_request_task() -> Iterator[RequestCredentials]:
         yield credentials
     finally:
         request_state.active_tasks.discard(current_task)
+
+
+def _credentials_from_access_token(
+    access_token: AccessToken,
+) -> RequestCredentials:
+    """Relay the verified upstream token returned by FastMCP's OIDC proxy."""
+    claims = access_token.claims or {}
+    upstream_claims = claims.get('upstream_claims')
+    if isinstance(upstream_claims, dict):
+        claims = upstream_claims
+
+    user_name = next((
+        value
+        for name in ('preferred_username', 'unique_name', 'upn', 'email', 'sub')
+        if isinstance((value := claims.get(name)), str)
+        and _is_valid_user_name(value)
+    ), None)
+    authorization_header = f'Bearer {access_token.token}'
+    if user_name is None or not _is_supported_authorization_header(
+        authorization_header
+    ):
+        raise RequestContextUnavailable(
+            'MCP request credentials are unavailable.')
+
+    request_id = None
+    try:
+        raw_request_ids = [
+            value
+            for name, value in get_http_request().scope.get('headers', [])
+            if name.lower() == _REQUEST_ID_HEADER
+        ]
+    except RuntimeError:
+        raw_request_ids = []
+    if len(raw_request_ids) > 1:
+        raise RequestContextUnavailable(
+            'MCP request credentials are unavailable.')
+    if raw_request_ids:
+        if len(raw_request_ids[0]) > MAX_REQUEST_ID_HEADER_BYTES:
+            raise RequestContextUnavailable(
+                'MCP request credentials are unavailable.')
+        request_id = _decode_ascii(raw_request_ids[0])
+        if (
+            request_id is None
+            or _REQUEST_ID.fullmatch(request_id) is None
+            or request_id_overlaps_bearer(authorization_header, request_id)
+        ):
+            raise RequestContextUnavailable(
+                'MCP request credentials are unavailable.')
+
+    return RequestCredentials(
+        authorization_header=authorization_header,
+        user_name=user_name,
+        request_id=request_id,
+    )
 
 
 def request_id_overlaps_bearer(

--- a/src/service/mcp/request_context.py
+++ b/src/service/mcp/request_context.py
@@ -127,7 +127,7 @@ class RequestContextMiddleware:
 
 
 def get_request_credentials() -> RequestCredentials:
-    """Return credentials for the active MCP request."""
+    """Return credentials from the active request's configured trust boundary."""
     access_token = get_access_token()
     if access_token is not None:
         return _credentials_from_access_token(access_token)
@@ -135,18 +135,6 @@ def get_request_credentials() -> RequestCredentials:
     request_state = _request_state.get()
     if request_state is not None and request_state.credentials is not None:
         return request_state.credentials
-
-    # Direct mode is retained for deployments where the Gateway authenticates
-    # /mcp before forwarding it to this process. Read the untouched ASGI header
-    # list so duplicate security-sensitive headers still fail closed.
-    try:
-        request = get_http_request()
-    except RuntimeError:
-        request = None
-    if request is not None:
-        credentials = _parse_credentials(request.scope.get('headers', []))
-        if credentials is not None:
-            return credentials
 
     raise RequestContextUnavailable(
         'MCP request credentials are unavailable.')
@@ -222,21 +210,13 @@ def _credentials_from_access_token(
         ]
     except RuntimeError:
         raw_request_ids = []
-    if len(raw_request_ids) > 1:
+    request_id_is_valid, request_id = _parse_request_id(
+        raw_request_ids,
+        authorization_header,
+    )
+    if not request_id_is_valid:
         raise RequestContextUnavailable(
             'MCP request credentials are unavailable.')
-    if raw_request_ids:
-        if len(raw_request_ids[0]) > MAX_REQUEST_ID_HEADER_BYTES:
-            raise RequestContextUnavailable(
-                'MCP request credentials are unavailable.')
-        request_id = _decode_ascii(raw_request_ids[0])
-        if (
-            request_id is None
-            or _REQUEST_ID.fullmatch(request_id) is None
-            or request_id_overlaps_bearer(authorization_header, request_id)
-        ):
-            raise RequestContextUnavailable(
-                'MCP request credentials are unavailable.')
 
     return RequestCredentials(
         authorization_header=authorization_header,
@@ -286,13 +266,8 @@ def _parse_credentials(
     if (
         len(authorization_values) != 1
         or len(user_values) != 1
-        or len(request_id_values) > 1
         or len(authorization_values[0]) > MAX_AUTHORIZATION_HEADER_BYTES
         or len(user_values[0]) > MAX_USER_HEADER_BYTES
-        or (
-            request_id_values
-            and len(request_id_values[0]) > MAX_REQUEST_ID_HEADER_BYTES
-        )
     ):
         return None
 
@@ -306,24 +281,43 @@ def _parse_credentials(
     ):
         return None
 
-    request_id: str | None = None
-    if request_id_values:
-        request_id = _decode_ascii(request_id_values[0])
-        if (
-            request_id is None
-            or _REQUEST_ID.fullmatch(request_id) is None
-            or request_id_overlaps_bearer(
-                authorization_header,
-                request_id,
-            )
-        ):
-            return None
+    request_id_is_valid, request_id = _parse_request_id(
+        request_id_values,
+        authorization_header,
+    )
+    if not request_id_is_valid:
+        return None
 
     return RequestCredentials(
         authorization_header=authorization_header,
         user_name=user_name,
         request_id=request_id,
     )
+
+
+def _parse_request_id(
+    raw_values: list[bytes],
+    authorization_header: str,
+) -> tuple[bool, str | None]:
+    if (
+        len(raw_values) > 1
+        or (
+            raw_values
+            and len(raw_values[0]) > MAX_REQUEST_ID_HEADER_BYTES
+        )
+    ):
+        return False, None
+    if not raw_values:
+        return True, None
+
+    request_id = _decode_ascii(raw_values[0])
+    if (
+        request_id is None
+        or _REQUEST_ID.fullmatch(request_id) is None
+        or request_id_overlaps_bearer(authorization_header, request_id)
+    ):
+        return False, None
+    return True, request_id
 
 
 def _is_supported_authorization_header(value: str) -> bool:

--- a/src/service/mcp/resources.py
+++ b/src/service/mcp/resources.py
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 import pydantic
 
 from src.lib.utils import resource_quantities

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -139,7 +139,7 @@ def create_runtime_application(
     """Create the production application and process-lifetime Gateway client."""
     auth_runtime = (
         auth.create_auth_runtime(config)
-        if config.enabled
+        if config.auth_enabled
         else None
     )
     protocol_server = create_mcp_server(

--- a/src/service/mcp/server.py
+++ b/src/service/mcp/server.py
@@ -20,8 +20,9 @@ import asyncio
 from collections.abc import AsyncIterator
 import contextlib
 
+from fastmcp import FastMCP
+from fastmcp.server.auth import AuthProvider
 import httpx
-from mcp.server.fastmcp import FastMCP
 import pydantic
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -30,6 +31,7 @@ import uvicorn  # type: ignore
 
 from src.lib.utils import logging as logging_utils
 from src.service.mcp import (
+    auth,
     gateway,
     protocol,
     request_body,
@@ -43,6 +45,7 @@ class MCPServiceConfig(
     logging_utils.LoggingConfig,
     static_config.StaticConfig,
     ssl_config.SSLConfig,
+    auth.MCPAuthConfig,
 ):
     """Runtime configuration for the MCP service."""
 
@@ -74,15 +77,14 @@ class MCPServiceConfig(
         return self
 
 
-def create_mcp_server() -> FastMCP:
+def create_mcp_server(
+    auth_provider: AuthProvider | None = None,
+) -> FastMCP:
     """Create the stateless OSMO MCP protocol server."""
     server = protocol.OSMOFastMCP(
         name='OSMO MCP',
-        host='0.0.0.0',
-        port=8000,
-        streamable_http_path='/mcp',
-        stateless_http=True,
-        json_response=True,
+        auth=auth_provider,
+        mask_error_details=True,
     )
     tool_registry.register_tools(server)
 
@@ -103,7 +105,12 @@ def create_mcp_server() -> FastMCP:
 
 def create_application(protocol_server: FastMCP) -> Starlette:
     """Create the ASGI application for an MCP protocol server."""
-    application = protocol_server.streamable_http_app()
+    application = protocol_server.http_app(
+        path='/mcp',
+        transport='streamable-http',
+        stateless_http=True,
+        json_response=True,
+    )
     application.add_middleware(
         request_body.RequestBodyLimitMiddleware,
         path='/mcp',
@@ -113,10 +120,14 @@ def create_application(protocol_server: FastMCP) -> Starlette:
             request_body.MCP_REQUEST_BODY_TIMEOUT_SECONDS
         ),
     )
-    application.add_middleware(
-        request_context.RequestContextMiddleware,
-        path='/mcp',
-    )
+    if protocol_server.auth is None:
+        # Direct deployments still trust Gateway-injected identity headers and
+        # retain the original fail-before-body and header-stripping boundary.
+        # In OIDC mode FastMCP must receive Authorization itself.
+        application.add_middleware(
+            request_context.RequestContextMiddleware,
+            path='/mcp',
+        )
     return application
 
 
@@ -126,7 +137,14 @@ def create_runtime_application(
     http_transport: httpx.AsyncBaseTransport | None = None,
 ) -> Starlette:
     """Create the production application and process-lifetime Gateway client."""
-    protocol_server = create_mcp_server()
+    auth_runtime = (
+        auth.create_auth_runtime(config)
+        if config.enabled
+        else None
+    )
+    protocol_server = create_mcp_server(
+        auth_runtime.provider if auth_runtime is not None else None,
+    )
     application = create_application(protocol_server)
     protocol_lifespan = application.router.lifespan_context
 
@@ -145,6 +163,8 @@ def create_runtime_application(
                     yield
             finally:
                 del lifespan_application.state.mcp_app_context
+                if auth_runtime is not None:
+                    await auth_runtime.aclose()
 
     application.router.lifespan_context = application_lifespan
     return application

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -19,6 +19,19 @@ SPDX-License-Identifier: Apache-2.0
 load("//bzl:py.bzl", "osmo_py_library", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
+osmo_py_test(
+    name = "test_auth",
+    srcs = ["test_auth.py"],
+    deps = [
+        "//src/service/mcp:fastmcp_runtime",
+        requirement("httpx"),
+        requirement("py-key-value-aio"),
+        requirement("pydantic"),
+        "//src/service/mcp:auth",
+        "//src/service/mcp:mcp_service_lib",
+    ],
+)
+
 osmo_py_library(
     name = "protocol_harness",
     srcs = ["protocol_harness.py"],
@@ -113,6 +126,7 @@ osmo_py_test(
     name = "test_credential_actions",
     srcs = ["test_credential_actions.py"],
     deps = [
+        "//src/service/mcp:fastmcp_runtime",
         requirement("httpx"),
         requirement("mcp"),
         ":protocol_harness",
@@ -135,6 +149,7 @@ osmo_py_test(
     name = "test_pools",
     srcs = ["test_pools.py"],
     deps = [
+        "//src/service/mcp:fastmcp_runtime",
         requirement("httpx"),
         requirement("mcp"),
         ":protocol_harness",
@@ -148,6 +163,7 @@ osmo_py_test(
     name = "test_protocol",
     srcs = ["test_protocol.py"],
     deps = [
+        "//src/service/mcp:fastmcp_runtime",
         requirement("httpx"),
         requirement("mcp"),
         requirement("pydantic"),
@@ -172,6 +188,7 @@ osmo_py_test(
     name = "test_resources",
     srcs = ["test_resources.py"],
     deps = [
+        "//src/service/mcp:fastmcp_runtime",
         requirement("httpx"),
         requirement("mcp"),
         ":protocol_harness",
@@ -186,6 +203,7 @@ osmo_py_test(
     name = "test_request_context",
     srcs = ["test_request_context.py"],
     deps = [
+        "//src/service/mcp:fastmcp_runtime",
         requirement("starlette"),
         "//src/service/mcp:request_context",
     ],
@@ -195,6 +213,7 @@ osmo_py_test(
     name = "test_server",
     srcs = ["test_server.py"],
     deps = [
+        "//src/service/mcp:fastmcp_runtime",
         requirement("httpx"),
         requirement("mcp"),
         requirement("pydantic"),
@@ -212,6 +231,7 @@ osmo_py_test(
     name = "test_tool_support",
     srcs = ["test_tool_support.py"],
     deps = [
+        "//src/service/mcp:fastmcp_runtime",
         requirement("mcp"),
         "//src/lib/utils:osmo_errors",
         "//src/service/mcp:gateway",
@@ -235,6 +255,7 @@ osmo_py_test(
     name = "test_workflows",
     srcs = ["test_workflows.py"],
     deps = [
+        "//src/service/mcp:fastmcp_runtime",
         requirement("httpx"),
         requirement("mcp"),
         ":protocol_harness",
@@ -247,6 +268,7 @@ osmo_py_test(
     name = "test_workflow_actions",
     srcs = ["test_workflow_actions.py"],
     deps = [
+        "//src/service/mcp:fastmcp_runtime",
         requirement("httpx"),
         requirement("mcp"),
         ":protocol_harness",

--- a/src/service/mcp/tests/BUILD
+++ b/src/service/mcp/tests/BUILD
@@ -40,6 +40,7 @@ osmo_py_library(
         requirement("starlette"),
         "//src/lib/utils:login",
         "//src/service/mcp:gateway",
+        "//src/service/mcp:mcp_service_lib",
         "//src/service/mcp:protocol",
         "//src/service/mcp:request_context",
         "//src/service/mcp:tool_registry",

--- a/src/service/mcp/tests/protocol_harness.py
+++ b/src/service/mcp/tests/protocol_harness.py
@@ -82,14 +82,14 @@ class ProtocolHarness:
         """Build one isolated selected-tool protocol application."""
         mcp_server = protocol.OSMOFastMCP(
             name='OSMO MCP protocol test',
-            host='0.0.0.0',
-            port=8000,
-            streamable_http_path='/mcp',
+        )
+        tool_registry.register_tools(mcp_server, names=self.tool_names)
+        application = mcp_server.http_app(
+            path='/mcp',
+            transport='streamable-http',
             stateless_http=True,
             json_response=True,
         )
-        tool_registry.register_tools(mcp_server, names=self.tool_names)
-        application = mcp_server.streamable_http_app()
         application.add_middleware(
             request_context.RequestContextMiddleware,
             path='/mcp',

--- a/src/service/mcp/tests/protocol_harness.py
+++ b/src/service/mcp/tests/protocol_harness.py
@@ -29,6 +29,7 @@ from src.service.mcp import (
     gateway,
     protocol,
     request_context,
+    server,
     tool_registry,
 )
 
@@ -84,17 +85,7 @@ class ProtocolHarness:
             name='OSMO MCP protocol test',
         )
         tool_registry.register_tools(mcp_server, names=self.tool_names)
-        application = mcp_server.http_app(
-            path='/mcp',
-            transport='streamable-http',
-            stateless_http=True,
-            json_response=True,
-        )
-        application.add_middleware(
-            request_context.RequestContextMiddleware,
-            path='/mcp',
-        )
-        return application
+        return server.create_application(mcp_server)
 
     def headers(self) -> dict[str, str]:
         """Return the trusted Gateway headers for one MCP test request."""

--- a/src/service/mcp/tests/test_auth.py
+++ b/src/service/mcp/tests/test_auth.py
@@ -16,8 +16,6 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-import base64
-import json
 import tempfile
 import time
 from typing import Any
@@ -35,14 +33,14 @@ from src.service.mcp import auth, server
 
 class MCPAuthConfigTest(unittest.TestCase):
     def test_auth_is_disabled_without_any_oidc_configuration(self) -> None:
-        self.assertFalse(auth.MCPAuthConfig().enabled)
+        self.assertFalse(auth.MCPAuthConfig().auth_enabled)
 
     def test_enabled_auth_requires_complete_configuration(self) -> None:
         with self.assertRaisesRegex(
             pydantic.ValidationError,
             'Enabled MCP auth is missing',
         ):
-            auth.MCPAuthConfig(enabled=True)
+            auth.MCPAuthConfig(auth_enabled=True)
 
     def test_enabled_auth_normalizes_and_validates_scope_contract(self) -> None:
         config = _config()
@@ -51,30 +49,40 @@ class MCPAuthConfigTest(unittest.TestCase):
             config.allowed_client_redirect_uris,
             ['http://localhost:*', 'http://127.0.0.1:*', 'http://[::1]:*'],
         )
-        with self.assertRaisesRegex(pydantic.ValidationError, 'scope must be'):
-            _config(scope='https://osmo.example/mcp/wrong')
+        with self.assertRaisesRegex(
+            pydantic.ValidationError,
+            'auth_scope must be',
+        ):
+            _config(auth_scope='https://osmo.example/mcp/wrong')
 
         service_config = server.MCPServiceConfig(
             gateway_url='https://gateway.example',
             **config.model_dump(),
         )
-        self.assertTrue(service_config.enabled)
-        self.assertEqual(service_config.scope, config.scope)
+        self.assertTrue(service_config.auth_enabled)
+        self.assertEqual(service_config.auth_scope, config.auth_scope)
+
+    def test_auth_field_renames_preserve_environment_contract(self) -> None:
+        self.assertEqual(
+            auth.MCPAuthConfig.model_fields['auth_enabled'].json_schema_extra,
+            {'env': 'OSMO_MCP_AUTH_ENABLED'},
+        )
+        self.assertEqual(
+            auth.MCPAuthConfig.model_fields['auth_scope'].json_schema_extra,
+            {'env': 'OSMO_MCP_AUTH_SCOPE'},
+        )
 
 
 class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
     async def test_factory_uses_plain_oidc_proxy_and_split_scope_contract(self) -> None:
-        signing_key = b's' * 32
-        with (
-            _secret_file('client-secret') as client_secret_file,
-            _jwks_file(signing_key) as signing_jwks_file,
-        ):
+        with _secret_file('client-secret') as client_secret_file:
             config = _config(
                 oidc_client_secret_file=client_secret_file,
-                signing_jwks_file=signing_jwks_file,
             )
-            redis_client = mock.Mock()
-            redis_client.aclose = mock.AsyncMock()
+            redis_client = mock.create_autospec(
+                auth.redis_asyncio.Redis,
+                instance=True,
+            )
             oidc_configuration = OIDCConfiguration(
                 issuer='https://login.example/tenant/v2.0',
                 authorization_endpoint=(
@@ -103,8 +111,11 @@ class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
                 mock.patch.object(
                     auth,
                     'FernetEncryptionWrapper',
-                    side_effect=lambda key_value, fernet: key_value,
-                ),
+                    side_effect=(
+                        lambda key_value, fernet, raise_on_decryption_error:
+                        key_value
+                    ),
+                ) as encryption_wrapper,
                 mock.patch.object(
                     OIDCProxy,
                     'get_oidc_configuration',
@@ -116,6 +127,13 @@ class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
             try:
                 provider = runtime.provider
                 self.assertIs(type(provider), OIDCProxy)
+                self.assertEqual(
+                    provider._jwt_signing_key,  # pylint: disable=protected-access
+                    auth.derive_jwt_key(
+                        high_entropy_material='client-secret',
+                        salt='fastmcp-jwt-signing-key',
+                    ),
+                )
                 self.assertEqual(provider.required_scopes, ['access_as_user'])
                 self.assertEqual(
                     provider._token_validator.required_scopes,  # pylint: disable=protected-access
@@ -141,6 +159,11 @@ class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
                 # would pass the keyword twice on its refresh path.
                 self.assertEqual(provider._extra_token_params, {})  # pylint: disable=protected-access
                 self.assertFalse(provider._forward_resource)  # pylint: disable=protected-access
+                self.assertFalse(
+                    encryption_wrapper.call_args.kwargs[
+                        'raise_on_decryption_error'
+                    ]
+                )
 
                 application = server.create_application(
                     server.create_mcp_server(provider)
@@ -252,24 +275,52 @@ class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
                 await runtime.aclose()
             redis_client.aclose.assert_awaited_once()
 
-    def test_signing_jwks_requires_one_256_bit_symmetric_key(self) -> None:
-        signing_key = b'k' * 32
-        with _jwks_file(signing_key) as path:
-            self.assertEqual(
-                auth._read_signing_jwks(path),  # pylint: disable=protected-access
-                signing_key,
-            )
-        with _secret_file(json.dumps({'keys': [{'kty': 'RSA', 'k': 'bad'}]})) as path:
-            with self.assertRaisesRegex(ValueError, 'symmetric JWK'):
-                auth._read_signing_jwks(path)  # pylint: disable=protected-access
+    async def test_close_releases_redis_when_http_close_fails(self) -> None:
+        provider = mock.create_autospec(OIDCProxy, instance=True)
+        redis_client = mock.create_autospec(
+            auth.redis_asyncio.Redis,
+            instance=True,
+        )
+        http_client = mock.create_autospec(httpx.AsyncClient, instance=True)
+        http_client.aclose.side_effect = RuntimeError('HTTP close failed')
+        runtime = auth.MCPAuthRuntime(provider, redis_client, http_client)
+
+        with self.assertRaisesRegex(RuntimeError, 'HTTP close failed'):
+            await runtime.aclose()
+
+        http_client.aclose.assert_awaited_once_with()
+        redis_client.aclose.assert_awaited_once_with()
+
+    def test_storage_key_matches_fastmcp_default_and_is_deterministic(self) -> None:
+        first = auth._storage_encryption_key(  # pylint: disable=protected-access
+            'client-secret',
+        )
+        second = auth._storage_encryption_key(  # pylint: disable=protected-access
+            'client-secret',
+        )
+        different = auth._storage_encryption_key(  # pylint: disable=protected-access
+            'rotated-client-secret',
+        )
+        signing_key = auth.derive_jwt_key(
+            high_entropy_material='client-secret',
+            salt='fastmcp-jwt-signing-key',
+        )
+        expected = auth.derive_jwt_key(
+            high_entropy_material=signing_key.decode('ascii'),
+            salt='fastmcp-storage-encryption-key',
+        )
+
+        self.assertEqual(first, expected)
+        self.assertEqual(first, second)
+        self.assertNotEqual(first, different)
 
 
 def _config(**overrides: object) -> auth.MCPAuthConfig:
     values: dict[str, object] = {
-        'enabled': True,
+        'auth_enabled': True,
         'issuer_url': 'https://osmo.example/',
         'resource_url': 'https://osmo.example/mcp',
-        'scope': 'https://osmo.example/mcp/access_as_user',
+        'auth_scope': 'https://osmo.example/mcp/access_as_user',
         'redis_url': 'rediss://redis.example:6379/7',
         'oidc_config_url': (
             'https://login.example/tenant/.well-known/openid-configuration'
@@ -279,7 +330,6 @@ def _config(**overrides: object) -> auth.MCPAuthConfig:
         'oidc_access_token_jwks_url': 'https://sts.example/tenant/keys',
         'oidc_access_token_issuer': 'https://sts.example/tenant/',
         'oidc_access_token_audience': 'https://osmo.example/mcp',
-        'signing_jwks_file': '/signing-key',
     }
     values.update(overrides)
     return auth.MCPAuthConfig(**values)
@@ -308,18 +358,6 @@ class _TemporaryFile:
 
 def _secret_file(content: str) -> _TemporaryFile:
     return _TemporaryFile(content)
-
-
-def _jwks_file(signing_key: bytes) -> _TemporaryFile:
-    encoded = base64.urlsafe_b64encode(signing_key).rstrip(b'=').decode()
-    return _TemporaryFile(json.dumps({
-        'keys': [{
-            'kty': 'oct',
-            'alg': 'HS256',
-            'use': 'sig',
-            'k': encoded,
-        }],
-    }))
 
 
 if __name__ == '__main__':

--- a/src/service/mcp/tests/test_auth.py
+++ b/src/service/mcp/tests/test_auth.py
@@ -1,0 +1,326 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import base64
+import json
+import tempfile
+import time
+from typing import Any
+import unittest
+from unittest import mock
+
+from fastmcp.server.auth.oidc_proxy import OIDCConfiguration, OIDCProxy
+from fastmcp.server.auth.oauth_proxy.models import UpstreamTokenSet
+import httpx
+from key_value.aio.stores.memory import MemoryStore
+import pydantic
+
+from src.service.mcp import auth, server
+
+
+class MCPAuthConfigTest(unittest.TestCase):
+    def test_auth_is_disabled_without_any_oidc_configuration(self) -> None:
+        self.assertFalse(auth.MCPAuthConfig().enabled)
+
+    def test_enabled_auth_requires_complete_configuration(self) -> None:
+        with self.assertRaisesRegex(
+            pydantic.ValidationError,
+            'Enabled MCP auth is missing',
+        ):
+            auth.MCPAuthConfig(enabled=True)
+
+    def test_enabled_auth_normalizes_and_validates_scope_contract(self) -> None:
+        config = _config()
+        self.assertEqual(config.issuer_url, 'https://osmo.example')
+        self.assertEqual(
+            config.allowed_client_redirect_uris,
+            ['http://localhost:*', 'http://127.0.0.1:*', 'http://[::1]:*'],
+        )
+        with self.assertRaisesRegex(pydantic.ValidationError, 'scope must be'):
+            _config(scope='https://osmo.example/mcp/wrong')
+
+        service_config = server.MCPServiceConfig(
+            gateway_url='https://gateway.example',
+            **config.model_dump(),
+        )
+        self.assertTrue(service_config.enabled)
+        self.assertEqual(service_config.scope, config.scope)
+
+
+class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
+    async def test_factory_uses_plain_oidc_proxy_and_split_scope_contract(self) -> None:
+        signing_key = b's' * 32
+        with (
+            _secret_file('client-secret') as client_secret_file,
+            _jwks_file(signing_key) as signing_jwks_file,
+        ):
+            config = _config(
+                oidc_client_secret_file=client_secret_file,
+                signing_jwks_file=signing_jwks_file,
+            )
+            redis_client = mock.Mock()
+            redis_client.aclose = mock.AsyncMock()
+            oidc_configuration = OIDCConfiguration(
+                issuer='https://login.example/tenant/v2.0',
+                authorization_endpoint=(
+                    'https://login.example/tenant/oauth2/v2.0/authorize'
+                ),
+                token_endpoint=(
+                    'https://login.example/tenant/oauth2/v2.0/token'
+                ),
+                jwks_uri='https://login.example/tenant/discovery/v2.0/keys',
+                response_types_supported=['code'],
+                subject_types_supported=['public'],
+                id_token_signing_alg_values_supported=['RS256'],
+            )
+            with (
+                mock.patch.object(
+                    auth.redis_asyncio.Redis,
+                    'from_url',
+                    return_value=redis_client,
+                ),
+                mock.patch.object(auth, 'RedisStore', return_value=MemoryStore()),
+                mock.patch.object(
+                    auth,
+                    'PrefixCollectionsWrapper',
+                    side_effect=lambda key_value, prefix: key_value,
+                ),
+                mock.patch.object(
+                    auth,
+                    'FernetEncryptionWrapper',
+                    side_effect=lambda key_value, fernet: key_value,
+                ),
+                mock.patch.object(
+                    OIDCProxy,
+                    'get_oidc_configuration',
+                    return_value=oidc_configuration,
+                ),
+            ):
+                runtime = auth.create_auth_runtime(config)
+
+            try:
+                provider = runtime.provider
+                self.assertIs(type(provider), OIDCProxy)
+                self.assertEqual(provider.required_scopes, ['access_as_user'])
+                self.assertEqual(
+                    provider._token_validator.required_scopes,  # pylint: disable=protected-access
+                    ['access_as_user'],
+                )
+                registration = provider.client_registration_options
+                self.assertIsNotNone(registration)
+                assert registration is not None
+                self.assertEqual(
+                    registration.default_scopes,
+                    ['https://osmo.example/mcp/access_as_user'],
+                )
+                expected_upstream_scope = (
+                    'https://osmo.example/mcp/access_as_user '
+                    'openid profile email offline_access'
+                )
+                self.assertEqual(
+                    provider._extra_authorize_params['scope'],  # pylint: disable=protected-access
+                    expected_upstream_scope,
+                )
+                # FastMCP supplies the stored full client scope itself during
+                # code exchange and refresh. Supplying another `scope` here
+                # would pass the keyword twice on its refresh path.
+                self.assertEqual(provider._extra_token_params, {})  # pylint: disable=protected-access
+                self.assertFalse(provider._forward_resource)  # pylint: disable=protected-access
+
+                application = server.create_application(
+                    server.create_mcp_server(provider)
+                )
+                route_paths = {
+                    route.path
+                    for route in application.routes
+                    if hasattr(route, 'path')
+                }
+                self.assertIn('/authorize', route_paths)
+                self.assertIn('/token', route_paths)
+                self.assertIn('/register', route_paths)
+                self.assertIn('/auth/callback', route_paths)
+                self.assertIn(
+                    '/.well-known/oauth-authorization-server',
+                    route_paths,
+                )
+                async with (
+                    application.router.lifespan_context(application),
+                    httpx.AsyncClient(
+                        transport=httpx.ASGITransport(app=application),
+                        base_url='https://osmo.example',
+                    ) as client,
+                ):
+                    metadata = await client.get(
+                        '/.well-known/oauth-authorization-server'
+                    )
+                    protected = await client.get(
+                        '/.well-known/oauth-protected-resource/mcp'
+                    )
+                self.assertEqual(metadata.status_code, 200, metadata.text)
+                metadata_body = metadata.json()
+                self.assertEqual(
+                    metadata_body['scopes_supported'],
+                    ['https://osmo.example/mcp/access_as_user'],
+                )
+                self.assertEqual(
+                    metadata_body['registration_endpoint'],
+                    'https://osmo.example/register',
+                )
+                self.assertTrue(
+                    metadata_body['client_id_metadata_document_supported']
+                )
+                self.assertEqual(protected.status_code, 200, protected.text)
+                self.assertEqual(
+                    protected.json()['scopes_supported'],
+                    ['https://osmo.example/mcp/access_as_user'],
+                )
+                self.assertEqual(
+                    protected.json()['resource'],
+                    'https://osmo.example/mcp',
+                )
+
+                captured_refresh: dict[str, object] = {}
+
+                class FakeOAuthClient:
+                    async def refresh_token(
+                        self,
+                        **kwargs: object,
+                    ) -> dict[str, object]:
+                        captured_refresh.update(kwargs)
+                        return {
+                            'access_token': 'refreshed-entra-token',
+                            'expires_in': 3600,
+                            'scope': (
+                                'https://osmo.example/mcp/access_as_user'
+                            ),
+                        }
+
+                class FakeOAuthContext:
+                    async def __aenter__(self) -> FakeOAuthClient:
+                        return FakeOAuthClient()
+
+                    async def __aexit__(self, *args: object) -> None:
+                        del args
+
+                token_set = UpstreamTokenSet(
+                    upstream_token_id='upstream-token-id',
+                    access_token='expired-entra-token',
+                    refresh_token='entra-refresh-token',
+                    refresh_token_expires_at=time.time() + 3600,
+                    expires_at=time.time() - 1,
+                    token_type='Bearer',
+                    scope='https://osmo.example/mcp/access_as_user',
+                    client_id='codex-client',
+                    created_at=time.time(),
+                )
+                with mock.patch.object(
+                    provider,
+                    '_upstream_oauth_client',
+                    new=lambda: FakeOAuthContext(),
+                ):
+                    refreshed = await provider._try_transparent_refresh(  # pylint: disable=protected-access
+                        token_set
+                    )
+                self.assertEqual(
+                    captured_refresh['scope'],
+                    'https://osmo.example/mcp/access_as_user',
+                )
+                self.assertEqual(
+                    captured_refresh['refresh_token'],
+                    'entra-refresh-token',
+                )
+                self.assertEqual(
+                    refreshed.access_token,
+                    'refreshed-entra-token',
+                )
+            finally:
+                await runtime.aclose()
+            redis_client.aclose.assert_awaited_once()
+
+    def test_signing_jwks_requires_one_256_bit_symmetric_key(self) -> None:
+        signing_key = b'k' * 32
+        with _jwks_file(signing_key) as path:
+            self.assertEqual(
+                auth._read_signing_jwks(path),  # pylint: disable=protected-access
+                signing_key,
+            )
+        with _secret_file(json.dumps({'keys': [{'kty': 'RSA', 'k': 'bad'}]})) as path:
+            with self.assertRaisesRegex(ValueError, 'symmetric JWK'):
+                auth._read_signing_jwks(path)  # pylint: disable=protected-access
+
+
+def _config(**overrides: object) -> auth.MCPAuthConfig:
+    values: dict[str, object] = {
+        'enabled': True,
+        'issuer_url': 'https://osmo.example/',
+        'resource_url': 'https://osmo.example/mcp',
+        'scope': 'https://osmo.example/mcp/access_as_user',
+        'redis_url': 'rediss://redis.example:6379/7',
+        'oidc_config_url': (
+            'https://login.example/tenant/.well-known/openid-configuration'
+        ),
+        'oidc_client_id': 'oidc-client',
+        'oidc_client_secret_file': '/secret',
+        'oidc_access_token_jwks_url': 'https://sts.example/tenant/keys',
+        'oidc_access_token_issuer': 'https://sts.example/tenant/',
+        'oidc_access_token_audience': 'https://osmo.example/mcp',
+        'signing_jwks_file': '/signing-key',
+    }
+    values.update(overrides)
+    return auth.MCPAuthConfig(**values)
+
+
+class _TemporaryFile:
+    """Keep a named temporary text file open for one test context."""
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self._file: Any = None
+
+    def __enter__(self) -> str:
+        self._file = tempfile.NamedTemporaryFile(
+            mode='w+',
+            encoding='utf-8',
+        )
+        self._file.write(self._content)
+        self._file.flush()
+        return self._file.name
+
+    def __exit__(self, *args: object) -> None:
+        assert self._file is not None
+        self._file.close()
+
+
+def _secret_file(content: str) -> _TemporaryFile:
+    return _TemporaryFile(content)
+
+
+def _jwks_file(signing_key: bytes) -> _TemporaryFile:
+    encoded = base64.urlsafe_b64encode(signing_key).rstrip(b'=').decode()
+    return _TemporaryFile(json.dumps({
+        'keys': [{
+            'kty': 'oct',
+            'alg': 'HS256',
+            'use': 'sig',
+            'k': encoded,
+        }],
+    }))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/mcp/tests/test_catalog.py
+++ b/src/service/mcp/tests/test_catalog.py
@@ -381,11 +381,11 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
         tool_registry.register_tools(mcp_server)
 
         self.assertEqual(
-            mcp_server.add_tool.call_count,
+            mcp_server.tool.call_count,
             len(_EXPECTED_SPECS),
         )
         for call, (function, name, title, description) in zip(
-            mcp_server.add_tool.call_args_list,
+            mcp_server.tool.call_args_list,
             _EXPECTED_SPECS,
             strict=True,
         ):
@@ -393,7 +393,6 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(call.kwargs['name'], name)
             self.assertEqual(call.kwargs['title'], title)
             self.assertEqual(call.kwargs['description'], description)
-            self.assertTrue(call.kwargs['structured_output'])
             annotations = call.kwargs['annotations']
             is_write = name in _WRITE_TOOL_NAMES
             is_destructive = name in _DESTRUCTIVE_TOOL_NAMES
@@ -440,16 +439,16 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
                 tool.annotations.openWorldHint,
                 tool.name in _OPEN_WORLD_TOOL_NAMES,
             )
-            self._assert_recursively_closed(tool.inputSchema, tool.name)
-            self.assertIsNotNone(tool.outputSchema)
-            assert tool.outputSchema is not None
-            self._assert_recursively_closed(tool.outputSchema, tool.name)
+            self._assert_recursively_closed(tool.parameters, tool.name)
+            self.assertIsNotNone(tool.output_schema)
+            assert tool.output_schema is not None
+            self._assert_recursively_closed(tool.output_schema, tool.name)
 
             self.assertEqual(
-                tool.inputSchema.get('required', []),
+                tool.parameters.get('required', []),
                 _EXPECTED_REQUIRED_FIELDS[tool.name],
             )
-            properties = tool.inputSchema['properties']
+            properties = tool.parameters['properties']
             for field, expected_default in _EXPECTED_DEFAULTS.get(
                 tool.name,
                 {},
@@ -467,7 +466,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
             'osmo_list_workflows',
             'osmo_list_apps',
         ):
-            properties = tools_by_name[tool_name].inputSchema['properties']
+            properties = tools_by_name[tool_name].parameters['properties']
             self.assertEqual(properties['limit']['minimum'], 1)
             self.assertEqual(
                 properties['limit']['maximum'],
@@ -477,7 +476,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
 
         log_properties = tools_by_name[
             'osmo_get_workflow_logs'
-        ].inputSchema['properties']
+        ].parameters['properties']
         self.assertEqual(log_properties['last_n_lines']['anyOf'][0]['minimum'], 1)
         self.assertEqual(
             log_properties['last_n_lines']['anyOf'][0]['maximum'],
@@ -526,7 +525,7 @@ class ToolCatalogContractTest(unittest.IsolatedAsyncioTestCase):
                 names={'osmo_unknown'},
             )
 
-        mcp_server.add_tool.assert_not_called()
+        mcp_server.tool.assert_not_called()
 
     def _assert_recursively_closed(
         self,

--- a/src/service/mcp/tests/test_credential_actions.py
+++ b/src/service/mcp/tests/test_credential_actions.py
@@ -20,7 +20,7 @@ import unittest
 from unittest import mock
 
 import httpx
-from mcp.server.fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError
 
 from src.service.mcp import credential_actions
 from src.service.mcp.tests import protocol_harness

--- a/src/service/mcp/tests/test_pools.py
+++ b/src/service/mcp/tests/test_pools.py
@@ -20,7 +20,7 @@ import unittest
 from unittest import mock
 
 import httpx
-from mcp.server.fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError
 
 from src.service.mcp import (
     pools,

--- a/src/service/mcp/tests/test_protocol.py
+++ b/src/service/mcp/tests/test_protocol.py
@@ -23,7 +23,7 @@ import unittest
 from unittest import mock
 
 import httpx
-from mcp.server.fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError
 import pydantic
 
 from src.lib.utils import login
@@ -49,14 +49,14 @@ class PublicExceptionBoundaryTest(unittest.IsolatedAsyncioTestCase):
     ) -> httpx.Response:
         mcp_server = protocol.OSMOFastMCP(
             name='OSMO public exception boundary test',
-            host='0.0.0.0',
-            port=8000,
-            streamable_http_path='/mcp',
+        )
+        mcp_server.tool(function, name='boundary_test_tool')
+        application = mcp_server.http_app(
+            path='/mcp',
+            transport='streamable-http',
             stateless_http=True,
             json_response=True,
         )
-        mcp_server.add_tool(function, name='boundary_test_tool')
-        application = mcp_server.streamable_http_app()
         application.add_middleware(
             request_context.RequestContextMiddleware,
             path='/mcp',
@@ -258,7 +258,7 @@ class PublicExceptionBoundaryTest(unittest.IsolatedAsyncioTestCase):
             self.fail('tool must not execute without a request context')
 
         mcp_server = protocol.OSMOFastMCP(name='context boundary test')
-        mcp_server.add_tool(unused_tool, name='context_test_tool')
+        mcp_server.tool(unused_tool, name='context_test_tool')
 
         with (
             self.assertLogs(

--- a/src/service/mcp/tests/test_request_context.py
+++ b/src/service/mcp/tests/test_request_context.py
@@ -19,11 +19,50 @@ SPDX-License-Identifier: Apache-2.0
 import asyncio
 import json
 import unittest
+from unittest import mock
 
+from fastmcp.server.auth import AccessToken
+from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from src.service.mcp import request_context
+
+
+class OIDCRequestCredentialsTest(unittest.TestCase):
+    def test_verified_upstream_token_is_relayed_to_gateway(self) -> None:
+        access_token = AccessToken(
+            token='verified-entra-token-value',
+            client_id='codex-client',
+            scopes=['access_as_user'],
+            claims={'preferred_username': 'alice@example.com'},
+        )
+        request = Request({
+            'type': 'http',
+            'method': 'POST',
+            'path': '/mcp',
+            'headers': [(b'x-request-id', b'oidc-request-123')],
+        })
+        with (
+            mock.patch.object(
+                request_context,
+                'get_access_token',
+                return_value=access_token,
+            ),
+            mock.patch.object(
+                request_context,
+                'get_http_request',
+                return_value=request,
+            ),
+        ):
+            credentials = request_context.get_request_credentials()
+
+        self.assertEqual(
+            credentials.authorization_header,
+            'Bearer verified-entra-token-value',
+        )
+        self.assertEqual(credentials.user_name, 'alice@example.com')
+        self.assertEqual(credentials.request_id, 'oidc-request-123')
 
 
 class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):

--- a/src/service/mcp/tests/test_request_context.py
+++ b/src/service/mcp/tests/test_request_context.py
@@ -41,7 +41,11 @@ class OIDCRequestCredentialsTest(unittest.TestCase):
             'type': 'http',
             'method': 'POST',
             'path': '/mcp',
-            'headers': [(b'x-request-id', b'oidc-request-123')],
+            'headers': [
+                (b'authorization', b'Bearer client-supplied-token'),
+                (b'x-osmo-user', b'mallory@example.com'),
+                (b'x-request-id', b'oidc-request-123'),
+            ],
         })
         with (
             mock.patch.object(
@@ -63,6 +67,77 @@ class OIDCRequestCredentialsTest(unittest.TestCase):
         )
         self.assertEqual(credentials.user_name, 'alice@example.com')
         self.assertEqual(credentials.request_id, 'oidc-request-123')
+
+    def test_unverified_request_headers_are_not_credentials(self) -> None:
+        request = Request({
+            'type': 'http',
+            'method': 'POST',
+            'path': '/mcp',
+            'headers': [
+                (b'authorization', b'Bearer client-supplied-token'),
+                (b'x-osmo-user', b'mallory@example.com'),
+            ],
+        })
+        with (
+            mock.patch.object(
+                request_context,
+                'get_access_token',
+                return_value=None,
+            ),
+            mock.patch.object(
+                request_context,
+                'get_http_request',
+                return_value=request,
+            ),
+            self.assertRaisesRegex(
+                request_context.RequestContextUnavailable,
+                'credentials are unavailable',
+            ),
+        ):
+            request_context.get_request_credentials()
+
+    def test_verified_token_rejects_invalid_request_ids(self) -> None:
+        access_token = AccessToken(
+            token='verified-entra-token-value',
+            client_id='codex-client',
+            scopes=['access_as_user'],
+            claims={'preferred_username': 'alice@example.com'},
+        )
+        invalid_headers = (
+            [(b'x-request-id', b'')],
+            [(b'x-request-id', b'invalid/request')],
+            [
+                (b'x-request-id', b'first-request'),
+                (b'X-Request-ID', b'second-request'),
+            ],
+            [(b'x-request-id', b'verified-entra-token-value')],
+        )
+
+        for headers in invalid_headers:
+            with self.subTest(headers=headers):
+                request = Request({
+                    'type': 'http',
+                    'method': 'POST',
+                    'path': '/mcp',
+                    'headers': headers,
+                })
+                with (
+                    mock.patch.object(
+                        request_context,
+                        'get_access_token',
+                        return_value=access_token,
+                    ),
+                    mock.patch.object(
+                        request_context,
+                        'get_http_request',
+                        return_value=request,
+                    ),
+                    self.assertRaisesRegex(
+                        request_context.RequestContextUnavailable,
+                        'credentials are unavailable',
+                    ),
+                ):
+                    request_context.get_request_credentials()
 
 
 class RequestContextMiddlewareTest(unittest.IsolatedAsyncioTestCase):

--- a/src/service/mcp/tests/test_resources.py
+++ b/src/service/mcp/tests/test_resources.py
@@ -20,7 +20,7 @@ import unittest
 from unittest import mock
 
 import httpx
-from mcp.server.fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError
 
 from src.lib.utils import resource_quantities
 from src.service.mcp import (
@@ -530,14 +530,8 @@ class ResourceToolTest(unittest.IsolatedAsyncioTestCase):
             messages.append(result['content'][0]['text'])
 
         self.assertEqual(messages, [
-            (
-                'Error executing tool osmo_get_resource: '
-                'The requested node is not available.'
-            ),
-            (
-                'Error executing tool osmo_get_resource: '
-                'The requested node is not available.'
-            ),
+            'The requested node is not available.',
+            'The requested node is not available.',
         ])
 
     async def test_protocol_rejects_boolean_pagination_before_transport(self) -> None:

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -28,7 +28,7 @@ import unittest
 from unittest import mock
 
 import httpx
-from mcp.server.fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError
 from mcp.types import LATEST_PROTOCOL_VERSION
 import pydantic
 from starlette.applications import Starlette
@@ -50,10 +50,16 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
     def test_create_application_uses_protocol_server(self) -> None:
         application = mock.Mock()
         protocol_server = mock.Mock()
-        protocol_server.streamable_http_app.return_value = application
+        protocol_server.auth = None
+        protocol_server.http_app.return_value = application
 
         self.assertIs(server.create_application(protocol_server), application)
-        protocol_server.streamable_http_app.assert_called_once_with()
+        protocol_server.http_app.assert_called_once_with(
+            path='/mcp',
+            transport='streamable-http',
+            stateless_http=True,
+            json_response=True,
+        )
         self.assertEqual(application.add_middleware.call_args_list, [
             mock.call(
                 request_body.RequestBodyLimitMiddleware,
@@ -394,9 +400,8 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_initialize_and_tool_catalog(self) -> None:
         mcp_server = server.create_mcp_server()
-        self.assertTrue(mcp_server.settings.stateless_http)
-        self.assertTrue(mcp_server.settings.json_response)
-        self.assertEqual(mcp_server.settings.streamable_http_path, '/mcp')
+        self.assertFalse(mcp_server.strict_input_validation)
+        self.assertIsNone(mcp_server.auth)
 
         application = server.create_application(mcp_server)
         headers = {

--- a/src/service/mcp/tests/test_server.py
+++ b/src/service/mcp/tests/test_server.py
@@ -47,7 +47,7 @@ from src.service.mcp import (
 
 class MCPServerTest(unittest.IsolatedAsyncioTestCase):
 
-    def test_create_application_uses_protocol_server(self) -> None:
+    def test_create_application_direct_mode_uses_header_middleware(self) -> None:
         application = mock.Mock()
         protocol_server = mock.Mock()
         protocol_server.auth = None
@@ -75,6 +75,27 @@ class MCPServerTest(unittest.IsolatedAsyncioTestCase):
             mock.call(
                 request_context.RequestContextMiddleware,
                 path='/mcp',
+            ),
+        ])
+
+    def test_create_application_oidc_mode_skips_header_middleware(self) -> None:
+        application = mock.Mock()
+        protocol_server = mock.Mock()
+        protocol_server.auth = mock.sentinel.auth_provider
+        protocol_server.http_app.return_value = application
+
+        self.assertIs(server.create_application(protocol_server), application)
+        self.assertEqual(application.add_middleware.call_args_list, [
+            mock.call(
+                request_body.RequestBodyLimitMiddleware,
+                path='/mcp',
+                max_body_bytes=request_body.MAX_MCP_REQUEST_BODY_BYTES,
+                max_concurrent_requests=(
+                    request_body.MAX_CONCURRENT_MCP_REQUESTS
+                ),
+                body_timeout_seconds=(
+                    request_body.MCP_REQUEST_BODY_TIMEOUT_SECONDS
+                ),
             ),
         ])
 

--- a/src/service/mcp/tests/test_tool_support.py
+++ b/src/service/mcp/tests/test_tool_support.py
@@ -20,7 +20,7 @@ import json
 import unittest
 from unittest import mock
 
-from mcp.server.fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError
 
 from src.lib.utils import osmo_errors
 from src.service.mcp import (

--- a/src/service/mcp/tests/test_workflow_actions.py
+++ b/src/service/mcp/tests/test_workflow_actions.py
@@ -20,7 +20,7 @@ import json
 import unittest
 
 import httpx
-from mcp.server.fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError
 
 from src.service.mcp import workflow_actions
 from src.service.mcp.tests import protocol_harness

--- a/src/service/mcp/tests/test_workflows.py
+++ b/src/service/mcp/tests/test_workflows.py
@@ -23,7 +23,7 @@ import json
 import unittest
 
 import httpx
-from mcp.server.fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError
 
 from src.service.mcp import request_context, workflows
 from src.service.mcp.tests import protocol_harness

--- a/src/service/mcp/tool_errors.py
+++ b/src/service/mcp/tool_errors.py
@@ -20,7 +20,7 @@ import json
 import re
 import unicodedata
 
-from mcp.server.fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ToolError
 
 
 GENERIC_TOOL_ERROR = 'MCP tool failed.'
@@ -76,6 +76,8 @@ def uncertain_write_error(operation: str) -> PublicToolError:
 
 def from_fastmcp_error(error: ToolError) -> PublicToolError | None:
     """Recover an intentional public error from FastMCP's generic wrapper."""
+    if type(error) is PublicToolError:  # pylint: disable=unidiomatic-typecheck
+        return PublicToolError(str(error))
     cause = error.__cause__
     # Subclasses are not implicitly trusted to preserve the bounded message.
     if type(cause) is PublicToolError:  # pylint: disable=unidiomatic-typecheck

--- a/src/service/mcp/tool_registry.py
+++ b/src/service/mcp/tool_registry.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 from collections.abc import Callable, Collection
 import dataclasses
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from src.service.mcp import (
@@ -347,11 +347,10 @@ def register_tools(
 ) -> None:
     """Register the selected external tools without wrapping their functions."""
     for spec in select_tool_specs(names):
-        server.add_tool(
+        server.tool(
             spec.function,
             name=spec.name,
             title=spec.title,
             description=spec.description,
             annotations=spec.annotations,
-            structured_output=True,
         )

--- a/src/service/mcp/tool_requests.py
+++ b/src/service/mcp/tool_requests.py
@@ -20,7 +20,8 @@ import dataclasses
 import json
 from typing import Literal, TypeAlias
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
+from fastmcp.server.dependencies import get_http_request
 import pydantic
 from starlette.requests import Request
 
@@ -195,9 +196,10 @@ async def request_active_profile(context: Context) -> ActiveProfile:
 
 def get_app_context(context: Context) -> gateway.AppContext:
     """Resolve process-lifetime dependencies from a real MCP HTTP request."""
+    del context
     try:
-        request = context.request_context.request
-    except ValueError:
+        request = get_http_request()
+    except RuntimeError:
         raise tool_errors.PublicToolError(
             'MCP runtime context is unavailable.'
         ) from None

--- a/src/service/mcp/workflow_actions.py
+++ b/src/service/mcp/workflow_actions.py
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 
 from src.service.mcp import (
     gateway,

--- a/src/service/mcp/workflow_submission.py
+++ b/src/service/mcp/workflow_submission.py
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 
 import src.lib.utils.workflow_labels as shared_labels
 from src.lib.utils import workflow as workflow_utils

--- a/src/service/mcp/workflows.py
+++ b/src/service/mcp/workflows.py
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import re
 
-from mcp.server.fastmcp import Context
+from fastmcp import Context
 
 import src.lib.utils.workflow_labels as shared_labels
 from src.service.mcp import (


### PR DESCRIPTION
## Summary

Upgrade the MCP service to FastMCP 3 and pass FastMCP's built-in `OIDCProxy` directly to the existing server as its `auth` provider.

FastMCP handles OAuth discovery, CIMD with DCR fallback, PKCE, token exchange, refresh, and encrypted state. The verified upstream Entra access token continues through the existing OSMO Gateway and RBAC path.

No standalone OAuth service or custom OAuth endpoints are introduced.

Issue #None

## Testing

- `bazel test //src/service/mcp/tests:all --test_output=errors --lockfile_mode=error` — 39/39 passed
- `bazel build //src/service/mcp:mcp_binary --lockfile_mode=error`

## Checklist

- [x] Tests cover the changes.
- [x] The stacked chart PR documents deployment and rollback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional OIDC/OAuth authentication for the MCP endpoint, including token verification, refresh, secure credential storage, and trusted redirects.
  - Added support for Streamable HTTP, stateless operation, and JSON responses.
  - Improved authenticated request handling and access-token relay.
  - Added deployment configuration for OAuth proxy routing, secrets, Redis, and configurable credentials.

- **Bug Fixes**
  - Sanitized validation and tool errors to avoid exposing sensitive details.
  - Improved middleware, tool discovery, and request metadata handling.

- **Documentation**
  - Expanded guidance for authentication modes, configuration, security, rollout, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->