### PR TITLE
Sanitize identity-provider roles before forwarding headers

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -75,10 +75,11 @@ OSMO services write logs to standard streams for collection by the platform log 
 ### Self-hosted MCP service
 
 The optional MCP workload exposes predefined OSMO operations to compatible
-native or desktop MCP clients. The Gateway authenticates and authorizes every
-`/mcp` request, and the MCP service relays the unchanged caller bearer through
-the same Gateway for each mapped OSMO API request. The second Gateway pass
-applies the API-specific action; `mcp:Access` alone grants no API permission.
+native or desktop MCP clients. In direct-provider mode, the Gateway validates
+the bearer on `/mcp`. With `oidcProxy.enabled`, FastMCP validates its own proxy
+token and relays the verified upstream access token through the same Gateway
+for each mapped OSMO API request. That API request still passes the deployment's
+normal identity-provider validation and semantic RBAC.
 
 `services.mcp.resourceUrl` is the single source of truth for the public MCP
 resource and the outbound Gateway origin. It must be an externally reachable
@@ -95,17 +96,42 @@ destination, but it cannot validate external DNS.
 | `services.mcp.imageName` | MCP image repository name. | `mcp` |
 | `services.mcp.imageTag` | Per-MCP image tag override; falls back to `global.osmoImageTag` when empty. | `""` |
 | `services.mcp.resourceUrl` | Canonical public HTTPS MCP URL ending in exact `/mcp`; also determines the fixed outbound Gateway origin. | `""` |
-| `services.mcp.authorizationServers` | OAuth/OIDC issuer identifiers advertised in protected-resource metadata. At least one is required when enabled. | `[]` |
-| `services.mcp.scopes` | OAuth scopes advertised in protected-resource metadata. | `[]` |
+| `services.mcp.authorizationServers` | OAuth/OIDC issuers advertised in direct-provider mode; ignored when `oidcProxy.enabled` is true. | `[]` |
+| `services.mcp.scopes` | OAuth scopes advertised in direct-provider mode; ignored when `oidcProxy.enabled` is true. | `[]` |
 | `services.mcp.allowedOrigins` | Exact browser origins permitted on `/mcp`; native clients normally omit `Origin`. | `[]` |
 | `services.mcp.requestTimeoutSeconds` | Total timeout for each MCP-initiated Gateway request, from 1 through 60 seconds. | `10` |
-| `services.mcp.replicas` | Number of stateless MCP replicas. | `1` |
+| `services.mcp.replicas` | Number of MCP replicas. Must remain `1` with `oidcProxy.enabled` because FastMCP 3.4.7 refresh serialization is process-local. | `1` |
 | `services.mcp.extraEnv` | Additional non-managed environment variables. It cannot override MCP host, port, Gateway origin, or request timeout. | `[]` |
+| `services.mcp.extraVolumeMounts` | Additional MCP container volume mounts, including Vault-injected credential files. | `[]` |
+| `services.mcp.extraVolumes` | Additional MCP pod volumes. | `[]` |
+| `services.mcp.oidcProxy.enabled` | Enable FastMCP's built-in OIDC proxy inside the existing MCP process. It advertises CIMD and retains DCR as a compatibility fallback. | `false` |
+| `services.mcp.oidcProxy.scope` | Full delegated scope URI advertised to MCP clients and requested upstream, normally `<resourceUrl>/access_as_user`. | `""` |
+| `services.mcp.oidcProxy.oidc.configUrl` | Upstream OIDC discovery URL. | `""` |
+| `services.mcp.oidcProxy.oidc.clientId` | Administrator-managed confidential OIDC application client ID. | `""` |
+| `services.mcp.oidcProxy.oidc.clientSecretFile` | Mounted file containing the upstream OIDC client secret. | `/etc/osmo/mcp-auth/client-secret` |
+| `services.mcp.oidcProxy.oidc.accessTokenIssuer` | Exact issuer required on upstream API access tokens. | `""` |
+| `services.mcp.oidcProxy.oidc.accessTokenAudience` | Exact OSMO MCP resource audience required on upstream API access tokens; must equal `resourceUrl`. | `""` |
+| `services.mcp.oidcProxy.oidc.accessTokenJwksUrl` | HTTPS JWKS URL used to verify upstream API access tokens. | `""` |
+| `services.mcp.oidcProxy.oidc.accessTokenRequiredScope` | Short scope value required in the upstream access token's `scp` claim. | `access_as_user` |
+| `services.mcp.oidcProxy.redis` | Redis connection used by FastMCP for registrations, authorization state, and encrypted upstream tokens; blank host/port inherit `services.redis`. | See `values.yaml` |
+| `services.mcp.oidcProxy.signingJwksFile` | Private single-key HS256 JWKS mounted only in the MCP pod. | `/etc/osmo/mcp-auth/signing-jwks.json` |
+| `services.mcp.oidcProxy.existingSecret` | Optional existing Secret holding the OIDC client secret, signing JWKS, and Redis password. The chart references it but never creates credential material. | See `values.yaml` |
+
+The in-process proxy follows OSMO's OIDC profile: a full delegated scope URI is requested
+from the upstream provider while its short suffix is enforced in the verified
+API access token. Register the single stable upstream redirect URI
+`<resourceUrl origin>/auth/callback`. MCP clients still configure only `resourceUrl`.
+CIMD-capable clients identify themselves with a hosted metadata document;
+older clients can use FastMCP's `/register` DCR endpoint. Both paths use
+authorization-code flow with PKCE and end in the same OSMO Gateway and semantic
+RBAC checks.
 
 Enabling MCP always renders an ingress NetworkPolicy whose allow rule selects
 only this release's Gateway Envoy pods, even when
 `gateway.networkPolicies.enabled` is false for other upstreams. This is
-required because MCP trusts the identity context created by Gateway.
+required because direct-provider mode trusts the identity context created by
+Gateway, while OIDC-proxy mode accepts traffic only through the same public
+Gateway boundary.
 NetworkPolicies require enforcement by the cluster CNI and are additive, so
 operators must also ensure no other policy grants MCP ingress. The pod does
 not mount a service-account token, and the chart creates no MCP credential

--- a/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
+++ b/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Synthetic values used only to validate FastMCP's in-process OIDC proxy.
+services:
+  mcp:
+    enabled: true
+    resourceUrl: https://osmo.example.com/mcp
+    allowedOrigins:
+    - http://localhost:6274
+    oidcProxy:
+      enabled: true
+      scope: https://osmo.example.com/mcp/access_as_user
+      trustedHttpsRedirectOrigins:
+      - https://trusted-client.example.com
+      oidc:
+        configUrl: https://login.example.com/example-tenant/v2.0/.well-known/openid-configuration
+        clientId: example-mcp-proxy-client
+        accessTokenIssuer: https://sts.example.com/example-tenant/
+        accessTokenAudience: https://osmo.example.com/mcp
+        accessTokenJwksUrl: https://login.example.com/example-tenant/discovery/v2.0/keys
+        accessTokenRequiredScope: access_as_user
+      redis:
+        serviceName: proxy-redis.example.internal
+        port: 6380
+        dbNumber: 14
+        tlsEnabled: true
+        passwordFile: /etc/osmo/mcp-auth/redis-password
+        keyPrefix: test:mcp-auth
+      existingSecret:
+        name: mcp-oidc-proxy-secrets
+
+gateway:
+  networkPolicies:
+    enabled: false
+  envoy:
+    jwt:
+      providers:
+      - issuer: https://sts.example.com/example-tenant/
+        audience: https://osmo.example.com/mcp
+        jwks_uri: https://login.example.com/example-tenant/discovery/v2.0/keys
+        cluster: idp
+        user_claim: preferred_username

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -103,6 +103,9 @@ assert_rendered '\"authorization_servers\":[\"https://issuer.example.com\"]'
 assert_rendered '\"bearer_methods_supported\":[\"header\"]'
 assert_rendered '\"resource\":\"https://osmo.example.com/mcp\"'
 assert_rendered '\"scopes_supported\":[\"mcp:Access\"]'
+assert_rendered 'local safe_roles = {}'
+assert_rendered "not string.find(role, '[,%c]')"
+assert_rendered "table.concat(safe_roles, ',')"
 assert_env_value 'OSMO_GATEWAY_URL' 'https://osmo.example.com'
 assert_env_value 'OSMO_MCP_REQUEST_TIMEOUT_SECONDS' '10'
 

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -20,44 +20,80 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 CHART_DIR="$(dirname -- "$SCRIPT_DIR")"
 VALUES_FILE="$SCRIPT_DIR/mcp-values.yaml"
+PROXY_VALUES_FILE="$SCRIPT_DIR/mcp-oidc-proxy-values.yaml"
 RENDERED_MANIFEST="$(mktemp)"
 MCP_MANIFEST="$(mktemp)"
 DISABLED_MANIFEST="$(mktemp)"
-trap 'rm -f "$RENDERED_MANIFEST" "$MCP_MANIFEST" "$DISABLED_MANIFEST"' EXIT
+PROXY_RENDERED_MANIFEST="$(mktemp)"
+PROXY_MCP_MANIFEST="$(mktemp)"
+trap 'rm -f "$RENDERED_MANIFEST" "$MCP_MANIFEST" "$DISABLED_MANIFEST" \
+  "$PROXY_RENDERED_MANIFEST" "$PROXY_MCP_MANIFEST"' EXIT
 
 fail() {
   echo "MCP chart validation failed: $*" >&2
   exit 1
 }
 
-assert_rendered() {
-  local expected="$1"
-  grep -F -- "$expected" "$RENDERED_MANIFEST" >/dev/null || \
-    fail "rendered manifest is missing: $expected"
+assert_file_contains() {
+  local file="$1"
+  local expected="$2"
+  grep -F -- "$expected" "$file" >/dev/null || \
+    fail "$(basename "$file") is missing: $expected"
 }
 
-assert_mcp_rendered() {
-  local expected="$1"
-  grep -F -- "$expected" "$MCP_MANIFEST" >/dev/null || \
-    fail "rendered MCP manifest is missing: $expected"
+assert_file_omits() {
+  local file="$1"
+  local forbidden="$2"
+  if grep -F -- "$forbidden" "$file" >/dev/null; then
+    fail "$(basename "$file") unexpectedly contains: $forbidden"
+  fi
 }
 
 assert_env_value() {
-  local name="$1"
-  local value="$2"
-  grep -A1 -F -- "name: $name" "$MCP_MANIFEST" | \
+  local file="$1"
+  local name="$2"
+  local value="$3"
+  grep -A1 -F -- "name: $name" "$file" | \
     grep -F -- "value: \"$value\"" >/dev/null || \
     fail "managed environment variable $name does not equal $value"
 }
 
+assert_route_contains() {
+  local file="$1"
+  local route="$2"
+  local expected="$3"
+  awk -v marker="                - name: $route" '
+    $0 == marker { found = 1 }
+    found && $0 != marker && index($0, "                - ") == 1 { exit }
+    found { print }
+  ' "$file" | \
+    grep -F -- "$expected" >/dev/null || \
+    fail "Gateway route $route is missing: $expected"
+}
+
+assert_route_omits() {
+  local file="$1"
+  local route="$2"
+  local forbidden="$3"
+  if awk -v marker="                - name: $route" '
+      $0 == marker { found = 1 }
+      found && $0 != marker && index($0, "                - ") == 1 { exit }
+      found { print }
+    ' "$file" | \
+      grep -F -- "$forbidden" >/dev/null; then
+    fail "Gateway route $route unexpectedly contains: $forbidden"
+  fi
+}
+
 expect_render_failure() {
-  local description="$1"
-  local expected_error="$2"
-  shift 2
+  local values_file="$1"
+  local description="$2"
+  local expected_error="$3"
+  shift 3
 
   local output
   if output=$(helm template mcp-validation "$CHART_DIR" \
-      --values "$VALUES_FILE" "$@" 2>&1); then
+      --values "$values_file" "$@" 2>&1); then
     fail "$description unexpectedly rendered successfully"
   fi
   case "$output" in
@@ -67,87 +103,188 @@ expect_render_failure() {
 }
 
 helm lint "$CHART_DIR" --values "$VALUES_FILE"
+helm lint "$CHART_DIR" --values "$PROXY_VALUES_FILE"
 helm template mcp-disabled "$CHART_DIR" >"$DISABLED_MANIFEST"
 helm template mcp-validation "$CHART_DIR" \
   --values "$VALUES_FILE" >"$RENDERED_MANIFEST"
 helm template mcp-validation "$CHART_DIR" \
   --values "$VALUES_FILE" \
   --show-only templates/mcp-service.yaml >"$MCP_MANIFEST"
+helm template mcp-proxy-validation "$CHART_DIR" \
+  --values "$PROXY_VALUES_FILE" >"$PROXY_RENDERED_MANIFEST"
+helm template mcp-proxy-validation "$CHART_DIR" \
+  --values "$PROXY_VALUES_FILE" \
+  --show-only templates/mcp-service.yaml >"$PROXY_MCP_MANIFEST"
 
 for forbidden in \
     'name: osmo-mcp' \
     'cluster: osmo-mcp' \
     'path: /mcp' \
     'path: /.well-known/oauth-protected-resource/mcp'; do
-  if grep -F -- "$forbidden" "$DISABLED_MANIFEST" >/dev/null; then
-    fail "disabled mode rendered MCP configuration: $forbidden"
-  fi
+  assert_file_omits "$DISABLED_MANIFEST" "$forbidden"
 done
 
-assert_mcp_rendered 'kind: Deployment'
-assert_mcp_rendered 'kind: Service'
-assert_mcp_rendered 'name: osmo-mcp'
-assert_mcp_rendered 'image: nvcr.io/nvidia/osmo/mcp:latest'
-assert_mcp_rendered 'name: OSMO_GATEWAY_URL'
-assert_mcp_rendered 'name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS'
-assert_mcp_rendered 'kind: NetworkPolicy'
-assert_mcp_rendered 'name: osmo-mcp-allow-gateway-envoy'
-assert_mcp_rendered 'app.kubernetes.io/component: envoy'
-assert_mcp_rendered 'livenessProbe:'
-assert_mcp_rendered 'readinessProbe:'
-assert_mcp_rendered 'startupProbe:'
-assert_mcp_rendered 'automountServiceAccountToken: false'
-assert_rendered 'path: /mcp'
-assert_rendered 'path: /.well-known/oauth-protected-resource/mcp'
-assert_rendered '\"authorization_servers\":[\"https://issuer.example.com\"]'
-assert_rendered '\"bearer_methods_supported\":[\"header\"]'
-assert_rendered '\"resource\":\"https://osmo.example.com/mcp\"'
-assert_rendered '\"scopes_supported\":[\"mcp:Access\"]'
-assert_rendered 'local safe_roles = {}'
-assert_rendered "not string.find(role, '[,%c]')"
-assert_rendered "table.concat(safe_roles, ',')"
-assert_env_value 'OSMO_GATEWAY_URL' 'https://osmo.example.com'
-assert_env_value 'OSMO_MCP_REQUEST_TIMEOUT_SECONDS' '10'
+for forbidden in \
+    'path: /.well-known/oauth-authorization-server' \
+    'path: /authorize' \
+    'path: /auth/callback' \
+    'path: /register' \
+    'path: /token' \
+    'path: /consent'; do
+  assert_file_omits "$RENDERED_MANIFEST" "$forbidden"
+done
 
-if grep -A12 -B2 -F 'kind: Secret' "$MCP_MANIFEST" | \
+for expected in \
+    'kind: Deployment' \
+    'kind: Service' \
+    'name: osmo-mcp' \
+    'image: nvcr.io/nvidia/osmo/mcp:latest' \
+    'name: OSMO_GATEWAY_URL' \
+    'name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS' \
+    'name: OSMO_MCP_AUTH_ENABLED' \
+    'kind: NetworkPolicy' \
+    'name: osmo-mcp-allow-gateway-envoy' \
+    'app.kubernetes.io/component: envoy' \
+    'automountServiceAccountToken: false'; do
+  assert_file_contains "$MCP_MANIFEST" "$expected"
+done
+assert_file_contains "$RENDERED_MANIFEST" 'path: /mcp'
+assert_file_contains "$RENDERED_MANIFEST" 'path: /.well-known/oauth-protected-resource/mcp'
+assert_file_contains "$RENDERED_MANIFEST" '\"authorization_servers\":[\"https://issuer.example.com\"]'
+assert_file_contains "$RENDERED_MANIFEST" '\"resource\":\"https://osmo.example.com/mcp\"'
+assert_file_contains "$RENDERED_MANIFEST" '\"scopes_supported\":[\"mcp:Access\"]'
+assert_file_contains "$RENDERED_MANIFEST" 'local safe_roles = {}'
+assert_file_contains "$RENDERED_MANIFEST" "not string.find(role, '[,%c]')"
+assert_file_contains "$RENDERED_MANIFEST" "table.concat(safe_roles, ',')"
+assert_env_value "$MCP_MANIFEST" OSMO_GATEWAY_URL https://osmo.example.com
+assert_env_value "$MCP_MANIFEST" OSMO_MCP_REQUEST_TIMEOUT_SECONDS 10
+assert_env_value "$MCP_MANIFEST" OSMO_MCP_AUTH_ENABLED false
+assert_route_omits "$RENDERED_MANIFEST" osmo-mcp 'typed_per_filter_config:'
+
+for expected in \
+    'name: OSMO_MCP_AUTH_ISSUER_URL' \
+    'name: OSMO_MCP_AUTH_RESOURCE_URL' \
+    'name: OSMO_MCP_AUTH_SCOPE' \
+    'name: OSMO_MCP_AUTH_REDIS_URL' \
+    'name: OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS' \
+    'name: OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS' \
+    'name: OSMO_MCP_AUTH_OIDC_CONFIG_URL' \
+    'name: OSMO_MCP_AUTH_OIDC_CLIENT_ID' \
+    'name: OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE' \
+    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER' \
+    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE' \
+    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL' \
+    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE' \
+    'name: OSMO_MCP_AUTH_SIGNING_JWKS_FILE' \
+    'name: OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS' \
+    'secretName: mcp-oidc-proxy-secrets'; do
+  assert_file_contains "$PROXY_MCP_MANIFEST" "$expected"
+done
+
+for route in \
+    mcp-protected-resource-metadata \
+    mcp-oauth-authorization-server-metadata \
+    mcp-oauth-authorize-get \
+    mcp-oauth-authorize-post \
+    mcp-oauth-oidc-callback \
+    mcp-oauth-register \
+    mcp-oauth-token \
+    mcp-oauth-consent-get \
+    mcp-oauth-consent-post \
+    mcp-oauth-authorization-server-metadata-options \
+    mcp-oauth-authorize-options \
+    mcp-oauth-oidc-callback-options \
+    mcp-oauth-register-options \
+    mcp-oauth-token-options \
+    mcp-oauth-consent-options; do
+  assert_route_contains "$PROXY_RENDERED_MANIFEST" "$route" 'cluster: osmo-mcp'
+  assert_route_contains "$PROXY_RENDERED_MANIFEST" "$route" 'envoy.filters.http.jwt_authn:'
+  assert_route_contains "$PROXY_RENDERED_MANIFEST" "$route" 'envoy.filters.http.ext_authz:'
+done
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_ENABLED true
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_ISSUER_URL https://osmo.example.com
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_RESOURCE_URL https://osmo.example.com/mcp
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_SCOPE https://osmo.example.com/mcp/access_as_user
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_REDIS_URL rediss://proxy-redis.example.internal:6380/14
+
+for expected in \
+    'path: /.well-known/oauth-authorization-server' \
+    'path: /authorize' \
+    'path: /auth/callback' \
+    'path: /register' \
+    'path: /token' \
+    'path: /consent' \
+    'name: mcp-protected-resource-metadata' \
+    'name: osmo-mcp' \
+    'cluster: osmo-mcp' \
+    'path: "%PATH(NQ:ORIG_OR_PATH)%"'; do
+  assert_file_contains "$PROXY_RENDERED_MANIFEST" "$expected"
+done
+
+for forbidden in \
+    'name: osmo-mcp-oauth' \
+    'cluster: osmo-mcp-oauth' \
+    'app.kubernetes.io/component: mcp-oauth-broker' \
+    '- mcp-auth' \
+    'local_jwks:' \
+    'mcp-oauth-signing-jwks' \
+    'upstream_claims' \
+    'meta.verified_jwt.token_use'; do
+  assert_file_omits "$PROXY_RENDERED_MANIFEST" "$forbidden"
+done
+
+assert_route_contains "$PROXY_RENDERED_MANIFEST" osmo-mcp 'envoy.filters.http.jwt_authn:'
+assert_route_contains "$PROXY_RENDERED_MANIFEST" osmo-mcp 'envoy.filters.http.ext_authz:'
+assert_file_omits "$PROXY_RENDERED_MANIFEST" '\"authorization_servers\"'
+
+if grep -A12 -B2 -F 'kind: Secret' "$PROXY_MCP_MANIFEST" | \
     grep -i -F 'mcp' >/dev/null; then
-  fail 'enabled mode rendered an MCP credential Secret'
-fi
-if grep -E 'OSMO_MCP_(TOKEN|CREDENTIAL|SECRET)' \
-    "$MCP_MANIFEST" >/dev/null; then
-  fail 'enabled mode rendered an MCP credential environment variable'
+  fail 'OIDC proxy mode rendered credential material into a Secret'
 fi
 
-expect_render_failure \
+expect_render_failure "$VALUES_FILE" \
   'encoded alternate Gateway origin' \
   'services.mcp.resourceUrl must be a valid HTTPS origin' \
   --set 'services.mcp.resourceUrl=https://osmo.example.com%40evil.example.com/mcp'
 
-expect_render_failure \
-  'non-integer timeout' \
-  'services.mcp.requestTimeoutSeconds must be between 1 and 60' \
-  --set 'services.mcp.requestTimeoutSeconds=true'
-
-expect_render_failure \
+expect_render_failure "$VALUES_FILE" \
   'managed Gateway URL override' \
   'services.mcp.extraEnv must not override managed variable OSMO_GATEWAY_URL' \
-  --set-json \
-  'services.mcp.extraEnv=[{"name":"OSMO_GATEWAY_URL","value":"https://evil.example.com"}]'
+  --set-json 'services.mcp.extraEnv=[{"name":"OSMO_GATEWAY_URL","value":"https://evil.example.com"}]'
 
-expect_render_failure \
-  'MCP authentication bypass' \
-  'overlaps a protected MCP path' \
-  --set 'gateway.envoy.extraSkipAuthPaths[0]=/mcp'
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy without MCP' \
+  'services.mcp.oidcProxy.enabled requires services.mcp.enabled=true' \
+  --set 'services.mcp.enabled=false'
 
-expect_render_failure \
-  'query-prefixed MCP authentication bypass' \
-  'overlaps a protected MCP path' \
-  --set-string 'gateway.envoy.extraSkipAuthPaths[0]=/mcp?bypass=true'
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC proxy with multiple replicas' \
+  'services.mcp.replicas must be 1 when services.mcp.oidcProxy.enabled=true' \
+  --set 'services.mcp.replicas=2'
 
-expect_render_failure \
-  'query-prefixed MCP metadata authentication bypass' \
-  'overlaps a protected MCP path' \
-  --set-string \
-  'gateway.envoy.extraSkipAuthPaths[0]=/.well-known/oauth-protected-resource/mcp?bypass=true'
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'invalid OIDC proxy Redis port' \
+  'services.mcp.oidcProxy.redis.port must be between 1 and 65535' \
+  --set 'services.mcp.oidcProxy.redis.port=0'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC access-token audience mismatch' \
+  'services.mcp.oidcProxy.oidc.accessTokenAudience must equal services.mcp.resourceUrl' \
+  --set 'services.mcp.oidcProxy.oidc.accessTokenAudience=https://other.example.com/mcp'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'OIDC full scope mismatch' \
+  'services.mcp.oidcProxy.scope must equal services.mcp.resourceUrl followed by oidc.accessTokenRequiredScope' \
+  --set 'services.mcp.oidcProxy.scope=https://other.example.com/access_as_user'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'untrusted redirect origin with a path' \
+  'trustedHttpsRedirectOrigins entries must be exact HTTPS origins' \
+  --set 'services.mcp.oidcProxy.trustedHttpsRedirectOrigins[0]=https://trusted.example.com/callback'
+
+expect_render_failure "$PROXY_VALUES_FILE" \
+  'managed OIDC proxy issuer override' \
+  'services.mcp.extraEnv must not override managed variable OSMO_MCP_AUTH_ISSUER_URL' \
+  --set-json 'services.mcp.extraEnv=[{"name":"OSMO_MCP_AUTH_ISSUER_URL","value":"https://evil.example.com"}]'
 
 echo 'MCP chart validation passed'

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -777,7 +777,13 @@ data:
                       end
                       local roles = meta.verified_jwt.roles
                       if (roles ~= nil and type(roles) == 'table') then
-                        request_handle:headers():replace('x-osmo-roles', table.concat(roles, ','))
+                        local safe_roles = {}
+                        for _, role in ipairs(roles) do
+                          if (type(role) == 'string' and #role <= 256 and not string.find(role, '[,%c]')) then
+                            table.insert(safe_roles, role)
+                          end
+                        end
+                        request_handle:headers():replace('x-osmo-roles', table.concat(safe_roles, ','))
                       end
                       if (meta.verified_jwt.osmo_token_name ~= nil) then
                         request_handle:headers():replace('x-osmo-token-name', tostring(meta.verified_jwt.osmo_token_name))

--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -30,10 +30,35 @@ setting detects this rotation and triggers Envoy to reload.
 {{- $envoy := $gw.envoy }}
 {{- $mcp := .Values.services.mcp }}
 {{- $mcpEnabled := $mcp.enabled | default false }}
+{{- $mcpOidcProxy := $mcp.oidcProxy }}
+{{- if and ($mcpOidcProxy.enabled | default false) (not $mcpEnabled) }}
+{{- fail "services.mcp.oidcProxy.enabled requires services.mcp.enabled=true" }}
+{{- end }}
+{{- $mcpOidcProxyEnabled := and $mcpEnabled ($mcpOidcProxy.enabled | default false) }}
 {{- $mcpPath := "/mcp" }}
 {{- $mcpMetadataPath := "/.well-known/oauth-protected-resource/mcp" }}
+{{- $mcpOidcProxyRoutes := list
+      (dict "name" "mcp-oauth-authorization-server-metadata" "path" "/.well-known/oauth-authorization-server" "pathRegex" "^/[.]well-known/oauth-authorization-server([?].*)?$" "method" "GET")
+      (dict "name" "mcp-oauth-authorize-get" "path" "/authorize" "pathRegex" "^/authorize([?].*)?$" "method" "GET")
+      (dict "name" "mcp-oauth-authorize-post" "path" "/authorize" "pathRegex" "^/authorize([?].*)?$" "method" "POST")
+      (dict "name" "mcp-oauth-oidc-callback" "path" "/auth/callback" "pathRegex" "^/auth/callback([?].*)?$" "method" "GET" "timeout" "45s")
+      (dict "name" "mcp-oauth-register" "path" "/register" "pathRegex" "^/register([?].*)?$" "method" "POST")
+      (dict "name" "mcp-oauth-token" "path" "/token" "pathRegex" "^/token([?].*)?$" "method" "POST" "timeout" "45s")
+      (dict "name" "mcp-oauth-consent-get" "path" "/consent" "pathRegex" "^/consent([?].*)?$" "method" "GET")
+      (dict "name" "mcp-oauth-consent-post" "path" "/consent" "pathRegex" "^/consent([?].*)?$" "method" "POST")
+    }}
+{{- $mcpOidcProxyOptionRoutes := list
+      (dict "name" "mcp-oauth-authorization-server-metadata-options" "path" "/.well-known/oauth-authorization-server" "pathRegex" "^/[.]well-known/oauth-authorization-server([?].*)?$")
+      (dict "name" "mcp-oauth-authorize-options" "path" "/authorize" "pathRegex" "^/authorize([?].*)?$")
+      (dict "name" "mcp-oauth-oidc-callback-options" "path" "/auth/callback" "pathRegex" "^/auth/callback([?].*)?$" "timeout" "45s")
+      (dict "name" "mcp-oauth-register-options" "path" "/register" "pathRegex" "^/register([?].*)?$")
+      (dict "name" "mcp-oauth-token-options" "path" "/token" "pathRegex" "^/token([?].*)?$")
+      (dict "name" "mcp-oauth-consent-options" "path" "/consent" "pathRegex" "^/consent([?].*)?$")
+    }}
 {{- $mcpResourceUrl := "" }}
 {{- $mcpMetadataUrl := "" }}
+{{- $mcpAuthorizationServers := $mcp.authorizationServers }}
+{{- $mcpScopes := $mcp.scopes }}
 {{- $skipAuthPaths := concat (default (list) $envoy.skipAuthPaths) (default (list) $envoy.extraSkipAuthPaths) }}
 {{- $authnSkipPaths := $skipAuthPaths }}
 {{- if $gw.oauth2Proxy.enabled }}
@@ -46,10 +71,8 @@ setting detects this rotation and triggers Envoy to reload.
 {{- if not $gw.authz.enabled }}
 {{- fail "services.mcp.enabled requires gateway.authz.enabled=true" }}
 {{- end }}
-{{- if not $envoy.jwt.providers }}
-{{- fail "services.mcp.enabled requires at least one gateway.envoy.jwt.providers entry" }}
-{{- end }}
 {{- $mcpResourceUrl = include "osmo.mcp-resource-url" . }}
+{{- if not $mcpOidcProxyEnabled }}
 {{- if not (kindIs "slice" $mcp.authorizationServers) }}
 {{- fail "services.mcp.authorizationServers must be a list" }}
 {{- end }}
@@ -70,6 +93,10 @@ setting detects this rotation and triggers Envoy to reload.
 {{- fail "services.mcp.scopes entries must not be empty" }}
 {{- end }}
 {{- end }}
+{{- end }}
+{{- if not $envoy.jwt.providers }}
+{{- fail "services.mcp.enabled requires at least one gateway.envoy.jwt.providers entry" }}
+{{- end }}
 {{- $mcpServiceName := required "services.mcp.serviceName is required when MCP is enabled" $mcp.serviceName }}
 {{- $mcpImageName := required "services.mcp.imageName is required when MCP is enabled" $mcp.imageName }}
 {{- if or (lt (int $mcp.port) 1) (gt (int $mcp.port) 65535) }}
@@ -86,7 +113,15 @@ setting detects this rotation and triggers Envoy to reload.
 {{- range $skipPath := $skipAuthPaths }}
 {{- $overlapsMcpPath := or (hasPrefix $skipPath $mcpPath) (hasPrefix $mcpPath $skipPath) }}
 {{- $overlapsMcpMetadataPath := or (hasPrefix $skipPath $mcpMetadataPath) (hasPrefix $mcpMetadataPath $skipPath) }}
-{{- if or $overlapsMcpPath $overlapsMcpMetadataPath }}
+{{- $overlapsMcpOidcProxyPath := false }}
+{{- if $mcpOidcProxyEnabled }}
+{{- range $route := $mcpOidcProxyRoutes }}
+{{- if or (hasPrefix $skipPath $route.path) (hasPrefix $route.path $skipPath) }}
+{{- $overlapsMcpOidcProxyPath = true }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if or $overlapsMcpPath $overlapsMcpMetadataPath $overlapsMcpOidcProxyPath }}
 {{- fail (printf "gateway auth bypass prefix %q overlaps a protected MCP path" $skipPath) }}
 {{- end }}
 {{- end }}
@@ -171,7 +206,9 @@ data:
                   json_format:
                     start_time: "%START_TIME%"
                     method: "%REQ(:METHOD)%"
-                    path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                    # Never persist query parameters. OAuth callbacks carry
+                    # short-lived authorization codes and state in the query.
+                    path: "%PATH(NQ:ORIG_OR_PATH)%"
                     protocol: "%PROTOCOL%"
                     response_code: "%RESPONSE_CODE%"
                     response_code_details: "%RESPONSE_CODE_DETAILS%"
@@ -285,9 +322,8 @@ data:
                 {{- end }}
 
                 {{- if $mcpEnabled }}
-                # RFC 9728 metadata is the only public MCP route. Keep the
-                # method and path exact so no neighboring path or write method
-                # inherits the authentication bypass.
+                # Keep the public protected-resource route exact so no
+                # neighboring path or write method inherits the bypass.
                 - name: mcp-protected-resource-metadata
                   match:
                     path: {{ $mcpMetadataPath }}
@@ -295,10 +331,16 @@ data:
                     - name: ":method"
                       string_match:
                         exact: GET
+                  {{- if $mcpOidcProxyEnabled }}
+                  route:
+                    cluster: osmo-mcp
+                    timeout: 15s
+                  {{- else }}
                   direct_response:
                     status: 200
                     body:
-                      inline_string: {{ dict "resource" $mcpResourceUrl "authorization_servers" $mcp.authorizationServers "bearer_methods_supported" (list "header") "scopes_supported" $mcp.scopes | toJson | quote }}
+                      inline_string: {{ dict "resource" $mcpResourceUrl "authorization_servers" $mcpAuthorizationServers "bearer_methods_supported" (list "header") "scopes_supported" $mcpScopes | toJson | quote }}
+                  {{- end }}
                   response_headers_to_add:
                   - header:
                       key: content-type
@@ -318,15 +360,67 @@ data:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
                       disabled: true
 
-                # Streamable HTTP uses the same exact endpoint for its
-                # supported methods. Authentication and semantic authorization
-                # remain enabled on this route.
+                {{- if $mcpOidcProxyEnabled }}
+                # FastMCP owns this complete public OAuth surface in the same
+                # process as /mcp. Every route remains method/path exact.
+                {{- range $route := $mcpOidcProxyRoutes }}
+                - name: {{ $route.name }}
+                  match:
+                    path: {{ $route.path }}
+                    headers:
+                    - name: ":method"
+                      string_match:
+                        exact: {{ $route.method }}
+                  route:
+                    cluster: osmo-mcp
+                    timeout: {{ default "15s" $route.timeout }}
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+                {{- end }}
+                {{- range $route := $mcpOidcProxyOptionRoutes }}
+                - name: {{ $route.name }}
+                  match:
+                    path: {{ $route.path }}
+                    headers:
+                    - name: ":method"
+                      string_match:
+                        exact: OPTIONS
+                  route:
+                    cluster: osmo-mcp
+                    timeout: {{ default "15s" $route.timeout }}
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+                {{- end }}
+                {{- end }}
+
+                # In direct mode Gateway validates and authorizes /mcp. With
+                # the in-process proxy enabled, FastMCP validates its own token
+                # and relays the verified upstream token to protected /api.
                 - name: osmo-mcp
                   match:
                     path: {{ $mcpPath }}
                   route:
                     cluster: osmo-mcp
                     timeout: 0s
+                  {{- if $mcpOidcProxyEnabled }}
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+                  {{- end }}
                 {{- end }}
 
                 {{- if $gw.upstreams.router.enabled }}
@@ -651,6 +745,54 @@ data:
                                       header_name: ":method"
                                   value_match:
                                     exact: "GET"
+                          {{- if $mcpOidcProxyEnabled }}
+                          # Skip the browser-session proxy only for the exact
+                          # method/path pairs owned by FastMCP's OIDC proxy.
+                          {{- range $route := $mcpOidcProxyRoutes }}
+                          - and_matcher:
+                              predicate:
+                              - single_predicate:
+                                  input:
+                                    name: request-headers
+                                    typed_config:
+                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                      header_name: ":path"
+                                  value_match:
+                                    safe_regex:
+                                      google_re2: {}
+                                      regex: {{ $route.pathRegex | quote }}
+                              - single_predicate:
+                                  input:
+                                    name: request-headers
+                                    typed_config:
+                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                      header_name: ":method"
+                                  value_match:
+                                    exact: {{ $route.method | quote }}
+                          {{- end }}
+                          {{- range $route := $mcpOidcProxyOptionRoutes }}
+                          - and_matcher:
+                              predicate:
+                              - single_predicate:
+                                  input:
+                                    name: request-headers
+                                    typed_config:
+                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                      header_name: ":path"
+                                  value_match:
+                                    safe_regex:
+                                      google_re2: {}
+                                      regex: {{ $route.pathRegex | quote }}
+                              - single_predicate:
+                                  input:
+                                    name: request-headers
+                                    typed_config:
+                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
+                                      header_name: ":method"
+                                  value_match:
+                                    exact: "OPTIONS"
+                          {{- end }}
+                          {{- end }}
                           {{- end }}
                           {{- if $authnSkipPaths }}
                           - single_predicate:

--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -16,6 +16,8 @@
 
 {{- if .Values.services.mcp.enabled }}
 {{- $mcp := .Values.services.mcp }}
+{{- $oidcProxy := $mcp.oidcProxy }}
+{{- $oidcProxyEnabled := $oidcProxy.enabled | default false }}
 {{- $imageTag := $mcp.imageTag | default .Values.global.osmoImageTag }}
 {{- $mcpResourceUrl := include "osmo.mcp-resource-url" . }}
 {{- $gatewayUrl := trimSuffix "/mcp" $mcpResourceUrl }}
@@ -23,7 +25,156 @@
 {{- if not (regexMatch "^([1-9]|[1-5][0-9]|60)$" $requestTimeoutSeconds) }}
 {{- fail "services.mcp.requestTimeoutSeconds must be between 1 and 60" }}
 {{- end }}
-{{- $reservedEnvNames := list "OSMO_MCP_HOST" "OSMO_MCP_PORT" "OSMO_GATEWAY_URL" "OSMO_MCP_REQUEST_TIMEOUT_SECONDS" }}
+{{- $scope := "" }}
+{{- $oidcConfigUrl := "" }}
+{{- $oidcClientId := "" }}
+{{- $oidcClientSecretFile := "" }}
+{{- $oidcAccessTokenIssuer := "" }}
+{{- $oidcAccessTokenAudience := "" }}
+{{- $oidcAccessTokenJwksUrl := "" }}
+{{- $oidcAccessTokenRequiredScope := "" }}
+{{- $signingJwksFile := "" }}
+{{- $redisKeyPrefix := "" }}
+{{- $redisUrl := "" }}
+{{- if $oidcProxyEnabled }}
+{{- if ne (int $mcp.replicas) 1 }}
+{{- fail "services.mcp.replicas must be 1 when services.mcp.oidcProxy.enabled=true" }}
+{{- end }}
+{{- if not (kindIs "slice" $oidcProxy.trustedHttpsRedirectOrigins) }}
+{{- fail "services.mcp.oidcProxy.trustedHttpsRedirectOrigins must be a list" }}
+{{- end }}
+{{- range $origin := $oidcProxy.trustedHttpsRedirectOrigins }}
+{{- if or (not (kindIs "string" $origin)) (not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?$" $origin)) }}
+{{- fail "services.mcp.oidcProxy.trustedHttpsRedirectOrigins entries must be exact HTTPS origins" }}
+{{- end }}
+{{- $originPortSuffix := regexFind ":[0-9]+$" $origin }}
+{{- if $originPortSuffix }}
+{{- $originPort := trimPrefix ":" $originPortSuffix | int }}
+{{- if or (lt $originPort 1) (gt $originPort 65535) }}
+{{- fail "services.mcp.oidcProxy.trustedHttpsRedirectOrigins ports must be between 1 and 65535" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- $scope = required "services.mcp.oidcProxy.scope is required when the OIDC proxy is enabled" $oidcProxy.scope }}
+{{- $oidcConfigUrl = required "services.mcp.oidcProxy.oidc.configUrl is required when the OIDC proxy is enabled" $oidcProxy.oidc.configUrl }}
+{{- $oidcClientId = required "services.mcp.oidcProxy.oidc.clientId is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientId }}
+{{- $oidcClientSecretFile = required "services.mcp.oidcProxy.oidc.clientSecretFile is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientSecretFile }}
+{{- $oidcAccessTokenIssuer = required "services.mcp.oidcProxy.oidc.accessTokenIssuer is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenIssuer }}
+{{- $oidcAccessTokenAudience = required "services.mcp.oidcProxy.oidc.accessTokenAudience is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenAudience }}
+{{- $oidcAccessTokenJwksUrl = required "services.mcp.oidcProxy.oidc.accessTokenJwksUrl is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenJwksUrl }}
+{{- $oidcAccessTokenRequiredScope = required "services.mcp.oidcProxy.oidc.accessTokenRequiredScope is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenRequiredScope }}
+{{- if not (regexMatch "^[A-Za-z0-9:._~-]{1,128}$" $oidcAccessTokenRequiredScope) }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenRequiredScope must be one non-empty scope" }}
+{{- end }}
+{{- if or (gt (len $oidcAccessTokenAudience) 2048) (not (regexMatch "^[^[:space:][:cntrl:]]+$" $oidcAccessTokenAudience)) }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenAudience must be one non-empty value without whitespace or control characters" }}
+{{- end }}
+{{- if ne $oidcAccessTokenAudience $mcpResourceUrl }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenAudience must equal services.mcp.resourceUrl" }}
+{{- end }}
+{{- if ne $scope (printf "%s/%s" $mcpResourceUrl $oidcAccessTokenRequiredScope) }}
+{{- fail "services.mcp.oidcProxy.scope must equal services.mcp.resourceUrl followed by oidc.accessTokenRequiredScope" }}
+{{- end }}
+{{- $oidcHttpsUrlPattern := "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?(/[A-Za-z0-9._~%!$&'()*+,;=:@/-]*)?$" }}
+{{- if not (regexMatch $oidcHttpsUrlPattern $oidcConfigUrl) }}
+{{- fail "services.mcp.oidcProxy.oidc.configUrl must be an absolute HTTPS URL without query or fragment" }}
+{{- end }}
+{{- if not (regexMatch $oidcHttpsUrlPattern $oidcAccessTokenIssuer) }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenIssuer must be an absolute HTTPS issuer without query or fragment" }}
+{{- end }}
+{{- if not (regexMatch $oidcHttpsUrlPattern $oidcAccessTokenJwksUrl) }}
+{{- fail "services.mcp.oidcProxy.oidc.accessTokenJwksUrl must be an absolute HTTPS URL without query or fragment" }}
+{{- end }}
+{{- range $name, $url := dict "configUrl" $oidcConfigUrl "accessTokenIssuer" $oidcAccessTokenIssuer "accessTokenJwksUrl" $oidcAccessTokenJwksUrl }}
+{{- $portMatch := regexFind ":[0-9]+(/|$)" $url }}
+{{- if $portMatch }}
+{{- $urlPort := trimSuffix "/" (trimPrefix ":" $portMatch) | int }}
+{{- if or (lt $urlPort 1) (gt $urlPort 65535) }}
+{{- fail (printf "services.mcp.oidcProxy.oidc.%s port must be between 1 and 65535" $name) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- $signingJwksFile = required "services.mcp.oidcProxy.signingJwksFile is required when the OIDC proxy is enabled" $oidcProxy.signingJwksFile }}
+{{- if not (hasPrefix "/" $oidcClientSecretFile) }}
+{{- fail "services.mcp.oidcProxy.oidc.clientSecretFile must be an absolute path" }}
+{{- end }}
+{{- if not (hasPrefix "/" $signingJwksFile) }}
+{{- fail "services.mcp.oidcProxy.signingJwksFile must be an absolute path" }}
+{{- end }}
+{{- $redisHost := $oidcProxy.redis.serviceName | default .Values.services.redis.serviceName | required "services.mcp.oidcProxy.redis.serviceName or services.redis.serviceName is required" }}
+{{- $redisPort := .Values.services.redis.port }}
+{{- if not (kindIs "invalid" $oidcProxy.redis.port) }}
+{{- $redisPort = $oidcProxy.redis.port }}
+{{- end }}
+{{- if or (lt (int $redisPort) 1) (gt (int $redisPort) 65535) }}
+{{- fail "services.mcp.oidcProxy.redis.port must be between 1 and 65535" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.redis.dbNumber) 0) (gt (int $oidcProxy.redis.dbNumber) 15) }}
+{{- fail "services.mcp.oidcProxy.redis.dbNumber must be between 0 and 15" }}
+{{- end }}
+{{- $redisKeyPrefix = required "services.mcp.oidcProxy.redis.keyPrefix is required" $oidcProxy.redis.keyPrefix }}
+{{- if not (regexMatch "^[A-Za-z0-9:._~-]{1,128}$" $redisKeyPrefix) }}
+{{- fail "services.mcp.oidcProxy.redis.keyPrefix contains unsupported characters" }}
+{{- end }}
+{{- if and $oidcProxy.redis.passwordFile (not (hasPrefix "/" $oidcProxy.redis.passwordFile)) }}
+{{- fail "services.mcp.oidcProxy.redis.passwordFile must be an absolute path" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.redis.connectTimeoutSeconds) 1) (gt (int $oidcProxy.redis.connectTimeoutSeconds) 30) }}
+{{- fail "services.mcp.oidcProxy.redis.connectTimeoutSeconds must be between 1 and 30" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.redis.operationTimeoutSeconds) 1) (gt (int $oidcProxy.redis.operationTimeoutSeconds) 30) }}
+{{- fail "services.mcp.oidcProxy.redis.operationTimeoutSeconds must be between 1 and 30" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.accessTokenTtlSeconds) 60) (gt (int $oidcProxy.accessTokenTtlSeconds) 3600) }}
+{{- fail "services.mcp.oidcProxy.accessTokenTtlSeconds must be between 60 and 3600" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.refreshTokenTtlSeconds) 300) (gt (int $oidcProxy.refreshTokenTtlSeconds) 604800) }}
+{{- fail "services.mcp.oidcProxy.refreshTokenTtlSeconds must be between 300 and 604800" }}
+{{- end }}
+{{- if or (lt (int $oidcProxy.upstreamTimeoutSeconds) 1) (gt (int $oidcProxy.upstreamTimeoutSeconds) 60) }}
+{{- fail "services.mcp.oidcProxy.upstreamTimeoutSeconds must be between 1 and 60" }}
+{{- end }}
+{{- if $oidcProxy.existingSecret.name }}
+{{- $mountPath := required "services.mcp.oidcProxy.existingSecret.mountPath is required when an existing Secret is configured" $oidcProxy.existingSecret.mountPath }}
+{{- if not (hasPrefix "/" $mountPath) }}
+{{- fail "services.mcp.oidcProxy.existingSecret.mountPath must be an absolute path" }}
+{{- end }}
+{{- $clientSecretKey := required "services.mcp.oidcProxy.existingSecret.clientSecretKey is required" $oidcProxy.existingSecret.clientSecretKey }}
+{{- $signingKey := required "services.mcp.oidcProxy.existingSecret.signingJwksKey is required" $oidcProxy.existingSecret.signingJwksKey }}
+{{- if and $oidcProxy.redis.passwordFile (not $oidcProxy.existingSecret.redisPasswordKey) }}
+{{- fail "services.mcp.oidcProxy.existingSecret.redisPasswordKey is required when redis.passwordFile is configured" }}
+{{- end }}
+{{- end }}
+{{- $redisScheme := ternary "rediss" "redis" $oidcProxy.redis.tlsEnabled }}
+{{- $redisUrl = printf "%s://%s:%v/%v" $redisScheme $redisHost $redisPort $oidcProxy.redis.dbNumber }}
+{{- end }}
+{{- $reservedEnvNames := list
+      "OSMO_MCP_HOST"
+      "OSMO_MCP_PORT"
+      "OSMO_GATEWAY_URL"
+      "OSMO_MCP_REQUEST_TIMEOUT_SECONDS"
+      "OSMO_MCP_AUTH_ENABLED"
+      "OSMO_MCP_AUTH_ISSUER_URL"
+      "OSMO_MCP_AUTH_RESOURCE_URL"
+      "OSMO_MCP_AUTH_SCOPE"
+      "OSMO_MCP_AUTH_TRUSTED_HTTPS_REDIRECT_ORIGINS"
+      "OSMO_MCP_AUTH_REDIS_URL"
+      "OSMO_MCP_AUTH_REDIS_PASSWORD_FILE"
+      "OSMO_MCP_AUTH_REDIS_KEY_PREFIX"
+      "OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS"
+      "OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS"
+      "OSMO_MCP_AUTH_OIDC_CONFIG_URL"
+      "OSMO_MCP_AUTH_OIDC_CLIENT_ID"
+      "OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE"
+      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER"
+      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE"
+      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL"
+      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE"
+      "OSMO_MCP_AUTH_SIGNING_JWKS_FILE"
+      "OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS"
+      "OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS"
+      "OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS"
+    }}
 {{- range $env := $mcp.extraEnv }}
 {{- if has (toString (default "" $env.name)) $reservedEnvNames }}
 {{- fail (printf "services.mcp.extraEnv must not override managed variable %s" $env.name) }}
@@ -93,14 +244,70 @@ spec:
           value: {{ $gatewayUrl | quote }}
         - name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS
           value: {{ $requestTimeoutSeconds | quote }}
+        - name: OSMO_MCP_AUTH_ENABLED
+          value: {{ $oidcProxyEnabled | quote }}
+        {{- if $oidcProxyEnabled }}
+        - name: OSMO_MCP_AUTH_ISSUER_URL
+          value: {{ $gatewayUrl | quote }}
+        - name: OSMO_MCP_AUTH_RESOURCE_URL
+          value: {{ $mcpResourceUrl | quote }}
+        - name: OSMO_MCP_AUTH_SCOPE
+          value: {{ $scope | quote }}
+        - name: OSMO_MCP_AUTH_TRUSTED_HTTPS_REDIRECT_ORIGINS
+          value: {{ join "," $oidcProxy.trustedHttpsRedirectOrigins | quote }}
+        - name: OSMO_MCP_AUTH_REDIS_URL
+          value: {{ $redisUrl | quote }}
+        {{- if $oidcProxy.redis.passwordFile }}
+        - name: OSMO_MCP_AUTH_REDIS_PASSWORD_FILE
+          value: {{ $oidcProxy.redis.passwordFile | quote }}
+        {{- end }}
+        - name: OSMO_MCP_AUTH_REDIS_KEY_PREFIX
+          value: {{ $redisKeyPrefix | quote }}
+        - name: OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS
+          value: {{ $oidcProxy.redis.connectTimeoutSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS
+          value: {{ $oidcProxy.redis.operationTimeoutSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_CONFIG_URL
+          value: {{ $oidcConfigUrl | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_CLIENT_ID
+          value: {{ $oidcClientId | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE
+          value: {{ $oidcClientSecretFile | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER
+          value: {{ $oidcAccessTokenIssuer | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE
+          value: {{ $oidcAccessTokenAudience | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL
+          value: {{ $oidcAccessTokenJwksUrl | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE
+          value: {{ $oidcAccessTokenRequiredScope | quote }}
+        - name: OSMO_MCP_AUTH_SIGNING_JWKS_FILE
+          value: {{ $signingJwksFile | quote }}
+        - name: OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS
+          value: {{ $oidcProxy.accessTokenTtlSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS
+          value: {{ $oidcProxy.refreshTokenTtlSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS
+          value: {{ $oidcProxy.upstreamTimeoutSeconds | int | quote }}
+        {{- end }}
         {{- with $mcp.extraEnv }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         resources:
           {{- toYaml $mcp.resources | nindent 10 }}
-        {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
+        {{- if or (and $oidcProxyEnabled $oidcProxy.existingSecret.name) $mcp.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp) }}
         volumeMounts:
+        {{- if and $oidcProxyEnabled $oidcProxy.existingSecret.name }}
+        - name: mcp-auth-secrets
+          mountPath: {{ $oidcProxy.existingSecret.mountPath }}
+          readOnly: true
+        {{- end }}
+        {{- with $mcp.extraVolumeMounts }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
         {{- include "osmo.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 8 }}
+        {{- end }}
         {{- end }}
         livenessProbe:
           {{- include "osmo.upstream-probe-yaml" (dict "probe" $mcp.livenessProbe "context" .) | nindent 10 }}
@@ -108,9 +315,28 @@ spec:
           {{- include "osmo.upstream-probe-yaml" (dict "probe" $mcp.readinessProbe "context" .) | nindent 10 }}
         startupProbe:
           {{- include "osmo.upstream-probe-yaml" (dict "probe" $mcp.startupProbe "context" .) | nindent 10 }}
-      {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
+      {{- if or (and $oidcProxyEnabled $oidcProxy.existingSecret.name) $mcp.extraVolumes (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp) }}
       volumes:
+      {{- if and $oidcProxyEnabled $oidcProxy.existingSecret.name }}
+      - name: mcp-auth-secrets
+        secret:
+          secretName: {{ $oidcProxy.existingSecret.name }}
+          items:
+          - key: {{ $oidcProxy.existingSecret.clientSecretKey }}
+            path: client-secret
+          - key: {{ $oidcProxy.existingSecret.signingJwksKey }}
+            path: signing-jwks.json
+          {{- if $oidcProxy.redis.passwordFile }}
+          - key: {{ $oidcProxy.existingSecret.redisPasswordKey }}
+            path: redis-password
+          {{- end }}
+      {{- end }}
+      {{- with $mcp.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- if and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.mcp }}
       {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.mcp) | nindent 6 }}
+      {{- end }}
       {{- end }}
 
 ---

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -116,11 +116,12 @@ services:
   mcp:
     ## Enable the MCP workload and its gateway routes. Disabled by default.
     ## When enabled, the chart always renders an ingress NetworkPolicy for
-    ## MCP because only Gateway-authenticated requests may reach the service.
+    ## MCP because only this deployment's Gateway may reach the service.
     ##
     enabled: false
 
-    ## Number of MCP replicas.
+    ## Number of MCP replicas. Keep this at 1 while oidcProxy is enabled;
+    ## FastMCP 3.4.7 serializes refreshes within one process.
     ##
     replicas: 1
 
@@ -166,6 +167,68 @@ services:
     ##
     allowedOrigins: []
 
+    ## Built-in FastMCP OIDC proxy for endpoint-only client setup. This runs
+    ## inside the existing MCP process and publishes OAuth metadata, CIMD/DCR,
+    ## PKCE, callback, and token endpoints on the same public origin. The MCP
+    ## process validates its proxy token, then relays the verified upstream
+    ## identity-provider access token to the OSMO Gateway for normal RBAC.
+    ##
+    oidcProxy:
+      enabled: false
+
+      ## Full delegated scope URI advertised to MCP clients and requested from
+      ## the upstream provider, normally <resourceUrl>/access_as_user.
+      ##
+      scope: ""
+
+      ## Public HTTPS redirect origins allowed for pre-registered web clients.
+      ## Native clients use dynamically allocated loopback redirects.
+      ##
+      trustedHttpsRedirectOrigins: []
+
+      ## Upstream OpenID Connect provider. Register the fixed redirect URL
+      ## <resourceUrl origin>/auth/callback on this confidential application.
+      ##
+      oidc:
+        configUrl: ""
+        clientId: ""
+        clientSecretFile: /etc/osmo/mcp-auth/client-secret
+        accessTokenIssuer: ""
+        accessTokenAudience: ""
+        accessTokenJwksUrl: ""
+        accessTokenRequiredScope: access_as_user
+
+      ## Redis stores proxy registrations, authorization state, and encrypted
+      ## upstream tokens. Empty serviceName/port inherit services.redis.
+      ##
+      redis:
+        serviceName: ""
+        port: null
+        dbNumber: 0
+        tlsEnabled: true
+        passwordFile: ""
+        keyPrefix: osmo:mcp-fastmcp
+        connectTimeoutSeconds: 3
+        operationTimeoutSeconds: 5
+
+      ## Private single-key HS256 JWKS used only by the MCP process.
+      ##
+      signingJwksFile: /etc/osmo/mcp-auth/signing-jwks.json
+
+      accessTokenTtlSeconds: 600
+      refreshTokenTtlSeconds: 28800
+      upstreamTimeoutSeconds: 10
+
+      ## Optionally mount all proxy credentials from an existing Secret.
+      ## Leave name empty when Vault injection or extra volumes provide them.
+      ##
+      existingSecret:
+        name: ""
+        mountPath: /etc/osmo/mcp-auth
+        clientSecretKey: client-secret
+        signingJwksKey: signing-jwks
+        redisPasswordKey: redis-password
+
     ## Additional pod labels and annotations.
     ##
     extraPodLabels: {}
@@ -174,6 +237,12 @@ services:
     ## Additional environment variables for the MCP container.
     ##
     extraEnv: []
+
+    ## Additional volume mounts and volumes for the MCP container and pod.
+    ## These can provide Vault-injected OIDC proxy credentials.
+    ##
+    extraVolumeMounts: []
+    extraVolumes: []
 
     ## Service account name. Empty uses global.serviceAccountName.
     ##

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -18,26 +18,47 @@
 
 # OSMO MCP service
 
-The self-hosted MCP service is a stateless, thin adapter over predefined OSMO
-REST APIs. It does not authenticate users itself. The deployment contract
-requires every MCP request and every resulting API request to pass through the
-same deployment's Gateway.
+The self-hosted MCP service is a thin adapter over predefined OSMO REST APIs.
+Every MCP request and every resulting API request enters through the same
+deployment's Gateway. Authentication can remain at the Gateway or run inside
+the existing MCP process through FastMCP's built-in `OIDCProxy`.
+
+OSMO can expose MCP authentication in either of two deployment modes:
+
+- **Direct identity-provider mode** retains the existing behavior. The Gateway
+  advertises the configured identity provider, and clients may need an OAuth
+  client ID, scopes, and callback configuration supplied by the deployment
+  administrator.
+- **OIDC proxy mode** passes an `OIDCProxy` as the existing FastMCP server's
+  `auth` argument. A client configures only `/mcp`, discovers FastMCP's OAuth
+  endpoints, and completes the deployment identity-provider login in a browser.
+  FastMCP supports Client ID Metadata Documents (CIMD) and retains Dynamic
+  Client Registration (DCR) for older clients. It authenticates MCP access but
+  does not replace OSMO's API-specific authorization.
+
+OIDC proxy mode is feature-gated by `services.mcp.oidcProxy.enabled` and
+disabled by default. No second executable, process, Service, or Deployment is
+created.
 
 ## Request flow and trust boundary
 
 ```text
-MCP client
-  -> Gateway (token validation + mcp:Access)
-  -> MCP (request-local token reference + fixed tool mapping)
-  -> same Gateway (second token validation + API-specific action)
-  -> OSMO API
+Direct mode:
+  MCP client -> Gateway JWT + mcp:Access -> MCP
+             -> same Gateway JWT + API action -> OSMO API
+
+OIDC proxy mode:
+  MCP client -> Gateway routing -> FastMCP OIDCProxy -> MCP
+             -> same Gateway with verified upstream token + API action
+             -> OSMO API
 ```
 
-The Gateway supplies one `Authorization: Bearer ...` header and trusted
-`x-osmo-user` identity to the MCP request. The MCP middleware validates the
-forwarded context, removes those headers from the downstream ASGI scope, and
-holds the exact authorization value only in request-local context. A tool must
-pass those credentials explicitly to `GatewayClient`; the shared HTTP client
+In direct mode, Gateway supplies the validated bearer and trusted user identity;
+the request-context middleware strips those headers from the downstream ASGI
+scope and retains one request-local credential. In OIDC proxy mode, FastMCP
+validates its resource token and `get_access_token()` exposes the verified
+upstream identity-provider bearer to the active tool request. A tool passes the
+selected credential explicitly to `GatewayClient`; the shared HTTP client
 contains no caller credentials.
 
 The relay boundary has these invariants:
@@ -49,14 +70,17 @@ The relay boundary has these invariants:
   by each tool and values are encoded from bounded typed inputs. Unknown tool
   arguments, alternate URLs, embedded queries or fragments, redirects, and
   path traversal fail closed.
-- The unchanged authorization value and optional request ID are the only
-  caller-derived headers forwarded on the second Gateway pass. MCP does not
+- The direct-mode bearer or OIDC proxy's verified upstream bearer, plus an
+  optional request ID, are the only caller-derived values forwarded on the
+  second Gateway pass. MCP does not
   copy `x-osmo-*`, cookies, proxy headers, or other inbound request headers.
   Request IDs that reuse a meaningful bearer-token substring are rejected
   before forwarding or telemetry.
-- MCP does not exchange, refresh, modify, cache, persist, log, or return the
-  bearer token. It clears request context and upstream cookies on completion,
-  failure, timeout, or cancellation.
+- The tool adapter does not independently exchange, refresh, modify, cache,
+  persist, log, or return bearer tokens. In OIDC proxy mode, FastMCP alone owns
+  upstream exchange, refresh, and encrypted Redis state. Tool request context
+  and upstream cookies are cleared on completion, failure, timeout, or
+  cancellation.
 - Tool arguments are rejected before execution if they contain the active
   authorization value or bearer token, preventing credential reflection into
   dynamic path or query values.
@@ -95,8 +119,150 @@ The relay boundary has these invariants:
   to a generic error without reflecting exception text.
 
 The Gateway, MCP process, receiving OSMO APIs, and applicable middleware are
-inside the bearer-token handling boundary. None of them may log or persist the
-authorization value.
+inside the bearer-token handling boundary. None may log the authorization
+value. The only intentional persistence is FastMCP's encrypted upstream-token
+state in Redis while OIDC proxy mode is enabled.
+
+## Endpoint-only OAuth
+
+When OIDC proxy mode is enabled, the public flow is:
+
+```text
+MCP client
+  -> Gateway /mcp (401 with protected-resource metadata)
+  -> FastMCP OAuth discovery in the existing MCP process
+  -> CIMD client identity, or DCR registration as a compatibility fallback
+  -> deployment identity provider login in the user's browser
+  -> FastMCP authorization-code exchange with PKCE
+  -> Gateway routes the FastMCP resource token to /mcp
+  -> FastMCP validates it and exposes the verified upstream access token
+  -> Gateway validates that upstream token on each /api tool request
+```
+
+The client still performs an interactive browser login, but it does not need a
+deployment-specific client ID, scope list, callback URL, or callback port. For
+example, a fresh Codex profile requires only:
+
+```bash
+codex mcp add osmo --url https://<osmo-host>/mcp
+codex mcp login osmo
+```
+
+Clients that support OAuth discovery, CIMD, and PKCE S256 use their HTTPS
+metadata-document URL as a stable client ID. DCR-capable clients without CIMD
+support can use the same endpoint-only flow through `/register`. A DCR record
+is stored in OSMO; neither approach creates an application in the upstream
+identity provider. The deployment owns one administrator-managed confidential
+upstream OIDC application and one stable `/auth/callback` redirect URL.
+
+FastMCP's OIDC proxy owns CIMD, DCR fallback, PKCE, consent, upstream OIDC
+exchange, refresh, proxy-token issuance, and encrypted state. OSMO supplies a
+built-in `JWTVerifier` for the upstream API token's RS256 signature, issuer,
+audience, and short `access_as_user` `scp` value. The full delegated scope URI
+is advertised to clients with `update_default_scopes()` and requested upstream
+alongside `openid profile email offline_access`.
+
+Gateway does not validate FastMCP's private proxy token. In this mode it routes
+the exact `/mcp`, metadata, authorization, callback, registration, token, and
+consent paths to the existing `osmo-mcp` cluster with Gateway JWT and ext-authz
+disabled only on those routes. FastMCP authenticates `/mcp`; each tool then
+relays the verified upstream access token to `/api`, where the existing Gateway
+identity-provider validation, OSMO roles, API actions, and pool scope still
+apply. The private FastMCP signing key is never mounted into Gateway.
+
+### Deployment prerequisites
+
+Before enabling OIDC proxy mode, an administrator must provide:
+
+- one confidential OIDC application in the deployment identity provider, with
+  the exact `https://<osmo-host>/auth/callback` redirect registered;
+- its client ID and client secret through the deployment's secret manager;
+- the full delegated `<resource-url>/access_as_user` scope on that application;
+- OIDC discovery plus explicit issuer, audience, JWKS URL, and short
+  `access_as_user` scope requirements for upstream API access-token validation;
+- one private 256-bit HS256 key as a single-key JWKS mounted only in the MCP
+  pod; this symmetric key must never be exposed publicly;
+- a shared Redis namespace for FastMCP's encrypted clients, authorization
+  transactions, upstream tokens, and refresh state;
+- an exact public MCP resource URL; the OAuth issuer is its origin; and
+- an existing Gateway identity-provider JWT provider and role mapping for the
+  verified upstream token relayed to `/api`.
+
+The public protocol surface is deliberately narrow:
+
+```text
+GET  /.well-known/oauth-protected-resource/mcp
+GET  /.well-known/oauth-authorization-server
+GET  /authorize
+POST /authorize
+GET  /auth/callback
+POST /register
+POST /token
+GET  /consent
+POST /consent
+```
+
+Only these exact OAuth paths and methods bypass the normal Gateway JWT and OSMO
+authorization filters. In OIDC proxy mode, exact `/mcp` also bypasses those
+Gateway filters because FastMCP authenticates it in-process. Neighboring paths
+remain protected. All resulting `/api` calls use normal Gateway authentication
+and authorization.
+
+A minimal values overlay selects OIDC proxy mode and its upstream provider;
+credentials remain file-mounted secrets:
+
+```yaml
+services:
+  mcp:
+    resourceUrl: https://<osmo-host>/mcp
+    replicas: 1
+    oidcProxy:
+      enabled: true
+      scope: https://<osmo-host>/mcp/access_as_user
+      oidc:
+        configUrl: https://login.microsoftonline.com/<tenant-id>/v2.0/.well-known/openid-configuration
+        clientId: <oidc-application-client-id>
+        clientSecretFile: /etc/osmo/mcp-auth/client-secret
+        accessTokenIssuer: https://sts.windows.net/<tenant-id>/
+        accessTokenAudience: https://<osmo-host>/mcp
+        accessTokenJwksUrl: https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys
+        accessTokenRequiredScope: access_as_user
+      signingJwksFile: /etc/osmo/mcp-auth/signing-jwks.json
+      redis:
+        dbNumber: <dedicated-database-number>
+        keyPrefix: osmo:mcp-fastmcp
+```
+
+Do not place the upstream client secret, signing key, access token, refresh
+token, authorization code, or user session in Helm values, Git, or logs. The
+existing `/usr/bin/mcp` process loads `OIDCProxy` and the
+file-mounted secrets directly. Startup fails if required configuration or key
+material is missing; health probes report process health and do not perform an
+upstream OIDC or Redis transaction. Operators should
+monitor CIMD metadata-fetch failures, registration, authorization, callback,
+token, refresh, consent, Redis, and upstream identity-provider outcomes without
+logging credential or identity payloads. CIMD fetches are outbound requests to
+client-controlled URLs; retain FastMCP's validation and SSRF protections and do
+not add an unrestricted custom metadata-fetch path.
+
+### Rollout and rollback
+
+The feature gate updates the existing MCP Deployment, adds exact Gateway
+routes, and lets FastMCP serve protected-resource metadata in one rollout. Use
+it first on a dev instance and run discovery, DCR fallback, CIMD, login,
+access-token expiry, refresh, restart recovery, and key-rotation tests from
+clean client profiles. Confirm CIMD through
+`client_id_metadata_document_supported: true` in authorization-server metadata
+and DCR fallback through `registration_endpoint`. Keep `services.mcp.replicas`
+at `1` while using FastMCP 3.4.7 because refresh serialization is process-local.
+
+After changing an Entra app-role assignment, users should log out and
+authenticate again so the next token definitely contains the updated role set.
+
+To roll back, disable `services.mcp.oidcProxy.enabled`, restore the direct-mode
+`authorizationServers` and `scopes` values, and redeploy. Existing proxy tokens
+will no longer authenticate, so clients must log in again through the direct
+provider. The MCP tool catalog and API-specific authorization do not change.
 
 ## Available tools
 
@@ -205,6 +371,11 @@ projection, and handlers in the matching domain module. `tool_registry.py` is
 the single source of registration metadata used by both the server and
 catalog.
 
+Optional authentication lives in `auth.py`. It constructs FastMCP's built-in
+`OIDCProxy`, upstream `JWTVerifier`, encrypted Redis store, and signing key, then
+passes the provider as the `auth` argument to the same `OSMOFastMCP` instance.
+OSMO does not implement OAuth endpoints or run a second auth service.
+
 Do not import the CLI runtime. Extract only pure public helpers when behavior
 genuinely needs to match another OSMO surface.
 
@@ -234,17 +405,22 @@ Keep each new tool a narrow adapter:
 ## Local validation
 
 ```bash
-bazel test --test_output=errors //src/service/mcp/...
+bazel test --test_output=errors \
+  //src/service/mcp/...
 bazel build \
   //src/service/mcp:mcp_binary \
   //test/smoke:mcp-checks
+bazel build \
+  --platforms=//bzl/platforms:linux_x86_64 \
+  //src/service/mcp:mcp_image_x86_64
 bazel test //test/smoke:mcp-checks-pylint
 bash deployments/charts/service/ci/validate-mcp-chart.sh
 ```
 
-The chart validation covers MCP-disabled and MCP-enabled renders, the derived
-Gateway origin, OAuth metadata, probes, ingress isolation, absence of MCP
-credential material, and expected configuration failures.
+The chart validation covers MCP-disabled, direct-provider, and in-process OIDC
+proxy renders; the derived Gateway origin; exact OAuth routing; the `/mcp`
+filter boundary; secret mounts; ingress isolation; and expected configuration
+failures.
 
 ## Deployment validation
 


### PR DESCRIPTION
## Summary

Sanitize verified identity-provider role claims before serializing them into the internal `x-osmo-roles` header.

The Gateway now ignores non-string, oversized, comma-delimited, and control-character role values. This prevents one malformed claim from being interpreted as multiple OSMO roles.

This independent hardening PR is stacked on #1300.

Issue #None

## Testing

- `bash deployments/charts/service/ci/validate-mcp-chart.sh`
- Added render assertions for role filtering and safe header serialization.