### PR TITLE
Add embedded seaweedfs to umbrella chart

### DIFF
--- a/deployments/charts/BUILD
+++ b/deployments/charts/BUILD
@@ -15,6 +15,9 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 filegroup(
     name = "service",
     srcs = glob(["service/**"]),
@@ -31,4 +34,10 @@ filegroup(
     name = "osmo",
     srcs = glob(["osmo/**"]),
     visibility = ["//visibility:public"],
+)
+
+sh_test(
+    name = "test_osmo_charts",
+    srcs = ["osmo/tests/test_osmo_charts.sh"],
+    data = [":osmo"],
 )

--- a/deployments/charts/osmo/Chart.lock
+++ b/deployments/charts/osmo/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: cluster
   repository: https://cloudnative-pg.github.io/charts
   version: 0.8.0
-digest: sha256:833a704e62d5ef4e34f9a33c45932d84ba53f1a370f504bd45daf112ef71282f
-generated: "2026-08-14T15:30:28.185960161-04:00"
+- name: seaweedfs
+  repository: https://seaweedfs.github.io/seaweedfs/helm
+  version: 4.41.0
+digest: sha256:bf3c861fc06a9d526bf020323156589c564bb2d93d948b86ccb7c746c92182c2
+generated: "2026-08-17T15:46:22.370124677-04:00"

--- a/deployments/charts/osmo/Chart.yaml
+++ b/deployments/charts/osmo/Chart.yaml
@@ -27,3 +27,7 @@ dependencies:
   version: 0.8.0
   repository: https://cloudnative-pg.github.io/charts
   condition: embeddedDependencies.postgresql.enabled
+- name: seaweedfs
+  version: "4.41.0"
+  repository: https://seaweedfs.github.io/seaweedfs/helm
+  condition: embeddedDependencies.objectStorage.enabled

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -11,8 +11,9 @@ The supported `split-plane-control` profile installs the API, UI, router,
 worker, logger, agent, delayed-job monitor, and standalone OSMO gateway. It
 can create a persistent PostgreSQL cluster through CloudNativePG or connect to
 an external PostgreSQL service, and it can deploy embedded Valkey or connect
-to an external Valkey service. Object storage and the remaining Kubernetes
-Secrets are externally managed. Compute-plane workloads and the other embedded
+to an external Valkey service. S3-compatible object storage can be provided by
+embedded SeaweedFS or an external service. The remaining Kubernetes Secrets
+are externally managed. Compute-plane workloads and the other embedded
 dependencies remain future work.
 
 ## Embedded PostgreSQL
@@ -123,6 +124,7 @@ Keep `embeddedDependencies.postgresql.enabled: false` (the default), then
 install the chart by layering the environment values after the profile:
 
 ```bash
+helm repo add seaweedfs https://seaweedfs.github.io/seaweedfs/helm
 helm dependency build deployments/charts/osmo
 helm upgrade --install osmo deployments/charts/osmo \
   --namespace osmo \
@@ -132,6 +134,10 @@ helm upgrade --install osmo deployments/charts/osmo \
   --wait \
   --timeout 25m
 ```
+
+The dependency build is only needed for a source checkout. Packaged charts
+include the official `valkey/valkey` chart version `0.11.0`, CloudNativePG
+cluster chart version `0.8.0`, and SeaweedFS chart version `4.41.0`.
 
 ## Embedded Valkey
 
@@ -184,13 +190,15 @@ configure `externalDependencies.valkey` and
   under `imagePullSecrets`, and component images under `runtimeImage` and each
   component's `image` block. Configure dependency images and pull credentials
   in their native values blocks; for example, Valkey uses `valkey.image` and
-  `valkey.imagePullSecrets`.
+  `valkey.imagePullSecrets`, while SeaweedFS uses `seaweedfs.image` and
+  `seaweedfs.global.imagePullSecrets`.
 - Configure replicas, autoscaling, resources, disruption budgets, scheduling,
   security contexts, probes, volumes, and ServiceAccounts under `services`,
   `gateway`, and `podDefaults`.
 - Enable Prometheus Operator PodMonitors with `monitoring.podMonitor.enabled`.
 - Apply shared resource metadata to OSMO-owned resources with `commonLabels`
-  and `commonAnnotations`; configure dependency metadata under `valkey`.
+  and `commonAnnotations`; configure dependency metadata under `valkey` and
+  `seaweedfs`.
 - Supply OSMO application configuration under `configuration`.
 
 See [`values.yaml`](values.yaml) for the complete configuration reference.
@@ -227,6 +235,146 @@ that bundle through `SSL_CERT_FILE`. The default Valkey key is `ca-bundle.crt`.
 
 For an external Valkey endpoint signed by a public CA, leave
 `caExistingSecret` empty to use the image's system trust store.
+
+The chart does not mutate or delete referenced existing Secrets. Generated
+embedded credentials follow the retained dependency-specific behavior
+described below.
+
+## Embedded S3-compatible storage
+
+The chart pins SeaweedFS chart `4.41.0` (SeaweedFS `4.41`) from the
+project-owned Helm repository. SeaweedFS is disabled by default. To replace
+only the external object-storage dependency, layer this over the control-plane
+values:
+
+```yaml
+embeddedDependencies:
+  objectStorage:
+    enabled: true
+
+secrets:
+  objectStorage:
+    generate: true
+    existingSecret: ''
+
+# Make this unique if more than one release shares a namespace.
+seaweedfs:
+  global:
+    seaweedfs:
+      serviceAccountName: osmo-seaweedfs
+```
+
+The PostgreSQL, Valkey, master-encryption-key, `externalUrl`, and component
+image values are still required. The external object-storage endpoint and
+bucket values are ignored in this mode. Enabling the dependency provisions a `10Gi`
+`ReadWriteOnce` PVC, starts the all-in-one S3 endpoint, creates
+`osmo-workflows`, `osmo-logs`, and `osmo-apps` idempotently, and configures
+OSMO to use the release-scoped in-cluster endpoint. Override
+`seaweedfs.allInOne.data.size` and `storageClass` before installation when the
+cluster default is unsuitable. Bucket names can be changed in
+`seaweedfs.allInOne.s3.createBuckets`; keep the workflows, logs, apps order.
+
+SeaweedFS's native retained pre-install/pre-upgrade hook creates
+`<release>-seaweedfs-s3-secret` with the S3 identity. A later least-privilege
+OSMO hook reads that native admin identity and synchronizes
+`<release>-object-storage-credentials`, which contains the
+`object-storage.yaml` file expected by OSMO. SeaweedFS remains the credential
+source of truth; the derived OSMO Secret can be recreated from it. The native
+Secret and PVC are retained after `helm uninstall`. Back up the native Secret
+with the PVC, restrict access to Helm release history, and use `--hide-secret`
+when previewing an install or upgrade.
+
+To supply credentials instead, create one Secret with both keys below:
+
+| Key | Content |
+| --- | --- |
+| `object-storage.yaml` | YAML containing `access_key_id`, `access_key`, and `addressing_style: path` |
+| `seaweedfs_s3_config` | SeaweedFS S3 identity JSON granting the matching identity `Admin`, `Read`, and `Write` |
+
+Then configure the same Secret in the parent and dependency values:
+
+```yaml
+embeddedDependencies:
+  objectStorage:
+    enabled: true
+secrets:
+  objectStorage:
+    generate: false
+    existingSecret: osmo-seaweedfs-s3
+seaweedfs:
+  s3:
+    existingConfigSecret: osmo-seaweedfs-s3
+```
+
+The chart rejects mismatched names because OSMO and SeaweedFS must read the
+same identity. Existing Secrets are never created, changed, or deleted by the
+chart.
+
+### Availability, data protection, and scaling
+
+The default all-in-one topology is persistent but **not highly available**.
+It uses one pod and a `Recreate` update strategy. Do not increase
+`allInOne.replicas` on a `ReadWriteOnce` volume; use the distributed topology
+instead.
+
+[`embedded-seaweedfs-ha-values.yaml`](embedded-seaweedfs-ha-values.yaml) is a
+render-tested production-oriented starting point. It uses three masters,
+three persistent volume servers, two filers, two S3 gateways, pod
+anti-affinity, and `001` data replication. Multiple filers require one shared
+metadata database; the example disables local LevelDB and references an
+operator-managed PostgreSQL database and Secret. Replace every storage class,
+capacity, endpoint, Secret name, and service-account name for the target
+cluster. For zone failure protection, define named `seaweedfs.volumes` groups
+with explicit `dataCenter`/`rack` placement and choose a replication policy
+that places copies across those failure domains. Replica counts without a
+matching replication policy do not protect object data.
+
+Before production use:
+
+- size master, volume, filer, S3, and PostgreSQL resources from load tests;
+- use failure-domain-aware persistent volumes and confirm anti-affinity can be
+  scheduled on the available nodes;
+- back up the filer PostgreSQL database, SeaweedFS master metadata, object
+  data, and the S3 credential Secret on the same recovery schedule;
+- enable bucket versioning/object lock in `createBuckets` when the retention
+  model requires it, understanding that object lock is irreversible;
+- enable SeaweedFS transport security and namespace network policy when the
+  cluster does not provide an equivalent trusted service network; and
+- run restore and node-loss drills before relying on replication as data
+  protection.
+
+Scale volume servers by adding failure-domain-aware replicas or named volume
+groups, then allow SeaweedFS to rebalance data. Scale stateless S3 gateways
+independently. Scale filers only after configuring a shared metadata store.
+Keep an odd number of masters and change master membership deliberately; do
+not simply remove a quorum member and its PVC.
+
+For upgrades, first back up metadata, data, and credentials; render the new
+chart against current values; review upstream SeaweedFS release notes; and
+upgrade one pinned dependency version at a time. Confirm master quorum, volume
+replication, filer health, bucket access, and OSMO API health before removing
+old replicas or backups. A normal pod failure is recovered by Kubernetes using
+the same PVC. For a lost volume/PVC, replace capacity and let a healthy replica
+restore data before reducing redundancy. For filer database loss, restore the
+shared metadata database before accepting writes. For total loss, restore
+credentials and metadata first, then object data, and validate all three OSMO
+buckets.
+
+### Provenance
+
+The dependency comes from the SeaweedFS project-owned Helm repository and is
+Apache-2.0 licensed. The upstream chart is not signed, and it selects the
+multi-architecture `chrislusf/seaweedfs:4.41` image by tag rather than digest.
+Mirror and scan the chart and image when organizational supply-chain policy
+requires it.
+
+## External S3-compatible storage
+
+To disable embedded storage, keep
+`embeddedDependencies.objectStorage.enabled: false`, configure
+`externalDependencies.objectStorage`, and reference an existing
+`secrets.objectStorage.existingSecret` containing `object-storage.yaml`. No
+SeaweedFS Deployment, StatefulSet, Service, PVC, RBAC, or hook is rendered.
 
 ## Exposure
 

--- a/deployments/charts/osmo/embedded-seaweedfs-ha-values.yaml
+++ b/deployments/charts/osmo/embedded-seaweedfs-ha-values.yaml
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Production-oriented distributed example. Replace storage classes, capacities,
+# service-account name, PostgreSQL endpoint/Secret, and S3 Secret name for the
+# target cluster before installing. See README.md for the operational contract.
+embeddedDependencies:
+  objectStorage:
+    enabled: true
+
+secrets:
+  objectStorage:
+    generate: false
+    existingSecret: osmo-seaweedfs-s3
+
+seaweedfs:
+  global:
+    seaweedfs:
+      createClusterRole: false
+      serviceAccountName: osmo-seaweedfs-ha
+      automountServiceAccountToken: false
+      enableReplication: true
+      replicationPlacement: "001"
+  allInOne:
+    enabled: false
+  master:
+    enabled: true
+    replicas: 3
+    defaultReplication: "001"
+    data:
+      type: persistentVolumeClaim
+      size: 10Gi
+      storageClass: standard
+    logs:
+      type: emptyDir
+    podSecurityContext:
+      enabled: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+  volume:
+    enabled: true
+    replicas: 3
+    dataDirs:
+    - name: data
+      type: persistentVolumeClaim
+      size: 100Gi
+      storageClass: standard
+      maxVolumes: 0
+    logs:
+      type: emptyDir
+    resizeHook:
+      enabled: false
+    podSecurityContext:
+      enabled: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+  filer:
+    enabled: true
+    replicas: 2
+    defaultReplicaPlacement: "001"
+    # Multiple filers need one shared metadata store; local LevelDB must be off.
+    data:
+      type: emptyDir
+    logs:
+      type: emptyDir
+    extraEnvironmentVars:
+      WEED_LEVELDB2_ENABLED: "false"
+      WEED_POSTGRES_ENABLED: "true"
+      WEED_POSTGRES_HOSTNAME: seaweedfs-postgresql
+      WEED_POSTGRES_PORT: "5432"
+      WEED_POSTGRES_DATABASE: seaweedfs
+      WEED_POSTGRES_SSLMODE: require
+    secretExtraEnvironmentVars:
+      WEED_POSTGRES_USERNAME:
+        secretKeyRef:
+          name: seaweedfs-postgresql
+          key: username
+      WEED_POSTGRES_PASSWORD:
+        secretKeyRef:
+          name: seaweedfs-postgresql
+          key: password
+    podSecurityContext:
+      enabled: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+  s3:
+    enabled: true
+    replicas: 2
+    enableAuth: true
+    existingConfigSecret: osmo-seaweedfs-s3
+    createBuckets:
+    - name: osmo-workflows
+    - name: osmo-logs
+    - name: osmo-apps
+    logs:
+      type: emptyDir
+    podSecurityContext:
+      enabled: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000

--- a/deployments/charts/osmo/files/object-storage-bootstrap.sh
+++ b/deployments/charts/osmo/files/object-storage-bootstrap.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+namespace=""
+release_name=""
+source_secret_name=""
+secret_name=""
+
+log_error() {
+    printf 'ERROR %s\n' "$*" >&2
+}
+
+read_secret_name() {
+    kubectl get secret "$1" \
+        --namespace "$namespace" \
+        --ignore-not-found=true \
+        -o go-template='{{.metadata.name}}'
+}
+
+read_secret_key() {
+    target_secret=$1
+    key=$2
+    output_file=$3
+    encoded_value=$(kubectl get secret "$target_secret" \
+        --namespace "$namespace" \
+        -o "go-template={{with index .data \"$key\"}}{{.}}{{end}}") || {
+        log_error "Unable to read source SeaweedFS Secret $target_secret"
+        return 1
+    }
+    if [ -z "$encoded_value" ]; then
+        log_error "Source SeaweedFS Secret $target_secret is missing key $key"
+        return 1
+    fi
+    if ! printf '%s' "$encoded_value" | base64 -d >"$output_file"; then
+        log_error "Source SeaweedFS Secret $target_secret key $key is not valid base64"
+        return 1
+    fi
+}
+
+validate_credential() {
+    credential_file=$1
+    key=$2
+    minimum_length=$3
+    if ! grep -Eq "^[[:alnum:]]{$minimum_length,}$" "$credential_file"; then
+        log_error "Source SeaweedFS Secret $source_secret_name key $key has invalid format"
+        return 1
+    fi
+}
+
+synchronize_secret() (
+    source_name=$(read_secret_name "$source_secret_name") || {
+        log_error "Unable to read source SeaweedFS Secret $source_secret_name"
+        return 1
+    }
+    if [ -z "$source_name" ]; then
+        log_error "Source SeaweedFS Secret $source_secret_name is missing"
+        return 1
+    fi
+
+    working_directory=$(mktemp -d)
+    trap 'rm -rf "$working_directory"' EXIT INT TERM
+    access_key_id_file="$working_directory/admin_access_key_id"
+    secret_access_key_file="$working_directory/admin_secret_access_key"
+    credentials_file="$working_directory/object-storage.yaml"
+
+    read_secret_key "$source_secret_name" admin_access_key_id \
+        "$access_key_id_file"
+    read_secret_key "$source_secret_name" admin_secret_access_key \
+        "$secret_access_key_file"
+    validate_credential "$access_key_id_file" admin_access_key_id 20
+    validate_credential "$secret_access_key_file" admin_secret_access_key 32
+
+    access_key_id=$(cat "$access_key_id_file")
+    secret_access_key=$(cat "$secret_access_key_file")
+    printf 'access_key_id: %s\naccess_key: %s\naddressing_style: path\n' \
+        "$access_key_id" "$secret_access_key" >"$credentials_file"
+
+    kubectl create secret generic "$secret_name" \
+        --namespace "$namespace" \
+        --from-file=object-storage.yaml="$credentials_file" \
+        --dry-run=client \
+        -o yaml >"$working_directory/secret.yaml"
+    kubectl label --local -f "$working_directory/secret.yaml" \
+        app.kubernetes.io/managed-by=osmo-object-storage-bootstrap \
+        "app.kubernetes.io/instance=$release_name" \
+        -o yaml >"$working_directory/labeled-secret.yaml"
+    kubectl annotate --local -f "$working_directory/labeled-secret.yaml" \
+        "osmo.nvidia.com/credential-source=$source_secret_name" \
+        -o yaml >"$working_directory/annotated-secret.yaml"
+    kubectl apply -f "$working_directory/annotated-secret.yaml" >/dev/null
+
+    printf 'INFO Synchronized object-storage Secret %s from %s\n' \
+        "$secret_name" "$source_secret_name"
+)
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --namespace|--release-name|--source-secret-name|--secret-name)
+            if [ "$#" -lt 2 ]; then
+                log_error "Missing value for $1"
+                exit 2
+            fi
+            case "$1" in
+                --namespace) namespace=$2 ;;
+                --release-name) release_name=$2 ;;
+                --source-secret-name) source_secret_name=$2 ;;
+                --secret-name) secret_name=$2 ;;
+            esac
+            shift 2
+            ;;
+        *)
+            log_error "Unknown argument $1"
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$namespace" ] || [ -z "$release_name" ] || \
+        [ -z "$source_secret_name" ] || [ -z "$secret_name" ]; then
+    log_error 'Namespace, release name, source Secret name, and target Secret name are required'
+    exit 2
+fi
+
+synchronize_secret

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -252,7 +252,7 @@ data:
 - name: configs
   mountPath: /etc/osmo/configs
   readOnly: true
-{{- with .Values.secrets.objectStorage.existingSecret }}
+{{- with (include "osmo.objectStorage.secretName" .) }}
 - name: object-storage-credentials
   mountPath: /etc/osmo/secrets/{{ . }}
   readOnly: true
@@ -265,7 +265,7 @@ data:
 - name: configs
   configMap:
     name: {{ include "osmo.api.fullname" . }}-config
-{{- with .Values.secrets.objectStorage.existingSecret }}
+{{- with (include "osmo.objectStorage.secretName" .) }}
 - name: object-storage-credentials
   secret:
     secretName: {{ . }}
@@ -482,4 +482,57 @@ disable
 - name: SSL_CERT_FILE
   value: /etc/osmo/ca/valkey/ca-bundle.crt
 {{- end }}
+{{- end -}}
+
+{{- define "osmo.seaweedfs.fullname" -}}
+{{- if .Values.seaweedfs.fullnameOverride -}}
+{{- .Values.seaweedfs.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "seaweedfs" .Values.seaweedfs.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.seaweedfs.s3SecretName" -}}
+{{- printf "%s-s3-secret" (include "osmo.seaweedfs.fullname" .) -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.generatedSecretName" -}}
+{{- printf "%s-object-storage-credentials" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.secretName" -}}
+{{- if and .Values.embeddedDependencies.objectStorage.enabled .Values.secrets.objectStorage.generate -}}
+{{- include "osmo.objectStorage.generatedSecretName" . -}}
+{{- else -}}
+{{- .Values.secrets.objectStorage.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.endpoint" -}}
+{{- if .Values.embeddedDependencies.objectStorage.enabled -}}
+{{- if .Values.seaweedfs.allInOne.enabled -}}
+{{- printf "http://%s-all-in-one:%v" (include "osmo.seaweedfs.fullname" .) (.Values.seaweedfs.allInOne.s3.port | default .Values.seaweedfs.s3.port) -}}
+{{- else -}}
+{{- printf "http://%s-s3:%v" (include "osmo.seaweedfs.fullname" .) .Values.seaweedfs.s3.port -}}
+{{- end -}}
+{{- else -}}
+{{- .Values.externalDependencies.objectStorage.endpoint -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.bucket" -}}
+{{- if .root.Values.embeddedDependencies.objectStorage.enabled -}}
+{{- $buckets := .root.Values.seaweedfs.s3.createBuckets -}}
+{{- if .root.Values.seaweedfs.allInOne.enabled -}}
+{{- $buckets = .root.Values.seaweedfs.allInOne.s3.createBuckets -}}
+{{- end -}}
+{{- (index $buckets .index).name -}}
+{{- else -}}
+{{- index .root.Values.externalDependencies.objectStorage.buckets .purpose -}}
+{{- end -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/_notes.tpl
+++ b/deployments/charts/osmo/templates/_notes.tpl
@@ -12,6 +12,18 @@ Configured public URL:
 
   {{ .Values.externalUrl }}
 
+{{- if .Values.embeddedDependencies.objectStorage.enabled }}
+
+Embedded SeaweedFS object storage is enabled at:
+
+  {{ include "osmo.objectStorage.endpoint" . }}
+
+The default all-in-one topology is persistent but not highly available. Its
+PVC and native SeaweedFS credential Secret are retained after uninstall; OSMO's
+derived credential Secret can be synchronized from that source. Follow the
+README backup and recovery guidance before changing topology or deleting them.
+{{- end }}
+
 {{ if .Values.httproute.enabled }}
 An HTTPRoute attaches to an existing Gateway named in httproute.parentRefs;
 this chart does not create a Gateway or GatewayClass.

--- a/deployments/charts/osmo/templates/configs.yaml
+++ b/deployments/charts/osmo/templates/configs.yaml
@@ -40,9 +40,14 @@ data:
       {{- $workflow := deepCopy $cfg.workflow }}
       {{- $storage := .Values.externalDependencies.objectStorage }}
       {{- $secret := .Values.secrets.objectStorage }}
-      {{- $_ := set $workflow "workflow_data" (dict "credential" (dict "secretName" $secret.existingSecret "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/workflows" $storage.buckets.workflows) "override_url" $storage.endpoint "region" $storage.region)) }}
-      {{- $_ := set $workflow "workflow_log" (dict "credential" (dict "secretName" $secret.existingSecret "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/logs" $storage.buckets.logs) "override_url" $storage.endpoint "region" $storage.region)) }}
-      {{- $_ := set $workflow "workflow_app" (dict "credential" (dict "secretName" $secret.existingSecret "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/apps" $storage.buckets.apps) "override_url" $storage.endpoint "region" $storage.region)) }}
+      {{- $secretName := include "osmo.objectStorage.secretName" . }}
+      {{- $overrideUrl := include "osmo.objectStorage.endpoint" . }}
+      {{- $workflowBucket := include "osmo.objectStorage.bucket" (dict "root" . "purpose" "workflows" "index" 0) }}
+      {{- $logBucket := include "osmo.objectStorage.bucket" (dict "root" . "purpose" "logs" "index" 1) }}
+      {{- $appBucket := include "osmo.objectStorage.bucket" (dict "root" . "purpose" "apps" "index" 2) }}
+      {{- $_ := set $workflow "workflow_data" (dict "credential" (dict "secretName" $secretName "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/workflows" $workflowBucket) "override_url" $overrideUrl "region" $storage.region)) }}
+      {{- $_ := set $workflow "workflow_log" (dict "credential" (dict "secretName" $secretName "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/logs" $logBucket) "override_url" $overrideUrl "region" $storage.region)) }}
+      {{- $_ := set $workflow "workflow_app" (dict "credential" (dict "secretName" $secretName "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/apps" $appBucket) "override_url" $overrideUrl "region" $storage.region)) }}
       {{- toYaml $workflow | nindent 6 }}
     {{- end }}
     {{- if $cfg.pools }}

--- a/deployments/charts/osmo/templates/object-storage-bootstrap.yaml
+++ b/deployments/charts/osmo/templates/object-storage-bootstrap.yaml
@@ -1,0 +1,137 @@
+{{/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.embeddedDependencies.objectStorage.enabled .Values.secrets.objectStorage.generate }}
+{{- $bootstrapName := include "osmo.component.fullname" (dict "root" . "suffix" "object-storage-bootstrap") }}
+{{- $secretName := include "osmo.objectStorage.secretName" . }}
+{{- $sourceSecretName := include "osmo.seaweedfs.s3SecretName" . }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $bootstrapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "object-storage-bootstrap") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict
+          "helm.sh/hook" "pre-install,pre-upgrade"
+          "helm.sh/hook-weight" "-20"
+          "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded,hook-failed")) | nindent 4 }}
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $bootstrapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "object-storage-bootstrap") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict
+          "helm.sh/hook" "pre-install,pre-upgrade"
+          "helm.sh/hook-weight" "-20"
+          "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded,hook-failed")) | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames:
+  - {{ $sourceSecretName | quote }}
+  - {{ $secretName | quote }}
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames:
+  - {{ $secretName | quote }}
+  verbs: ["patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $bootstrapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "object-storage-bootstrap") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict
+          "helm.sh/hook" "pre-install,pre-upgrade"
+          "helm.sh/hook-weight" "-20"
+          "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded,hook-failed")) | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $bootstrapName }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $bootstrapName }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $bootstrapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "object-storage-bootstrap") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict
+          "helm.sh/hook" "pre-install,pre-upgrade"
+          "helm.sh/hook-weight" "10"
+          "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded")) | nindent 4 }}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- include "osmo.component.labels" (dict "root" . "component" "object-storage-bootstrap") | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $bootstrapName }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      containers:
+      - name: object-storage-bootstrap
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.embeddedDependencies.objectStorage.bootstrap) | quote }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.embeddedDependencies.objectStorage.bootstrap) }}
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - |
+{{ .Files.Get "files/object-storage-bootstrap.sh" | nindent 10 }}
+        - object-storage-bootstrap
+        - --namespace
+        - {{ .Release.Namespace | quote }}
+        - --release-name
+        - {{ .Release.Name | quote }}
+        - --source-secret-name
+        - {{ $sourceSecretName | quote }}
+        - --secret-name
+        - {{ $secretName | quote }}
+        env:
+        - name: HOME
+          value: /tmp
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+          runAsGroup: 1001
+        resources:
+          {{- toYaml .Values.embeddedDependencies.objectStorage.bootstrap.resources | nindent 10 }}
+        volumeMounts:
+        - name: bootstrap-tmp
+          mountPath: /tmp
+      volumes:
+      - name: bootstrap-tmp
+        emptyDir: {}
+{{- end }}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -49,9 +49,6 @@
 {{- end -}}
 {{- end -}}
 {{- end -}}
-{{- if .Values.embeddedDependencies.objectStorage.enabled -}}
-{{- fail "embeddedDependencies.objectStorage.enabled: embedded object storage is not implemented" -}}
-{{- end -}}
 {{- if .Values.embeddedDependencies.kaiScheduler.enabled -}}
 {{- fail "embeddedDependencies.kaiScheduler.enabled: embedded KAI Scheduler is not implemented" -}}
 {{- end -}}
@@ -125,7 +122,7 @@
 {{- if and .Values.httproute.enabled (eq (len .Values.httproute.parentRefs) 0) -}}
 {{- fail "httproute.parentRefs requires at least one entry when httproute.enabled=true" -}}
 {{- end -}}
-{{- if or .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
+{{- if or .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
 {{- fail "secrets: generated Secrets are not implemented; configure existingSecret" -}}
 {{- end -}}
 {{- $autoscaledComponents := list
@@ -186,16 +183,16 @@
 {{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.externalDependencies.valkey.host) -}}
 {{- fail "externalDependencies.valkey.host is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.objectStorage.endpoint -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.endpoint) -}}
 {{- fail "externalDependencies.objectStorage.endpoint is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.objectStorage.buckets.workflows -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.buckets.workflows) -}}
 {{- fail "externalDependencies.objectStorage.buckets.workflows is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.objectStorage.buckets.logs -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.buckets.logs) -}}
 {{- fail "externalDependencies.objectStorage.buckets.logs is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.objectStorage.buckets.apps -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.buckets.apps) -}}
 {{- fail "externalDependencies.objectStorage.buckets.apps is required for the control plane" -}}
 {{- end -}}
 {{- if and (not .Values.embeddedDependencies.postgresql.enabled) (not .Values.secrets.postgresql.existingSecret) -}}
@@ -204,8 +201,47 @@
 {{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.secrets.valkey.existingSecret) -}}
 {{- fail "secrets.valkey.existingSecret is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.secrets.objectStorage.existingSecret -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.secrets.objectStorage.existingSecret) -}}
 {{- fail "secrets.objectStorage.existingSecret is required for the control plane" -}}
+{{- end -}}
+{{- if and .Values.embeddedDependencies.objectStorage.enabled .Values.secrets.objectStorage.generate .Values.secrets.objectStorage.existingSecret -}}
+{{- fail "secrets.objectStorage: generate and existingSecret are mutually exclusive for embedded object storage" -}}
+{{- end -}}
+{{- if and .Values.embeddedDependencies.objectStorage.enabled (not .Values.secrets.objectStorage.generate) (not .Values.secrets.objectStorage.existingSecret) -}}
+{{- fail "secrets.objectStorage: enable generate or configure existingSecret for embedded object storage" -}}
+{{- end -}}
+{{- if and .Values.embeddedDependencies.objectStorage.enabled .Values.secrets.objectStorage.generate (not .Values.seaweedfs.allInOne.enabled) -}}
+{{- fail "embedded object-storage generated credentials are supported only with seaweedfs.allInOne.enabled; distributed deployments require an existing Secret" -}}
+{{- end -}}
+{{- if and .Values.embeddedDependencies.objectStorage.enabled .Values.secrets.objectStorage.generate (not .Values.seaweedfs.s3.enableAuth) -}}
+{{- fail "seaweedfs.s3.enableAuth must be true for generated credentials" -}}
+{{- end -}}
+{{- $seaweedfsExistingSecret := .Values.seaweedfs.s3.existingConfigSecret | default "" -}}
+{{- $allInOneExistingSecret := .Values.seaweedfs.allInOne.s3.existingConfigSecret | default "" -}}
+{{- if and .Values.embeddedDependencies.objectStorage.enabled .Values.secrets.objectStorage.generate (or $seaweedfsExistingSecret $allInOneExistingSecret) -}}
+{{- fail "generated credentials cannot configure a SeaweedFS existingConfigSecret" -}}
+{{- end -}}
+{{- if .Values.embeddedDependencies.objectStorage.enabled -}}
+{{- with .Values.seaweedfs.s3.credentials -}}
+{{- fail "inline SeaweedFS credentials are not supported; use generated credentials or an existing Secret" -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.embeddedDependencies.objectStorage.enabled .Values.secrets.objectStorage.existingSecret -}}
+{{- if ne $seaweedfsExistingSecret .Values.secrets.objectStorage.existingSecret -}}
+{{- fail "seaweedfs.s3.existingConfigSecret must match secrets.objectStorage.existingSecret for embedded object storage" -}}
+{{- end -}}
+{{- if and $allInOneExistingSecret (ne $allInOneExistingSecret .Values.secrets.objectStorage.existingSecret) -}}
+{{- fail "seaweedfs.allInOne.s3.existingConfigSecret must be empty or match secrets.objectStorage.existingSecret" -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.embeddedDependencies.objectStorage.enabled -}}
+{{- $buckets := .Values.seaweedfs.s3.createBuckets -}}
+{{- if .Values.seaweedfs.allInOne.enabled -}}
+{{- $buckets = .Values.seaweedfs.allInOne.s3.createBuckets -}}
+{{- end -}}
+{{- if lt (len $buckets) 3 -}}
+{{- fail "embedded object storage requires three SeaweedFS createBuckets entries in workflows, logs, apps order" -}}
+{{- end -}}
 {{- end -}}
 {{- if not .Values.secrets.masterEncryptionKey.existingSecret -}}
 {{- fail "secrets.masterEncryptionKey.existingSecret is required for the control plane" -}}

--- a/deployments/charts/osmo/tests/test_object_storage_bootstrap.sh
+++ b/deployments/charts/osmo/tests/test_object_storage_bootstrap.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+CHART_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$CHART_ROOT/files/object-storage-bootstrap.sh"
+TEST_DIRECTORY=$(mktemp -d)
+trap 'rm -rf "$TEST_DIRECTORY"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+[[ -x "$SCRIPT" ]] || fail "bootstrap script is missing or not executable: $SCRIPT"
+
+mkdir -p "$TEST_DIRECTORY/bin"
+cat >"$TEST_DIRECTORY/bin/kubectl" <<'FAKE_KUBECTL'
+#!/bin/sh
+set -eu
+
+secret_directory() {
+    printf '%s/secrets/%s' "$FAKE_STATE" "$1"
+}
+
+read_manifest() {
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = -f ]; then
+            if [ "$2" = - ]; then
+                cat
+            else
+                cat "$2"
+            fi
+            return
+        fi
+        shift
+    done
+    exit 2
+}
+
+command_name=$1
+shift
+
+case "$command_name" in
+    get)
+        resource=$1
+        secret_name=$2
+        shift 2
+        [ "$resource" = secret ] || exit 2
+        directory=$(secret_directory "$secret_name")
+        [ -d "$directory" ] || exit 0
+        case "$*" in
+            *metadata.name*) printf '%s' "$secret_name" ;;
+            *)
+                key=$(printf '%s' "$*" | sed -n 's/.*index \.data "\([^"]*\)".*/\1/p')
+                if [ -f "$FAKE_STATE/invalid-$secret_name-$key" ]; then
+                    printf '%s' 'not-valid-base64!'
+                elif [ -n "$key" ] && [ -f "$directory/$key" ]; then
+                    base64 <"$directory/$key" | tr -d '\n'
+                fi
+                ;;
+        esac
+        ;;
+    create)
+        if [ "${1:-}" = secret ]; then
+            [ "${2:-}" = generic ] || exit 2
+            target_name=$3
+            shift 3
+            pending_directory="$FAKE_STATE/pending/$target_name"
+            mkdir -p "$pending_directory"
+            for argument in "$@"; do
+                case "$argument" in
+                    --from-file=*)
+                        mapping=${argument#--from-file=}
+                        key=${mapping%%=*}
+                        source_file=${mapping#*=}
+                        cp "$source_file" "$pending_directory/$key"
+                        ;;
+                esac
+            done
+            printf 'apiVersion: v1\nkind: Secret\nmetadata:\n  name: %s\n' "$target_name"
+        else
+            echo "unsupported fake kubectl create: $*" >&2
+            exit 2
+        fi
+        ;;
+    label|annotate)
+        read_manifest "$@"
+        ;;
+    apply)
+        manifest=$(read_manifest "$@")
+        target_name=$(printf '%s\n' "$manifest" | awk '$1 == "name:" { print $2; exit }')
+        [ -n "$target_name" ] || exit 2
+        pending_directory="$FAKE_STATE/pending/$target_name"
+        target_directory=$(secret_directory "$target_name")
+        [ -d "$pending_directory" ] || exit 2
+        mkdir -p "$target_directory"
+        cp "$pending_directory"/* "$target_directory/"
+        printf 'secret/%s configured\n' "$target_name"
+        ;;
+    *)
+        echo "unsupported fake kubectl command: $command_name" >&2
+        exit 2
+        ;;
+esac
+FAKE_KUBECTL
+chmod +x "$TEST_DIRECTORY/bin/kubectl"
+
+SOURCE_SECRET=osmo-6602-app-seaweedfs-s3-secret
+TARGET_SECRET=osmo-6602-app-object-storage-credentials
+
+write_source_credentials() {
+    local state_directory=$1
+    local access_key_id=$2
+    local secret_access_key=$3
+    local source_directory="$state_directory/secrets/$SOURCE_SECRET"
+    mkdir -p "$source_directory"
+    printf '%s' "$access_key_id" >"$source_directory/admin_access_key_id"
+    printf '%s' "$secret_access_key" >"$source_directory/admin_secret_access_key"
+}
+
+run_bootstrap() {
+    local state_directory=$1
+    mkdir -p "$state_directory"
+    PATH="$TEST_DIRECTORY/bin:$PATH" FAKE_STATE="$state_directory" \
+        TMPDIR="$state_directory" \
+        "$SCRIPT" \
+        --namespace osmo-6602-app \
+        --release-name osmo-6602-app \
+        --source-secret-name "$SOURCE_SECRET" \
+        --secret-name "$TARGET_SECRET"
+}
+
+generated_state="$TEST_DIRECTORY/generated"
+write_source_credentials "$generated_state" \
+    AAAAAAAAAAAAAAAAAAAA \
+    BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+run_bootstrap "$generated_state" >"$TEST_DIRECTORY/install.out"
+expected_credentials="$TEST_DIRECTORY/expected-object-storage.yaml"
+printf '%s\n' \
+    'access_key_id: AAAAAAAAAAAAAAAAAAAA' \
+    'access_key: BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' \
+    'addressing_style: path' >"$expected_credentials"
+cmp "$expected_credentials" \
+    "$generated_state/secrets/$TARGET_SECRET/object-storage.yaml" || \
+    fail "derived OSMO credentials do not match the native SeaweedFS credentials"
+[[ ! -e "$generated_state/secrets/$TARGET_SECRET/seaweedfs_s3_config" ]] || \
+    fail "derived OSMO Secret duplicated the SeaweedFS S3 configuration"
+grep -Fq "Synchronized object-storage Secret $TARGET_SECRET from $SOURCE_SECRET" \
+    "$TEST_DIRECTORY/install.out" || fail "bootstrap did not report synchronization"
+
+before=$(sha256sum "$generated_state/secrets/$TARGET_SECRET/object-storage.yaml")
+run_bootstrap "$generated_state" >"$TEST_DIRECTORY/reinstall.out"
+[[ "$before" = "$(sha256sum "$generated_state/secrets/$TARGET_SECRET/object-storage.yaml")" ]] || \
+    fail "repeat synchronization changed unchanged credentials"
+
+write_source_credentials "$generated_state" \
+    CCCCCCCCCCCCCCCCCCCC \
+    DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
+run_bootstrap "$generated_state" >"$TEST_DIRECTORY/rotation.out"
+grep -Fqx 'access_key_id: CCCCCCCCCCCCCCCCCCCC' \
+    "$generated_state/secrets/$TARGET_SECRET/object-storage.yaml" || \
+    fail "source access-key rotation did not reach the OSMO Secret"
+grep -Fqx 'access_key: DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD' \
+    "$generated_state/secrets/$TARGET_SECRET/object-storage.yaml" || \
+    fail "source secret-key rotation did not reach the OSMO Secret"
+
+missing_state="$TEST_DIRECTORY/missing"
+if run_bootstrap "$missing_state" >"$TEST_DIRECTORY/missing.out" 2>&1; then
+    fail "bootstrap accepted a missing native SeaweedFS Secret"
+fi
+grep -Fq "Source SeaweedFS Secret $SOURCE_SECRET is missing" \
+    "$TEST_DIRECTORY/missing.out" || fail "missing source Secret was not identified"
+
+missing_key_state="$TEST_DIRECTORY/missing-key"
+write_source_credentials "$missing_key_state" \
+    EEEEEEEEEEEEEEEEEEEE \
+    FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+rm "$missing_key_state/secrets/$SOURCE_SECRET/admin_secret_access_key"
+if run_bootstrap "$missing_key_state" >"$TEST_DIRECTORY/missing-key.out" 2>&1; then
+    fail "bootstrap accepted a native Secret with a missing key"
+fi
+grep -Fq "missing key admin_secret_access_key" \
+    "$TEST_DIRECTORY/missing-key.out" || fail "missing source key was not identified"
+
+invalid_base64_state="$TEST_DIRECTORY/invalid-base64"
+write_source_credentials "$invalid_base64_state" \
+    GGGGGGGGGGGGGGGGGGGG \
+    HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHH
+touch "$invalid_base64_state/invalid-$SOURCE_SECRET-admin_access_key_id"
+if run_bootstrap "$invalid_base64_state" \
+        >"$TEST_DIRECTORY/invalid-base64.out" 2>&1; then
+    fail "bootstrap accepted invalid base64 in the native Secret"
+fi
+grep -Fq "key admin_access_key_id is not valid base64" \
+    "$TEST_DIRECTORY/invalid-base64.out" || fail "invalid base64 was not identified"
+
+malformed_state="$TEST_DIRECTORY/malformed"
+write_source_credentials "$malformed_state" short also-short
+if run_bootstrap "$malformed_state" >"$TEST_DIRECTORY/malformed.out" 2>&1; then
+    fail "bootstrap accepted malformed native credentials"
+fi
+grep -Fq "key admin_access_key_id has invalid format" \
+    "$TEST_DIRECTORY/malformed.out" || fail "malformed credential was not identified"
+
+echo "PASS: object-storage credential bootstrap tests"

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -358,12 +358,53 @@ EOF
 
 test_control_umbrella() {
     local charts_copy="$TEST_DIRECTORY/charts"
+    local helm_state="$TEST_DIRECTORY/helm"
     local rendered="$TEST_DIRECTORY/osmo.yaml"
+    export HELM_CACHE_HOME="$helm_state/cache"
+    export HELM_CONFIG_HOME="$helm_state/config"
+    export HELM_DATA_HOME="$helm_state/data"
     mkdir -p "$charts_copy"
+    helm repo add cnpg https://cloudnative-pg.github.io/charts \
+        >"$TEST_DIRECTORY/cnpg-repo-add.out"
+    helm repo add seaweedfs https://seaweedfs.github.io/seaweedfs/helm \
+        >"$TEST_DIRECTORY/seaweedfs-repo-add.out"
     cp -R "$CHARTS_ROOT/osmo" "$charts_copy/osmo"
-    if ! compgen -G "$charts_copy/osmo/charts/valkey-0.11.0.tgz" >/dev/null || \
-        ! compgen -G "$charts_copy/osmo/charts/cluster-0.8.0.tgz" >/dev/null; then
-        helm dependency build "$charts_copy/osmo" >/dev/null
+    if ! helm dependency build "$charts_copy/osmo" \
+        >"$TEST_DIRECTORY/osmo-dependency-build.out" 2>&1; then
+        cat "$TEST_DIRECTORY/osmo-dependency-build.out" >&2
+        fail "expected OSMO chart dependencies to build"
+    fi
+    helm dependency list "$charts_copy/osmo" \
+        >"$TEST_DIRECTORY/osmo-dependency-list.out"
+    if ! awk '
+        $1 == "valkey" &&
+        $2 == "0.11.0" &&
+        $3 == "oci://ghcr.io/valkey-io/valkey-helm" &&
+        $4 == "ok" { found = 1 }
+        END { exit !found }
+    ' "$TEST_DIRECTORY/osmo-dependency-list.out"; then
+        cat "$TEST_DIRECTORY/osmo-dependency-list.out" >&2
+        fail "expected official Valkey 0.11.0 dependency"
+    fi
+    if ! awk '
+        $1 == "cluster" &&
+        $2 == "0.8.0" &&
+        $3 == "https://cloudnative-pg.github.io/charts" &&
+        $4 == "ok" { found = 1 }
+        END { exit !found }
+    ' "$TEST_DIRECTORY/osmo-dependency-list.out"; then
+        cat "$TEST_DIRECTORY/osmo-dependency-list.out" >&2
+        fail "expected official CloudNativePG cluster 0.8.0 dependency"
+    fi
+    if ! awk '
+        $1 == "seaweedfs" &&
+        $2 == "4.41.0" &&
+        $3 == "https://seaweedfs.github.io/seaweedfs/helm" &&
+        $4 == "ok" { found = 1 }
+        END { exit !found }
+    ' "$TEST_DIRECTORY/osmo-dependency-list.out"; then
+        cat "$TEST_DIRECTORY/osmo-dependency-list.out" >&2
+        fail "expected official SeaweedFS 4.41.0 dependency"
     fi
 
     if ! helm lint "$charts_copy/osmo" >"$TEST_DIRECTORY/osmo-lint.out" 2>&1; then
@@ -384,6 +425,12 @@ test_control_umbrella() {
         ! grep -Fq "osmo/charts/cluster-0.8.0.tgz" \
         "$TEST_DIRECTORY/osmo-package.txt"; then
         fail "packaged OSMO chart does not contain CloudNativePG cluster 0.8.0"
+    fi
+    if ! grep -Fq "osmo/charts/seaweedfs/Chart.yaml" \
+        "$TEST_DIRECTORY/osmo-package.txt" && \
+        ! grep -Fq "osmo/charts/seaweedfs-4.41.0.tgz" \
+        "$TEST_DIRECTORY/osmo-package.txt"; then
+        fail "packaged OSMO chart does not contain SeaweedFS 4.41.0"
     fi
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "osmo/tests/"
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "osmo/migrations/"
@@ -462,6 +509,7 @@ test_control_umbrella() {
     require_no_resource "$rendered" Secret "osmo-valkey-credentials"
     require_no_resource "$rendered" PersistentVolumeClaim "osmo-valkey"
     require_no_deployment "$rendered" "localstack-s3"
+    require_not_contains "$rendered" "app.kubernetes.io/name: seaweedfs"
     require_no_deployment "$rendered" "osmo-backend-listener"
     require_no_deployment "$rendered" "osmo-backend-worker"
     require_contains "$rendered" "external-postgresql"
@@ -1139,6 +1187,277 @@ EOF
         >"$TEST_DIRECTORY/osmo-replicated-valkey-init.yaml"
     require_contains "$TEST_DIRECTORY/osmo-replicated-valkey-init.yaml" \
         "min-replicas-to-write 1"
+    helm_template embedded "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set-string externalDependencies.objectStorage.endpoint= \
+        --set-string externalDependencies.objectStorage.buckets.workflows= \
+        --set-string externalDependencies.objectStorage.buckets.logs= \
+        --set-string externalDependencies.objectStorage.buckets.apps= \
+        --set-string secrets.objectStorage.existingSecret= \
+        >"$TEST_DIRECTORY/osmo-embedded.yaml"
+    require_deployment "$TEST_DIRECTORY/osmo-embedded.yaml" \
+        "embedded-seaweedfs-all-in-one"
+    resource_document "$TEST_DIRECTORY/osmo-embedded.yaml" PersistentVolumeClaim \
+        embedded-seaweedfs-all-in-one-data \
+        >"$TEST_DIRECTORY/osmo-embedded-pvc.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-pvc.yaml" "storage: 10Gi"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-pvc.yaml" \
+        "helm.sh/resource-policy: keep"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" \
+        "s3.bucket.create --name osmo-workflows"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" \
+        "s3.bucket.create --name osmo-logs"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" \
+        "s3.bucket.create --name osmo-apps"
+    resource_document "$TEST_DIRECTORY/osmo-embedded.yaml" Job \
+        embedded-osmo-object-storage-bootstrap \
+        >"$TEST_DIRECTORY/osmo-object-storage-bootstrap.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap.yaml" \
+        "helm.sh/hook: pre-install,pre-upgrade"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap.yaml" \
+        'helm.sh/hook-weight: "10"'
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap.yaml" \
+        'image: "alpine/kubectl:1.33.4"'
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap.yaml" \
+        "embedded-seaweedfs-s3-secret"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap.yaml" \
+        "embedded-object-storage-credentials"
+    resource_document "$TEST_DIRECTORY/osmo-embedded.yaml" Role \
+        embedded-osmo-object-storage-bootstrap \
+        >"$TEST_DIRECTORY/osmo-object-storage-bootstrap-role.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-role.yaml" \
+        "resourceNames:"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-role.yaml" \
+        'verbs: ["get"]'
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-role.yaml" \
+        'verbs: ["patch", "update"]'
+    require_resource "$TEST_DIRECTORY/osmo-embedded.yaml" Secret \
+        embedded-seaweedfs-s3-secret
+    require_no_resource "$TEST_DIRECTORY/osmo-embedded.yaml" Secret \
+        embedded-object-storage-credentials
+    resource_document "$TEST_DIRECTORY/osmo-embedded.yaml" ConfigMap \
+        embedded-osmo-api-config \
+        >"$TEST_DIRECTORY/osmo-embedded-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-config.yaml" \
+        "override_url: http://embedded-seaweedfs-all-in-one:8333"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-config.yaml" \
+        "endpoint: s3://osmo-workflows/workflows"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-config.yaml" \
+        "endpoint: s3://osmo-logs/logs"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-config.yaml" \
+        "endpoint: s3://osmo-apps/apps"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-config.yaml" \
+        "secretName: embedded-object-storage-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-config.yaml" \
+        "region: us-east-1"
+    resource_document "$TEST_DIRECTORY/osmo-embedded.yaml" Deployment \
+        embedded-osmo-api >"$TEST_DIRECTORY/osmo-embedded-api.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-api.yaml" \
+        "mountPath: /etc/osmo/secrets/embedded-object-storage-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-api.yaml" \
+        "secretName: embedded-object-storage-credentials"
+
+    helm_template embedded-renamed "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set-string externalDependencies.objectStorage.endpoint= \
+        --set-string secrets.objectStorage.existingSecret= \
+        --set seaweedfs.fullnameOverride=custom-storage \
+        >"$TEST_DIRECTORY/osmo-embedded-renamed.yaml"
+    require_deployment "$TEST_DIRECTORY/osmo-embedded-renamed.yaml" \
+        custom-storage-all-in-one
+    require_resource "$TEST_DIRECTORY/osmo-embedded-renamed.yaml" Secret \
+        custom-storage-s3-secret
+    resource_document "$TEST_DIRECTORY/osmo-embedded-renamed.yaml" Job \
+        embedded-renamed-osmo-object-storage-bootstrap \
+        >"$TEST_DIRECTORY/osmo-embedded-renamed-bootstrap.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-renamed-bootstrap.yaml" \
+        "custom-storage-s3-secret"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-renamed.yaml" ConfigMap \
+        embedded-renamed-osmo-api-config \
+        >"$TEST_DIRECTORY/osmo-embedded-renamed-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-renamed-config.yaml" \
+        "override_url: http://custom-storage-all-in-one:8333"
+
+    helm_template embedded-mirror "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set-string externalDependencies.objectStorage.endpoint= \
+        --set-string secrets.objectStorage.existingSecret= \
+        --set imageRegistry=mirror.example.com \
+        >"$TEST_DIRECTORY/osmo-embedded-mirror.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-mirror.yaml" Job \
+        embedded-mirror-osmo-object-storage-bootstrap \
+        >"$TEST_DIRECTORY/osmo-embedded-mirror-bootstrap.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-mirror-bootstrap.yaml" \
+        'image: "mirror.example.com/alpine/kubectl:1.33.4"'
+
+    if helm_template embedded-generated-native-existing "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set-string externalDependencies.objectStorage.endpoint= \
+        --set-string secrets.objectStorage.existingSecret= \
+        --set seaweedfs.s3.existingConfigSecret=native-existing \
+        >"$TEST_DIRECTORY/embedded-generated-native-existing.out" 2>&1; then
+        fail "expected generated credentials with a native existing Secret to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-generated-native-existing.out" \
+        "generated credentials cannot configure a SeaweedFS existingConfigSecret"
+
+    if helm_template embedded-generated-all-in-one-existing "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set-string externalDependencies.objectStorage.endpoint= \
+        --set-string secrets.objectStorage.existingSecret= \
+        --set seaweedfs.allInOne.s3.existingConfigSecret=native-existing \
+        >"$TEST_DIRECTORY/embedded-generated-all-in-one-existing.out" 2>&1; then
+        fail "expected generated credentials with an all-in-one existing Secret to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-generated-all-in-one-existing.out" \
+        "generated credentials cannot configure a SeaweedFS existingConfigSecret"
+
+    if helm_template embedded-existing-mismatch "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set secrets.objectStorage.generate=false \
+        --set secrets.objectStorage.existingSecret=embedded-object-storage-existing \
+        >"$TEST_DIRECTORY/embedded-existing-mismatch.out" 2>&1; then
+        fail "expected mismatched embedded existing Secret references to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-existing-mismatch.out" \
+        "seaweedfs.s3.existingConfigSecret must match secrets.objectStorage.existingSecret"
+
+    helm_template embedded-existing "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set secrets.objectStorage.generate=false \
+        --set secrets.objectStorage.existingSecret=embedded-object-storage-existing \
+        --set seaweedfs.s3.existingConfigSecret=embedded-object-storage-existing \
+        >"$TEST_DIRECTORY/osmo-embedded-existing.yaml"
+    require_not_contains "$TEST_DIRECTORY/osmo-embedded-existing.yaml" \
+        "object-storage-bootstrap"
+    require_no_resource "$TEST_DIRECTORY/osmo-embedded-existing.yaml" Secret \
+        embedded-object-storage-existing
+    require_no_resource "$TEST_DIRECTORY/osmo-embedded-existing.yaml" Secret \
+        embedded-existing-seaweedfs-s3-secret
+    require_contains "$TEST_DIRECTORY/osmo-embedded-existing.yaml" \
+        "secretName: embedded-object-storage-existing"
+
+    if helm_template embedded-existing-all-in-one-mismatch "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set secrets.objectStorage.generate=false \
+        --set secrets.objectStorage.existingSecret=embedded-object-storage-existing \
+        --set seaweedfs.s3.existingConfigSecret=embedded-object-storage-existing \
+        --set seaweedfs.allInOne.s3.existingConfigSecret=other-existing \
+        >"$TEST_DIRECTORY/embedded-existing-all-in-one-mismatch.out" 2>&1; then
+        fail "expected mismatched all-in-one embedded Secret reference to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-existing-all-in-one-mismatch.out" \
+        "seaweedfs.allInOne.s3.existingConfigSecret must be empty or match secrets.objectStorage.existingSecret"
+
+    if helm_template embedded-conflicting-credentials "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set secrets.objectStorage.existingSecret=embedded-object-storage-existing \
+        >"$TEST_DIRECTORY/embedded-conflicting-credentials.out" 2>&1; then
+        fail "expected conflicting embedded credential sources to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-conflicting-credentials.out" \
+        "generate and existingSecret are mutually exclusive"
+
+    if helm_template embedded-native-auth-disabled "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set-string externalDependencies.objectStorage.endpoint= \
+        --set-string secrets.objectStorage.existingSecret= \
+        --set seaweedfs.s3.enableAuth=false \
+        >"$TEST_DIRECTORY/embedded-native-auth-disabled.out" 2>&1; then
+        fail "expected generated storage without native SeaweedFS auth to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-native-auth-disabled.out" \
+        "seaweedfs.s3.enableAuth must be true for generated credentials"
+
+    if helm_template embedded-inline-credentials "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set embeddedDependencies.objectStorage.enabled=true \
+        --set-string externalDependencies.objectStorage.endpoint= \
+        --set-string secrets.objectStorage.existingSecret= \
+        --set-string seaweedfs.s3.credentials.admin.accessKey=plaintext \
+        --set-string seaweedfs.s3.credentials.admin.secretKey=plaintext \
+        >"$TEST_DIRECTORY/embedded-inline-credentials.out" 2>&1; then
+        fail "expected inline SeaweedFS credentials to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-inline-credentials.out" \
+        "inline SeaweedFS credentials are not supported"
+
+    local embedded_ha_values="$CHARTS_ROOT/osmo/embedded-seaweedfs-ha-values.yaml"
+    [[ -f "$embedded_ha_values" ]] || \
+        fail "expected distributed embedded storage values at $embedded_ha_values"
+    helm_template ha "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$embedded_ha_values" \
+        >"$TEST_DIRECTORY/osmo-embedded-ha.yaml"
+    require_no_deployment "$TEST_DIRECTORY/osmo-embedded-ha.yaml" \
+        "ha-seaweedfs-all-in-one"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-ha.yaml" StatefulSet \
+        ha-seaweedfs-master >"$TEST_DIRECTORY/osmo-embedded-ha-master.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-master.yaml" "replicas: 3"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-master.yaml" \
+        "volumeClaimTemplates:"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-ha.yaml" StatefulSet \
+        ha-seaweedfs-volume >"$TEST_DIRECTORY/osmo-embedded-ha-volume.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-volume.yaml" "replicas: 3"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-volume.yaml" \
+        "volumeClaimTemplates:"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-volume.yaml" \
+        "requiredDuringSchedulingIgnoredDuringExecution:"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-ha.yaml" StatefulSet \
+        ha-seaweedfs-filer >"$TEST_DIRECTORY/osmo-embedded-ha-filer.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-filer.yaml" "replicas: 2"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-filer.yaml" \
+        'value: "true"'
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-filer.yaml" \
+        "name: WEED_POSTGRES_PASSWORD"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-ha.yaml" Deployment \
+        ha-seaweedfs-s3 >"$TEST_DIRECTORY/osmo-embedded-ha-s3.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-s3.yaml" "replicas: 2"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha-s3.yaml" \
+        "secretName: osmo-seaweedfs-s3"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha.yaml" \
+        "-defaultReplication=001"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha.yaml" \
+        "s3.bucket.create --name osmo-workflows"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-ha.yaml" \
+        "override_url: http://ha-seaweedfs-s3:8333"
+    require_no_resource "$TEST_DIRECTORY/osmo-embedded-ha.yaml" Secret \
+        osmo-seaweedfs-s3
+
+    if helm_template unsafe-generated-ha "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$embedded_ha_values" \
+        --set secrets.objectStorage.generate=true \
+        --set-string secrets.objectStorage.existingSecret= \
+        --set-string seaweedfs.s3.existingConfigSecret= \
+        >"$TEST_DIRECTORY/unsafe-generated-ha.out" 2>&1; then
+        fail "expected generated credentials with distributed SeaweedFS to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/unsafe-generated-ha.out" \
+        "generated credentials are supported only with seaweedfs.allInOne.enabled"
 
     cat >"$charts_copy/osmo/templates/postgresql-helper-contract.yaml" <<'EOF'
 {{- if .Values.embeddedDependencies.postgresql.enabled }}
@@ -2295,6 +2614,7 @@ case "$MODE" in
     osmo|all)
         test_yaml_helpers
         require_clean_osmo_sources
+        bash "$CHARTS_ROOT/osmo/tests/test_object_storage_bootstrap.sh"
         test_control_umbrella
         ;;
     *)

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -17,12 +17,16 @@
       "properties": {
         "postgresql": { "$ref": "#/definitions/enabledBlock" },
         "valkey": { "$ref": "#/definitions/enabledBlock" },
-        "objectStorage": { "$ref": "#/definitions/enabledBlock" },
+        "objectStorage": { "$ref": "#/definitions/embeddedObjectStorage" },
         "kaiScheduler": { "$ref": "#/definitions/enabledBlock" }
       }
     },
     "valkey": { "type": "object" },
     "postgresql": { "type": "object" },
+    "seaweedfs": {
+      "type": "object",
+      "description": "Values passed through to the pinned SeaweedFS dependency."
+    },
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "imageRegistry": { "type": "string" },
@@ -104,6 +108,21 @@
       "type": "object",
       "properties": { "enabled": { "type": "boolean" } },
       "required": ["enabled"]
+    },
+    "embeddedObjectStorage": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "bootstrap": {
+          "type": "object",
+          "properties": {
+            "image": { "$ref": "#/definitions/componentImage" },
+            "resources": { "type": "object" }
+          },
+          "required": ["image"]
+        }
+      },
+      "required": ["enabled", "bootstrap"]
     },
     "stringMap": {
       "type": "object",

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -14,7 +14,7 @@ planes:
 
 # Select supporting systems managed by this Helm release. Embedded PostgreSQL
 # requires a compatible CloudNativePG operator to be installed first. Embedded
-# Valkey is managed directly by this release.
+# Valkey and S3-compatible object storage are managed directly by this release.
 embeddedDependencies:
   postgresql:
     enabled: false
@@ -22,8 +22,98 @@ embeddedDependencies:
     enabled: false
   objectStorage:
     enabled: false
+    bootstrap:
+      image:
+        registry: ''
+        repository: alpine/kubectl
+        tag: 1.33.4
+        digest: ''
+        pullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
   kaiScheduler:
     enabled: false
+
+# Pinned SeaweedFS dependency defaults. These values intentionally select a
+# persistent, single-pod topology that also works on one-node clusters. It is
+# not highly available; use embedded-seaweedfs-ha-values.yaml as the starting
+# point for a failure-domain-aware production deployment.
+seaweedfs:
+  global:
+    seaweedfs:
+      createClusterRole: false
+      serviceAccountName: osmo-seaweedfs
+      automountServiceAccountToken: false
+      securityConfig:
+        jwtSigning:
+          volumeWrite: false
+          volumeRead: false
+          filerWrite: false
+          filerRead: false
+  master:
+    enabled: false
+  volume:
+    enabled: false
+  filer:
+    enabled: false
+  s3:
+    enabled: false
+    # The dependency's retained hook owns generated S3 credentials. OSMO's
+    # bootstrap bridge derives object-storage.yaml from its admin identity.
+    enableAuth: true
+  allInOne:
+    enabled: true
+    affinity: ''
+    data:
+      type: persistentVolumeClaim
+      size: 10Gi
+      storageClass: null
+      accessModes:
+      - ReadWriteOnce
+      annotations:
+        helm.sh/resource-policy: keep
+    s3:
+      enabled: true
+      enableAuth: true
+      createBuckets:
+      - name: osmo-workflows
+      - name: osmo-logs
+      - name: osmo-apps
+      createBucketsHook:
+        resources:
+          requests:
+            cpu: 25m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+    podSecurityContext:
+      enabled: true
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+    containerSecurityContext:
+      enabled: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        memory: 2Gi
 
 # Connection details for dependencies owned outside this release. Each
 # endpoint is required only when its embedded dependency is disabled.
@@ -162,8 +252,8 @@ monitoring:
 # References to Kubernetes Secrets. Inline credentials are not accepted.
 # Embedded PostgreSQL credentials are owned by
 # postgresql.cluster.initdb.secret.name. These Secret settings are external-only
-# for PostgreSQL. Generated credentials are supported by embedded Valkey; other
-# `generate` switches must remain false.
+# for PostgreSQL. Generated credentials are supported by embedded Valkey and
+# embedded object storage; other `generate` switches must remain false.
 secrets:
   # Credentials for external PostgreSQL. Embedded PostgreSQL credentials are
   # created by CloudNativePG or configured with
@@ -183,7 +273,7 @@ secrets:
       password: redis-password
   # Storage SDK configuration file mounted for all three object-storage uses.
   objectStorage:
-    generate: false
+    generate: true
     existingSecret: ''
     keys:
       credentials: object-storage.yaml


### PR DESCRIPTION
## Description
Add embedded seaweedfs to umbrella chart

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional embedded SeaweedFS object storage with single-node and highly available configurations.
  * Added automatic credential synchronization, bucket provisioning, persistent storage, and support for existing secrets.
  * Added configuration options for external or embedded object storage, scaling, security, and recovery guidance.

* **Bug Fixes**
  * Improved validation for object-storage credentials, endpoints, buckets, and deployment settings.

* **Documentation**
  * Added comprehensive guidance for installation, configuration, operations, and recovery.

* **Tests**
  * Expanded chart tests covering packaging, rendering, bootstrap behavior, upgrades, and credential handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->