### PR TITLE
#None - Document MCP OIDC proxy setup

### DIFF
--- a/docs/deployment_guide/advanced_config/mcp.rst
+++ b/docs/deployment_guide/advanced_config/mcp.rst
@@ -22,80 +22,254 @@ MCP
 ===
 
 MCP is an optional feature deployed in the same Helm release as the OSMO
-service. It uses the existing OSMO Gateway and does not require a separate
-chart or load balancer. When enabled, the chart creates the MCP Deployment,
-ClusterIP Service, Gateway routes, protected-resource metadata, and an ingress
-NetworkPolicy for this release's Gateway Envoy pods.
+service. The chart creates an MCP Deployment, a ClusterIP Service, Gateway
+routes, and an ingress NetworkPolicy. The recommended authentication mode passes
+FastMCP's built-in ``OIDCProxy`` directly to the existing MCP server; it does
+not deploy a second OAuth broker service.
 
-Identity and Permissions
-========================
+Authentication Modes
+====================
 
-MCP acts on behalf of the signed-in user and has the same effective OSMO
-identity, roles, accessible pools, and API permissions as the equivalent
-authenticated CLI request. It does not assume a service identity or elevate
-access. MCP relays the caller's bearer token unchanged rather than performing
-an OAuth token exchange. See :ref:`mcp_identity_permissions` for the complete
-permission model.
+OSMO supports two MCP authentication modes:
 
-Before You Enable MCP
-=====================
+.. list-table::
+   :header-rows: 1
+   :widths: 24 38 38
+
+   * - Mode
+     - Client configuration
+     - Request authentication
+   * - OIDC proxy (recommended)
+     - The user configures only ``https://<osmo-host>/mcp``. FastMCP advertises
+       Client ID Metadata Documents (CIMD) and retains Dynamic Client
+       Registration (DCR) as a compatibility fallback.
+     - FastMCP authenticates requests to the exact ``/mcp`` route in the MCP
+       process and relays the verified upstream access token to normal OSMO API
+       authorization.
+   * - Direct identity provider
+     - The user might need a public OAuth client ID, scopes, and callback
+       settings supplied by the administrator.
+     - Gateway validates the bearer token and enforces ``mcp:Access`` before
+       forwarding requests to the exact ``/mcp`` route.
+
+In both modes, every tool call re-enters the OSMO Gateway and is authorized by
+the normal API action and pool scope. MCP never assumes a service identity and
+cannot elevate the user. See :ref:`mcp_identity_permissions` and
+:ref:`actions_resources_reference`.
+
+Shared Prerequisites
+====================
+
+Before enabling either mode:
 
 * Keep ``gateway.envoy.enabled`` and ``gateway.authz.enabled`` set to ``true``.
-* Configure at least one ``gateway.envoy.jwt.providers`` entry for the token
-  used by the MCP client. Match the token's actual issuer and audience, and
-  ensure its claims or mappings resolve to an OSMO user and role.
-* Register a public/native OAuth client for MCP client sign-in. Enable the
-  authorization-code flow with PKCE using ``S256``, register the exact client
-  callback URI, and do not create or distribute a client secret.
-* Grant the public client the delegated scope for the MCP resource.
-* Ensure that the public OSMO hostname resolves to this release's Gateway over
-  HTTPS. The MCP pod must also be able to resolve and reach that hostname.
-* Add ``mcp:Access`` and the required tool permissions to the OSMO roles that
-  can use MCP. The default ``osmo-user`` role already includes
-  ``mcp:Access``; custom roles might not.
+* Configure a ``gateway.envoy.jwt.providers`` entry that validates the bearer
+  token used for downstream ``/api`` requests and resolves its identity and
+  roles to the intended OSMO user.
+* Publish the release Gateway on one HTTPS hostname. Set
+  ``services.mcp.resourceUrl`` to that origin plus the exact ``/mcp`` path.
+* Ensure that the MCP pod can resolve and reach the public Gateway origin.
+* Grant users the API actions and pool-scoped permissions required by the
+  tools they can call. Direct mode additionally requires ``mcp:Access``.
+* Keep Gateway NetworkPolicy enforcement enabled and ensure that no broader
+  policy unintentionally permits direct ingress to the MCP pod.
 
-Configure MCP
-=============
+Configure OIDC Proxy Mode
+=========================
 
-Add the following values to ``osmo_values.yaml``:
+OIDC proxy mode provides endpoint-only client setup. The deployment owns one
+confidential upstream OIDC application. Individual MCP clients do not need to
+configure its client ID and never receive its client secret.
+
+Register the Upstream Application
+---------------------------------
+
+Configure one confidential application in the identity provider with:
+
+* The exact redirect URL ``https://<osmo-host>/auth/callback``.
+* Authorization code flow and the ``client_secret_post`` token authentication
+  method.
+* A delegated API scope whose full URI is
+  ``https://<osmo-host>/mcp/access_as_user``.
+* User or group assignments and administrator consent appropriate for the
+  deployment.
+
+``access_as_user`` permits delegated MCP access as the signed-in user. It does
+not grant workflow, application, credential, or pool permissions; each tool's
+normal OSMO authorization still applies.
+
+The upstream access token must be an RS256 JWT with the configured issuer, the
+exact ``https://<osmo-host>/mcp`` audience, and the short scope value
+``access_as_user`` in its ``scp`` claim. Configure the existing Gateway JWT
+provider for the same token and its OSMO identity or role mappings.
+
+FastMCP's proxy is based on standard OIDC discovery, but this OSMO profile
+currently supports one upstream provider and enforces the token contract above.
+Microsoft Entra is the validated provider profile. Test claim and scope
+compatibility before using another provider.
+
+.. important::
+
+   Do not confuse the fixed upstream ``/auth/callback`` URL with a native MCP
+   client's temporary localhost callback. FastMCP accepts native loopback
+   callbacks automatically. Browser-hosted clients require separately
+   configured HTTPS redirect origins.
+
+Provide Redis and Secrets
+-------------------------
+
+FastMCP stores client registrations, authorization transactions, and encrypted
+upstream token state in Redis. Use a dedicated database number or key prefix.
+The chart mounts externally managed credentials but does not generate them.
+
+Create or inject the client secret and, when required, the Redis password at
+their configured paths. The example below uses:
+
+* The upstream OIDC client secret at
+  ``/etc/osmo/mcp-auth/client-secret``.
+* The Redis password at ``/etc/osmo/mcp-auth/redis-password`` when Redis
+  requires one.
+
+Use an external secret manager or an existing Kubernetes Secret. Never place
+the client secret, Redis password, authorization code, access token, or refresh
+token in Helm values, Git, or logs.
+
+FastMCP deterministically derives its proxy-token signing key from the OIDC
+client secret. OSMO derives the Redis encryption key from the same secret with
+a separate salt. Rotating the client secret therefore invalidates active proxy
+sessions and makes old encrypted state, including DCR registrations, unusable.
+Users must authenticate again, and DCR clients might need to remove and re-add
+the MCP entry before login.
+
+.. warning::
+
+   OSMO currently relies on FastMCP's default derived signing key to avoid a
+   second operator-managed secret. FastMCP documents that default as a
+   development or local-testing convenience and recommends an explicit
+   independent signing key for production. The current OSMO chart does not
+   expose that independent-key option. Assess this limitation before a
+   production rollout and require a high-entropy upstream client secret. See
+   the `FastMCP OIDC proxy signing-key guidance
+   <https://gofastmcp.com/servers/auth/oidc-proxy#param-jwt-signing-key>`_.
+
+Configure Helm Values
+---------------------
+
+The following example uses an existing Secret. Adapt the OIDC and Redis values
+to the deployment:
 
 .. code-block:: yaml
 
    services:
      mcp:
        enabled: true
-       resourceUrl: https://<your-domain>/mcp
+       replicas: 1
+       resourceUrl: https://osmo.example.com/mcp
+       oidcProxy:
+         enabled: true
+         scope: https://osmo.example.com/mcp/access_as_user
+         oidc:
+           configUrl: https://idp.example.com/.well-known/openid-configuration
+           clientId: <confidential-oidc-client-id>
+           clientSecretFile: /etc/osmo/mcp-auth/client-secret
+           accessTokenIssuer: https://issuer.example.com/
+           accessTokenAudience: https://osmo.example.com/mcp
+           accessTokenJwksUrl: https://idp.example.com/jwks
+           accessTokenRequiredScope: access_as_user
+         redis:
+           dbNumber: 0
+           keyPrefix: osmo:mcp-fastmcp
+           passwordFile: /etc/osmo/mcp-auth/redis-password
+         existingSecret:
+           name: osmo-mcp-oidc
+           mountPath: /etc/osmo/mcp-auth
+           clientSecretKey: client-secret
+           redisPasswordKey: redis-password
+
+Blank OIDC proxy Redis host and port values inherit ``services.redis``.
+``services.mcp.authorizationServers`` and ``services.mcp.scopes`` are ignored
+while the proxy is enabled. Keep ``services.mcp.replicas`` at ``1`` because
+the current refresh lock is process-local and does not serialize refreshes
+across replicas.
+
+Native clients normally omit ``Origin`` and need neither of the following
+settings. For a browser-hosted MCP client, configure both concepts separately:
+
+* ``services.mcp.allowedOrigins`` controls which browser origins can call
+  ``/mcp`` through CORS.
+* ``services.mcp.oidcProxy.trustedHttpsRedirectOrigins`` controls which exact
+  HTTPS origins can receive OAuth callbacks for browser-hosted clients.
+
+How the Proxy Flow Works
+------------------------
+
+FastMCP serves OAuth and MCP from the same process:
+
+#. The client discovers protected-resource and authorization-server metadata.
+#. The client uses CIMD or falls back to DCR through ``POST /register``.
+#. FastMCP obtains user consent, runs authorization code flow with Proof Key for
+   Code Exchange (PKCE), and sends the user to the upstream OIDC provider.
+#. The provider returns to the fixed ``/auth/callback`` URL.
+#. FastMCP exchanges the upstream authorization code for tokens, stores the
+   resulting token state encrypted in Redis, and redirects the browser to the
+   MCP client with a FastMCP authorization code.
+#. The client sends that code and its PKCE verifier to ``POST /token``. FastMCP
+   validates them and issues a short-lived resource token.
+#. FastMCP authenticates the resource token on ``/mcp`` and exposes the
+   verified upstream bearer to the tool request.
+#. The tool relays that upstream bearer to ``/api``, where Gateway JWT,
+   semantic RBAC, and pool authorization remain authoritative.
+
+FastMCP requests the full delegated MCP scope plus ``openid``, ``profile``,
+``email``, and ``offline_access`` upstream. Clients discover the delegated MCP
+scope and do not supply these upstream scopes manually. Proxy access tokens
+default to 600 seconds. ``refreshTokenTtlSeconds`` is a fallback only when the
+upstream provider omits refresh-token expiry.
+
+``offline_access`` lets the proxy request a refresh token so a session can
+renew without another browser sign-in. It does not grant additional OSMO
+permissions.
+
+Configure Direct Identity-Provider Mode
+=======================================
+
+Use direct mode when clients are already registered with the identity provider
+and the deployment does not need endpoint-only setup.
+
+Register a public or native OAuth client with authorization code flow and PKCE
+with ``S256``. Do not create or distribute a client secret for that public
+client. Then configure:
+
+.. code-block:: yaml
+
+   services:
+     mcp:
+       enabled: true
+       resourceUrl: https://osmo.example.com/mcp
+       oidcProxy:
+         enabled: false
        authorizationServers:
-       - <idp-issuer-url>
+       - https://issuer.example.com/
        scopes:
-       - <delegated-mcp-scope>
-       requestTimeoutSeconds: 10
+       - api://<resource-id>/access_as_user
        # Browser-hosted clients only:
        # allowedOrigins:
-       # - https://<mcp-client-origin>
+       # - https://client.example.com
 
-``resourceUrl`` must be the public HTTPS URL ending in exact ``/mcp``.
-``authorizationServers`` contains OAuth or OIDC issuer identifiers, not
-authorize or token endpoints. ``scopes`` contains the MCP resource scopes
-advertised to clients. The complete client scope list can also contain
-identity-provider scopes such as ``openid``, ``profile``, ``email``, or
-``offline_access``.
-
-The public client ID is not a Helm value and is not necessarily the access
-token audience. Configure the Gateway JWT provider from the token's actual
-issuer and audience. Native clients such as Codex normally omit the ``Origin``
-header and do not need ``allowedOrigins``.
-
-See the `MCP sign-in requirements
-<https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization>`_
-for sign-in discovery, PKCE, and redirect URI requirements.
+``authorizationServers`` contains issuer identifiers, not authorization or
+token endpoints. ``scopes`` contains the resource scopes advertised to
+clients. Configure Gateway JWT validation from the access token's actual
+issuer and audience; the public client ID is not a Helm value and is not
+necessarily the token audience.
 
 Deploy or Upgrade
 =================
 
-Save ``osmo_values.yaml``, then use the normal OSMO service install or upgrade
-in :ref:`Step 5: Deploy Components <deploy_service_deploy_components>`. MCP is
-included in that Helm release when ``services.mcp.enabled`` is ``true``.
+Save the values overlay, then use the normal OSMO service install or upgrade in
+:ref:`Step 5: Deploy Components <deploy_service_deploy_components>`. MCP is
+part of that Helm release when ``services.mcp.enabled`` is ``true``. Enabling
+OIDC proxy changes the existing MCP Deployment and Gateway routes; it does not
+create another application service.
 
 Verify MCP
 ==========
@@ -112,36 +286,64 @@ Verify the chart-created resources:
        -n osmo
    $ kubectl get networkpolicy -n osmo
 
-Confirm that the NetworkPolicy named
-``<services.mcp.serviceName>-allow-gateway-envoy`` is present. With the default
-service name, it is ``osmo-mcp-allow-gateway-envoy``.
+Confirm that ``<services.mcp.serviceName>-allow-gateway-envoy`` is present.
+With the default service name, it is
+``osmo-mcp-allow-gateway-envoy``.
 
-After DNS is configured, verify the public protected-resource metadata:
+For either mode, verify protected-resource metadata:
 
 .. code-block:: bash
 
    $ curl --fail --silent --show-error \
-       https://<your-domain>/.well-known/oauth-protected-resource/mcp
+       https://osmo.example.com/.well-known/oauth-protected-resource/mcp
 
-Confirm that the response contains the expected ``resource``,
-``authorization_servers``, and ``scopes_supported`` values. This confirms the
-deployment and client discovery configuration. User access is verified after
-the user connects.
+In OIDC proxy mode, also verify authorization-server metadata:
+
+.. code-block:: bash
+
+   $ curl --fail --silent --show-error \
+       https://osmo.example.com/.well-known/oauth-authorization-server
+
+Confirm the exact resource URL and full delegated scope. Proxy metadata must
+also contain ``client_id_metadata_document_supported`` set to ``true`` and a
+``registration_endpoint`` for DCR fallback. Complete a fresh endpoint-only
+login and run the read-only verification in :ref:`getting_started_mcp`.
 
 Provide Connection Details
 ==========================
 
-Give users:
+For OIDC proxy mode, give users only the MCP URL. Clients discover scopes from
+the proxy metadata, and the proxy accepts native loopback redirects
+automatically.
 
-* The MCP URL from ``services.mcp.resourceUrl``.
-* The non-secret public OAuth client ID.
-* The complete OAuth scope list, including any required identity-provider
-  scopes.
-* The client-specific redirect URI requirements.
+For direct mode, also give users the public client ID, complete OAuth scope
+list, and client-specific callback requirements. Direct users to
+:ref:`getting_started_mcp`.
 
-Direct users to :ref:`getting_started_mcp` to connect and run the read-only
-verification. If a client reveals its exact callback URI only during sign-in,
-register that URI and have the user repeat the sign-in.
+Operate OIDC Proxy Safely
+=========================
+
+* Monitor authorization, callback, token, refresh, Redis, and upstream OIDC
+  outcomes without recording codes, tokens, client secrets, or identity
+  payloads.
+* Health probes report MCP process health; they do not prove Redis or upstream
+  identity-provider connectivity.
+* Keep FastMCP's CIMD URL validation and server-side request forgery (SSRF)
+  protections enabled. CIMD causes the server to fetch client-controlled HTTPS
+  metadata URLs.
+* Add deliberate ingress or Gateway rate limits to the exact public OAuth
+  routes, especially ``POST /register`` and ``POST /token``. Do not apply a
+  shared limit to long-lived MCP traffic without considering denial-of-service
+  effects.
+* Keep the MCP ingress NetworkPolicy. It is additive, so audit other policies
+  that select the same pod.
+
+The public proxy surface is limited to exact protected-resource and
+authorization-server metadata, ``/authorize``, ``/auth/callback``,
+``/register``, ``/token``, and ``/consent`` routes. Gateway bypasses its own JWT
+and semantic authorization filters only for these OAuth routes and exact
+``/mcp`` in proxy mode. FastMCP authenticates ``/mcp``; all ``/api`` calls keep
+normal Gateway validation and authorization.
 
 .. _mcp_deployment_troubleshooting:
 
@@ -150,23 +352,52 @@ Troubleshooting
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 70
+   :widths: 32 68
 
    * - Symptom
      - Action
    * - Metadata returns ``404`` or unexpected values
-     - Verify that ``services.mcp.enabled`` is ``true``, DNS points to this
-       release's Gateway, and the resource URL, issuer, and scopes match the
-       expected values.
-   * - Sign-in succeeds but MCP returns ``HTTP 401``
-     - Verify that the token's issuer and audience match a
-       ``gateway.envoy.jwt.providers`` entry.
+     - Verify that ``services.mcp.enabled`` is true, DNS points to this
+       release's Gateway, and ``resourceUrl`` ends with the exact path
+       ``/mcp``. In proxy mode, also verify ``oidcProxy.enabled`` and the
+       authorization-server metadata route.
+   * - MCP pod does not become ready
+     - Inspect configuration and credential-file errors first. The client
+       secret and optional Redis password must exist at the configured absolute
+       paths.
+   * - Browser reports a redirect mismatch or no reply address
+     - Register exact ``https://<osmo-host>/auth/callback`` on the confidential
+       upstream application. For Entra, use the Web platform for this
+       server-side client.
+   * - Browser reports ``Approval required``
+     - Grant administrator consent and assign the intended users or groups to
+       the upstream application and delegated MCP scope.
+   * - Proxy login or refresh fails
+     - Verify Redis connectivity, OIDC discovery, client-secret validity,
+       upstream token endpoint responses, and the configured issuer, audience,
+       JWKS URL, and short access-token scope. Never log response tokens.
+   * - MCP initialization returns ``HTTP 401``
+     - Have the user log out and authenticate again. If it persists, verify the
+       FastMCP token route and proxy session state.
+   * - MCP initialization returns ``HTTP 403``
+     - In direct mode, verify ``mcp:Access``. In OIDC proxy mode, verify the
+       advertised full MCP scope and the scope on the issued FastMCP resource
+       token.
    * - A tool returns ``HTTP 403``
-     - Verify that the user's OSMO role contains ``mcp:Access`` and the normal
-       API permission required by the tool.
+     - Authentication succeeded. Verify the user's OSMO API action and pool
+       scope for that tool.
    * - Tools time out or report a Gateway dependency failure
-     - Verify that ``services.mcp.resourceUrl`` ends in exact ``/mcp`` and that
-       the MCP pod can resolve and reach its public Gateway origin.
+     - Verify that the MCP pod can resolve and reach the public origin derived
+       from ``resourceUrl``, and inspect Gateway and target API health.
    * - Direct in-cluster requests to MCP fail
      - This is expected when NetworkPolicy is enforced. The chart permits
        ingress from this release's Gateway Envoy pods, not arbitrary pods.
+
+Rollback
+========
+
+To return to direct mode, disable ``services.mcp.oidcProxy.enabled``, restore
+``authorizationServers`` and ``scopes``, and redeploy. Existing proxy sessions
+will no longer authenticate; users must configure and log in through the
+direct provider. The MCP tool catalog and API-specific permissions do not
+change.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -92,6 +92,7 @@ exec'd
 executables
 exitActions
 extraArgs
+FastMCP
 filebrowser
 Filebrowser
 filesystem
@@ -296,6 +297,7 @@ stateful
 stderr
 stdin
 stdout
+Streamable
 sts
 subfolder
 subnet
@@ -342,6 +344,7 @@ uuid
 vace
 validator
 validators
+verifier
 vCPUs
 VNet
 Volce

--- a/docs/user_guide/appendix/mcp/index.rst
+++ b/docs/user_guide/appendix/mcp/index.rst
@@ -45,6 +45,55 @@ MCP uses the signed-in user's existing OSMO access. Users have the same roles,
 accessible pools, and API permissions as when they use OSMO through the CLI.
 MCP does not grant additional access or elevate permissions.
 
+Authentication depends on the deployment mode:
+
+* In the recommended OIDC proxy mode, the user configures only the MCP URL.
+  FastMCP handles OAuth discovery, client identification with Client ID
+  Metadata Documents (CIMD) or registration with Dynamic Client Registration
+  (DCR), Proof Key for Code Exchange (PKCE), browser sign-in, token exchange,
+  and refresh inside the existing MCP process.
+* In direct identity-provider mode, the administrator can also require a public
+  client ID, scopes, and callback configuration. Gateway requires
+  ``mcp:Access`` before forwarding MCP protocol requests in this mode.
+
+In either mode, successful login does not authorize every tool. Each tool's
+OSMO API request is checked separately. Workflow operations are authorized
+against the owning or target pool, so a user can connect to MCP and inspect a
+profile while still being unable to submit to a restricted pool.
+
+Common permission requirements are summarized below. The receiving OSMO API
+remains authoritative.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Tool area
+     - Typical OSMO actions
+   * - Health and profile
+     - ``profile:Read`` for health and profile inspection;
+       ``profile:Update`` for supported profile changes.
+   * - Pools and resources
+     - ``profile:Read`` plus ``pool:List`` for pool search, or
+       ``profile:Read`` plus ``resources:Read`` for resource inspection.
+   * - Workflow inspection
+     - ``profile:Read`` plus ``workflow:List`` for lists, and
+       ``workflow:Read`` for workflow details, logs, events, and
+       specifications.
+   * - Workflow actions
+     - Pool-scoped ``workflow:Create`` for validation and submission;
+       omitting the pool also requires ``profile:Read``. Cancellation requires
+       ``workflow:Cancel``. Restart also reads the source workflow and creates
+       a workflow in the target pool.
+   * - Applications
+     - ``app:Read`` for inspection; ``app:Create`` for create and rename;
+       ``app:Update`` for update; and ``app:Delete`` for deletion. Application
+       submission requires ``app:Read`` plus pool-scoped ``workflow:Create``,
+       and also ``profile:Read`` when the pool is omitted.
+   * - Credentials
+     - ``credentials:Read`` for metadata and ``credentials:Delete`` for
+       deletion. MCP never returns secret payloads.
+
 MCP and the OSMO Agent Skill
 ============================
 
@@ -125,10 +174,11 @@ MCP deliberately exposes a smaller surface than the CLI:
   the result uncertain, inspect OSMO state before retrying.
 * Workflow validation is not completely side-effect free: a failed validation
   can create a ``FAILED_SUBMISSION`` record.
-* MCP does not return or log credential payloads or submitted specifications.
-  However, the calling client can retain those arguments in its transcript or
-  logs. Reference OSMO credentials instead of embedding secrets in workflow or
-  application YAML.
+* Credential tools never accept or return secret payloads. Mutation responses
+  do not echo newly submitted specifications, and MCP does not log them. Read
+  tools can return bounded, redacted stored specifications. The calling client
+  can retain mutation arguments in its transcript or logs, so reference OSMO
+  credentials instead of embedding secrets in workflow or application YAML.
 * Application descriptions can appear in service access logs and must not
   contain secrets.
 * Workflow label overrides can appear in service access logs and must not
@@ -139,7 +189,8 @@ Capabilities Not Exposed
 
 The self-hosted MCP does not expose:
 
-* CLI login, logout, or access-token management;
+* OSMO CLI login, logout, or OSMO access-token management as MCP tools (the
+  calling client can still manage its own MCP OAuth session);
 * credential creation or replacement;
 * local file expansion or data upload and download;
 * workflow exec, port forwarding, or rsync;

--- a/docs/user_guide/getting_started/mcp.rst
+++ b/docs/user_guide/getting_started/mcp.rst
@@ -21,8 +21,9 @@
 MCP
 ===
 
-MCP lets a compatible client use predefined tools against your OSMO
-deployment. You sign in with your existing OSMO identity.
+MCP lets a compatible client use a bounded set of tools against your OSMO
+deployment. You sign in with your existing OSMO identity. MCP does not require
+the OSMO CLI or the OSMO Agent Skill.
 
 Before You Connect
 ==================
@@ -30,99 +31,163 @@ Before You Connect
 MCP must be enabled before you connect. If it is unavailable, ask your OSMO
 administrator to follow :ref:`MCP deployment <mcp_deployment>`.
 
+Ask your administrator for the MCP URL. It normally has the following form:
+
+.. code-block:: text
+
+   https://<osmo-host>/mcp
+
+Start with the OIDC proxy instructions below unless your administrator says
+that the deployment uses direct identity-provider mode. Proxy mode requires
+only the URL. Direct mode also requires a public OAuth client ID, complete
+scope list, and callback requirements from the administrator.
+
+MCP acts on your behalf. Every tool call is authorized with your existing OSMO
+roles, API actions, and accessible pools; MCP cannot elevate your access. See
+:ref:`mcp_identity_permissions` for details.
+
+Connect with OIDC Proxy Mode
+============================
+
+The following example uses Codex and the recommended endpoint-only login.
+Replace ``osmo.example.com`` with your deployment hostname:
+
+.. code-block:: bash
+
+   $ codex mcp add osmo --url https://osmo.example.com/mcp
+   $ codex mcp login osmo
+
+In the browser, follow the prompts to review and approve FastMCP consent and to
+complete the upstream identity-provider sign-in, then return to the terminal.
+FastMCP handles OAuth discovery, client identification with Client ID
+Metadata Documents (CIMD) or registration with Dynamic Client Registration
+(DCR), Proof Key for Code Exchange (PKCE), scopes, callbacks, token exchange,
+and refresh. Do not add a client ID, scope list, client secret, callback port,
+or bearer token unless your administrator explicitly says that the deployment
+uses direct mode.
+
+Run ``codex mcp list`` to confirm that the entry is configured, then start or
+restart Codex so it loads the authenticated server.
+
+For another compatible client, select Streamable HTTP, enter only the MCP URL,
+and leave headers, bearer token, client ID, and scopes unset. To use the
+endpoint-only flow, the client must support OAuth discovery, PKCE S256, and
+either CIMD client identification or DCR registration.
+
 .. note::
 
-   This is separate from the Agent Skill described under
-   :doc:`Install Client <install/index>`. MCP connects directly to a remote
-   HTTPS endpoint and does not require the OSMO CLI or Agent Skill.
+   The identity provider returns to the deployment's fixed
+   ``https://<osmo-host>/auth/callback`` URL. After FastMCP completes that
+   exchange, the browser redirects to a temporary loopback URL owned by the MCP
+   client. The administrator registers only the fixed upstream callback with
+   the identity provider.
 
-Ask your OSMO administrator for:
+.. _getting_started_mcp_direct_mode:
 
-* The MCP URL, such as ``https://osmo.example.com/mcp``.
-* The public OAuth client ID.
-* The complete OAuth scope list to request, including any IdP/client scopes.
-* Any redirect URI requirements for your identity provider.
+Connect with Direct Identity-Provider Mode
+==========================================
 
-MCP acts on your behalf with the same OSMO identity, roles, accessible pools,
-and API permissions as the equivalent authenticated CLI request; it cannot
-elevate your access. See :ref:`mcp_identity_permissions` for details.
-
-Your role must include ``mcp:Access`` to connect to MCP. Each tool also
-requires the normal OSMO permission for its API. For example,
-``osmo_get_profile`` requires ``profile:Read``.
-
-Connect Codex
-=============
-
-The following example uses Codex. Replace ``osmo.example.com`` and
-``<mcp-public-client-id>`` with the values from your administrator.
+Use this mode only when your administrator explicitly provides a public OAuth
+client ID and scopes. Replace all example values with the supplied values:
 
 .. code-block:: bash
 
    $ codex mcp add osmo \
        --url https://osmo.example.com/mcp \
-       --oauth-client-id <mcp-public-client-id>
+       --oauth-client-id YOUR_MCP_PUBLIC_CLIENT_ID
    $ codex mcp login \
-       --scopes '<comma-separated-oauth-scopes>' \
+       --scopes 'YOUR_COMMA_SEPARATED_OAUTH_SCOPES' \
        osmo
 
-The login command starts a browser-based OAuth flow.
-
-Use the exact scopes supplied by your administrator. If permitted by your
-identity provider, adding ``offline_access`` lets Codex request a refresh token;
-it does not need to be advertised by the MCP resource.
-
-Configure a Fixed Redirect URI
-==============================
-
-If your identity provider requires a pre-registered redirect URI, start login
-with a temporary callback configuration:
-
-.. code-block:: bash
-
-   $ codex mcp login \
-       -c 'mcp_oauth_callback_port=53682' \
-       -c 'mcp_oauth_callback_url="http://localhost:53682/oauth/callback"' \
-       --scopes '<comma-separated-oauth-scopes>' \
-       osmo
-
-Codex appends a server-specific ID to the callback URL. Ask your administrator
-to register the exact ``redirect_uri`` shown during login, then run the login
-command again. These ``-c`` options apply only to this command.
+Use the complete scope list exactly as supplied. Direct mode can also require
+a pre-registered callback URL; follow the client-specific callback settings
+from your administrator. In direct mode, your OSMO role must grant
+``mcp:Access`` in addition to each tool's normal API permission.
 
 Verify Access
 =============
 
-Ask your MCP client to perform a read-only check:
+First ask the client to perform a caller-bound health check:
 
 .. code-block:: text
 
-   Use MCP to call osmo_get_profile. Do not make any changes.
+   Use only the osmo MCP server to call osmo_health. Do not make any changes.
 
-A successful result confirms sign-in, ``mcp:Access``,
-``profile:Read``, and the complete request path through OSMO. You can then try
-other read-only tools permitted by your role.
+Then inspect your identity and accessible pools:
+
+.. code-block:: text
+
+   Use only the osmo MCP server to call osmo_get_profile. Do not make any changes.
+
+A successful result confirms the MCP login and the normal OSMO profile access
+required by these tools. Other tools can still return ``HTTP 403`` when your
+role lacks their API action or when the requested pool is outside your access.
+
+Refresh or Replace a Login
+==========================
+
+FastMCP normally refreshes an expiring session automatically. Log out and sign
+in again after an administrator changes your identity-provider assignment, or
+when the session is expired, revoked, or cannot be refreshed:
+
+.. code-block:: bash
+
+   $ codex mcp logout osmo
+   $ codex mcp login osmo
+
+Remove and re-add the MCP entry when its URL or authentication mode has changed,
+or when an administrator rotates the proxy's upstream client secret and a
+stored DCR registration no longer works. The following sequence resets an OIDC
+proxy configuration:
+
+.. code-block:: bash
+
+   $ codex mcp logout osmo
+   $ codex mcp remove osmo
+   $ codex mcp add osmo --url https://osmo.example.com/mcp
+   $ codex mcp login osmo
+
+When switching to direct mode, repeat the
+:ref:`direct identity-provider instructions <getting_started_mcp_direct_mode>`
+instead.
 
 Troubleshooting
 ===============
 
 .. list-table::
    :header-rows: 1
-   :widths: 25 75
+   :widths: 30 70
 
    * - Symptom
      - Action
-   * - ``HTTP 401``
-     - Run the same ``codex mcp login`` variant again with the full
-       ``--scopes`` list. If you configured a fixed callback, preserve both
-       ``-c`` callback options. If the error continues, contact your OSMO
-       administrator.
-   * - ``HTTP 403``
-     - Ask your administrator to verify ``mcp:Access`` and the OSMO permission
-       required by that tool.
-   * - Redirect URI mismatch
-     - Ask your administrator to register the exact ``redirect_uri`` displayed
-       during login.
+   * - OAuth discovery or registration fails
+     - Confirm that the configured URL ends with the exact path ``/mcp``. If
+       the error continues, ask the administrator to verify the FastMCP
+       metadata and registration routes.
+   * - The browser reports ``Approval required``
+     - The identity-provider application or delegated MCP scope requires
+       administrator approval. This is not an MCP client configuration error.
+   * - The browser reports ``AADSTS50011`` or ``AADSTS900971``
+     - Ask the administrator to verify that the confidential upstream
+       application has the exact ``https://<osmo-host>/auth/callback`` redirect
+       registered for the correct application type.
+   * - MCP initialization returns ``HTTP 401``
+     - Run ``codex mcp logout osmo`` and ``codex mcp login osmo``. If the error
+       continues, contact the administrator.
+   * - MCP initialization returns ``HTTP 403``
+     - In direct mode, ask the administrator to verify ``mcp:Access``. In OIDC
+       proxy mode, log out and sign in again; if it persists, ask them to
+       verify the advertised and issued MCP resource scope.
+   * - A tool returns ``HTTP 403``
+     - Login succeeded, but the user lacks the API action or pool access needed
+       by that tool.
+   * - Token refresh reports ``invalid_grant`` or cannot parse the response
+     - Log out and authenticate once more. If it repeats, ask the administrator
+       to inspect the FastMCP token route, Redis, and the upstream identity
+       provider without logging tokens.
+   * - Opening ``/mcp`` in a browser returns ``405``
+     - This is expected. The endpoint accepts MCP protocol requests from a
+       compatible client; it is not a browser page.
    * - Timeout or Gateway dependency error
      - Contact your administrator and refer them to
        :ref:`MCP deployment troubleshooting
@@ -134,9 +199,9 @@ Use MCP Safely
 .. warning::
 
    An MCP client can retain tool arguments in its transcript or logs,
-   including credential payloads and inline workflow or application
-   specifications. Use a client and retention policy approved for secret
-   entry. Reference OSMO credentials instead of embedding secrets in YAML.
+   including secret values placed in inline workflow or application
+   specifications. Use a client and retention policy approved for handling
+   secrets. Reference OSMO credentials instead of embedding secrets in YAML.
 
 State-changing tools are not automatically retried. If a write reports a
 timeout or another ambiguous failure, inspect the current OSMO state before


### PR DESCRIPTION
## Description

Document the FastMCP OIDC proxy introduced by #1300 as a separate,
documentation-only change.

This updates the MCP getting-started guide, user reference, and deployment
guide with endpoint-only client setup, direct-mode fallback, authentication
and callback behavior, permissions, Redis and secret handling, deployment
verification, and troubleshooting.

Depends on #1300.

Issue #None

## Testing

- `make -C docs build`
- `make -C docs spelling`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] The documentation is based on the implemented runtime and Helm behavior.
- [x] HTML, Markdown, spelling, and link rendering were validated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated MCP setup guidance with OIDC proxy and direct identity-provider authentication options.
  - Added instructions for OAuth discovery, token handling, session refresh, endpoint configuration, and access verification.
  - Expanded deployment guidance for Redis, scaling, security, monitoring, rate limiting, and rollback.
  - Documented MCP authorization, tool permissions, credential safety, and OSMO access requirements.
  - Added troubleshooting guidance for authentication, authorization, registration, callback, token, and connection issues.
  - Updated spelling references for MCP terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->