### PR TITLE
Add embedded postgres to umbrella chart

### DIFF
--- a/.github/workflows/helm-chart-lint.yaml
+++ b/.github/workflows/helm-chart-lint.yaml
@@ -102,6 +102,9 @@ jobs:
           CHART: ${{ matrix.chart }}
         run: |
           echo "Building dependencies for: $CHART"
+          if [ "$CHART" = "osmo" ]; then
+            helm repo add cnpg https://cloudnative-pg.github.io/charts
+          fi
           helm dependency build "deployments/charts/$CHART" || true
           # Show what was fetched
           if [ -d "deployments/charts/$CHART/charts" ]; then

--- a/deployments/charts/osmo/Chart.lock
+++ b/deployments/charts/osmo/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: valkey
   repository: oci://ghcr.io/valkey-io/valkey-helm
   version: 0.11.0
-digest: sha256:ae07432cf278943cbce1cc10870f47daf360653e2554d115dfeb91bd380eaaab
-generated: "2026-08-13T09:31:35.816536897-04:00"
+- name: cluster
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.8.0
+digest: sha256:833a704e62d5ef4e34f9a33c45932d84ba53f1a370f504bd45daf112ef71282f
+generated: "2026-08-14T15:30:28.185960161-04:00"

--- a/deployments/charts/osmo/Chart.yaml
+++ b/deployments/charts/osmo/Chart.yaml
@@ -22,3 +22,8 @@ dependencies:
   version: 0.11.0
   repository: oci://ghcr.io/valkey-io/valkey-helm
   condition: embeddedDependencies.valkey.enabled
+- name: cluster
+  alias: postgresql
+  version: 0.8.0
+  repository: https://cloudnative-pg.github.io/charts
+  condition: embeddedDependencies.postgresql.enabled

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -125,12 +125,15 @@ instances again:
 ```bash
 primary=$(kubectl --namespace osmo get cluster osmo-postgresql \
   -o jsonpath='{.status.currentPrimary}')
-kubectl --namespace osmo delete pod "$primary"
-kubectl --namespace osmo wait pod \
-  --for=condition=Ready \
-  --selector=cnpg.io/cluster=osmo-postgresql \
+kubectl --namespace osmo delete pod "$primary" \
+  --grace-period=0 --force --wait=false
+kubectl --namespace osmo wait cluster/osmo-postgresql \
+  --for=jsonpath='{.status.phase}'='Cluster in healthy state' \
   --timeout=10m
 ```
+
+The forced deletion deliberately simulates abrupt instance failure and should
+never be used as a routine restart procedure.
 
 Scale by changing `postgresql.cluster.instances` and running `helm upgrade`.
 Add nodes/topology domains before scaling up so anti-affinity can place the new

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -18,9 +18,9 @@ dependencies remain future work.
 ## CloudNativePG prerequisite
 
 Embedded PostgreSQL requires the official CloudNativePG operator and CRDs.
-Install the pinned, Apache-2.0 CloudNativePG operator chart once per Kubernetes
-cluster before installing OSMO. The operator watches OSMO namespaces but has a
-separate Helm lifecycle:
+Install the pinned, Apache-2.0 CloudNativePG operator chart `0.29.0`
+(CloudNativePG `1.30.0`) once per Kubernetes cluster before installing OSMO.
+The operator watches OSMO namespaces but has a separate Helm lifecycle:
 
 ```bash
 helm repo add cnpg https://cloudnative-pg.github.io/charts
@@ -99,17 +99,21 @@ OSMO connects only to the stable `<release>-postgresql-rw` service. CNPG
 creates the application credential Secret (normally
 `<release>-postgresql-app`) and CA Secret, and OSMO uses certificate
 verification for every database connection. The generated database and owner
-are both `osmo` by default.
+are both `osmo` by default. Embedded PostgreSQL must remain in the OSMO release
+namespace. When `postgresql.cluster.certificates.serverCASecret` supplies a
+custom CNPG server CA, OSMO mounts `ca.crt` from that Secret automatically.
 
 ## High availability and operations
 
-The production defaults spread instances by `kubernetes.io/hostname`, enable a
-PodDisruptionBudget, and require quorum-based synchronous replication with
-`ANY 1`: a commit must be acknowledged by one standby. CNPG performs automatic
-failover and uses an unsupervised switchover when updating the primary. Loss of
-the primary should therefore promote a healthy standby; loss of enough
-instances to satisfy the synchronous requirement intentionally stops writes
-rather than acknowledging data that has not reached a standby.
+The production defaults require instances to run on different
+`kubernetes.io/hostname` values, enable a PodDisruptionBudget, and require
+quorum-based synchronous replication with `ANY 1`: a commit must be
+acknowledged by one standby. At least three schedulable nodes are therefore
+required for the default cluster. CNPG performs automatic failover and uses an
+unsupervised switchover when updating the primary. Loss of the primary should
+promote a healthy standby; loss of enough instances to satisfy the synchronous
+requirement intentionally stops writes rather than acknowledging data that has
+not reached a standby.
 
 Inspect the cluster and its persistent storage with:
 

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -66,7 +66,7 @@ Leaving `postgresql.cluster.initdb.secret.name` empty lets CloudNativePG create
 `<cluster>-app`.
 Set `postgresql.cluster.storage.storageClass` when the cluster default is not
 the desired durable StorageClass. See the
-[CloudNativePG cluster chart](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster)
+[CloudNativePG cluster chart](https://github.com/cloudnative-pg/charts/tree/cluster-v0.8.0/charts/cluster)
 for additional `postgresql` values.
 
 For resource-constrained development, explicitly relax the production settings:

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -15,16 +15,12 @@ to an external Valkey service. Object storage and the remaining Kubernetes
 Secrets are externally managed. Compute-plane workloads and the other embedded
 dependencies remain future work.
 
-## CloudNativePG prerequisite
+## Embedded PostgreSQL
 
-Embedded PostgreSQL requires the official CloudNativePG operator and CRDs.
-Install the pinned, Apache-2.0 CloudNativePG operator chart `0.29.0`
-(CloudNativePG `1.30.0`) once per Kubernetes cluster before installing OSMO.
-The operator watches OSMO namespaces but has a separate Helm lifecycle:
+Embedded PostgreSQL requires CloudNativePG chart `0.29.0` (operator `1.30.0`):
 
 ```bash
 helm repo add cnpg https://cloudnative-pg.github.io/charts
-helm repo update cnpg
 helm upgrade --install osmo-cnpg cnpg/cloudnative-pg \
   --version 0.29.0 \
   --namespace cnpg-system \
@@ -32,73 +28,28 @@ helm upgrade --install osmo-cnpg cnpg/cloudnative-pg \
   --wait
 ```
 
-The OSMO chart declares the official CloudNativePG `cluster` chart at version
-`0.8.0`, which creates a `Cluster` custom resource. Published OSMO chart
-packages include that dependency. The source repository stores `Chart.lock`
-for reproducible dependency resolution but does not store downloaded chart
-archives. Build them before installing directly from a source checkout:
-
-```bash
-helm dependency build deployments/charts/osmo
-```
-
-The OSMO chart does not install or upgrade the operator. The default PostgreSQL
-16 image is obtained from the CloudNativePG project on GHCR. Confirm that the
-operator and database images are mirrored or pullable in restricted
-environments.
-
-The embedded-mode preflight checks the discovered CNPG API. For offline render
-validation, supply that capability explicitly (this Helm version does not
-provide the equivalent flag on `helm lint`):
-
-```bash
-helm template osmo deployments/charts/osmo \
-  --api-versions postgresql.cnpg.io/v1 \
-  -f deployments/charts/osmo/profiles/split-plane-control.yaml \
-  -f <embedded-environment-values.yaml>
-```
-
-## Installation with embedded PostgreSQL
-
-Enable the dependency in the same environment values file used for OSMO:
+Add the following PostgreSQL settings to the environment values used with the
+`split-plane-control` profile:
 
 ```yaml
 embeddedDependencies:
   postgresql:
     enabled: true
 
-externalUrl: https://osmo.example.com
-
 externalDependencies:
   postgresql:
     host: ''
-  valkey:
-    host: valkey.example.com
-    port: 6379
-    database: 0
-  objectStorage:
-    endpoint: https://s3.example.com
-    region: us-east-1
-    buckets:
-      workflows: osmo-workflows
-      logs: osmo-logs
-      apps: osmo-apps
 
 secrets:
   postgresql:
     generate: true
     existingSecret: ''
-  valkey:
-    existingSecret: osmo-valkey
-  objectStorage:
-    existingSecret: osmo-object-storage
-  masterEncryptionKey:
-    existingSecret: osmo-master-encryption-key
 ```
 
-Install OSMO after the operator is Ready:
+Install the chart after the operator is Ready:
 
 ```bash
+helm dependency build deployments/charts/osmo
 helm upgrade --install osmo deployments/charts/osmo \
   --namespace osmo \
   --create-namespace \
@@ -108,79 +59,33 @@ helm upgrade --install osmo deployments/charts/osmo \
   --timeout 25m
 ```
 
-The production defaults create three PostgreSQL 16 instances. Each instance
-has its own 20 Gi `ReadWriteOnce` PVC, using the cluster's default StorageClass,
-and requests and limits one CPU and 2 Gi memory for Guaranteed QoS. Override
-`postgresql.cluster.storage.storageClass` when the default class is not the
-durable storage class intended for database data. Separate WAL storage is
-available through `postgresql.cluster.walStorage`, but is disabled by default.
+The defaults create three PostgreSQL 16 instances with one 20 Gi
+`ReadWriteOnce` PVC per instance, required hostname anti-affinity, a
+PodDisruptionBudget, and synchronous replication to one standby. A generated
+application Secret is wired into every OSMO PostgreSQL client automatically.
+Set `postgresql.cluster.storage.storageClass` when the cluster default is not
+the desired durable StorageClass. See the
+[CloudNativePG cluster chart](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster)
+for additional `postgresql` values.
 
-OSMO connects only to the stable `<release>-postgresql-rw` service. CNPG
-creates the application credential Secret (normally
-`<release>-postgresql-app`) and CA Secret, and OSMO uses certificate
-verification for every database connection. The generated database and owner
-are both `osmo` by default. Embedded PostgreSQL must remain in the OSMO release
-namespace. When `postgresql.cluster.certificates.serverCASecret` supplies a
-custom CNPG server CA, OSMO mounts `ca.crt` from that Secret automatically.
+### PostgreSQL operations
 
-## High availability and operations
+- **Health and failure recovery:** Check `kubectl --namespace osmo get
+  clusters.postgresql.cnpg.io,pods,pvc,pdb`. CloudNativePG promotes a healthy
+  standby after primary failure; wait for the cluster to return to three Ready
+  instances before considering recovery complete.
+- **Scaling:** Change `postgresql.cluster.instances` and run `helm upgrade`.
+  Ensure enough topology domains exist for required anti-affinity before
+  scaling up, and verify replication health before scaling down.
+- **Upgrades:** Upgrade through `helm upgrade`. Keep PostgreSQL on the configured
+  major version for rolling updates; major-version changes require a separate
+  data-migration plan.
+- **Backup and restore:** PVCs survive Pod replacement but are not backups.
+  Embedded backup/restore is deferred to
+  [OSMO-6609](https://jirasw.nvidia.com/browse/OSMO-6609); use an external
+  PostgreSQL service when a tested backup and restore path is required.
 
-The production defaults require instances to run on different
-`kubernetes.io/hostname` values, enable a PodDisruptionBudget, and require
-quorum-based synchronous replication with `ANY 1`: a commit must be
-acknowledged by one standby. At least three schedulable nodes are therefore
-required for the default cluster. CNPG performs automatic failover and uses an
-unsupervised switchover when updating the primary. Loss of the primary should
-promote a healthy standby; loss of enough instances to satisfy the synchronous
-requirement intentionally stops writes rather than acknowledging data that has
-not reached a standby.
-
-Inspect the cluster and its persistent storage with:
-
-```bash
-kubectl --namespace osmo get clusters.postgresql.cnpg.io,pods,pvc,pdb
-kubectl --namespace osmo describe cluster osmo-postgresql
-```
-
-To exercise recovery in a non-production environment, record the current
-primary, delete that Pod, and wait for the cluster to report three Ready
-instances again:
-
-```bash
-primary=$(kubectl --namespace osmo get cluster osmo-postgresql \
-  -o jsonpath='{.status.currentPrimary}')
-kubectl --namespace osmo delete pod "$primary" \
-  --grace-period=0 --force --wait=false
-kubectl --namespace osmo wait cluster/osmo-postgresql \
-  --for=jsonpath='{.status.phase}'='Cluster in healthy state' \
-  --timeout=10m
-```
-
-The forced deletion deliberately simulates abrupt instance failure and should
-never be used as a routine restart procedure.
-
-Scale by changing `postgresql.cluster.instances` and running `helm upgrade`.
-Add nodes/topology domains before scaling up so anti-affinity can place the new
-instances. Before scaling down, verify replication health and confirm that the
-PVCs selected for removal contain no uniquely required data.
-
-Routine image changes within the configured PostgreSQL major version roll
-through replicas and finish with a primary switchover. Upgrade the
-CloudNativePG operator using its own pinned Helm release, review its supported
-upgrade path, and wait for it to become Ready before upgrading OSMO. A
-PostgreSQL major-version change is a data migration, not a routine image
-upgrade; create and validate a migration/recovery plan first.
-
-PVCs preserve data across Pod replacement. They are not backups, and deleting
-the CNPG `Cluster` (including through `helm uninstall`) can delete its owned
-PVCs. Embedded backup, restore, and point-in-time recovery configuration is
-deliberately rejected in this chart and is tracked by
-[OSMO-6609](https://jirasw.nvidia.com/browse/OSMO-6609). Do not use embedded
-PostgreSQL for production data until an independent, tested backup and restore
-procedure is in place.
-
-For resource-constrained development only, a single instance can be rendered
-by explicitly relaxing durability and disabling the PDB:
+For resource-constrained development, explicitly relax the production settings:
 
 ```yaml
 postgresql:
@@ -192,8 +97,6 @@ postgresql:
         number: 0
         dataDurability: preferred
 ```
-
-This is not a highly available or production-ready configuration.
 
 ## Install the control plane with external PostgreSQL
 
@@ -246,10 +149,6 @@ helm upgrade --install osmo deployments/charts/osmo \
   --wait \
   --timeout 25m
 ```
-
-The dependency build is only needed for a source checkout. Packaged charts
-include the official Valkey chart version `0.11.0` and CloudNativePG cluster
-chart version `0.8.0`.
 
 ## Embedded Valkey
 
@@ -325,10 +224,8 @@ may reference a separate Secret. The defaults expect these keys:
 | `secrets.objectStorage` | `object-storage.yaml` | Workflow data, logs, and apps |
 | `secrets.masterEncryptionKey` | `mek.yaml` | OSMO encryption-key configuration |
 
-For an existing embedded PostgreSQL credential, CNPG requires a
-`kubernetes.io/basic-auth` Secret with `username` and `password` keys. The
-username must match `postgresql.cluster.initdb.owner`. Set both OSMO references
-to the same Secret:
+To use an existing credential Secret, provide a `kubernetes.io/basic-auth`
+Secret whose `username` matches `postgresql.cluster.initdb.owner`, then set:
 
 ```yaml
 secrets:
@@ -347,13 +244,11 @@ postgresql:
         name: osmo-postgresql-credentials
 ```
 
-Except for the generated CNPG application credentials, the chart only reads
-operator-owned Secrets. It does not mutate or delete external Secrets. When an
-external PostgreSQL or Valkey service uses a private CA, enable TLS in the
-matching `externalDependencies` block and reference the CA Secret there. The
-Valkey `caKey` must hold a complete PEM trust bundle, including the public or
-system roots used by other HTTPS endpoints; OSMO's Python services consume that
-bundle through `SSL_CERT_FILE`. The default Valkey key is `ca-bundle.crt`.
+When an external PostgreSQL or Valkey service uses a private CA, enable TLS in
+the matching `externalDependencies` block and reference the CA Secret there.
+The Valkey `caKey` must hold a complete PEM trust bundle, including the public
+or system roots used by other HTTPS endpoints; OSMO's Python services consume
+that bundle through `SSL_CERT_FILE`. The default Valkey key is `ca-bundle.crt`.
 
 For an external Valkey endpoint signed by a public CA, leave
 `caExistingSecret` empty to use the image's system trust store.

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -81,8 +81,7 @@ for additional `postgresql` values.
   major version for rolling updates; major-version changes require a separate
   data-migration plan.
 - **Backup and restore:** PVCs survive Pod replacement but are not backups.
-  Embedded backup/restore is deferred to
-  [OSMO-6609](https://jirasw.nvidia.com/browse/OSMO-6609); use an external
+  Embedded backup/restore is not currently supported; use an external
   PostgreSQL service when a tested backup and restore path is required.
 
 For resource-constrained development, explicitly relax the production settings:

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -69,22 +69,6 @@ the desired durable StorageClass. See the
 [CloudNativePG cluster chart](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster)
 for additional `postgresql` values.
 
-### PostgreSQL operations
-
-- **Health and failure recovery:** Check `kubectl --namespace osmo get
-  clusters.postgresql.cnpg.io,pods,pvc,pdb`. CloudNativePG promotes a healthy
-  standby after primary failure; wait for the cluster to return to three Ready
-  instances before considering recovery complete.
-- **Scaling:** Change `postgresql.cluster.instances` and run `helm upgrade`.
-  Ensure enough topology domains exist for required anti-affinity before
-  scaling up, and verify replication health before scaling down.
-- **Upgrades:** Upgrade through `helm upgrade`. Keep PostgreSQL on the configured
-  major version for rolling updates; major-version changes require a separate
-  data-migration plan.
-- **Backup and restore:** PVCs survive Pod replacement but are not backups.
-  Embedded backup/restore is not currently supported; use an external
-  PostgreSQL service when a tested backup and restore path is required.
-
 For resource-constrained development, explicitly relax the production settings:
 
 ```yaml

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -42,7 +42,6 @@ externalDependencies:
 
 secrets:
   postgresql:
-    generate: true
     existingSecret: ''
 ```
 
@@ -63,6 +62,8 @@ The defaults create three PostgreSQL 16 instances with one 20 Gi
 `ReadWriteOnce` PVC per instance, required hostname anti-affinity, a
 PodDisruptionBudget, and synchronous replication to one standby. A generated
 application Secret is wired into every OSMO PostgreSQL client automatically.
+Leaving `postgresql.cluster.initdb.secret.name` empty lets CloudNativePG create
+`<cluster>-app`.
 Set `postgresql.cluster.storage.storageClass` when the cluster default is not
 the desired durable StorageClass. See the
 [CloudNativePG cluster chart](https://github.com/cloudnative-pg/charts/tree/main/charts/cluster)
@@ -125,7 +126,6 @@ externalDependencies:
 
 secrets:
   postgresql:
-    generate: false
     existingSecret: osmo-postgresql
   valkey:
     existingSecret: osmo-valkey
@@ -223,22 +223,14 @@ may reference a separate Secret. The defaults expect these keys:
 | `secrets.objectStorage` | `object-storage.yaml` | Workflow data, logs, and apps |
 | `secrets.masterEncryptionKey` | `mek.yaml` | OSMO encryption-key configuration |
 
-To use an existing credential Secret, provide a `kubernetes.io/basic-auth`
-Secret whose `username` matches `postgresql.cluster.initdb.owner`, then set:
+To use an existing embedded PostgreSQL credential Secret, provide a
+`kubernetes.io/basic-auth` Secret whose `username` matches
+`postgresql.cluster.initdb.owner`, then set:
 
 ```yaml
-secrets:
-  postgresql:
-    generate: false
-    existingSecret: osmo-postgresql-credentials
-    keys:
-      username: username
-      password: password
 postgresql:
   cluster:
     initdb:
-      database: osmo
-      owner: osmo
       secret:
         name: osmo-postgresql-credentials
 ```

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -38,6 +38,17 @@ upgrade the operator. The default PostgreSQL 16 image is obtained from the
 CloudNativePG project on GHCR. Confirm that the operator and database images
 are mirrored or pullable in restricted environments.
 
+The embedded-mode preflight checks the discovered CNPG API. For offline render
+validation, supply that capability explicitly (this Helm version does not
+provide the equivalent flag on `helm lint`):
+
+```bash
+helm template osmo deployments/charts/osmo \
+  --api-versions postgresql.cnpg.io/v1 \
+  -f deployments/charts/osmo/profiles/split-plane-control.yaml \
+  -f <embedded-environment-values.yaml>
+```
+
 ## Installation with embedded PostgreSQL
 
 Enable the dependency in the same environment values file used for OSMO:

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -32,11 +32,20 @@ helm upgrade --install osmo-cnpg cnpg/cloudnative-pg \
   --wait
 ```
 
-The OSMO chart vendors the official CloudNativePG `cluster` chart at version
-`0.8.0`, which creates a `Cluster` custom resource. It does not install or
-upgrade the operator. The default PostgreSQL 16 image is obtained from the
-CloudNativePG project on GHCR. Confirm that the operator and database images
-are mirrored or pullable in restricted environments.
+The OSMO chart declares the official CloudNativePG `cluster` chart at version
+`0.8.0`, which creates a `Cluster` custom resource. Published OSMO chart
+packages include that dependency. The source repository stores `Chart.lock`
+for reproducible dependency resolution but does not store downloaded chart
+archives. Build them before installing directly from a source checkout:
+
+```bash
+helm dependency build deployments/charts/osmo
+```
+
+The OSMO chart does not install or upgrade the operator. The default PostgreSQL
+16 image is obtained from the CloudNativePG project on GHCR. Confirm that the
+operator and database images are mirrored or pullable in restricted
+environments.
 
 The embedded-mode preflight checks the discovered CNPG API. For offline render
 validation, supply that capability explicitly (this Helm version does not

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -7,11 +7,168 @@ SPDX-License-Identifier: Apache-2.0
 
 The `osmo` chart is the unified OSMO deployment entry point.
 
-The chart currently deploys the OSMO control-plane services and gateway, with
-an optional embedded Valkey dependency. Compute-plane workloads and other
-dependencies will be added in future work.
+The supported `split-plane-control` profile installs the API, UI, router,
+worker, logger, agent, delayed-job monitor, and standalone OSMO gateway. It
+can create a persistent PostgreSQL cluster through CloudNativePG or connect to
+an external PostgreSQL service, and it can deploy embedded Valkey or connect
+to an external Valkey service. Object storage and the remaining Kubernetes
+Secrets are externally managed. Compute-plane workloads and the other embedded
+dependencies remain future work.
 
-## Install the control plane
+## CloudNativePG prerequisite
+
+Embedded PostgreSQL requires the official CloudNativePG operator and CRDs.
+Install the pinned, Apache-2.0 CloudNativePG operator chart once per Kubernetes
+cluster before installing OSMO. The operator watches OSMO namespaces but has a
+separate Helm lifecycle:
+
+```bash
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update cnpg
+helm upgrade --install osmo-cnpg cnpg/cloudnative-pg \
+  --version 0.29.0 \
+  --namespace cnpg-system \
+  --create-namespace \
+  --wait
+```
+
+The OSMO chart vendors the official CloudNativePG `cluster` chart at version
+`0.8.0`, which creates a `Cluster` custom resource. It does not install or
+upgrade the operator. The default PostgreSQL 16 image is obtained from the
+CloudNativePG project on GHCR. Confirm that the operator and database images
+are mirrored or pullable in restricted environments.
+
+## Installation with embedded PostgreSQL
+
+Enable the dependency in the same environment values file used for OSMO:
+
+```yaml
+embeddedDependencies:
+  postgresql:
+    enabled: true
+
+externalUrl: https://osmo.example.com
+
+externalDependencies:
+  postgresql:
+    host: ''
+  valkey:
+    host: valkey.example.com
+    port: 6379
+    database: 0
+  objectStorage:
+    endpoint: https://s3.example.com
+    region: us-east-1
+    buckets:
+      workflows: osmo-workflows
+      logs: osmo-logs
+      apps: osmo-apps
+
+secrets:
+  postgresql:
+    generate: true
+    existingSecret: ''
+  valkey:
+    existingSecret: osmo-valkey
+  objectStorage:
+    existingSecret: osmo-object-storage
+  masterEncryptionKey:
+    existingSecret: osmo-master-encryption-key
+```
+
+Install OSMO after the operator is Ready:
+
+```bash
+helm upgrade --install osmo deployments/charts/osmo \
+  --namespace osmo \
+  --create-namespace \
+  -f deployments/charts/osmo/profiles/split-plane-control.yaml \
+  -f <environment-values.yaml> \
+  --wait \
+  --timeout 25m
+```
+
+The production defaults create three PostgreSQL 16 instances. Each instance
+has its own 20 Gi `ReadWriteOnce` PVC, using the cluster's default StorageClass,
+and requests and limits one CPU and 2 Gi memory for Guaranteed QoS. Override
+`postgresql.cluster.storage.storageClass` when the default class is not the
+durable storage class intended for database data. Separate WAL storage is
+available through `postgresql.cluster.walStorage`, but is disabled by default.
+
+OSMO connects only to the stable `<release>-postgresql-rw` service. CNPG
+creates the application credential Secret (normally
+`<release>-postgresql-app`) and CA Secret, and OSMO uses certificate
+verification for every database connection. The generated database and owner
+are both `osmo` by default.
+
+## High availability and operations
+
+The production defaults spread instances by `kubernetes.io/hostname`, enable a
+PodDisruptionBudget, and require quorum-based synchronous replication with
+`ANY 1`: a commit must be acknowledged by one standby. CNPG performs automatic
+failover and uses an unsupervised switchover when updating the primary. Loss of
+the primary should therefore promote a healthy standby; loss of enough
+instances to satisfy the synchronous requirement intentionally stops writes
+rather than acknowledging data that has not reached a standby.
+
+Inspect the cluster and its persistent storage with:
+
+```bash
+kubectl --namespace osmo get clusters.postgresql.cnpg.io,pods,pvc,pdb
+kubectl --namespace osmo describe cluster osmo-postgresql
+```
+
+To exercise recovery in a non-production environment, record the current
+primary, delete that Pod, and wait for the cluster to report three Ready
+instances again:
+
+```bash
+primary=$(kubectl --namespace osmo get cluster osmo-postgresql \
+  -o jsonpath='{.status.currentPrimary}')
+kubectl --namespace osmo delete pod "$primary"
+kubectl --namespace osmo wait pod \
+  --for=condition=Ready \
+  --selector=cnpg.io/cluster=osmo-postgresql \
+  --timeout=10m
+```
+
+Scale by changing `postgresql.cluster.instances` and running `helm upgrade`.
+Add nodes/topology domains before scaling up so anti-affinity can place the new
+instances. Before scaling down, verify replication health and confirm that the
+PVCs selected for removal contain no uniquely required data.
+
+Routine image changes within the configured PostgreSQL major version roll
+through replicas and finish with a primary switchover. Upgrade the
+CloudNativePG operator using its own pinned Helm release, review its supported
+upgrade path, and wait for it to become Ready before upgrading OSMO. A
+PostgreSQL major-version change is a data migration, not a routine image
+upgrade; create and validate a migration/recovery plan first.
+
+PVCs preserve data across Pod replacement. They are not backups, and deleting
+the CNPG `Cluster` (including through `helm uninstall`) can delete its owned
+PVCs. Embedded backup, restore, and point-in-time recovery configuration is
+deliberately rejected in this chart and is tracked by
+[OSMO-6609](https://jirasw.nvidia.com/browse/OSMO-6609). Do not use embedded
+PostgreSQL for production data until an independent, tested backup and restore
+procedure is in place.
+
+For resource-constrained development only, a single instance can be rendered
+by explicitly relaxing durability and disabling the PDB:
+
+```yaml
+postgresql:
+  cluster:
+    instances: 1
+    enablePDB: false
+    postgresql:
+      synchronous:
+        number: 0
+        dataDurability: preferred
+```
+
+This is not a highly available or production-ready configuration.
+
+## Install the control plane with external PostgreSQL
 
 Create an environment values file containing the external endpoints and
 Secret references:
@@ -39,6 +196,7 @@ externalDependencies:
 
 secrets:
   postgresql:
+    generate: false
     existingSecret: osmo-postgresql
   valkey:
     existingSecret: osmo-valkey
@@ -48,7 +206,8 @@ secrets:
     existingSecret: osmo-master-encryption-key
 ```
 
-Install the chart by layering the environment values after the profile:
+Keep `embeddedDependencies.postgresql.enabled: false` (the default), then
+install the chart by layering the environment values after the profile:
 
 ```bash
 helm dependency build deployments/charts/osmo
@@ -62,7 +221,8 @@ helm upgrade --install osmo deployments/charts/osmo \
 ```
 
 The dependency build is only needed for a source checkout. Packaged charts
-include the official `valkey/valkey` chart version `0.11.0`.
+include the official Valkey chart version `0.11.0` and CloudNativePG cluster
+chart version `0.8.0`.
 
 ## Embedded Valkey
 
@@ -133,17 +293,43 @@ may reference a separate Secret. The defaults expect these keys:
 
 | Values block | Default key | Consumer |
 | --- | --- | --- |
-| `secrets.postgresql` | `db-password` | PostgreSQL clients |
+| `secrets.postgresql` (external) | `db-password` | PostgreSQL clients |
 | `secrets.valkey` | `redis-password` | Valkey clients |
 | `secrets.objectStorage` | `object-storage.yaml` | Workflow data, logs, and apps |
 | `secrets.masterEncryptionKey` | `mek.yaml` | OSMO encryption-key configuration |
 
-For an external Valkey endpoint signed by a public CA, enable
-`externalDependencies.valkey.tls.enabled` and leave `caExistingSecret` empty to
-use the image's system trust store. For a private CA, set `caExistingSecret` and
-`caKey` in the same block. The selected key must contain the complete trust
-bundle because clients use it through `SSL_CERT_FILE`. PostgreSQL private CAs
-are also configured in its `externalDependencies` TLS block.
+For an existing embedded PostgreSQL credential, CNPG requires a
+`kubernetes.io/basic-auth` Secret with `username` and `password` keys. The
+username must match `postgresql.cluster.initdb.owner`. Set both OSMO references
+to the same Secret:
+
+```yaml
+secrets:
+  postgresql:
+    generate: false
+    existingSecret: osmo-postgresql-credentials
+    keys:
+      username: username
+      password: password
+postgresql:
+  cluster:
+    initdb:
+      database: osmo
+      owner: osmo
+      secret:
+        name: osmo-postgresql-credentials
+```
+
+Except for the generated CNPG application credentials, the chart only reads
+operator-owned Secrets. It does not mutate or delete external Secrets. When an
+external PostgreSQL or Valkey service uses a private CA, enable TLS in the
+matching `externalDependencies` block and reference the CA Secret there. The
+Valkey `caKey` must hold a complete PEM trust bundle, including the public or
+system roots used by other HTTPS endpoints; OSMO's Python services consume that
+bundle through `SSL_CERT_FILE`. The default Valkey key is `ca-bundle.crt`.
+
+For an external Valkey endpoint signed by a public CA, leave
+`caExistingSecret` empty to use the image's system trust store.
 
 ## Exposure
 

--- a/deployments/charts/osmo/profiles/split-plane-control.yaml
+++ b/deployments/charts/osmo/profiles/split-plane-control.yaml
@@ -108,6 +108,7 @@ monitoring:
 
 secrets:
   postgresql:
+    generate: false
     existingSecret: osmo-postgresql
   valkey:
     existingSecret: osmo-valkey

--- a/deployments/charts/osmo/profiles/split-plane-control.yaml
+++ b/deployments/charts/osmo/profiles/split-plane-control.yaml
@@ -108,7 +108,6 @@ monitoring:
 
 secrets:
   postgresql:
-    generate: false
     existingSecret: osmo-postgresql
   valkey:
     existingSecret: osmo-valkey

--- a/deployments/charts/osmo/templates/NOTES.txt
+++ b/deployments/charts/osmo/templates/NOTES.txt
@@ -2,3 +2,20 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 
 {{ include "osmo.notes" . }}
+
+{{- if .Values.embeddedDependencies.postgresql.enabled }}
+
+Embedded PostgreSQL is managed by CloudNativePG:
+
+  Cluster: {{ include "osmo.v1.postgresql-cluster-name" . }}
+  Read/write service: {{ include "osmo.v1.postgresql-host" . }}
+  Application Secret: {{ include "osmo.v1.postgresql-secret-name" . }}
+
+Check database readiness with:
+
+  kubectl --namespace {{ .Release.Namespace }} get clusters.postgresql.cnpg.io,pods,pvc
+{{- else }}
+
+OSMO is configured to use external PostgreSQL at
+{{ include "osmo.v1.postgresql-host" . }}:{{ include "osmo.v1.postgresql-port" . }}.
+{{- end }}

--- a/deployments/charts/osmo/templates/NOTES.txt
+++ b/deployments/charts/osmo/templates/NOTES.txt
@@ -7,9 +7,9 @@
 
 Embedded PostgreSQL is managed by CloudNativePG:
 
-  Cluster: {{ include "osmo.v1.postgresql-cluster-name" . }}
-  Read/write service: {{ include "osmo.v1.postgresql-host" . }}
-  Application Secret: {{ include "osmo.v1.postgresql-secret-name" . }}
+  Cluster: {{ include "osmo.postgresql.clusterName" . }}
+  Read/write service: {{ include "osmo.postgresql.host" . }}
+  Application Secret: {{ include "osmo.postgresql.secretName" . }}
 
 Check database readiness with:
 
@@ -17,5 +17,5 @@ Check database readiness with:
 {{- else }}
 
 OSMO is configured to use external PostgreSQL at
-{{ include "osmo.v1.postgresql-host" . }}:{{ include "osmo.v1.postgresql-port" . }}.
+{{ include "osmo.postgresql.host" . }}:{{ include "osmo.postgresql.port" . }}.
 {{- end }}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -305,11 +305,15 @@ data:
 {{- end -}}
 
 {{- define "osmo.v1.postgresql-cluster-name" -}}
-{{- $name := "postgresql" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := .Values.postgresql.nameOverride | default "postgresql" -}}
 {{- if contains $name .Release.Name -}}
 {{- .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -403,7 +403,8 @@ data:
 
 {{- define "osmo.v1.postgresql-ca-secret-name" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}
-{{- printf "%s-ca" (include "osmo.v1.postgresql-cluster-name" .) -}}
+{{- $serverCASecret := dig "cluster" "certificates" "serverCASecret" "" .Values.postgresql -}}
+{{- $serverCASecret | default (printf "%s-ca" (include "osmo.v1.postgresql-cluster-name" .)) -}}
 {{- else -}}
 {{- .Values.externalDependencies.postgresql.tls.caExistingSecret -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -397,8 +397,12 @@ data:
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}password{{- else -}}{{ .Values.secrets.postgresql.keys.password }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.postgresql.tlsEnabled" -}}
-{{- if .Values.embeddedDependencies.postgresql.enabled -}}true{{- else -}}{{ .Values.externalDependencies.postgresql.tls.enabled }}{{- end -}}
+{{- define "osmo.postgresql.sslMode" -}}
+{{- if or .Values.embeddedDependencies.postgresql.enabled .Values.externalDependencies.postgresql.tls.enabled -}}
+verify-full
+{{- else -}}
+disable
+{{- end -}}
 {{- end -}}
 
 {{- define "osmo.postgresql.caSecretName" -}}
@@ -415,11 +419,14 @@ data:
 {{- end -}}
 
 {{- define "osmo.externalDependencies.connectionCaEnabled" -}}
-{{- if or (eq (include "osmo.postgresql.tlsEnabled" .) "true") (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
+{{- if or
+  .Values.embeddedDependencies.postgresql.enabled
+  .Values.externalDependencies.postgresql.tls.enabled
+  (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
 {{- define "osmo.externalDependencies.caVolumeMounts" -}}
-{{- if eq (include "osmo.postgresql.tlsEnabled" .) "true" }}
+{{- if or .Values.embeddedDependencies.postgresql.enabled .Values.externalDependencies.postgresql.tls.enabled }}
 - name: postgresql-ca
   mountPath: /etc/osmo/ca/postgresql
   readOnly: true
@@ -432,7 +439,7 @@ data:
 {{- end -}}
 
 {{- define "osmo.externalDependencies.caVolumes" -}}
-{{- if eq (include "osmo.postgresql.tlsEnabled" .) "true" }}
+{{- if or .Values.embeddedDependencies.postgresql.enabled .Values.externalDependencies.postgresql.tls.enabled }}
 - name: postgresql-ca
   secret:
     secretName: {{ include "osmo.postgresql.caSecretName" . }}
@@ -465,7 +472,7 @@ data:
       name: {{ . }}
       key: {{ $.Values.secrets.valkey.keys.password }}
 {{- end }}
-{{- if eq (include "osmo.postgresql.tlsEnabled" .) "true" }}
+{{- if or .Values.embeddedDependencies.postgresql.enabled .Values.externalDependencies.postgresql.tls.enabled }}
 - name: PGSSLMODE
   value: verify-full
 - name: PGSSLROOTCERT

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -304,6 +304,15 @@ data:
 {{- end -}}
 {{- end -}}
 
+{{- define "osmo.v1.postgresql-cluster-name" -}}
+{{- $name := "postgresql" -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "osmo.valkey.generatedSecretName" -}}
 {{- printf "%s-valkey-credentials" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -351,8 +360,61 @@ data:
 {{- end -}}
 {{- end -}}
 
+{{- define "osmo.v1.postgresql-host" -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}
+{{- printf "%s-rw" (include "osmo.v1.postgresql-cluster-name" .) -}}
+{{- else -}}
+{{- .Values.externalDependencies.postgresql.host -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.v1.postgresql-port" -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}5432{{- else -}}{{ .Values.externalDependencies.postgresql.port }}{{- end -}}
+{{- end -}}
+
+{{- define "osmo.v1.postgresql-database" -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}{{ .Values.postgresql.cluster.initdb.database }}{{- else -}}{{ .Values.externalDependencies.postgresql.database }}{{- end -}}
+{{- end -}}
+
+{{- define "osmo.v1.postgresql-username" -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}{{ .Values.postgresql.cluster.initdb.owner }}{{- else -}}{{ .Values.externalDependencies.postgresql.username }}{{- end -}}
+{{- end -}}
+
+{{- define "osmo.v1.postgresql-secret-name" -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}
+{{- $existingSecret := dig "cluster" "initdb" "secret" "name" "" .Values.postgresql -}}
+{{- $existingSecret | default (printf "%s-app" (include "osmo.v1.postgresql-cluster-name" .)) -}}
+{{- else -}}
+{{- .Values.secrets.postgresql.existingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.v1.postgresql-password-key" -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}password{{- else -}}{{ .Values.secrets.postgresql.keys.password }}{{- end -}}
+{{- end -}}
+
+{{- define "osmo.v1.postgresql-tls-enabled" -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}true{{- else -}}{{ .Values.externalDependencies.postgresql.tls.enabled }}{{- end -}}
+{{- end -}}
+
+{{- define "osmo.v1.postgresql-ca-secret-name" -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}
+{{- printf "%s-ca" (include "osmo.v1.postgresql-cluster-name" .) -}}
+{{- else -}}
+{{- .Values.externalDependencies.postgresql.tls.caExistingSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.v1.postgresql-ca-key" -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}ca.crt{{- else -}}{{ .Values.externalDependencies.postgresql.tls.caKey }}{{- end -}}
+{{- end -}}
+
+{{- define "osmo.v1.connection-ca-enabled" -}}
+{{- if or (eq (include "osmo.v1.postgresql-tls-enabled" .) "true") (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
 {{- define "osmo.externalDependencies.caVolumeMounts" -}}
-{{- if .Values.externalDependencies.postgresql.tls.enabled }}
+{{- if eq (include "osmo.v1.postgresql-tls-enabled" .) "true" }}
 - name: postgresql-ca
   mountPath: /etc/osmo/ca/postgresql
   readOnly: true
@@ -365,12 +427,12 @@ data:
 {{- end -}}
 
 {{- define "osmo.externalDependencies.caVolumes" -}}
-{{- if .Values.externalDependencies.postgresql.tls.enabled }}
+{{- if eq (include "osmo.v1.postgresql-tls-enabled" .) "true" }}
 - name: postgresql-ca
   secret:
-    secretName: {{ .Values.externalDependencies.postgresql.tls.caExistingSecret }}
+    secretName: {{ include "osmo.v1.postgresql-ca-secret-name" . }}
     items:
-    - key: {{ .Values.externalDependencies.postgresql.tls.caKey }}
+    - key: {{ include "osmo.v1.postgresql-ca-key" . }}
       path: ca.crt
 {{- end }}
 {{- if eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true" }}
@@ -384,12 +446,12 @@ data:
 {{- end -}}
 
 {{- define "osmo.externalDependencies.connectionSecretEnv" -}}
-{{- with .Values.secrets.postgresql.existingSecret }}
+{{- with (include "osmo.v1.postgresql-secret-name" .) }}
 - name: OSMO_POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ . }}
-      key: {{ $.Values.secrets.postgresql.keys.password }}
+      key: {{ include "osmo.v1.postgresql-password-key" $ }}
 {{- end }}
 {{- with (include "osmo.valkey.secretName" .) }}
 - name: OSMO_REDIS_PASSWORD
@@ -398,7 +460,9 @@ data:
       name: {{ . }}
       key: {{ $.Values.secrets.valkey.keys.password }}
 {{- end }}
-{{- if .Values.externalDependencies.postgresql.tls.enabled }}
+{{- if eq (include "osmo.v1.postgresql-tls-enabled" .) "true" }}
+- name: PGSSLMODE
+  value: verify-full
 - name: PGSSLROOTCERT
   value: /etc/osmo/ca/postgresql/ca.crt
 {{- end }}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -304,7 +304,7 @@ data:
 {{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-cluster-name" -}}
+{{- define "osmo.postgresql.clusterName" -}}
 {{- if .Values.postgresql.fullnameOverride -}}
 {{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -364,62 +364,62 @@ data:
 {{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-host" -}}
+{{- define "osmo.postgresql.host" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}
-{{- printf "%s-rw" (include "osmo.v1.postgresql-cluster-name" .) -}}
+{{- printf "%s-rw" (include "osmo.postgresql.clusterName" .) -}}
 {{- else -}}
 {{- .Values.externalDependencies.postgresql.host -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-port" -}}
+{{- define "osmo.postgresql.port" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}5432{{- else -}}{{ .Values.externalDependencies.postgresql.port }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-database" -}}
+{{- define "osmo.postgresql.database" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}{{ .Values.postgresql.cluster.initdb.database }}{{- else -}}{{ .Values.externalDependencies.postgresql.database }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-username" -}}
+{{- define "osmo.postgresql.username" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}{{ .Values.postgresql.cluster.initdb.owner }}{{- else -}}{{ .Values.externalDependencies.postgresql.username }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-secret-name" -}}
+{{- define "osmo.postgresql.secretName" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}
 {{- $existingSecret := dig "cluster" "initdb" "secret" "name" "" .Values.postgresql -}}
-{{- $existingSecret | default (printf "%s-app" (include "osmo.v1.postgresql-cluster-name" .)) -}}
+{{- $existingSecret | default (printf "%s-app" (include "osmo.postgresql.clusterName" .)) -}}
 {{- else -}}
 {{- .Values.secrets.postgresql.existingSecret -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-password-key" -}}
+{{- define "osmo.postgresql.passwordKey" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}password{{- else -}}{{ .Values.secrets.postgresql.keys.password }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-tls-enabled" -}}
+{{- define "osmo.postgresql.tlsEnabled" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}true{{- else -}}{{ .Values.externalDependencies.postgresql.tls.enabled }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-ca-secret-name" -}}
+{{- define "osmo.postgresql.caSecretName" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}
 {{- $serverCASecret := dig "cluster" "certificates" "serverCASecret" "" .Values.postgresql -}}
-{{- $serverCASecret | default (printf "%s-ca" (include "osmo.v1.postgresql-cluster-name" .)) -}}
+{{- $serverCASecret | default (printf "%s-ca" (include "osmo.postgresql.clusterName" .)) -}}
 {{- else -}}
 {{- .Values.externalDependencies.postgresql.tls.caExistingSecret -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.postgresql-ca-key" -}}
+{{- define "osmo.postgresql.caKey" -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}ca.crt{{- else -}}{{ .Values.externalDependencies.postgresql.tls.caKey }}{{- end -}}
 {{- end -}}
 
-{{- define "osmo.v1.connection-ca-enabled" -}}
-{{- if or (eq (include "osmo.v1.postgresql-tls-enabled" .) "true") (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
+{{- define "osmo.externalDependencies.connectionCaEnabled" -}}
+{{- if or (eq (include "osmo.postgresql.tlsEnabled" .) "true") (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
 {{- define "osmo.externalDependencies.caVolumeMounts" -}}
-{{- if eq (include "osmo.v1.postgresql-tls-enabled" .) "true" }}
+{{- if eq (include "osmo.postgresql.tlsEnabled" .) "true" }}
 - name: postgresql-ca
   mountPath: /etc/osmo/ca/postgresql
   readOnly: true
@@ -432,12 +432,12 @@ data:
 {{- end -}}
 
 {{- define "osmo.externalDependencies.caVolumes" -}}
-{{- if eq (include "osmo.v1.postgresql-tls-enabled" .) "true" }}
+{{- if eq (include "osmo.postgresql.tlsEnabled" .) "true" }}
 - name: postgresql-ca
   secret:
-    secretName: {{ include "osmo.v1.postgresql-ca-secret-name" . }}
+    secretName: {{ include "osmo.postgresql.caSecretName" . }}
     items:
-    - key: {{ include "osmo.v1.postgresql-ca-key" . }}
+    - key: {{ include "osmo.postgresql.caKey" . }}
       path: ca.crt
 {{- end }}
 {{- if eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true" }}
@@ -451,12 +451,12 @@ data:
 {{- end -}}
 
 {{- define "osmo.externalDependencies.connectionSecretEnv" -}}
-{{- with (include "osmo.v1.postgresql-secret-name" .) }}
+{{- with (include "osmo.postgresql.secretName" .) }}
 - name: OSMO_POSTGRES_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ . }}
-      key: {{ include "osmo.v1.postgresql-password-key" $ }}
+      key: {{ include "osmo.postgresql.passwordKey" $ }}
 {{- end }}
 {{- with (include "osmo.valkey.secretName" .) }}
 - name: OSMO_REDIS_PASSWORD
@@ -465,7 +465,7 @@ data:
       name: {{ . }}
       key: {{ $.Values.secrets.valkey.keys.password }}
 {{- end }}
-{{- if eq (include "osmo.v1.postgresql-tls-enabled" .) "true" }}
+{{- if eq (include "osmo.postgresql.tlsEnabled" .) "true" }}
 - name: PGSSLMODE
   value: verify-full
 - name: PGSSLROOTCERT

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -101,18 +101,18 @@ spec:
         - {{ $serviceHostname }}
         {{- end }}
         - --postgres_host
-        - {{ .Values.externalDependencies.postgresql.host }}
+        - {{ include "osmo.v1.postgresql-host" . }}
         - --postgres_port
-        - {{ .Values.externalDependencies.postgresql.port | quote }}
+        - {{ include "osmo.v1.postgresql-port" . | quote }}
         - --postgres_database_name
-        - {{ .Values.externalDependencies.postgresql.database}}
+        - {{ include "osmo.v1.postgresql-database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end}}
-        {{- if .Values.externalDependencies.postgresql.username }}
+        {{- with (include "osmo.v1.postgresql-username" .) }}
         - --postgres_user
-        - {{ .Values.externalDependencies.postgresql.username }}
+        - {{ . }}
         {{- end }}
         {{- if .Values.logging.enabled }}
         - --log_level

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -101,16 +101,16 @@ spec:
         - {{ $serviceHostname }}
         {{- end }}
         - --postgres_host
-        - {{ include "osmo.v1.postgresql-host" . }}
+        - {{ include "osmo.postgresql.host" . }}
         - --postgres_port
-        - {{ include "osmo.v1.postgresql-port" . | quote }}
+        - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
-        - {{ include "osmo.v1.postgresql-database" . }}
+        - {{ include "osmo.postgresql.database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end}}
-        {{- with (include "osmo.v1.postgresql-username" .) }}
+        {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
         - {{ . }}
         {{- end }}

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -92,16 +92,16 @@ spec:
         - "true"
         {{- end}}
         - --postgres_host
-        - {{ include "osmo.v1.postgresql-host" . }}
+        - {{ include "osmo.postgresql.host" . }}
         - --postgres_port
-        - {{ include "osmo.v1.postgresql-port" . | quote }}
+        - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
-        - {{ include "osmo.v1.postgresql-database" . }}
+        - {{ include "osmo.postgresql.database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end }}
-        {{- with (include "osmo.v1.postgresql-username" .) }}
+        {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
         - {{ . }}
         {{- end }}

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -92,18 +92,18 @@ spec:
         - "true"
         {{- end}}
         - --postgres_host
-        - {{ .Values.externalDependencies.postgresql.host }}
+        - {{ include "osmo.v1.postgresql-host" . }}
         - --postgres_port
-        - {{ .Values.externalDependencies.postgresql.port | quote }}
+        - {{ include "osmo.v1.postgresql-port" . | quote }}
         - --postgres_database_name
-        - {{ .Values.externalDependencies.postgresql.database}}
+        - {{ include "osmo.v1.postgresql-database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end }}
-        {{- if .Values.externalDependencies.postgresql.username }}
+        {{- with (include "osmo.v1.postgresql-username" .) }}
         - --postgres_user
-        - {{ .Values.externalDependencies.postgresql.username }}
+        - {{ . }}
         {{- end }}
         {{- if .Values.services.api.auth.enabled }}
         - --device_endpoint

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -88,18 +88,18 @@ spec:
         - "true"
         {{- end}}
         - --postgres_host
-        - {{ .Values.externalDependencies.postgresql.host }}
+        - {{ include "osmo.v1.postgresql-host" . }}
         - --postgres_port
-        - {{ .Values.externalDependencies.postgresql.port | quote }}
+        - {{ include "osmo.v1.postgresql-port" . | quote }}
         - --postgres_database_name
-        - {{ .Values.externalDependencies.postgresql.database}}
+        - {{ include "osmo.v1.postgresql-database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end}}
-        {{- if .Values.externalDependencies.postgresql.username }}
+        {{- with (include "osmo.v1.postgresql-username" .) }}
         - --postgres_user
-        - {{ .Values.externalDependencies.postgresql.username }}
+        - {{ . }}
         {{- end }}
         {{- if .Values.logging.enabled }}
         - --log_level

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -88,16 +88,16 @@ spec:
         - "true"
         {{- end}}
         - --postgres_host
-        - {{ include "osmo.v1.postgresql-host" . }}
+        - {{ include "osmo.postgresql.host" . }}
         - --postgres_port
-        - {{ include "osmo.v1.postgresql-port" . | quote }}
+        - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
-        - {{ include "osmo.v1.postgresql-database" . }}
+        - {{ include "osmo.postgresql.database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end}}
-        {{- with (include "osmo.v1.postgresql-username" .) }}
+        {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
         - {{ . }}
         {{- end }}

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -536,11 +536,11 @@ spec:
           {{- if .Values.configuration.enabled }}
           - "--roles-file=/etc/osmo/configs/config.yaml"
           {{- else }}
-          - "--postgres-host={{ include "osmo.v1.postgresql-host" . }}"
-          - "--postgres-port={{ include "osmo.v1.postgresql-port" . }}"
-          - "--postgres-database={{ include "osmo.v1.postgresql-database" . }}"
-          - "--postgres-user={{ include "osmo.v1.postgresql-username" . }}"
-          - "--postgres-ssl-mode={{ ternary "verify-full" "disable" (eq (include "osmo.v1.postgresql-tls-enabled" .) "true") }}"
+          - "--postgres-host={{ include "osmo.postgresql.host" . }}"
+          - "--postgres-port={{ include "osmo.postgresql.port" . }}"
+          - "--postgres-database={{ include "osmo.postgresql.database" . }}"
+          - "--postgres-user={{ include "osmo.postgresql.username" . }}"
+          - "--postgres-ssl-mode={{ ternary "verify-full" "disable" (eq (include "osmo.postgresql.tlsEnabled" .) "true") }}"
           - "--postgres-max-conns={{ $gw.authz.postgres.maxConns }}"
           - "--postgres-min-conns={{ $gw.authz.postgres.minConns }}"
           - "--postgres-max-conn-lifetime={{ $gw.authz.postgres.maxConnLifetimeMin }}"
@@ -553,7 +553,7 @@ spec:
         env:
           {{- include "osmo.component.extraEnv" $gw.authz | nindent 10 }}
           {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 10 }}
-        {{- if or .Values.configuration.enabled $gw.authz.extraVolumeMounts (eq (include "osmo.v1.connection-ca-enabled" .) "true") }}
+        {{- if or .Values.configuration.enabled $gw.authz.extraVolumeMounts (eq (include "osmo.externalDependencies.connectionCaEnabled" .) "true") }}
         volumeMounts:
           {{- if .Values.configuration.enabled }}
           - name: configs

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -536,11 +536,11 @@ spec:
           {{- if .Values.configuration.enabled }}
           - "--roles-file=/etc/osmo/configs/config.yaml"
           {{- else }}
-          - "--postgres-host={{ .Values.externalDependencies.postgresql.host }}"
-          - "--postgres-port={{ .Values.externalDependencies.postgresql.port }}"
-          - "--postgres-database={{ .Values.externalDependencies.postgresql.database }}"
-          - "--postgres-user={{ .Values.externalDependencies.postgresql.username }}"
-          - "--postgres-ssl-mode={{ ternary "verify-full" "disable" .Values.externalDependencies.postgresql.tls.enabled }}"
+          - "--postgres-host={{ include "osmo.v1.postgresql-host" . }}"
+          - "--postgres-port={{ include "osmo.v1.postgresql-port" . }}"
+          - "--postgres-database={{ include "osmo.v1.postgresql-database" . }}"
+          - "--postgres-user={{ include "osmo.v1.postgresql-username" . }}"
+          - "--postgres-ssl-mode={{ ternary "verify-full" "disable" (eq (include "osmo.v1.postgresql-tls-enabled" .) "true") }}"
           - "--postgres-max-conns={{ $gw.authz.postgres.maxConns }}"
           - "--postgres-min-conns={{ $gw.authz.postgres.minConns }}"
           - "--postgres-max-conn-lifetime={{ $gw.authz.postgres.maxConnLifetimeMin }}"
@@ -553,7 +553,7 @@ spec:
         env:
           {{- include "osmo.component.extraEnv" $gw.authz | nindent 10 }}
           {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 10 }}
-        {{- if or .Values.configuration.enabled $gw.authz.extraVolumeMounts .Values.externalDependencies.postgresql.tls.enabled (eq (include "osmo.externalDependencies.valkeyCustomCaEnabled" .) "true") }}
+        {{- if or .Values.configuration.enabled $gw.authz.extraVolumeMounts (eq (include "osmo.v1.connection-ca-enabled" .) "true") }}
         volumeMounts:
           {{- if .Values.configuration.enabled }}
           - name: configs

--- a/deployments/charts/osmo/templates/gateway.yaml
+++ b/deployments/charts/osmo/templates/gateway.yaml
@@ -540,7 +540,7 @@ spec:
           - "--postgres-port={{ include "osmo.postgresql.port" . }}"
           - "--postgres-database={{ include "osmo.postgresql.database" . }}"
           - "--postgres-user={{ include "osmo.postgresql.username" . }}"
-          - "--postgres-ssl-mode={{ ternary "verify-full" "disable" (eq (include "osmo.postgresql.tlsEnabled" .) "true") }}"
+          - "--postgres-ssl-mode={{ include "osmo.postgresql.sslMode" . }}"
           - "--postgres-max-conns={{ $gw.authz.postgres.maxConns }}"
           - "--postgres-min-conns={{ $gw.authz.postgres.minConns }}"
           - "--postgres-max-conn-lifetime={{ $gw.authz.postgres.maxConnLifetimeMin }}"

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -96,16 +96,16 @@ spec:
         - "true"
         {{- end}}
         - --postgres_host
-        - {{ include "osmo.v1.postgresql-host" . }}
+        - {{ include "osmo.postgresql.host" . }}
         - --postgres_port
-        - {{ include "osmo.v1.postgresql-port" . | quote }}
+        - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
-        - {{ include "osmo.v1.postgresql-database" . }}
+        - {{ include "osmo.postgresql.database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end}}
-        {{- with (include "osmo.v1.postgresql-username" .) }}
+        {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
         - {{ . }}
         {{- end }}

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -96,18 +96,18 @@ spec:
         - "true"
         {{- end}}
         - --postgres_host
-        - {{ .Values.externalDependencies.postgresql.host }}
+        - {{ include "osmo.v1.postgresql-host" . }}
         - --postgres_port
-        - {{ .Values.externalDependencies.postgresql.port | quote }}
+        - {{ include "osmo.v1.postgresql-port" . | quote }}
         - --postgres_database_name
-        - {{ .Values.externalDependencies.postgresql.database}}
+        - {{ include "osmo.v1.postgresql-database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end}}
-        {{- if .Values.externalDependencies.postgresql.username }}
+        {{- with (include "osmo.v1.postgresql-username" .) }}
         - --postgres_user
-        - {{ .Values.externalDependencies.postgresql.username }}
+        - {{ . }}
         {{- end }}
         {{- if .Values.logging.enabled }}
         - --log_level

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -84,12 +84,12 @@ spec:
         - {{ $routerHostname }}
         {{- end }}
         - --postgres_host
-        - {{ include "osmo.v1.postgresql-host" . }}
+        - {{ include "osmo.postgresql.host" . }}
         - --postgres_port
-        - {{ include "osmo.v1.postgresql-port" . | quote }}
+        - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
-        - {{ include "osmo.v1.postgresql-database" . }}
-        {{- with (include "osmo.v1.postgresql-username" .) }}
+        - {{ include "osmo.postgresql.database" . }}
+        {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
         - {{ . }}
         {{- end }}

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -84,14 +84,14 @@ spec:
         - {{ $routerHostname }}
         {{- end }}
         - --postgres_host
-        - {{ .Values.externalDependencies.postgresql.host }}
+        - {{ include "osmo.v1.postgresql-host" . }}
         - --postgres_port
-        - {{ .Values.externalDependencies.postgresql.port | quote }}
+        - {{ include "osmo.v1.postgresql-port" . | quote }}
         - --postgres_database_name
-        - {{ .Values.externalDependencies.postgresql.database}}
-        {{- if .Values.externalDependencies.postgresql.username }}
+        - {{ include "osmo.v1.postgresql-database" . }}
+        {{- with (include "osmo.v1.postgresql-username" .) }}
         - --postgres_user
-        - {{ .Values.externalDependencies.postgresql.username }}
+        - {{ . }}
         {{- end }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -13,6 +13,9 @@
 {{- $initdbSecretName := dig "cluster" "initdb" "secret" "name" "" .Values.postgresql -}}
 {{- $synchronousInstances := int (dig "cluster" "postgresql" "synchronous" "number" 0 .Values.postgresql) -}}
 {{- $dataDurability := dig "cluster" "postgresql" "synchronous" "dataDurability" "" .Values.postgresql -}}
+{{- if .Values.postgresql.namespaceOverride -}}
+{{- fail "postgresql.namespaceOverride must be empty because embedded PostgreSQL and OSMO must share a namespace" -}}
+{{- end -}}
 {{- if .Values.externalDependencies.postgresql.host -}}
 {{- fail "externalDependencies.postgresql.host must be empty when embedded PostgreSQL is enabled" -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -19,7 +19,11 @@
 {{- if .Values.externalDependencies.postgresql.host -}}
 {{- fail "externalDependencies.postgresql.host must be empty when embedded PostgreSQL is enabled" -}}
 {{- end -}}
-{{- if and (eq $dataDurability "required") (le (int .Values.postgresql.cluster.instances) $synchronousInstances) -}}
+{{- if and
+  (eq $dataDurability "required")
+  (or
+    (lt (int .Values.postgresql.cluster.instances) 2)
+    (le (int .Values.postgresql.cluster.instances) $synchronousInstances)) -}}
 {{- fail "postgresql.cluster: required synchronous replication needs at least 2 instances and more instances than synchronous standbys" -}}
 {{- end -}}
 {{- if and .Values.secrets.postgresql.generate (or .Values.secrets.postgresql.existingSecret $initdbSecretName) -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -10,7 +10,6 @@
 {{- fail "embeddedDependencies.postgresql.enabled: install a compatible CloudNativePG operator before enabling embedded PostgreSQL" -}}
 {{- end -}}
 {{- if .Values.embeddedDependencies.postgresql.enabled -}}
-{{- $initdbSecretName := dig "cluster" "initdb" "secret" "name" "" .Values.postgresql -}}
 {{- $synchronousInstances := int (dig "cluster" "postgresql" "synchronous" "number" 0 .Values.postgresql) -}}
 {{- $dataDurability := dig "cluster" "postgresql" "synchronous" "dataDurability" "" .Values.postgresql -}}
 {{- $serverTLSSecret := dig "cluster" "certificates" "serverTLSSecret" "" .Values.postgresql -}}
@@ -34,17 +33,8 @@
     (le (int .Values.postgresql.cluster.instances) $synchronousInstances)) -}}
 {{- fail "postgresql.cluster: required synchronous replication needs at least 2 instances and more instances than synchronous standbys" -}}
 {{- end -}}
-{{- if and .Values.secrets.postgresql.generate (or .Values.secrets.postgresql.existingSecret $initdbSecretName) -}}
-{{- fail "secrets.postgresql: generate and existingSecret are mutually exclusive in embedded mode" -}}
-{{- end -}}
-{{- if and (not .Values.secrets.postgresql.generate) (not .Values.secrets.postgresql.existingSecret) -}}
-{{- fail "secrets.postgresql.existingSecret is required when embedded credential generation is disabled" -}}
-{{- end -}}
-{{- if and (not .Values.secrets.postgresql.generate) (ne .Values.secrets.postgresql.existingSecret $initdbSecretName) -}}
-{{- fail "secrets.postgresql.existingSecret must match postgresql.cluster.initdb.secret.name in embedded mode" -}}
-{{- end -}}
-{{- if and (not .Values.secrets.postgresql.generate) (or (ne .Values.secrets.postgresql.keys.username "username") (ne .Values.secrets.postgresql.keys.password "password")) -}}
-{{- fail "secrets.postgresql.keys.username and keys.password must be username and password for a CNPG existing Secret" -}}
+{{- if .Values.secrets.postgresql.existingSecret -}}
+{{- fail "secrets.postgresql.existingSecret must be empty when embedded PostgreSQL is enabled; use postgresql.cluster.initdb.secret.name for an existing Secret" -}}
 {{- end -}}
 {{- if .Values.postgresql.backups.enabled -}}
 {{- fail "postgresql.backups.enabled: embedded backup and restore are not supported" -}}
@@ -126,7 +116,7 @@
 {{- if and .Values.httproute.enabled (eq (len .Values.httproute.parentRefs) 0) -}}
 {{- fail "httproute.parentRefs requires at least one entry when httproute.enabled=true" -}}
 {{- end -}}
-{{- if or (and .Values.secrets.postgresql.generate (not .Values.embeddedDependencies.postgresql.enabled)) .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
+{{- if or .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
 {{- fail "secrets: generated Secrets are not implemented; configure existingSecret" -}}
 {{- end -}}
 {{- $autoscaledComponents := list

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -6,8 +6,8 @@
 {{- if not .Values.planes.control.enabled -}}
 {{- fail "planes.control.enabled: this chart version requires the control plane" -}}
 {{- end -}}
-{{- if .Values.embeddedDependencies.postgresql.enabled -}}
-{{- fail "embeddedDependencies.postgresql.enabled: embedded PostgreSQL is not implemented" -}}
+{{- if and .Values.embeddedDependencies.postgresql.enabled (not (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1")) -}}
+{{- fail "embeddedDependencies.postgresql.enabled: install a compatible CloudNativePG operator before enabling embedded PostgreSQL" -}}
 {{- end -}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
 {{- fail "embeddedDependencies.objectStorage.enabled: embedded object storage is not implemented" -}}
@@ -85,7 +85,7 @@
 {{- if and .Values.httproute.enabled (eq (len .Values.httproute.parentRefs) 0) -}}
 {{- fail "httproute.parentRefs requires at least one entry when httproute.enabled=true" -}}
 {{- end -}}
-{{- if or .Values.secrets.postgresql.generate .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
+{{- if or (and .Values.secrets.postgresql.generate (not .Values.embeddedDependencies.postgresql.enabled)) .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
 {{- fail "secrets: generated Secrets are not implemented; configure existingSecret" -}}
 {{- end -}}
 {{- $autoscaledComponents := list
@@ -140,7 +140,7 @@
 {{- if hasKey .Values "components" -}}
 {{- fail "components is not a supported value; configure services and gateway" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.postgresql.host -}}
+{{- if and (not .Values.embeddedDependencies.postgresql.enabled) (not .Values.externalDependencies.postgresql.host) -}}
 {{- fail "externalDependencies.postgresql.host is required for the control plane" -}}
 {{- end -}}
 {{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.externalDependencies.valkey.host) -}}
@@ -158,7 +158,7 @@
 {{- if not .Values.externalDependencies.objectStorage.buckets.apps -}}
 {{- fail "externalDependencies.objectStorage.buckets.apps is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.secrets.postgresql.existingSecret -}}
+{{- if and (not .Values.embeddedDependencies.postgresql.enabled) (not .Values.secrets.postgresql.existingSecret) -}}
 {{- fail "secrets.postgresql.existingSecret is required for the control plane" -}}
 {{- end -}}
 {{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.secrets.valkey.existingSecret) -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -13,11 +13,19 @@
 {{- $initdbSecretName := dig "cluster" "initdb" "secret" "name" "" .Values.postgresql -}}
 {{- $synchronousInstances := int (dig "cluster" "postgresql" "synchronous" "number" 0 .Values.postgresql) -}}
 {{- $dataDurability := dig "cluster" "postgresql" "synchronous" "dataDurability" "" .Values.postgresql -}}
+{{- $serverTLSSecret := dig "cluster" "certificates" "serverTLSSecret" "" .Values.postgresql -}}
+{{- $serverCASecret := dig "cluster" "certificates" "serverCASecret" "" .Values.postgresql -}}
 {{- if .Values.postgresql.namespaceOverride -}}
 {{- fail "postgresql.namespaceOverride must be empty because embedded PostgreSQL and OSMO must share a namespace" -}}
 {{- end -}}
 {{- if .Values.externalDependencies.postgresql.host -}}
 {{- fail "externalDependencies.postgresql.host must be empty when embedded PostgreSQL is enabled" -}}
+{{- end -}}
+{{- if ne .Values.postgresql.mode "standalone" -}}
+{{- fail "postgresql.mode: standalone is the only supported embedded mode" -}}
+{{- end -}}
+{{- if and $serverTLSSecret (not $serverCASecret) -}}
+{{- fail "postgresql.cluster.certificates.serverCASecret is required when serverTLSSecret is set" -}}
 {{- end -}}
 {{- if and
   (eq $dataDurability "required")

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -43,6 +43,11 @@
 {{- if .Values.postgresql.backups.enabled -}}
 {{- fail "postgresql.backups.enabled: embedded backup and restore are not supported" -}}
 {{- end -}}
+{{- range $plugin := .Values.postgresql.cluster.plugins -}}
+{{- if and (dig "enabled" false $plugin) (dig "isWALArchiver" false $plugin) -}}
+{{- fail "postgresql.cluster.plugins: embedded WAL archiver plugins are not supported" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
 {{- fail "embeddedDependencies.objectStorage.enabled: embedded object storage is not implemented" -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -9,6 +9,32 @@
 {{- if and .Values.embeddedDependencies.postgresql.enabled (not (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1")) -}}
 {{- fail "embeddedDependencies.postgresql.enabled: install a compatible CloudNativePG operator before enabling embedded PostgreSQL" -}}
 {{- end -}}
+{{- if .Values.embeddedDependencies.postgresql.enabled -}}
+{{- $initdbSecretName := dig "cluster" "initdb" "secret" "name" "" .Values.postgresql -}}
+{{- $synchronousInstances := int (dig "cluster" "postgresql" "synchronous" "number" 0 .Values.postgresql) -}}
+{{- $dataDurability := dig "cluster" "postgresql" "synchronous" "dataDurability" "" .Values.postgresql -}}
+{{- if .Values.externalDependencies.postgresql.host -}}
+{{- fail "externalDependencies.postgresql.host must be empty when embedded PostgreSQL is enabled" -}}
+{{- end -}}
+{{- if and (eq $dataDurability "required") (le (int .Values.postgresql.cluster.instances) $synchronousInstances) -}}
+{{- fail "postgresql.cluster: required synchronous replication needs at least 2 instances and more instances than synchronous standbys" -}}
+{{- end -}}
+{{- if and .Values.secrets.postgresql.generate (or .Values.secrets.postgresql.existingSecret $initdbSecretName) -}}
+{{- fail "secrets.postgresql: generate and existingSecret are mutually exclusive in embedded mode" -}}
+{{- end -}}
+{{- if and (not .Values.secrets.postgresql.generate) (not .Values.secrets.postgresql.existingSecret) -}}
+{{- fail "secrets.postgresql.existingSecret is required when embedded credential generation is disabled" -}}
+{{- end -}}
+{{- if and (not .Values.secrets.postgresql.generate) (ne .Values.secrets.postgresql.existingSecret $initdbSecretName) -}}
+{{- fail "secrets.postgresql.existingSecret must match postgresql.cluster.initdb.secret.name in embedded mode" -}}
+{{- end -}}
+{{- if and (not .Values.secrets.postgresql.generate) (or (ne .Values.secrets.postgresql.keys.username "username") (ne .Values.secrets.postgresql.keys.password "password")) -}}
+{{- fail "secrets.postgresql.keys.username and keys.password must be username and password for a CNPG existing Secret" -}}
+{{- end -}}
+{{- if .Values.postgresql.backups.enabled -}}
+{{- fail "postgresql.backups.enabled: embedded backup and restore will be added in OSMO-6609" -}}
+{{- end -}}
+{{- end -}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
 {{- fail "embeddedDependencies.objectStorage.enabled: embedded object storage is not implemented" -}}
 {{- end -}}
@@ -170,6 +196,6 @@
 {{- if not .Values.secrets.masterEncryptionKey.existingSecret -}}
 {{- fail "secrets.masterEncryptionKey.existingSecret is required for the control plane" -}}
 {{- end -}}
-{{- if and .Values.externalDependencies.postgresql.tls.enabled (not .Values.externalDependencies.postgresql.tls.caExistingSecret) -}}
+{{- if and (not .Values.embeddedDependencies.postgresql.enabled) .Values.externalDependencies.postgresql.tls.enabled (not .Values.externalDependencies.postgresql.tls.caExistingSecret) -}}
 {{- fail "externalDependencies.postgresql.tls.caExistingSecret is required when TLS is enabled" -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -14,6 +14,10 @@
 {{- $dataDurability := dig "cluster" "postgresql" "synchronous" "dataDurability" "" .Values.postgresql -}}
 {{- $serverTLSSecret := dig "cluster" "certificates" "serverTLSSecret" "" .Values.postgresql -}}
 {{- $serverCASecret := dig "cluster" "certificates" "serverCASecret" "" .Values.postgresql -}}
+{{- $clusterName := include "osmo.postgresql.clusterName" . -}}
+{{- if gt (len $clusterName) 60 -}}
+{{- fail "embedded PostgreSQL cluster name must be at most 60 characters so the CloudNativePG -rw Service name is valid" -}}
+{{- end -}}
 {{- if .Values.postgresql.namespaceOverride -}}
 {{- fail "postgresql.namespaceOverride must be empty because embedded PostgreSQL and OSMO must share a namespace" -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -47,7 +47,7 @@
 {{- fail "secrets.postgresql.keys.username and keys.password must be username and password for a CNPG existing Secret" -}}
 {{- end -}}
 {{- if .Values.postgresql.backups.enabled -}}
-{{- fail "postgresql.backups.enabled: embedded backup and restore will be added in OSMO-6609" -}}
+{{- fail "postgresql.backups.enabled: embedded backup and restore are not supported" -}}
 {{- end -}}
 {{- end -}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -94,18 +94,18 @@ spec:
         - "true"
         {{- end}}
         - --postgres_host
-        - {{ .Values.externalDependencies.postgresql.host }}
+        - {{ include "osmo.v1.postgresql-host" . }}
         - --postgres_port
-        - {{ .Values.externalDependencies.postgresql.port | quote }}
+        - {{ include "osmo.v1.postgresql-port" . | quote }}
         - --postgres_database_name
-        - {{ .Values.externalDependencies.postgresql.database}}
+        - {{ include "osmo.v1.postgresql-database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end}}
-        {{- if .Values.externalDependencies.postgresql.username }}
+        {{- with (include "osmo.v1.postgresql-username" .) }}
         - --postgres_user
-        - {{ .Values.externalDependencies.postgresql.username }}
+        - {{ . }}
         {{- end }}
         {{- if .Values.logging.enabled }}
         - --log_level

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -94,16 +94,16 @@ spec:
         - "true"
         {{- end}}
         - --postgres_host
-        - {{ include "osmo.v1.postgresql-host" . }}
+        - {{ include "osmo.postgresql.host" . }}
         - --postgres_port
-        - {{ include "osmo.v1.postgresql-port" . | quote }}
+        - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
-        - {{ include "osmo.v1.postgresql-database" . }}
+        - {{ include "osmo.postgresql.database" . }}
         {{- if .Values.secrets.masterEncryptionKey.existingSecret }}
         - --mek_file
         - {{ .Values.secrets.masterEncryptionKey.mountPath }}
         {{- end}}
-        {{- with (include "osmo.v1.postgresql-username" .) }}
+        {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
         - {{ . }}
         {{- end }}

--- a/deployments/charts/osmo/tests/control-embedded-values.yaml
+++ b/deployments/charts/osmo/tests/control-embedded-values.yaml
@@ -36,4 +36,4 @@ secrets:
 services:
   api:
     image:
-      name: service
+      repository: nvidia/osmo/service

--- a/deployments/charts/osmo/tests/control-embedded-values.yaml
+++ b/deployments/charts/osmo/tests/control-embedded-values.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+embeddedDependencies:
+  postgresql:
+    enabled: true
+
+externalUrl: http://osmo-gateway
+
+externalDependencies:
+  postgresql:
+    host: ''
+  valkey:
+    host: external-valkey
+    port: 6379
+    database: 0
+  objectStorage:
+    endpoint: https://s3.external.example.com
+    region: us-east-1
+    buckets:
+      workflows: osmo-workflows
+      logs: osmo-logs
+      apps: osmo-apps
+
+secrets:
+  postgresql:
+    generate: true
+    existingSecret: ''
+  valkey:
+    existingSecret: external-control-secrets
+  objectStorage:
+    existingSecret: external-control-secrets
+  masterEncryptionKey:
+    existingSecret: external-control-secrets
+
+services:
+  api:
+    image:
+      name: service

--- a/deployments/charts/osmo/tests/control-embedded-values.yaml
+++ b/deployments/charts/osmo/tests/control-embedded-values.yaml
@@ -24,7 +24,6 @@ externalDependencies:
 
 secrets:
   postgresql:
-    generate: true
     existingSecret: ''
   valkey:
     existingSecret: external-control-secrets

--- a/deployments/charts/osmo/tests/control-external-values.yaml
+++ b/deployments/charts/osmo/tests/control-external-values.yaml
@@ -23,7 +23,6 @@ externalDependencies:
 
 secrets:
   postgresql:
-    generate: false
     existingSecret: external-postgresql-secret
   valkey:
     existingSecret: external-valkey-secret

--- a/deployments/charts/osmo/tests/control-external-values.yaml
+++ b/deployments/charts/osmo/tests/control-external-values.yaml
@@ -24,6 +24,8 @@ externalDependencies:
 secrets:
   postgresql:
     existingSecret: external-postgresql-secret
+    keys:
+      password: external-db-password
   valkey:
     existingSecret: external-valkey-secret
   objectStorage:

--- a/deployments/charts/osmo/tests/control-external-values.yaml
+++ b/deployments/charts/osmo/tests/control-external-values.yaml
@@ -23,6 +23,7 @@ externalDependencies:
 
 secrets:
   postgresql:
+    generate: false
     existingSecret: external-postgresql-secret
   valkey:
     existingSecret: external-valkey-secret

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1319,9 +1319,12 @@ EOF
         --api-versions postgresql.cnpg.io/v1 \
         -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
         --set postgresql.cluster.certificates.serverCASecret=custom-server-ca \
+        --set postgresql.cluster.certificates.serverTLSSecret=custom-server-tls \
         >"$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml"
     require_contains "$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml" \
         "serverCASecret: custom-server-ca"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml" \
+        "serverTLSSecret: custom-server-tls"
     require_contains "$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml" \
         "secretName: custom-server-ca"
     require_not_contains "$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml" \
@@ -1974,6 +1977,41 @@ EOF
     fi
     require_contains "$TEST_DIRECTORY/embedded-other-namespace.out" \
         "postgresql.namespaceOverride must be empty"
+
+    if helm_template embedded-postgresql-recovery "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.mode=recovery \
+        >"$TEST_DIRECTORY/embedded-postgresql-recovery.out" 2>&1; then
+        fail "expected embedded PostgreSQL recovery mode to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-postgresql-recovery.out" \
+        "postgresql.mode"
+    require_contains "$TEST_DIRECTORY/embedded-postgresql-recovery.out" \
+        "standalone"
+
+    if helm_template embedded-postgresql-replica "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.mode=replica \
+        --set postgresql.replica.bootstrap.source=pg_basebackup \
+        >"$TEST_DIRECTORY/embedded-postgresql-replica.out" 2>&1; then
+        fail "expected embedded PostgreSQL replica mode to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-postgresql-replica.out" \
+        "postgresql.mode"
+    require_contains "$TEST_DIRECTORY/embedded-postgresql-replica.out" \
+        "standalone"
+
+    if helm_template embedded-postgresql-server-tls-only "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.cluster.certificates.serverTLSSecret=custom-server-tls \
+        >"$TEST_DIRECTORY/embedded-postgresql-server-tls-only.out" 2>&1; then
+        fail "expected embedded PostgreSQL server TLS without a CA Secret to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-postgresql-server-tls-only.out" \
+        "serverCASecret is required"
 
     if helm_template embedded-too-small "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -2090,6 +2090,18 @@ EOF
     require_contains "$TEST_DIRECTORY/embedded-backups.out" \
         "embedded backup and restore are not supported"
 
+    if helm_template embedded-wal-archiver "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.cluster.plugins[0].name=test-wal-archiver \
+        --set postgresql.cluster.plugins[0].enabled=true \
+        --set postgresql.cluster.plugins[0].isWALArchiver=true \
+        >"$TEST_DIRECTORY/embedded-wal-archiver.out" 2>&1; then
+        fail "expected an enabled embedded WAL archiver plugin to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-wal-archiver.out" \
+        "postgresql.cluster.plugins: embedded WAL archiver plugins are not supported"
+
     if helm_template invalid-postgresql-instances "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
         -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1186,6 +1186,20 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-embedded-scaled.yaml" \
         "embedded-scaled-postgresql-rw"
 
+    helm_template embedded-named "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.fullnameOverride=custom-embedded-database \
+        >"$TEST_DIRECTORY/osmo-embedded-named.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-named.yaml" \
+        "name: custom-embedded-database"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-named.yaml" \
+        "custom-embedded-database-rw"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-named.yaml" \
+        "name: custom-embedded-database-app"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-named.yaml" \
+        "secretName: custom-embedded-database-ca"
+
     helm_template embedded-dev "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
         -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -2073,7 +2073,8 @@ EOF
         >"$TEST_DIRECTORY/embedded-backups.out" 2>&1; then
         fail "expected the deferred embedded backup surface to fail"
     fi
-    require_contains "$TEST_DIRECTORY/embedded-backups.out" "OSMO-6609"
+    require_contains "$TEST_DIRECTORY/embedded-backups.out" \
+        "embedded backup and restore are not supported"
 
     if helm_template invalid-postgresql-instances "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1132,6 +1132,54 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-replicated-valkey-init.yaml" \
         "min-replicas-to-write 1"
 
+    cat >"$charts_copy/osmo/templates/postgresql-helper-contract.yaml" <<'EOF'
+{{- if .Values.embeddedDependencies.postgresql.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-postgresql-helper-contract
+data:
+  clusterName: {{ include "osmo.postgresql.clusterName" . | quote }}
+  host: {{ include "osmo.postgresql.host" . | quote }}
+  port: {{ include "osmo.postgresql.port" . | quote }}
+  database: {{ include "osmo.postgresql.database" . | quote }}
+  username: {{ include "osmo.postgresql.username" . | quote }}
+  secretName: {{ include "osmo.postgresql.secretName" . | quote }}
+  passwordKey: {{ include "osmo.postgresql.passwordKey" . | quote }}
+  tlsEnabled: {{ include "osmo.postgresql.tlsEnabled" . | quote }}
+  caSecretName: {{ include "osmo.postgresql.caSecretName" . | quote }}
+  caKey: {{ include "osmo.postgresql.caKey" . | quote }}
+  connectionCaEnabled: {{ include "osmo.externalDependencies.connectionCaEnabled" . | quote }}
+{{- end }}
+EOF
+    helm_template embedded-helper-contract "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml"
+    rm "$charts_copy/osmo/templates/postgresql-helper-contract.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'clusterName: "embedded-helper-contract-postgresql"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'host: "embedded-helper-contract-postgresql-rw"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'port: "5432"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'database: "osmo"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'username: "osmo"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'secretName: "embedded-helper-contract-postgresql-app"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'passwordKey: "password"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'tlsEnabled: "true"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'caSecretName: "embedded-helper-contract-postgresql-ca"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'caKey: "ca.crt"'
+    require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
+        'connectionCaEnabled: "true"'
+
     helm_template embedded-osmo "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
         -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -291,7 +291,13 @@ require_no_resource() {
 }
 
 require_clean_osmo_sources() {
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "name: cluster"
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "version: 0.8.0"
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" \
+        "condition: embeddedDependencies.postgresql.enabled"
     [[ -e "$CHARTS_ROOT/osmo/Chart.lock" ]] || fail "osmo must have a dependency lock"
+    [[ ! -e "$CHARTS_ROOT/osmo/charts/cluster-0.8.0.tgz" ]] || \
+        fail "osmo must not check in the CloudNativePG cluster archive"
     [[ ! -e "$CHARTS_ROOT/osmo/templates/postgres.yaml" ]] || \
         fail "osmo must not contain an unimplemented embedded PostgreSQL template"
     [[ ! -e "$CHARTS_ROOT/osmo/templates/redis.yaml" ]] || \
@@ -358,6 +364,12 @@ test_control_umbrella() {
         ! grep -Fq "osmo/charts/valkey-0.11.0.tgz" \
         "$TEST_DIRECTORY/osmo-package.txt"; then
         fail "packaged OSMO chart does not contain Valkey 0.11.0"
+    fi
+    if ! grep -Fq "osmo/charts/cluster/Chart.yaml" \
+        "$TEST_DIRECTORY/osmo-package.txt" && \
+        ! grep -Fq "osmo/charts/cluster-0.8.0.tgz" \
+        "$TEST_DIRECTORY/osmo-package.txt"; then
+        fail "packaged OSMO chart does not contain CloudNativePG cluster 0.8.0"
     fi
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "osmo/tests/"
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "osmo/migrations/"
@@ -1106,6 +1118,26 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-replicated-valkey-init.yaml" \
         "min-replicas-to-write 1"
 
+    helm_template embedded-osmo "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-embedded.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" \
+        "apiVersion: postgresql.cnpg.io/v1"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "kind: Cluster"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "instances: 3"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "size: 20Gi"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "method: any"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "number: 1"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" \
+        "dataDurability: required"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "database: osmo"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "owner: osmo"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" \
+        "enableSuperuserAccess: false"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "cpu: \"1\""
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "memory: 2Gi"
+
     resource_document "$rendered" Deployment osmo-agent \
         >"$TEST_DIRECTORY/osmo-agent.yaml"
     require_occurrences "$TEST_DIRECTORY/osmo-agent.yaml" "        ports:" 1
@@ -1710,15 +1742,13 @@ EOF
     require_contains "$TEST_DIRECTORY/unsupported-compute.out" \
         "compute plane is not implemented"
 
-    if helm_template unsupported-embedded "$charts_copy/osmo" \
-        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set embeddedDependencies.postgresql.enabled=true \
-        >"$TEST_DIRECTORY/unsupported-embedded.out" 2>&1; then
-        fail "expected embeddedDependencies.postgresql.enabled=true to fail"
+    if helm_template missing-cnpg-operator "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        >"$TEST_DIRECTORY/missing-cnpg-operator.out" 2>&1; then
+        fail "expected embedded PostgreSQL without the CloudNativePG API to fail"
     fi
-    require_contains "$TEST_DIRECTORY/unsupported-embedded.out" \
-        "embedded PostgreSQL is not implemented"
+    require_contains "$TEST_DIRECTORY/missing-cnpg-operator.out" \
+        "install a compatible CloudNativePG operator"
 
     if helm_template unsupported-generated-secret "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1146,7 +1146,7 @@ data:
   username: {{ include "osmo.postgresql.username" . | quote }}
   secretName: {{ include "osmo.postgresql.secretName" . | quote }}
   passwordKey: {{ include "osmo.postgresql.passwordKey" . | quote }}
-  tlsEnabled: {{ include "osmo.postgresql.tlsEnabled" . | quote }}
+  sslMode: {{ include "osmo.postgresql.sslMode" . | quote }}
   caSecretName: {{ include "osmo.postgresql.caSecretName" . | quote }}
   caKey: {{ include "osmo.postgresql.caKey" . | quote }}
   connectionCaEnabled: {{ include "osmo.externalDependencies.connectionCaEnabled" . | quote }}
@@ -1172,7 +1172,7 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
         'passwordKey: "password"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
-        'tlsEnabled: "true"'
+        'sslMode: "verify-full"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
         'caSecretName: "embedded-helper-contract-postgresql-ca"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
@@ -1219,6 +1219,8 @@ EOF
             "name: PGSSLMODE"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
             "value: verify-full"
+        require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
+            "name: PGSSLROOTCERT"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
             "secretName: embedded-osmo-postgresql-ca"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1135,6 +1135,8 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "owner: osmo"
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" \
         "enableSuperuserAccess: false"
+    require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" \
+        "podAntiAffinityType: required"
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "cpu: \"1\""
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "memory: 2Gi"
 
@@ -1162,6 +1164,16 @@ EOF
     done
     require_contains "$TEST_DIRECTORY/osmo-embedded-gateway-authz.yaml" \
         "--postgres-ssl-mode=verify-full"
+
+    helm_template embedded-profile "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-embedded-profile.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-profile.yaml" \
+        "kind: Cluster"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-profile.yaml" \
+        "name: embedded-profile-postgresql-app"
 
     helm_template embedded-existing "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
@@ -1199,6 +1211,30 @@ EOF
         "name: custom-embedded-database-app"
     require_contains "$TEST_DIRECTORY/osmo-embedded-named.yaml" \
         "secretName: custom-embedded-database-ca"
+
+    helm_template embedded-name-override "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.nameOverride=custom-postgresql \
+        >"$TEST_DIRECTORY/osmo-embedded-name-override.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-name-override.yaml" \
+        "name: embedded-name-override-custom-postgresql"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-name-override.yaml" \
+        "embedded-name-override-custom-postgresql-rw"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-name-override.yaml" \
+        "secretName: embedded-name-override-custom-postgresql-ca"
+
+    helm_template embedded-custom-ca "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.cluster.certificates.serverCASecret=custom-server-ca \
+        >"$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml" \
+        "serverCASecret: custom-server-ca"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml" \
+        "secretName: custom-server-ca"
+    require_not_contains "$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml" \
+        "secretName: embedded-custom-ca-postgresql-ca"
 
     helm_template embedded-dev "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
@@ -1833,6 +1869,16 @@ EOF
     fi
     require_contains "$TEST_DIRECTORY/embedded-external-host.out" \
         "externalDependencies.postgresql.host must be empty"
+
+    if helm_template embedded-other-namespace "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.namespaceOverride=another-namespace \
+        >"$TEST_DIRECTORY/embedded-other-namespace.out" 2>&1; then
+        fail "expected embedded PostgreSQL in another namespace to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-other-namespace.out" \
+        "postgresql.namespaceOverride must be empty"
 
     if helm_template embedded-too-small "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1336,6 +1336,10 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-embedded-dev.yaml" "instances: 1"
     require_contains "$TEST_DIRECTORY/osmo-embedded-dev.yaml" \
         "dataDurability: preferred"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-dev.yaml" \
+        "enablePDB: false"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-dev.yaml" \
+        "number: 0"
 
     resource_document "$rendered" Deployment osmo-agent \
         >"$TEST_DIRECTORY/osmo-agent.yaml"
@@ -1973,6 +1977,8 @@ EOF
         --api-versions postgresql.cnpg.io/v1 \
         -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
         --set postgresql.cluster.instances=1 \
+        --set postgresql.cluster.postgresql.synchronous.number=0 \
+        --set postgresql.cluster.postgresql.synchronous.dataDurability=required \
         >"$TEST_DIRECTORY/embedded-too-small.out" 2>&1; then
         fail "expected required synchronous replication with one instance to fail"
     fi
@@ -1982,6 +1988,7 @@ EOF
     if helm_template embedded-both-secrets "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
         -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set secrets.postgresql.generate=true \
         --set secrets.postgresql.existingSecret=embedded-postgresql-credentials \
         --set postgresql.cluster.initdb.secret.name=embedded-postgresql-credentials \
         >"$TEST_DIRECTORY/embedded-both-secrets.out" 2>&1; then

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1166,9 +1166,9 @@ EOF
         >"$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml"
     rm "$charts_copy/osmo/templates/postgresql-helper-contract.yaml"
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
-        'clusterName: "embedded-helper-contract-postgresql"'
+        'clusterName: "embedded-helper-contract-pg"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
-        'host: "embedded-helper-contract-postgresql-rw"'
+        'host: "embedded-helper-contract-pg-rw"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
         'port: "5432"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
@@ -1176,17 +1176,42 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
         'username: "osmo"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
-        'secretName: "embedded-helper-contract-postgresql-app"'
+        'secretName: "embedded-helper-contract-pg-app"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
         'passwordKey: "password"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
         'sslMode: "verify-full"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
-        'caSecretName: "embedded-helper-contract-postgresql-ca"'
+        'caSecretName: "embedded-helper-contract-pg-ca"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
         'caKey: "ca.crt"'
     require_contains "$TEST_DIRECTORY/osmo-postgresql-helper-contract.yaml" \
         'connectionCaEnabled: "true"'
+
+    local long_release
+    long_release=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    helm_template "$long_release" "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-long-release.yaml"
+    require_resource "$TEST_DIRECTORY/osmo-long-release.yaml" Cluster \
+        "$long_release-pg"
+    resource_document "$TEST_DIRECTORY/osmo-long-release.yaml" Deployment \
+        "$long_release-osmo-api" >"$TEST_DIRECTORY/osmo-long-release-api.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-long-release-api.yaml" \
+        "$long_release-pg-rw"
+
+    local long_override
+    long_override=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    if helm_template embedded-name-too-long "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set "postgresql.fullnameOverride=$long_override" \
+        >"$TEST_DIRECTORY/osmo-long-override.out" 2>&1; then
+        fail "expected an embedded PostgreSQL cluster name over 60 characters to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/osmo-long-override.out" \
+        "embedded PostgreSQL cluster name must be at most 60 characters"
 
     helm_template embedded-osmo "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
@@ -1210,7 +1235,7 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "cpu: \"1\""
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "memory: 2Gi"
     resource_document "$TEST_DIRECTORY/osmo-embedded.yaml" Cluster \
-        embedded-osmo-postgresql >"$TEST_DIRECTORY/osmo-embedded-postgresql.yaml"
+        embedded-osmo-pg >"$TEST_DIRECTORY/osmo-embedded-postgresql.yaml"
     require_contains "$TEST_DIRECTORY/osmo-embedded-postgresql.yaml" "bootstrap:"
     require_contains "$TEST_DIRECTORY/osmo-embedded-postgresql.yaml" "initdb:"
     require_not_contains "$TEST_DIRECTORY/osmo-embedded-postgresql.yaml" "secret:"
@@ -1221,11 +1246,11 @@ EOF
             "embedded-osmo-$embedded_deployment" \
             >"$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
-            "embedded-osmo-postgresql-rw"
+            "embedded-osmo-pg-rw"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
             "name: OSMO_POSTGRES_PASSWORD"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
-            "name: embedded-osmo-postgresql-app"
+            "name: embedded-osmo-pg-app"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
             "key: password"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
@@ -1235,7 +1260,7 @@ EOF
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
             "name: PGSSLROOTCERT"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
-            "secretName: embedded-osmo-postgresql-ca"
+            "secretName: embedded-osmo-pg-ca"
         require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
             "/etc/osmo/ca/postgresql/ca.crt"
     done
@@ -1250,7 +1275,7 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-embedded-profile.yaml" \
         "kind: Cluster"
     require_contains "$TEST_DIRECTORY/osmo-embedded-profile.yaml" \
-        "name: embedded-profile-postgresql-app"
+        "name: embedded-profile-pg-app"
 
     helm_template combined-embedded "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
@@ -1262,7 +1287,7 @@ EOF
         --set-string secrets.valkey.existingSecret= \
         >"$TEST_DIRECTORY/osmo-combined-embedded.yaml"
     require_resource "$TEST_DIRECTORY/osmo-combined-embedded.yaml" Cluster \
-        combined-embedded-postgresql
+        combined-embedded-pg
     require_deployment "$TEST_DIRECTORY/osmo-combined-embedded.yaml" \
         combined-embedded-valkey
     require_resource "$TEST_DIRECTORY/osmo-combined-embedded.yaml" Secret \
@@ -1271,11 +1296,11 @@ EOF
         combined-embedded-osmo-api \
         >"$TEST_DIRECTORY/osmo-combined-embedded-api.yaml"
     require_contains "$TEST_DIRECTORY/osmo-combined-embedded-api.yaml" \
-        "- combined-embedded-postgresql-rw"
+        "- combined-embedded-pg-rw"
     require_contains "$TEST_DIRECTORY/osmo-combined-embedded-api.yaml" \
         "- combined-embedded-valkey"
     require_contains "$TEST_DIRECTORY/osmo-combined-embedded-api.yaml" \
-        "name: combined-embedded-postgresql-app"
+        "name: combined-embedded-pg-app"
     require_contains "$TEST_DIRECTORY/osmo-combined-embedded-api.yaml" \
         "name: combined-embedded-valkey-credentials"
 
@@ -1285,7 +1310,7 @@ EOF
         --set postgresql.cluster.initdb.secret.name=embedded-postgresql-credentials \
         >"$TEST_DIRECTORY/osmo-embedded-existing.yaml"
     resource_document "$TEST_DIRECTORY/osmo-embedded-existing.yaml" Cluster \
-        embedded-existing-postgresql >"$TEST_DIRECTORY/osmo-embedded-existing-postgresql.yaml"
+        embedded-existing-pg >"$TEST_DIRECTORY/osmo-embedded-existing-postgresql.yaml"
     require_contains "$TEST_DIRECTORY/osmo-embedded-existing-postgresql.yaml" \
         "name: embedded-postgresql-credentials"
     resource_document "$TEST_DIRECTORY/osmo-embedded-existing.yaml" Deployment \
@@ -1301,7 +1326,7 @@ EOF
         >"$TEST_DIRECTORY/osmo-embedded-scaled.yaml"
     require_contains "$TEST_DIRECTORY/osmo-embedded-scaled.yaml" "instances: 5"
     require_contains "$TEST_DIRECTORY/osmo-embedded-scaled.yaml" \
-        "embedded-scaled-postgresql-rw"
+        "embedded-scaled-pg-rw"
 
     helm_template embedded-named "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
@@ -1342,7 +1367,7 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml" \
         "secretName: custom-server-ca"
     require_not_contains "$TEST_DIRECTORY/osmo-embedded-custom-ca.yaml" \
-        "secretName: embedded-custom-ca-postgresql-ca"
+        "secretName: embedded-custom-ca-pg-ca"
 
     helm_template embedded-dev "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1201,6 +1201,11 @@ EOF
         "podAntiAffinityType: required"
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "cpu: \"1\""
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "memory: 2Gi"
+    resource_document "$TEST_DIRECTORY/osmo-embedded.yaml" Cluster \
+        embedded-osmo-postgresql >"$TEST_DIRECTORY/osmo-embedded-postgresql.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-postgresql.yaml" "bootstrap:"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-postgresql.yaml" "initdb:"
+    require_not_contains "$TEST_DIRECTORY/osmo-embedded-postgresql.yaml" "secret:"
 
     local embedded_deployment
     for embedded_deployment in agent api delayed-job-monitor gateway-authz logger router worker; do
@@ -1269,16 +1274,17 @@ EOF
     helm_template embedded-existing "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
         -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
-        --set secrets.postgresql.generate=false \
-        --set secrets.postgresql.existingSecret=embedded-postgresql-credentials \
-        --set secrets.postgresql.keys.username=username \
-        --set secrets.postgresql.keys.password=password \
         --set postgresql.cluster.initdb.secret.name=embedded-postgresql-credentials \
         >"$TEST_DIRECTORY/osmo-embedded-existing.yaml"
-    require_contains "$TEST_DIRECTORY/osmo-embedded-existing.yaml" \
+    resource_document "$TEST_DIRECTORY/osmo-embedded-existing.yaml" Cluster \
+        embedded-existing-postgresql >"$TEST_DIRECTORY/osmo-embedded-existing-postgresql.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-existing-postgresql.yaml" \
         "name: embedded-postgresql-credentials"
-    require_contains "$TEST_DIRECTORY/osmo-embedded-existing.yaml" "key: password"
-    require_contains "$TEST_DIRECTORY/osmo-embedded-existing.yaml" "owner: osmo"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-existing.yaml" Deployment \
+        embedded-existing-osmo-api >"$TEST_DIRECTORY/osmo-embedded-existing-api.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-existing-api.yaml" \
+        "name: embedded-postgresql-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-existing-api.yaml" "key: password"
 
     helm_template embedded-scaled "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
@@ -2025,42 +2031,17 @@ EOF
     require_contains "$TEST_DIRECTORY/embedded-too-small.out" \
         "required synchronous replication needs at least 2 instances"
 
-    if helm_template embedded-both-secrets "$charts_copy/osmo" \
+    if helm_template embedded-external-secret "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
         -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
-        --set secrets.postgresql.generate=true \
-        --set secrets.postgresql.existingSecret=embedded-postgresql-credentials \
-        --set postgresql.cluster.initdb.secret.name=embedded-postgresql-credentials \
-        >"$TEST_DIRECTORY/embedded-both-secrets.out" 2>&1; then
-        fail "expected generated and existing embedded credentials to fail"
+        --set secrets.postgresql.existingSecret=external-only-secret \
+        >"$TEST_DIRECTORY/embedded-external-secret.out" 2>&1; then
+        fail "expected external PostgreSQL Secret to fail in embedded mode"
     fi
-    require_contains "$TEST_DIRECTORY/embedded-both-secrets.out" \
-        "generate and existingSecret are mutually exclusive"
-
-    if helm_template embedded-secret-mismatch "$charts_copy/osmo" \
-        --api-versions postgresql.cnpg.io/v1 \
-        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
-        --set secrets.postgresql.generate=false \
-        --set secrets.postgresql.existingSecret=osmo-postgresql-credentials \
-        --set postgresql.cluster.initdb.secret.name=different-credentials \
-        >"$TEST_DIRECTORY/embedded-secret-mismatch.out" 2>&1; then
-        fail "expected mismatched embedded credential Secret names to fail"
-    fi
-    require_contains "$TEST_DIRECTORY/embedded-secret-mismatch.out" \
-        "must match postgresql.cluster.initdb.secret.name"
-
-    if helm_template embedded-secret-keys "$charts_copy/osmo" \
-        --api-versions postgresql.cnpg.io/v1 \
-        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
-        --set secrets.postgresql.generate=false \
-        --set secrets.postgresql.existingSecret=osmo-postgresql-credentials \
-        --set postgresql.cluster.initdb.secret.name=osmo-postgresql-credentials \
-        --set secrets.postgresql.keys.username=db-user \
-        >"$TEST_DIRECTORY/embedded-secret-keys.out" 2>&1; then
-        fail "expected non-CNPG embedded credential keys to fail"
-    fi
-    require_contains "$TEST_DIRECTORY/embedded-secret-keys.out" \
-        "keys.username and keys.password must be username and password"
+    require_contains "$TEST_DIRECTORY/embedded-external-secret.out" \
+        "secrets.postgresql.existingSecret must be empty when embedded PostgreSQL is enabled"
+    require_contains "$TEST_DIRECTORY/embedded-external-secret.out" \
+        "postgresql.cluster.initdb.secret.name"
 
     if helm_template embedded-backups "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
@@ -2085,16 +2066,6 @@ EOF
     fi
     require_contains "$TEST_DIRECTORY/invalid-postgresql-instances.out" "instances"
     require_contains "$TEST_DIRECTORY/invalid-postgresql-instances.out" "integer"
-
-    if helm_template unsupported-generated-secret "$charts_copy/osmo" \
-        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set secrets.postgresql.generate=true \
-        >"$TEST_DIRECTORY/unsupported-generated-secret.out" 2>&1; then
-        fail "expected secrets.postgresql.generate=true to fail"
-    fi
-    require_contains "$TEST_DIRECTORY/unsupported-generated-secret.out" \
-        "generated Secrets are not implemented"
 
     if helm_template unsupported-legacy-values "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -395,6 +395,14 @@ test_control_umbrella() {
         >"$rendered"
 
     require_deployment "$rendered" "osmo-api"
+    resource_document "$rendered" Deployment osmo-api \
+        >"$TEST_DIRECTORY/osmo-api-external-postgresql.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-api-external-postgresql.yaml" \
+        "name: OSMO_POSTGRES_PASSWORD"
+    require_contains "$TEST_DIRECTORY/osmo-api-external-postgresql.yaml" \
+        "name: external-postgresql-secret"
+    require_contains "$TEST_DIRECTORY/osmo-api-external-postgresql.yaml" \
+        "key: external-db-password"
     require_no_deployment "$rendered" "osmo-service"
     require_not_contains "$rendered" "name: osmo-service"
     require_deployment "$rendered" "osmo-worker"

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1237,6 +1237,33 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-embedded-profile.yaml" \
         "name: embedded-profile-postgresql-app"
 
+    helm_template combined-embedded "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set embeddedDependencies.valkey.enabled=true \
+        --set-string externalDependencies.valkey.host= \
+        --set secrets.valkey.generate=true \
+        --set-string secrets.valkey.existingSecret= \
+        >"$TEST_DIRECTORY/osmo-combined-embedded.yaml"
+    require_resource "$TEST_DIRECTORY/osmo-combined-embedded.yaml" Cluster \
+        combined-embedded-postgresql
+    require_deployment "$TEST_DIRECTORY/osmo-combined-embedded.yaml" \
+        combined-embedded-valkey
+    require_resource "$TEST_DIRECTORY/osmo-combined-embedded.yaml" Secret \
+        combined-embedded-valkey-credentials
+    resource_document "$TEST_DIRECTORY/osmo-combined-embedded.yaml" Deployment \
+        combined-embedded-osmo-api \
+        >"$TEST_DIRECTORY/osmo-combined-embedded-api.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-combined-embedded-api.yaml" \
+        "- combined-embedded-postgresql-rw"
+    require_contains "$TEST_DIRECTORY/osmo-combined-embedded-api.yaml" \
+        "- combined-embedded-valkey"
+    require_contains "$TEST_DIRECTORY/osmo-combined-embedded-api.yaml" \
+        "name: combined-embedded-postgresql-app"
+    require_contains "$TEST_DIRECTORY/osmo-combined-embedded-api.yaml" \
+        "name: combined-embedded-valkey-credentials"
+
     helm_template embedded-existing "$charts_copy/osmo" \
         --api-versions postgresql.cnpg.io/v1 \
         -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -290,14 +290,27 @@ require_no_resource() {
     fi
 }
 
+require_downloaded_dependencies_untracked() {
+    local repository_root
+    local tracked_archives
+
+    if ! repository_root=$(git -C "$CHARTS_ROOT/osmo" rev-parse --show-toplevel 2>/dev/null); then
+        return
+    fi
+
+    tracked_archives=$(git -C "$repository_root" ls-files -- \
+        'deployments/charts/osmo/charts/*.tgz')
+    [[ -z "$tracked_archives" ]] || \
+        fail "downloaded Helm dependency archives must not be tracked: $tracked_archives"
+}
+
 require_clean_osmo_sources() {
     require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "name: cluster"
     require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "version: 0.8.0"
     require_contains "$CHARTS_ROOT/osmo/Chart.yaml" \
         "condition: embeddedDependencies.postgresql.enabled"
     [[ -e "$CHARTS_ROOT/osmo/Chart.lock" ]] || fail "osmo must have a dependency lock"
-    [[ ! -e "$CHARTS_ROOT/osmo/charts/cluster-0.8.0.tgz" ]] || \
-        fail "osmo must not check in the CloudNativePG cluster archive"
+    require_downloaded_dependencies_untracked
     [[ ! -e "$CHARTS_ROOT/osmo/templates/postgres.yaml" ]] || \
         fail "osmo must not contain an unimplemented embedded PostgreSQL template"
     [[ ! -e "$CHARTS_ROOT/osmo/templates/redis.yaml" ]] || \
@@ -348,7 +361,8 @@ test_control_umbrella() {
     local rendered="$TEST_DIRECTORY/osmo.yaml"
     mkdir -p "$charts_copy"
     cp -R "$CHARTS_ROOT/osmo" "$charts_copy/osmo"
-    if ! compgen -G "$charts_copy/osmo/charts/valkey-0.11.0.tgz" >/dev/null; then
+    if ! compgen -G "$charts_copy/osmo/charts/valkey-0.11.0.tgz" >/dev/null || \
+        ! compgen -G "$charts_copy/osmo/charts/cluster-0.8.0.tgz" >/dev/null; then
         helm dependency build "$charts_copy/osmo" >/dev/null
     fi
 

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1138,6 +1138,66 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "cpu: \"1\""
     require_contains "$TEST_DIRECTORY/osmo-embedded.yaml" "memory: 2Gi"
 
+    local embedded_deployment
+    for embedded_deployment in agent api delayed-job-monitor gateway-authz logger router worker; do
+        resource_document "$TEST_DIRECTORY/osmo-embedded.yaml" Deployment \
+            "embedded-osmo-$embedded_deployment" \
+            >"$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml"
+        require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
+            "embedded-osmo-postgresql-rw"
+        require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
+            "name: OSMO_POSTGRES_PASSWORD"
+        require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
+            "name: embedded-osmo-postgresql-app"
+        require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
+            "key: password"
+        require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
+            "name: PGSSLMODE"
+        require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
+            "value: verify-full"
+        require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
+            "secretName: embedded-osmo-postgresql-ca"
+        require_contains "$TEST_DIRECTORY/osmo-embedded-$embedded_deployment.yaml" \
+            "/etc/osmo/ca/postgresql/ca.crt"
+    done
+    require_contains "$TEST_DIRECTORY/osmo-embedded-gateway-authz.yaml" \
+        "--postgres-ssl-mode=verify-full"
+
+    helm_template embedded-existing "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set secrets.postgresql.generate=false \
+        --set secrets.postgresql.existingSecret=embedded-postgresql-credentials \
+        --set secrets.postgresql.keys.username=username \
+        --set secrets.postgresql.keys.password=password \
+        --set postgresql.cluster.initdb.secret.name=embedded-postgresql-credentials \
+        >"$TEST_DIRECTORY/osmo-embedded-existing.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-existing.yaml" \
+        "name: embedded-postgresql-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-existing.yaml" "key: password"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-existing.yaml" "owner: osmo"
+
+    helm_template embedded-scaled "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.cluster.instances=5 \
+        >"$TEST_DIRECTORY/osmo-embedded-scaled.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-scaled.yaml" "instances: 5"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-scaled.yaml" \
+        "embedded-scaled-postgresql-rw"
+
+    helm_template embedded-dev "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.cluster.instances=1 \
+        --set postgresql.cluster.enablePDB=false \
+        --set postgresql.cluster.postgresql.synchronous.number=0 \
+        --set postgresql.cluster.postgresql.synchronous.dataDurability=preferred \
+        >"$TEST_DIRECTORY/osmo-embedded-dev.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-dev.yaml" "instances: 1"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-dev.yaml" \
+        "dataDurability: preferred"
+
     resource_document "$rendered" Deployment osmo-agent \
         >"$TEST_DIRECTORY/osmo-agent.yaml"
     require_occurrences "$TEST_DIRECTORY/osmo-agent.yaml" "        ports:" 1
@@ -1749,6 +1809,85 @@ EOF
     fi
     require_contains "$TEST_DIRECTORY/missing-cnpg-operator.out" \
         "install a compatible CloudNativePG operator"
+
+    if helm_template embedded-external-host "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set externalDependencies.postgresql.host=unexpected-postgresql \
+        >"$TEST_DIRECTORY/embedded-external-host.out" 2>&1; then
+        fail "expected an external PostgreSQL host in embedded mode to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-external-host.out" \
+        "externalDependencies.postgresql.host must be empty"
+
+    if helm_template embedded-too-small "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.cluster.instances=1 \
+        >"$TEST_DIRECTORY/embedded-too-small.out" 2>&1; then
+        fail "expected required synchronous replication with one instance to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-too-small.out" \
+        "required synchronous replication needs at least 2 instances"
+
+    if helm_template embedded-both-secrets "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set secrets.postgresql.existingSecret=embedded-postgresql-credentials \
+        --set postgresql.cluster.initdb.secret.name=embedded-postgresql-credentials \
+        >"$TEST_DIRECTORY/embedded-both-secrets.out" 2>&1; then
+        fail "expected generated and existing embedded credentials to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-both-secrets.out" \
+        "generate and existingSecret are mutually exclusive"
+
+    if helm_template embedded-secret-mismatch "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set secrets.postgresql.generate=false \
+        --set secrets.postgresql.existingSecret=osmo-postgresql-credentials \
+        --set postgresql.cluster.initdb.secret.name=different-credentials \
+        >"$TEST_DIRECTORY/embedded-secret-mismatch.out" 2>&1; then
+        fail "expected mismatched embedded credential Secret names to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-secret-mismatch.out" \
+        "must match postgresql.cluster.initdb.secret.name"
+
+    if helm_template embedded-secret-keys "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set secrets.postgresql.generate=false \
+        --set secrets.postgresql.existingSecret=osmo-postgresql-credentials \
+        --set postgresql.cluster.initdb.secret.name=osmo-postgresql-credentials \
+        --set secrets.postgresql.keys.username=db-user \
+        >"$TEST_DIRECTORY/embedded-secret-keys.out" 2>&1; then
+        fail "expected non-CNPG embedded credential keys to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-secret-keys.out" \
+        "keys.username and keys.password must be username and password"
+
+    if helm_template embedded-backups "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set postgresql.backups.enabled=true \
+        --set postgresql.backups.s3.region=us-east-1 \
+        --set postgresql.backups.s3.bucket=test-backups \
+        --set postgresql.backups.s3.accessKey=test-access \
+        --set postgresql.backups.s3.secretKey=test-secret \
+        >"$TEST_DIRECTORY/embedded-backups.out" 2>&1; then
+        fail "expected the deferred embedded backup surface to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-backups.out" "OSMO-6609"
+
+    if helm_template invalid-postgresql-instances "$charts_copy/osmo" \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$CHARTS_ROOT/osmo/tests/control-embedded-values.yaml" \
+        --set-string postgresql.cluster.instances=invalid \
+        >"$TEST_DIRECTORY/invalid-postgresql-instances.out" 2>&1; then
+        fail "expected non-integer postgresql.cluster.instances to fail schema validation"
+    fi
+    require_contains "$TEST_DIRECTORY/invalid-postgresql-instances.out" "instances"
+    require_contains "$TEST_DIRECTORY/invalid-postgresql-instances.out" "integer"
 
     if helm_template unsupported-generated-secret "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -22,7 +22,7 @@
       }
     },
     "valkey": { "type": "object" },
-    "postgresql": { "$ref": "#/definitions/embeddedPostgresql" },
+    "postgresql": { "type": "object" },
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "imageRegistry": { "type": "string" },
@@ -930,72 +930,6 @@
             "password": { "type": "string", "minLength": 1 }
           }
         }
-      }
-    },
-    "embeddedPostgresql": {
-      "type": "object",
-      "properties": {
-        "type": { "type": "string", "enum": ["postgresql"] },
-        "version": {
-          "type": "object",
-          "properties": {
-            "postgresql": { "type": "string", "pattern": "^[0-9]+$" }
-          }
-        },
-        "mode": { "type": "string", "enum": ["standalone"] },
-        "cluster": {
-          "type": "object",
-          "properties": {
-            "instances": { "type": "integer", "minimum": 1 },
-            "storage": { "$ref": "#/definitions/postgresqlStorage" },
-            "walStorage": {
-              "allOf": [
-                { "$ref": "#/definitions/postgresqlStorage" },
-                {
-                  "type": "object",
-                  "properties": { "enabled": { "type": "boolean" } }
-                }
-              ]
-            },
-            "resources": { "type": "object" },
-            "primaryUpdateMethod": { "type": "string", "enum": ["switchover", "restart"] },
-            "primaryUpdateStrategy": { "type": "string", "enum": ["unsupervised", "supervised"] },
-            "affinity": {
-              "type": "object",
-              "properties": {
-                "topologyKey": { "type": "string", "minLength": 1 },
-                "podAntiAffinityType": { "type": "string", "enum": ["preferred", "required"] }
-              }
-            },
-            "enableSuperuserAccess": { "type": "boolean" },
-            "enablePDB": { "type": "boolean" },
-            "postgresql": {
-              "type": "object",
-              "properties": {
-                "synchronous": {
-                  "type": "object",
-                  "properties": {
-                    "method": { "type": "string", "enum": ["any", "first"] },
-                    "number": { "type": "integer", "minimum": 0 },
-                    "dataDurability": { "type": "string", "enum": ["preferred", "required"] }
-                  }
-                }
-              }
-            },
-            "initdb": { "type": "object" }
-          }
-        },
-        "backups": {
-          "type": "object",
-          "properties": { "enabled": { "type": "boolean" } }
-        }
-      }
-    },
-    "postgresqlStorage": {
-      "type": "object",
-      "properties": {
-        "size": { "type": "string", "minLength": 1 },
-        "storageClass": { "type": "string" }
       }
     }
   }

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -921,7 +921,6 @@
     "postgresqlSecretReference": {
       "type": "object",
       "properties": {
-        "generate": { "type": "boolean" },
         "existingSecret": { "type": "string" },
         "keys": {
           "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -960,7 +960,13 @@
             "resources": { "type": "object" },
             "primaryUpdateMethod": { "type": "string", "enum": ["switchover", "restart"] },
             "primaryUpdateStrategy": { "type": "string", "enum": ["unsupervised", "supervised"] },
-            "affinity": { "type": "object" },
+            "affinity": {
+              "type": "object",
+              "properties": {
+                "topologyKey": { "type": "string", "minLength": 1 },
+                "podAntiAffinityType": { "type": "string", "enum": ["preferred", "required"] }
+              }
+            },
             "enableSuperuserAccess": { "type": "boolean" },
             "enablePDB": { "type": "boolean" },
             "postgresql": {

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -22,6 +22,7 @@
       }
     },
     "valkey": { "type": "object" },
+    "postgresql": { "type": "object" },
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "imageRegistry": { "type": "string" },

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -22,7 +22,7 @@
       }
     },
     "valkey": { "type": "object" },
-    "postgresql": { "type": "object" },
+    "postgresql": { "$ref": "#/definitions/embeddedPostgresql" },
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "imageRegistry": { "type": "string" },
@@ -64,7 +64,7 @@
     "secrets": {
       "type": "object",
       "properties": {
-        "postgresql": { "$ref": "#/definitions/secretReference" },
+        "postgresql": { "$ref": "#/definitions/postgresqlSecretReference" },
         "valkey": { "$ref": "#/definitions/secretReference" },
         "objectStorage": { "$ref": "#/definitions/secretReference" },
         "masterEncryptionKey": { "$ref": "#/definitions/secretReference" },
@@ -917,6 +917,80 @@
         "username": { "type": "string" }
       },
       "required": ["generate", "existingSecret", "keys"]
+    },
+    "postgresqlSecretReference": {
+      "type": "object",
+      "properties": {
+        "generate": { "type": "boolean" },
+        "existingSecret": { "type": "string" },
+        "keys": {
+          "type": "object",
+          "properties": {
+            "username": { "type": "string", "minLength": 1 },
+            "password": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "embeddedPostgresql": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["postgresql"] },
+        "version": {
+          "type": "object",
+          "properties": {
+            "postgresql": { "type": "string", "pattern": "^[0-9]+$" }
+          }
+        },
+        "mode": { "type": "string", "enum": ["standalone"] },
+        "cluster": {
+          "type": "object",
+          "properties": {
+            "instances": { "type": "integer", "minimum": 1 },
+            "storage": { "$ref": "#/definitions/postgresqlStorage" },
+            "walStorage": {
+              "allOf": [
+                { "$ref": "#/definitions/postgresqlStorage" },
+                {
+                  "type": "object",
+                  "properties": { "enabled": { "type": "boolean" } }
+                }
+              ]
+            },
+            "resources": { "type": "object" },
+            "primaryUpdateMethod": { "type": "string", "enum": ["switchover", "restart"] },
+            "primaryUpdateStrategy": { "type": "string", "enum": ["unsupervised", "supervised"] },
+            "affinity": { "type": "object" },
+            "enableSuperuserAccess": { "type": "boolean" },
+            "enablePDB": { "type": "boolean" },
+            "postgresql": {
+              "type": "object",
+              "properties": {
+                "synchronous": {
+                  "type": "object",
+                  "properties": {
+                    "method": { "type": "string", "enum": ["any", "first"] },
+                    "number": { "type": "integer", "minimum": 0 },
+                    "dataDurability": { "type": "string", "enum": ["preferred", "required"] }
+                  }
+                }
+              }
+            },
+            "initdb": { "type": "object" }
+          }
+        },
+        "backups": {
+          "type": "object",
+          "properties": { "enabled": { "type": "boolean" } }
+        }
+      }
+    },
+    "postgresqlStorage": {
+      "type": "object",
+      "properties": {
+        "size": { "type": "string", "minLength": 1 },
+        "storageClass": { "type": "string" }
+      }
     }
   }
 }

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -1307,6 +1307,7 @@ configuration:
 # CloudNativePG cluster chart values. These settings are used only when
 # embeddedDependencies.postgresql.enabled is true.
 postgresql:
+  nameOverride: pg
   type: postgresql
   version:
     postgresql: "16"

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -204,12 +204,12 @@ monitoring:
 # Generated credentials are supported by embedded PostgreSQL and embedded
 # Valkey; other `generate` switches must remain false.
 secrets:
-  # Embedded PostgreSQL generates a CNPG application Secret by default. For an
+  # Embedded PostgreSQL can use a CNPG-generated application Secret. For an
   # existing embedded Secret, use the CNPG keys `username` and `password` and
   # set postgresql.cluster.initdb.secret.name to the same Secret name. External
   # PostgreSQL requires generate=false and uses keys.password.
   postgresql:
-    generate: true
+    generate: false
     existingSecret: ''
     keys:
       username: username

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -200,14 +200,18 @@ monitoring:
     metricRelabelings: []
 
 # References to Kubernetes Secrets. Inline credentials are not accepted.
-# Generated credentials are supported only for embedded Valkey; every other
-# `generate` switch must remain false.
+# Generated credentials are supported by embedded PostgreSQL and embedded
+# Valkey; other `generate` switches must remain false.
 secrets:
-  # Password used with `externalDependencies.postgresql.username`.
+  # Embedded PostgreSQL generates a CNPG application Secret by default. For an
+  # existing embedded Secret, use the CNPG keys `username` and `password` and
+  # set postgresql.cluster.initdb.secret.name to the same Secret name. External
+  # PostgreSQL requires generate=false and uses keys.password.
   postgresql:
-    generate: false
+    generate: true
     existingSecret: ''
     keys:
+      username: username
       password: db-password
   # Password used for the effective Valkey connection. Embedded mode supports
   # either a retained generated Secret or an existing Secret; external mode

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -12,8 +12,9 @@ planes:
   compute:
     enabled: false
 
-# Select supporting systems managed by this Helm release. Embedded Valkey is
-# available; the other switches remain reserved for later chart dependencies.
+# Select supporting systems managed by this Helm release. Embedded PostgreSQL
+# requires a compatible CloudNativePG operator to be installed first. Embedded
+# Valkey is managed directly by this release.
 embeddedDependencies:
   postgresql:
     enabled: false
@@ -24,8 +25,48 @@ embeddedDependencies:
   kaiScheduler:
     enabled: false
 
-# Connection details for dependencies owned outside this release. The Valkey
-# endpoint is required only when embedded Valkey is disabled.
+# CloudNativePG cluster chart values. These settings are used only when
+# embeddedDependencies.postgresql.enabled is true.
+postgresql:
+  type: postgresql
+  version:
+    postgresql: "16"
+  mode: standalone
+  cluster:
+    instances: 3
+    storage:
+      size: 20Gi
+      storageClass: ''
+    walStorage:
+      enabled: false
+      size: 5Gi
+      storageClass: ''
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+    primaryUpdateMethod: switchover
+    primaryUpdateStrategy: unsupervised
+    affinity:
+      topologyKey: kubernetes.io/hostname
+    enableSuperuserAccess: false
+    enablePDB: true
+    postgresql:
+      synchronous:
+        method: any
+        number: 1
+        dataDurability: required
+    initdb:
+      database: osmo
+      owner: osmo
+  backups:
+    enabled: false
+
+# Connection details for dependencies owned outside this release. Each
+# endpoint is required only when its embedded dependency is disabled.
 externalDependencies:
   # PostgreSQL stores OSMO control-plane state. Set caExistingSecret when the
   # server certificate is signed by a private CA.

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -25,47 +25,6 @@ embeddedDependencies:
   kaiScheduler:
     enabled: false
 
-# CloudNativePG cluster chart values. These settings are used only when
-# embeddedDependencies.postgresql.enabled is true.
-postgresql:
-  type: postgresql
-  version:
-    postgresql: "16"
-  mode: standalone
-  cluster:
-    instances: 3
-    storage:
-      size: 20Gi
-      storageClass: ''
-    walStorage:
-      enabled: false
-      size: 5Gi
-      storageClass: ''
-    resources:
-      requests:
-        cpu: "1"
-        memory: 2Gi
-      limits:
-        cpu: "1"
-        memory: 2Gi
-    primaryUpdateMethod: switchover
-    primaryUpdateStrategy: unsupervised
-    affinity:
-      topologyKey: kubernetes.io/hostname
-      podAntiAffinityType: required
-    enableSuperuserAccess: false
-    enablePDB: true
-    postgresql:
-      synchronous:
-        method: any
-        number: 1
-        dataDurability: required
-    initdb:
-      database: osmo
-      owner: osmo
-  backups:
-    enabled: false
-
 # Connection details for dependencies owned outside this release. Each
 # endpoint is required only when its embedded dependency is disabled.
 externalDependencies:
@@ -1344,6 +1303,47 @@ configuration:
         default: {}
   backendTests: {}
   groupTemplates: {}
+
+# CloudNativePG cluster chart values. These settings are used only when
+# embeddedDependencies.postgresql.enabled is true.
+postgresql:
+  type: postgresql
+  version:
+    postgresql: "16"
+  mode: standalone
+  cluster:
+    instances: 3
+    storage:
+      size: 20Gi
+      storageClass: ''
+    walStorage:
+      enabled: false
+      size: 5Gi
+      storageClass: ''
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+    primaryUpdateMethod: switchover
+    primaryUpdateStrategy: unsupervised
+    affinity:
+      topologyKey: kubernetes.io/hostname
+      podAntiAffinityType: required
+    enableSuperuserAccess: false
+    enablePDB: true
+    postgresql:
+      synchronous:
+        method: any
+        number: 1
+        dataDurability: required
+    initdb:
+      database: osmo
+      owner: osmo
+  backups:
+    enabled: false
 
 # Official Valkey dependency configuration. These defaults provide an
 # authenticated, persistent standalone primary when embedded Valkey is enabled.

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -201,15 +201,15 @@ monitoring:
     metricRelabelings: []
 
 # References to Kubernetes Secrets. Inline credentials are not accepted.
-# Generated credentials are supported by embedded PostgreSQL and embedded
-# Valkey; other `generate` switches must remain false.
+# Embedded PostgreSQL credentials are owned by
+# postgresql.cluster.initdb.secret.name. These Secret settings are external-only
+# for PostgreSQL. Generated credentials are supported by embedded Valkey; other
+# `generate` switches must remain false.
 secrets:
-  # Embedded PostgreSQL can use a CNPG-generated application Secret. For an
-  # existing embedded Secret, use the CNPG keys `username` and `password` and
-  # set postgresql.cluster.initdb.secret.name to the same Secret name. External
-  # PostgreSQL requires generate=false and uses keys.password.
+  # Credentials for external PostgreSQL. Embedded PostgreSQL credentials are
+  # created by CloudNativePG or configured with
+  # postgresql.cluster.initdb.secret.name.
   postgresql:
-    generate: false
     existingSecret: ''
     keys:
       username: username

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -52,6 +52,7 @@ postgresql:
     primaryUpdateStrategy: unsupervised
     affinity:
       topologyKey: kubernetes.io/hostname
+      podAntiAffinityType: required
     enableSuperuserAccess: false
     enablePDB: true
     postgresql:


### PR DESCRIPTION
## Description
Provide the option to add an embedded postgres instance to the umbrella chart

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional embedded PostgreSQL deployment through CloudNativePG.
  - Added support for configuring PostgreSQL storage, resources, replication, initialization, credentials, and TLS.
  - Added connection wiring for OSMO services and clearer deployment output for embedded or external PostgreSQL.
- **Bug Fixes**
  - Improved validation for PostgreSQL modes, credentials, certificates, backups, and operator compatibility.
- **Documentation**
  - Expanded Helm chart guidance for embedded PostgreSQL, external databases, profiles, operations, and private certificate authorities.
- **Tests**
  - Added comprehensive coverage for embedded PostgreSQL rendering, configuration, scaling, security, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->