### PR TITLE
Add UDP port-forwarding OETF regression test

### DIFF
--- a/test/oetf/README.md
+++ b/test/oetf/README.md
@@ -612,7 +612,7 @@ if __name__ == "__main__":
 ```python
 # test/scenarios/router_connectivity/test_runner.py
 import unittest
-from test.oetf.runner_fixture import RunnerFixture
+from test.oetf.runner_fixture import RunnerFixture, udp_round_trip_until
 
 # Kept in sync with task.py — the two files run on different machines
 # (task.py in-container, test_runner.py on the caller) so they can't share
@@ -639,6 +639,14 @@ class RouterConnectivity(RunnerFixture):
         with handle.cli_port_forward("router-target", 18080, 8080):
             # ... curl through the forward ...
             pass
+
+        # UDP uses the same checkpoint-gated context manager. Require an
+        # exact echoed datagram so a merely-running CLI cannot pass.
+        handle.wait_for_task_checkpoint("udp_listening", task_name="router-target")
+        with handle.cli_port_forward("router-target", 18081, 8081, udp=True):
+            udp_round_trip_until(
+                "127.0.0.1", 18081, b"udp-sentinel", deadline_seconds=30,
+            )
 
         handle.cancel()
         handle.expect_outcome("failed")
@@ -709,7 +717,7 @@ different name than you waited on.
 `wait_for_task_checkpoint` / `wait_for_any_task_checkpoints` /
 `wait_for_all_task_checkpoints`, `wait_for_terminal`, `cli_exec`
 (PTY-attached `osmo workflow exec`), `cli_port_forward` (context manager
-around `osmo workflow port-forward`), `cancel`, `expect_outcome`, plus
+around TCP or UDP `osmo workflow port-forward`), `cancel`, `expect_outcome`, plus
 lazy `status` / `tasks` / `logs` properties and
 `assert_in_task_checks_passed` / `assert_all_task_checks_passed`.
 

--- a/test/oetf/runner_fixture.py
+++ b/test/oetf/runner_fixture.py
@@ -203,6 +203,9 @@ def udp_round_trip_until(
                 last_error = f"received unexpected payload {response!r}"
             except OSError as error:
                 last_error = f"{type(error).__name__}: {error}"
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                time.sleep(min(0.1, remaining))
     raise RuntimeError(
         f"UDP endpoint {host}:{port} never echoed {payload!r} within "
         f"{deadline_seconds}s (last: {last_error})"

--- a/test/oetf/runner_fixture.py
+++ b/test/oetf/runner_fixture.py
@@ -30,6 +30,7 @@ import pty
 import re
 import select
 import shutil
+import socket
 import subprocess
 import sys
 import tempfile
@@ -181,6 +182,30 @@ def curl_until(url: str, match: str, deadline_seconds: int) -> None:
     raise RuntimeError(
         f"curl {url} never returned {match!r} within {deadline_seconds}s "
         f"(last: {last_error})"
+    )
+
+
+def udp_round_trip_until(
+    host: str, port: int, payload: bytes, deadline_seconds: int,
+) -> None:
+    """Send a UDP datagram until the endpoint echoes the exact payload."""
+    deadline = time.monotonic() + deadline_seconds
+    last_error = "not attempted"
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as client:
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            client.settimeout(min(1.0, max(remaining, 0.1)))
+            try:
+                client.sendto(payload, (host, port))
+                response, _ = client.recvfrom(max(4096, len(payload)))
+                if response == payload:
+                    return
+                last_error = f"received unexpected payload {response!r}"
+            except OSError as error:
+                last_error = f"{type(error).__name__}: {error}"
+    raise RuntimeError(
+        f"UDP endpoint {host}:{port} never echoed {payload!r} within "
+        f"{deadline_seconds}s (last: {last_error})"
     )
 
 
@@ -1078,14 +1103,16 @@ class WorkflowHandle:
 
     @contextlib.contextmanager
     def cli_port_forward(
-        self, task_name: str, local_port: int, remote_port: int,
+        self, task_name: str, local_port: int, remote_port: int, *, udp: bool = False,
     ) -> Iterator[int]:
-        """Background-spawn `osmo workflow port-forward` for the duration of the block."""
+        """Run TCP or UDP `osmo workflow port-forward` for the duration of the block."""
         cli = resolve_osmo_cli(self._fixture.config)
         argv = [
             cli, "workflow", "port-forward", self.workflow_id, task_name,
             "--port", f"{local_port}:{remote_port}",
         ]
+        if udp:
+            argv.append("--udp")
         process = subprocess.Popen(  # pylint: disable=consider-using-with
             argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
         )
@@ -1098,6 +1125,9 @@ class WorkflowHandle:
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=5)
+            for stream in (process.stdout, process.stderr):
+                if stream is not None:
+                    stream.close()
 
     # --- Lazy accessors ---
 

--- a/test/oetf/tests/test_runner_fixture.py
+++ b/test/oetf/tests/test_runner_fixture.py
@@ -407,17 +407,21 @@ class UdpRoundTripUntilTest(unittest.TestCase):
         client.__enter__.return_value = client
         client.recvfrom.side_effect = [
             (b"wrong payload", ("127.0.0.1", 18081)),
+            OSError("temporary failure"),
             (b"sentinel", ("127.0.0.1", 18081)),
         ]
 
         with mock.patch(
             "test.oetf.runner_fixture.socket.socket", return_value=client,
-        ):
+        ), mock.patch(
+            "test.oetf.runner_fixture.time.sleep",
+        ) as sleep:
             udp_round_trip_until(
                 "127.0.0.1", 18081, b"sentinel", deadline_seconds=5,
             )
 
-        self.assertEqual(client.sendto.call_count, 2)
+        self.assertEqual(client.sendto.call_count, 3)
+        self.assertEqual(sleep.call_args_list, [mock.call(0.1), mock.call(0.1)])
 
 
 class CliPortForwardTest(unittest.TestCase):

--- a/test/oetf/tests/test_runner_fixture.py
+++ b/test/oetf/tests/test_runner_fixture.py
@@ -17,6 +17,7 @@ import os
 import pathlib
 import tempfile
 import unittest
+from unittest import mock
 from unittest.mock import MagicMock
 
 import yaml
@@ -31,6 +32,7 @@ from test.oetf.runner_fixture import (
     _inject_task_files,
     _iter_checkpoints,
     _runfiles_repo_root_for,
+    udp_round_trip_until,
 )
 
 
@@ -396,6 +398,56 @@ class WaitForTaskCheckpointTest(unittest.TestCase):
         )
         with self.assertRaises(TypeError):
             handle.wait_for_task_checkpoint("ready")  # type: ignore[call-arg]
+
+
+class UdpRoundTripUntilTest(unittest.TestCase):
+
+    def test_retries_until_exact_payload_is_echoed(self):
+        client = MagicMock()
+        client.__enter__.return_value = client
+        client.recvfrom.side_effect = [
+            (b"wrong payload", ("127.0.0.1", 18081)),
+            (b"sentinel", ("127.0.0.1", 18081)),
+        ]
+
+        with mock.patch(
+            "test.oetf.runner_fixture.socket.socket", return_value=client,
+        ):
+            udp_round_trip_until(
+                "127.0.0.1", 18081, b"sentinel", deadline_seconds=5,
+            )
+
+        self.assertEqual(client.sendto.call_count, 2)
+
+
+class CliPortForwardTest(unittest.TestCase):
+
+    def test_udp_port_forward_appends_udp_flag_and_stops_process(self):
+        fixture = MagicMock()
+        handle = WorkflowHandle(
+            fixture=fixture, workflow_id="wf-test-1", timeout_seconds=60,
+        )
+        process = MagicMock()
+
+        with mock.patch(
+            "test.oetf.runner_fixture.resolve_osmo_cli", return_value="/bin/osmo",
+        ), mock.patch(
+            "test.oetf.runner_fixture.subprocess.Popen", return_value=process,
+        ) as popen:
+            with handle.cli_port_forward("task-a", 18081, 8081, udp=True):
+                pass
+
+        argv = popen.call_args.args[0]
+        self.assertEqual(
+            argv,
+            [
+                "/bin/osmo", "workflow", "port-forward", "wf-test-1", "task-a",
+                "--port", "18081:8081", "--udp",
+            ],
+        )
+        process.terminate.assert_called_once_with()
+        process.stdout.close.assert_called_once_with()
+        process.stderr.close.assert_called_once_with()
 
 
 class TestRunnerFixtureDefaults(unittest.TestCase):

--- a/test/scenarios/BUILD
+++ b/test/scenarios/BUILD
@@ -27,7 +27,16 @@ oetf_scenario_test(
 oetf_scenario_test(
     name = "router-connectivity",
     test_dir = "router_connectivity",
+    test_filter = "RouterConnectivity.test_router_connectivity",
     tags = ["router", "positive", "kind"],
+)
+
+# Separate until the UDP CLI path has also been qualified against KIND.
+oetf_scenario_test(
+    name = "udp-port-forwarding",
+    test_dir = "router_connectivity",
+    test_filter = "RouterConnectivity.test_udp_port_forwarding",
+    tags = ["router", "portforward", "udp", "positive"],
 )
 
 # --- Plain workflow scenarios (no in-task code) ---

--- a/test/scenarios/router_connectivity/spec.yaml
+++ b/test/scenarios/router_connectivity/spec.yaml
@@ -10,13 +10,13 @@
 
 # Router Connectivity Test
 #
-# Validates the OSMO router can proxy exec/port-forward/rsync to a live task:
+# Validates the OSMO router can proxy exec and TCP/UDP port-forwarding to a live task:
 #   - INSIDE (task.py): writes a sentinel file to /workspace, starts a simple
-#     HTTP server on port 8080, sleeps to keep the task alive while the
-#     external runner exercises the router.
+#     HTTP server on TCP port 8080 and a UDP echo server on port 8081, then
+#     sleeps to keep the task alive while the external runner exercises the router.
 #   - OUTSIDE (test_runner.py): waits for the task to be RUNNING, then
-#     shells out to the osmo CLI to exec, port-forward, and rsync. Cancels
-#     the workflow after the three probes complete (pass or fail).
+#     shells out to the osmo CLI to exec and port-forward. Cancels the
+#     workflow after the probes complete (pass or fail).
 #
 # Expected outcome: "failed" — the workflow ends in FAILED_CANCELED, which
 # the builder's expect_failed() / handle.expect_outcome("failed") accepts.

--- a/test/scenarios/router_connectivity/task.py
+++ b/test/scenarios/router_connectivity/task.py
@@ -26,6 +26,7 @@ from task_fixture import TaskFixture
 OETF_ROUTER_SENTINEL_CONTENT = "OETF_ROUTER_SENTINEL_c5b41e"
 OETF_ROUTER_SENTINEL_FILE = "sentinel.txt"
 OETF_ROUTER_HTTP_PORT = 8080
+OETF_ROUTER_UDP_PORT = 8081
 OETF_ROUTER_KEEPALIVE_SECONDS = 200
 OETF_ROUTER_WORKSPACE_DIR = "/workspace"
 
@@ -33,10 +34,11 @@ OETF_ROUTER_WORKSPACE_DIR = "/workspace"
 class RouterProbe(TaskFixture):
     """Writes a sentinel, serves it over HTTP, and keeps the task alive.
 
-    Emits two checkpoints so the external test_runner can sync before
+    Emits checkpoints so the external test_runner can sync before
     exec/port-forward probes:
       - "sentinel_written": sentinel file exists on disk (runner can `cat`).
       - "http_listening":   HTTP server bound (runner can port-forward + curl).
+      - "udp_listening":    UDP echo server bound (runner can verify a round trip).
     """
 
     def run_checks(self):
@@ -71,6 +73,21 @@ class RouterProbe(TaskFixture):
                 f"failed to bind {OETF_ROUTER_WORKSPACE_DIR}",
             )
 
+        if _start_udp_echo_server(OETF_ROUTER_UDP_PORT):
+            self.record_pass(
+                f"udp:listen:{OETF_ROUTER_UDP_PORT}",
+                "echo server ready",
+            )
+            self.checkpoint(
+                "udp_listening", message=f"port={OETF_ROUTER_UDP_PORT}",
+            )
+        else:
+            self.record_fail(
+                f"udp:listen:{OETF_ROUTER_UDP_PORT}",
+                "failed to bind UDP echo server",
+            )
+            return
+
         # Keep task alive for external runner to exec/port-forward into.
         print(
             f"[OETF-ROUTER] probe ready; sleeping {OETF_ROUTER_KEEPALIVE_SECONDS}s",
@@ -99,6 +116,24 @@ def _start_http_server(serve_dir: str, port: int) -> bool:
         return False
 
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return True
+
+
+def _start_udp_echo_server(port: int) -> bool:
+    """Start a UDP echo server in a background daemon thread."""
+    class _EchoHandler(socketserver.BaseRequestHandler):
+        def handle(self):
+            data, server_socket = self.request
+            server_socket.sendto(data, self.client_address)
+
+    try:
+        server = socketserver.ThreadingUDPServer(("0.0.0.0", port), _EchoHandler)
+    except OSError as error:
+        print(f"[OETF-ROUTER] UDP bind({port}) failed: {error}", flush=True)
+        return False
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     return True
 

--- a/test/scenarios/router_connectivity/test_runner.py
+++ b/test/scenarios/router_connectivity/test_runner.py
@@ -16,14 +16,17 @@ license agreement from NVIDIA CORPORATION is strictly prohibited.
 import unittest
 
 from test.oetf.models import WorkflowServerStatus
-from test.oetf.runner_fixture import RunnerFixture, curl_until
+from test.oetf.runner_fixture import RunnerFixture, curl_until, udp_round_trip_until
 
-# Kept in sync with staging/scenarios/router_connectivity/task.py.
+# Kept in sync with test/scenarios/router_connectivity/task.py.
 SENTINEL_CONTENT = "OETF_ROUTER_SENTINEL_c5b41e"
 SENTINEL_FILE = "sentinel.txt"
 TASK_NAME = "router-target"
 IN_TASK_HTTP_PORT = 8080
 LOCAL_HTTP_PORT = 18080
+IN_TASK_UDP_PORT = 8081
+LOCAL_UDP_PORT = 18081
+UDP_SENTINEL = b"OETF_UDP_PORT_FORWARD_SENTINEL_9e57ac"
 IN_TASK_WORKSPACE = "/workspace"
 
 
@@ -65,6 +68,28 @@ class RouterConnectivity(RunnerFixture):
         # Specifically FAILED_CANCELED, not the `failed` union — a regression
         # where the workflow ends as plain FAILED (e.g., a router fault
         # unrelated to cancellation) would otherwise silently pass.
+        self.assertEqual(handle.status, WorkflowServerStatus.FAILED_CANCELED)
+
+    def test_udp_port_forwarding(self):
+        """UDP traffic reaches the task and its response returns to the caller."""
+        self.login_cli()
+        handle = self.workflow("spec.yaml").submit()
+        try:
+            handle.wait_for_task_checkpoint(
+                "udp_listening", task_name=TASK_NAME,
+            )
+            with handle.cli_port_forward(
+                TASK_NAME, LOCAL_UDP_PORT, IN_TASK_UDP_PORT, udp=True,
+            ):
+                udp_round_trip_until(
+                    "127.0.0.1",
+                    LOCAL_UDP_PORT,
+                    UDP_SENTINEL,
+                    deadline_seconds=30,
+                )
+        finally:
+            handle.cancel()
+
         self.assertEqual(handle.status, WorkflowServerStatus.FAILED_CANCELED)
 
 


### PR DESCRIPTION
## Description

Add an OETF scenario that exercises UDP port forwarding end to end through the CLI, router, and a live workflow task.

PR #1291 fixed `run_udp()` passing bare coroutines to `asyncio.wait()` on Python 3.11+. The CLI could appear to start while forwarding no datagrams. This change adds a checkpoint-gated UDP echo server and requires an exact sentinel datagram round trip, so a merely-running CLI cannot pass.

The runner fixture now supports `cli_port_forward(..., udp=True)` and a reusable exact-payload UDP probe. 

Issue #None

## Validation

- `bazel test //test/oetf/tests:test_runner_fixture //test/oetf/tests:test_runner_fixture-pylint //test/scenarios:udp-port-forwarding-pylint`
- `bazel build //test/scenarios:router-connectivity //test/scenarios:udp-port-forwarding`
- `bazel query //test/...`
- Staging pass with the fixed Python 3.14 CLI: 78.56s
- Fail-on-bad with the pre-fix Python 3.14 CLI: exact UDP echo timed out as expected
- Confirmed the fail-on-bad workflow reached `FAILED_CANCELED`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added UDP port-forwarding validation alongside existing TCP connectivity checks.
  - Added UDP echo-server probing and checkpoint reporting for router connectivity scenarios.
  - Added support for configuring UDP port forwarding through the CLI.
  - Added retry-based UDP round-trip verification for reliable datagram testing.

- **Bug Fixes**
  - Improved forwarding-process cleanup by explicitly closing output streams.

- **Documentation**
  - Updated router connectivity guidance with UDP testing examples.
  - Clarified that port forwarding supports both TCP and UDP.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->