### PR TITLE
Support Kubernetes Secret MEK rotation

### DIFF
--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -189,7 +189,13 @@ jobs:
             df -h /
             echo "::endgroup::"
           ' EXIT
+          # Keep this below the job's 60-minute ceiling. Without an inner
+          # deadline, a stuck Helm/Kubernetes wait consumes the whole job and
+          # GitHub kills it before the diagnostic and artifact steps can run.
+          # `timeout` returns 124, which is an ordinary step failure, leaving
+          # roughly ten minutes for cluster state and logs to be collected.
           /usr/bin/time -p -o /tmp/oetf.time \
+            timeout --signal=TERM --kill-after=30s 40m \
             bazel run //test/oetf:deploy_and_run -- \
               --env kind --tags kind \
               --target-pattern //test/smoke/... \

--- a/.github/workflows/oetf-kind.yaml
+++ b/.github/workflows/oetf-kind.yaml
@@ -248,6 +248,13 @@ jobs:
           done
           echo "::endgroup::"
 
+          echo "::group::All OSMO pod logs (last 80 lines)"
+          for pod in $(kubectl get pods -n osmo -o name 2>/dev/null || true); do
+            echo "--- osmo/$pod ---"
+            kubectl logs -n osmo "$pod" --all-containers --tail=80 2>/dev/null || true
+          done
+          echo "::endgroup::"
+
           echo "::group::Helm releases (helm list -A)"
           helm list -A || true
           echo "::endgroup::"

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -161,18 +161,6 @@ kubectl create secret generic local-admin-password \
   --from-literal=password="$LOCAL_ADMIN_PASSWORD" \
   --dry-run=client -o yaml | kubectl apply -f -
 
-if ! kubectl get configmap mek-config --namespace osmo >/dev/null 2>&1; then
-  MEK_KEY=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d '\n')
-  MEK_JWK=$(printf '{"k":"%s","kid":"key1","kty":"oct"}' "$MEK_KEY" | base64 | tr -d '\n')
-  MEK_FILE=$(mktemp)
-  printf 'currentMek: key1\nmeks:\n  key1: %s\n' "$MEK_JWK" > "$MEK_FILE"
-  kubectl create configmap mek-config \
-    --namespace osmo \
-    --from-file=mek.yaml="$MEK_FILE" \
-    --dry-run=client -o yaml | kubectl apply -f -
-  rm -f "$MEK_FILE"
-fi
-
 helm repo add osmo https://helm.ngc.nvidia.com/nvidia/osmo
 helm repo update osmo
 
@@ -187,10 +175,10 @@ helm upgrade --install osmo-backend-operator osmo/backend-operator \
   --wait
 ```
 
-For the local quick-start only, the service values generate
-`backend-operator-token` during the first Helm install. Because the backend
-operator is installed in the same namespace, it consumes that Secret directly;
-no pre-created backend Secret is required.
+For the local quick-start only, the service values generate `osmo-mek` and
+`backend-operator-token` during the first Helm install. Both are generated
+inside Kubernetes and preserved across upgrades; no pre-created MEK or backend
+Secret is required. Production values keep both bootstrap modes disabled.
 
 After installing the CLI and logging in, set the demo pool and LocalStack data credential:
 

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -195,7 +195,9 @@ secrets:
   objectStorage:
     existingSecret: osmo-object-storage
   masterEncryptionKey:
-    existingSecret: osmo-master-encryption-key
+    existingSecret:
+      name: osmo-master-encryption-key
+      key: mek.yaml
 ```
 
 Keep `embeddedDependencies.postgresql.enabled: false` (the default), then
@@ -462,14 +464,96 @@ postgresql:
         name: osmo-postgresql-credentials
 ```
 
-When an external PostgreSQL or Valkey service uses a private CA, enable TLS in
-the matching `externalDependencies` block and reference the CA Secret there.
-The Valkey `caKey` must hold a complete PEM trust bundle, including the public
-or system roots used by other HTTPS endpoints; OSMO's Python services consume
-that bundle through `SSL_CERT_FILE`. The default Valkey key is `ca-bundle.crt`.
+The MEK is mounted through the typed
+`secrets.masterEncryptionKey.existingSecret.{name,key}` reference. Use
+`managementMode: external` for an operator-owned read-only Secret. Use
+`managementMode: osmo` when this release should create and update that exact
+Secret through explicitly requested lifecycle Jobs.
 
-For an external Valkey endpoint signed by a public CA, leave
-`caExistingSecret` empty to use the image's system trust store.
+For a disposable install backed by a new database, enable `bootstrap`. Helm
+renders no MEK Secret data. A namespace-scoped create-only lifecycle Job waits
+for PostgreSQL, proves that the database has no users, UEKs, or dynamic
+configuration, verifies that every chart consumer is blocked before its writer
+container starts, and atomically creates the full Secret. Key material never
+enters Helm output or release state. A retry accepts only the exact Secret owned
+by this installation and authenticates the retained database before succeeding;
+it never overwrites or deletes a Secret. Non-chart database writers must be
+stopped for initial bootstrap.
+
+After the bootstrap Job succeeds, commit and sync
+`secrets.masterEncryptionKey.bootstrap.enabled: false`. This mandatory second
+Helm/GitOps transaction removes bootstrap Secret-creation RBAC from desired
+state. The chart rejects a rotation phase while bootstrap remains enabled.
+If bootstrap fails or its database credentials are corrected under Argo CD or
+Flux, increment the non-secret `bootstrap.attempt` before syncing again; this
+creates a new immutable retry Job without deriving public names from credential
+bytes.
+
+Every consumer loads its keyring once at process startup. Before becoming
+ready, it performs a bounded authenticated inventory of every UEK wrapper and
+registered direct-MEK configuration value. It then logs one machine-readable
+`OSMO_MEK_DESCRIPTOR` containing only the current key ID, loaded key IDs,
+generation, and non-secret bundle digest. There are no MEK database tables,
+triggers, polling loops, or hot reloads.
+
+Rotation is an explicit three-phase operation. Use one unique request ID for
+the whole rotation and keep every previous key in the Secret:
+
+1. Set `rotation.phase=prepare`. The managed Job adds exactly one key and leaves
+   `currentMek` unchanged. After the Job succeeds, clear the phase, change
+   `rotation.rolloutRevision`, and sync again to roll every consumer.
+2. Set `rotation.phase=activate`. The Job first verifies that the complete,
+   Ready Pod cohort belongs to the expected Deployments and logged the PREPARE
+   descriptor, then selects the new key. Clear the phase, change
+   `rolloutRevision` again, and sync to perform the second rollout.
+3. Set `rotation.phase=rewrap`. The Job verifies the ACTIVATE cohort, then
+   compare-and-swap rewraps all UEKs and registered direct-MEK configuration
+   from the beginning and runs two authenticated inventories. Clear the phase
+   after success.
+
+For example, the same values changes work with Helm upgrades or separate Argo
+CD syncs:
+
+```yaml
+secrets:
+  masterEncryptionKey:
+    managementMode: osmo
+    bootstrap:
+      enabled: false
+      attempt: "1" # increment only to retry a failed bootstrap
+    rotation:
+      requestId: rotate-2026-08-21
+      phase: prepare       # then "", activate, "", rewrap, ""
+      rolloutRevision: "1" # change to "2" after PREPARE and "3" after ACTIVATE
+```
+
+Each Job creates or reuses a release-scoped Kubernetes Lease directly. The
+Lease is intentionally absent from Helm desired state, so GitOps self-heal
+cannot clear a live holder. A Lease held by another attempt is never stolen,
+even after its timestamp expires. If an attempt dies, delete its old Job/Pod,
+verify it is gone, clear the Lease holder, increment `rotation.attempt`, and
+retry the same phase. Jobs never delete Pods or patch Deployments; Helm or the
+GitOps controller owns both rollouts. Clear a completed phase promptly so its
+narrowly scoped ServiceAccount and RoleBinding leave the desired state.
+
+In `managementMode=external`, the operator performs PREPARE and ACTIVATE by
+updating the existing Secret, with one rollout after each update. Then set only
+`rotation.phase=rewrap`. The rewrap Job has exact-name Secret `get` permission,
+not `patch` or `update`, and enforces the same ACTIVATE Pod attestation before
+touching ciphertext.
+
+Rewrap completion is point-in-time evidence, not permission to remove an old
+key. Because this design deliberately has no database write fence, all old MEKs
+remain mandatory. User plaintext and UEK key material do not change; only their
+encrypted wrappers change. Normal application reads never perform MEK rewrap
+writes; the explicit Job is the sole orchestrator.
+
+For an external Valkey endpoint signed by a public CA, enable
+`externalDependencies.valkey.tls.enabled` and leave `caExistingSecret` empty to
+use the image's system trust store. For a private CA, set `caExistingSecret` and
+`caKey` in the same block. The selected key must contain the complete trust
+bundle because clients use it through `SSL_CERT_FILE`. PostgreSQL private CAs
+are also configured in its `externalDependencies` TLS block.
 
 ## Exposure
 

--- a/deployments/charts/osmo/profiles/kind-self-contained.yaml
+++ b/deployments/charts/osmo/profiles/kind-self-contained.yaml
@@ -44,8 +44,12 @@ secrets:
       managedSecret:
         name: osmo-backend-token
   masterEncryptionKey:
-    generate: true
-    existingSecret: ''
+    managementMode: osmo
+    existingSecret:
+      name: osmo-master-encryption-key
+      key: mek.yaml
+    bootstrap:
+      enabled: true
 
 services:
   mcp:

--- a/deployments/charts/osmo/profiles/split-plane-control.yaml
+++ b/deployments/charts/osmo/profiles/split-plane-control.yaml
@@ -115,4 +115,6 @@ secrets:
   objectStorage:
     existingSecret: osmo-object-storage
   masterEncryptionKey:
-    existingSecret: osmo-master-encryption-key
+    existingSecret:
+      name: osmo-master-encryption-key
+      key: mek.yaml

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -393,26 +393,23 @@ data:
 {{- end -}}
 
 {{- define "osmo.secrets.mekVolume" -}}
-{{- with (include "osmo.masterEncryptionKey.secretName" .) }}
+{{- with .Values.secrets.masterEncryptionKey.existingSecret.name }}
 - name: mek-volume
   secret:
-    secretName: {{ . }}
+    secretName: {{ . | quote }}
     items:
-    - key: {{ $.Values.secrets.masterEncryptionKey.keys.config }}
-      path: mek.yaml
+    - key: {{ required "secrets.masterEncryptionKey.existingSecret.key is required" $.Values.secrets.masterEncryptionKey.existingSecret.key | quote }}
+      path: "mek.yaml"
 {{- end }}
 {{- end -}}
 
-{{- define "osmo.masterEncryptionKey.secretName" -}}
-{{- if .Values.secrets.masterEncryptionKey.generate -}}
-{{- printf "%s-master-encryption-key" (include "osmo.fullname" .) | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- .Values.secrets.masterEncryptionKey.existingSecret -}}
-{{- end -}}
-{{- end -}}
+{{- define "osmo.secrets.mekFile" -}}/opt/osmo/mek/mek.yaml{{- end -}}
+{{- define "osmo.secrets.mekMountPath" -}}/opt/osmo/mek{{- end -}}
 
-{{- define "osmo.masterEncryptionKey.bootstrapName" -}}
-{{- printf "%s-mek-bootstrap" (include "osmo.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- define "osmo.secrets.mekRolloutAnnotation" -}}
+{{- with .Values.secrets.masterEncryptionKey.rotation.rolloutRevision }}
+osmo.nvidia.com/mek-rollout: {{ . | quote }}
+{{- end }}
 {{- end -}}
 
 {{- define "osmo.valkey.fullname" -}}

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -46,6 +46,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.agent "componentName" "agent") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.agent) | nindent 8 }}
+        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.agent.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -107,9 +108,9 @@ spec:
         - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
         - {{ include "osmo.postgresql.database" . }}
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
         - --mek_file
-        - {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        - {{ include "osmo.secrets.mekFile" . | quote }}
         {{- end}}
         {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
@@ -138,10 +139,10 @@ spec:
           mountPath: /tmp
         - name: osmo-progress-files
           mountPath: /var/run/osmo
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
-        - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
+        - mountPath: {{ include "osmo.secrets.mekMountPath" . | quote }}
           name: mek-volume
-          subPath: mek.yaml
+          readOnly: true
         {{- end }}
         {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -47,6 +47,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.api "componentName" "api") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.api "protectedAnnotations" $protectedPodAnnotations) | nindent 8 }}
+        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.api.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -102,9 +103,9 @@ spec:
         - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
         - {{ include "osmo.postgresql.database" . }}
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
         - --mek_file
-        - {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        - {{ include "osmo.secrets.mekFile" . | quote }}
         {{- end }}
         {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
@@ -180,10 +181,10 @@ spec:
         volumeMounts:
         - name: osmo-runtime-tmp
           mountPath: /tmp
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
-        - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
+        - mountPath: {{ include "osmo.secrets.mekMountPath" . | quote }}
           name: mek-volume
-          subPath: mek.yaml
+          readOnly: true
         {{- end }}
         {{- if .Values.secrets.backendApiTokens.enabled }}
         {{- range .Values.secrets.backendApiTokens.credentials }}

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -40,7 +40,8 @@ spec:
       labels:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.delayedJobMonitor "componentName" "delayed-job-monitor") | nindent 8 }}
       annotations:
-      {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
+        {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.delayedJobMonitor) | nindent 8 }}
+        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.delayedJobMonitor.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -98,9 +99,9 @@ spec:
         - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
         - {{ include "osmo.postgresql.database" . }}
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
         - --mek_file
-        - {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        - {{ include "osmo.secrets.mekFile" . | quote }}
         {{- end}}
         {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
@@ -127,10 +128,10 @@ spec:
         volumeMounts:
         - name: osmo-progress-files
           mountPath: /var/run/osmo
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
-        - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
+        - mountPath: {{ include "osmo.secrets.mekMountPath" . | quote }}
           name: mek-volume
-          subPath: mek.yaml
+          readOnly: true
         {{- end }}
         {{- include "osmo.component.extraVolumeMounts" .Values.services.delayedJobMonitor | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -46,6 +46,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.logger "componentName" "logger") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.logger) | nindent 8 }}
+        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.logger.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -102,9 +103,9 @@ spec:
         - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
         - {{ include "osmo.postgresql.database" . }}
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
         - --mek_file
-        - {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        - {{ include "osmo.secrets.mekFile" . | quote }}
         {{- end}}
         {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
@@ -133,10 +134,10 @@ spec:
           mountPath: /tmp
         - name: osmo-progress-files
           mountPath: /var/run/osmo
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
-        - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
+        - mountPath: {{ include "osmo.secrets.mekMountPath" . | quote }}
           name: mek-volume
-          subPath: mek.yaml
+          readOnly: true
         {{- end }}
         {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}

--- a/deployments/charts/osmo/templates/mek-bootstrap.yaml
+++ b/deployments/charts/osmo/templates/mek-bootstrap.yaml
@@ -1,136 +1,237 @@
-{{- if .Values.planes.control.enabled }}
-{{/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{- if .Values.secrets.masterEncryptionKey.generate }}
-{{- $bootstrapName := include "osmo.masterEncryptionKey.bootstrapName" . }}
-{{- $secretName := include "osmo.masterEncryptionKey.secretName" . }}
-{{- $hookResourceAnnotations := dict
-      "helm.sh/hook" "pre-install,pre-upgrade"
-      "helm.sh/hook-weight" "-20"
-      "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded,hook-failed" }}
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- $mek := .Values.secrets.masterEncryptionKey -}}
+{{- $secretName := $mek.existingSecret.name -}}
+{{- $secretKey := $mek.existingSecret.key -}}
+{{- $operation := $mek.rotation.phase -}}
+{{- if not (has $mek.managementMode (list "external" "osmo")) -}}
+{{- fail "secrets.masterEncryptionKey.managementMode must be external or osmo" -}}
+{{- end -}}
+{{- if not (has $operation (list "" "prepare" "activate" "rewrap")) -}}
+{{- fail "secrets.masterEncryptionKey.rotation.phase must be empty, prepare, activate, or rewrap" -}}
+{{- end -}}
+{{- if and $operation (not $mek.rotation.requestId) -}}
+{{- fail "secrets.masterEncryptionKey.rotation.requestId is required for a lifecycle phase" -}}
+{{- end -}}
+{{- if and (has $operation (list "prepare" "activate")) (ne $mek.managementMode "osmo") -}}
+{{- fail "prepare and activate require managementMode=osmo; external operators update the Secret directly" -}}
+{{- end -}}
+{{- if and $mek.bootstrap.enabled (ne $mek.managementMode "osmo") -}}
+{{- fail "secrets.masterEncryptionKey.bootstrap.enabled requires managementMode=osmo" -}}
+{{- end -}}
+{{- if and $mek.bootstrap.enabled $operation -}}
+{{- fail "disable secrets.masterEncryptionKey.bootstrap.enabled before requesting a rotation phase" -}}
+{{- end -}}
+
+{{- if or $mek.bootstrap.enabled $operation }}
+{{- $secretName = required "secrets.masterEncryptionKey.existingSecret.name is required" $secretName }}
+{{- $secretKey = required "secrets.masterEncryptionKey.existingSecret.key is required" $secretKey }}
+{{- $leaseHash := printf "%s/%s:%s" .Release.Namespace .Release.Name $secretName | sha256sum | trunc 10 }}
+{{- $leasePrefix := regexReplaceAll "[^a-z0-9-]" (lower .Release.Name) "-" | trimAll "-" | trunc 46 | trimSuffix "-" }}
+{{- $leaseName := printf "%s-mek-%s" $leasePrefix $leaseHash }}
+{{- $actualOperation := ternary "bootstrap" $operation $mek.bootstrap.enabled }}
+{{- $needsDatabase := or $mek.bootstrap.enabled (eq $operation "rewrap") }}
+{{- $request := ternary "initial" $mek.rotation.requestId $mek.bootstrap.enabled }}
+{{- $consumerDeployments := list }}
+{{- if and .Values.planes.control.enabled .Values.services.api.enabled }}{{- $consumerDeployments = append $consumerDeployments (include "osmo.api.fullname" .) }}{{- end }}
+{{- if and .Values.planes.control.enabled .Values.services.worker.enabled }}{{- $consumerDeployments = append $consumerDeployments (include "osmo.component.fullname" (dict "root" . "suffix" "worker")) }}{{- end }}
+{{- if and .Values.planes.control.enabled .Values.services.router.enabled }}{{- $consumerDeployments = append $consumerDeployments (include "osmo.component.fullname" (dict "root" . "suffix" "router")) }}{{- end }}
+{{- if and .Values.planes.control.enabled .Values.services.logger.enabled }}{{- $consumerDeployments = append $consumerDeployments (include "osmo.component.fullname" (dict "root" . "suffix" "logger")) }}{{- end }}
+{{- if and .Values.planes.control.enabled .Values.services.agent.enabled }}{{- $consumerDeployments = append $consumerDeployments (include "osmo.component.fullname" (dict "root" . "suffix" "agent")) }}{{- end }}
+{{- if and .Values.planes.control.enabled .Values.services.delayedJobMonitor.enabled }}{{- $consumerDeployments = append $consumerDeployments (include "osmo.component.fullname" (dict "root" . "suffix" "delayed-job-monitor")) }}{{- end }}
+{{- if eq (len $consumerDeployments) 0 }}{{- fail "MEK lifecycle requires at least one enabled control-plane consumer" }}{{- end }}
+{{- $bootstrapInputs := dict
+      "chartVersion" .Chart.Version
+      "chartAppVersion" .Chart.AppVersion
+      "releaseRevision" .Release.Revision
+      "attempt" $mek.bootstrap.attempt
+      "commonLabels" .Values.commonLabels
+      "image" (include "osmo.component.image" (dict "root" . "component" .Values.services.api))
+      "imagePullPolicy" $mek.bootstrap.imagePullPolicy
+      "imagePullSecrets" (include "osmo.component.imagePullSecrets" .)
+      "deadline" $mek.bootstrap.activeDeadlineSeconds
+      "consumers" $consumerDeployments
+      "secretName" $secretName
+      "secretKey" $secretKey
+      "postgresHost" (include "osmo.postgresql.host" .)
+      "postgresPort" (include "osmo.postgresql.port" .)
+      "postgresDatabase" (include "osmo.postgresql.database" .)
+      "postgresUsername" (include "osmo.postgresql.username" .)
+      "postgresSecretName" (include "osmo.postgresql.secretName" .)
+      "postgresPasswordKey" (include "osmo.postgresql.passwordKey" .)
+      "postgresCaName" (include "osmo.postgresql.caSecretName" .)
+      "postgresCaKey" (include "osmo.postgresql.caKey" .) -}}
+{{- $bootstrapIdentity := toJson $bootstrapInputs | sha256sum }}
+{{- $attemptIdentity := ternary $bootstrapIdentity $mek.rotation.attempt $mek.bootstrap.enabled }}
+{{- $hash := printf "%s:%s:%s" $actualOperation $request $attemptIdentity | sha256sum | trunc 10 }}
+{{- $name := printf "%s-mek-%s-%s" (include "osmo.fullname" .) $actualOperation $hash | trunc 63 | trimSuffix "-" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $bootstrapName }}
+  name: {{ $name | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "mek-bootstrap") | nindent 4 }}
-  annotations:
-    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" $hookResourceAnnotations) | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "mek-lifecycle") | nindent 4 }}
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ $bootstrapName }}
+  name: {{ $name | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "mek-bootstrap") | nindent 4 }}
-  annotations:
-    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" $hookResourceAnnotations) | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "mek-lifecycle") | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  resourceNames:
-  - {{ $secretName | quote }}
-  verbs: ["get"]
+  resourceNames: [{{ $secretName | quote }}]
+  verbs: ["get"{{- if and (eq $mek.managementMode "osmo") $operation }}, "patch"{{- end }}]
+{{- if $mek.bootstrap.enabled }}
 - apiGroups: [""]
   resources: ["secrets"]
+  verbs: ["create"]
+{{- end }}
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets"]
+  verbs: ["get", "list"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  resourceNames: [{{ $leaseName | quote }}]
+  verbs: ["get", "patch", "update"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
   verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ $bootstrapName }}
+  name: {{ $name | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "mek-bootstrap") | nindent 4 }}
-  annotations:
-    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" $hookResourceAnnotations) | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "mek-lifecycle") | nindent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ $bootstrapName }}
+  name: {{ $name | quote }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ $bootstrapName }}
+  name: {{ $name | quote }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $bootstrapName }}
+  name: {{ $name | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "osmo.component.labels" (dict "root" . "component" "mek-bootstrap") | nindent 4 }}
-  annotations:
-    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict "helm.sh/hook" "pre-install,pre-upgrade" "helm.sh/hook-weight" "-10" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded")) | nindent 4 }}
+    {{- include "osmo.component.labels" (dict "root" . "component" "mek-lifecycle") | nindent 4 }}
 spec:
   backoffLimit: 0
+  activeDeadlineSeconds: {{ ternary $mek.bootstrap.activeDeadlineSeconds $mek.rotation.activeDeadlineSeconds $mek.bootstrap.enabled }}
   template:
     metadata:
       labels:
-        {{- include "osmo.component.selectorLabels" (dict "root" . "component" "mek-bootstrap") | nindent 8 }}
+        {{- include "osmo.component.standardLabels" (dict "root" . "component" "mek-lifecycle") | nindent 8 }}
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ $bootstrapName }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1001
-        runAsGroup: 1001
-        seccompProfile:
-          type: RuntimeDefault
+      serviceAccountName: {{ $name | quote }}
+      automountServiceAccountToken: false
       {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
-      {{- with .Values.podDefaults.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      tolerations:
-        {{- toYaml .Values.podDefaults.tolerations | nindent 8 }}
       containers:
-      - name: mek-bootstrap
-        image: {{ include "osmo.image" (dict "root" . "image" .Values.secrets.masterEncryptionKey.bootstrap.image "useSharedRegistry" false "useSharedTag" false) | quote }}
-        imagePullPolicy: {{ .Values.secrets.masterEncryptionKey.bootstrap.image.pullPolicy }}
-        command:
-        - /bin/ash
+      - name: mek-lifecycle
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.api) }}
+        imagePullPolicy: {{ ternary $mek.bootstrap.imagePullPolicy $mek.rotation.imagePullPolicy $mek.bootstrap.enabled | quote }}
+        command: ["mek-lifecycle"]
         args:
-        - -c
-        - |
-{{ .Files.Get "files/mek-bootstrap.sh" | nindent 10 }}
-        - mek-bootstrap
+        - --operation
+        - {{ $actualOperation | quote }}
         - --namespace
         - {{ .Release.Namespace | quote }}
-        - --release-name
-        - {{ .Release.Name | quote }}
-        - --secret-name
+        - --secret_name
         - {{ $secretName | quote }}
-        - --secret-key
-        - {{ .Values.secrets.masterEncryptionKey.keys.config | quote }}
-        {{- if .Release.IsUpgrade }}
-        - --fail-if-missing
+        - --secret_key
+        - {{ $secretKey | quote }}
+        - --installation_id
+        - {{ printf "%s/%s" .Release.Namespace .Release.Name | quote }}
+        - --management_mode
+        - {{ $mek.managementMode | quote }}
+        - --request_id
+        - {{ $request | quote }}
+        - --consumer_deployments
+        - {{ join "," $consumerDeployments | quote }}
+        {{- if $needsDatabase }}
+        - --postgres_host
+        - {{ include "osmo.postgresql.host" . | quote }}
+        - --postgres_port
+        - {{ include "osmo.postgresql.port" . | quote }}
+        - --postgres_database_name
+        - {{ include "osmo.postgresql.database" . | quote }}
+        - --postgres_user
+        - {{ include "osmo.postgresql.username" . | quote }}
         {{- end }}
+        - --active_deadline_seconds
+        - {{ ternary $mek.bootstrap.activeDeadlineSeconds $mek.rotation.activeDeadlineSeconds $mek.bootstrap.enabled | quote }}
         env:
-        - name: HOME
-          value: /tmp
+        - name: OSMO_POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        {{- if $needsDatabase }}
+        {{- include "osmo.externalDependencies.connectionSecretEnv" . | nindent 8 }}
+        {{- end }}
+        volumeMounts:
+        - name: lifecycle-temp
+          mountPath: /tmp
+        {{- if not $mek.bootstrap.enabled }}
+        - name: mek-volume
+          mountPath: {{ include "osmo.secrets.mekMountPath" . | quote }}
+          readOnly: true
+        {{- end }}
+        {{- if $needsDatabase }}
+        {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
+        {{- end }}
+        - name: kubernetes-api
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
-            drop:
-            - ALL
+            drop: ["ALL"]
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1001
-        volumeMounts:
-        - name: bootstrap-tmp
-          mountPath: /tmp
-        resources:
-          requests:
-            cpu: 10m
-            memory: 32Mi
-          limits:
-            cpu: 100m
-            memory: 128Mi
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
-      - name: bootstrap-tmp
+      - name: lifecycle-temp
         emptyDir: {}
-{{- end }}
+      {{- if not $mek.bootstrap.enabled }}
+      - name: mek-volume
+        secret:
+          secretName: {{ $secretName | quote }}
+          items:
+          - key: {{ $secretKey | quote }}
+            path: "mek.yaml"
+      {{- end }}
+      {{- if $needsDatabase }}
+      {{- include "osmo.externalDependencies.caVolumes" . | nindent 6 }}
+      {{- end }}
+      - name: kubernetes-api
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 600
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+              - key: ca.crt
+                path: ca.crt
 {{- end }}

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -44,6 +44,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.router "componentName" "router") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.router) | nindent 8 }}
+        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.router.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -94,12 +95,9 @@ spec:
         - --postgres_user
         - {{ . }}
         {{- end }}
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
         - --mek_file
-        - {{ .Values.secrets.masterEncryptionKey.mountPath }}
-        {{- else }}
-        - --config
-        - {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        - {{ include "osmo.secrets.mekFile" . | quote }}
         {{- end }}
         {{- if .Values.logging.enabled }}
         - --log_level
@@ -145,10 +143,10 @@ spec:
         volumeMounts:
         - name: osmo-runtime-tmp
           mountPath: /tmp
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
-        - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
+        - mountPath: {{ include "osmo.secrets.mekMountPath" . | quote }}
           name: mek-volume
-          subPath: mek.yaml
+          readOnly: true
         {{- end }}
         {{- with .Values.services.router.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -313,16 +313,6 @@
 {{- if and .Values.httproute.enabled (eq (len .Values.httproute.parentRefs) 0) -}}
 {{- fail "httproute.parentRefs requires at least one entry when httproute.enabled=true" -}}
 {{- end -}}
-{{- if and .Values.secrets.masterEncryptionKey.generate .Values.secrets.masterEncryptionKey.existingSecret -}}
-{{- fail "secrets.masterEncryptionKey.generate and existingSecret are mutually exclusive" -}}
-{{- end -}}
-{{- $mekSecretKey := .Values.secrets.masterEncryptionKey.keys.config -}}
-{{- if or
-  (not $mekSecretKey)
-  (gt (len $mekSecretKey) 253)
-  (not (regexMatch "^[A-Za-z0-9._-]+$" $mekSecretKey)) -}}
-{{- fail "secrets.masterEncryptionKey.keys.config must be a non-empty valid Kubernetes Secret data key" -}}
-{{- end -}}
 {{- if .Values.secrets.defaultAdmin.generate -}}
 {{- fail "secrets.defaultAdmin.generate is not implemented; configure existingSecret" -}}
 {{- end -}}
@@ -405,8 +395,11 @@
 {{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.secrets.objectStorage.existingSecret) -}}
 {{- fail "secrets.objectStorage.existingSecret is required for the control plane" -}}
 {{- end -}}
-{{- if not (include "osmo.masterEncryptionKey.secretName" .) -}}
-{{- fail "secrets.masterEncryptionKey.existingSecret is required for the control plane" -}}
+{{- if not .Values.secrets.masterEncryptionKey.existingSecret.name -}}
+{{- fail "secrets.masterEncryptionKey.existingSecret.name is required for the control plane" -}}
+{{- end -}}
+{{- if not .Values.secrets.masterEncryptionKey.existingSecret.key -}}
+{{- fail "secrets.masterEncryptionKey.existingSecret.key is required for the control plane" -}}
 {{- end -}}
 {{- if and (not .Values.embeddedDependencies.postgresql.enabled) .Values.externalDependencies.postgresql.tls.enabled (not .Values.externalDependencies.postgresql.tls.caExistingSecret) -}}
 {{- fail "externalDependencies.postgresql.tls.caExistingSecret is required when TLS is enabled" -}}

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -43,6 +43,7 @@ spec:
         {{- include "osmo.pod.labels" (dict "root" . "component" .Values.services.worker "componentName" "worker") | nindent 8 }}
       annotations:
         {{- include "osmo.pod.annotations" (dict "root" . "component" .Values.services.worker) | nindent 8 }}
+        {{- include "osmo.secrets.mekRolloutAnnotation" . | nindent 8 }}
     spec:
       automountServiceAccountToken: {{ .Values.services.worker.serviceAccount.automountServiceAccountToken }}
       securityContext:
@@ -100,9 +101,9 @@ spec:
         - {{ include "osmo.postgresql.port" . | quote }}
         - --postgres_database_name
         - {{ include "osmo.postgresql.database" . }}
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
         - --mek_file
-        - {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        - {{ include "osmo.secrets.mekFile" . | quote }}
         {{- end}}
         {{- with (include "osmo.postgresql.username" .) }}
         - --postgres_user
@@ -127,10 +128,10 @@ spec:
         volumeMounts:
         - name: osmo-progress-files
           mountPath: /var/run/osmo
-        {{- if (include "osmo.masterEncryptionKey.secretName" .) }}
-        - mountPath: {{ .Values.secrets.masterEncryptionKey.mountPath }}
+        {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
+        - mountPath: {{ include "osmo.secrets.mekMountPath" . | quote }}
           name: mek-volume
-          subPath: mek.yaml
+          readOnly: true
         {{- end }}
         {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}

--- a/deployments/charts/osmo/tests/control-embedded-values.yaml
+++ b/deployments/charts/osmo/tests/control-embedded-values.yaml
@@ -30,7 +30,9 @@ secrets:
   objectStorage:
     existingSecret: external-control-secrets
   masterEncryptionKey:
-    existingSecret: external-control-secrets
+    existingSecret:
+      name: external-control-secrets
+      key: mek.yaml
 
 services:
   api:

--- a/deployments/charts/osmo/tests/control-external-values.yaml
+++ b/deployments/charts/osmo/tests/control-external-values.yaml
@@ -31,7 +31,9 @@ secrets:
   objectStorage:
     existingSecret: external-object-storage-secret
   masterEncryptionKey:
-    existingSecret: external-master-encryption-key-secret
+    existingSecret:
+      name: external-master-encryption-key-secret
+      key: keyring.yaml
 
 services:
   api:

--- a/deployments/charts/osmo/tests/conventions-values.yaml
+++ b/deployments/charts/osmo/tests/conventions-values.yaml
@@ -48,15 +48,6 @@ secrets:
     - name: convention
       managedSecret:
         name: convention-backend-token
-  masterEncryptionKey:
-    bootstrap:
-      image:
-        registry: registry.example.com
-        repository: conventions/mek-bootstrap
-        tag: ignored
-        digest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-        pullPolicy: Always
-
 services:
   api:
     extraEnv:

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -161,6 +161,7 @@ resource_document() {
         in_metadata && /^  name: / && document_name == "" {
             document_name = $0
             sub(/^  name: /, "", document_name)
+            gsub(/^"|"$/, "", document_name)
             next
         }
         in_metadata && /^[^ ]/ {
@@ -185,6 +186,19 @@ secret_data_value() {
             print $2
             exit
         }
+    ' "$file"
+}
+
+first_resource_name() {
+    local file=$1
+    local kind=$2
+    awk -v expected_kind="$kind" '
+        $0 == "kind: " expected_kind { resource = 1; metadata = 0; next }
+        resource && /^metadata:$/ { metadata = 1; next }
+        resource && metadata && /^  name: / {
+            sub(/^  name: /, ""); gsub(/^"|"$/, ""); print; exit
+        }
+        /^---$/ { resource = 0; metadata = 0 }
     ' "$file"
 }
 
@@ -592,8 +606,8 @@ test_control_umbrella() {
         "osmo-rustfs-svc"
     require_resource "$TEST_DIRECTORY/kind-self-contained.yaml" Job \
         "osmo-backend-token-bootstrap"
-    require_resource "$TEST_DIRECTORY/kind-self-contained.yaml" Job \
-        "osmo-mek-bootstrap"
+    require_contains "$TEST_DIRECTORY/kind-self-contained.yaml" \
+        'name: "osmo-mek-bootstrap-'
     require_resource "$TEST_DIRECTORY/kind-self-contained.yaml" Job \
         "osmo-object-storage-bootstrap"
     require_contains "$TEST_DIRECTORY/kind-self-contained.yaml" \
@@ -860,9 +874,6 @@ test_control_umbrella() {
         osmo-backend-token-bootstrap \
         >"$TEST_DIRECTORY/conventions-backend-token-bootstrap.yaml"
     resource_document "$TEST_DIRECTORY/conventions.yaml" Job \
-        osmo-mek-bootstrap \
-        >"$TEST_DIRECTORY/conventions-mek-bootstrap.yaml"
-    resource_document "$TEST_DIRECTORY/conventions.yaml" Job \
         osmo-object-storage-bootstrap \
         >"$TEST_DIRECTORY/conventions-object-storage-bootstrap.yaml"
     resource_document "$TEST_DIRECTORY/conventions.yaml" ConfigMap \
@@ -873,14 +884,11 @@ test_control_umbrella() {
     local convention_image_resource
     local convention_image_repository
     for convention_image_resource in \
-            backend-token-bootstrap mek-bootstrap object-storage-bootstrap \
+            backend-token-bootstrap object-storage-bootstrap \
             test-runner-template; do
         case "$convention_image_resource" in
             backend-token-bootstrap)
                 convention_image_repository=backend-token-bootstrap
-                ;;
-            mek-bootstrap)
-                convention_image_repository=mek-bootstrap
                 ;;
             object-storage-bootstrap)
                 convention_image_repository=object-storage-bootstrap
@@ -1133,62 +1141,16 @@ duplicate-secret|--set secrets.backendApiTokens.credentials[0].name=one --set se
 invalid-secret|--set secrets.backendApiTokens.credentials[0].name=default --set secrets.backendApiTokens.credentials[0].existingSecret.name=INVALID_SECRET|invalid backend API token Secret name "INVALID_SECRET"
 EOF
 
-    helm_template generated-mek "$charts_copy/osmo" \
-        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set secrets.masterEncryptionKey.generate=true \
-        --set secrets.masterEncryptionKey.existingSecret= \
-        >"$TEST_DIRECTORY/generated-mek.yaml"
-    require_resource "$TEST_DIRECTORY/generated-mek.yaml" Job \
-        "generated-mek-osmo-mek-bootstrap"
-    require_no_resource "$TEST_DIRECTORY/generated-mek.yaml" Secret \
-        "generated-mek-osmo-master-encryption-key"
-    require_contains "$TEST_DIRECTORY/generated-mek.yaml" \
-        'image: "alpine/k8s:1.30.14"'
-    require_not_contains "$TEST_DIRECTORY/generated-mek.yaml" "currentMek:"
-    local mek_consumer
-    for mek_consumer in \
-            api router worker logger agent delayed-job-monitor; do
-        resource_document "$TEST_DIRECTORY/generated-mek.yaml" Deployment \
-            "generated-mek-osmo-$mek_consumer" \
-            >"$TEST_DIRECTORY/generated-mek-$mek_consumer.yaml"
-        require_contains "$TEST_DIRECTORY/generated-mek-$mek_consumer.yaml" \
-            "secretName: generated-mek-osmo-master-encryption-key"
-        require_contains "$TEST_DIRECTORY/generated-mek-$mek_consumer.yaml" \
-            "mountPath: /opt/osmo/config.yaml"
-        require_contains "$TEST_DIRECTORY/generated-mek-$mek_consumer.yaml" \
-            "--mek_file"
+    local mek_component
+    for mek_component in api worker router logger agent delayed-job-monitor; do
+        resource_document "$rendered" Deployment "osmo-$mek_component" \
+            >"$TEST_DIRECTORY/mek-$mek_component-deployment.yaml"
+        require_contains "$TEST_DIRECTORY/mek-$mek_component-deployment.yaml" \
+            "app.kubernetes.io/instance: osmo"
+        require_contains "$TEST_DIRECTORY/mek-$mek_component-deployment.yaml" \
+            "app.kubernetes.io/part-of: osmo"
     done
-
-    helm_template upgraded-mek "$charts_copy/osmo" \
-        --is-upgrade \
-        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-        --set secrets.masterEncryptionKey.generate=true \
-        --set secrets.masterEncryptionKey.existingSecret= \
-        >"$TEST_DIRECTORY/upgraded-mek.yaml"
-    require_contains "$TEST_DIRECTORY/upgraded-mek.yaml" "--fail-if-missing"
-
-    require_no_resource "$rendered" Job "osmo-mek-bootstrap"
-    if helm_template conflicting-mek "$charts_copy/osmo" \
-            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-            --set secrets.masterEncryptionKey.generate=true \
-            >"$TEST_DIRECTORY/conflicting-mek.out" 2>&1; then
-        fail "expected generated and existing MEK ownership to fail"
-    fi
-    require_contains "$TEST_DIRECTORY/conflicting-mek.out" \
-        "secrets.masterEncryptionKey.generate and existingSecret are mutually exclusive"
-    if helm_template invalid-mek-key "$charts_copy/osmo" \
-            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-            --set secrets.masterEncryptionKey.keys.config=invalid/key \
-            >"$TEST_DIRECTORY/invalid-mek-key.out" 2>&1; then
-        fail "expected an invalid MEK Secret key to fail"
-    fi
-    require_contains "$TEST_DIRECTORY/invalid-mek-key.out" \
-        "secrets.masterEncryptionKey.keys.config must be a non-empty valid Kubernetes Secret data key"
-
+    require_not_contains "$rendered" "osmo.nvidia.com/mek-consumer"
     local hardened_component
     for hardened_component in \
         api worker router logger agent delayed-job-monitor ui gateway-envoy; do
@@ -1246,7 +1208,206 @@ EOF
     require_contains "$rendered" "name: external-postgresql-secret"
     require_contains "$rendered" "name: external-valkey-secret"
     require_contains "$rendered" "secretName: external-object-storage-secret"
-    require_contains "$rendered" "secretName: external-master-encryption-key-secret"
+    require_contains "$rendered" 'secretName: "external-master-encryption-key-secret"'
+    require_occurrences "$rendered" 'secretName: "external-master-encryption-key-secret"' 6
+    require_occurrences "$rendered" 'key: "keyring.yaml"' 6
+    require_occurrences "$rendered" 'mountPath: "/opt/osmo/mek"' 6
+    require_not_contains "$rendered" "name: OSMO_POD_UID"
+    require_not_contains "$rendered" "name: OSMO_MEK_CONSUMER"
+    require_not_contains "$rendered" "name: OSMO_ALLOW_EXISTING_MEK_ADOPTION"
+    require_not_contains "$rendered" "subPath: mek.yaml"
+    require_not_contains "$rendered" "command: [\"mek-lifecycle\"]"
+
+    helm_template bootstrap-osmo "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.masterEncryptionKey.managementMode=osmo \
+        --set secrets.masterEncryptionKey.bootstrap.enabled=true \
+        >"$TEST_DIRECTORY/mek-bootstrap.yaml"
+    require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'command: ["mek-lifecycle"]'
+    require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" '- "bootstrap"'
+    require_not_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'kind: Lease'
+    require_not_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'kind: Secret'
+    require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'verbs: ["create"]'
+    require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'runAsUser: 1001'
+    helm_template bootstrap-osmo "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.masterEncryptionKey.managementMode=osmo \
+        --set secrets.masterEncryptionKey.bootstrap.enabled=true \
+        --set secrets.masterEncryptionKey.bootstrap.activeDeadlineSeconds=899 \
+        >"$TEST_DIRECTORY/mek-bootstrap-changed.yaml"
+    local mek_bootstrap_name mek_bootstrap_changed_name
+    mek_bootstrap_name=$(awk '/^kind: Job$/{job=1; next} job && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+        "$TEST_DIRECTORY/mek-bootstrap.yaml")
+    mek_bootstrap_changed_name=$(awk '/^kind: Job$/{job=1; next} job && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+        "$TEST_DIRECTORY/mek-bootstrap-changed.yaml")
+    if [[ "$mek_bootstrap_name" == "$mek_bootstrap_changed_name" ]]; then
+        echo 'MEK bootstrap immutable template change reused a completed Job name' >&2
+        exit 1
+    fi
+    helm_template bootstrap-osmo "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.masterEncryptionKey.managementMode=osmo \
+        --set secrets.masterEncryptionKey.bootstrap.enabled=true \
+        --set-string secrets.masterEncryptionKey.bootstrap.attempt=2 \
+        >"$TEST_DIRECTORY/mek-bootstrap-retry.yaml"
+    local mek_bootstrap_retry_name
+    mek_bootstrap_retry_name=$(awk '/^kind: Job$/{job=1; next} job && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+        "$TEST_DIRECTORY/mek-bootstrap-retry.yaml")
+    if [[ "$mek_bootstrap_name" == "$mek_bootstrap_retry_name" ]]; then
+        echo 'MEK bootstrap attempt did not create a new GitOps retry Job name' >&2
+        exit 1
+    fi
+    if helm_template invalid-bootstrap-rotation "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set secrets.masterEncryptionKey.managementMode=osmo \
+            --set secrets.masterEncryptionKey.bootstrap.enabled=true \
+            --set secrets.masterEncryptionKey.rotation.requestId=rotate \
+            --set secrets.masterEncryptionKey.rotation.phase=prepare \
+            >/dev/null 2>&1; then
+        echo 'MEK rotation phase was accepted while bootstrap remained enabled' >&2
+        exit 1
+    fi
+
+    helm_template prepare-osmo "$charts_copy/osmo" \
+        --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.masterEncryptionKey.managementMode=osmo \
+        --set secrets.masterEncryptionKey.rotation.requestId=rotate-2026-08 \
+        --set secrets.masterEncryptionKey.rotation.phase=prepare \
+        --set secrets.masterEncryptionKey.rotation.rolloutRevision=prepare-2026-08 \
+        --set secrets.masterEncryptionKey.rotation.activeDeadlineSeconds=321 \
+        >"$TEST_DIRECTORY/mek-prepare.yaml"
+    require_contains "$TEST_DIRECTORY/mek-prepare.yaml" '- "prepare"'
+    require_contains "$TEST_DIRECTORY/mek-prepare.yaml" '- "321"'
+    require_contains "$TEST_DIRECTORY/mek-prepare.yaml" 'resources: ["pods/log"]'
+    require_contains "$TEST_DIRECTORY/mek-prepare.yaml" 'resources: ["deployments", "replicasets"]'
+    local mek_prepare_name
+    mek_prepare_name=$(awk '/^kind: Role$/{role=1; next} role && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+        "$TEST_DIRECTORY/mek-prepare.yaml")
+    resource_document "$TEST_DIRECTORY/mek-prepare.yaml" Job "$mek_prepare_name" \
+        >"$TEST_DIRECTORY/mek-prepare-job.yaml"
+    require_not_contains "$TEST_DIRECTORY/mek-prepare-job.yaml" 'name: OSMO_POSTGRES_PASSWORD'
+    require_occurrences "$TEST_DIRECTORY/mek-prepare.yaml" \
+        'osmo.nvidia.com/mek-rollout: "prepare-2026-08"' 6
+    require_not_contains "$TEST_DIRECTORY/mek-prepare.yaml" 'verbs: ["delete"]'
+
+    helm_template activate-osmo "$charts_copy/osmo" \
+        --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.masterEncryptionKey.managementMode=osmo \
+        --set secrets.masterEncryptionKey.rotation.requestId=rotate-2026-08 \
+        --set secrets.masterEncryptionKey.rotation.phase=activate \
+        >"$TEST_DIRECTORY/mek-activate.yaml"
+    require_contains "$TEST_DIRECTORY/mek-activate.yaml" '- "activate"'
+
+    helm_template rewrap-external "$charts_copy/osmo" \
+        --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.masterEncryptionKey.managementMode=external \
+        --set secrets.masterEncryptionKey.rotation.requestId=rotate-2026-08 \
+        --set secrets.masterEncryptionKey.rotation.phase=rewrap \
+        >"$TEST_DIRECTORY/mek-rewrap.yaml"
+    require_contains "$TEST_DIRECTORY/mek-rewrap.yaml" '- "rewrap"'
+    rewrap_role_name=$(first_resource_name "$TEST_DIRECTORY/mek-rewrap.yaml" Role)
+    resource_document "$TEST_DIRECTORY/mek-rewrap.yaml" Role "$rewrap_role_name" \
+        >"$TEST_DIRECTORY/mek-rewrap-role.yaml"
+    awk '
+        /resources: \["secrets"\]/ { secret_rule = 1; next }
+        secret_rule && /verbs:/ {
+            if ($0 != "  verbs: [\"get\"]") exit 1
+            found = 1
+            secret_rule = 0
+        }
+        END { if (!found) exit 1 }
+    ' "$TEST_DIRECTORY/mek-rewrap-role.yaml" || \
+        fail "external MEK rewrap has Secret mutation permission"
+
+    if helm_template invalid-external-prepare "$charts_copy/osmo" \
+        --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.masterEncryptionKey.managementMode=external \
+        --set secrets.masterEncryptionKey.rotation.requestId=invalid \
+        --set secrets.masterEncryptionKey.rotation.phase=prepare \
+        >"$TEST_DIRECTORY/mek-invalid.out" 2>&1; then
+        fail "external PREPARE Secret mutation was accepted"
+    fi
+    require_contains "$TEST_DIRECTORY/mek-invalid.out" \
+        'prepare and activate require managementMode=osmo'
+
+    helm_template prepare-disabled-consumer "$charts_copy/osmo" \
+        --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.masterEncryptionKey.managementMode=osmo \
+        --set secrets.masterEncryptionKey.rotation.requestId=rotate-disabled \
+        --set secrets.masterEncryptionKey.rotation.phase=prepare \
+        --set services.logger.enabled=false \
+        >"$TEST_DIRECTORY/mek-disabled-consumer.yaml"
+    if grep -A1 -- '--consumer_deployments' "$TEST_DIRECTORY/mek-disabled-consumer.yaml" \
+            | grep -q 'logger'; then
+        fail "disabled logger was included in the MEK consumer set"
+    fi
+
+    if helm_template prepare-empty "$charts_copy/osmo" \
+        --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.masterEncryptionKey.managementMode=osmo \
+        --set secrets.masterEncryptionKey.rotation.requestId=rotate-empty \
+        --set secrets.masterEncryptionKey.rotation.phase=prepare \
+        --set services.api.enabled=false \
+        --set services.worker.enabled=false \
+        --set services.router.enabled=false \
+        --set services.logger.enabled=false \
+        --set services.agent.enabled=false \
+        --set services.delayedJobMonitor.enabled=false \
+        >"$TEST_DIRECTORY/mek-empty.out" 2>&1; then
+        fail "expected MEK lifecycle with no enabled consumers to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/mek-empty.out" \
+        'requires at least one enabled control-plane consumer'
+
+    helm_template mek-string-sentinels "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string secrets.masterEncryptionKey.existingSecret.name=true \
+        --set-string secrets.masterEncryptionKey.existingSecret.key=null \
+        >"$TEST_DIRECTORY/mek-string-sentinels.yaml"
+    require_occurrences "$TEST_DIRECTORY/mek-string-sentinels.yaml" \
+        'secretName: "true"' 6
+    require_occurrences "$TEST_DIRECTORY/mek-string-sentinels.yaml" 'key: "null"' 6
+    require_occurrences "$TEST_DIRECTORY/mek-string-sentinels.yaml" 'path: "mek.yaml"' 6
+    require_occurrences "$TEST_DIRECTORY/mek-string-sentinels.yaml" \
+        'mountPath: "/opt/osmo/mek"' 6
+    require_occurrences "$TEST_DIRECTORY/mek-string-sentinels.yaml" \
+        '- "/opt/osmo/mek/mek.yaml"' 6
+
+    if helm_template invalid-mek-secret "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string secrets.masterEncryptionKey.existingSecret=legacy-secret \
+        >"$TEST_DIRECTORY/invalid-mek-secret.out" 2>&1; then
+        fail "expected legacy scalar MEK existingSecret to fail schema validation"
+    fi
+    require_schema_path "$TEST_DIRECTORY/invalid-mek-secret.out" \
+        "secrets.masterEncryptionKey.existingSecret"
+    if helm_template invalid-mek-bootstrap "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string secrets.masterEncryptionKey.bootstrap.imagePullPolicy=Sometimes \
+        >"$TEST_DIRECTORY/invalid-mek-bootstrap.out" 2>&1; then
+        fail "expected invalid MEK bootstrap imagePullPolicy to fail schema validation"
+    fi
+    require_schema_path "$TEST_DIRECTORY/invalid-mek-bootstrap.out" \
+        "secrets.masterEncryptionKey.bootstrap.imagePullPolicy"
     require_contains "$rendered" "https://s3.external.example.com"
     resource_document "$rendered" ConfigMap osmo-api-config \
         >"$TEST_DIRECTORY/osmo-external-object-storage-config.yaml"

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -70,7 +70,7 @@
         "valkey": { "$ref": "#/definitions/secretReference" },
         "objectStorage": { "$ref": "#/definitions/secretReference" },
         "backendApiTokens": { "$ref": "#/definitions/backendApiTokens" },
-        "masterEncryptionKey": { "$ref": "#/definitions/masterEncryptionKeySecretReference" },
+        "masterEncryptionKey": { "$ref": "#/definitions/masterEncryptionKeyReference" },
         "defaultAdmin": { "$ref": "#/definitions/secretReference" }
       }
     },
@@ -1220,28 +1220,52 @@
       },
       "required": ["name"]
     },
-    "masterEncryptionKeySecretReference": {
+    "masterEncryptionKeyReference": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "generate": { "type": "boolean" },
-        "existingSecret": { "type": "string" },
-        "mountPath": { "type": "string", "minLength": 1 },
-        "keys": {
+        "managementMode": { "type": "string", "enum": ["external", "osmo"] },
+        "existingSecret": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "config": { "type": "string" }
+            "name": { "type": "string" },
+            "key": { "type": "string", "minLength": 1 }
           },
-          "required": ["config"]
+          "required": ["name", "key"]
         },
         "bootstrap": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "image": { "$ref": "#/definitions/componentImage" }
+            "enabled": { "type": "boolean" },
+            "attempt": { "type": "string", "minLength": 1, "maxLength": 32 },
+            "imagePullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            },
+            "activeDeadlineSeconds": { "type": "integer", "minimum": 1 }
           },
-          "required": ["image"]
+          "required": ["enabled", "attempt", "imagePullPolicy", "activeDeadlineSeconds"]
+        },
+        "rotation": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "requestId": { "type": "string", "maxLength": 64 },
+            "phase": { "type": "string", "enum": ["", "prepare", "activate", "rewrap"] },
+            "attempt": { "type": "string", "minLength": 1, "maxLength": 32 },
+            "rolloutRevision": { "type": "string", "maxLength": 128 },
+            "imagePullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"]
+            },
+            "activeDeadlineSeconds": { "type": "integer", "minimum": 1 }
+          },
+          "required": ["requestId", "phase", "attempt", "rolloutRevision", "imagePullPolicy", "activeDeadlineSeconds"]
         }
       },
-      "required": ["generate", "existingSecret", "mountPath", "keys", "bootstrap"]
+      "required": ["managementMode", "existingSecret", "bootstrap", "rotation"]
     },
     "postgresqlSecretReference": {
       "type": "object",

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -282,18 +282,28 @@ secrets:
     #     name: osmo-backend-token-local
   # Master encryption key configuration mounted into OSMO services.
   masterEncryptionKey:
-    generate: false
-    existingSecret: ''
-    mountPath: /opt/osmo/config.yaml
-    keys:
-      config: mek.yaml
+    managementMode: external
+    existingSecret:
+      name: ''
+      key: mek.yaml
     bootstrap:
-      image:
-        registry: ''
-        repository: alpine/k8s
-        tag: 1.30.14
-        digest: ''
-        pullPolicy: IfNotPresent
+      # Must be set back to false immediately after a successful bootstrap.
+      enabled: false
+      # Increment after a failed GitOps attempt or credential correction.
+      attempt: "1"
+      imagePullPolicy: IfNotPresent
+      activeDeadlineSeconds: 900
+    rotation:
+      requestId: ''
+      # Explicit operation: prepare, activate, or rewrap. Leave empty to
+      # perform the lifecycle manually without a chart Job.
+      phase: ''
+      attempt: "1"
+      # Change this only after PREPARE and again after ACTIVATE. It is copied
+      # to every MEK consumer Pod template to produce startup-only rollouts.
+      rolloutRevision: ''
+      imagePullPolicy: IfNotPresent
+      activeDeadlineSeconds: 900
   # Optional password used to bootstrap the named administrator account.
   defaultAdmin:
     generate: false

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -20,12 +20,13 @@
 
 This Helm chart deploys the OSMO platform with its core services and an optional standalone API gateway.
 
-For a local deployment that previously used quick-start values, create the
-namespaces, `local-admin-password` and backend token Secrets, and the
-`mek-config` ConfigMap from
-[../README.md](../README.md), then install this chart first with
-`quick-start-values.yaml`. Install the `backend-operator` chart with its
-matching values file after the service release is available:
+For a disposable local deployment, create the namespaces and the
+`local-admin-password` Secret from [../README.md](../README.md), then install
+this chart with `quick-start-values.yaml`. Those values opt into Kubernetes
+Jobs that create the initial MEK Secret and shared backend token Secret without
+putting their material in Helm output or release state. Install the
+`backend-operator` chart with its matching values file after the service
+release is available:
 
 ```bash
 helm upgrade --install osmo osmo/service \
@@ -35,6 +36,15 @@ helm upgrade --install osmo osmo/service \
 ```
 
 See [../README.md](../README.md) for the full two-chart flow.
+
+The MEK bootstrap mode is only safe with a new, empty database. A Helm install
+or a new release name can still point at retained PostgreSQL data; in that case,
+restore or supply the MEK that encrypted that data instead of enabling
+bootstrap.
+
+The retained Secret is created empty by Helm; the namespace-scoped lifecycle
+Job generates the key and commits its identity to PostgreSQL before the OSMO
+pods can become healthy. It never places key material in Helm release state.
 
 ## Values
 
@@ -69,6 +79,15 @@ OSMO services write logs to standard streams for collection by the platform log 
 |-----------|-------------|---------|
 | `services.configFile.enabled` | Enable external configuration file loading | `false` |
 | `services.configFile.path` | Path to the configuration file | `/opt/osmo/config.yaml` |
+| `services.masterEncryptionKey.existingSecret.name` | Existing Kubernetes Secret containing the MEK keyring | `osmo-mek` |
+| `services.masterEncryptionKey.existingSecret.key` | Key containing the MEK YAML | `mek.yaml` |
+| `services.masterEncryptionKey.managementMode` | `external` for an operator-owned read-only Secret; `osmo` for install bootstrap and explicit Secret mutation Jobs | `external` |
+| `services.masterEncryptionKey.bootstrap.enabled` | Atomically create the MEK Secret for a new, empty install | `false` |
+| `services.masterEncryptionKey.bootstrap.attempt` | Non-secret retry identity; increment after a failed GitOps bootstrap or credential correction | `"1"` |
+| `services.masterEncryptionKey.rotation.requestId` | Unique non-secret ID shared by all phases of one rotation | `""` |
+| `services.masterEncryptionKey.rotation.phase` | Explicit `prepare`, `activate`, or `rewrap` Job; empty disables Jobs | `""` |
+| `services.masterEncryptionKey.rotation.attempt` | Retry identity used to create an immutable Job name | `"1"` |
+| `services.masterEncryptionKey.rotation.rolloutRevision` | Operator-changed value that rolls every MEK consumer after PREPARE and ACTIVATE | `""` |
 | `services.configs.enabled` | Enable ConfigMap-backed dynamic configuration | `false` |
 | `services.configs.extraAnnotations` | Annotations on the generated configs ConfigMap (e.g., ArgoCD sync options) | `{}` |
 
@@ -436,7 +455,7 @@ The router was its own Helm chart prior to v6.3 and is now deployed as part of t
 | `services.router.serviceAccountName` | Per-router ServiceAccount name. When empty, falls back to `global.serviceAccountName`. | `""` |
 | `services.router.extraArgs` | Additional command line arguments | `[]` |
 | `services.router.extraPodLabels` | Extra labels applied to the router pod | `{}` |
-| `services.router.extraPodAnnotations` | Extra annotations applied to the router pod (e.g. vault-injector annotations) | `{}` |
+| `services.router.extraPodAnnotations` | Extra annotations applied to the router pod | `{}` |
 | `services.router.extraEnvs` | Extra container env vars (list of `{name, value}` or `{name, valueFrom}`) | `[]` |
 | `services.router.extraPorts` | Extra named container ports | `[]` |
 | `services.router.extraVolumes` | Extra pod volumes | `[]` |
@@ -451,7 +470,85 @@ The router was its own Helm chart prior to v6.3 and is now deployed as part of t
 | `services.router.startupProbe` | Startup probe configuration | See values.yaml |
 | `services.router.readinessProbe` | Readiness probe configuration | See values.yaml |
 
-The router reads the same `services.configFile.path` as the API service. When `services.configFile.enabled: false` (default), the router gets `--config <path>` as a CLI arg. The API service ignores `services.configFile.path` unless `services.configFile.enabled: true`, so setting just the path lets you point the router at a vault-injected config without affecting the API service.
+The router and all other control-plane database consumers read the MEK through
+the typed `services.masterEncryptionKey.existingSecret` reference.
+
+Use `managementMode: external` when an operator owns the Secret. OSMO mounts it
+read-only and never creates, patches, or rotates it. Use `managementMode: osmo`
+only when this release should create or update that exact Secret through an
+explicit lifecycle Job. With `bootstrap.enabled: true`, Helm renders no MEK
+Secret data. A create-only Job waits for PostgreSQL, proves that the database
+has no users, UEKs, or dynamic configuration, verifies that every chart
+consumer is blocked before its writer container starts, and atomically creates
+the full Secret. A retry accepts only the exact Secret owned by this
+installation and authenticates retained ciphertext; it never deletes or
+overwrites a Secret. Stop every non-chart database writer during bootstrap.
+
+Immediately after bootstrap succeeds, perform a second Helm upgrade or GitOps
+sync with `services.masterEncryptionKey.bootstrap.enabled=false`. This removes
+the bootstrap Secret-creation ServiceAccount/RoleBinding. The chart rejects a
+rotation phase until bootstrap is disabled.
+If bootstrap fails or its database credentials are corrected under Argo CD or
+Flux, increment the non-secret `services.masterEncryptionKey.bootstrap.attempt`
+before the next sync. Credential bytes never influence public lifecycle names.
+
+Every consumer loads the keyring once at process startup. Before becoming
+ready, it performs a bounded authenticated inventory of every UEK wrapper and
+registered direct-MEK configuration value. It logs a machine-readable
+`OSMO_MEK_DESCRIPTOR` containing only non-secret rollout identity. There are no
+MEK database tables, triggers, hot reloads, or background reconciliation loops.
+
+Rotation is explicit, not scheduled. Use one unique non-secret request ID for
+three operator-driven phases:
+
+```bash
+helm upgrade <release> deployments/charts/service -n <namespace> \
+  --reuse-values --wait \
+  --set services.masterEncryptionKey.bootstrap.enabled=false \
+  --set services.masterEncryptionKey.rotation.requestId=rotate-2026-08-21 \
+  --set services.masterEncryptionKey.rotation.phase=prepare
+```
+
+1. PREPARE adds exactly one key while the old key remains `currentMek`. After
+   the Job succeeds, clear `phase`, change `rotation.rolloutRevision`, and sync
+   again to restart all six consumers.
+2. ACTIVATE first verifies that the complete Ready Pod cohort is owned by the
+   expected Deployments and logged the PREPARE descriptor, then selects the new
+   key. Clear `phase`, change `rolloutRevision` again, and sync the second
+   rollout.
+3. REWRAP verifies the ACTIVATE cohort, compare-and-swap rewraps every UEK and
+   registered direct-MEK configuration from the beginning, and runs two full
+   authenticated inventories. Clear `phase` after success.
+
+The chart changes only Pod-template annotations for the rollouts; the Job never
+deletes Pods or patches Deployments. The same values sequence therefore works
+with direct Helm upgrades and separate Argo CD or Flux syncs.
+
+With `managementMode=external`, the operator updates the Secret with PREPARE,
+changes `rolloutRevision`, updates it with ACTIVATE, then changes
+`rolloutRevision` again. After both rollouts, request the read-only rewrap Job:
+
+```bash
+helm upgrade <release> deployments/charts/service -n <namespace> \
+  --reuse-values --wait \
+  --set services.masterEncryptionKey.rotation.requestId=rotate-2026-08-21 \
+  --set services.masterEncryptionKey.rotation.phase=rewrap
+```
+
+The rewrap Role can only `get` the exact MEK Secret; it has no Secret mutation
+verbs. Every phase creates or reuses a release-scoped Kubernetes Lease directly.
+The Lease is absent from Helm desired state, so GitOps self-heal cannot clear a
+live holder. It is never stolen from another holder, even when its timestamp is
+old. For a terminated attempt, delete the old Job/Pod, verify it is absent,
+clear the Lease holder, increment `rotation.attempt`, and retry the same phase.
+Clear a successful phase promptly so GitOps removes its ServiceAccount and
+RoleBinding.
+
+Rewrap completion is point-in-time evidence, not a safe retirement proof.
+Because there are deliberately no database fences or lifecycle tables, every
+old MEK must remain in the Secret. User plaintext and UEK material do not
+change; only encrypted wrappers change. Normal reads never rewrite direct-MEK
+ciphertext; the explicit Job is the sole MEK rewrap orchestrator.
 
 ### Prometheus Metrics Settings
 

--- a/deployments/charts/service/quick-start-values.yaml
+++ b/deployments/charts/service/quick-start-values.yaml
@@ -27,6 +27,12 @@ global:
     node_group: service
 
 services:
+  masterEncryptionKey:
+    managementMode: osmo
+    bootstrap:
+      # Set false in a second sync immediately after the first install succeeds.
+      enabled: true
+
   configFile:
     enabled: true
 

--- a/deployments/charts/service/templates/_helpers.tpl
+++ b/deployments/charts/service/templates/_helpers.tpl
@@ -177,6 +177,32 @@ must select exactly one source so chart-managed generation is always explicit.
 {{- printf "%s-backend-token-bootstrap" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
+{{/* Kubernetes Secret-only MEK projection shared by every database consumer. */}}
+{{- define "osmo.mek-file" -}}
+{{- "/opt/osmo/mek/mek.yaml" | quote -}}
+{{- end -}}
+
+{{- define "osmo.mek-volume-mount" -}}
+- name: mek-volume
+  mountPath: "/opt/osmo/mek"
+  readOnly: true
+{{- end -}}
+
+{{- define "osmo.mek-volume" -}}
+- name: mek-volume
+  secret:
+    secretName: {{ required "services.masterEncryptionKey.existingSecret.name is required" .Values.services.masterEncryptionKey.existingSecret.name | quote }}
+    items:
+    - key: {{ required "services.masterEncryptionKey.existingSecret.key is required" .Values.services.masterEncryptionKey.existingSecret.key | quote }}
+      path: "mek.yaml"
+{{- end -}}
+
+{{- define "osmo.mek-rollout-annotation" -}}
+{{- with .Values.services.masterEncryptionKey.rotation.rolloutRevision }}
+osmo.nvidia.com/mek-rollout: {{ . | quote }}
+{{- end }}
+{{- end -}}
+
 {{/*
 ConfigMap-mode mounts (shared by api-service, worker, agent, logger).
 All four services need the same configs ConfigMap and its referenced

--- a/deployments/charts/service/templates/agent-service.yaml
+++ b/deployments/charts/service/templates/agent-service.yaml
@@ -22,6 +22,7 @@ metadata:
   name: {{ .Values.services.agent.serviceName }}
   labels:
     app: {{ .Values.services.agent.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
 spec:
   selector:
     matchLabels:
@@ -30,10 +31,13 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.agent.serviceName }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/part-of: osmo
         {{- with .Values.services.agent.extraPodLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+        {{- include "osmo.mek-rollout-annotation" . | nindent 8 }}
         {{- include "osmo.extra-annotations" .Values.services.agent | nindent 8 }}
     spec:
       {{- with .Values.services.agent.hostAliases }}
@@ -106,10 +110,8 @@ spec:
         - {{ .Values.services.postgres.port | quote }}
         - --postgres_database_name
         - {{ .Values.services.postgres.db}}
-        {{- if .Values.services.configFile.enabled }}
         - --mek_file
-        - {{ .Values.services.configFile.path }}
-        {{- end}}
+        - {{ include "osmo.mek-file" . }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -151,14 +153,8 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.services.agent.imagePullPolicy }}
         ports:
-        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.agent.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.agent) }}
         volumeMounts:
-        {{- end }}
-        {{- if .Values.services.configFile.enabled}}
-        - mountPath: {{ .Values.services.configFile.path }}
-          name: mek-volume
-          subPath: mek.yaml
-        {{- end }}
+        {{- include "osmo.mek-volume-mount" . | nindent 8 }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
         {{- include "osmo.extra-volume-mounts" .Values.services.agent | nindent 8 }}
         {{- include "osmo.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
@@ -198,15 +194,7 @@ spec:
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.agent | nindent 8 }}
         {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.agent) | nindent 8 }}
-        {{- if .Values.services.configFile.enabled}}
-        - configMap:
-            defaultMode: 420
-            items:
-            - key: mek.yaml
-              path: mek.yaml
-            name: mek-config
-          name: mek-volume
-        {{- end}}
+        {{- include "osmo.mek-volume" . | nindent 8 }}
         {{- include "osmo.configmap-volumes" . | nindent 8 }}
 
 ---
@@ -234,6 +222,7 @@ metadata:
   name: {{ .Values.services.agent.serviceName }}
   labels:
     app: {{ .Values.services.agent.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/service/templates/api-service.yaml
+++ b/deployments/charts/service/templates/api-service.yaml
@@ -41,6 +41,7 @@ metadata:
   name: {{ .Values.services.service.serviceName }}
   labels:
     app: {{ .Values.services.service.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
 spec:
   selector:
     matchLabels:
@@ -49,10 +50,13 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.service.serviceName }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/part-of: osmo
         {{- with .Values.services.service.extraPodLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+        {{- include "osmo.mek-rollout-annotation" . | nindent 8 }}
         {{- include "osmo.extra-annotations" .Values.services.service | nindent 8 }}
         {{- if .Values.services.backendApiTokens.enabled }}
         osmo.nvidia.com/backend-token-rollout: {{ .Values.services.backendApiTokens.rolloutNonce | quote }}
@@ -118,10 +122,8 @@ spec:
         - {{ .Values.services.postgres.port | quote }}
         - --postgres_database_name
         - {{ .Values.services.postgres.db}}
-        {{- if .Values.services.configFile.enabled }}
         - --mek_file
-        - {{ .Values.services.configFile.path }}
-        {{- end }}
+        - {{ include "osmo.mek-file" . }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -219,14 +221,8 @@ spec:
         ports:
         - name: metrics
           containerPort: 9464
-        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.backendApiTokens.enabled .Values.services.service.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.service) }}
         volumeMounts:
-        {{- end }}
-        {{- if .Values.services.configFile.enabled}}
-        - mountPath: {{ .Values.services.configFile.path }}
-          name: mek-volume
-          subPath: mek.yaml
-        {{- end }}
+        {{- include "osmo.mek-volume-mount" . | nindent 8 }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
         {{- if .Values.services.backendApiTokens.enabled }}
         {{- range .Values.services.backendApiTokens.credentials }}
@@ -269,15 +265,7 @@ spec:
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.service | nindent 8 }}
         {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.service) | nindent 8 }}
-        {{- if .Values.services.configFile.enabled}}
-        - configMap:
-            defaultMode: 420
-            items:
-            - key: mek.yaml
-              path: mek.yaml
-            name: mek-config
-          name: mek-volume
-        {{- end}}
+        {{- include "osmo.mek-volume" . | nindent 8 }}
         {{- include "osmo.configmap-volumes" . | nindent 8 }}
         {{- if .Values.services.backendApiTokens.enabled }}
         {{- range .Values.services.backendApiTokens.credentials }}
@@ -311,6 +299,7 @@ metadata:
   name: {{ .Values.services.service.serviceName }}
   labels:
     app: {{ .Values.services.service.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/service/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/service/templates/delayed-job-monitor.yaml
@@ -19,6 +19,7 @@ metadata:
   name: {{ .Values.services.delayedJobMonitor.serviceName }}
   labels:
     app: {{ .Values.services.delayedJobMonitor.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
 spec:
   replicas: {{ .Values.services.delayedJobMonitor.replicas }}
   selector:
@@ -28,10 +29,13 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.delayedJobMonitor.serviceName }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/part-of: osmo
         {{- with .Values.services.delayedJobMonitor.extraPodLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+        {{- include "osmo.mek-rollout-annotation" . | nindent 8 }}
       {{- include "osmo.extra-annotations" .Values.services.delayedJobMonitor | nindent 8 }}
     spec:
       nodeSelector:
@@ -88,10 +92,8 @@ spec:
         - {{ .Values.services.postgres.port | quote }}
         - --postgres_database_name
         - {{ .Values.services.postgres.db}}
-        {{- if .Values.services.configFile.enabled }}
         - --mek_file
-        - {{ .Values.services.configFile.path }}
-        {{- end}}
+        - {{ include "osmo.mek-file" . }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -128,14 +130,8 @@ spec:
         resources:
         {{- toYaml .Values.services.service.resources | nindent 10 }}
 
-        {{- if or .Values.services.configFile.enabled .Values.services.delayedJobMonitor.extraVolumeMounts .Values.services.delayedJobMonitor.volumeMounts }}
         volumeMounts:
-        {{- end }}
-        {{- if .Values.services.configFile.enabled}}
-        - mountPath: {{ .Values.services.configFile.path }}
-          name: mek-volume
-          subPath: mek.yaml
-        {{- end }}
+        {{- include "osmo.mek-volume-mount" . | nindent 8 }}
         {{- include "osmo.extra-volume-mounts" .Values.services.delayedJobMonitor | nindent 8 }}
         {{- if .Values.services.delayedJobMonitor.volumeMounts }}
         {{- toYaml .Values.services.delayedJobMonitor.volumeMounts | nindent 8 }}
@@ -160,15 +156,7 @@ spec:
       {{- include "osmo.extra-sidecars" .Values.services.delayedJobMonitor | nindent 6 }}
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.delayedJobMonitor | nindent 8 }}
-        {{- if .Values.services.configFile.enabled}}
-        - configMap:
-            defaultMode: 420
-            items:
-            - key: mek.yaml
-              path: mek.yaml
-            name: mek-config
-          name: mek-volume
-        {{- end}}
+        {{- include "osmo.mek-volume" . | nindent 8 }}
         {{- if .Values.services.delayedJobMonitor.volumes }}
         {{- toYaml .Values.services.delayedJobMonitor.volumes | nindent 8 }}
         {{- end }}

--- a/deployments/charts/service/templates/logger-service.yaml
+++ b/deployments/charts/service/templates/logger-service.yaml
@@ -22,6 +22,7 @@ metadata:
   name: {{ .Values.services.logger.serviceName }}
   labels:
     app: {{ .Values.services.logger.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
 spec:
   selector:
     matchLabels:
@@ -30,10 +31,13 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.logger.serviceName }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/part-of: osmo
         {{- with .Values.services.logger.extraPodLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+        {{- include "osmo.mek-rollout-annotation" . | nindent 8 }}
         {{- include "osmo.extra-annotations" .Values.services.logger | nindent 8 }}
     spec:
       {{- with .Values.services.logger.hostAliases }}
@@ -101,10 +105,8 @@ spec:
         - {{ .Values.services.postgres.port | quote }}
         - --postgres_database_name
         - {{ .Values.services.postgres.db}}
-        {{- if .Values.services.configFile.enabled }}
         - --mek_file
-        - {{ .Values.services.configFile.path }}
-        {{- end}}
+        - {{ include "osmo.mek-file" . }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -142,14 +144,8 @@ spec:
         {{- end }}
         imagePullPolicy: {{ .Values.services.logger.imagePullPolicy }}
         ports:
-        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.logger.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.logger) }}
         volumeMounts:
-        {{- end }}
-        {{- if .Values.services.configFile.enabled}}
-        - mountPath: {{ .Values.services.configFile.path }}
-          name: mek-volume
-          subPath: mek.yaml
-        {{- end }}
+        {{- include "osmo.mek-volume-mount" . | nindent 8 }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
         {{- include "osmo.extra-volume-mounts" .Values.services.logger | nindent 8 }}
         {{- include "osmo.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
@@ -191,15 +187,7 @@ spec:
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.logger | nindent 8 }}
         {{- include "osmo.upstream-tls-volume" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.logger) | nindent 8 }}
-        {{- if .Values.services.configFile.enabled}}
-        - configMap:
-            defaultMode: 420
-            items:
-            - key: mek.yaml
-              path: mek.yaml
-            name: mek-config
-          name: mek-volume
-        {{- end}}
+        {{- include "osmo.mek-volume" . | nindent 8 }}
         {{- include "osmo.configmap-volumes" . | nindent 8 }}
 
 ---
@@ -245,6 +233,7 @@ metadata:
   name: {{ .Values.services.logger.serviceName }}
   labels:
     app: {{ .Values.services.logger.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/service/templates/mek-bootstrap.yaml
+++ b/deployments/charts/service/templates/mek-bootstrap.yaml
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- $mek := .Values.services.masterEncryptionKey -}}
+{{- if or (not (kindIs "map" $mek)) (ne (len $mek) 4) -}}{{- fail "services.masterEncryptionKey must be the exact supported object" -}}{{- end -}}
+{{- if not (kindIs "string" (index $mek "managementMode")) -}}{{- fail "services.masterEncryptionKey.managementMode must be a string" -}}{{- end -}}
+{{- $existingSecret := index $mek "existingSecret" -}}
+{{- if or (not (kindIs "map" $existingSecret)) (ne (len $existingSecret) 2) -}}{{- fail "services.masterEncryptionKey.existingSecret must be an exact name/key object" -}}{{- end -}}
+{{- range $field := list "name" "key" -}}
+{{- if not (kindIs "string" (index $existingSecret $field)) -}}{{- fail "services.masterEncryptionKey.existingSecret fields must be strings" -}}{{- end -}}
+{{- end -}}
+{{- $bootstrap := index $mek "bootstrap" -}}
+{{- if or (not (kindIs "map" $bootstrap)) (ne (len $bootstrap) 4) -}}{{- fail "services.masterEncryptionKey.bootstrap must be the exact supported object" -}}{{- end -}}
+{{- if not (kindIs "bool" (index $bootstrap "enabled")) -}}{{- fail "services.masterEncryptionKey.bootstrap.enabled must be a boolean" -}}{{- end -}}
+{{- if or (not (kindIs "string" (index $bootstrap "attempt"))) (eq (index $bootstrap "attempt") "") (gt (len (index $bootstrap "attempt")) 32) -}}{{- fail "services.masterEncryptionKey.bootstrap.attempt must be a nonempty string of at most 32 characters" -}}{{- end -}}
+{{- if or (not (kindIs "string" (index $bootstrap "imagePullPolicy"))) (not (has (index $bootstrap "imagePullPolicy") (list "Always" "IfNotPresent" "Never"))) -}}{{- fail "services.masterEncryptionKey.bootstrap.imagePullPolicy is invalid" -}}{{- end -}}
+{{- $bootstrapDeadline := index $bootstrap "activeDeadlineSeconds" -}}
+{{- if or (not (or (kindIs "int" $bootstrapDeadline) (kindIs "int64" $bootstrapDeadline) (kindIs "float64" $bootstrapDeadline))) (le (int $bootstrapDeadline) 0) (ne (float64 $bootstrapDeadline) (float64 (int $bootstrapDeadline))) -}}{{- fail "services.masterEncryptionKey.bootstrap.activeDeadlineSeconds must be a positive integer" -}}{{- end -}}
+{{- $rotation := index $mek "rotation" -}}
+{{- if or (not (kindIs "map" $rotation)) (ne (len $rotation) 6) -}}{{- fail "services.masterEncryptionKey.rotation must be the exact supported object" -}}{{- end -}}
+{{- range $field := list "requestId" "phase" "attempt" "rolloutRevision" "imagePullPolicy" -}}
+{{- if not (kindIs "string" (index $rotation $field)) -}}{{- fail "services.masterEncryptionKey.rotation string fields must be strings" -}}{{- end -}}
+{{- end -}}
+{{- if or (eq (index $rotation "attempt") "") (not (has (index $rotation "imagePullPolicy") (list "Always" "IfNotPresent" "Never"))) -}}{{- fail "services.masterEncryptionKey.rotation attempt or imagePullPolicy is invalid" -}}{{- end -}}
+{{- if or (gt (len (index $rotation "requestId")) 64) (gt (len (index $rotation "attempt")) 32) (gt (len (index $rotation "rolloutRevision")) 128) -}}{{- fail "services.masterEncryptionKey.rotation string fields exceed supported lengths" -}}{{- end -}}
+{{- $rotationDeadline := index $rotation "activeDeadlineSeconds" -}}
+{{- if or (not (or (kindIs "int" $rotationDeadline) (kindIs "int64" $rotationDeadline) (kindIs "float64" $rotationDeadline))) (le (int $rotationDeadline) 0) (ne (float64 $rotationDeadline) (float64 (int $rotationDeadline))) -}}{{- fail "services.masterEncryptionKey.rotation.activeDeadlineSeconds must be a positive integer" -}}{{- end -}}
+{{- $secretName := $mek.existingSecret.name -}}
+{{- $secretKey := $mek.existingSecret.key -}}
+{{- $operation := $mek.rotation.phase -}}
+{{- if not (has $mek.managementMode (list "external" "osmo")) -}}{{- fail "services.masterEncryptionKey.managementMode must be external or osmo" -}}{{- end -}}
+{{- if not (has $operation (list "" "prepare" "activate" "rewrap")) -}}{{- fail "services.masterEncryptionKey.rotation.phase must be empty, prepare, activate, or rewrap" -}}{{- end -}}
+{{- if and $operation (not $mek.rotation.requestId) -}}{{- fail "services.masterEncryptionKey.rotation.requestId is required for a lifecycle phase" -}}{{- end -}}
+{{- if and (has $operation (list "prepare" "activate")) (ne $mek.managementMode "osmo") -}}{{- fail "prepare and activate require managementMode=osmo; external operators update the Secret directly" -}}{{- end -}}
+{{- if and $mek.bootstrap.enabled (ne $mek.managementMode "osmo") -}}{{- fail "services.masterEncryptionKey.bootstrap.enabled requires managementMode=osmo" -}}{{- end -}}
+{{- if and $mek.bootstrap.enabled $operation -}}{{- fail "disable services.masterEncryptionKey.bootstrap.enabled before requesting a rotation phase" -}}{{- end -}}
+
+{{- if or $mek.bootstrap.enabled $operation }}
+{{- $secretName = required "services.masterEncryptionKey.existingSecret.name is required" $secretName }}
+{{- $secretKey = required "services.masterEncryptionKey.existingSecret.key is required" $secretKey }}
+{{- $leaseHash := printf "%s/%s:%s" .Release.Namespace .Release.Name $secretName | sha256sum | trunc 10 }}
+{{- $leasePrefix := regexReplaceAll "[^a-z0-9-]" (lower .Release.Name) "-" | trimAll "-" | trunc 46 | trimSuffix "-" }}
+{{- $leaseName := printf "%s-mek-%s" $leasePrefix $leaseHash }}
+{{- $actualOperation := ternary "bootstrap" $operation $mek.bootstrap.enabled }}
+{{- $needsDatabase := or $mek.bootstrap.enabled (eq $operation "rewrap") }}
+{{- $request := ternary "initial" $mek.rotation.requestId $mek.bootstrap.enabled }}
+{{- $consumerDeployments := list .Values.services.service.serviceName .Values.services.worker.serviceName .Values.services.router.serviceName .Values.services.logger.serviceName .Values.services.agent.serviceName .Values.services.delayedJobMonitor.serviceName }}
+{{- $bootstrapInputs := dict
+      "chartVersion" .Chart.Version
+      "chartAppVersion" .Chart.AppVersion
+      "releaseRevision" .Release.Revision
+      "attempt" $mek.bootstrap.attempt
+      "image" (printf "%s/%s:%s" .Values.global.osmoImageLocation .Values.services.service.imageName .Values.global.osmoImageTag)
+      "imagePullPolicy" $mek.bootstrap.imagePullPolicy
+      "imagePullSecret" .Values.global.imagePullSecret
+      "deadline" $mek.bootstrap.activeDeadlineSeconds
+      "consumers" $consumerDeployments
+      "secretName" $secretName
+      "secretKey" $secretKey
+      "postgresHost" .Values.services.postgres.serviceName
+      "postgresPort" .Values.services.postgres.port
+      "postgresDatabase" .Values.services.postgres.db
+      "postgresUsername" .Values.services.postgres.user
+      "postgresUsesInlinePassword" (not (empty .Values.services.postgres.password))
+      "postgresPasswordSecretName" .Values.services.postgres.passwordSecretName
+      "postgresPasswordSecretKey" .Values.services.postgres.passwordSecretKey -}}
+{{- $bootstrapIdentity := toJson $bootstrapInputs | sha256sum }}
+{{- $attemptIdentity := ternary $bootstrapIdentity $mek.rotation.attempt $mek.bootstrap.enabled }}
+{{- $hash := printf "%s:%s:%s" $actualOperation $request $attemptIdentity | sha256sum | trunc 10 }}
+{{- $name := printf "%s-mek-%s-%s" (include "osmo.fullname" .) $actualOperation $hash | trunc 63 | trimSuffix "-" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mek-lifecycle
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mek-lifecycle
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [{{ $secretName | quote }}]
+  verbs: ["get"{{- if and (eq $mek.managementMode "osmo") $operation }}, "patch"{{- end }}]
+{{- if $mek.bootstrap.enabled }}
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+{{- end }}
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "replicasets"]
+  verbs: ["get", "list"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  resourceNames: [{{ $leaseName | quote }}]
+  verbs: ["get", "patch", "update"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mek-lifecycle
+subjects:
+- kind: ServiceAccount
+  name: {{ $name | quote }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name | quote }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mek-lifecycle
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ ternary $mek.bootstrap.activeDeadlineSeconds $mek.rotation.activeDeadlineSeconds $mek.bootstrap.enabled }}
+  template:
+    metadata:
+      labels:
+        {{- include "osmo.labels" . | nindent 8 }}
+        app.kubernetes.io/component: mek-lifecycle
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $name | quote }}
+      automountServiceAccountToken: false
+      {{- if .Values.global.imagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecret | quote }}
+      {{- end }}
+      containers:
+      - name: mek-lifecycle
+        image: {{ .Values.global.osmoImageLocation }}/{{ .Values.services.service.imageName }}:{{ .Values.global.osmoImageTag }}
+        imagePullPolicy: {{ ternary $mek.bootstrap.imagePullPolicy $mek.rotation.imagePullPolicy $mek.bootstrap.enabled | quote }}
+        command: ["mek-lifecycle"]
+        args:
+        - --operation
+        - {{ $actualOperation | quote }}
+        - --namespace
+        - {{ .Release.Namespace | quote }}
+        - --secret_name
+        - {{ $secretName | quote }}
+        - --secret_key
+        - {{ $secretKey | quote }}
+        - --installation_id
+        - {{ printf "%s/%s" .Release.Namespace .Release.Name | quote }}
+        - --management_mode
+        - {{ $mek.managementMode | quote }}
+        - --request_id
+        - {{ $request | quote }}
+        - --consumer_deployments
+        - {{ join "," $consumerDeployments | quote }}
+        {{- if $needsDatabase }}
+        - --postgres_host
+        - {{ .Values.services.postgres.serviceName | quote }}
+        - --postgres_port
+        - {{ .Values.services.postgres.port | quote }}
+        - --postgres_database_name
+        - {{ .Values.services.postgres.db | quote }}
+        - --postgres_user
+        - {{ .Values.services.postgres.user | quote }}
+        {{- end }}
+        - --active_deadline_seconds
+        - {{ ternary $mek.bootstrap.activeDeadlineSeconds $mek.rotation.activeDeadlineSeconds $mek.bootstrap.enabled | quote }}
+        env:
+        - name: OSMO_POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        {{- if $needsDatabase }}
+        {{- if .Values.services.postgres.password }}
+        - name: OSMO_POSTGRES_PASSWORD
+          value: {{ .Values.services.postgres.password | quote }}
+        {{- else }}
+        - name: OSMO_POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.services.postgres.passwordSecretName | quote }}
+              key: {{ .Values.services.postgres.passwordSecretKey | quote }}
+        {{- end }}
+        {{- end }}
+        volumeMounts:
+        - name: lifecycle-temp
+          mountPath: /tmp
+        {{- if not $mek.bootstrap.enabled }}
+        - name: mek-volume
+          mountPath: "/opt/osmo/mek"
+          readOnly: true
+        {{- end }}
+        - name: kubernetes-api
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: lifecycle-temp
+        emptyDir: {}
+      {{- if not $mek.bootstrap.enabled }}
+      - name: mek-volume
+        secret:
+          secretName: {{ $secretName | quote }}
+          items:
+          - key: {{ $secretKey | quote }}
+            path: "mek.yaml"
+      {{- end }}
+      - name: kubernetes-api
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 600
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+              - key: ca.crt
+                path: ca.crt
+{{- end }}

--- a/deployments/charts/service/templates/router-service.yaml
+++ b/deployments/charts/service/templates/router-service.yaml
@@ -20,6 +20,7 @@ metadata:
   name: {{ .Values.services.router.serviceName }}
   labels:
     app: {{ .Values.services.router.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
 spec:
   replicas: {{ .Values.services.router.scaling.minReplicas }}
   selector:
@@ -29,10 +30,13 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.router.serviceName }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/part-of: osmo
         {{- with .Values.services.router.extraPodLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+        {{- include "osmo.mek-rollout-annotation" . | nindent 8 }}
         {{- with .Values.services.router.extraPodAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -96,13 +100,8 @@ spec:
         - --postgres_user
         - {{ .Values.services.postgres.user }}
         {{- end }}
-        {{- if .Values.services.configFile.enabled }}
         - --mek_file
-        - {{ .Values.services.configFile.path }}
-        {{- else }}
-        - --config
-        - {{ .Values.services.configFile.path }}
-        {{- end }}
+        - {{ include "osmo.mek-file" . }}
         {{- if .Values.global.logs.enabled }}
         - --log_level
         - {{ .Values.global.logs.logLevel }}
@@ -159,18 +158,12 @@ spec:
           protocol: {{ .protocol | default "TCP" }}
         {{- end }}
         {{- end }}
-        {{- if or .Values.services.configFile.enabled .Values.services.router.extraVolumeMounts (and .Values.gateway.tls.enabled .Values.gateway.tls.upstreamCerts.router) }}
         volumeMounts:
-        {{- if .Values.services.configFile.enabled}}
-        - mountPath: {{ .Values.services.configFile.path }}
-          name: mek-volume
-          subPath: mek.yaml
-        {{- end }}
+        {{- include "osmo.mek-volume-mount" . | nindent 8 }}
         {{- with .Values.services.router.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- include "osmo.upstream-tls-volume-mount" (dict "context" . "secretName" .Values.gateway.tls.upstreamCerts.router) | nindent 8 }}
-        {{- end }}
         resources:
         {{- toYaml .Values.services.router.resources | nindent 10 }}
 
@@ -193,15 +186,7 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       volumes:
-        {{- if .Values.services.configFile.enabled}}
-        - configMap:
-            defaultMode: 420
-            items:
-            - key: mek.yaml
-              path: mek.yaml
-            name: mek-config
-          name: mek-volume
-        {{- end}}
+        {{- include "osmo.mek-volume" . | nindent 8 }}
         {{- with .Values.services.router.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -250,6 +235,7 @@ metadata:
   name: {{ .Values.services.router.serviceName }}
   labels:
     app: {{ .Values.services.router.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/service/templates/worker.yaml
+++ b/deployments/charts/service/templates/worker.yaml
@@ -19,6 +19,7 @@ metadata:
   name: {{ .Values.services.worker.serviceName }}
   labels:
     app: {{ .Values.services.worker.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
 spec:
   selector:
     matchLabels:
@@ -27,10 +28,13 @@ spec:
     metadata:
       labels:
         app: {{ .Values.services.worker.serviceName }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/part-of: osmo
         {{- with .Values.services.worker.extraPodLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+        {{- include "osmo.mek-rollout-annotation" . | nindent 8 }}
         {{- include "osmo.extra-annotations" .Values.services.worker | nindent 8 }}
     spec:
       topologySpreadConstraints:
@@ -99,10 +103,8 @@ spec:
         - {{ .Values.services.postgres.port | quote }}
         - --postgres_database_name
         - {{ .Values.services.postgres.db}}
-        {{- if .Values.services.configFile.enabled }}
         - --mek_file
-        - {{ .Values.services.configFile.path }}
-        {{- end}}
+        - {{ include "osmo.mek-file" . }}
         {{- if .Values.services.postgres.user }}
         - --postgres_user
         - {{ .Values.services.postgres.user }}
@@ -141,14 +143,8 @@ spec:
               name: redis-secret
               key: redis-password
         {{- end }}
-        {{- if or .Values.services.configFile.enabled .Values.services.configs.enabled .Values.services.worker.extraVolumeMounts }}
         volumeMounts:
-        {{- end }}
-        {{- if .Values.services.configFile.enabled}}
-        - mountPath: {{ .Values.services.configFile.path }}
-          name: mek-volume
-          subPath: mek.yaml
-        {{- end }}
+        {{- include "osmo.mek-volume-mount" . | nindent 8 }}
         {{- include "osmo.configmap-volume-mounts" . | nindent 8 }}
         {{- include "osmo.extra-volume-mounts" .Values.services.worker | nindent 8 }}
         resources:
@@ -174,15 +170,7 @@ spec:
       {{- include "osmo.extra-sidecars" .Values.services.worker | nindent 6 }}
       volumes:
         {{- include "osmo.extra-volumes" .Values.services.worker | nindent 8 }}
-        {{- if .Values.services.configFile.enabled}}
-        - configMap:
-            defaultMode: 420
-            items:
-            - key: mek.yaml
-              path: mek.yaml
-            name: mek-config
-          name: mek-volume
-        {{- end}}
+        {{- include "osmo.mek-volume" . | nindent 8 }}
         {{- include "osmo.configmap-volumes" . | nindent 8 }}
 
 ---
@@ -193,6 +181,7 @@ metadata:
   name: {{ .Values.services.worker.serviceName }}
   labels:
     app: {{ .Values.services.worker.serviceName }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
   annotations:
 spec:
   scaleTargetRef:

--- a/deployments/charts/service/tests/render-tests.sh
+++ b/deployments/charts/service/tests/render-tests.sh
@@ -7,6 +7,33 @@ set -euo pipefail
 
 CHART_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
+resource_document() {
+    local rendered=$1
+    local kind=$2
+    local name=$3
+    awk -v kind="$kind" -v name="$name" '
+        function reset() { document = ""; document_kind = ""; document_name = ""; metadata = 0 }
+        function finish() {
+            if (document_kind == kind && document_name == name) {
+                printf "%s", document
+                found = 1
+            }
+        }
+        BEGIN { found = 0; reset() }
+        /^---[[:space:]]*$/ { finish(); reset(); next }
+        { document = document $0 ORS }
+        /^kind: / { document_kind = $0; sub(/^kind: /, "", document_kind); next }
+        /^metadata:$/ { metadata = 1; next }
+        metadata && /^  name: / {
+            document_name = $0
+            sub(/^  name: /, "", document_name)
+            gsub(/^"|"$/, "", document_name)
+            metadata = 0
+        }
+        END { finish(); if (!found) exit 1 }
+    ' <<<"$rendered"
+}
+
 helm_args=(
     --namespace osmo
     --set 'services.backendApiTokens.enabled=true'
@@ -76,3 +103,222 @@ fi
 
 bash -n "$CHART_DIR/files/backend-token-bootstrap.sh"
 bash "$CHART_DIR/tests/backend-token-bootstrap-tests.sh"
+
+mek_bootstrap_render=$(helm template mek-bootstrap "$CHART_DIR" --namespace osmo \
+    --set 'services.masterEncryptionKey.managementMode=osmo' \
+    --set 'services.masterEncryptionKey.bootstrap.enabled=true' \
+    --set 'services.masterEncryptionKey.existingSecret.name=test-mek' \
+    --set 'services.masterEncryptionKey.existingSecret.key=keyring.yaml')
+if grep -q '^kind: Lease$\|^kind: Secret$' <<<"$mek_bootstrap_render"; then
+    echo 'MEK bootstrap rendered mutable lifecycle state into Helm desired state' >&2
+    exit 1
+fi
+grep -q 'command: \["mek-lifecycle"\]' <<<"$mek_bootstrap_render"
+grep -A1 -- '- --operation' <<<"$mek_bootstrap_render" | grep -q -- '- "bootstrap"'
+grep -q 'resourceNames: \["test-mek"\]' <<<"$mek_bootstrap_render"
+grep -q 'verbs: \["create"\]' <<<"$mek_bootstrap_render"
+grep -q 'runAsUser: 1001' <<<"$mek_bootstrap_render"
+mek_bootstrap_name=$(awk '/^kind: Job$/{job=1; next} job && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+    <<<"$mek_bootstrap_render")
+mek_bootstrap_changed=$(helm template mek-bootstrap "$CHART_DIR" --namespace osmo \
+    --set 'services.masterEncryptionKey.managementMode=osmo' \
+    --set 'services.masterEncryptionKey.bootstrap.enabled=true' \
+    --set 'services.masterEncryptionKey.bootstrap.activeDeadlineSeconds=899' \
+    --set 'services.masterEncryptionKey.existingSecret.name=test-mek' \
+    --set 'services.masterEncryptionKey.existingSecret.key=keyring.yaml')
+mek_bootstrap_changed_name=$(awk '/^kind: Job$/{job=1; next} job && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+    <<<"$mek_bootstrap_changed")
+if [[ "$mek_bootstrap_name" == "$mek_bootstrap_changed_name" ]]; then
+    echo 'MEK bootstrap immutable template change reused a completed Job name' >&2
+    exit 1
+fi
+mek_bootstrap_retry=$(helm template mek-bootstrap "$CHART_DIR" --namespace osmo \
+    --set 'services.masterEncryptionKey.managementMode=osmo' \
+    --set 'services.masterEncryptionKey.bootstrap.enabled=true' \
+    --set-string 'services.masterEncryptionKey.bootstrap.attempt=2' \
+    --set 'services.masterEncryptionKey.existingSecret.name=test-mek' \
+    --set 'services.masterEncryptionKey.existingSecret.key=keyring.yaml')
+mek_bootstrap_retry_name=$(awk '/^kind: Job$/{job=1; next} job && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+    <<<"$mek_bootstrap_retry")
+if [[ "$mek_bootstrap_name" == "$mek_bootstrap_retry_name" ]]; then
+    echo 'MEK bootstrap attempt did not create a new GitOps retry Job name' >&2
+    exit 1
+fi
+mek_bootstrap_password_one=$(helm template mek-bootstrap "$CHART_DIR" --namespace osmo \
+    --set 'services.masterEncryptionKey.managementMode=osmo' \
+    --set 'services.masterEncryptionKey.bootstrap.enabled=true' \
+    --set 'services.masterEncryptionKey.existingSecret.name=test-mek' \
+    --set-string 'services.postgres.password=credential-sentinel-one')
+mek_bootstrap_password_two=$(helm template mek-bootstrap "$CHART_DIR" --namespace osmo \
+    --set 'services.masterEncryptionKey.managementMode=osmo' \
+    --set 'services.masterEncryptionKey.bootstrap.enabled=true' \
+    --set 'services.masterEncryptionKey.existingSecret.name=test-mek' \
+    --set-string 'services.postgres.password=credential-sentinel-two')
+mek_bootstrap_password_one_name=$(awk '/^kind: Job$/{job=1; next} job && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+    <<<"$mek_bootstrap_password_one")
+mek_bootstrap_password_two_name=$(awk '/^kind: Job$/{job=1; next} job && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+    <<<"$mek_bootstrap_password_two")
+if [[ "$mek_bootstrap_password_one_name" != "$mek_bootstrap_password_two_name" ]]; then
+    echo 'Inline credential bytes influenced a public MEK lifecycle resource name' >&2
+    exit 1
+fi
+if helm template mek-bootstrap "$CHART_DIR" --namespace osmo \
+        --set 'services.masterEncryptionKey.managementMode=osmo' \
+        --set 'services.masterEncryptionKey.bootstrap.enabled=true' \
+        --set 'services.masterEncryptionKey.rotation.requestId=rotate' \
+        --set 'services.masterEncryptionKey.rotation.phase=prepare' >/dev/null 2>&1; then
+    echo 'MEK rotation phase was accepted while bootstrap remained enabled' >&2
+    exit 1
+fi
+if grep -q 'name: mek-volume' <<<"$(resource_document "$mek_bootstrap_render" Job \
+        "$(awk '/^kind: Role$/{role=1; next} role && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+        <<<"$mek_bootstrap_render")")"; then
+    echo 'Create-only MEK bootstrap Job requires the not-yet-created Secret volume' >&2
+    exit 1
+fi
+
+quick_start_render=$(helm template quick-start "$CHART_DIR" --namespace osmo \
+    -f "$CHART_DIR/quick-start-values.yaml")
+grep -q 'command: \["mek-lifecycle"\]' <<<"$quick_start_render"
+
+mek_prepare_render=$(helm template mek-prepare "$CHART_DIR" --namespace osmo \
+    --is-upgrade \
+    --set 'services.masterEncryptionKey.managementMode=osmo' \
+    --set 'services.masterEncryptionKey.existingSecret.name=test-mek' \
+    --set 'services.masterEncryptionKey.rotation.requestId=rotate-2026-08' \
+    --set 'services.masterEncryptionKey.rotation.phase=prepare' \
+    --set 'services.masterEncryptionKey.rotation.rolloutRevision=prepare-2026-08' \
+    --set 'services.masterEncryptionKey.rotation.activeDeadlineSeconds=321')
+grep -A1 -- '- --operation' <<<"$mek_prepare_render" | grep -q -- '- "prepare"'
+grep -q 'resources: \["pods/log"\]' <<<"$mek_prepare_render"
+grep -q 'resources: \["deployments", "replicasets"\]' <<<"$mek_prepare_render"
+mek_prepare_name=$(awk '/^kind: Role$/{role=1; next} role && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+    <<<"$mek_prepare_render")
+mek_prepare_job=$(resource_document "$mek_prepare_render" Job "$mek_prepare_name")
+if grep -q 'name: OSMO_POSTGRES_PASSWORD' <<<"$mek_prepare_job"; then
+    echo 'MEK PREPARE received unnecessary database credentials' >&2
+    exit 1
+fi
+grep -A1 -- '--active_deadline_seconds' <<<"$mek_prepare_render" | grep -q -- '"321"'
+if [[ $(grep -c 'osmo.nvidia.com/mek-rollout: "prepare-2026-08"' \
+        <<<"$mek_prepare_render") -ne 6 ]]; then
+    echo 'MEK rollout revision was not applied to all six consumers' >&2
+    exit 1
+fi
+if grep -q 'verbs: \["delete"\]' <<<"$mek_prepare_render"; then
+    echo 'MEK lifecycle received workload deletion authority' >&2
+    exit 1
+fi
+
+mek_rewrap_render=$(helm template mek-rewrap "$CHART_DIR" --namespace osmo \
+    --is-upgrade \
+    --set 'services.masterEncryptionKey.managementMode=external' \
+    --set 'services.masterEncryptionKey.existingSecret.name=test-mek' \
+    --set 'services.masterEncryptionKey.rotation.requestId=rotate-2026-08' \
+    --set 'services.masterEncryptionKey.rotation.phase=rewrap' \
+    --set 'services.masterEncryptionKey.rotation.activeDeadlineSeconds=432')
+grep -A1 -- '- --operation' <<<"$mek_rewrap_render" | grep -q -- '- "rewrap"'
+grep -A1 -- '--active_deadline_seconds' <<<"$mek_rewrap_render" | grep -q -- '"432"'
+mek_rewrap_name=$(awk '/^kind: Role$/{role=1; next} role && /^  name:/{gsub(/"/,"",$2); print $2; exit}' \
+    <<<"$mek_rewrap_render")
+mek_rewrap_role=$(resource_document "$mek_rewrap_render" Role "$mek_rewrap_name")
+awk '
+    /resources: \["secrets"\]/ { secret_rule = 1; next }
+    secret_rule && /verbs:/ {
+        if ($0 != "  verbs: [\"get\"]") exit 1
+        found = 1
+        secret_rule = 0
+    }
+    END { if (!found) exit 1 }
+' <<<"$mek_rewrap_role" || {
+    echo 'External MEK rewrap has Secret mutation permission' >&2
+    exit 1
+}
+mek_rewrap_job=$(resource_document "$mek_rewrap_render" Job "$mek_rewrap_name")
+grep -q 'runAsUser: 1001' <<<"$mek_rewrap_job"
+grep -q 'name: "db-secret"' <<<"$mek_rewrap_job"
+grep -q 'key: "db-password"' <<<"$mek_rewrap_job"
+if grep -q 'ttlSecondsAfterFinished' <<<"$mek_rewrap_job"; then
+    echo 'GitOps would recreate a TTL-cleaned MEK Job' >&2
+    exit 1
+fi
+
+if helm template invalid-external-prepare "$CHART_DIR" --namespace osmo --is-upgrade \
+        --set 'services.masterEncryptionKey.managementMode=external' \
+        --set 'services.masterEncryptionKey.rotation.requestId=invalid' \
+        --set 'services.masterEncryptionKey.rotation.phase=prepare' >/dev/null 2>&1; then
+    echo 'External PREPARE Secret mutation was accepted' >&2
+    exit 1
+fi
+
+mek_settled_external_render=$(helm template mek-settled "$CHART_DIR" --namespace osmo \
+    --is-upgrade \
+    --set 'services.masterEncryptionKey.managementMode=external')
+if grep -q 'command: \["mek-lifecycle"\]' <<<"$mek_settled_external_render"; then
+    echo 'Settled external mode rendered lifecycle RBAC or a Job' >&2
+    exit 1
+fi
+
+
+mek_render=$(helm template mek-test "$CHART_DIR" --namespace osmo \
+    --set 'services.masterEncryptionKey.existingSecret.name=customer-mek' \
+    --set 'services.masterEncryptionKey.existingSecret.key=keyring.yaml' \
+    --set 'services.router.extraVolumeMounts[0].name=router-extra' \
+    --set 'services.router.extraVolumeMounts[0].mountPath=/tmp/router-extra')
+grep -q 'mountPath: /tmp/router-extra' <<<"$mek_render"
+if [[ $(grep -c -- '- --mek_file' <<<"$mek_render") -ne 6 ]]; then
+    echo 'Not every MEK consumer receives --mek_file' >&2
+    exit 1
+fi
+if [[ $(grep -c 'secretName: "customer-mek"' <<<"$mek_render") -ne 6 ]]; then
+    echo 'Not every MEK consumer mounts the existing Secret' >&2
+    exit 1
+fi
+if [[ $(grep -c -- '- "/opt/osmo/mek/mek.yaml"' <<<"$mek_render") -ne 6 ]] || \
+   [[ $(grep -c 'mountPath: "/opt/osmo/mek"' <<<"$mek_render") -ne 6 ]]; then
+    echo 'MEK consumers do not use the fixed chart-owned path' >&2
+    exit 1
+fi
+if grep -q 'name: OSMO_MEK_CONSUMER\|name: OSMO_ALLOW_EXISTING_MEK_ADOPTION' <<<"$mek_render"; then
+    echo 'Legacy database-backed MEK adoption environment is still rendered' >&2
+    exit 1
+fi
+if grep -q 'subPath:.*mek' <<<"$mek_render"; then
+    echo 'MEK is still mounted with subPath and cannot receive kubelet updates' >&2
+    exit 1
+fi
+if grep -q 'name: mek-config' <<<"$mek_render"; then
+    echo 'Legacy MEK ConfigMap support is still rendered' >&2
+    exit 1
+fi
+if grep -q 'vault.hashicorp.com' <<<"$mek_render"; then
+    echo 'Vault annotations are still rendered for the MEK' >&2
+    exit 1
+fi
+
+mek_deployments=(
+    osmo-service osmo-worker osmo-router osmo-logger osmo-agent
+    osmo-delayed-job-monitor
+)
+for deployment in "${mek_deployments[@]}"; do
+    document=$(resource_document "$mek_render" Deployment "$deployment")
+    if ! grep -q 'app.kubernetes.io/instance: "mek-test"' <<<"$document"; then
+        echo "MEK rollout selector is incomplete on Deployment/$deployment" >&2
+        exit 1
+    fi
+    if ! grep -q 'app.kubernetes.io/part-of: osmo' <<<"$document"; then
+        echo "MEK consumer Deployment/$deployment lacks the standard part-of label" >&2
+        exit 1
+    fi
+done
+for hpa in osmo-service osmo-worker osmo-router osmo-logger osmo-agent; do
+    document=$(resource_document "$mek_render" HorizontalPodAutoscaler "$hpa")
+    if ! grep -q 'app.kubernetes.io/instance: "mek-test"' <<<"$document"; then
+        echo "MEK rollout selector is incomplete on HorizontalPodAutoscaler/$hpa" >&2
+        exit 1
+    fi
+done
+if grep -q 'osmo.nvidia.com/mek-consumer' <<<"$mek_render"; then
+    echo 'Product chart rendered the KIND-only MEK consumer label' >&2
+    exit 1
+fi

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -111,6 +111,34 @@ services:
     ##
     path: /opt/osmo/config.yaml
 
+  ## Master encryption key keyring. External mode is read-only. OSMO-managed
+  ## mode can atomically create the Secret for a fresh database and rotate it
+  ## only through an explicitly requested, fenced lifecycle Job.
+  masterEncryptionKey:
+    # `external` is read-only. `osmo` enables fresh-install generation and
+    # explicitly requested Kubernetes lifecycle Jobs for this exact Secret.
+    managementMode: external
+    existingSecret:
+      name: osmo-mek
+      key: mek.yaml
+    bootstrap:
+      # Must be set back to false immediately after a successful bootstrap.
+      enabled: false
+      # Increment after a failed GitOps attempt or credential correction.
+      attempt: "1"
+      imagePullPolicy: IfNotPresent
+      activeDeadlineSeconds: 900
+    rotation:
+      requestId: ""
+      # Explicit operation: prepare, activate, or rewrap. Leave empty to
+      # perform the lifecycle manually without a chart Job.
+      phase: ""
+      attempt: "1"
+      # Change after PREPARE and again after ACTIVATE to restart every MEK consumer.
+      rolloutRevision: ""
+      imagePullPolicy: IfNotPresent
+      activeDeadlineSeconds: 900
+
   ## External self-hosted MCP service configuration
   ##
   mcp:

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -93,7 +93,6 @@ STORAGE_VALUES_FILE="${STORAGE_VALUES_FILE:-}"
 # Force-regenerate the master encryption key (MEK) ConfigMap. Default is to
 # preserve any existing one so encrypted DB data remains decryptable across
 # re-runs. Set to "true" only on a clean cluster + clean DB.
-RESET_MEK="${RESET_MEK:-false}"
 
 # Provider-specific settings. Idempotent under `source` — the wrapper
 # (deploy-osmo-minimal.sh) sets these before sourcing this file.
@@ -693,50 +692,53 @@ create_secrets() {
 
     # MEK (Master Encryption Key) — DO NOT regenerate on re-run. Any data
     # encrypted with the previous MEK becomes unreadable if we replace it.
-    # Generate only when the ConfigMap is missing, OR when RESET_MEK=true is
-    # set explicitly (use only on a clean DB — replacing the MEK against an
-    # existing DB silently breaks decryption of every encrypted field).
+    # Generate only when the Secret is missing. This script never replaces an
+    # existing MEK because doing so can orphan encrypted database fields.
     local mek_exists="false"
-    if $RUN_KUBECTL "get configmap mek-config -n $OSMO_NAMESPACE" &>/dev/null; then
+    if $RUN_KUBECTL "get secret osmo-mek -n $OSMO_NAMESPACE" &>/dev/null; then
         mek_exists="true"
     fi
 
-    if [[ "$mek_exists" == "true" && "$RESET_MEK" != "true" ]]; then
-        log_info "MEK ConfigMap already present in $OSMO_NAMESPACE — preserving (re-using existing key)"
-        log_info "  Pass RESET_MEK=true (or --reset-mek) to force a fresh key — DESTRUCTIVE if DB has encrypted data"
+    if [[ "$mek_exists" == "true" ]]; then
+        log_info "MEK Secret already present in $OSMO_NAMESPACE — preserving (re-using existing key)"
     else
-        if [[ "$RESET_MEK" == "true" ]]; then
-            log_warning "RESET_MEK=true — minting a fresh MEK. Data encrypted with any previous key will be unreadable."
-        else
-            # Refuse to mint a new MEK if the DB still has encrypted data from a
-            # previous install. $DB_TABLE_COUNT is populated by create_database.
-            if [[ "$DB_TABLE_COUNT" == "UNKNOWN" ]]; then
+        # Refuse to mint a new MEK if the DB still has encrypted data from a
+        # previous install. $DB_TABLE_COUNT is populated by create_database.
+        if [[ "$DB_TABLE_COUNT" != "0" ]]; then
+            if [[ -z "$DB_TABLE_COUNT" || "$DB_TABLE_COUNT" == "UNKNOWN" ]]; then
                 log_error "Could not verify whether '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST has existing data (db-ops probe failed or timed out)."
                 log_error "Refusing to mint a fresh MEK without confirmation — minting against a populated DB silently orphans encrypted columns."
-                log_error "Retry once Postgres connectivity is healthy, or pass RESET_MEK=true to acknowledge data loss and proceed."
-                exit 1
-            elif [[ -n "$DB_TABLE_COUNT" && "$DB_TABLE_COUNT" -gt 0 ]]; then
-                log_error "MEK ConfigMap 'mek-config' not found in $OSMO_NAMESPACE, but the database '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST already has $DB_TABLE_COUNT user table(s)."
+                log_error "Retry once Postgres connectivity is healthy or restore the previous 'osmo-mek' Secret."
+            else
+                log_error "MEK Secret 'osmo-mek' not found in $OSMO_NAMESPACE, but the database '${POSTGRES_DB_NAME:-osmo}' on $POSTGRES_HOST already has $DB_TABLE_COUNT user table(s)."
                 log_error "Generating a new MEK now would orphan every encrypted column (service_auth.private_key, workflow secrets, ...). To resolve:"
-                log_error "  - Restore the previous 'mek-config' ConfigMap from backup, OR"
+                log_error "  - Restore the previous 'osmo-mek' Secret from backup, OR"
                 log_error "  - Wipe the database before re-running:"
                 log_error "      psql -h $POSTGRES_HOST -U ${POSTGRES_USERNAME} -d postgres \\"
                 log_error "        -c 'DROP DATABASE IF EXISTS ${POSTGRES_DB_NAME:-osmo}; CREATE DATABASE ${POSTGRES_DB_NAME:-osmo};'"
-                log_error "  - Pass RESET_MEK=true to acknowledge data loss and proceed."
-                exit 1
             fi
-            log_info "Generating Master Encryption Key (MEK) — first install"
+            exit 1
         fi
-        local random_key=$(openssl rand -base64 32 | tr -d '\n')
+        log_info "Generating Master Encryption Key (MEK) — first install"
+        local random_key
+        random_key=$(openssl rand 32 | openssl base64 -A | tr '+/' '-_' | tr -d '=') || {
+            log_error "Failed to generate Master Encryption Key material"
+            return 1
+        }
         local jwk_json="{\"k\":\"$random_key\",\"kid\":\"key1\",\"kty\":\"oct\"}"
-        local encoded_jwk=$(echo -n "$jwk_json" | base64 | tr -d '\n')
+        local encoded_jwk
+        encoded_jwk=$(printf '%s' "$jwk_json" | base64 | tr -d '\n') || {
+            log_error "Failed to encode Master Encryption Key material"
+            return 1
+        }
 
         local mek_manifest="apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: mek-config
+  name: osmo-mek
   namespace: $OSMO_NAMESPACE
-data:
+type: Opaque
+stringData:
   mek.yaml: |
     currentMek: key1
     meks:

--- a/deployments/scripts/tests/BUILD
+++ b/deployments/scripts/tests/BUILD
@@ -20,3 +20,12 @@ sh_test(
         "//deployments:scripts/deploy-k8s.sh",
     ],
 )
+
+sh_test(
+    name = "test_mek_generation_guard",
+    srcs = ["test_mek_generation_guard.sh"],
+    data = [
+        "//deployments:scripts/common.sh",
+        "//deployments:scripts/deploy-k8s.sh",
+    ],
+)

--- a/deployments/scripts/tests/test_mek_generation_guard.sh
+++ b/deployments/scripts/tests/test_mek_generation_guard.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# shellcheck source=/dev/null
+source "${TEST_SRCDIR}/_main/deployments/scripts/deploy-k8s.sh"
+
+export OSMO_NAMESPACE="test-control"
+export POSTGRES_HOST="postgres.test"
+export POSTGRES_USERNAME="postgres"
+export POSTGRES_DB_NAME="osmo"
+export POSTGRES_PASSWORD="password"
+
+create_backend_token_secrets() {
+    return 0
+}
+
+fake_kubectl() {
+    case "$1" in
+        *"get secret osmo-mek"*) return 1 ;;
+        *"get secret default-admin-secret"*) return 0 ;;
+        *) return 0 ;;
+    esac
+}
+
+capture_manifest() {
+    printf '%s' "$1" > "$manifest_file"
+}
+
+RUN_KUBECTL=fake_kubectl
+RUN_KUBECTL_APPLY_STDIN=capture_manifest
+
+for table_count in "" UNKNOWN invalid 1; do
+    DB_TABLE_COUNT="$table_count"
+    manifest_file=$(mktemp)
+    if output=$(create_secrets 2>&1); then
+        echo "MEK generation unexpectedly accepted DB_TABLE_COUNT=$table_count" >&2
+        exit 1
+    fi
+    if [[ -s "$manifest_file" ]]; then
+        echo "MEK manifest was created for unverified DB_TABLE_COUNT=$table_count" >&2
+        exit 1
+    fi
+    rm -f "$manifest_file"
+done
+
+DB_TABLE_COUNT=0
+manifest_file=$(mktemp)
+trap 'rm -f "$manifest_file"' EXIT INT TERM
+create_secrets >/dev/null
+grep -q '^  name: osmo-mek$' "$manifest_file"
+grep -q '^    currentMek: key1$' "$manifest_file"

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -289,18 +289,6 @@ the charts independently managed.
      --from-literal=password="$LOCAL_ADMIN_PASSWORD" \
      --dry-run=client -o yaml | kubectl apply -f -
 
-   if ! kubectl get configmap mek-config --namespace osmo >/dev/null 2>&1; then
-     MEK_KEY=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d '\n')
-     MEK_JWK=$(printf '{"k":"%s","kid":"key1","kty":"oct"}' "$MEK_KEY" | base64 | tr -d '\n')
-     MEK_FILE=$(mktemp)
-     printf 'currentMek: key1\nmeks:\n  key1: %s\n' "$MEK_JWK" > "$MEK_FILE"
-     kubectl create configmap mek-config \
-       --namespace osmo \
-       --from-file=mek.yaml="$MEK_FILE" \
-       --dry-run=client -o yaml | kubectl apply -f -
-     rm -f "$MEK_FILE"
-   fi
-
    helm repo add osmo https://helm.ngc.nvidia.com/nvidia/osmo
    helm repo update osmo
    helm upgrade --install osmo osmo/service \
@@ -308,6 +296,11 @@ the charts independently managed.
      -f osmo-values/service.yaml \
      --wait \
      --timeout 25m
+
+The quick-start values enable the install-only MEK bootstrap hook. It creates
+the ``osmo-mek`` Secret for this disposable local installation without placing
+key material in Helm values or release state. Existing Secrets are preserved,
+and upgrades fail if the Secret is missing rather than generating a new key.
 
    helm upgrade --install osmo-backend-operator osmo/backend-operator \
      --namespace osmo \

--- a/docs/deployment_guide/appendix/deploy_minimal.rst
+++ b/docs/deployment_guide/appendix/deploy_minimal.rst
@@ -115,82 +115,33 @@ Create the master encryption key (MEK) for database encryption:
 
      {"k":"<base64-encoded-32-byte-key>","kid":"key1","kty":"oct"}
 
-2. **Generate the key using OpenSSL**:
+2. **Generate the key and create its Secret without printing key material**:
 
    .. code-block:: bash
 
-      # Generate a 32-byte (256-bit) random key and base64 encode it
-      RANDOM_KEY=$(openssl rand -base64 32 | tr -d '\n')
-
-      # Create the JWK format
-      echo "{\"k\":\"$RANDOM_KEY\",\"kid\":\"key1\",\"kty\":\"oct\"}"
-
-3. **Base64 encode the entire JWK**:
-
-   .. code-block:: bash
-
-      # Take the JWK output from step 2 and base64 encode it
-      JWK_JSON='{"k":"<your-base64-key>","kid":"key1","kty":"oct"}'
-      ENCODED_JWK=$(echo -n "$JWK_JSON" | base64 | tr -d '\n')
-      echo $ENCODED_JWK
-
-4. **Create the ConfigMap with your generated MEK**:
-
-   .. code-block:: bash
-
-     $ kubectl apply -f - <<EOF
-     apiVersion: v1
-     kind: ConfigMap
-     metadata:
-       name: mek-config
-       namespace: osmo-minimal
-     data:
-       mek.yaml: |
-         currentMek: key1
-         meks:
-           key1: $ENCODED_JWK
-     EOF
+     $ set -euo pipefail
+     $ MEK_FILE=$(mktemp)
+     $ chmod 600 "$MEK_FILE"
+     $ trap 'rm -f "$MEK_FILE"' EXIT
+     $ RANDOM_KEY=$(openssl rand 32 | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+     $ ENCODED_JWK=$(printf '{"k":"%s","kid":"key1","kty":"oct"}' "$RANDOM_KEY" | base64 | tr -d '\n')
+     $ printf 'currentMek: key1\nmeks:\n  key1: %s\n' "$ENCODED_JWK" > "$MEK_FILE"
+     $ kubectl create secret generic osmo-mek --namespace osmo-minimal \
+         --from-file=mek.yaml="$MEK_FILE"
+     $ rm -f "$MEK_FILE" && trap - EXIT
+     $ unset RANDOM_KEY ENCODED_JWK
 
 .. admonition:: Security Considerations
   :class: important
 
   - Store the original JWK securely as you'll need it for backups and recovery
   - Never commit the MEK to version control
-  - Use a secure key management system, such as Vault in production
+  - Restrict Kubernetes RBAC access to the Secret and back it up securely
   - The MEK is used to encrypt sensitive data in the database
 
-**Example MEK generation script**:
-
-.. code-block:: bash
-
-   #!/bin/bash
-   # Generate MEK for OSMO
-
-   # Generate random 32-byte key
-   RANDOM_KEY=$(openssl rand -base64 32 | tr -d '\n')
-
-   # Create JWK
-   JWK_JSON="{\"k\":\"$RANDOM_KEY\",\"kid\":\"key1\",\"kty\":\"oct\"}"
-
-   # Base64 encode the JWK
-   ENCODED_JWK=$(echo -n "$JWK_JSON" | base64 | tr -d '\n')
-
-   echo "Generated JWK: $JWK_JSON"
-   echo "Encoded JWK: $ENCODED_JWK"
-
-   # Create ConfigMap
-   $ kubectl apply -f - <<EOF
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: mek-config
-     namespace: osmo-minimal
-   data:
-     mek.yaml: |
-       currentMek: key1
-       meks:
-         key1: $ENCODED_JWK
-   EOF
+  This create-only command intentionally fails if ``osmo-mek`` already exists.
+  For an installation with retained database data, restore the original MEK
+  Secret; never overwrite it or generate a replacement.
 
 Step 4: Configure PostgreSQL
 ============================

--- a/docs/deployment_guide/getting_started/deploy_service.rst
+++ b/docs/deployment_guide/getting_started/deploy_service.rst
@@ -147,87 +147,33 @@ Create the workflow data credentials Secret (you can use the same bucket or a di
 
 Create the master encryption key (MEK) for database encryption:
 
-1. **Generate a new master encryption key**:
-
-   The MEK should be a JSON Web Key (JWK) with the following format:
-
-   .. code-block:: json
-
-      {"k":"<base64-encoded-32-byte-key>","kid":"key1","kty":"oct"}
-
-2. **Generate the key using OpenSSL**:
+1. **Generate a new master encryption key and create its Secret**:
 
    .. code-block:: bash
 
-      # Generate a 32-byte (256-bit) random key and base64 encode it
-      $ export RANDOM_KEY=$(openssl rand -base64 32 | tr -d '\n')
-
-      # Create the JWK format
-      $ export JWK_JSON="{\"k\":\"$RANDOM_KEY\",\"kid\":\"key1\",\"kty\":\"oct\"}"
-
-3. **Base64 encode the entire JWK**:
-
-   .. code-block:: bash
-
-      $ export ENCODED_JWK=$(echo -n "$JWK_JSON" | base64 | tr -d '\n')
-      $ echo $ENCODED_JWK
-
-4. **Create the ConfigMap with your generated MEK**:
-
-   .. code-block:: bash
-
-      $ kubectl apply -f - <<EOF
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: mek-config
-        namespace: osmo
-      data:
-        mek.yaml: |
-          currentMek: key1
-          meks:
-            key1: $ENCODED_JWK
-      EOF
+      $ set -euo pipefail
+      $ MEK_FILE=$(mktemp)
+      $ chmod 600 "$MEK_FILE"
+      $ trap 'rm -f "$MEK_FILE"' EXIT
+      $ RANDOM_KEY=$(openssl rand 32 | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+      $ ENCODED_JWK=$(printf '{"k":"%s","kid":"key1","kty":"oct"}' "$RANDOM_KEY" | base64 | tr -d '\n')
+      $ printf 'currentMek: key1\nmeks:\n  key1: %s\n' "$ENCODED_JWK" > "$MEK_FILE"
+      $ kubectl create secret generic osmo-mek --namespace osmo \
+          --from-file=mek.yaml="$MEK_FILE"
+      $ rm -f "$MEK_FILE" && trap - EXIT
+      $ unset RANDOM_KEY ENCODED_JWK
 
 .. warning::
    **Security Considerations**:
 
    - Store the original JWK securely as you'll need it for backups and recovery
    - Never commit the MEK to version control
-   - Use a secure key management system, such as Vault or secrets manager in production
+   - Restrict Kubernetes RBAC access to the Secret and back it up securely
    - The MEK is used to encrypt sensitive data in the database
 
-**Example MEK generation script**:
-
-.. code-block:: bash
-
-   #!/bin/bash
-   # Generate MEK for OSMO
-
-   # Generate random 32-byte key
-   $ export RANDOM_KEY=$(openssl rand -base64 32 | tr -d '\n')
-
-   # Create JWK
-   $ export JWK_JSON="{\"k\":\"$RANDOM_KEY\",\"kid\":\"key1\",\"kty\":\"oct\"}"
-
-   # Base64 encode the JWK
-   $ export ENCODED_JWK=$(echo -n "$JWK_JSON" | base64 | tr -d '\n')
-   $ echo "Encoded JWK: $ENCODED_JWK"
-
-   # Create ConfigMap
-   $ kubectl apply -f - <<EOF
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     name: mek-config
-     namespace: osmo
-   data:
-     mek.yaml: |
-       currentMek: key1
-       meks:
-         key1: $ENCODED_JWK
-   EOF
-
+   The create-only command fails if ``osmo-mek`` already exists. If the
+   database contains retained data, restore the original MEK Secret instead
+   of generating or applying a replacement.
 
 .. _configure_storage_access:
 .. _configure_data:

--- a/run/minimal/osmo_values.yaml
+++ b/run/minimal/osmo_values.yaml
@@ -31,7 +31,6 @@ services:
 
   configFile:
     enabled: true
-    path: /home/osmo/config/mek.yaml
 
   postgres:
     enabled: true

--- a/run/start_service_kind.py
+++ b/run/start_service_kind.py
@@ -18,12 +18,8 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import argparse
-import base64
-import json
 import logging
 import os
-import secrets
-import tempfile
 import time
 
 from bazel_tools.tools.python.runfiles import runfiles  # type: ignore
@@ -41,75 +37,6 @@ from run.print_next_steps import print_next_steps
 logging.basicConfig(format='%(message)s')
 logger = logging.getLogger()
 RUNFILES = runfiles.Create()
-
-
-def _generate_mek() -> None:
-    """Generate the Master Encryption Key (MEK) directly in Python if it doesn't exist."""
-    logger.info('🔑 Checking for existing Master Encryption Key (MEK)...')
-
-    try:
-        process = run_command_with_logging([
-            'kubectl', 'get', 'configmap', 'mek-config', '-n', 'osmo'
-        ], 'Checking for existing MEK ConfigMap')
-
-        if not process.has_failed():
-            logger.info('✅ MEK ConfigMap already exists, skipping generation')
-            return
-
-        logger.info('🔑 Generating new Master Encryption Key (MEK)...')
-
-        random_key = base64.b64encode(secrets.token_bytes(32)).decode('utf-8')
-
-        jwk_json = {
-            'k': random_key,
-            'kid': 'key1',
-            'kty': 'oct'
-        }
-
-        encoded_jwk = base64.b64encode(
-            json.dumps(jwk_json).encode('utf-8')).decode('utf-8')
-
-        configmap_yaml = f"""apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: mek-config
-  namespace: osmo
-data:
-  mek.yaml: |
-    # MEK generated {time.strftime('%Y-%m-%d %H:%M:%S')}
-    currentMek: key1
-    meks:
-      key1: {encoded_jwk}
-"""
-
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as temp_file:
-            temp_file.write(configmap_yaml)
-            temp_file_path = temp_file.name
-
-        try:
-            process = run_command_with_logging([
-                'kubectl', 'apply', '-f', temp_file_path
-            ], 'Creating MEK ConfigMap')
-
-            if not process.has_failed():
-                logger.info(
-                    '✅ MEK generated and ConfigMap created successfully in %.2fs',
-                    process.get_elapsed_time())
-            else:
-                logger.error('❌ Error creating MEK ConfigMap')
-                logger.error('   Check output files for details:')
-                logger.error('   - stdout: %s', process.stdout_file)
-                logger.error('   - stderr: %s', process.stderr_file)
-                raise RuntimeError('Error creating MEK ConfigMap')
-        finally:
-            try:
-                os.unlink(temp_file_path)
-            except OSError:
-                pass
-
-    except OSError as e:
-        logger.error('❌ Unexpected error generating MEK: %s', e)
-        raise RuntimeError(f'Unexpected error generating MEK: {e}') from e
 
 
 def _install_osmo_service(
@@ -141,6 +68,7 @@ def _install_osmo_service(
             '-f', values_path,
             '--set', image_location_override,
             '--set', f'global.osmoImageTag={image_tag}',
+            '--set', 'services.masterEncryptionKey.bootstrap.enabled=true',
             '--set', rf'global.nodeSelector.kubernetes\.io\/arch={detected_platform}',
             '-n', 'osmo', '--wait'
         ], f'Installing {service_name}')
@@ -214,7 +142,6 @@ def start_service_kind(args: argparse.Namespace) -> None:
             args.container_registry,
             args.container_registry_username,
             args.container_registry_password)
-        _generate_mek()
         _install_osmo_services(args.image_location, args.image_tag, detected_platform)
 
         total_time = time.time() - start_time

--- a/src/service/core/BUILD
+++ b/src/service/core/BUILD
@@ -73,6 +73,28 @@ osmo_python_wrapper(
     include_progress_check = True,
 )
 
+py_image_layer(
+    name = "mek_lifecycle_layer",
+    binary = "//src/utils/secret_manager:mek_lifecycle",
+)
+
+osmo_python_wrapper(
+    name = "mek_lifecycle_wrapper",
+    bin_name = "mek-lifecycle",
+    main = "/src/utils/secret_manager/mek_lifecycle.py",
+    runfiles_dir = "/src/utils/secret_manager/mek_lifecycle.runfiles",
+)
+
+filegroup(
+    name = "mek_lifecycle_image_layers",
+    srcs = [
+        ":mek_lifecycle_layer_default",
+        ":mek_lifecycle_layer_interpreter",
+        ":mek_lifecycle_layer_packages",
+        ":mek_lifecycle_wrapper",
+    ],
+)
+
 filegroup(
     name = "service_image_layers",
     srcs = [
@@ -91,6 +113,7 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_amd64",
     tars = [
         ":service_image_layers",
+        ":mek_lifecycle_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -131,6 +154,7 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_arm64",
     tars = [
         ":service_image_layers",
+        ":mek_lifecycle_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1629,7 +1629,17 @@ class PostgresConnector:
                         key_id = self.secret_manager.authenticate_mek_encrypted(encrypted_value)
                         counts[key_id] += 1
                     except (KeyError, osmo_errors.OSMOError):
-                        blockers.append(f'configs/{config_type}/{path}: authentication failed')
+                        try:
+                            header = self._jwe_header(encrypted_value) or {}
+                            failed_key_id = header.get('kid')
+                        except (JWException, ValueError, TypeError):
+                            failed_key_id = None
+                        key_context = (
+                            f' (kid={failed_key_id})'
+                            if isinstance(failed_key_id, str) else '')
+                        blockers.append(
+                            f'configs/{config_type}/{path}: authentication failed'
+                            f'{key_context}')
                 for config_key, raw_value in raw_by_type[config_type].items():
                     try:
                         for path, _ in self._walk_jwe_values(raw_value, config_key):

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -443,17 +443,16 @@ class PostgresConnector:
         # domain with the startup-only keyring. This prevents a replacement
         # pod from joining a rollout with a keyring that cannot read existing
         # data, without introducing lifecycle tables or triggers.
-        counts, blockers = self._scan_mek_references()
-        if blockers:
-            for blocker in blockers:
-                logging.error('MEK startup inventory blocker: %s', blocker)
-            raise osmo_errors.OSMOError(
-                'Mounted MEK keyring cannot authenticate persisted ciphertext.')
-        logging.info('MEK startup inventory references=%s', counts)
+        self._assert_mek_inventory('startup')
 
         logging.debug('Initializing configs')
         self._init_configs()
         logging.debug('Configs initialized')
+
+        # Default SecretStr values are inserted under the mounted MEK. Verify
+        # those writes, plus any concurrent initializer's winners, before this
+        # process can become ready.
+        self._assert_mek_inventory('post-initialization')
 
         # Recreate pool with search_path set to the pgroll versioned schema
         if self.config.schema_version != 'public':
@@ -1375,15 +1374,13 @@ class PostgresConnector:
         self.execute_commit_command(create_cmd, ())
 
 
-    def _init_configs(self):
-        """ Initializes configs table. """
-        # Create config objects with deployment values if provided
+    def _init_default_configs(self):
+        """Insert missing defaults with every SecretStr already MEK-encrypted."""
         service_configs = ServiceConfig()
-
         workflow_configs = WorkflowConfig()
 
         def set_default_values(configs: 'DynamicConfig', config_type: ConfigType):
-            for key, value in configs.plaintext_dict(by_alias=True).items():
+            for key, value in configs.serialize(self, exclude_unset=False).items():
                 if isinstance(value, str):
                     self._set_default_config(key, value, config_type)
                 else:
@@ -1391,6 +1388,10 @@ class PostgresConnector:
 
         set_default_values(service_configs, ConfigType.SERVICE)
         set_default_values(workflow_configs, ConfigType.WORKFLOW)
+
+    def _init_configs(self):
+        """ Initializes configs table. """
+        self._init_default_configs()
 
         self.create_default_roles()
 
@@ -1653,6 +1654,16 @@ class PostgresConnector:
             except (pydantic.ValidationError, ValueError, TypeError):
                 blockers.append(f'configs/{config_type}: config schema validation failed')
         return counts, blockers
+
+    def _assert_mek_inventory(self, boundary: str) -> None:
+        """Fail readiness when any registered persistence location is unreadable."""
+        counts, blockers = self._scan_mek_references()
+        if blockers:
+            for blocker in blockers:
+                logging.error('MEK %s inventory blocker: %s', boundary, blocker)
+            raise osmo_errors.OSMOError(
+                'Mounted MEK keyring cannot authenticate persisted ciphertext.')
+        logging.info('MEK %s inventory references=%s', boundary, counts)
 
     def _rewrap_ueks(self, snapshot: Keyring, deadline: float | None = None) -> bool:
         """Rewrap all UEKs in bounded pages, restarting from zero on every invocation."""

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1707,7 +1707,8 @@ class PostgresConnector:
             logging.error(
                 'Config MEK rewrap found a malformed compact JWE at %s.', path)
             raise osmo_errors.OSMOError(
-                'A persisted config ciphertext is malformed; inspect service logs.')
+                'A persisted config ciphertext is malformed; inspect service logs.'
+            ) from None
         if header is None or header.get('kid') not in self.secret_manager.meks:
             return value, False
         try:

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -28,6 +28,7 @@ import types
 import os
 import re
 import threading
+import time
 import typing
 from functools import wraps
 from typing import Any, Callable, Dict, Generator, List, Literal, Mapping, Optional, Tuple, Type
@@ -46,7 +47,7 @@ from src.utils import configmap_state
 from src.lib.utils import (common, credentials, jinja_sandbox, login,
                            osmo_errors, role, validation, version)
 from src.utils import auth, notify
-from src.utils.secret_manager import Encrypted, SecretManager
+from src.utils.secret_manager import Encrypted, Keyring, SecretManager
 
 
 def backend_action_queue_name(backend_name: str) -> str:
@@ -65,6 +66,19 @@ class ConfigType(enum.Enum):
     """ Type of Config to fetch or set """
     SERVICE = 'SERVICE'
     WORKFLOW = 'WORKFLOW'
+
+
+# Increment whenever a new database location can persist ciphertext encrypted directly by a MEK.
+# UEK-encrypted credential and workflow payloads are covered transitively by the UEK wrapper row.
+MEK_PERSISTENCE_REGISTRY_VERSION = 1
+MEK_PERSISTENCE_REGISTRY = {
+    'ueks.keys.*': 'uek-wrapper-jwe',
+    'configs.value.<DynamicConfig.SecretStr>': 'direct-mek-jwe',
+}
+MEK_RECONCILE_BATCH_SIZE = 100
+MEK_MAX_UEK_ROWS = 1000
+MEK_MAX_CONFIG_ROWS = 1000
+MEK_REWRAP_DEADLINE_SECONDS = 300
 
 
 class ConfigHistoryType(enum.Enum):
@@ -164,7 +178,7 @@ class PostgresConfig(pydantic.BaseModel):
             'env': 'OSMO_POSTGRES_RECONNECT_RETRY'
         })
     mek_file: str = pydantic.Field(
-        default='/home/osmo/vault-agent/secrets/vault-secrets.yaml',
+        default='/opt/osmo/mek/mek.yaml',
         description='Path to the file that stores master encryption keys',
         json_schema_extra={'command_line': 'mek_file', 'env': 'OSMO_MEK_FILE'})
     method: Literal['dev'] | None = pydantic.Field(
@@ -371,6 +385,25 @@ class PostgresConnector:
             # Always release the semaphore
             semaphore.release()
 
+    @contextlib.contextmanager
+    def _get_reserved_reconciler_connection(self) -> Generator:
+        """Use the pool's reserved +1 connection without consuming the application semaphore."""
+        pool = self._pool
+        if pool is None:
+            raise osmo_errors.OSMOConnectionError('Connection pool is not initialized.')
+        connection = pool.getconn()
+        try:
+            connection.rollback()
+            connection.set_session(autocommit=True)
+            yield connection
+        finally:
+            try:
+                connection.rollback()
+                connection.set_session(autocommit=False)
+                pool.putconn(connection)
+            except Exception:  # pylint: disable=broad-except
+                pool.putconn(connection, close=True)
+
     def __init__(self, config: PostgresConfig):
         if PostgresConnector._instance:
             raise osmo_errors.OSMOError(
@@ -391,11 +424,32 @@ class PostgresConnector:
         self.secret_manager = SecretManager(
             mek_file,
             self.read_uek, self.write_uek, self.read_current_kid, self.add_user)
+        logging.info(
+            'OSMO_MEK_DESCRIPTOR %s',
+            json.dumps({
+                'currentKid': self.secret_manager.current_mek_id,
+                'loadedKids': sorted(self.secret_manager.meks),
+                'generation': self.secret_manager.generation,
+                'digest': self.secret_manager.fingerprint_bundle_digest(),
+            }, separators=(',', ':'), sort_keys=True))
         logging.debug('Secret manager initialized')
 
         logging.debug('Initializing tables')
         self._init_tables()
         logging.debug('Tables initialized')
+
+        # Startup is the rollout acknowledgement boundary. Before this process
+        # can become ready, authenticate every registered MEK persistence
+        # domain with the startup-only keyring. This prevents a replacement
+        # pod from joining a rollout with a keyring that cannot read existing
+        # data, without introducing lifecycle tables or triggers.
+        counts, blockers = self._scan_mek_references()
+        if blockers:
+            for blocker in blockers:
+                logging.error('MEK startup inventory blocker: %s', blocker)
+            raise osmo_errors.OSMOError(
+                'Mounted MEK keyring cannot authenticate persisted ciphertext.')
+        logging.info('MEK startup inventory references=%s', counts)
 
         logging.debug('Initializing configs')
         self._init_configs()
@@ -496,8 +550,10 @@ class PostgresConnector:
             try:
                 cur = conn.cursor()
                 cur.execute(command, args)
+                affected_rows = cur.rowcount
                 cur.close()
                 conn.commit()
+                return affected_rows
             except (psycopg2.DatabaseError, psycopg2.InterfaceError) as error:
                 try:
                     if cur is not None:
@@ -1442,6 +1498,385 @@ class PostgresConnector:
                 description='Updated roles',
             )
 
+    @staticmethod
+    def _jwe_header(value: str) -> Mapping[str, Any] | None:
+        if value.count('.') != 4:
+            return None
+        token = jwe.JWE()
+        token.deserialize(value)
+        return token.jose_header
+
+    @classmethod
+    def _walk_jwe_values(
+            cls, value: Any, path: str = '') -> Generator[Tuple[str, str], None, None]:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                child_path = f'{path}.{key}' if path else str(key)
+                yield from cls._walk_jwe_values(child, child_path)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                yield from cls._walk_jwe_values(child, f'{path}[{index}]')
+        elif isinstance(value, str) and cls._jwe_header(value) is not None:
+            yield path, value
+
+    @classmethod
+    def _walk_registered_secrets(cls, value: Any, path: str = '') \
+            -> Generator[Tuple[str, str], None, None]:
+        """Walk Pydantic-coerced config values using SecretStr as the registry contract."""
+        if isinstance(value, pydantic.SecretStr):
+            yield path, value.get_secret_value()
+        elif isinstance(value, dict):
+            for key, child in value.items():
+                child_path = f'{path}.{key}' if path else str(key)
+                yield from cls._walk_registered_secrets(child, child_path)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                yield from cls._walk_registered_secrets(child, f'{path}[{index}]')
+
+    def _scan_mek_references(
+            self, deadline: float | None = None) -> Tuple[Dict[str, int], List[str]]:
+        """Authenticate every registered ciphertext location within bounded resources."""
+        counts = {key_id: 0 for key_id in self.secret_manager.meks}
+        blockers: List[str] = []
+        cursor_uid, cursor_key = '', ''
+        uek_row_count = 0
+        while uek_row_count <= MEK_MAX_UEK_ROWS:
+            if deadline is not None and time.monotonic() >= deadline:
+                return counts, blockers + ['inventory: deadline exceeded']
+            uek_rows = self.execute_fetch_command('''
+                SELECT uid, entry.key AS key, entry.value AS value
+                FROM ueks CROSS JOIN LATERAL each(keys) AS entry
+                WHERE entry.key <> 'current' AND (uid, entry.key) > (%s, %s)
+                ORDER BY uid, entry.key
+                LIMIT %s;
+            ''', (cursor_uid, cursor_key, MEK_RECONCILE_BATCH_SIZE), return_raw=True)
+            uek_row_count += len(uek_rows)
+            if uek_row_count > MEK_MAX_UEK_ROWS:
+                return counts, blockers + ['ueks: row limit exceeded']
+            for row in uek_rows:
+                try:
+                    key_id = self.secret_manager.authenticate_uek_wrapper(
+                        row['value'], row['key'])
+                    counts[key_id] += 1
+                except (KeyError, osmo_errors.OSMOError):
+                    user_id = row['uid']
+                    user_key_id = row['key']
+                    blockers.append(f'ueks/{user_id}/{user_key_id}: authentication failed')
+            if len(uek_rows) < MEK_RECONCILE_BATCH_SIZE:
+                break
+            cursor_uid, cursor_key = uek_rows[-1]['uid'], uek_rows[-1]['key']
+
+        config_rows: List[Dict[str, Any]] = []
+        cursor_type, cursor_key = '', ''
+        while len(config_rows) <= MEK_MAX_CONFIG_ROWS:
+            if deadline is not None and time.monotonic() >= deadline:
+                return counts, blockers + ['inventory: deadline exceeded']
+            batch = self.execute_fetch_command('''
+                SELECT key, type, value FROM configs
+                WHERE (type, key) > (%s, %s)
+                ORDER BY type, key
+                LIMIT %s;
+            ''', (cursor_type, cursor_key, MEK_RECONCILE_BATCH_SIZE), return_raw=True)
+            config_rows.extend(batch)
+            if len(batch) < MEK_RECONCILE_BATCH_SIZE:
+                break
+            cursor_type, cursor_key = batch[-1]['type'], batch[-1]['key']
+        if len(config_rows) > MEK_MAX_CONFIG_ROWS:
+            return counts, ['configs: row limit exceeded']
+        rows_by_type: Dict[str, Dict[str, Any]] = {}
+        raw_by_type: Dict[str, Dict[str, Any]] = {}
+        for row in config_rows:
+            try:
+                try:
+                    parsed_value = json.loads(row['value'])
+                except (json.JSONDecodeError, TypeError):
+                    parsed_value = row['value']
+                rows_by_type.setdefault(row['type'], {})[row['key']] = parsed_value
+                raw_by_type.setdefault(row['type'], {})[row['key']] = parsed_value
+            except (ValueError, TypeError):
+                config_type = row['type']
+                config_key = row['key']
+                blockers.append(f'configs/{config_type}/{config_key}: value cannot be parsed')
+
+        config_models: Dict[str, Type[DynamicConfig]] = {
+            ConfigType.SERVICE.value: ServiceConfig,
+            ConfigType.WORKFLOW.value: WorkflowConfig,
+        }
+        for config_type, config_values in rows_by_type.items():
+            model_class = config_models.get(config_type)
+            if model_class is None:
+                for config_key, raw_value in raw_by_type[config_type].items():
+                    try:
+                        for path, _ in self._walk_jwe_values(raw_value, config_key):
+                            blockers.append(
+                                f'configs/{config_type}/{path}: unregistered compact JWE')
+                    except (JWException, ValueError, TypeError):
+                        blockers.append(
+                            f'configs/{config_type}/{config_key}: malformed compact JWE')
+                continue
+            unknown_keys = set(config_values) - set(model_class.model_fields)
+            if unknown_keys:
+                blockers.append(
+                    f'configs/{config_type}: unregistered fields {sorted(unknown_keys)}')
+                continue
+            try:
+                model = model_class.from_db(config_values)
+                registered_values = list(self._walk_registered_secrets(
+                    model.model_dump(exclude_unset=True, by_alias=True)))
+                registered_paths = {path for path, _ in registered_values}
+                for path, encrypted_value in registered_values:
+                    try:
+                        key_id = self.secret_manager.authenticate_mek_encrypted(encrypted_value)
+                        counts[key_id] += 1
+                    except (KeyError, osmo_errors.OSMOError):
+                        blockers.append(f'configs/{config_type}/{path}: authentication failed')
+                for config_key, raw_value in raw_by_type[config_type].items():
+                    try:
+                        for path, _ in self._walk_jwe_values(raw_value, config_key):
+                            if path not in registered_paths:
+                                blockers.append(
+                                    f'configs/{config_type}/{config_key}: '
+                                    'unregistered compact JWE')
+                    except (JWException, ValueError, TypeError):
+                        blockers.append(
+                            f'configs/{config_type}/{config_key}: malformed compact JWE')
+            except (pydantic.ValidationError, ValueError, TypeError):
+                blockers.append(f'configs/{config_type}: config schema validation failed')
+        return counts, blockers
+
+    def _rewrap_ueks(self, snapshot: Keyring, deadline: float | None = None) -> bool:
+        """Rewrap all UEKs in bounded pages, restarting from zero on every invocation."""
+        cursor_uid, cursor_key = '', ''
+        row_count = 0
+        while row_count <= MEK_MAX_UEK_ROWS:
+            if deadline is not None and time.monotonic() >= deadline:
+                raise osmo_errors.OSMOError('UEK rewrap deadline exceeded.')
+            rows = self.execute_fetch_command('''
+                SELECT uid, entry.key AS key
+                FROM ueks CROSS JOIN LATERAL each(keys) AS entry
+                WHERE entry.key <> 'current' AND (uid, entry.key) > (%s, %s)
+                ORDER BY uid, entry.key
+                LIMIT %s;
+            ''', (cursor_uid, cursor_key, MEK_RECONCILE_BATCH_SIZE), return_raw=True)
+            row_count += len(rows)
+            if row_count > MEK_MAX_UEK_ROWS:
+                raise osmo_errors.OSMOError('UEK rewrap row limit exceeded.')
+            for row in rows:
+                try:
+                    self.secret_manager.rewrap_uek(row['uid'], row['key'], snapshot)
+                except osmo_errors.OSMOError as error:
+                    logging.error(
+                        'UEK rewrap authentication failed for uid=%s slot=%s.',
+                        row['uid'], row['key'])
+                    raise osmo_errors.OSMOError(
+                        'A persisted UEK wrapper failed authentication; inspect service logs.'
+                    ) from error
+            if len(rows) < MEK_RECONCILE_BATCH_SIZE:
+                return True
+            cursor_uid, cursor_key = rows[-1]['uid'], rows[-1]['key']
+        raise osmo_errors.OSMOError('UEK rewrap row limit exceeded.')
+
+    def _rewrap_config_value(
+            self, value: Any, registered_paths: frozenset[str], snapshot: Keyring,
+            path: str = ''
+    ) -> Tuple[Any, bool]:
+        changed = False
+        if isinstance(value, dict):
+            result = {}
+            for key, child in value.items():
+                child_path = f'{path}.{key}' if path else str(key)
+                result[key], child_changed = self._rewrap_config_value(
+                    child, registered_paths, snapshot, child_path)
+                changed = changed or child_changed
+            return result, changed
+        if isinstance(value, list):
+            result_list = []
+            for index, child in enumerate(value):
+                result, child_changed = self._rewrap_config_value(
+                    child, registered_paths, snapshot, f'{path}[{index}]')
+                result_list.append(result)
+                changed = changed or child_changed
+            return result_list, changed
+        if not isinstance(value, str):
+            return value, False
+        if path not in registered_paths:
+            return value, False
+        try:
+            header = self._jwe_header(value)
+        except (JWException, ValueError, TypeError):
+            logging.error(
+                'Config MEK rewrap found a malformed compact JWE at %s.', path)
+            raise osmo_errors.OSMOError(
+                'A persisted config ciphertext is malformed; inspect service logs.')
+        if header is None or header.get('kid') not in self.secret_manager.meks:
+            return value, False
+        try:
+            rewrap_result = self.secret_manager.rewrap_direct_mek(value, snapshot)
+        except (JWException, osmo_errors.OSMOError, UnicodeError, ValueError, TypeError) as error:
+            logging.error(
+                'Config MEK rewrap authentication failed at %s.', path)
+            raise osmo_errors.OSMOError(
+                'A persisted config ciphertext failed authentication; inspect service logs.'
+            ) from error
+        return rewrap_result.value, rewrap_result.status == 'rewrapped'
+
+    def _registered_config_rewrap_paths(
+            self, rows: List[Dict[str, Any]]
+    ) -> Dict[Tuple[str, str], frozenset[str]]:
+        """Resolve exact per-row SecretStr paths from the versioned config models."""
+        rows_by_type: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            try:
+                parsed = json.loads(row['value'])
+            except (json.JSONDecodeError, TypeError):
+                parsed = row['value']
+            rows_by_type.setdefault(row['type'], {})[row['key']] = parsed
+        config_models: Dict[str, Type[DynamicConfig]] = {
+            ConfigType.SERVICE.value: ServiceConfig,
+            ConfigType.WORKFLOW.value: WorkflowConfig,
+        }
+        result: Dict[Tuple[str, str], set[str]] = {}
+        for config_type, config_values in rows_by_type.items():
+            model_class = config_models.get(config_type)
+            if model_class is None or set(config_values) - set(model_class.model_fields):
+                continue
+            try:
+                model = model_class.from_db(config_values)
+                for full_path, _ in self._walk_registered_secrets(
+                        model.model_dump(exclude_unset=True, by_alias=True)):
+                    row_key, separator, relative_path = full_path.partition('.')
+                    if row_key in config_values:
+                        result.setdefault((config_type, row_key), set()).add(
+                            relative_path if separator else '')
+            except (pydantic.ValidationError, ValueError, TypeError):
+                continue
+        return {key: frozenset(paths) for key, paths in result.items()}
+
+    def _rewrap_configs(self, snapshot: Keyring, deadline: float | None = None) -> bool:
+        """Rewrap all registered direct-MEK config values without durable cursors."""
+        cursor_type, cursor_key = '', ''
+        rows: List[Dict[str, Any]] = []
+        while len(rows) <= MEK_MAX_CONFIG_ROWS:
+            if deadline is not None and time.monotonic() >= deadline:
+                raise osmo_errors.OSMOError('Config rewrap deadline exceeded.')
+            batch = self.execute_fetch_command('''
+                SELECT key, type, value FROM configs
+                WHERE (type, key) > (%s, %s)
+                ORDER BY type, key
+                LIMIT %s;
+            ''', (cursor_type, cursor_key, MEK_RECONCILE_BATCH_SIZE), return_raw=True)
+            rows.extend(batch)
+            if len(rows) > MEK_MAX_CONFIG_ROWS:
+                raise osmo_errors.OSMOError('Config rewrap row limit exceeded.')
+            if len(batch) < MEK_RECONCILE_BATCH_SIZE:
+                break
+            cursor_type, cursor_key = batch[-1]['type'], batch[-1]['key']
+        registered_paths = self._registered_config_rewrap_paths(rows)
+        for row in rows:
+            allowed_paths = registered_paths.get((row['type'], row['key']), frozenset())
+            if not allowed_paths:
+                continue
+            original = row['value']
+            for _ in range(3):
+                try:
+                    parsed = json.loads(original)
+                    encoded_as_json = True
+                except (json.JSONDecodeError, TypeError):
+                    parsed = original
+                    encoded_as_json = False
+                replacement, changed = self._rewrap_config_value(
+                    parsed, allowed_paths, snapshot)
+                if not changed:
+                    break
+                serialized = json.dumps(replacement) if encoded_as_json else replacement
+                command = '''
+                    UPDATE configs SET value = %s
+                    WHERE key = %s AND type = %s AND value = %s;
+                '''
+                if self.execute_commit_command(
+                        command, (serialized, row['key'], row['type'], original)) == 1:
+                    break
+                current_rows = self.execute_fetch_command('''
+                    SELECT value FROM configs WHERE key = %s AND type = %s;
+                ''', (row['key'], row['type']), return_raw=True)
+                if not current_rows:
+                    break
+                original = current_rows[0]['value']
+            else:
+                config_type = row['type']
+                config_key = row['key']
+                raise osmo_errors.OSMOError(
+                    'Concurrent config updates repeatedly blocked MEK rewrap for '
+                    f'{config_type}/{config_key}.')
+        return True
+
+    def rewrap_mek_references(
+            self, deadline_seconds: int = MEK_REWRAP_DEADLINE_SECONDS,
+            expected_generation: str = '', expected_current_kid: str = '',
+            expected_registry_digest: str = '') -> Dict[str, int]:
+        """Restart from zero, CAS-rewrap every registered MEK reference, and inventory it.
+
+        This operation intentionally keeps every old MEK. The final inventory is
+        point-in-time completion evidence, not permission to retire a key.
+        """
+        deadline = time.monotonic() + deadline_seconds
+        snapshot = self.secret_manager.rewrap_snapshot()
+        snapshot_digest = self.secret_manager.rewrap_snapshot_digest(snapshot)
+        if (
+            (expected_generation and snapshot.generation != expected_generation)
+            or (expected_current_kid and snapshot.current_mek_id != expected_current_kid)
+            or (expected_registry_digest and snapshot_digest != expected_registry_digest)
+        ):
+            raise osmo_errors.OSMOError(
+                'Mounted MEK keyring does not match the requested rewrap snapshot.')
+
+        with self._get_reserved_reconciler_connection() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute('SELECT pg_try_advisory_lock(%s);', (0x4F534D4F4D454B,))
+                if not cursor.fetchone()[0]:
+                    raise osmo_errors.OSMOError('Another MEK rewrap is already running.')
+            try:
+                while time.monotonic() < deadline:
+                    self._rewrap_ueks(snapshot, deadline)
+                    self._rewrap_configs(snapshot, deadline)
+                    counts, blockers = self._scan_mek_references(deadline)
+                    if blockers:
+                        for blocker in blockers:
+                            logging.error('MEK inventory blocker: %s', blocker)
+                        raise osmo_errors.OSMOError(
+                            'MEK inventory contains authenticated coverage blockers.')
+                    noncurrent = sum(
+                        count for key_id, count in counts.items()
+                        if key_id != snapshot.current_mek_id)
+                    if noncurrent:
+                        continue
+
+                    # A second restart-from-zero inventory makes completion
+                    # insensitive to page boundaries and confirms a stable
+                    # point-in-time result. Old keys remain mandatory because
+                    # there is deliberately no database write fence.
+                    confirmed, blockers = self._scan_mek_references(deadline)
+                    if blockers:
+                        for blocker in blockers:
+                            logging.error('MEK inventory blocker: %s', blocker)
+                        raise osmo_errors.OSMOError(
+                            'MEK inventory contains authenticated coverage blockers.')
+                    if any(
+                        count for key_id, count in confirmed.items()
+                        if key_id != snapshot.current_mek_id
+                    ):
+                        continue
+                    logging.info(
+                        'MEK rewrap complete current_kid=%s references=%s '
+                        'retirement_supported=false',
+                        snapshot.current_mek_id, confirmed)
+                    return confirmed
+                raise osmo_errors.OSMOError('MEK rewrap deadline exceeded.')
+            finally:
+                with connection.cursor() as cursor:
+                    cursor.execute('SELECT pg_advisory_unlock(%s);', (0x4F534D4F4D454B,))
+
+
     def read_uek(self, uid: str, kid: str) -> str:
         cmd = 'SELECT keys -> %s as value FROM ueks WHERE uid = %s;'
         uek_value = self.execute_fetch_command(cmd, (kid, uid))
@@ -1454,10 +1889,10 @@ class PostgresConnector:
         current_kid = current_kid_value[0].value
         return current_kid
 
-    def write_uek(self, uid: str, kid: str, new_uek: str, old_uek: str):
+    def write_uek(self, uid: str, kid: str, new_uek: str, old_uek: str) -> bool:
         new_key_value = self.encode_hstore({kid: new_uek})
         cmd = 'UPDATE ueks SET keys = keys || %s :: hstore WHERE uid = %s AND keys[%s] = %s;'
-        self.execute_commit_command(cmd, (new_key_value, uid, kid, old_uek))
+        return self.execute_commit_command(cmd, (new_key_value, uid, kid, old_uek)) == 1
 
     def add_user(self, uid: str, uek: Dict):
         cmd = 'INSERT INTO ueks (uid, keys) VALUES (%s, %s) ON CONFLICT DO NOTHING;'
@@ -2738,7 +3173,7 @@ class DynamicConfig(ExtraArgBaseModel):
             elif isinstance(encrypted_data, list):
                 for index in range(len(encrypted_data)):
                     decrypted, new_encrypted = _decrypt(
-                        result_data[index], result_data[index], top_level_key)
+                        result_data[index], encrypted_data[index], top_level_key)
                     result_data[index] = decrypted
                     if new_encrypted is not None:
                         encrypted_data[index] = new_encrypted
@@ -2781,17 +3216,23 @@ class DynamicConfig(ExtraArgBaseModel):
 
         # Encrypt updated secrets
         for key in encrypt_keys:
-            if isinstance(encrypted_dict[key], str):
-                postgres.set_config(key, encrypted_dict[key], dynamic_config.get_type())
-            else:
-                old_value = json.dumps(config_dict[key])
-                new_value = json.dumps(encrypted_dict[key])
-                cmd = 'UPDATE configs SET value = %s WHERE key = %s AND value = %s;'
-                postgres.execute_commit_command(cmd, (new_value, key, old_value))
+            old_value = (config_dict[key] if isinstance(config_dict[key], str)
+                         else json.dumps(config_dict[key]))
+            new_value = (encrypted_dict[key] if isinstance(encrypted_dict[key], str)
+                         else json.dumps(encrypted_dict[key]))
+            cmd = '''
+                UPDATE configs SET value = %s
+                WHERE key = %s AND type = %s AND value = %s;
+            '''
+            if postgres.execute_commit_command(
+                    cmd, (new_value, key, dynamic_config.get_type().value, old_value)) != 1:
+                logging.warning(
+                    'Concurrent config update deferred config encryption for %s/%s.',
+                    dynamic_config.get_type().value, key)
         return dynamic_config
 
     def serialize_helper(self, config_dict: Dict, postgres: PostgresConnector,
-                         top_level: bool = False) -> Dict[str, str | None]:
+                         top_level: bool = False) -> Dict[str, Any]:
         """ Recursively encrypt all secret fields in any dictionary or list. """
         for key, value in config_dict.items():
             value_for_typecheck = value
@@ -2801,18 +3242,22 @@ class DynamicConfig(ExtraArgBaseModel):
                 else:
                     config_dict[key] = self.serialize_helper(value, postgres)
             elif isinstance(value_for_typecheck, list):
-                if all(isinstance(v, dict) for v in value_for_typecheck):
-                    config_dict[key] = \
-                        [self.serialize_helper(v, postgres) for v in value_for_typecheck]
-                else:
-                    config_dict[key] = value_for_typecheck
+                serialized_values: List[Any] = []
+                for item in value_for_typecheck:
+                    if isinstance(item, dict):
+                        serialized_values.append(self.serialize_helper(item, postgres))
+                    elif isinstance(item, list):
+                        nested = self.serialize_helper({'value': item}, postgres)
+                        serialized_values.append(nested['value'])
+                    elif isinstance(item, pydantic.SecretStr):
+                        serialized_values.append(postgres.secret_manager.encrypt(
+                            item.get_secret_value(), '').value)
+                    else:
+                        serialized_values.append(item)
+                config_dict[key] = serialized_values
             elif isinstance(value_for_typecheck, pydantic.SecretStr):
-                if top_level:
-                    encrypted = postgres.secret_manager.encrypt(value.get_secret_value(), '')
-                    config_dict[key] = encrypted.value
-                # TODO: Enable recursive encryption
-                else:
-                    config_dict[key] = value.get_secret_value()
+                encrypted = postgres.secret_manager.encrypt(value.get_secret_value(), '')
+                config_dict[key] = encrypted.value
             elif value_for_typecheck is None:
                 config_dict[key] = None
             elif not isinstance(value_for_typecheck, str):

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -108,3 +108,29 @@ osmo_py_test(
     size = "medium",
     tags = ["requires-network"],
 )
+
+py_test(
+    name = "test_mek_reconciliation",
+    srcs = ["test_mek_reconciliation.py"],
+    deps = [
+        "//src/lib/utils:osmo_errors",
+        "//src/utils/connectors:connectors",
+    ],
+    size = "small",
+)
+
+py_test(
+    name = "test_mek_reconciliation_postgres",
+    srcs = ["test_mek_reconciliation_postgres.py"],
+    deps = [
+        requirement("jwcrypto"),
+        requirement("psycopg2-binary"),
+        "//src/lib/utils:osmo_errors",
+        "//src/utils/connectors:connectors",
+        "//src/utils/secret_manager",
+        "//src/utils/secret_manager:mek_lifecycle",
+    ],
+    local = True,
+    size = "medium",
+    tags = ["exclusive", "integration"],
+)

--- a/src/utils/connectors/tests/test_mek_reconciliation.py
+++ b/src/utils/connectors/tests/test_mek_reconciliation.py
@@ -1,0 +1,77 @@
+"""Unit coverage for stateless, restart-from-zero MEK reconciliation."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest import mock
+
+from src.lib.utils import osmo_errors
+from src.utils.connectors.postgres import PostgresConnector
+
+
+def _database() -> tuple[PostgresConnector, mock.Mock]:
+    database = PostgresConnector.__new__(PostgresConnector)
+    manager = mock.Mock()
+    database.secret_manager = manager
+    return database, manager
+
+
+class TestMekReconciliation(unittest.TestCase):
+    def test_uek_rewrap_restarts_from_zero_and_uses_cas_primitive(self):
+        database, manager = _database()
+        database.execute_fetch_command = mock.Mock(side_effect=[
+            [{"uid": "a", "key": "u1"}, {"uid": "b", "key": "u2"}],
+        ])  # type: ignore[method-assign]
+        manager.rewrap_uek.return_value = mock.Mock(status="rewrapped")
+        self.assertTrue(database._rewrap_ueks(mock.sentinel.snapshot))
+        self.assertEqual(manager.rewrap_uek.call_count, 2)
+        query = database.execute_fetch_command.call_args.args[0]
+        self.assertIn("entry.key <> 'current'", query)
+        self.assertNotIn("mek_rewrap", query)
+
+    def test_uek_authentication_failure_blocks_immediately(self):
+        database, manager = _database()
+        database.execute_fetch_command = mock.Mock(return_value=[
+            {"uid": "a", "key": "u1"},
+        ])  # type: ignore[method-assign]
+        manager.rewrap_uek.side_effect = osmo_errors.OSMOError("bad")
+        with self.assertRaisesRegex(osmo_errors.OSMOError, "authentication"):
+            database._rewrap_ueks(mock.sentinel.snapshot)
+
+    def test_unknown_config_path_is_never_mutated(self):
+        database, manager = _database()
+        value = {"known": "not-a-jwe", "extension": "opaque"}
+        replacement, changed = database._rewrap_config_value(
+            value, frozenset({"known"}), mock.sentinel.snapshot)
+        self.assertEqual(replacement, value)
+        self.assertFalse(changed)
+        manager.rewrap_direct_mek.assert_not_called()
+
+    def test_registered_config_path_uses_explicit_rewrap(self):
+        database, manager = _database()
+        database._jwe_header = mock.Mock(return_value={"kid": "key1"})  # type: ignore[method-assign]
+        manager.meks = {"key1": mock.sentinel.key}
+        manager.rewrap_direct_mek.return_value = mock.Mock(
+            value="replacement", status="rewrapped")
+        replacement, changed = database._rewrap_config_value(
+            "ciphertext", frozenset({"secret"}), mock.sentinel.snapshot, "secret")
+        self.assertEqual(replacement, "replacement")
+        self.assertTrue(changed)
+
+    def test_inventory_blocker_never_becomes_completion(self):
+        database, manager = _database()
+        manager.rewrap_snapshot.return_value = mock.Mock(
+            generation="generation", current_mek_id="key2",
+            fingerprints={"key1": "a", "key2": "b"})
+        manager.rewrap_snapshot_digest.return_value = "digest"
+        database._get_reserved_reconciler_connection = mock.Mock(  # type: ignore[method-assign]
+            side_effect=osmo_errors.OSMOError("lock unavailable"))
+        with self.assertRaisesRegex(osmo_errors.OSMOError, "lock unavailable"):
+            database.rewrap_mek_references(
+                expected_generation="generation",
+                expected_current_kid="key2",
+                expected_registry_digest="digest")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/utils/connectors/tests/test_mek_reconciliation_postgres.py
+++ b/src/utils/connectors/tests/test_mek_reconciliation_postgres.py
@@ -169,6 +169,35 @@ class TestMekReconciliationPostgres(unittest.TestCase):
             (), return_raw=True)
         self.assertEqual(trigger_rows, [])
 
+    def test_default_config_secrets_are_encrypted_before_insert(self) -> None:
+        probe = self.database.secret_manager.encrypt("", "").value
+        self.assertEqual(
+            self.database.secret_manager.authenticate_mek_encrypted(probe), "old")
+        self.database._init_default_configs()
+
+        rows = self.database.execute_fetch_command(
+            "SELECT key, value FROM configs WHERE type = 'WORKFLOW' "
+            "AND key IN ('backend_images', 'workflow_alerts');",
+            (), return_raw=True)
+        self.assertEqual(len(rows), 2)
+        for row in rows:
+            self.assertNotIn('**********', row["value"])
+        persisted = {row["key"]: json.loads(row["value"]) for row in rows}
+        for encrypted in (
+            persisted["backend_images"]["credential"]["auth"],
+            persisted["workflow_alerts"]["slack_token"],
+            persisted["workflow_alerts"]["smtp_settings"]["password"],
+        ):
+            self.assertEqual(
+                self.database.secret_manager.authenticate_mek_encrypted(encrypted), "old")
+
+        counts, blockers = self.database._scan_mek_references()
+        self.assertEqual(blockers, [])
+        # Registry auth, Slack, and SMTP defaults are all persisted as
+        # authenticated direct-MEK ciphertext even when no application read
+        # performs the historical lazy-encryption step.
+        self.assertGreaterEqual(counts["old"], 3)
+
     def test_startup_inventory_rejects_a_missing_historical_key(self) -> None:
         _write_keyring(self.keyring_path, "new", {"new": self.new_mek})
         self.database.secret_manager = SecretManager(

--- a/src/utils/connectors/tests/test_mek_reconciliation_postgres.py
+++ b/src/utils/connectors/tests/test_mek_reconciliation_postgres.py
@@ -1,0 +1,186 @@
+"""Real PostgreSQL coverage for the stateless MEK rollout contract."""
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+from pathlib import Path
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+
+from jwcrypto import jwk  # type: ignore
+import psycopg2  # type: ignore
+
+from src.utils import connectors
+from src.utils.secret_manager import SecretManager
+
+
+def _available_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return listener.getsockname()[1]
+
+
+def _write_keyring(path: Path, current: str, keys: dict[str, jwk.JWK]) -> None:
+    encoded = {}
+    for key_id, key in keys.items():
+        encoded[key_id] = base64.b64encode(
+            json.dumps(key.export(as_dict=True), separators=(",", ":")).encode()
+        ).decode()
+    path.write_text(
+        "currentMek: " + current + "\nmeks:\n" + "".join(
+            f"  {key_id}: {value}\n" for key_id, value in encoded.items()
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestMekReconciliationPostgres(unittest.TestCase):
+    """The MEK implementation may inspect/rewrap data, but may not own DB state."""
+
+    temporary_directory: tempfile.TemporaryDirectory
+    data_directory: Path
+    socket_directory: Path
+    postgres_process: subprocess.Popen
+    port: int
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        initdb = shutil.which("initdb")
+        postgres = shutil.which("postgres")
+        if not initdb or not postgres:
+            raise unittest.SkipTest("PostgreSQL server binaries are not installed")
+        cls.temporary_directory = tempfile.TemporaryDirectory()
+        root = Path(cls.temporary_directory.name)
+        cls.data_directory = root / "data"
+        cls.socket_directory = root / "socket"
+        cls.socket_directory.mkdir()
+        cls.port = _available_port()
+        subprocess.run(
+            [initdb, "-D", str(cls.data_directory), "-A", "trust", "-U", "postgres"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        cls.postgres_process = subprocess.Popen(
+            [
+                postgres,
+                "-D",
+                str(cls.data_directory),
+                "-F",
+                "-p",
+                str(cls.port),
+                "-k",
+                str(cls.socket_directory),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        deadline = time.monotonic() + 10
+        while True:
+            try:
+                with psycopg2.connect(
+                    host=str(cls.socket_directory), port=cls.port,
+                    dbname="postgres", user="postgres"
+                ):
+                    break
+            except psycopg2.OperationalError:
+                if time.monotonic() >= deadline:
+                    cls.postgres_process.terminate()
+                    raise
+                time.sleep(0.05)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.postgres_process.terminate()
+        cls.postgres_process.wait(timeout=10)
+        cls.temporary_directory.cleanup()
+
+    def setUp(self) -> None:
+        self.database = connectors.PostgresConnector.__new__(connectors.PostgresConnector)
+        self.database.config = connectors.PostgresConfig(
+            postgres_host=str(self.socket_directory),
+            postgres_port=self.port,
+            postgres_user="postgres",
+            postgres_password="",
+            postgres_database_name="postgres",
+        )
+        self.database._pool_lock = threading.Lock()
+        self.database._pool = None
+        self.database._create_pool()
+        for command in (
+            "CREATE EXTENSION IF NOT EXISTS hstore;",
+            "DROP TABLE IF EXISTS configs, ueks, users CASCADE;",
+            "CREATE TABLE users (id TEXT PRIMARY KEY);",
+            "CREATE TABLE ueks (uid TEXT PRIMARY KEY, keys HSTORE NOT NULL);",
+            "CREATE TABLE configs (key TEXT, type TEXT, value TEXT, PRIMARY KEY(key, type));",
+            "INSERT INTO users(id) VALUES ('user');",
+        ):
+            self.database.execute_commit_command(command, ())
+
+        self.keyring_path = Path(self.temporary_directory.name) / "integration-mek.yaml"
+        self.old_mek = jwk.JWK.generate(kty="oct", size=256, kid="old")
+        self.new_mek = jwk.JWK.generate(kty="oct", size=256, kid="new")
+        _write_keyring(self.keyring_path, "old", {"old": self.old_mek})
+        self.database.secret_manager = SecretManager(
+            str(self.keyring_path), self.database.read_uek, self.database.write_uek,
+            self.database.read_current_kid, self.database.add_user)
+        self.database.secret_manager.add_new_user("user")
+
+    def tearDown(self) -> None:
+        assert self.database._pool is not None
+        self.database._pool.closeall()
+
+    def _mek_relations(self) -> list[str]:
+        rows = self.database.execute_fetch_command(
+            "SELECT tablename FROM pg_tables "
+            "WHERE schemaname = 'public' AND tablename LIKE 'mek_%%' ORDER BY tablename;",
+            (), return_raw=True)
+        return [row["tablename"] for row in rows]
+
+    def test_rewrap_uses_no_mek_tables_or_triggers(self) -> None:
+        self.assertEqual(self._mek_relations(), [])
+        _write_keyring(
+            self.keyring_path, "new", {"old": self.old_mek, "new": self.new_mek})
+        self.database.secret_manager = SecretManager(
+            str(self.keyring_path), self.database.read_uek, self.database.write_uek,
+            self.database.read_current_kid, self.database.add_user)
+
+        before, blockers = self.database._scan_mek_references()
+        self.assertEqual(blockers, [])
+        self.assertEqual(before["old"], 1)
+        snapshot = self.database.secret_manager.rewrap_snapshot()
+        result = self.database.rewrap_mek_references(
+            expected_generation=snapshot.generation,
+            expected_current_kid="new",
+            expected_registry_digest=(
+                self.database.secret_manager.rewrap_snapshot_digest(snapshot)),
+        )
+        self.assertEqual(result, {"old": 0, "new": 1})
+        self.assertEqual(self._mek_relations(), [])
+        trigger_rows = self.database.execute_fetch_command(
+            "SELECT tgname FROM pg_trigger WHERE NOT tgisinternal AND tgname LIKE '%%mek%%';",
+            (), return_raw=True)
+        self.assertEqual(trigger_rows, [])
+
+    def test_startup_inventory_rejects_a_missing_historical_key(self) -> None:
+        _write_keyring(self.keyring_path, "new", {"new": self.new_mek})
+        self.database.secret_manager = SecretManager(
+            str(self.keyring_path), self.database.read_uek, self.database.write_uek,
+            self.database.read_current_kid, self.database.add_user)
+        counts, blockers = self.database._scan_mek_references()
+        self.assertEqual(counts, {"new": 0})
+        self.assertEqual(blockers, [
+            "ueks/user/" + self.database.read_current_kid("user")
+            + ": authentication failed"
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/utils/connectors/tests/test_workflow_label_schema.py
+++ b/src/utils/connectors/tests/test_workflow_label_schema.py
@@ -36,6 +36,7 @@ class TestWorkflowLabelSchema(unittest.TestCase):
     def setUpClass(cls) -> None:
         database = object.__new__(connectors.PostgresConnector)
         database.execute_commit_command = mock.Mock()
+        database.execute_commit_commands = mock.Mock()
         database.execute_autocommit_command = mock.Mock()
         database._init_tables()  # pylint: disable=protected-access
 

--- a/src/utils/secret_manager/BUILD
+++ b/src/utils/secret_manager/BUILD
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-load("//bzl:py.bzl", "osmo_py_library")
+load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_library(
@@ -32,6 +32,24 @@ osmo_py_library(
         requirement("jwcrypto"),
         requirement("pyyaml"),
         "//src/lib/utils:osmo_errors",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_binary(
+    name = "mek_lifecycle",
+    srcs = ["mek_lifecycle.py"],
+    main = "mek_lifecycle.py",
+    deps = [
+        requirement("jwcrypto"),
+        requirement("kubernetes"),
+        requirement("psycopg2-binary"),
+        requirement("pydantic"),
+        requirement("pyyaml"),
+        "//src/lib/utils:osmo_errors",
+        "//src/utils:static_config",
+        "//src/utils/connectors",
+        ":secret_manager",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/utils/secret_manager/mek_lifecycle.py
+++ b/src/utils/secret_manager/mek_lifecycle.py
@@ -226,7 +226,8 @@ def _lease_name(installation_id: str, secret_name: str) -> str:
     prefix = re.sub(r"[^a-z0-9-]", "-", release.lower()).strip("-") or "osmo"
     digest = hashlib.sha256(
         f"{installation_id}:{secret_name}".encode("utf-8")).hexdigest()[:10]
-    return f"{prefix[:46].rstrip('-')}-mek-{digest}"
+    trimmed_prefix = prefix[:46].rstrip("-")
+    return f"{trimmed_prefix}-mek-{digest}"
 
 
 class MekLifecycle:
@@ -366,14 +367,14 @@ class MekLifecycle:
         annotations = dict(secret.metadata.annotations or {})
         annotations.update(annotation_updates)
         encoded = base64.b64encode(keyring.encoded).decode("ascii")
+        escaped_key = self.config.secret_key.replace("~", "~0").replace("/", "~1")
         patch = [
             {"op": "test", "path": "/metadata/uid", "value": secret.metadata.uid},
             {"op": "test", "path": "/metadata/resourceVersion",
              "value": secret.metadata.resource_version},
             {"op": "add", "path": "/metadata/annotations", "value": annotations},
             {"op": "add", "path": "/data", "value": dict(secret.data or {})},
-            {"op": "add", "path": f"/data/{self.config.secret_key.replace('~', '~0').replace('/', '~1')}",
-             "value": encoded},
+            {"op": "add", "path": f"/data/{escaped_key}", "value": encoded},
         ]
         return self.core.patch_namespaced_secret(
             self.config.secret_name,
@@ -773,7 +774,10 @@ class MekLifecycle:
                 raise osmo_errors.OSMOError(
                     "Existing ACTIVATE state does not match Secret data.")
             return
-        if annotations.get(_REQUEST) != self.config.request_id or annotations.get(_PHASE) != "prepared":
+        if (
+            annotations.get(_REQUEST) != self.config.request_id
+            or annotations.get(_PHASE) != "prepared"
+        ):
             raise osmo_errors.OSMOError("ACTIVATE requires the matching completed PREPARE phase.")
         prepared = self._required_keyring_from_secret(secret)
         if (

--- a/src/utils/secret_manager/mek_lifecycle.py
+++ b/src/utils/secret_manager/mek_lifecycle.py
@@ -1,0 +1,885 @@
+"""Kubernetes-native MEK bootstrap and explicit rotation operations.
+
+The Kubernetes Secret is the durable state machine.  A release-scoped Lease
+serializes mutations, Pods load a keyring only at startup, and rotations use
+operator-driven rollouts between PREPARE, ACTIVATE, and REWRAP.  No MEK
+lifecycle state is stored in PostgreSQL.
+"""
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import dataclasses
+import datetime
+import hashlib
+import json
+import logging
+from pathlib import Path
+import re
+import tempfile
+import time
+from typing import Any, Dict, List, Literal, Mapping, Tuple
+
+from jwcrypto import jwk  # type: ignore
+from kubernetes import client, config as kubernetes_config  # type: ignore
+from kubernetes.client import exceptions as kubernetes_exceptions  # type: ignore
+import psycopg2  # type: ignore
+import pydantic
+import yaml
+
+from src.lib.utils import osmo_errors
+from src.utils import connectors, static_config
+from src.utils.secret_manager.secret_manager import (
+    MAX_KEYRING_BYTES,
+    MAX_MEK_COUNT,
+    SecretManager,
+)
+
+
+_PREFIX = "osmo.nvidia.com/mek-"
+_REQUEST = _PREFIX + "request"
+_PHASE = _PREFIX + "phase"
+_PREDECESSOR_GENERATION = _PREFIX + "predecessor-generation"
+_PREDECESSOR_DIGEST = _PREFIX + "predecessor-digest"
+_PREDECESSOR_CURRENT = _PREFIX + "predecessor-current"
+_PREPARE_GENERATION = _PREFIX + "prepare-generation"
+_ACTIVATE_GENERATION = _PREFIX + "activate-generation"
+_BUNDLE_DIGEST = _PREFIX + "bundle-digest"
+_CANDIDATE = _PREFIX + "candidate"
+_INSTALLATION = _PREFIX + "installation"
+_COMPLETED = _PREFIX + "completed"
+_DESCRIPTOR_PREFIX = "OSMO_MEK_DESCRIPTOR "
+_LEASE_DURATION_SECONDS = 30
+
+
+@dataclasses.dataclass(frozen=True)
+class ParsedKeyring:
+    """Validated keyring identities and its YAML representation."""
+
+    document: Dict
+    encoded: bytes
+    generation: str
+    current_key_id: str
+    fingerprints: Mapping[str, str]
+    registry_digest: str
+
+
+class MekLifecycleConfig(connectors.PostgresConfig, static_config.StaticConfig):
+    """Configuration for one explicit Kubernetes lifecycle operation."""
+
+    postgres_password: str = pydantic.Field(
+        default="",
+        description="PostgreSQL password, required only by bootstrap and rewrap.",
+        json_schema_extra={"env": "OSMO_POSTGRES_PASSWORD"},
+    )
+
+    operation: Literal["bootstrap", "validate", "prepare", "activate", "rewrap"] = (
+        pydantic.Field(
+            description="Lifecycle operation to execute.",
+            json_schema_extra={"command_line": "operation", "env": "OSMO_MEK_OPERATION"},
+        )
+    )
+    namespace: str = pydantic.Field(
+        description="Kubernetes namespace containing the MEK Secret.",
+        json_schema_extra={"command_line": "namespace", "env": "OSMO_NAMESPACE"},
+    )
+    secret_name: str = pydantic.Field(
+        description="Exact MEK Secret name.",
+        json_schema_extra={"command_line": "secret_name", "env": "OSMO_MEK_SECRET_NAME"},
+    )
+    secret_key: str = pydantic.Field(
+        default="mek.yaml",
+        description="Secret data key containing the keyring.",
+        json_schema_extra={"command_line": "secret_key", "env": "OSMO_MEK_SECRET_KEY"},
+    )
+    installation_id: str = pydantic.Field(
+        description="Immutable namespace/release identity.",
+        json_schema_extra={
+            "command_line": "installation_id", "env": "OSMO_MEK_INSTALLATION_ID"
+        },
+    )
+    management_mode: Literal["external", "osmo"] = pydantic.Field(
+        default="external",
+        description="Whether OSMO may mutate the MEK Secret.",
+        json_schema_extra={
+            "command_line": "management_mode", "env": "OSMO_MEK_MANAGEMENT_MODE"
+        },
+    )
+    request_id: str = pydantic.Field(
+        default="",
+        max_length=64,
+        description="Stable non-secret rotation identifier.",
+        json_schema_extra={"command_line": "request_id", "env": "OSMO_MEK_REQUEST_ID"},
+    )
+    pod_uid: str = pydantic.Field(
+        default="",
+        description="UID of this Job Pod.",
+        json_schema_extra={"command_line": "pod_uid", "env": "OSMO_POD_UID"},
+    )
+    consumer_deployments: List[str] = pydantic.Field(
+        default_factory=list,
+        description="Exact enabled MEK-consuming Deployment names.",
+        json_schema_extra={
+            "command_line": "consumer_deployments",
+            "env": "OSMO_MEK_CONSUMER_DEPLOYMENTS",
+        },
+    )
+    active_deadline_seconds: int = pydantic.Field(
+        default=900,
+        gt=0,
+        description="Maximum operation duration.",
+        json_schema_extra={
+            "command_line": "active_deadline_seconds",
+            "env": "OSMO_MEK_ACTIVE_DEADLINE_SECONDS",
+        },
+    )
+
+
+def _generation(current_key_id: str, key_ids: List[str]) -> str:
+    descriptor = json.dumps(
+        {"currentMek": current_key_id, "mekIds": sorted(key_ids)},
+        separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(descriptor).hexdigest()[:16]
+
+
+def _registry_digest(fingerprints: Mapping[str, str]) -> str:
+    descriptor = json.dumps(
+        fingerprints, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(descriptor).hexdigest()
+
+
+def _parse_keyring(encoded: bytes) -> ParsedKeyring:
+    if not encoded or len(encoded) > MAX_KEYRING_BYTES:
+        raise osmo_errors.OSMOError("MEK keyring is empty or exceeds its size limit.")
+    keyring_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(mode="wb", delete=False) as keyring_file:
+            keyring_file.write(encoded)
+            keyring_path = keyring_file.name
+        manager = SecretManager(
+            keyring_path,
+            lambda _uid, _kid: "",
+            lambda _uid, _kid, _new, _old: False,
+            lambda _uid: "",
+            lambda _uid, _keys: None,
+        )
+        document = yaml.safe_load(encoded)
+    except osmo_errors.OSMOError:
+        raise
+    except (KeyError, TypeError, ValueError, yaml.YAMLError):
+        raise osmo_errors.OSMOError("MEK keyring is invalid.") from None
+    finally:
+        if keyring_path:
+            Path(keyring_path).unlink(missing_ok=True)
+    fingerprints = manager.key_fingerprints()
+    return ParsedKeyring(
+        document=document,
+        encoded=encoded,
+        generation=manager.generation,
+        current_key_id=manager.current_mek_id,
+        fingerprints=fingerprints,
+        registry_digest=_registry_digest(fingerprints),
+    )
+
+
+def _serialize_keyring(document: Dict) -> bytes:
+    encoded = yaml.safe_dump(document, sort_keys=True).encode("utf-8")
+    if len(encoded) > MAX_KEYRING_BYTES:
+        raise osmo_errors.OSMOError("MEK keyring would exceed its size limit.")
+    return encoded
+
+
+def _candidate_key_id(request_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]", "-", request_id).strip("-.") or "rotation"
+    return f"mek-{safe}"[:64]
+
+
+def _new_keyring(request_id: str) -> ParsedKeyring:
+    key_id = _candidate_key_id(request_id)
+    key = jwk.JWK.generate(kty="oct", size=256, kid=key_id)
+    encoded_jwk = base64.b64encode(
+        json.dumps(key.export(as_dict=True), separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+    return _parse_keyring(_serialize_keyring({
+        "currentMek": key_id,
+        "meks": {key_id: encoded_jwk},
+    }))
+
+
+def _add_candidate(keyring: ParsedKeyring, request_id: str) -> ParsedKeyring:
+    if len(keyring.fingerprints) >= MAX_MEK_COUNT:
+        raise osmo_errors.OSMOError(
+            "MEK keyring limit reached; this release does not support key retirement.")
+    candidate = _new_keyring(request_id)
+    key_id = candidate.current_key_id
+    if key_id in keyring.document["meks"]:
+        raise osmo_errors.OSMOError("Rotation request already names a loaded MEK.")
+    document = dict(keyring.document)
+    document["meks"] = dict(keyring.document["meks"])
+    document["meks"][key_id] = candidate.document["meks"][key_id]
+    return _parse_keyring(_serialize_keyring(document))
+
+
+def _lease_name(installation_id: str, secret_name: str) -> str:
+    release = installation_id.rsplit("/", 1)[-1]
+    prefix = re.sub(r"[^a-z0-9-]", "-", release.lower()).strip("-") or "osmo"
+    digest = hashlib.sha256(
+        f"{installation_id}:{secret_name}".encode("utf-8")).hexdigest()[:10]
+    return f"{prefix[:46].rstrip('-')}-mek-{digest}"
+
+
+class MekLifecycle:
+    """One fenced, explicit lifecycle operation."""
+
+    def __init__(self, lifecycle_config: MekLifecycleConfig):
+        self.config = lifecycle_config
+        if not lifecycle_config.pod_uid:
+            raise osmo_errors.OSMOError("Lifecycle Job Pod UID is required.")
+        self.deadline = time.monotonic() + lifecycle_config.active_deadline_seconds
+        self.holder = (
+            f"{lifecycle_config.request_id or lifecycle_config.operation}:"
+            f"{lifecycle_config.operation}:{lifecycle_config.pod_uid}"
+        )
+        self.lease_name = _lease_name(
+            lifecycle_config.installation_id, lifecycle_config.secret_name)
+        kubernetes_config.load_incluster_config()
+        self.core = client.CoreV1Api()
+        self.apps = client.AppsV1Api()
+        self.coordination = client.CoordinationV1Api()
+
+    def _check_deadline(self) -> None:
+        if time.monotonic() >= self.deadline:
+            raise osmo_errors.OSMOError("MEK lifecycle operation exceeded its deadline.")
+
+    def acquire_lease(self) -> None:
+        """Acquire without stealing: an expired holder may still be a paused Job."""
+        try:
+            lease = self.coordination.read_namespaced_lease(
+                self.lease_name, self.config.namespace)
+        except kubernetes_exceptions.ApiException as error:
+            if error.status != 404:
+                raise
+            release = self.config.installation_id.rsplit("/", 1)[-1]
+            try:
+                lease = self.coordination.create_namespaced_lease(
+                    self.config.namespace,
+                    {
+                        "apiVersion": "coordination.k8s.io/v1",
+                        "kind": "Lease",
+                        "metadata": {
+                            "name": self.lease_name,
+                            "labels": {
+                                "app.kubernetes.io/name": "osmo",
+                                "app.kubernetes.io/instance": release,
+                                "app.kubernetes.io/component": "mek-lifecycle",
+                                "app.kubernetes.io/managed-by": "osmo-mek-lifecycle",
+                            },
+                        },
+                        "spec": {},
+                    },
+                )
+            except kubernetes_exceptions.ApiException as create_error:
+                if create_error.status != 409:
+                    raise
+                lease = self.coordination.read_namespaced_lease(
+                    self.lease_name, self.config.namespace)
+        holder = lease.spec.holder_identity or ""
+        if holder and holder != self.holder:
+            raise osmo_errors.OSMOError(
+                "MEK lifecycle Lease is held; delete the old Job Pod and clear its holder "
+                "before retrying.")
+        now = datetime.datetime.now(datetime.timezone.utc)
+        body = {
+            "metadata": {"resourceVersion": lease.metadata.resource_version},
+            "spec": {
+                "holderIdentity": self.holder,
+                "leaseDurationSeconds": _LEASE_DURATION_SECONDS,
+                "acquireTime": now.isoformat(),
+                "renewTime": now.isoformat(),
+            },
+        }
+        self.coordination.patch_namespaced_lease(
+            self.lease_name, self.config.namespace, body)
+
+    def _assert_lease(self) -> None:
+        lease = self.coordination.read_namespaced_lease(
+            self.lease_name, self.config.namespace)
+        if lease.spec.holder_identity != self.holder:
+            raise osmo_errors.OSMOError("MEK lifecycle Lease ownership changed.")
+        lease.spec.renew_time = datetime.datetime.now(datetime.timezone.utc)
+        self.coordination.patch_namespaced_lease(
+            self.lease_name,
+            self.config.namespace,
+            {"metadata": {"resourceVersion": lease.metadata.resource_version},
+             "spec": {"holderIdentity": self.holder,
+                      "renewTime": lease.spec.renew_time.isoformat()}},
+        )
+
+    def release_lease(self) -> None:
+        lease = self.coordination.read_namespaced_lease(
+            self.lease_name, self.config.namespace)
+        if lease.spec.holder_identity != self.holder:
+            return
+        self.coordination.patch_namespaced_lease(
+            self.lease_name,
+            self.config.namespace,
+            {"metadata": {"resourceVersion": lease.metadata.resource_version},
+             "spec": {"holderIdentity": None, "renewTime": None}},
+        )
+
+    def _secret(self):
+        return self.core.read_namespaced_secret(
+            self.config.secret_name, self.config.namespace)
+
+    def _optional_secret(self):
+        try:
+            return self._secret()
+        except kubernetes_exceptions.ApiException as error:
+            if error.status == 404:
+                return None
+            raise
+
+    def _keyring_from_secret(self, secret, required: bool = True) -> ParsedKeyring | None:
+        encoded = (secret.data or {}).get(self.config.secret_key)
+        if not encoded:
+            if required:
+                raise osmo_errors.OSMOError("MEK Secret data key is empty.")
+            return None
+        try:
+            return _parse_keyring(base64.b64decode(encoded, validate=True))
+        except (ValueError, TypeError):
+            raise osmo_errors.OSMOError("MEK Secret data is invalid.") from None
+
+    def _required_keyring_from_secret(self, secret) -> ParsedKeyring:
+        keyring = self._keyring_from_secret(secret, required=True)
+        if keyring is None:  # Kept explicit for static type checking and fail-closed behavior.
+            raise osmo_errors.OSMOError("MEK Secret data key is empty.")
+        return keyring
+
+    def _patch_secret(
+            self, secret, keyring: ParsedKeyring, annotation_updates: Mapping[str, str]
+    ):
+        """JSON-patch with UID/resourceVersion tests immediately after Lease validation."""
+        self._check_deadline()
+        self._assert_lease()
+        annotations = dict(secret.metadata.annotations or {})
+        annotations.update(annotation_updates)
+        encoded = base64.b64encode(keyring.encoded).decode("ascii")
+        patch = [
+            {"op": "test", "path": "/metadata/uid", "value": secret.metadata.uid},
+            {"op": "test", "path": "/metadata/resourceVersion",
+             "value": secret.metadata.resource_version},
+            {"op": "add", "path": "/metadata/annotations", "value": annotations},
+            {"op": "add", "path": "/data", "value": dict(secret.data or {})},
+            {"op": "add", "path": f"/data/{self.config.secret_key.replace('~', '~0').replace('/', '~1')}",
+             "value": encoded},
+        ]
+        return self.core.patch_namespaced_secret(
+            self.config.secret_name,
+            self.config.namespace,
+            patch,
+        )
+
+    def _create_secret(self, keyring: ParsedKeyring):
+        """Create the full initialized Secret atomically; never patch an empty placeholder."""
+        self._check_deadline()
+        self._assert_lease()
+        release = self.config.installation_id.rsplit("/", 1)[-1]
+        return self.core.create_namespaced_secret(
+            self.config.namespace,
+            {
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": {
+                    "name": self.config.secret_name,
+                    "labels": {
+                        "app.kubernetes.io/name": "osmo",
+                        "app.kubernetes.io/instance": release,
+                        "app.kubernetes.io/component": "master-encryption-key",
+                        "app.kubernetes.io/managed-by": "osmo-mek-lifecycle",
+                    },
+                    "annotations": {
+                        _INSTALLATION: self.config.installation_id,
+                        _PHASE: "idle",
+                        _BUNDLE_DIGEST: keyring.registry_digest,
+                    },
+                },
+                "type": "Opaque",
+                "data": {
+                    self.config.secret_key: base64.b64encode(keyring.encoded).decode("ascii")
+                },
+            },
+        )
+
+    @staticmethod
+    def _rotation_annotations(secret) -> Dict[str, str]:
+        return dict(secret.metadata.annotations or {})
+
+    def _assert_installation(self, annotations: Mapping[str, str]) -> None:
+        existing = annotations.get(_INSTALLATION)
+        if existing and existing != self.config.installation_id:
+            raise osmo_errors.OSMOError("MEK Secret belongs to another Helm release.")
+
+    @staticmethod
+    def _descriptor_from_log(log_text: str) -> Dict:
+        matches = []
+        for line in log_text.splitlines():
+            try:
+                structured = json.loads(line)
+            except json.JSONDecodeError:
+                structured = None
+            candidates = [line]
+            if isinstance(structured, dict) and isinstance(structured.get("message"), str):
+                candidates.append(structured["message"])
+            for candidate in candidates:
+                marker = candidate.find(_DESCRIPTOR_PREFIX)
+                if marker < 0:
+                    continue
+                try:
+                    descriptor = json.loads(candidate[marker + len(_DESCRIPTOR_PREFIX):])
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(descriptor, dict):
+                    matches.append(descriptor)
+        if not matches:
+            raise osmo_errors.OSMOError("Pod has no machine-readable MEK startup descriptor.")
+        return matches[-1]
+
+    def _current_replica_sets(self, deployment, selector: str) -> Dict[str, Any]:
+        """Return only the exact highest-revision ReplicaSet(s) for one Deployment."""
+        revisions = []
+        for replica_set in self.apps.list_namespaced_replica_set(
+                self.config.namespace, label_selector=selector).items:
+            owners = [
+                owner for owner in replica_set.metadata.owner_references or []
+                if owner.controller and owner.kind == "Deployment"
+            ]
+            if (
+                len(owners) != 1
+                or owners[0].name != deployment.metadata.name
+                or owners[0].uid != deployment.metadata.uid
+            ):
+                continue
+            try:
+                revision = int((replica_set.metadata.annotations or {})[
+                    "deployment.kubernetes.io/revision"])
+            except (KeyError, TypeError, ValueError):
+                raise osmo_errors.OSMOError(
+                    f"MEK consumer ReplicaSet {replica_set.metadata.name} has no revision.") \
+                    from None
+            revisions.append((revision, replica_set))
+        if not revisions:
+            return {}
+        current_revision = max(revision for revision, _ in revisions)
+        return {
+            replica_set.metadata.name: replica_set
+            for revision, replica_set in revisions
+            if revision == current_revision
+        }
+
+    def _observe_pods_once(self, expected: ParsedKeyring) -> Tuple[str, ...]:
+        if not self.config.consumer_deployments:
+            raise osmo_errors.OSMOError("No MEK consumer Deployments were configured.")
+        observed = []
+        expected_descriptor = {
+            "currentKid": expected.current_key_id,
+            "loadedKids": sorted(expected.fingerprints),
+            "generation": expected.generation,
+            "digest": expected.registry_digest,
+        }
+        for deployment_name in sorted(set(self.config.consumer_deployments)):
+            deployment = self.apps.read_namespaced_deployment(
+                deployment_name, self.config.namespace)
+            desired = deployment.spec.replicas or 0
+            status = deployment.status
+            if (
+                desired < 1
+                or status.observed_generation != deployment.metadata.generation
+                or status.updated_replicas != desired
+                or status.ready_replicas != desired
+                or status.available_replicas != desired
+            ):
+                raise osmo_errors.OSMOError(
+                    f"MEK consumer Deployment {deployment_name} rollout is incomplete.")
+            selector = ",".join(
+                f"{key}={value}" for key, value in
+                sorted((deployment.spec.selector.match_labels or {}).items()))
+            current_replica_sets = self._current_replica_sets(deployment, selector)
+            if not current_replica_sets:
+                raise osmo_errors.OSMOError(
+                    f"MEK consumer Deployment {deployment_name} has no current ReplicaSet.")
+            pods = self.core.list_namespaced_pod(
+                self.config.namespace, label_selector=selector).items
+            owned = []
+            for pod in pods:
+                if pod.status.phase in ("Succeeded", "Failed"):
+                    continue
+                owners = [owner for owner in pod.metadata.owner_references or []
+                          if owner.controller and owner.kind == "ReplicaSet"]
+                if len(owners) != 1:
+                    raise osmo_errors.OSMOError(
+                        f"Selected MEK consumer Pod {pod.metadata.name} has an unexpected owner.")
+                replica_set = current_replica_sets.get(owners[0].name)
+                if replica_set is None:
+                    raise osmo_errors.OSMOError(
+                        f"Selected MEK consumer Pod {pod.metadata.name} is not in the current "
+                        "ReplicaSet.")
+                if owners[0].uid != replica_set.metadata.uid:
+                    raise osmo_errors.OSMOError(
+                        f"MEK consumer Pod {pod.metadata.name} has a stale ReplicaSet owner.")
+                deployment_owners = [owner for owner in replica_set.metadata.owner_references or []
+                                     if owner.controller and owner.kind == "Deployment"]
+                if len(deployment_owners) != 1 or deployment_owners[0].name != deployment_name:
+                    raise osmo_errors.OSMOError(
+                        f"Selected MEK consumer Pod {pod.metadata.name} has the wrong Deployment.")
+                if deployment_owners[0].uid != deployment.metadata.uid:
+                    raise osmo_errors.OSMOError(
+                        f"MEK consumer ReplicaSet {replica_set.metadata.name} has a stale owner.")
+                ready = any(
+                    condition.type == "Ready" and condition.status == "True"
+                    for condition in pod.status.conditions or [])
+                if pod.metadata.deletion_timestamp or pod.status.phase != "Running" or not ready:
+                    raise osmo_errors.OSMOError(
+                        f"MEK consumer Pod {pod.metadata.name} is not stably Ready.")
+                container_name = pod.spec.containers[0].name
+                log_text = self.core.read_namespaced_pod_log(
+                    pod.metadata.name, self.config.namespace, container=container_name)
+                if self._descriptor_from_log(log_text) != expected_descriptor:
+                    raise osmo_errors.OSMOError(
+                        f"MEK consumer Pod {pod.metadata.name} loaded another keyring.")
+                owned.append(pod.metadata.uid)
+            if len(owned) != desired:
+                raise osmo_errors.OSMOError(
+                    f"MEK consumer Deployment {deployment_name} has an unexpected Pod cohort.")
+            observed.extend(owned)
+        return tuple(sorted(observed))
+
+    def verify_rollout(self, expected: ParsedKeyring) -> None:
+        """Require two identical observations of every exact owned consumer Pod."""
+        first = self._observe_pods_once(expected)
+        self._check_deadline()
+        time.sleep(2)
+        second = self._observe_pods_once(expected)
+        if first != second:
+            raise osmo_errors.OSMOError("MEK consumer Pod cohort changed during verification.")
+
+    def _connect_database_ready(self):
+        """Wait within the Job deadline for PostgreSQL to accept connections."""
+        while True:
+            self._check_deadline()
+            try:
+                return psycopg2.connect(
+                    host=self.config.postgres_host,
+                    port=self.config.postgres_port,
+                    user=self.config.postgres_user,
+                    password=self.config.postgres_password,
+                    dbname=self.config.postgres_database_name,
+                    connect_timeout=max(1, min(5, int(self.deadline - time.monotonic()))),
+                )
+            except psycopg2.OperationalError:
+                time.sleep(min(2, max(0.1, self.deadline - time.monotonic())))
+
+    @staticmethod
+    def _database_is_fresh(connection) -> bool:
+        with connection.cursor() as cursor:
+            for table in ("users", "ueks", "configs"):
+                cursor.execute("SELECT to_regclass(%s);", (f"public.{table}",))
+                if cursor.fetchone()[0] is None:
+                    continue
+                cursor.execute(f"SELECT 1 FROM public.{table} LIMIT 1;")
+                if cursor.fetchone() is not None:
+                    return False
+        return True
+
+    def _bootstrap_consumer_cohort(self) -> Tuple[str, ...]:
+        """Prove chart consumer application containers have never started."""
+        observed = []
+        for deployment_name in sorted(set(self.config.consumer_deployments)):
+            deployment = self.apps.read_namespaced_deployment(
+                deployment_name, self.config.namespace)
+            selector = ",".join(
+                f"{key}={value}" for key, value in
+                sorted((deployment.spec.selector.match_labels or {}).items()))
+            current_replica_sets = self._current_replica_sets(deployment, selector)
+            for pod in self.core.list_namespaced_pod(
+                    self.config.namespace, label_selector=selector).items:
+                if pod.status.phase in ("Succeeded", "Failed"):
+                    continue
+                owners = [owner for owner in pod.metadata.owner_references or []
+                          if owner.controller and owner.kind == "ReplicaSet"]
+                if len(owners) != 1:
+                    raise osmo_errors.OSMOError(
+                        f"Selected bootstrap Pod {pod.metadata.name} has an unexpected owner.")
+                replica_set = current_replica_sets.get(owners[0].name)
+                if replica_set is None:
+                    raise osmo_errors.OSMOError(
+                        f"Selected bootstrap Pod {pod.metadata.name} is not in the current "
+                        "ReplicaSet.")
+                if owners[0].uid != replica_set.metadata.uid:
+                    raise osmo_errors.OSMOError(
+                        f"Selected bootstrap Pod {pod.metadata.name} has a stale owner.")
+                deployment_owners = [
+                    owner for owner in replica_set.metadata.owner_references or []
+                    if owner.controller and owner.kind == "Deployment"
+                ]
+                if (
+                    len(deployment_owners) != 1
+                    or deployment_owners[0].name != deployment_name
+                    or deployment_owners[0].uid != deployment.metadata.uid
+                ):
+                    raise osmo_errors.OSMOError(
+                        f"Selected bootstrap Pod {pod.metadata.name} has the wrong Deployment.")
+                statuses = pod.status.container_statuses or []
+                if any(
+                    status.state.running is not None
+                    or status.state.terminated is not None
+                    or status.restart_count
+                    or status.container_id
+                    for status in statuses
+                ):
+                    raise osmo_errors.OSMOError(
+                        f"MEK bootstrap consumer Pod {pod.metadata.name} has started a writer.")
+                observed.append(pod.metadata.uid)
+        return tuple(sorted(observed))
+
+    def _verify_bootstrap_quiescence(self) -> None:
+        while True:
+            self._check_deadline()
+            try:
+                first = self._bootstrap_consumer_cohort()
+                time.sleep(2)
+                if first == self._bootstrap_consumer_cohort():
+                    return
+            except kubernetes_exceptions.ApiException as error:
+                if error.status != 404:
+                    raise
+            time.sleep(1)
+
+    def _authenticate_existing_database(self, keyring: ParsedKeyring) -> None:
+        keyring_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as keyring_file:
+                keyring_file.write(keyring.encoded)
+                keyring_path = keyring_file.name
+            config = self.config.model_copy(update={"mek_file": keyring_path})
+            connector = connectors.PostgresConnector(config)
+            connector.close()
+        finally:
+            if keyring_path:
+                Path(keyring_path).unlink(missing_ok=True)
+
+    def bootstrap(self) -> None:
+        if self.config.management_mode != "osmo":
+            raise osmo_errors.OSMOError("Automatic MEK bootstrap requires managed mode.")
+        secret = self._optional_secret()
+        if secret is not None:
+            annotations = self._rotation_annotations(secret)
+            if (
+                annotations.get(_INSTALLATION) != self.config.installation_id
+                or annotations.get(_PHASE) != "idle"
+            ):
+                raise osmo_errors.OSMOError(
+                    "Existing MEK Secret is not an exact bootstrap retry for this installation.")
+            existing = self._required_keyring_from_secret(secret)
+            if annotations.get(_BUNDLE_DIGEST) != existing.registry_digest:
+                raise osmo_errors.OSMOError(
+                    "Existing bootstrap MEK Secret identity does not match its data.")
+            self._authenticate_existing_database(existing)
+            logging.info(
+                "Validated existing bootstrap MEK Secret current_kid=%s",
+                existing.current_key_id)
+            return
+        connection = self._connect_database_ready()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT pg_advisory_lock(%s);", (0x4F534D4F4D454B,))
+            if not self._database_is_fresh(connection):
+                raise osmo_errors.OSMOError(
+                    "Automatic MEK generation is allowed only for a fresh OSMO database.")
+            self._verify_bootstrap_quiescence()
+            if self._optional_secret() is not None:
+                raise osmo_errors.OSMOError(
+                    "MEK Secret appeared during bootstrap; retry exact-state validation.")
+            keyring = _new_keyring("initial")
+            self._create_secret(keyring)
+        finally:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute("SELECT pg_advisory_unlock(%s);", (0x4F534D4F4D454B,))
+            finally:
+                connection.close()
+        logging.info("Initialized Kubernetes MEK Secret current_kid=%s", keyring.current_key_id)
+
+    def validate(self) -> None:
+        secret = self._secret()
+        self._assert_installation(self._rotation_annotations(secret))
+        keyring = self._required_keyring_from_secret(secret)
+        logging.info(
+            "Validated Kubernetes MEK Secret current_kid=%s loaded_kids=%s",
+            keyring.current_key_id, sorted(keyring.fingerprints))
+
+    def prepare(self) -> None:
+        if self.config.management_mode != "osmo":
+            raise osmo_errors.OSMOError("PREPARE Secret mutation requires managed mode.")
+        if not self.config.request_id:
+            raise osmo_errors.OSMOError("MEK PREPARE requires a request ID.")
+        secret = self._secret()
+        annotations = self._rotation_annotations(secret)
+        self._assert_installation(annotations)
+        keyring = self._required_keyring_from_secret(secret)
+        phase = annotations.get(_PHASE, "idle")
+        if phase == "prepared" and annotations.get(_REQUEST) == self.config.request_id:
+            if (
+                annotations.get(_PREPARE_GENERATION) != keyring.generation
+                or annotations.get(_BUNDLE_DIGEST) != keyring.registry_digest
+            ):
+                raise osmo_errors.OSMOError("Existing PREPARE state does not match Secret data.")
+            return
+        if phase not in ("idle", "complete"):
+            raise osmo_errors.OSMOError("Another MEK rotation is incomplete.")
+        candidate = _add_candidate(keyring, self.config.request_id)
+        if candidate.current_key_id != keyring.current_key_id:
+            raise osmo_errors.OSMOError("PREPARE cannot change the current MEK.")
+        candidate_id = next(iter(set(candidate.fingerprints) - set(keyring.fingerprints)))
+        self._patch_secret(secret, candidate, {
+            _INSTALLATION: self.config.installation_id,
+            _REQUEST: self.config.request_id,
+            _PHASE: "prepared",
+            _PREDECESSOR_GENERATION: keyring.generation,
+            _PREDECESSOR_DIGEST: keyring.registry_digest,
+            _PREDECESSOR_CURRENT: keyring.current_key_id,
+            _PREPARE_GENERATION: candidate.generation,
+            _BUNDLE_DIGEST: candidate.registry_digest,
+            _CANDIDATE: candidate_id,
+            _COMPLETED: "",
+        })
+        logging.info("MEK PREPARE committed candidate=%s", candidate_id)
+
+    def activate(self) -> None:
+        if self.config.management_mode != "osmo":
+            raise osmo_errors.OSMOError("ACTIVATE Secret mutation requires managed mode.")
+        secret = self._secret()
+        annotations = self._rotation_annotations(secret)
+        self._assert_installation(annotations)
+        if annotations.get(_REQUEST) == self.config.request_id and annotations.get(
+                _PHASE) in ("activated", "complete"):
+            activated = self._required_keyring_from_secret(secret)
+            if (
+                activated.generation != annotations.get(_ACTIVATE_GENERATION)
+                or activated.registry_digest != annotations.get(_BUNDLE_DIGEST)
+                or activated.current_key_id != annotations.get(_CANDIDATE)
+            ):
+                raise osmo_errors.OSMOError(
+                    "Existing ACTIVATE state does not match Secret data.")
+            return
+        if annotations.get(_REQUEST) != self.config.request_id or annotations.get(_PHASE) != "prepared":
+            raise osmo_errors.OSMOError("ACTIVATE requires the matching completed PREPARE phase.")
+        prepared = self._required_keyring_from_secret(secret)
+        if (
+            prepared.generation != annotations.get(_PREPARE_GENERATION)
+            or prepared.registry_digest != annotations.get(_BUNDLE_DIGEST)
+            or prepared.current_key_id != annotations.get(_PREDECESSOR_CURRENT)
+            or annotations.get(_CANDIDATE) not in prepared.fingerprints
+        ):
+            raise osmo_errors.OSMOError("PREPARE annotations do not match Secret data.")
+        self.verify_rollout(prepared)
+        document = dict(prepared.document)
+        document["currentMek"] = annotations[_CANDIDATE]
+        activated = _parse_keyring(_serialize_keyring(document))
+        self._patch_secret(secret, activated, {
+            _PHASE: "activated",
+            _ACTIVATE_GENERATION: activated.generation,
+            _BUNDLE_DIGEST: activated.registry_digest,
+        })
+        logging.info("MEK ACTIVATE committed current_kid=%s", activated.current_key_id)
+
+    def rewrap(self) -> None:
+        secret = self._secret()
+        annotations = self._rotation_annotations(secret)
+        self._assert_installation(annotations)
+        activated = self._required_keyring_from_secret(secret)
+        if self.config.management_mode == "osmo":
+            if (
+                annotations.get(_REQUEST) == self.config.request_id
+                and annotations.get(_PHASE) == "complete"
+                and annotations.get(_COMPLETED) == self.config.request_id
+            ):
+                if (
+                    activated.generation != annotations.get(_ACTIVATE_GENERATION)
+                    or activated.registry_digest != annotations.get(_BUNDLE_DIGEST)
+                    or activated.current_key_id != annotations.get(_CANDIDATE)
+                ):
+                    raise osmo_errors.OSMOError(
+                        "Existing REWRAP completion does not match Secret data.")
+                return
+            if (
+                annotations.get(_REQUEST) != self.config.request_id
+                or annotations.get(_PHASE) != "activated"
+            ):
+                raise osmo_errors.OSMOError("REWRAP requires the matching ACTIVATE phase.")
+            if (
+                activated.generation != annotations.get(_ACTIVATE_GENERATION)
+                or activated.registry_digest != annotations.get(_BUNDLE_DIGEST)
+                or activated.current_key_id != annotations.get(_CANDIDATE)
+            ):
+                raise osmo_errors.OSMOError("ACTIVATE annotations do not match Secret data.")
+        elif len(activated.fingerprints) < 2:
+            raise osmo_errors.OSMOError(
+                "External REWRAP requires an activated keyring that retains historical MEKs.")
+        self.verify_rollout(activated)
+        connector = connectors.PostgresConnector(self.config)
+        try:
+            connector.rewrap_mek_references(
+                deadline_seconds=max(1, int(self.deadline - time.monotonic())),
+                expected_generation=activated.generation,
+                expected_current_kid=activated.current_key_id,
+                expected_registry_digest=activated.registry_digest,
+            )
+        finally:
+            connector.close()
+        live = self._secret()
+        if (
+            live.metadata.uid != secret.metadata.uid
+            or live.metadata.resource_version != secret.metadata.resource_version
+            or self._required_keyring_from_secret(live).encoded != activated.encoded
+        ):
+            raise osmo_errors.OSMOError("MEK Secret changed during database rewrap.")
+        self.verify_rollout(activated)
+        if self.config.management_mode == "osmo":
+            self._patch_secret(live, activated, {
+                _PHASE: "complete",
+                _COMPLETED: self.config.request_id,
+            })
+        logging.info(
+            "MEK rotation complete request=%s; all historical MEKs remain mandatory",
+            self.config.request_id)
+
+    def run(self) -> None:
+        self.acquire_lease()
+        try:
+            getattr(self, self.config.operation)()
+        finally:
+            self.release_lease()
+
+
+def _run() -> None:
+    lifecycle_config = MekLifecycleConfig.load()
+    MekLifecycle(lifecycle_config).run()
+
+
+def main() -> None:
+    try:
+        _run()
+    except (osmo_errors.OSMOError, kubernetes_exceptions.ApiException, psycopg2.Error):
+        # Never stringify Kubernetes/DB exceptions: admission responses can echo
+        # the submitted Secret body and therefore MEK bytes.
+        logging.error("MEK lifecycle operation failed; inspect redacted preceding logs.")
+        raise SystemExit(1) from None
+    except Exception:  # pylint: disable=broad-exception-caught
+        logging.error("MEK lifecycle operation failed unexpectedly; sensitive details omitted.")
+        raise SystemExit(1) from None
+
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/secret_manager/mek_lifecycle.py
+++ b/src/utils/secret_manager/mek_lifecycle.py
@@ -691,14 +691,19 @@ class MekLifecycle:
                 "Validated existing bootstrap MEK Secret current_kid=%s",
                 existing.current_key_id)
             return
+        logging.info("MEK bootstrap is waiting for PostgreSQL readiness.")
         connection = self._connect_database_ready()
         try:
+            logging.info("MEK bootstrap connected to PostgreSQL; acquiring its lock.")
             with connection.cursor() as cursor:
                 cursor.execute("SELECT pg_advisory_lock(%s);", (0x4F534D4F4D454B,))
+            logging.info("MEK bootstrap acquired the PostgreSQL lock.")
             if not self._database_is_fresh(connection):
                 raise osmo_errors.OSMOError(
                     "Automatic MEK generation is allowed only for a fresh OSMO database.")
+            logging.info("MEK bootstrap verified that the database is fresh.")
             self._verify_bootstrap_quiescence()
+            logging.info("MEK bootstrap verified the consumer cohort is quiescent.")
             if self._optional_secret() is not None:
                 raise osmo_errors.OSMOError(
                     "MEK Secret appeared during bootstrap; retry exact-state validation.")

--- a/src/utils/secret_manager/secret_manager.py
+++ b/src/utils/secret_manager/secret_manager.py
@@ -17,37 +17,114 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import base64
+import binascii
+import dataclasses
+import hashlib
+import json
 import os
-from typing import Callable, Dict, Tuple
+import re
+from types import MappingProxyType
+from typing import Callable, Dict, Literal, Mapping, Tuple
 import uuid
 
-from jwcrypto import jwk, jwe # type: ignore
-from jwcrypto.common import json_encode # type: ignore
+from jwcrypto import jwk, jwe  # type: ignore
+from jwcrypto.common import JWException, json_encode  # type: ignore
 import yaml
+from yaml.tokens import AliasToken, AnchorToken, TagToken
 
 from src.lib.utils import osmo_errors
 
 
+class _DuplicateKeySafeLoader(yaml.SafeLoader):
+    """Safe YAML loader which rejects duplicate mapping keys."""
+
+
+def _construct_unique_mapping(loader, node, deep=False):
+    mapping = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found a duplicate key",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_DuplicateKeySafeLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_unique_mapping
+)
+
+
+MAX_KEYRING_BYTES = 1024 * 1024
+MAX_MEK_COUNT = 32
+MAX_MEK_ID_LENGTH = 64
+MEK_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+@dataclasses.dataclass(frozen=True)
+class Keyring:
+    """An immutable, validated MEK keyring snapshot."""
+
+    current_mek_id: str
+    meks: Mapping[str, jwk.JWK]
+    fingerprints: Mapping[str, str]
+    generation: str
+
+
+@dataclasses.dataclass(frozen=True)
+class MekRewrapResult:
+    """Result of one explicit, snapshot-pinned MEK rewrap operation."""
+
+    status: Literal["already-current", "rewrapped", "concurrent-winner"]
+    value: str
+
+
+def _json_object_without_duplicates(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON member")
+        result[key] = value
+    return result
+
+
 class Encrypted:
     """Represents an encrypted secret"""
+
     def __init__(self, value: str):
         self.value = value
+
     def __str__(self):
         return self.value
 
+
 class Decrypted:
     """Represents a decrypted secret"""
+
     def __init__(self, value: str):
         self.value = value
+
     def __str__(self):
-        return 'xxxxx'
+        return "xxxxx"
+
 
 class SecretManager:
     """Class to read and write encrypted user secrets to postgres"""
-    def __init__(self, mek_file: str, read_uek: Callable[[str, str], str],
-                 write_uek: Callable[[str, str, str, str], None],
-                 read_current_kid: Callable[[str], str], add_user: Callable[[str, Dict], None],
-                 alg: str = 'A256GCMKW', enc: str = 'A256GCM',):
+
+    def __init__(
+        self,
+        mek_file: str,
+        read_uek: Callable[[str, str], str],
+        write_uek: Callable[[str, str, str, str], bool],
+        read_current_kid: Callable[[str], str],
+        add_user: Callable[[str, Dict], None],
+        alg: str = "A256GCMKW",
+        enc: str = "A256GCM",
+    ):
         """Constructor
 
         Args:
@@ -58,7 +135,8 @@ class SecretManager:
                     mek1: base64 encoded JWK
             read_uek (Callable[[str, str], str]): A function to read encrypted uek.
                 `read_uek(uid, kid)` will be called to read the uek.
-            write_uek (Callable[[str, str, str, str], None]): A function to write encrypted uek.
+            write_uek (Callable[[str, str, str, str], bool]): A compare-and-set function to write
+                an encrypted uek and report whether the row was updated.
                 `write_uek(uid, kid, new_uek, old_uek)` will be called to re-encrypt uek.
             read_current_kid (Callable[[str], str]): A function to get current uek kid.
                 `read_current_kid(uid)` will be called to get current kid.
@@ -72,36 +150,225 @@ class SecretManager:
         """
         self.alg = alg
         self.enc = enc
-        self.meks = {}
-        self.current_mek_id = ''
+        self.mek_file = mek_file
         self.read_uek = read_uek
         self.write_uek = write_uek
         self.read_current_kid = read_current_kid
         self.add_user = add_user
-
         if not os.path.isfile(mek_file):
-            raise osmo_errors.OSMOError(f'MEK file {mek_file} does not exist.')
-        with open(mek_file, 'r', encoding='utf-8') as fp:
-            meks = yaml.safe_load(fp)
+            raise osmo_errors.OSMOError(f"MEK file {mek_file} does not exist.")
+        self._keyring, _ = self._read_keyring()
 
-        self.current_mek_id = meks['currentMek']
-        for kid, jwk_encoded in meks['meks'].items():
-            jwk_json = base64.b64decode(jwk_encoded.encode('utf-8')).decode('utf-8')
-            self.meks[kid] = jwk.JWK.from_json(jwk_json)
+    @property
+    def current_mek_id(self) -> str:
+        return self._keyring.current_mek_id
 
-    def get_mek(self, kid: str = '') -> jwk.JWK:
+    @property
+    def meks(self) -> Mapping[str, jwk.JWK]:
+        return self._keyring.meks
+
+    @property
+    def generation(self) -> str:
+        """Return a non-secret identifier for the loaded keyring revision."""
+        return self._keyring.generation
+
+    def key_fingerprints(self) -> Dict[str, str]:
+        """Return a copy of the non-secret key fingerprints."""
+        return dict(self._keyring.fingerprints)
+
+    def fingerprint_bundle_digest(self) -> str:
+        """Return a stable, non-secret identity for the complete loaded MEK bundle."""
+        descriptor = json.dumps(
+            dict(self._keyring.fingerprints), separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+        return hashlib.sha256(descriptor).hexdigest()
+
+    def rewrap_snapshot(self) -> Keyring:
+        """Capture the immutable activated keyring used by one explicit rewrap run."""
+        return self._keyring
+
+    @staticmethod
+    def rewrap_snapshot_digest(snapshot: Keyring) -> str:
+        descriptor = json.dumps(
+            dict(snapshot.fingerprints), separators=(",", ":"), sort_keys=True
+        ).encode("utf-8")
+        return hashlib.sha256(descriptor).hexdigest()
+
+    def validate_rewrap_snapshot(self, snapshot: Keyring) -> None:
+        """Fail if the live keyring no longer matches the pinned rewrap authority."""
+        live = self._keyring
+        if (
+            live.generation != snapshot.generation
+            or live.current_mek_id != snapshot.current_mek_id
+            or dict(live.fingerprints) != dict(snapshot.fingerprints)
+        ):
+            raise osmo_errors.OSMOError("Active MEK keyring changed during explicit rewrap.")
+
+    @staticmethod
+    def _file_stat_signature(file_stat: os.stat_result) -> Tuple[int, int, int, int]:
+        return (file_stat.st_dev, file_stat.st_ino, file_stat.st_mtime_ns, file_stat.st_size)
+
+    def _read_keyring(self) -> Tuple[Keyring, Tuple[int, int, int, int]]:
+        try:
+            with open(self.mek_file, "rb") as file_pointer:
+                signature = self._file_stat_signature(os.fstat(file_pointer.fileno()))
+                contents = file_pointer.read(MAX_KEYRING_BYTES + 1)
+                if self._file_stat_signature(os.fstat(file_pointer.fileno())) != signature:
+                    raise osmo_errors.OSMOError(
+                        f"MEK file {self.mek_file} changed while it was being read."
+                    )
+            if len(contents) > MAX_KEYRING_BYTES:
+                raise osmo_errors.OSMOError(
+                    f"MEK file {self.mek_file} exceeds the {MAX_KEYRING_BYTES}-byte limit."
+                )
+            text = contents.decode("utf-8")
+            if any(
+                isinstance(token, (AliasToken, AnchorToken, TagToken)) for token in yaml.scan(text)
+            ):
+                raise osmo_errors.OSMOError(
+                    f"MEK file {self.mek_file} cannot contain YAML aliases, anchors, or tags."
+                )
+            config = yaml.load(text, Loader=_DuplicateKeySafeLoader)
+        except osmo_errors.OSMOError:
+            raise
+        except (OSError, UnicodeError, yaml.YAMLError):
+            raise osmo_errors.OSMOError(
+                f"MEK file {self.mek_file} is not valid YAML."
+            ) from None
+
+        if not isinstance(config, dict):
+            raise osmo_errors.OSMOError(f"MEK file {self.mek_file} must contain a mapping.")
+        if set(config) != {"currentMek", "meks"}:
+            raise osmo_errors.OSMOError(
+                f"MEK file {self.mek_file} must contain only currentMek and meks."
+            )
+
+        current_mek_id = config["currentMek"]
+        encoded_meks = config["meks"]
+        if (
+            not isinstance(current_mek_id, str)
+            or not current_mek_id
+            or len(current_mek_id) > MAX_MEK_ID_LENGTH
+            or not MEK_ID_PATTERN.fullmatch(current_mek_id)
+        ):
+            raise osmo_errors.OSMOError(
+                "currentMek must use 1-64 letters, digits, dots, underscores, or dashes."
+            )
+        if not isinstance(encoded_meks, dict) or not encoded_meks:
+            raise osmo_errors.OSMOError("meks must be a non-empty mapping.")
+        if len(encoded_meks) > MAX_MEK_COUNT:
+            raise osmo_errors.OSMOError(f"meks cannot contain more than {MAX_MEK_COUNT} entries.")
+
+        parsed_meks = {}
+        fingerprints = {}
+        for mek_id, encoded_jwk in encoded_meks.items():
+            if (
+                not isinstance(mek_id, str)
+                or not mek_id
+                or len(mek_id) > MAX_MEK_ID_LENGTH
+                or not MEK_ID_PATTERN.fullmatch(mek_id)
+            ):
+                raise osmo_errors.OSMOError(
+                    "MEK identifiers must use 1-64 letters, digits, dots, underscores, or dashes."
+                )
+            if not isinstance(encoded_jwk, str) or not encoded_jwk:
+                raise osmo_errors.OSMOError("Every MEK must be a base64 encoded JWK.")
+            try:
+                jwk_json = base64.b64decode(encoded_jwk.encode("ascii"), validate=True).decode(
+                    "utf-8"
+                )
+                jwk_config = json.loads(
+                    jwk_json,
+                    object_pairs_hook=_json_object_without_duplicates,
+                    parse_constant=lambda value: (_ for _ in ()).throw(
+                        ValueError(f"invalid JSON constant {value}")
+                    ),
+                )
+                if not isinstance(jwk_config, dict) or set(jwk_config) != {"k", "kid", "kty"}:
+                    raise ValueError("JWK must contain exactly k, kid, and kty")
+                if jwk_config["kid"] != mek_id or jwk_config["kty"] != "oct":
+                    raise ValueError("JWK kid or kty does not match the MEK entry")
+                encoded_key = jwk_config["k"]
+                if not isinstance(encoded_key, str):
+                    raise ValueError("MEK key material must be a string")
+                key_padding = "=" * (-len(encoded_key) % 4)
+                try:
+                    key_bytes = base64.b64decode(
+                        encoded_key + key_padding, altchars=b"-_", validate=True
+                    )
+                except binascii.Error:
+                    key_bytes = base64.b64decode(encoded_key, validate=True)
+                if len(key_bytes) != 32:
+                    raise ValueError("MEK must contain exactly 256 bits")
+                canonical_key = base64.urlsafe_b64encode(key_bytes).decode("ascii").rstrip("=")
+                canonical_standard_key = base64.b64encode(key_bytes).decode("ascii")
+                if encoded_key not in (canonical_key, canonical_standard_key):
+                    raise ValueError("MEK key material is not canonical base64")
+                jwk_config["k"] = canonical_key
+                parsed_meks[mek_id] = jwk.JWK.from_json(
+                    json.dumps(jwk_config, separators=(",", ":"), sort_keys=True)
+                )
+                fingerprints[mek_id] = hashlib.sha256(key_bytes).hexdigest()
+            except (
+                UnicodeError,
+                ValueError,
+                TypeError,
+                binascii.Error,
+                jwk.InvalidJWKValue,
+            ):
+                raise osmo_errors.OSMOError("A MEK entry is invalid.") from None
+
+        if len(set(fingerprints.values())) != len(fingerprints):
+            raise osmo_errors.OSMOError("Each MEK identifier must contain unique key material.")
+
+        if current_mek_id not in parsed_meks:
+            raise osmo_errors.OSMOError("currentMek is not present in meks.")
+
+        descriptor = json.dumps(
+            {
+                "currentMek": current_mek_id,
+                "mekIds": sorted(parsed_meks),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return (
+            Keyring(
+                current_mek_id=current_mek_id,
+                meks=MappingProxyType(parsed_meks),
+                fingerprints=MappingProxyType(fingerprints),
+                generation=hashlib.sha256(descriptor).hexdigest()[:16],
+            ),
+            signature,
+        )
+
+    def _validate_jwe_header(self, header: Mapping[str, object]) -> str:
+        if header.get("alg") != self.alg or header.get("enc") != self.enc:
+            raise osmo_errors.OSMOError("Encrypted secret uses an unsupported JWE algorithm.")
+        kid = header.get("kid")
+        if (
+            not isinstance(kid, str)
+            or not kid
+            or len(kid) > MAX_MEK_ID_LENGTH
+            or not MEK_ID_PATTERN.fullmatch(kid)
+        ):
+            raise osmo_errors.OSMOError("Encrypted secret does not contain a valid kid.")
+        return kid
+
+    def get_mek(self, kid: str = "") -> jwk.JWK:
         """Returns master key according to kid. Returns the current master key if kid is empty"""
         if not kid:
             kid = self.current_mek_id
         if kid not in self.meks:
-            raise osmo_errors.OSMONotFoundError(f'Cannot find mek whose kid is {kid}.')
+            raise osmo_errors.OSMONotFoundError(f"Cannot find mek whose kid is {kid}.")
         return self.meks[kid]
 
-    def get_uek(self, uid: str, kid: str = '') -> Tuple[jwk.JWK, bool]:
+    def get_uek(self, uid: str, kid: str = "") -> Tuple[jwk.JWK, bool]:
         """Returns user key according to kid and uid. Returns master key if uid is empty.
         Returns current user key if kid is empty"""
         if not uid:
-            return (self.get_mek(kid), True)
+            is_current = not kid or kid == self.current_mek_id
+            return (self.get_mek(kid), is_current)
 
         # Get Encrypted UEK
         try:
@@ -112,30 +379,178 @@ class SecretManager:
             uek_jwe = self.read_uek(uid, kid)
             jwetoken = jwe.JWE()
             jwetoken.deserialize(uek_jwe)
-            mek_kid = jwetoken.jose_header['kid']
+            mek_kid = self._validate_jwe_header(jwetoken.jose_header)
 
         except Exception as exc:
-            raise osmo_errors.OSMOError(f'Cannot find user key for user {uid}.') from exc
-        # Get MEK
-        mek = self.get_mek(mek_kid)
+            raise osmo_errors.OSMOError(f"Cannot find user key for user {uid}.") from exc
+        if mek_kid not in self._keyring.meks:
+            raise osmo_errors.OSMONotFoundError(f"Cannot find mek whose kid is {mek_kid}.")
+        mek = self._keyring.meks[mek_kid]
         jwetoken.decrypt(mek)
 
-        jwk_json = jwetoken.payload.decode('utf-8')
+        jwk_json = jwetoken.payload.decode("utf-8")
+        user_key = jwk.JWK.from_json(jwk_json)
+        if user_key.key_id != kid:
+            raise osmo_errors.OSMOError(
+                f"User key wrapper for user {uid} does not match slot {kid}."
+            )
 
-        # Re-encrypt uek if not using the latest MEK
-        if mek_kid != self.current_mek_id:
-            new_jwe = jwe.JWE(
-                jwetoken.payload,
-                json_encode({'alg': self.alg, 'enc': self.enc, 'kid': self.current_mek_id}))
-            current_mek = self.get_mek()
-            new_jwe.add_recipient(current_mek)
-            self.write_uek(uid, kid, new_jwe.serialize(True), uek_jwe)
+        return (user_key, is_current)
 
-        return (jwk.JWK.from_json(jwk_json), is_current)
+    def rewrap_uek(self, uid: str, kid: str, snapshot: Keyring) -> MekRewrapResult:
+        """Explicitly rewrap one persisted UEK under one activated keyring snapshot."""
+        self.validate_rewrap_snapshot(snapshot)
+        try:
+            original = self.read_uek(uid, kid)
+            token = jwe.JWE()
+            token.deserialize(original)
+            wrapping_kid = self._validate_jwe_header(token.jose_header)
+            wrapping_mek = snapshot.meks.get(wrapping_kid)
+            if wrapping_mek is None:
+                raise osmo_errors.OSMOError("UEK wrapper references an unavailable MEK.")
+            token.decrypt(wrapping_mek)
+            payload = token.payload
+            user_key = jwk.JWK.from_json(payload.decode("utf-8"))
+            if user_key.key_id != kid:
+                raise osmo_errors.OSMOError("UEK wrapper does not match its persisted slot.")
+        except (
+            JWException, UnicodeError, ValueError, TypeError, KeyError, IndexError,
+            jwk.InvalidJWKValue,
+        ) as error:
+            raise osmo_errors.OSMOError("Persisted UEK wrapper failed authentication.") from error
+
+        if wrapping_kid == snapshot.current_mek_id:
+            self.validate_rewrap_snapshot(snapshot)
+            return MekRewrapResult("already-current", original)
+
+        replacement_token = jwe.JWE(
+            payload,
+            json_encode({
+                "alg": self.alg,
+                "enc": self.enc,
+                "kid": snapshot.current_mek_id,
+            }),
+        )
+        replacement_token.add_recipient(snapshot.meks[snapshot.current_mek_id])
+        replacement = replacement_token.serialize(True)
+        self.validate_rewrap_snapshot(snapshot)
+        if self.write_uek(uid, kid, replacement, original):
+            self.validate_rewrap_snapshot(snapshot)
+            return MekRewrapResult("rewrapped", replacement)
+
+        # Accept a CAS winner only when it authenticates under this exact target
+        # snapshot and preserves the canonical UEK payload.
+        concurrent = self.read_uek(uid, kid)
+        try:
+            concurrent_token = jwe.JWE()
+            concurrent_token.deserialize(concurrent)
+            concurrent_kid = self._validate_jwe_header(concurrent_token.jose_header)
+            if concurrent_kid != snapshot.current_mek_id:
+                raise osmo_errors.OSMOError(
+                    "Concurrent UEK rewrap did not use the pinned target MEK."
+                )
+            concurrent_token.decrypt(snapshot.meks[concurrent_kid])
+            concurrent_key = jwk.JWK.from_json(
+                concurrent_token.payload.decode("utf-8"))
+            if (
+                concurrent_key.key_id != kid
+                or concurrent_key.export(as_dict=True) != user_key.export(as_dict=True)
+            ):
+                raise osmo_errors.OSMOError(
+                    "Concurrent UEK rewrap changed the key payload."
+                )
+        except (JWException, UnicodeError, ValueError, jwk.InvalidJWKValue) as error:
+            raise osmo_errors.OSMOError(
+                "Concurrent UEK rewrap failed authentication."
+            ) from error
+        self.validate_rewrap_snapshot(snapshot)
+        return MekRewrapResult("concurrent-winner", concurrent)
+
+    def rewrap_direct_mek(self, value: str, snapshot: Keyring) -> MekRewrapResult:
+        """Explicitly rewrap one direct-MEK ciphertext under a pinned snapshot."""
+        self.validate_rewrap_snapshot(snapshot)
+        try:
+            token = jwe.JWE()
+            token.deserialize(value)
+            wrapping_kid = self._validate_jwe_header(token.jose_header)
+            wrapping_mek = snapshot.meks.get(wrapping_kid)
+            if wrapping_mek is None:
+                raise osmo_errors.OSMOError(
+                    "Direct-MEK ciphertext references an unavailable MEK."
+                )
+            token.decrypt(wrapping_mek)
+            plaintext = token.payload
+            plaintext.decode("utf-8")
+        except (JWException, UnicodeError, ValueError) as error:
+            raise osmo_errors.OSMOError(
+                "Persisted direct-MEK ciphertext failed authentication."
+            ) from error
+        if wrapping_kid == snapshot.current_mek_id:
+            self.validate_rewrap_snapshot(snapshot)
+            return MekRewrapResult("already-current", value)
+        replacement_token = jwe.JWE(
+            plaintext,
+            json_encode({
+                "alg": self.alg,
+                "enc": self.enc,
+                "kid": snapshot.current_mek_id,
+            }),
+        )
+        replacement_token.add_recipient(snapshot.meks[snapshot.current_mek_id])
+        replacement = replacement_token.serialize(True)
+        self.validate_rewrap_snapshot(snapshot)
+        return MekRewrapResult("rewrapped", replacement)
 
     def generate_uek(self) -> jwk.JWK:
         kid = uuid.uuid4().hex
-        return jwk.JWK.generate(kty='oct', size=256, kid=kid)
+        return jwk.JWK.generate(kty="oct", size=256, kid=kid)
+
+    def authenticate_mek_encrypted(self, value: str) -> str:
+        """Authenticate direct-MEK ciphertext without exposing its plaintext."""
+        try:
+            if value.count(".") != 4:
+                raise ValueError("ciphertext is not compact JWE")
+            token = jwe.JWE()
+            token.deserialize(value)
+            key_id = self._validate_jwe_header(token.jose_header)
+            token.decrypt(self.get_mek(key_id))
+            token.payload.decode("utf-8")
+            return key_id
+        except (JWException, UnicodeError, ValueError, osmo_errors.OSMOError) as error:
+            raise osmo_errors.OSMOError(
+                "Persisted direct-MEK ciphertext failed authentication."
+            ) from error
+
+    def authenticate_uek_wrapper(self, value: str, expected_uek_id: str = "") -> str:
+        """Authenticate a persisted UEK wrapper and validate its JWK payload."""
+        try:
+            if value.count(".") != 4:
+                raise ValueError("ciphertext is not compact JWE")
+            token = jwe.JWE()
+            token.deserialize(value)
+            key_id = self._validate_jwe_header(token.jose_header)
+            token.decrypt(self.get_mek(key_id))
+            user_key = jwk.JWK.from_json(token.payload.decode("utf-8"))
+            exported = user_key.export(as_dict=True)
+            if exported.get("kty") != "oct" or not exported.get("kid"):
+                raise ValueError("invalid UEK JWK")
+            if expected_uek_id and exported["kid"] != expected_uek_id:
+                raise ValueError("UEK JWK does not match its persisted slot")
+            padding = "=" * (-len(exported["k"]) % 4)
+            key_bytes = base64.b64decode(exported["k"] + padding, altchars=b"-_", validate=True)
+            if len(key_bytes) != 32:
+                raise ValueError("invalid UEK size")
+            return key_id
+        except (
+            JWException,
+            UnicodeError,
+            ValueError,
+            TypeError,
+            binascii.Error,
+            jwk.InvalidJWKValue,
+            osmo_errors.OSMOError,
+        ) as error:
+            raise osmo_errors.OSMOError("Persisted UEK wrapper failed authentication.") from error
 
     def add_new_user(self, uid: str):
         """Add uek for a new user"""
@@ -144,19 +559,21 @@ class SecretManager:
 
         # Encrypt uek by mek
         jwetoken = jwe.JWE(
-            uek.export().encode('utf-8'),
-            json_encode({'alg': self.alg, 'enc': self.enc, 'kid': mek.key_id}))
+            uek.export().encode("utf-8"),
+            json_encode({"alg": self.alg, "enc": self.enc, "kid": mek.key_id}),
+        )
         jwetoken.add_recipient(mek)
 
-        ueks = {'current': uek.key_id, uek.key_id: jwetoken.serialize(True)}
+        ueks = {"current": uek.key_id, uek.key_id: jwetoken.serialize(True)}
         self.add_user(uid, ueks)
 
     def encrypt(self, plain_text: str, uid: str) -> Encrypted:
         """Encrypts the plain_text using current user key. Use the master key if uid is empty."""
         uek, _ = self.get_uek(uid)
         jwetoken = jwe.JWE(
-            plain_text.encode('utf-8'),
-            json_encode({'alg': self.alg, 'enc': self.enc, 'kid': uek.key_id}))
+            plain_text.encode("utf-8"),
+            json_encode({"alg": self.alg, "enc": self.enc, "kid": uek.key_id}),
+        )
 
         jwetoken.add_recipient(uek)
         enc = Encrypted(jwetoken.serialize(True))
@@ -176,17 +593,20 @@ class SecretManager:
         """
         jwetoken = jwe.JWE()
         jwetoken.deserialize(enc.value)
-        kid = jwetoken.jose_header['kid']
+        kid = self._validate_jwe_header(jwetoken.jose_header)
         uek, is_current = self.get_uek(uid, kid)
         jwetoken.decrypt(uek)
-        decrypted = jwetoken.payload.decode('utf-8')
+        decrypted = jwetoken.payload.decode("utf-8")
 
-        if not is_current:
-            # Re-encrypt the secret
+        # MEK migration is an explicit lifecycle Job responsibility. Preserve
+        # the historical lazy UEK-to-UEK migration for user-owned ciphertext,
+        # but never mutate direct-MEK config values from an application read.
+        if uid and not is_current:
             current_uek, _ = self.get_uek(uid)
             new_jwe = jwe.JWE(
-                decrypted.value.encode('utf-8'),
-                json_encode({'alg': self.alg, 'enc': self.enc, 'kid': current_uek.key_id}))
+                decrypted.encode("utf-8"),
+                json_encode({"alg": self.alg, "enc": self.enc, "kid": current_uek.key_id}),
+            )
             new_jwe.add_recipient(current_uek)
             re_encrypted = new_jwe.serialize(True)
             update_secret(re_encrypted)

--- a/src/utils/secret_manager/secret_manager.py
+++ b/src/utils/secret_manager/secret_manager.py
@@ -355,6 +355,26 @@ class SecretManager:
             raise osmo_errors.OSMOError("Encrypted secret does not contain a valid kid.")
         return kid
 
+    @staticmethod
+    def _decrypt_token(token: jwe.JWE, key: jwk.JWK) -> bytes:
+        """Decrypt an authenticated JWE, including a valid empty payload.
+
+        jwcrypto raises ``InvalidJWEData`` after a successful decrypt when
+        the authenticated plaintext is ``b""`` because its public method
+        tests plaintext truthiness. It still sets ``plaintext`` only after
+        unwrap and tag verification, so that exact value is a successful
+        authenticated empty secret; ``None`` remains a real failure.
+        """
+        try:
+            token.decrypt(key)
+        except JWException:
+            if token.plaintext != b"":
+                raise
+        plaintext = token.plaintext
+        if plaintext is None:
+            raise osmo_errors.OSMOError("Encrypted secret authentication failed.")
+        return plaintext
+
     def get_mek(self, kid: str = "") -> jwk.JWK:
         """Returns master key according to kid. Returns the current master key if kid is empty"""
         if not kid:
@@ -386,9 +406,7 @@ class SecretManager:
         if mek_kid not in self._keyring.meks:
             raise osmo_errors.OSMONotFoundError(f"Cannot find mek whose kid is {mek_kid}.")
         mek = self._keyring.meks[mek_kid]
-        jwetoken.decrypt(mek)
-
-        jwk_json = jwetoken.payload.decode("utf-8")
+        jwk_json = self._decrypt_token(jwetoken, mek).decode("utf-8")
         user_key = jwk.JWK.from_json(jwk_json)
         if user_key.key_id != kid:
             raise osmo_errors.OSMOError(
@@ -408,8 +426,7 @@ class SecretManager:
             wrapping_mek = snapshot.meks.get(wrapping_kid)
             if wrapping_mek is None:
                 raise osmo_errors.OSMOError("UEK wrapper references an unavailable MEK.")
-            token.decrypt(wrapping_mek)
-            payload = token.payload
+            payload = self._decrypt_token(token, wrapping_mek)
             user_key = jwk.JWK.from_json(payload.decode("utf-8"))
             if user_key.key_id != kid:
                 raise osmo_errors.OSMOError("UEK wrapper does not match its persisted slot.")
@@ -449,9 +466,11 @@ class SecretManager:
                 raise osmo_errors.OSMOError(
                     "Concurrent UEK rewrap did not use the pinned target MEK."
                 )
-            concurrent_token.decrypt(snapshot.meks[concurrent_kid])
+            concurrent_payload = self._decrypt_token(
+                concurrent_token, snapshot.meks[concurrent_kid]
+            )
             concurrent_key = jwk.JWK.from_json(
-                concurrent_token.payload.decode("utf-8"))
+                concurrent_payload.decode("utf-8"))
             if (
                 concurrent_key.key_id != kid
                 or concurrent_key.export(as_dict=True) != user_key.export(as_dict=True)
@@ -478,8 +497,7 @@ class SecretManager:
                 raise osmo_errors.OSMOError(
                     "Direct-MEK ciphertext references an unavailable MEK."
                 )
-            token.decrypt(wrapping_mek)
-            plaintext = token.payload
+            plaintext = self._decrypt_token(token, wrapping_mek)
             plaintext.decode("utf-8")
         except (JWException, UnicodeError, ValueError) as error:
             raise osmo_errors.OSMOError(
@@ -513,8 +531,7 @@ class SecretManager:
             token = jwe.JWE()
             token.deserialize(value)
             key_id = self._validate_jwe_header(token.jose_header)
-            token.decrypt(self.get_mek(key_id))
-            token.payload.decode("utf-8")
+            self._decrypt_token(token, self.get_mek(key_id)).decode("utf-8")
             return key_id
         except (JWException, UnicodeError, ValueError, osmo_errors.OSMOError) as error:
             raise osmo_errors.OSMOError(
@@ -529,8 +546,8 @@ class SecretManager:
             token = jwe.JWE()
             token.deserialize(value)
             key_id = self._validate_jwe_header(token.jose_header)
-            token.decrypt(self.get_mek(key_id))
-            user_key = jwk.JWK.from_json(token.payload.decode("utf-8"))
+            plaintext = self._decrypt_token(token, self.get_mek(key_id))
+            user_key = jwk.JWK.from_json(plaintext.decode("utf-8"))
             exported = user_key.export(as_dict=True)
             if exported.get("kty") != "oct" or not exported.get("kid"):
                 raise ValueError("invalid UEK JWK")
@@ -595,8 +612,7 @@ class SecretManager:
         jwetoken.deserialize(enc.value)
         kid = self._validate_jwe_header(jwetoken.jose_header)
         uek, is_current = self.get_uek(uid, kid)
-        jwetoken.decrypt(uek)
-        decrypted = jwetoken.payload.decode("utf-8")
+        decrypted = self._decrypt_token(jwetoken, uek).decode("utf-8")
 
         # MEK migration is an explicit lifecycle Job responsibility. Preserve
         # the historical lazy UEK-to-UEK migration for user-owned ciphertext,

--- a/src/utils/secret_manager/tests/BUILD
+++ b/src/utils/secret_manager/tests/BUILD
@@ -1,0 +1,21 @@
+load("//bzl:py.bzl", "osmo_py_test")
+load("@osmo_python_deps//:requirements.bzl", "requirement")
+
+osmo_py_test(
+    name = "test_secret_manager",
+    srcs = ["test_secret_manager.py"],
+    deps = [
+        requirement("jwcrypto"),
+        "//src/lib/utils:osmo_errors",
+        "//src/utils/secret_manager",
+    ],
+)
+
+osmo_py_test(
+    name = "test_mek_lifecycle",
+    srcs = ["test_mek_lifecycle.py"],
+    deps = [
+        "//src/lib/utils:osmo_errors",
+        "//src/utils/secret_manager:mek_lifecycle",
+    ],
+)

--- a/src/utils/secret_manager/tests/test_mek_lifecycle.py
+++ b/src/utils/secret_manager/tests/test_mek_lifecycle.py
@@ -1,0 +1,375 @@
+"""Unit tests for the Kubernetes-only MEK state machine."""
+
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=protected-access
+
+import base64
+import json
+import time
+import types
+from typing import Literal
+import unittest
+from unittest import mock
+
+from src.lib.utils import osmo_errors
+from src.utils.secret_manager import mek_lifecycle as lifecycle_module
+from src.utils.secret_manager.mek_lifecycle import (
+    MekLifecycle,
+    MekLifecycleConfig,
+    _ACTIVATE_GENERATION,
+    _BUNDLE_DIGEST,
+    _CANDIDATE,
+    _COMPLETED,
+    _INSTALLATION,
+    _PHASE,
+    _PREDECESSOR_CURRENT,
+    _PREPARE_GENERATION,
+    _REQUEST,
+    _add_candidate,
+    _new_keyring,
+    _parse_keyring,
+    _serialize_keyring,
+)
+
+
+def _config(
+    operation: Literal["bootstrap", "validate", "prepare", "activate", "rewrap"] = "prepare",
+    mode: Literal["external", "osmo"] = "osmo",
+) -> MekLifecycleConfig:
+    return MekLifecycleConfig.model_construct(
+        operation=operation,
+        namespace="osmo",
+        secret_name="osmo-mek",
+        secret_key="mek.yaml",
+        installation_id="osmo/release",
+        management_mode=mode,
+        request_id="rotate-1",
+        pod_uid="pod-1",
+        consumer_deployments=["api"],
+        active_deadline_seconds=900,
+        postgres_host="postgres",
+        postgres_port=5432,
+        postgres_user="osmo",
+        postgres_password="redacted",
+        postgres_database_name="osmo",
+    )
+
+
+def _secret(keyring, annotations=None):
+    return types.SimpleNamespace(
+        metadata=types.SimpleNamespace(
+            uid="secret-uid", resource_version="1", annotations=annotations or {}),
+        data={"mek.yaml": base64.b64encode(keyring.encoded).decode()},
+    )
+
+
+def _lifecycle(
+    operation: Literal["bootstrap", "validate", "prepare", "activate", "rewrap"] = "prepare",
+    mode: Literal["external", "osmo"] = "osmo",
+) -> MekLifecycle:
+    lifecycle = MekLifecycle.__new__(MekLifecycle)
+    lifecycle.config = _config(operation, mode)
+    lifecycle.deadline = time.monotonic() + 900
+    return lifecycle
+
+
+def _owner(kind: str, name: str, uid: str):
+    return types.SimpleNamespace(kind=kind, name=name, uid=uid, controller=True)
+
+
+def _deployment():
+    return types.SimpleNamespace(
+        metadata=types.SimpleNamespace(name="api", uid="deployment-uid", generation=2),
+        spec=types.SimpleNamespace(
+            replicas=1, selector=types.SimpleNamespace(match_labels={"app": "api"})),
+        status=types.SimpleNamespace(
+            observed_generation=2, updated_replicas=1, ready_replicas=1,
+            available_replicas=1),
+    )
+
+
+def _replica_set(name: str, uid: str, revision: int, owner_name: str = "api"):
+    return types.SimpleNamespace(
+        metadata=types.SimpleNamespace(
+            name=name, uid=uid,
+            annotations={"deployment.kubernetes.io/revision": str(revision)},
+            owner_references=[_owner(
+                "Deployment", owner_name,
+                "deployment-uid" if owner_name == "api" else "other-uid")]),
+    )
+
+
+def _pod(owner_references, deletion_timestamp=None):
+    return types.SimpleNamespace(
+        metadata=types.SimpleNamespace(
+            name="api-pod", uid="pod-uid", deletion_timestamp=deletion_timestamp,
+            owner_references=owner_references),
+        status=types.SimpleNamespace(
+            phase="Running",
+            conditions=[types.SimpleNamespace(type="Ready", status="True")]),
+        spec=types.SimpleNamespace(containers=[types.SimpleNamespace(name="api")]),
+    )
+
+
+class TestMekLifecycle(unittest.TestCase):
+    """Validate the Kubernetes-only lifecycle state machine."""
+
+    def test_secret_json_patch_uses_generated_client_compatible_signature(self):
+        lifecycle = _lifecycle()
+        lifecycle._assert_lease = mock.Mock()  # type: ignore[method-assign]
+        calls = []
+
+        class CompatibleCore:
+            @staticmethod
+            def patch_namespaced_secret(name, namespace, body):
+                calls.append((name, namespace, body))
+                return "patched"
+
+        lifecycle.core = CompatibleCore()
+        keyring = _new_keyring("initial")
+        result = lifecycle._patch_secret(
+            _secret(keyring), keyring, {_PHASE: "prepared"})
+
+        self.assertEqual(result, "patched")
+        self.assertEqual(calls[0][0:2], ("osmo-mek", "osmo"))
+        self.assertEqual(calls[0][2][0]["op"], "test")
+
+    def test_prepare_adds_exactly_one_key_and_keeps_current(self):
+        original = _new_keyring("initial")
+        prepared = _add_candidate(original, "rotate-1")
+        self.assertEqual(prepared.current_key_id, original.current_key_id)
+        self.assertEqual(set(prepared.fingerprints) - set(original.fingerprints), {"mek-rotate-1"})
+        self.assertTrue(set(original.fingerprints).issubset(prepared.fingerprints))
+
+    def test_bootstrap_rejects_an_unowned_existing_secret(self):
+        lifecycle = _lifecycle("bootstrap")
+        lifecycle._optional_secret = mock.Mock(  # type: ignore[method-assign]
+            return_value=_secret(_new_keyring("initial")))
+        lifecycle._authenticate_existing_database = mock.Mock()  # type: ignore[method-assign]
+        with self.assertRaisesRegex(osmo_errors.OSMOError, "exact bootstrap retry"):
+            lifecycle.bootstrap()
+        lifecycle._authenticate_existing_database.assert_not_called()
+
+    def test_bootstrap_retry_authenticates_exact_owned_secret_without_mutation(self):
+        lifecycle = _lifecycle("bootstrap")
+        keyring = _new_keyring("initial")
+        lifecycle._optional_secret = mock.Mock(  # type: ignore[method-assign]
+            return_value=_secret(keyring, {
+                _INSTALLATION: "osmo/release",
+                _PHASE: "idle",
+                _BUNDLE_DIGEST: keyring.registry_digest,
+            }))
+        lifecycle._authenticate_existing_database = mock.Mock()  # type: ignore[method-assign]
+        lifecycle._create_secret = mock.Mock()  # type: ignore[method-assign]
+        lifecycle.bootstrap()
+        lifecycle._authenticate_existing_database.assert_called_once_with(keyring)
+        lifecycle._create_secret.assert_not_called()
+
+    def test_prepare_persists_strict_adjacent_annotations(self):
+        lifecycle = _lifecycle()
+        original = _new_keyring("initial")
+        secret = _secret(original, {_INSTALLATION: "osmo/release", _PHASE: "idle"})
+        lifecycle._secret = mock.Mock(return_value=secret)  # type: ignore[method-assign]
+        lifecycle._patch_secret = mock.Mock()  # type: ignore[method-assign]
+        lifecycle.prepare()
+        patched = lifecycle._patch_secret.call_args.args[1]
+        annotations = lifecycle._patch_secret.call_args.args[2]
+        self.assertEqual(patched.current_key_id, original.current_key_id)
+        self.assertEqual(annotations[_REQUEST], "rotate-1")
+        self.assertEqual(annotations[_PHASE], "prepared")
+        self.assertEqual(annotations[_PREDECESSOR_CURRENT], original.current_key_id)
+        self.assertEqual(annotations[_PREPARE_GENERATION], patched.generation)
+        self.assertEqual(annotations[_BUNDLE_DIGEST], patched.registry_digest)
+
+    def test_prepare_resume_reuses_candidate(self):
+        lifecycle = _lifecycle()
+        prepared = _add_candidate(_new_keyring("initial"), "rotate-1")
+        secret = _secret(prepared, {
+            _INSTALLATION: "osmo/release",
+            _REQUEST: "rotate-1",
+            _PHASE: "prepared",
+            _PREPARE_GENERATION: prepared.generation,
+            _BUNDLE_DIGEST: prepared.registry_digest,
+        })
+        lifecycle._secret = mock.Mock(return_value=secret)  # type: ignore[method-assign]
+        lifecycle._patch_secret = mock.Mock()  # type: ignore[method-assign]
+        lifecycle.prepare()
+        lifecycle._patch_secret.assert_not_called()
+
+    def test_activate_requires_verified_prepare_cohort(self):
+        lifecycle = _lifecycle("activate")
+        prepared = _add_candidate(_new_keyring("initial"), "rotate-1")
+        candidate = "mek-rotate-1"
+        secret = _secret(prepared, {
+            _INSTALLATION: "osmo/release",
+            _REQUEST: "rotate-1",
+            _PHASE: "prepared",
+            _PREDECESSOR_CURRENT: prepared.current_key_id,
+            _PREPARE_GENERATION: prepared.generation,
+            _BUNDLE_DIGEST: prepared.registry_digest,
+            _CANDIDATE: candidate,
+        })
+        lifecycle._secret = mock.Mock(return_value=secret)  # type: ignore[method-assign]
+        lifecycle.verify_rollout = mock.Mock()  # type: ignore[method-assign]
+        lifecycle._patch_secret = mock.Mock()  # type: ignore[method-assign]
+        lifecycle.activate()
+        lifecycle.verify_rollout.assert_called_once_with(prepared)
+        activated = lifecycle._patch_secret.call_args.args[1]
+        annotations = lifecycle._patch_secret.call_args.args[2]
+        self.assertEqual(activated.current_key_id, candidate)
+        self.assertEqual(annotations[_PHASE], "activated")
+        self.assertEqual(annotations[_ACTIVATE_GENERATION], activated.generation)
+
+    def test_activate_retry_accepts_already_committed_matching_state(self):
+        lifecycle = _lifecycle("activate")
+        prepared = _add_candidate(_new_keyring("initial"), "rotate-1")
+        document = dict(prepared.document)
+        document["currentMek"] = "mek-rotate-1"
+        activated = _parse_keyring(_serialize_keyring(document))
+        secret = _secret(activated, {
+            _INSTALLATION: "osmo/release",
+            _REQUEST: "rotate-1",
+            _PHASE: "activated",
+            _ACTIVATE_GENERATION: activated.generation,
+            _BUNDLE_DIGEST: activated.registry_digest,
+            _CANDIDATE: activated.current_key_id,
+        })
+        lifecycle._secret = mock.Mock(return_value=secret)  # type: ignore[method-assign]
+        lifecycle.verify_rollout = mock.Mock()  # type: ignore[method-assign]
+        lifecycle._patch_secret = mock.Mock()  # type: ignore[method-assign]
+        lifecycle.activate()
+        lifecycle.verify_rollout.assert_not_called()
+        lifecycle._patch_secret.assert_not_called()
+
+    def test_external_mode_cannot_mutate_prepare_or_activate(self):
+        for operation in ("prepare", "activate"):
+            with self.subTest(operation=operation):
+                lifecycle = _lifecycle(operation, "external")
+                with self.assertRaisesRegex(osmo_errors.OSMOError, "managed mode"):
+                    getattr(lifecycle, operation)()
+
+    @mock.patch("src.utils.secret_manager.mek_lifecycle.connectors.PostgresConnector")
+    def test_managed_rewrap_retry_accepts_matching_completion(self, connector_class):
+        lifecycle = _lifecycle("rewrap")
+        prepared = _add_candidate(_new_keyring("initial"), "rotate-1")
+        document = dict(prepared.document)
+        document["currentMek"] = "mek-rotate-1"
+        activated = _parse_keyring(_serialize_keyring(document))
+        secret = _secret(activated, {
+            _INSTALLATION: "osmo/release",
+            _REQUEST: "rotate-1",
+            _PHASE: "complete",
+            _COMPLETED: "rotate-1",
+            _ACTIVATE_GENERATION: activated.generation,
+            _BUNDLE_DIGEST: activated.registry_digest,
+            _CANDIDATE: activated.current_key_id,
+        })
+        lifecycle._secret = mock.Mock(return_value=secret)  # type: ignore[method-assign]
+        lifecycle.verify_rollout = mock.Mock()  # type: ignore[method-assign]
+        lifecycle.rewrap()
+        connector_class.assert_not_called()
+        lifecycle.verify_rollout.assert_not_called()
+
+    @mock.patch("src.utils.secret_manager.mek_lifecycle.connectors.PostgresConnector")
+    def test_external_rewrap_uses_live_activated_bundle_without_managed_annotations(
+            self, connector_class):
+        lifecycle = _lifecycle("rewrap", "external")
+        activated = _add_candidate(_new_keyring("initial"), "rotate-1")
+        secret = _secret(activated)
+        lifecycle._secret = mock.Mock(side_effect=[secret, secret])  # type: ignore[method-assign]
+        lifecycle.verify_rollout = mock.Mock()  # type: ignore[method-assign]
+        lifecycle._patch_secret = mock.Mock()  # type: ignore[method-assign]
+        lifecycle.rewrap()
+        self.assertEqual(lifecycle.verify_rollout.call_count, 2)
+        connector_class.return_value.rewrap_mek_references.assert_called_once_with(
+            deadline_seconds=mock.ANY,
+            expected_generation=activated.generation,
+            expected_current_kid=activated.current_key_id,
+            expected_registry_digest=activated.registry_digest,
+        )
+        lifecycle._patch_secret.assert_not_called()
+
+    def test_descriptor_log_is_exact_machine_readable_json(self):
+        descriptor = {
+            "currentKid": "key2",
+            "loadedKids": ["key1", "key2"],
+            "generation": "abc",
+            "digest": "def",
+        }
+        log = "prefix\nINFO OSMO_MEK_DESCRIPTOR " + json.dumps(descriptor)
+        self.assertEqual(MekLifecycle._descriptor_from_log(log), descriptor)
+        structured_log = json.dumps({
+            "timestamp": "2026-08-21T00:00:00Z",
+            "level": "INFO",
+            "message": "OSMO_MEK_DESCRIPTOR " + json.dumps(descriptor),
+        })
+        self.assertEqual(MekLifecycle._descriptor_from_log(structured_log), descriptor)
+        with self.assertRaisesRegex(osmo_errors.OSMOError, "descriptor"):
+            MekLifecycle._descriptor_from_log("normal startup")
+
+    def test_lease_is_never_stolen_from_another_holder(self):
+        lifecycle = _lifecycle()
+        lifecycle.holder = "rotate-1:prepare:pod-1"
+        lifecycle.lease_name = "release-mek-deadbeef"
+        lifecycle.coordination = mock.Mock()
+        lifecycle.coordination.read_namespaced_lease.return_value = types.SimpleNamespace(
+            spec=types.SimpleNamespace(holder_identity="old:prepare:pod-old"))
+        with self.assertRaisesRegex(osmo_errors.OSMOError, "delete the old Job Pod"):
+            lifecycle.acquire_lease()
+        lifecycle.coordination.patch_namespaced_lease.assert_not_called()
+
+    def test_missing_lease_is_created_outside_helm_desired_state(self):
+        lifecycle = _lifecycle()
+        lifecycle.holder = "rotate-1:prepare:pod-1"
+        lifecycle.lease_name = "release-mek-deadbeef"
+        lifecycle.coordination = mock.Mock()
+        missing = lifecycle_module.kubernetes_exceptions.ApiException(status=404)
+        created = types.SimpleNamespace(
+            metadata=types.SimpleNamespace(resource_version="1"),
+            spec=types.SimpleNamespace(holder_identity=""))
+        lifecycle.coordination.read_namespaced_lease.side_effect = missing
+        lifecycle.coordination.create_namespaced_lease.return_value = created
+        lifecycle.acquire_lease()
+        lifecycle.coordination.create_namespaced_lease.assert_called_once()
+        lifecycle.coordination.patch_namespaced_lease.assert_called_once()
+
+    def test_every_unexpected_selected_pod_blocks_attestation(self):
+        lifecycle = _lifecycle("activate")
+        lifecycle.apps = mock.Mock()
+        lifecycle.core = mock.Mock()
+        lifecycle.apps.read_namespaced_deployment.return_value = _deployment()
+        current = _replica_set("api-current", "rs-current", 2)
+        old = _replica_set("api-old", "rs-old", 1)
+        expected = _new_keyring("initial")
+        cases = {
+            "standalone": ([current], _pod([])),
+            "wrong-owner": ([current], _pod([_owner("ReplicaSet", "other", "other-rs")])),
+            "stale-rs-uid": (
+                [current], _pod([_owner("ReplicaSet", "api-current", "stale-uid")])),
+            "old-replica-set": (
+                [old, current], _pod([_owner("ReplicaSet", "api-old", "rs-old")])),
+            "terminating": (
+                [current], _pod(
+                    [_owner("ReplicaSet", "api-current", "rs-current")], "now")),
+        }
+        for name, (replica_sets, pod) in cases.items():
+            with self.subTest(name=name):
+                lifecycle.apps.list_namespaced_replica_set.return_value = \
+                    types.SimpleNamespace(items=replica_sets)
+                lifecycle.core.list_namespaced_pod.return_value = \
+                    types.SimpleNamespace(items=[pod])
+                with self.assertRaises(osmo_errors.OSMOError):
+                    lifecycle._observe_pods_once(expected)
+
+    @mock.patch("src.utils.secret_manager.mek_lifecycle._run")
+    def test_unexpected_failure_boundary_never_logs_exception_text(self, run):
+        sentinel = "MEK-SENTINEL-DO-NOT-LOG"
+        run.side_effect = RuntimeError(sentinel)
+        with self.assertLogs(level="ERROR") as captured:
+            with self.assertRaises(SystemExit):
+                lifecycle_module.main()
+        self.assertNotIn(sentinel, "\n".join(captured.output))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/utils/secret_manager/tests/test_secret_manager.py
+++ b/src/utils/secret_manager/tests/test_secret_manager.py
@@ -144,6 +144,20 @@ class TestSecretManager(unittest.TestCase):
             replacement.decrypt(new)
             self.assertEqual(replacement.payload, b"secret")
 
+    def test_empty_direct_mek_ciphertext_authenticates_and_decrypts(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mek.yaml"
+            key = _key("key1")
+            _write(path, "key1", {"key1": key})
+            manager = _manager(path, Store())
+
+            encrypted = manager.encrypt("", "")
+            self.assertEqual(manager.authenticate_mek_encrypted(encrypted.value), "key1")
+            callbacks: list[str] = []
+            self.assertEqual(
+                manager.decrypt(encrypted, "", callbacks.append).value, "")
+            self.assertEqual(callbacks, [])
+
     def test_uek_rewrap_is_cas_and_preserves_payload(self):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "mek.yaml"

--- a/src/utils/secret_manager/tests/test_secret_manager.py
+++ b/src/utils/secret_manager/tests/test_secret_manager.py
@@ -1,0 +1,189 @@
+"""Tests for startup-only MEK loading and explicit rewrap primitives."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+from pathlib import Path
+import tempfile
+import traceback
+import unittest
+
+from jwcrypto import jwk, jwe  # type: ignore
+from jwcrypto.common import json_encode  # type: ignore
+
+from src.lib.utils import osmo_errors
+from src.utils.secret_manager import Encrypted, SecretManager
+
+
+def _key(key_id: str) -> jwk.JWK:
+    return jwk.JWK.generate(kty="oct", size=256, kid=key_id)
+
+
+def _encoded(key: jwk.JWK) -> str:
+    return base64.b64encode(
+        json.dumps(key.export(as_dict=True), separators=(",", ":")).encode()
+    ).decode()
+
+
+def _write(path: Path, current: str, keys: dict[str, jwk.JWK]) -> None:
+    path.write_text(
+        "currentMek: " + current + "\nmeks:\n" +
+        "".join(f"  {key_id}: {_encoded(key)}\n" for key_id, key in keys.items()),
+        encoding="utf-8",
+    )
+
+
+class Store:
+    """Minimal compare-and-set persistence double."""
+
+    def __init__(self):
+        self.wrappers: dict[tuple[str, str], str] = {}
+        self.current: dict[str, str] = {}
+
+    def read(self, uid: str, kid: str) -> str:
+        return self.wrappers[(uid, kid)]
+
+    def write(self, uid: str, kid: str, new: str, old: str) -> bool:
+        if self.wrappers.get((uid, kid)) != old:
+            return False
+        self.wrappers[(uid, kid)] = new
+        return True
+
+    def add(self, uid: str, values: dict) -> None:
+        self.current[uid] = values["current"]
+        for kid, value in values.items():
+            if kid != "current":
+                self.wrappers[(uid, kid)] = value
+
+
+def _manager(path: Path, store: Store) -> SecretManager:
+    return SecretManager(
+        str(path), store.read, store.write,
+        lambda uid: store.current[uid], store.add)
+
+
+def _wrap_uek(user_key: jwk.JWK, wrapping_key: jwk.JWK) -> str:
+    token = jwe.JWE(
+        user_key.export().encode(),
+        json_encode({"alg": "A256GCMKW", "enc": "A256GCM", "kid": wrapping_key.key_id}),
+    )
+    token.add_recipient(wrapping_key)
+    return token.serialize(True)
+
+
+class TestSecretManager(unittest.TestCase):
+    """Validate startup-only loading and explicit authenticated rewrites."""
+
+    def test_keyring_is_loaded_only_at_startup(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mek.yaml"
+            first, second = _key("key1"), _key("key2")
+            _write(path, "key1", {"key1": first})
+            manager = _manager(path, Store())
+            _write(path, "key2", {"key1": first, "key2": second})
+            self.assertEqual(manager.current_mek_id, "key1")
+            self.assertEqual(sorted(manager.meks), ["key1"])
+
+            replacement = _manager(path, Store())
+            self.assertEqual(replacement.current_mek_id, "key2")
+            self.assertEqual(sorted(replacement.meks), ["key1", "key2"])
+
+    def test_generation_is_public_but_digest_binds_material(self):
+        with tempfile.TemporaryDirectory() as directory:
+            first_path = Path(directory) / "one.yaml"
+            second_path = Path(directory) / "two.yaml"
+            _write(first_path, "key1", {"key1": _key("key1")})
+            _write(second_path, "key1", {"key1": _key("key1")})
+            first = _manager(first_path, Store())
+            second = _manager(second_path, Store())
+            self.assertEqual(first.generation, second.generation)
+            self.assertNotEqual(
+                first.fingerprint_bundle_digest(), second.fingerprint_bundle_digest())
+
+    def test_parser_rejects_duplicate_material_and_does_not_leak(self):
+        sentinel = "MEK-SENTINEL-DO-NOT-LOG"
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mek.yaml"
+            path.write_text(
+                f"currentMek: key1\nmeks:\n  {sentinel}: first\n"
+                f"  {sentinel}: second\n",
+                encoding="utf-8",
+            )
+            try:
+                _manager(path, Store())
+            except osmo_errors.OSMOError as error:
+                rendered = "".join(traceback.format_exception(error))
+                self.assertNotIn(sentinel, str(error))
+                self.assertNotIn(sentinel, rendered)
+            else:
+                self.fail("invalid keyring was accepted")
+
+    def test_direct_mek_decrypt_is_read_only_and_explicit_rewraps(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mek.yaml"
+            old, new = _key("key1"), _key("key2")
+            _write(path, "key2", {"key1": old, "key2": new})
+            manager = _manager(path, Store())
+            token = jwe.JWE(
+                b"secret",
+                json_encode({"alg": manager.alg, "enc": manager.enc, "kid": "key1"}),
+            )
+            token.add_recipient(old)
+            original = token.serialize(True)
+            callbacks: list[str] = []
+            self.assertEqual(
+                manager.decrypt(Encrypted(original), "", callbacks.append).value, "secret")
+            self.assertEqual(callbacks, [])
+
+            result = manager.rewrap_direct_mek(original, manager.rewrap_snapshot())
+            self.assertEqual(result.status, "rewrapped")
+            replacement = jwe.JWE()
+            replacement.deserialize(result.value)
+            self.assertEqual(replacement.jose_header["kid"], "key2")
+            replacement.decrypt(new)
+            self.assertEqual(replacement.payload, b"secret")
+
+    def test_uek_rewrap_is_cas_and_preserves_payload(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mek.yaml"
+            old, new = _key("key1"), _key("key2")
+            _write(path, "key2", {"key1": old, "key2": new})
+            store = Store()
+            manager = _manager(path, store)
+            user_key = _key("uek1")
+            store.current["user"] = "uek1"
+            store.wrappers[("user", "uek1")] = _wrap_uek(user_key, old)
+
+            result = manager.rewrap_uek("user", "uek1", manager.rewrap_snapshot())
+            self.assertEqual(result.status, "rewrapped")
+            reread, _ = manager.get_uek("user", "uek1")
+            self.assertEqual(reread.export(as_dict=True), user_key.export(as_dict=True))
+            self.assertEqual(
+                manager.rewrap_uek("user", "uek1", manager.rewrap_snapshot()).status,
+                "already-current",
+            )
+
+    def test_uek_cas_loser_must_authenticate_same_payload(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mek.yaml"
+            old, new = _key("key1"), _key("key2")
+            _write(path, "key2", {"key1": old, "key2": new})
+            store = Store()
+            manager = _manager(path, store)
+            user_key = _key("uek1")
+            store.current["user"] = "uek1"
+            store.wrappers[("user", "uek1")] = _wrap_uek(user_key, old)
+
+            def lose_cas(uid: str, kid: str, new: str, old: str) -> bool:
+                del uid, kid, new, old
+                store.wrappers[("user", "uek1")] = "malformed"
+                return False
+
+            manager.write_uek = lose_cas
+            with self.assertRaisesRegex(osmo_errors.OSMOError, "authentication"):
+                manager.rewrap_uek("user", "uek1", manager.rewrap_snapshot())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/oetf/BUILD
+++ b/test/oetf/BUILD
@@ -67,6 +67,8 @@ osmo_py_library(
     srcs = ["deploy_adapters/kind_adapter.py"],
     data = [
         "data/kind-osmo-cluster-config.yaml",
+        "@osmo_workspace//deployments/charts:backend-operator",
+        "@osmo_workspace//deployments/charts:service",
     ],
     deps = [
         ":deploy_adapters_base",

--- a/test/oetf/README.md
+++ b/test/oetf/README.md
@@ -971,7 +971,7 @@ The adapter pins no chart version by default — it uses the latest from
 the helm repo. Pass `--chart-version <X.Y.Z>` to lock to a specific
 chart release (CI does this). Forward-compatibility relies on the
 override keys (`global.osmoImageTag`, `ingress-nginx.controller.nodeSelector.*`,
-`web-ui.services.ui.imagePullPolicy`) staying stable across chart releases.
+`service.services.ui.imagePullPolicy`) staying stable across chart releases.
 
 
 ### Prereqs (one-time)

--- a/test/oetf/bzl/oetf.bzl
+++ b/test/oetf/bzl/oetf.bzl
@@ -28,12 +28,20 @@ load("@osmo_python_deps//:requirements.bzl", "requirement")
 _COMMON_TAGS = ["external", "requires-network", "no-sandbox", "manual"]
 
 
-def oetf_smoke_test(name, src, tags = [], extra_deps = [], size = "medium", timeout = "moderate"):
+def oetf_smoke_test(
+        name,
+        src,
+        data = [],
+        tags = [],
+        extra_deps = [],
+        size = "medium",
+        timeout = "moderate"):
     """A smoke test — one py_test making HTTP/CLI/WebSocket probes against OSMO.
 
     Args:
       name: Bazel target name.
       src: the single .py file (a SmokeFixture subclass with test_* methods).
+      data: extra runfiles required by the test.
       tags: additional filter tags (e.g. ["health", "auth"]).
       extra_deps: additional Bazel labels the test needs (e.g. a requirement
         only this test uses).
@@ -44,6 +52,7 @@ def oetf_smoke_test(name, src, tags = [], extra_deps = [], size = "medium", time
         name = name,
         srcs = [src],
         main = src,
+        data = data,
         deps = [
             "@osmo_workspace//test/oetf:smoke_fixture",
             "@osmo_workspace//test/oetf:fixture_base",

--- a/test/oetf/deploy_adapters/kind_adapter.py
+++ b/test/oetf/deploy_adapters/kind_adapter.py
@@ -62,6 +62,7 @@ OSMO_HELM_REPO_URL = "https://helm.ngc.nvidia.com/nvidia/osmo"
 OSMO_CHART_REF = "osmo/quick-start"
 OSMO_NAMESPACE = "osmo"
 OSMO_GATEWAY_SERVICE = "osmo-gateway"
+OETF_HELM_CHART_PATH = "OETF_HELM_CHART_PATH"
 
 # kai-scheduler is a soft dependency of osmo/quick-start — its pods have
 # schedulerName=kai-scheduler and won't schedule without it installed. Version
@@ -362,6 +363,9 @@ class KindAdapter:
     # Injected for tests — callables matching subprocess.run / urllib.request.urlopen.
     subprocess_runner: Optional[Callable[..., Any]] = None
     url_opener: Optional[Callable[..., Any]] = None
+    _retained_quick_start_directory: Optional[
+        tempfile.TemporaryDirectory[str]
+    ] = dataclasses.field(default=None, init=False, repr=False)
 
     # --- Lifecycle -------------------------------------------------------- #
 
@@ -575,7 +579,10 @@ class KindAdapter:
 
     def teardown(self, params: DeployParams) -> None:
         cluster_name = params.cluster_name or DEFAULT_CLUSTER_NAME
-        self._kind_delete(cluster_name)
+        try:
+            self._kind_delete(cluster_name)
+        finally:
+            self._cleanup_retained_quick_start_chart()
 
     # --- Steps ------------------------------------------------------------ #
 
@@ -781,8 +788,40 @@ class KindAdapter:
         with self._quick_start_chart_ref() as chart_ref:
             self._helm_install_chart(chart_ref)
 
+    def _retain_quick_start_chart(self, chart_ref: str) -> str:
+        """Keep the exact installed umbrella chart available to live tests.
+
+        Local KIND installs substitute PR-local dependencies into a temporary
+        copy of the published quick-start chart. MEK phase tests must upgrade
+        that same umbrella release; using the standalone service subchart
+        changes the values shape and would also make Helm prune the umbrella's
+        other resources. Retain a second copy until the deploy/test session
+        ends and pass its path to Bazel through a dedicated environment value.
+        """
+        self._cleanup_retained_quick_start_chart()
+        retained_directory = tempfile.TemporaryDirectory(  # pylint: disable=consider-using-with
+            prefix="osmo-oetf-quick-start-",
+        )
+        retained_chart = os.path.join(retained_directory.name, "quick-start")
+        shutil.copytree(chart_ref, retained_chart)
+        self._retained_quick_start_directory = retained_directory
+        os.environ[OETF_HELM_CHART_PATH] = retained_chart
+        return retained_chart
+
+    def _cleanup_retained_quick_start_chart(self) -> None:
+        retained_directory = self._retained_quick_start_directory
+        if retained_directory is None:
+            return
+        retained_chart = os.path.join(retained_directory.name, "quick-start")
+        if os.environ.get(OETF_HELM_CHART_PATH) == retained_chart:
+            os.environ.pop(OETF_HELM_CHART_PATH, None)
+        retained_directory.cleanup()
+        self._retained_quick_start_directory = None
+
     def _helm_install_chart(self, chart_ref: str) -> None:
         """Install one resolved quick-start chart reference."""
+        if self.build_local and chart_ref != OSMO_CHART_REF:
+            chart_ref = self._retain_quick_start_chart(chart_ref)
         args = [
             "helm", "upgrade", "--install", "osmo", chart_ref,
             "--namespace", OSMO_NAMESPACE, "--create-namespace",

--- a/test/oetf/deploy_adapters/kind_adapter.py
+++ b/test/oetf/deploy_adapters/kind_adapter.py
@@ -813,6 +813,8 @@ class KindAdapter:
             args += _build_local_helm_args()
             args += [
                 "--set",
+                "service.services.masterEncryptionKey.managementMode=osmo",
+                "--set",
                 "service.services.masterEncryptionKey.bootstrap.enabled=true",
             ]
         for extra in self.extra_helm_sets:

--- a/test/oetf/deploy_adapters/kind_adapter.py
+++ b/test/oetf/deploy_adapters/kind_adapter.py
@@ -26,7 +26,9 @@ license agreement from NVIDIA CORPORATION is strictly prohibited.
 # this adapter — it had multiple upstream issues on CPU-only hosts and is
 # redundant with the umbrella chart.
 
+import contextlib
 import dataclasses
+import glob
 import json
 import logging
 import os
@@ -34,10 +36,13 @@ import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.request
 from typing import Any, Callable, Dict, List, Optional
+
+import yaml
 
 from test.oetf import local_images
 from test.oetf.deploy_adapters.base import DeployParams
@@ -56,6 +61,7 @@ OSMO_HELM_REPO_NAME = "osmo"
 OSMO_HELM_REPO_URL = "https://helm.ngc.nvidia.com/nvidia/osmo"
 OSMO_CHART_REF = "osmo/quick-start"
 OSMO_NAMESPACE = "osmo"
+OSMO_GATEWAY_SERVICE = "osmo-gateway"
 
 # kai-scheduler is a soft dependency of osmo/quick-start — its pods have
 # schedulerName=kai-scheduler and won't schedule without it installed. Version
@@ -88,11 +94,11 @@ _BUILD_LOCAL_SERVICES = (
     ("service", "service"),
     ("service", "delayedJobMonitor"),
     ("service", "logger"),
+    ("service", "router"),
+    ("service", "ui"),
     ("service", "worker"),
-    ("router", "service"),
     ("backend-operator", "backendListener"),
     ("backend-operator", "backendWorker"),
-    ("web-ui", "ui"),
 )
 _BUILD_LOCAL_PULL_POLICY_OVERRIDES = tuple(
     f"{chart}.services.{svc}.imagePullPolicy=IfNotPresent"
@@ -140,6 +146,166 @@ def _default_kind_config_path() -> str:
     )
 
 
+def _local_service_chart_path() -> str:
+    """Resolve the maintained service chart bundled in this adapter's runfiles."""
+    return os.path.normpath(os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "..", "..",
+        "deployments", "charts", "service",
+    ))
+
+
+def _local_backend_operator_chart_path() -> str:
+    """Resolve the maintained backend-operator chart in the runfiles."""
+    return os.path.normpath(os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "..", "..",
+        "deployments", "charts", "backend-operator",
+    ))
+
+
+def _replace_packaged_dependency(
+    chart_directory: str,
+    dependency_name: str,
+    local_chart: str,
+) -> None:
+    """Replace one dependency in a pulled umbrella with its source chart."""
+    dependency_directory = os.path.join(chart_directory, "charts")
+    packaged_chart = os.path.join(dependency_directory, dependency_name)
+    if os.path.isdir(packaged_chart):
+        shutil.rmtree(packaged_chart)
+    for archive in glob.glob(
+        os.path.join(dependency_directory, f"{dependency_name}-*.tgz"),
+    ):
+        os.unlink(archive)
+    shutil.copytree(local_chart, packaged_chart)
+
+
+def _merge_values(base: Dict[str, Any], overlay: Dict[str, Any]) -> None:
+    """Recursively merge a small compatibility overlay into Helm values."""
+    for key, value in overlay.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _merge_values(base[key], value)
+        else:
+            base[key] = value
+
+
+def _configure_current_quick_start_charts(
+    chart_directory: str,
+    local_backend_operator_chart: str,
+) -> None:
+    """Bridge the released umbrella values to the current source charts.
+
+    quick-start 1.2.1 predates both the gateway consolidation and managed
+    backend API-token Secrets. Keep its ingress-nginx and data-service values,
+    but apply the maintained charts' development authentication contract.
+    """
+    backend_values_path = os.path.join(
+        local_backend_operator_chart, "quick-start-values.yaml",
+    )
+    with open(backend_values_path, "r", encoding="utf-8") as values_file:
+        backend_values = yaml.safe_load(values_file)
+    backend_values["global"]["serviceUrl"] = (
+        f"http://{OSMO_GATEWAY_SERVICE}.{OSMO_NAMESPACE}.svc.cluster.local"
+    )
+    for component in ("backendListener", "backendWorker"):
+        for init_container in (
+            backend_values["services"][component].get("initContainers", [])
+        ):
+            if init_container.get("name") == "wait-for-gateway":
+                command = init_container.get("command", [])
+                if command:
+                    command[-1] = command[-1].replace(
+                        "quick-start", OSMO_GATEWAY_SERVICE,
+                    )
+
+    values_path = os.path.join(chart_directory, "values.yaml")
+    with open(values_path, "r", encoding="utf-8") as values_file:
+        values = yaml.safe_load(values_file)
+
+    overlay = {
+        "global": {
+            "hostname": KIND_HOSTNAME,
+        },
+        "service": {
+            "services": {
+                "backendApiTokens": {
+                    "enabled": True,
+                    "credentials": [{
+                        "name": "default",
+                        "managedSecret": {"name": "backend-operator-token"},
+                    }],
+                },
+            },
+            "gateway": {
+                # The umbrella ingress-nginx Service is already named
+                # quick-start. Keep the gateway on its standard internal
+                # name so both Services can coexist.
+                "name": OSMO_GATEWAY_SERVICE,
+                "envoy": {
+                    "hostname": KIND_HOSTNAME,
+                    "service": {
+                        "type": "ClusterIP",
+                        "httpsPort": None,
+                    },
+                    "ingress": {
+                        "enabled": True,
+                        "ingressClass": "nginx",
+                        "sslEnabled": False,
+                    },
+                    "defaultIdentity": {
+                        "user": "testuser",
+                        "roles": "osmo-admin",
+                        "allowedPools": "default",
+                    },
+                },
+                "oauth2Proxy": {"enabled": False},
+                "authz": {"enabled": False},
+            },
+        },
+        "backend-operator": backend_values,
+    }
+    _merge_values(values, overlay)
+    with open(values_path, "w", encoding="utf-8") as values_file:
+        yaml.safe_dump(values, values_file, sort_keys=False)
+
+
+def _remove_superseded_quick_start_dependencies(chart_directory: str) -> None:
+    """Remove subcharts now owned by the maintained service chart.
+
+    quick-start 1.2.1 predates the router/UI consolidation and bundles those
+    as independent subcharts. The current service chart renders both, so
+    retaining the old dependencies creates duplicate Kubernetes resources.
+    This is a temporary-copy edit only; the published artifact is untouched.
+    """
+    superseded = {"router", "web-ui"}
+    chart_path = os.path.join(chart_directory, "Chart.yaml")
+    with open(chart_path, "r", encoding="utf-8") as chart_file:
+        chart = yaml.safe_load(chart_file)
+    dependencies = chart.get("dependencies", [])
+    chart["dependencies"] = [
+        dependency for dependency in dependencies
+        if dependency.get("name") not in superseded
+    ]
+    with open(chart_path, "w", encoding="utf-8") as chart_file:
+        yaml.safe_dump(chart, chart_file, sort_keys=False)
+
+    dependency_directory = os.path.join(chart_directory, "charts")
+    for dependency_name in superseded:
+        unpacked = os.path.join(dependency_directory, dependency_name)
+        if os.path.isdir(unpacked):
+            shutil.rmtree(unpacked)
+        for archive in glob.glob(
+            os.path.join(dependency_directory, f"{dependency_name}-*.tgz"),
+        ):
+            os.unlink(archive)
+
+    # Chart.lock describes the original dependency list. Helm install does
+    # not need it, and retaining a stale lock invites a future accidental
+    # dependency update to restore the superseded charts.
+    lock_path = os.path.join(chart_directory, "Chart.lock")
+    if os.path.isfile(lock_path):
+        os.unlink(lock_path)
+
+
 @dataclasses.dataclass
 class KindAdapter:
     """Deploy OSMO on a local KIND cluster via the ``osmo/quick-start`` chart.
@@ -183,8 +349,8 @@ class KindAdapter:
     pre_install_hook: Optional[Callable[[str], None]] = None
     # When True, helm install adds overrides that make the chart use
     # kind-loaded images (imagePullPolicy=IfNotPresent so the pseudo-registry
-    # ``osmo.local`` isn't actually contacted) and skips the web-ui Deployment
-    # (we don't build the UI image locally — only the 9 Python services).
+    # ``osmo.local`` isn't actually contacted). The local build includes and
+    # deploys the UI image under the same IfNotPresent contract.
     build_local: bool = False
     # When True (paired with build_local), publish locally-built images to a
     # host-side ``registry:2`` container that KIND nodes pull from on-demand
@@ -479,6 +645,69 @@ class KindAdapter:
         )
         return release in out
 
+    @contextlib.contextmanager
+    def _quick_start_chart_ref(self):
+        """Use the PR-local service/backend charts for local-image tests.
+
+        The published quick-start chart necessarily contains the last released
+        dependencies. A source-build KIND gate must replace the charts whose
+        images it builds or chart changes in the PR are never exercised. Other
+        quick-start dependencies remain pinned by the released umbrella chart.
+        """
+        if not self.build_local:
+            yield OSMO_CHART_REF
+            return
+
+        local_service_chart = _local_service_chart_path()
+        local_backend_operator_chart = _local_backend_operator_chart_path()
+        for chart_name, chart_path in (
+            ("service", local_service_chart),
+            ("backend-operator", local_backend_operator_chart),
+        ):
+            if not os.path.isfile(os.path.join(chart_path, "Chart.yaml")):
+                raise RuntimeError(
+                    f"Local {chart_name} chart is unavailable at {chart_path}"
+                )
+
+        with tempfile.TemporaryDirectory(prefix="osmo-quick-start-") as directory:
+            pull_args = [
+                "helm", "pull", OSMO_CHART_REF, "--untar", "--untardir", directory,
+            ]
+            if self.chart_version:
+                pull_args += ["--version", self.chart_version]
+            self._run(pull_args, "Downloading quick-start chart for local substitution")
+
+            chart_directory = os.path.join(directory, "quick-start")
+            # ``helm pull`` downloads the packaged chart, including every
+            # dependency under ``charts/``. Do not run ``helm dependency
+            # update`` here: the released Chart.lock can reference private
+            # staging repositories that public CI cannot authenticate to, and
+            # updating would also move dependencies away from the exact
+            # versions carried by the published quick-start artifact.
+            _remove_superseded_quick_start_dependencies(chart_directory)
+            _replace_packaged_dependency(
+                chart_directory, "service", local_service_chart,
+            )
+            _replace_packaged_dependency(
+                chart_directory, "backend-operator",
+                local_backend_operator_chart,
+            )
+            _configure_current_quick_start_charts(
+                chart_directory, local_backend_operator_chart,
+            )
+
+            # The current service chart owns both bootstrap Secrets. Do not
+            # also run the released ConfigMap/token-generation mechanisms.
+            for legacy_template_name in (
+                "mek-configmap.yaml", "backend-operator-token-secret.yaml",
+            ):
+                legacy_template = os.path.join(
+                    chart_directory, "templates", legacy_template_name,
+                )
+                if os.path.isfile(legacy_template):
+                    os.unlink(legacy_template)
+            yield chart_directory
+
     def _install_kai_scheduler(self) -> None:
         """Install kai-scheduler if it isn't already present.
 
@@ -549,8 +778,13 @@ class KindAdapter:
         # forever, and ``helm --wait`` blocks indefinitely even with
         # metrics-server installed. We use ``kubectl wait`` on the actual
         # Deployments (more meaningful anyway).
+        with self._quick_start_chart_ref() as chart_ref:
+            self._helm_install_chart(chart_ref)
+
+    def _helm_install_chart(self, chart_ref: str) -> None:
+        """Install one resolved quick-start chart reference."""
         args = [
-            "helm", "upgrade", "--install", "osmo", OSMO_CHART_REF,
+            "helm", "upgrade", "--install", "osmo", chart_ref,
             "--namespace", OSMO_NAMESPACE, "--create-namespace",
             # First-run image pulls on CPU hosts can easily exceed 15 min;
             # subsequent runs re-use the docker image cache and are much faster.
@@ -569,7 +803,7 @@ class KindAdapter:
             "--set", "service.services.agent.resources.requests.memory=1Gi",
             "--set", "service.services.agent.resources.limits.memory=1Gi",
         ]
-        if self.chart_version:
+        if self.chart_version and chart_ref == OSMO_CHART_REF:
             args += ["--version", self.chart_version]
         if self.image_location:
             args += ["--set", f"global.osmoImageLocation={self.image_location}"]
@@ -577,6 +811,10 @@ class KindAdapter:
             args += ["--set", f"global.osmoImageTag={self.image_tag}"]
         if self.build_local:
             args += _build_local_helm_args()
+            args += [
+                "--set",
+                "service.services.masterEncryptionKey.bootstrap.enabled=true",
+            ]
         for extra in self.extra_helm_sets:
             args += ["--set", extra]
         self._run(args, "Installing osmo/quick-start (without --wait)")

--- a/test/oetf/main.py
+++ b/test/oetf/main.py
@@ -261,6 +261,13 @@ def build_bazel_command(
         "--test_summary=terse",
         f"--build_event_json_file={bep_path}",
     ]
+    if args.env == "kind":
+        # Bazel gives tests an isolated HOME, so kubectl cannot otherwise see
+        # the kubeconfig created by the KIND deployment step.
+        kubeconfig = os.environ.get("KUBECONFIG")
+        if not kubeconfig:
+            kubeconfig = str(Path.home() / ".kube" / "config")
+        cmd.append(f"--test_env=KUBECONFIG={kubeconfig}")
     cmd.extend(test_args)
     cmd.extend(args.bazel_arg)
     return cmd

--- a/test/oetf/main.py
+++ b/test/oetf/main.py
@@ -268,6 +268,12 @@ def build_bazel_command(
         if not kubeconfig:
             kubeconfig = str(Path.home() / ".kube" / "config")
         cmd.append(f"--test_env=KUBECONFIG={kubeconfig}")
+        # Local-source deploys install a temporary quick-start umbrella chart
+        # with PR-local dependencies. Live phase tests must upgrade that same
+        # chart, rather than replacing the release with a standalone subchart.
+        helm_chart_path = os.environ.get("OETF_HELM_CHART_PATH")
+        if helm_chart_path:
+            cmd.append(f"--test_env=OETF_HELM_CHART_PATH={helm_chart_path}")
     cmd.extend(test_args)
     cmd.extend(args.bazel_arg)
     return cmd

--- a/test/oetf/tests/test_deploy.py
+++ b/test/oetf/tests/test_deploy.py
@@ -427,6 +427,10 @@ class TestKindAdapter(unittest.TestCase):
         )
         osmo_helm_args = next(cmd for cmd in cmds if "/tmp/local-quick-start" in cmd)
         self.assertIn(
+            "service.services.masterEncryptionKey.managementMode=osmo",
+            osmo_helm_args,
+        )
+        self.assertIn(
             "service.services.masterEncryptionKey.bootstrap.enabled=true",
             osmo_helm_args,
         )

--- a/test/oetf/tests/test_deploy.py
+++ b/test/oetf/tests/test_deploy.py
@@ -208,7 +208,30 @@ class TestKindAdapter(unittest.TestCase):
             adapter._quick_start_chart_ref = (  # type: ignore[method-assign]  # pylint: disable=protected-access
                 fake_chart_ref
             )
+            adapter._retain_quick_start_chart = (  # type: ignore[method-assign]  # pylint: disable=protected-access
+                lambda chart_ref: chart_ref
+            )
         return adapter, calls
+
+    def test_local_install_retains_exact_quick_start_chart_for_live_tests(self):
+        adapter = KindAdapter(build_local=True)
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            with tempfile.TemporaryDirectory() as source_directory:
+                chart = os.path.join(source_directory, "quick-start")
+                os.makedirs(chart)
+                with open(
+                    os.path.join(chart, "Chart.yaml"), "w", encoding="utf-8",
+                ) as chart_file:
+                    chart_file.write(
+                        "apiVersion: v2\nname: quick-start\nversion: 0.0.0\n")
+                retained = adapter._retain_quick_start_chart(  # pylint: disable=protected-access
+                    chart)
+
+            self.assertTrue(os.path.isfile(os.path.join(retained, "Chart.yaml")))
+            self.assertEqual(retained, os.environ.get("OETF_HELM_CHART_PATH"))
+            adapter._cleanup_retained_quick_start_chart()  # pylint: disable=protected-access
+            self.assertFalse(os.path.exists(retained))
+            self.assertNotIn("OETF_HELM_CHART_PATH", os.environ)
 
     def test_deploy_creates_cluster_then_helm_installs(self):
         adapter, calls = self._adapter(capture_stdouts=["", "", ""])

--- a/test/oetf/tests/test_deploy.py
+++ b/test/oetf/tests/test_deploy.py
@@ -10,6 +10,7 @@ license agreement from NVIDIA CORPORATION is strictly prohibited.
 
 # Unit tests for oetf.deploy.base + oetf.deploy.kind_adapter + oetf.breadcrumb.
 
+import contextlib
 import dataclasses
 import json
 import os
@@ -17,6 +18,8 @@ import tempfile
 import unittest
 import unittest.mock
 from typing import List
+
+import yaml
 
 from test.oetf import breadcrumb, local_images, teardown_main
 from test.oetf.deploy_adapters import factory
@@ -190,13 +193,22 @@ class TestKindAdapter(unittest.TestCase):
                 capture_idx[0] += 1
             return _FakeCompleted(returncode=code, stdout=stdout)
 
-        return KindAdapter(
+        adapter = KindAdapter(
             image_tag="ci-123",
             subprocess_runner=fake_run,
             url_opener=_always_ok_opener,
             mode=mode,
             build_local=build_local,
-        ), calls
+        )
+        if build_local:
+            @contextlib.contextmanager
+            def fake_chart_ref():
+                yield "/tmp/local-quick-start"
+
+            adapter._quick_start_chart_ref = (  # type: ignore[method-assign]  # pylint: disable=protected-access
+                fake_chart_ref
+            )
+        return adapter, calls
 
     def test_deploy_creates_cluster_then_helm_installs(self):
         adapter, calls = self._adapter(capture_stdouts=["", "", ""])
@@ -413,25 +425,25 @@ class TestKindAdapter(unittest.TestCase):
              "-n", "osmo", "--timeout=10m"),
             cmds,
         )
-        osmo_helm_args = next(cmd for cmd in cmds if "osmo/quick-start" in cmd)
+        osmo_helm_args = next(cmd for cmd in cmds if "/tmp/local-quick-start" in cmd)
+        self.assertIn(
+            "service.services.masterEncryptionKey.bootstrap.enabled=true",
+            osmo_helm_args,
+        )
         self.assertIn(
             "service.services.mcp.imagePullPolicy=IfNotPresent",
             osmo_helm_args,
             f"expected MCP pull policy override, got: {osmo_helm_args}",
         )
         # Build-local helm overrides include UI's pull policy (UI now built locally).
-        helm_args_concat = " ".join(
-            arg for cmd in cmds for arg in cmd
-            if isinstance(arg, str) and arg.startswith("web-ui.")
-        )
         self.assertIn(
-            "web-ui.services.ui.imagePullPolicy=IfNotPresent",
-            helm_args_concat,
-            f"expected web-ui pull policy override, got: {helm_args_concat}",
+            "service.services.ui.imagePullPolicy=IfNotPresent",
+            osmo_helm_args,
+            f"expected web-ui pull policy override, got: {osmo_helm_args}",
         )
         self.assertNotIn(
-            "web-ui.services.ui.replicas=0",
-            helm_args_concat,
+            "service.services.ui.replicas=0",
+            osmo_helm_args,
             "build-local should NO LONGER scale UI to 0; we build it locally now",
         )
 
@@ -448,6 +460,240 @@ class TestKindAdapter(unittest.TestCase):
             rollout_calls, [],
             f"expected no rollout restart on first deploy, got: {rollout_calls}",
         )
+
+    def test_local_chart_substitution_keeps_packaged_dependencies_offline(self):
+        """Source charts replace obsolete packaged dependencies without network fetches."""
+        calls: List[List[str]] = []
+        with tempfile.TemporaryDirectory() as source_directory:
+            local_service = os.path.join(source_directory, "service")
+            os.makedirs(local_service)
+            with open(
+                os.path.join(local_service, "Chart.yaml"), "w", encoding="utf-8",
+            ) as chart_file:
+                chart_file.write("apiVersion: v2\nname: service\nversion: 1.0.0\n")
+            with open(
+                os.path.join(local_service, "source-marker"), "w", encoding="utf-8",
+            ) as marker:
+                marker.write("current service")
+
+            local_backend_operator = os.path.join(
+                source_directory, "backend-operator",
+            )
+            os.makedirs(local_backend_operator)
+            with open(
+                os.path.join(local_backend_operator, "Chart.yaml"),
+                "w", encoding="utf-8",
+            ) as chart_file:
+                chart_file.write(
+                    "apiVersion: v2\nname: backend-operator\nversion: 1.0.0\n",
+                )
+            with open(
+                os.path.join(local_backend_operator, "source-marker"),
+                "w", encoding="utf-8",
+            ) as marker:
+                marker.write("current backend operator")
+            with open(
+                os.path.join(local_backend_operator, "quick-start-values.yaml"),
+                "w", encoding="utf-8",
+            ) as values_file:
+                values_file.write(
+                    "global:\n"
+                    "  serviceUrl: http://quick-start.osmo.svc.cluster.local\n"
+                    "  accountTokenSecret: backend-operator-token\n"
+                    "  accountTokenSecretKey: token\n"
+                    "services:\n"
+                    "  backendListener:\n"
+                    "    initContainers:\n"
+                    "    - name: wait-for-gateway\n"
+                    "      command:\n"
+                    "      - sh\n"
+                    "      - -c\n"
+                    "      - until nc -z quick-start 80; do sleep 2; done\n"
+                    "  backendWorker:\n"
+                    "    initContainers:\n"
+                    "    - name: wait-for-gateway\n"
+                    "      command:\n"
+                    "      - sh\n"
+                    "      - -c\n"
+                    "      - until nc -z quick-start 80; do sleep 2; done\n"
+                )
+
+            def fake_run(args, **_kwargs):
+                calls.append(args)
+                if args[:2] == ["helm", "pull"]:
+                    untar_directory = args[args.index("--untardir") + 1]
+                    chart_directory = os.path.join(untar_directory, "quick-start")
+                    os.makedirs(os.path.join(chart_directory, "charts"))
+                    os.makedirs(os.path.join(chart_directory, "templates"))
+                    with open(
+                        os.path.join(chart_directory, "Chart.yaml"),
+                        "w", encoding="utf-8",
+                    ) as chart:
+                        chart.write(
+                            "apiVersion: v2\nname: quick-start\nversion: 1.2.1\n"
+                            "dependencies:\n"
+                            "- name: service\n  version: 1.2.1\n"
+                            "- name: backend-operator\n  version: 1.2.1\n"
+                            "- name: router\n  version: 1.2.1\n"
+                            "- name: web-ui\n  version: 1.2.1\n"
+                        )
+                    with open(
+                        os.path.join(chart_directory, "values.yaml"),
+                        "w", encoding="utf-8",
+                    ) as values_file:
+                        values_file.write(
+                            "global:\n  osmoImageTag: old\n"
+                            "service:\n"
+                            "  gateway:\n"
+                            "    oauth2Proxy:\n"
+                            "      enabled: true\n"
+                            "backend-operator:\n"
+                            "  services:\n"
+                            "    backendListener:\n"
+                            "      initContainers:\n"
+                            "      - name: wait-for-token\n"
+                        )
+                    with open(
+                        os.path.join(chart_directory, "Chart.lock"),
+                        "w", encoding="utf-8",
+                    ) as lock:
+                        lock.write("digest: stale-after-substitution\n")
+                    os.makedirs(os.path.join(chart_directory, "charts", "router"))
+                    os.makedirs(os.path.join(chart_directory, "charts", "web-ui"))
+                    released_backend = os.path.join(
+                        chart_directory, "charts", "backend-operator",
+                    )
+                    os.makedirs(released_backend)
+                    with open(
+                        os.path.join(released_backend, "released-marker"),
+                        "w", encoding="utf-8",
+                    ) as marker:
+                        marker.write("released backend operator")
+                    with open(
+                        os.path.join(chart_directory, "charts", "service-1.2.1.tgz"),
+                        "w", encoding="utf-8",
+                    ) as archive:
+                        archive.write("released service")
+                    with open(
+                        os.path.join(chart_directory, "templates", "mek-configmap.yaml"),
+                        "w", encoding="utf-8",
+                    ) as template:
+                        template.write("legacy MEK")
+                    with open(
+                        os.path.join(
+                            chart_directory, "templates",
+                            "backend-operator-token-secret.yaml",
+                        ),
+                        "w", encoding="utf-8",
+                    ) as template:
+                        template.write("legacy backend API token")
+                return _FakeCompleted()
+
+            adapter = KindAdapter(build_local=True, subprocess_runner=fake_run)
+            with unittest.mock.patch(
+                "test.oetf.deploy_adapters.kind_adapter._local_service_chart_path",
+                return_value=local_service,
+            ):
+                with unittest.mock.patch(
+                    "test.oetf.deploy_adapters.kind_adapter."
+                    "_local_backend_operator_chart_path",
+                    return_value=local_backend_operator,
+                ):
+                    with adapter._quick_start_chart_ref() as chart_ref:  # pylint: disable=protected-access
+                        self.assertTrue(os.path.isfile(os.path.join(
+                            chart_ref, "charts", "service", "source-marker",
+                        )))
+                        self.assertTrue(os.path.isfile(os.path.join(
+                            chart_ref, "charts", "backend-operator", "source-marker",
+                        )))
+                        self.assertFalse(os.path.exists(os.path.join(
+                            chart_ref, "charts", "backend-operator", "released-marker",
+                        )))
+                        self.assertFalse(os.path.exists(
+                            os.path.join(chart_ref, "charts", "service-1.2.1.tgz"),
+                        ))
+                        self.assertFalse(os.path.exists(os.path.join(
+                            chart_ref, "templates", "mek-configmap.yaml",
+                        )))
+                        self.assertFalse(os.path.exists(os.path.join(
+                            chart_ref, "templates",
+                            "backend-operator-token-secret.yaml",
+                        )))
+                        self.assertFalse(os.path.exists(
+                            os.path.join(chart_ref, "charts", "router"),
+                        ))
+                        self.assertFalse(os.path.exists(
+                            os.path.join(chart_ref, "charts", "web-ui"),
+                        ))
+                        self.assertFalse(os.path.exists(
+                            os.path.join(chart_ref, "Chart.lock"),
+                        ))
+                        with open(
+                            os.path.join(chart_ref, "Chart.yaml"), encoding="utf-8",
+                        ) as chart:
+                            chart_text = chart.read()
+                        self.assertIn("name: service", chart_text)
+                        self.assertIn("name: backend-operator", chart_text)
+                        self.assertNotIn("name: router", chart_text)
+                        self.assertNotIn("name: web-ui", chart_text)
+                        with open(
+                            os.path.join(chart_ref, "values.yaml"), encoding="utf-8",
+                        ) as values_file:
+                            values = yaml.safe_load(values_file)
+                        service_values = values["service"]
+                        self.assertFalse(
+                            service_values["gateway"]["oauth2Proxy"]["enabled"],
+                        )
+                        self.assertFalse(
+                            service_values["gateway"]["authz"]["enabled"],
+                        )
+                        self.assertEqual(
+                            service_values["gateway"]["name"], "osmo-gateway",
+                        )
+                        self.assertEqual(
+                            service_values["gateway"]["envoy"]["defaultIdentity"],
+                            {
+                                "user": "testuser",
+                                "roles": "osmo-admin",
+                                "allowedPools": "default",
+                            },
+                        )
+                        self.assertEqual(
+                            service_values["gateway"]["envoy"]["ingress"],
+                            {
+                                "enabled": True,
+                                "ingressClass": "nginx",
+                                "sslEnabled": False,
+                            },
+                        )
+                        self.assertEqual(
+                            service_values["services"]["backendApiTokens"]
+                            ["credentials"][0]["managedSecret"]["name"],
+                            "backend-operator-token",
+                        )
+                        backend_values = values["backend-operator"]
+                        self.assertEqual(
+                            backend_values["global"]["accountTokenSecret"],
+                            "backend-operator-token",
+                        )
+                        self.assertEqual(
+                            backend_values["global"]["serviceUrl"],
+                            "http://osmo-gateway.osmo.svc.cluster.local",
+                        )
+                        self.assertEqual(
+                            backend_values["services"]["backendListener"]
+                            ["initContainers"][0]["name"],
+                            "wait-for-gateway",
+                        )
+                        self.assertIn(
+                            "nc -z osmo-gateway 80",
+                            backend_values["services"]["backendListener"]
+                            ["initContainers"][0]["command"][-1],
+                        )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][:2], ["helm", "pull"])
+        self.assertNotIn("dependency", calls[0])
 
     def test_redeploy_without_build_local_does_not_rollout_restart(self):
         """Cluster pre-exists but build_local=False → no rollout restart (chart-default deploy)."""

--- a/test/oetf/tests/test_main.py
+++ b/test/oetf/tests/test_main.py
@@ -113,5 +113,96 @@ class MainResultContractTest(unittest.TestCase):
         self.assertIn("RESULT: PASS", output)
 
 
+class BuildBazelCommandTest(unittest.TestCase):
+    """Environment-specific host resources are passed into Bazel tests."""
+
+    @staticmethod
+    def _args(env: str) -> argparse.Namespace:
+        return argparse.Namespace(
+            bazel_arg=[],
+            env=env,
+            jobs=1,
+            name="",
+            tags="",
+            target_pattern=[],
+        )
+
+    @staticmethod
+    def _env() -> dict[str, str]:
+        return {
+            "auth_method": "token",
+            "auth_token": "test-token",
+            "auth_username": "test-user",
+            "exclude_tags": "",
+            "local_osmo": "",
+            "pool": "default",
+            "url": "https://kind.example",
+        }
+
+    @mock.patch.object(
+        oetf_main,
+        "_resolve_targets_via_query",
+        return_value=["//test/smoke:mek-rotation-kind"],
+    )
+    def test_kind_passes_explicit_kubeconfig_into_bazel(self, resolve_mock):
+        self.assertIsNotNone(resolve_mock)
+        with mock.patch.dict(
+            oetf_main.os.environ,
+            {"KUBECONFIG": "/runner/kind-kubeconfig"},
+            clear=True,
+        ):
+            command = oetf_main.build_bazel_command(
+                self._args("kind"), self._env(), "/tmp/bep.json",
+            )
+
+        self.assertIn(
+            "--test_env=KUBECONFIG=/runner/kind-kubeconfig",
+            command,
+        )
+
+    @mock.patch.object(
+        oetf_main,
+        "_resolve_targets_via_query",
+        return_value=["//test/smoke:mek-rotation-kind"],
+    )
+    def test_kind_passes_default_home_kubeconfig_into_bazel(self, resolve_mock):
+        self.assertIsNotNone(resolve_mock)
+        with mock.patch.dict(oetf_main.os.environ, {}, clear=True), \
+             mock.patch.object(
+                 oetf_main.Path,
+                 "home",
+                 return_value=oetf_main.Path("/runner"),
+             ):
+            command = oetf_main.build_bazel_command(
+                self._args("kind"), self._env(), "/tmp/bep.json",
+            )
+
+        self.assertIn(
+            "--test_env=KUBECONFIG=/runner/.kube/config",
+            command,
+        )
+
+    @mock.patch.object(
+        oetf_main,
+        "_resolve_targets_via_query",
+        return_value=["//test/smoke:profile-round-trip"],
+    )
+    def test_non_kind_does_not_pass_kubeconfig(self, resolve_mock):
+        self.assertIsNotNone(resolve_mock)
+        with mock.patch.dict(
+            oetf_main.os.environ,
+            {"KUBECONFIG": "/runner/unrelated-kubeconfig"},
+            clear=True,
+        ):
+            command = oetf_main.build_bazel_command(
+                self._args("staging"), self._env(), "/tmp/bep.json",
+            )
+
+        self.assertFalse(any(
+            argument.startswith("--test_env=KUBECONFIG=")
+            for argument in command
+        ))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/oetf/tests/test_main.py
+++ b/test/oetf/tests/test_main.py
@@ -165,6 +165,27 @@ class BuildBazelCommandTest(unittest.TestCase):
         "_resolve_targets_via_query",
         return_value=["//test/smoke:mek-rotation-kind"],
     )
+    def test_kind_passes_installed_quick_start_chart_into_bazel(self, resolve_mock):
+        self.assertIsNotNone(resolve_mock)
+        with mock.patch.dict(
+            oetf_main.os.environ,
+            {"OETF_HELM_CHART_PATH": "/tmp/installed-quick-start"},
+            clear=True,
+        ):
+            command = oetf_main.build_bazel_command(
+                self._args("kind"), self._env(), "/tmp/bep.json",
+            )
+
+        self.assertIn(
+            "--test_env=OETF_HELM_CHART_PATH=/tmp/installed-quick-start",
+            command,
+        )
+
+    @mock.patch.object(
+        oetf_main,
+        "_resolve_targets_via_query",
+        return_value=["//test/smoke:mek-rotation-kind"],
+    )
     def test_kind_passes_default_home_kubeconfig_into_bazel(self, resolve_mock):
         self.assertIsNotNone(resolve_mock)
         with mock.patch.dict(oetf_main.os.environ, {}, clear=True), \
@@ -191,7 +212,10 @@ class BuildBazelCommandTest(unittest.TestCase):
         self.assertIsNotNone(resolve_mock)
         with mock.patch.dict(
             oetf_main.os.environ,
-            {"KUBECONFIG": "/runner/unrelated-kubeconfig"},
+            {
+                "KUBECONFIG": "/runner/unrelated-kubeconfig",
+                "OETF_HELM_CHART_PATH": "/tmp/unrelated-quick-start",
+            },
             clear=True,
         ):
             command = oetf_main.build_bazel_command(
@@ -200,6 +224,10 @@ class BuildBazelCommandTest(unittest.TestCase):
 
         self.assertFalse(any(
             argument.startswith("--test_env=KUBECONFIG=")
+            for argument in command
+        ))
+        self.assertFalse(any(
+            argument.startswith("--test_env=OETF_HELM_CHART_PATH=")
             for argument in command
         ))
 

--- a/test/smoke/BUILD
+++ b/test/smoke/BUILD
@@ -8,6 +8,7 @@ distribution of this software and related documentation without an express
 license agreement from NVIDIA CORPORATION is strictly prohibited.
 """
 
+load("@osmo_python_deps//:requirements.bzl", "requirement")
 load("//test/oetf/bzl:oetf.bzl", "oetf_smoke_test")
 
 package(default_visibility = ["//visibility:public"])
@@ -44,4 +45,14 @@ oetf_smoke_test(
     name = "websocket-checks",
     src = "websocket_checks.py",
     tags = ["websocket", "kind"],
+)
+
+oetf_smoke_test(
+    name = "mek-rotation-kind",
+    src = "mek_rotation_kind.py",
+    data = ["//deployments/charts:service"],
+    extra_deps = [requirement("pyyaml")],
+    size = "large",
+    tags = ["database", "kind"],
+    timeout = "long",
 )

--- a/test/smoke/mek_rotation_kind.py
+++ b/test/smoke/mek_rotation_kind.py
@@ -252,6 +252,11 @@ class MekRotationKind(SmokeFixture):
             "--set", f"global.osmoImageTag={image_tag}",
             "--set", f"services.service.imageName={image_name}",
             "--set", f"services.masterEncryptionKey.existingSecret.name={secret_name}",
+            # The main KIND release already owns quick-start's fixed,
+            # cluster-scoped localstack PV. This isolated lifecycle release
+            # does not need object storage and must not collide with it before
+            # Helm creates the namespaced bootstrap resources under test.
+            "--set", "services.localstackS3.enabled=false",
             "--set", "gateway.envoy.service.type=ClusterIP",
             "--set", "gateway.envoy.service.nodePort=null",
         ]

--- a/test/smoke/mek_rotation_kind.py
+++ b/test/smoke/mek_rotation_kind.py
@@ -37,8 +37,8 @@ class MekRotationKind(SmokeFixture):
     def _json(self, *args):
         return json.loads(self._kubectl(*args, "-o", "json"))
 
-    def _wait(self, description, predicate):
-        deadline = time.monotonic() + self.timeout_seconds
+    def _wait(self, description, predicate, timeout_seconds=None):
+        deadline = time.monotonic() + (timeout_seconds or self.timeout_seconds)
         while time.monotonic() < deadline:
             value = predicate()
             if value is not None:
@@ -73,26 +73,77 @@ class MekRotationKind(SmokeFixture):
         return self._kubectl(*command, input_text=f"{query}\n").strip()
 
     @staticmethod
-    def _chart_path():
+    def _service_chart_path():
         return os.path.join(
             os.environ["TEST_SRCDIR"], os.environ["TEST_WORKSPACE"],
             "deployments", "charts", "service")
 
+    @staticmethod
+    def _quick_start_chart_path():
+        chart = os.environ.get("OETF_HELM_CHART_PATH", "")
+        if not os.path.isfile(os.path.join(chart, "Chart.yaml")):
+            raise RuntimeError(
+                "OETF_HELM_CHART_PATH does not identify the quick-start chart "
+                "used to install this KIND release")
+        return chart
+
     def _helm_sync(self, *values):
+        phase_prefix = "services.masterEncryptionKey.rotation.phase="
+        phase = next(
+            (value[len(phase_prefix):] for value in values
+             if value.startswith(phase_prefix)), "")
+        existing_jobs = {
+            job["metadata"]["uid"]
+            for job in self._json(
+                "get", "jobs", "-l",
+                "app.kubernetes.io/component=mek-lifecycle")["items"]
+        }
         command = [
-            "helm", "upgrade", self.release, self._chart_path(),
+            "helm", "upgrade", self.release, self._quick_start_chart_path(),
             "--namespace", self.namespace, "--reuse-values", "--wait",
-            "--wait-for-jobs", "--timeout", "10m",
-            "--set", "services.masterEncryptionKey.bootstrap.enabled=false",
+            "--timeout", "10m",
+            "--set", "service.services.masterEncryptionKey.bootstrap.enabled=false",
+            # The quick-start bucket initializer is unrelated to MEK and has
+            # a 30-second TTL. Leaving it in a wait-for-jobs phase upgrade
+            # races Helm's waiter against the TTL controller and produces a
+            # spurious `Job not found` after successful bucket creation.
+            "--set-json", "service.services.localstackS3.buckets=[]",
         ]
         for value in values:
-            command.extend(["--set-string", value])
+            command.extend(["--set-string", f"service.{value}"])
         result = subprocess.run(
             command, check=False, capture_output=True, text=True, timeout=900)
         if result.returncode:
             command_text = " ".join(command)
             raise RuntimeError(
                 f"{command_text} exited {result.returncode}: {result.stderr.strip()}")
+        if not phase:
+            return
+
+        def lifecycle_job_complete():
+            jobs = [
+                job for job in self._json(
+                    "get", "jobs", "-l",
+                    "app.kubernetes.io/component=mek-lifecycle")["items"]
+                if job["metadata"]["uid"] not in existing_jobs
+            ]
+            if len(jobs) > 1:
+                raise RuntimeError(
+                    f"MEK phase {phase} created an unexpected Job cohort")
+            if not jobs:
+                return None
+            job = jobs[0]
+            status = job.get("status", {})
+            if status.get("failed"):
+                name = job["metadata"]["name"]
+                logs = self._kubectl("logs", f"job/{name}")
+                raise RuntimeError(
+                    f"MEK phase {phase} Job {name} failed: {logs.strip()}")
+            return job if status.get("succeeded") else None
+
+        self._wait(
+            f"MEK {phase} Job completion", lifecycle_job_complete,
+            timeout_seconds=660)
 
     @staticmethod
     def _jwe_kid(value):
@@ -238,13 +289,14 @@ class MekRotationKind(SmokeFixture):
         namespace = f"mek-bootstrap-{suffix}"
         release = f"mek-bootstrap-{suffix}"
         secret_name = f"{release}-mek"
+        database_name = f"mek_bootstrap_{suffix}"
         deployment = self._api_deployment()
         service_container = next(
             container for container in deployment["spec"]["template"]["spec"]["containers"]
             if container.get("command") == ["service"])
         image_location, image_name, image_tag = self._split_image(
             service_container["image"])
-        chart = self._chart_path()
+        chart = self._service_chart_path()
         quick_start = os.path.join(chart, "quick-start-values.yaml")
         common = [
             "-f", quick_start,
@@ -252,11 +304,28 @@ class MekRotationKind(SmokeFixture):
             "--set", f"global.osmoImageTag={image_tag}",
             "--set", f"services.service.imageName={image_name}",
             "--set", f"services.masterEncryptionKey.existingSecret.name={secret_name}",
+            "--set", "services.masterEncryptionKey.bootstrap.activeDeadlineSeconds=300",
             # The main KIND release already owns quick-start's fixed,
             # cluster-scoped localstack PV. This isolated lifecycle release
             # does not need object storage and must not collide with it before
             # Helm creates the namespaced bootstrap resources under test.
             "--set", "services.localstackS3.enabled=false",
+            # Use a fresh database on the already-ready KIND PostgreSQL. The
+            # primary quick-start release exercises embedded bootstrap; this
+            # isolated release exercises the external-PostgreSQL Helm
+            # failure/retry path without adding a competing stateful pod.
+            "--set", "services.postgres.enabled=false",
+            "--set", f"services.postgres.db={database_name}",
+            # NodePorts are cluster-wide. The main quick-start release owns
+            # Redis's development NodePort already; the isolated lifecycle
+            # release only needs its namespaced ClusterIP Redis service.
+            "--set", "services.redis.enableNodePort=false",
+            # This test exercises the MEK lifecycle only. Removing the
+            # independent pre-install token hook makes any failed install
+            # unambiguously attributable to the intended missing UI image or
+            # to the normal MEK resources under test.
+            "--set", "services.backendApiTokens.enabled=false",
+            "--set", "services.defaultAdmin.enabled=false",
             "--set", "gateway.envoy.service.type=ClusterIP",
             "--set", "gateway.envoy.service.nodePort=null",
         ]
@@ -271,6 +340,55 @@ class MekRotationKind(SmokeFixture):
             result = kubectl_in("get", "secret", secret_name, "-o", "json")
             return json.loads(result.stdout) if result.returncode == 0 else None
 
+        failed_install = None
+
+        def secret_or_bootstrap_failure():
+            secret = secret_json()
+            if secret is not None:
+                return secret
+            jobs_result = kubectl_in(
+                "get", "jobs", "-l", "app.kubernetes.io/component=mek-lifecycle",
+                "-o", "json")
+            if jobs_result.returncode:
+                raise RuntimeError(
+                    f"could not inspect MEK bootstrap Jobs: {jobs_result.stderr.strip()}")
+            jobs = json.loads(jobs_result.stdout)["items"]
+            if not jobs:
+                detail = failed_install.stderr.strip() if failed_install else ""
+                raise RuntimeError(
+                    "failed Helm install did not create the MEK bootstrap Job: " + detail)
+            job = jobs[0]
+            status = job.get("status", {})
+            if status.get("failed"):
+                name = job["metadata"]["name"]
+                logs = kubectl_in("logs", f"job/{name}")
+                pods = kubectl_in(
+                    "get", "pods", "-l", f"job-name={name}", "-o", "json")
+                events = kubectl_in(
+                    "get", "events", "--sort-by=.lastTimestamp")
+                pod_statuses = []
+                if pods.returncode == 0:
+                    for pod in json.loads(pods.stdout)["items"]:
+                        pod_statuses.append({
+                            "name": pod["metadata"]["name"],
+                            "phase": pod.get("status", {}).get("phase"),
+                            "reason": pod.get("status", {}).get("reason"),
+                            "message": pod.get("status", {}).get("message"),
+                            "containerStatuses": pod.get("status", {}).get(
+                                "containerStatuses", []),
+                        })
+                raise RuntimeError(
+                    f"MEK bootstrap Job {name} failed: "
+                    f"logs={logs.stdout.strip()} {logs.stderr.strip()}; "
+                    f"pod_statuses={pod_statuses!r} {pods.stderr.strip()}; "
+                    f"events={events.stdout.strip()} {events.stderr.strip()}")
+            return None
+
+        self.addCleanup(
+            self._kubectl,
+            "exec", "deployment/postgres", "--", "psql",
+            "--username=postgres", "--dbname=postgres", "--set", "ON_ERROR_STOP=1",
+            "--command", f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE);')
         self.addCleanup(
             subprocess.run,
             ["kubectl", "delete", "namespace", namespace, "--ignore-not-found=true"],
@@ -278,24 +396,33 @@ class MekRotationKind(SmokeFixture):
         self._run_checked([
             "kubectl", "create", "namespace", namespace,
         ])
-        admin_secret = {
-            "apiVersion": "v1", "kind": "Secret",
-            "metadata": {"name": "local-admin-password", "namespace": namespace},
-            "stringData": {"password": secrets.token_urlsafe(32)},
+        self._kubectl(
+            "exec", "deployment/postgres", "--", "psql",
+            "--username=postgres", "--dbname=postgres", "--set", "ON_ERROR_STOP=1",
+            "--command", f'CREATE DATABASE "{database_name}";')
+        postgres_service = {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {"name": "postgres", "namespace": namespace},
+            "spec": {
+                "type": "ExternalName",
+                "externalName": f"postgres.{self.namespace}.svc.cluster.local",
+            },
         }
-        applied = subprocess.run(
-            ["kubectl", "apply", "-f", "-"], input=yaml.safe_dump(admin_secret),
-            check=False, capture_output=True, text=True)
-        if applied.returncode:
-            self.fail(applied.stderr)
-
+        service_result = kubectl_in(
+            "apply", "-f", "-", input_text=yaml.safe_dump(postgres_service))
+        if service_result.returncode:
+            self.fail(service_result.stderr)
         failed = [
             "helm", "install", release, chart, "--namespace", namespace,
             "--wait", "--wait-for-jobs", "--timeout", "90s",
             *common, "--set", "services.ui.imageName=definitely-missing",
         ]
-        self._run_checked(failed, expected_success=False, timeout=180)
-        first = self._wait("create-only bootstrap Secret", secret_json)
+        failed_install = self._run_checked(
+            failed, expected_success=False, timeout=180)
+        first = self._wait(
+            "create-only bootstrap Secret", secret_or_bootstrap_failure,
+            timeout_seconds=330)
         first_uid = first["metadata"]["uid"]
         first_data = first["data"]["mek.yaml"]
         manifest = self._run_checked([

--- a/test/smoke/mek_rotation_kind.py
+++ b/test/smoke/mek_rotation_kind.py
@@ -28,8 +28,9 @@ class MekRotationKind(SmokeFixture):
         result = subprocess.run(
             command, input=input_text, check=False, capture_output=True, text=True)
         if result.returncode:
+            command_text = " ".join(command)
             raise RuntimeError(
-                f"{' '.join(command)} failed with exit code {result.returncode}: "
+                f"{command_text} failed with exit code {result.returncode}: "
                 f"{result.stderr.strip()}")
         return result.stdout
 
@@ -50,8 +51,9 @@ class MekRotationKind(SmokeFixture):
         result = subprocess.run(
             command, check=False, capture_output=True, text=True, timeout=timeout)
         if (result.returncode == 0) != expected_success:
+            command_text = " ".join(command)
             raise RuntimeError(
-                f"{' '.join(command)} exited {result.returncode}: {result.stderr.strip()}")
+                f"{command_text} exited {result.returncode}: {result.stderr.strip()}")
         return result
 
     @staticmethod
@@ -88,8 +90,9 @@ class MekRotationKind(SmokeFixture):
         result = subprocess.run(
             command, check=False, capture_output=True, text=True, timeout=900)
         if result.returncode:
+            command_text = " ".join(command)
             raise RuntimeError(
-                f"{' '.join(command)} exited {result.returncode}: {result.stderr.strip()}")
+                f"{command_text} exited {result.returncode}: {result.stderr.strip()}")
 
     @staticmethod
     def _jwe_kid(value):

--- a/test/smoke/mek_rotation_kind.py
+++ b/test/smoke/mek_rotation_kind.py
@@ -1,0 +1,343 @@
+"""KIND coverage for Kubernetes-only MEK rotation."""
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+import os
+import secrets
+import subprocess
+import time
+import unittest
+
+import yaml
+
+from test.oetf.smoke_fixture import SmokeFixture
+
+
+class MekRotationKind(SmokeFixture):
+    """Exercise real Helm phase changes and prove no MEK database state exists."""
+
+    namespace = os.environ.get("OSMO_NAMESPACE", "osmo")
+    release = os.environ.get("OSMO_HELM_RELEASE", "osmo")
+    timeout_seconds = 600
+
+    def _kubectl(self, *args, input_text=None):
+        command = ["kubectl", "--namespace", self.namespace, *args]
+        result = subprocess.run(
+            command, input=input_text, check=False, capture_output=True, text=True)
+        if result.returncode:
+            raise RuntimeError(
+                f"{' '.join(command)} failed with exit code {result.returncode}: "
+                f"{result.stderr.strip()}")
+        return result.stdout
+
+    def _json(self, *args):
+        return json.loads(self._kubectl(*args, "-o", "json"))
+
+    def _wait(self, description, predicate):
+        deadline = time.monotonic() + self.timeout_seconds
+        while time.monotonic() < deadline:
+            value = predicate()
+            if value is not None:
+                return value
+            time.sleep(2)
+        self.fail(f"timed out waiting for {description}")
+
+    @staticmethod
+    def _run_checked(command, expected_success=True, timeout=900):
+        result = subprocess.run(
+            command, check=False, capture_output=True, text=True, timeout=timeout)
+        if (result.returncode == 0) != expected_success:
+            raise RuntimeError(
+                f"{' '.join(command)} exited {result.returncode}: {result.stderr.strip()}")
+        return result
+
+    @staticmethod
+    def _split_image(image):
+        repository, tag = image.rsplit(":", maxsplit=1)
+        location, image_name = repository.rsplit("/", maxsplit=1)
+        return location, image_name, tag
+
+    def _postgres_scalar(self, query, variables=None):
+        command = [
+            "exec", "-i", "deployment/postgres", "--", "psql",
+            "--username=postgres", "--dbname=osmo", "--tuples-only", "--no-align",
+            "--set", "ON_ERROR_STOP=1",
+        ]
+        for name, value in (variables or {}).items():
+            command.extend(["--set", f"{name}={value}"])
+        return self._kubectl(*command, input_text=f"{query}\n").strip()
+
+    @staticmethod
+    def _chart_path():
+        return os.path.join(
+            os.environ["TEST_SRCDIR"], os.environ["TEST_WORKSPACE"],
+            "deployments", "charts", "service")
+
+    def _helm_sync(self, *values):
+        command = [
+            "helm", "upgrade", self.release, self._chart_path(),
+            "--namespace", self.namespace, "--reuse-values", "--wait",
+            "--wait-for-jobs", "--timeout", "10m",
+            "--set", "services.masterEncryptionKey.bootstrap.enabled=false",
+        ]
+        for value in values:
+            command.extend(["--set-string", value])
+        result = subprocess.run(
+            command, check=False, capture_output=True, text=True, timeout=900)
+        if result.returncode:
+            raise RuntimeError(
+                f"{' '.join(command)} exited {result.returncode}: {result.stderr.strip()}")
+
+    @staticmethod
+    def _jwe_kid(value):
+        protected = value.split(".", maxsplit=1)[0]
+        protected += "=" * (-len(protected) % 4)
+        return json.loads(base64.urlsafe_b64decode(protected))["kid"]
+
+    def _api_deployment(self):
+        matches = [
+            deployment for deployment in self._json("get", "deployments")["items"]
+            if any(
+                container.get("command") == ["service"]
+                for container in deployment["spec"]["template"]["spec"]["containers"]
+            )
+        ]
+        self.assertEqual(1, len(matches))
+        return matches[0]
+
+    def _mek_secret_contract(self):
+        deployment = self._api_deployment()
+        volume = next(
+            volume["secret"]
+            for volume in deployment["spec"]["template"]["spec"]["volumes"]
+            if volume["name"] == "mek-volume")
+        return volume["secretName"], volume["items"][0]["key"]
+
+    def _keyring(self, name, key):
+        secret = self._json("get", "secret", name)
+        return yaml.safe_load(base64.b64decode(secret["data"][key]))
+
+    def _credential_uek_mek(self, credential_name):
+        value = self._postgres_scalar(
+            "SELECT u.keys -> (u.keys -> 'current') "
+            "FROM ueks u JOIN credential c ON c.user_name = u.uid "
+            "WHERE c.cred_name = :'credential_name' LIMIT 1;",
+            {"credential_name": credential_name})
+        return self._jwe_kid(value) if value else None
+
+    def _workflow_alerts_raw(self):
+        return self._postgres_scalar(
+            "SELECT value FROM configs "
+            "WHERE key = 'workflow_alerts' AND type = 'WORKFLOW';")
+
+    def _workflow_alerts_mek(self):
+        raw = self._workflow_alerts_raw()
+        token = json.loads(raw).get("slack_token", "") if raw else ""
+        return self._jwe_kid(token) if token else None
+
+    def _restore_workflow_alerts(self, raw):
+        encoded = base64.b64encode(raw.encode()).decode()
+        self._kubectl(
+            "exec", "-i", "deployment/postgres", "--", "psql",
+            "--username=postgres", "--dbname=osmo", "--set", "ON_ERROR_STOP=1",
+            input_text=(
+                "UPDATE configs SET value = "
+                f"convert_from(decode('{encoded}', 'base64'), 'UTF8') "
+                "WHERE key = 'workflow_alerts' AND type = 'WORKFLOW';\n"))
+
+    def _delete_credential(self, name):
+        self.http("DELETE", f"/api/credentials/{name}").expect_ok()
+
+    def test_prepare_activate_rollouts_and_rewrap(self):
+        secret_name, secret_key = self._mek_secret_contract()
+        initial = self._keyring(secret_name, secret_key)
+        old_key = initial["currentMek"]
+        request = f"kind-{secrets.token_hex(6)}"
+        credential = f"kind-mek-{secrets.token_hex(6)}"
+
+        self.http("POST", f"/api/credentials/{credential}").payload({
+            "generic_credential": {"credential": {"rotation_probe": "present"}}
+        }).expect_ok()
+        self.addCleanup(self._delete_credential, credential)
+        original_alerts = self._workflow_alerts_raw()
+        self.assertTrue(original_alerts)
+        self.addCleanup(self._restore_workflow_alerts, original_alerts)
+        self.http("PATCH", "/api/configs/workflow").payload({
+            "configs_dict": {"workflow_alerts": {
+                "slack_token": f"kind-direct-{secrets.token_hex(12)}"}},
+            "description": "MEK rotation direct-config seed",
+        }).expect_ok()
+        self.assertEqual(old_key, self._credential_uek_mek(credential))
+        self.assertEqual(old_key, self._workflow_alerts_mek())
+
+        self.assertEqual("", self._postgres_scalar(
+            "SELECT tablename FROM pg_tables WHERE schemaname='public' "
+            "AND tablename LIKE 'mek_%' ORDER BY tablename;"))
+        self.assertEqual("", self._postgres_scalar(
+            "SELECT tgname FROM pg_trigger WHERE NOT tgisinternal "
+            "AND tgname LIKE '%mek%';"))
+
+        self._helm_sync(
+            f"services.masterEncryptionKey.rotation.requestId={request}",
+            "services.masterEncryptionKey.rotation.phase=prepare")
+        prepared = self._keyring(secret_name, secret_key)
+        self.assertEqual(old_key, prepared["currentMek"])
+        self.assertEqual(len(initial["meks"]) + 1, len(prepared["meks"]))
+        new_key = next(iter(set(prepared["meks"]) - set(initial["meks"])))
+
+        self._helm_sync(
+            f"services.masterEncryptionKey.rotation.requestId={request}",
+            "services.masterEncryptionKey.rotation.phase=",
+            f"services.masterEncryptionKey.rotation.rolloutRevision={request}-prepare")
+        self._helm_sync(
+            f"services.masterEncryptionKey.rotation.requestId={request}",
+            "services.masterEncryptionKey.rotation.phase=activate",
+            f"services.masterEncryptionKey.rotation.rolloutRevision={request}-prepare")
+        activated = self._keyring(secret_name, secret_key)
+        self.assertEqual(new_key, activated["currentMek"])
+        self.assertIn(old_key, activated["meks"])
+
+        self._helm_sync(
+            f"services.masterEncryptionKey.rotation.requestId={request}",
+            "services.masterEncryptionKey.rotation.phase=",
+            f"services.masterEncryptionKey.rotation.rolloutRevision={request}-activate")
+        self._helm_sync(
+            f"services.masterEncryptionKey.rotation.requestId={request}",
+            "services.masterEncryptionKey.rotation.phase=rewrap",
+            f"services.masterEncryptionKey.rotation.rolloutRevision={request}-activate")
+        self.assertEqual(new_key, self._credential_uek_mek(credential))
+        self.assertEqual(new_key, self._workflow_alerts_mek())
+
+        self._helm_sync(
+            f"services.masterEncryptionKey.rotation.requestId={request}",
+            "services.masterEncryptionKey.rotation.phase=",
+            f"services.masterEncryptionKey.rotation.rolloutRevision={request}-activate")
+        lifecycle_bindings = [
+            item for item in self._json("get", "rolebindings")["items"]
+            if item.get("metadata", {}).get("labels", {}).get(
+                "app.kubernetes.io/instance") == self.release
+            and "-mek-" in item.get("metadata", {}).get("name", "")
+        ]
+        self.assertEqual(lifecycle_bindings, [])
+        for deployment in self._json("get", "deployments")["items"]:
+            containers = deployment["spec"]["template"]["spec"].get("containers", [])
+            if any("--mek_file" in container.get("args", []) for container in containers):
+                self.assertEqual(
+                    "osmo", deployment["spec"]["template"]["metadata"]["labels"].get(
+                        "app.kubernetes.io/part-of"))
+
+    def test_fresh_bootstrap_failed_install_upgrade_and_reinstall_preserve_secret(self):
+        """Exercise create-only bootstrap and Helm retry ownership in a fresh namespace."""
+        suffix = secrets.token_hex(4)
+        namespace = f"mek-bootstrap-{suffix}"
+        release = f"mek-bootstrap-{suffix}"
+        secret_name = f"{release}-mek"
+        deployment = self._api_deployment()
+        service_container = next(
+            container for container in deployment["spec"]["template"]["spec"]["containers"]
+            if container.get("command") == ["service"])
+        image_location, image_name, image_tag = self._split_image(
+            service_container["image"])
+        chart = self._chart_path()
+        quick_start = os.path.join(chart, "quick-start-values.yaml")
+        common = [
+            "-f", quick_start,
+            "--set", f"global.osmoImageLocation={image_location}",
+            "--set", f"global.osmoImageTag={image_tag}",
+            "--set", f"services.service.imageName={image_name}",
+            "--set", f"services.masterEncryptionKey.existingSecret.name={secret_name}",
+            "--set", "gateway.envoy.service.type=ClusterIP",
+            "--set", "gateway.envoy.service.nodePort=null",
+        ]
+
+        def kubectl_in(*args, input_text=None):
+            result = subprocess.run(
+                ["kubectl", "--namespace", namespace, *args], input=input_text,
+                check=False, capture_output=True, text=True)
+            return result
+
+        def secret_json():
+            result = kubectl_in("get", "secret", secret_name, "-o", "json")
+            return json.loads(result.stdout) if result.returncode == 0 else None
+
+        self.addCleanup(
+            subprocess.run,
+            ["kubectl", "delete", "namespace", namespace, "--ignore-not-found=true"],
+            check=False, capture_output=True, text=True)
+        self._run_checked([
+            "kubectl", "create", "namespace", namespace,
+        ])
+        admin_secret = {
+            "apiVersion": "v1", "kind": "Secret",
+            "metadata": {"name": "local-admin-password", "namespace": namespace},
+            "stringData": {"password": secrets.token_urlsafe(32)},
+        }
+        applied = subprocess.run(
+            ["kubectl", "apply", "-f", "-"], input=yaml.safe_dump(admin_secret),
+            check=False, capture_output=True, text=True)
+        if applied.returncode:
+            self.fail(applied.stderr)
+
+        failed = [
+            "helm", "install", release, chart, "--namespace", namespace,
+            "--wait", "--wait-for-jobs", "--timeout", "90s",
+            *common, "--set", "services.ui.imageName=definitely-missing",
+        ]
+        self._run_checked(failed, expected_success=False, timeout=180)
+        first = self._wait("create-only bootstrap Secret", secret_json)
+        first_uid = first["metadata"]["uid"]
+        first_data = first["data"]["mek.yaml"]
+        manifest = self._run_checked([
+            "helm", "get", "manifest", release, "--namespace", namespace,
+        ]).stdout
+        manifest_resources = [resource for resource in yaml.safe_load_all(manifest) if resource]
+        self.assertFalse(any(
+            resource.get("kind") == "Secret"
+            and resource.get("metadata", {}).get("name") == secret_name
+            for resource in manifest_resources))
+        self.assertFalse(any(
+            resource.get("kind") == "Lease" for resource in manifest_resources))
+
+        self._run_checked([
+            "helm", "upgrade", release, chart, "--namespace", namespace,
+            "--reuse-values", "--wait", "--wait-for-jobs", "--timeout", "10m",
+            "--set", "services.ui.imageName=web-ui",
+            "--set", "services.masterEncryptionKey.bootstrap.activeDeadlineSeconds=899",
+            "--set-string", "services.masterEncryptionKey.bootstrap.attempt=2",
+        ])
+        after_upgrade = secret_json()
+        self.assertEqual(first_uid, after_upgrade["metadata"]["uid"])
+        self.assertEqual(first_data, after_upgrade["data"]["mek.yaml"])
+
+        self._run_checked([
+            "helm", "upgrade", release, chart, "--namespace", namespace,
+            "--reuse-values", "--wait", "--timeout", "10m",
+            "--set", "services.masterEncryptionKey.bootstrap.enabled=false",
+        ])
+        lifecycle_bindings = kubectl_in(
+            "get", "rolebindings", "-l",
+            f"app.kubernetes.io/instance={release},app.kubernetes.io/component=mek-lifecycle",
+            "-o", "json")
+        self.assertEqual(0, len(json.loads(lifecycle_bindings.stdout)["items"]))
+        after_disable = secret_json()
+        self.assertEqual(first_uid, after_disable["metadata"]["uid"])
+        self.assertEqual(first_data, after_disable["data"]["mek.yaml"])
+
+        self._run_checked(["helm", "uninstall", release, "--namespace", namespace])
+        after_uninstall = secret_json()
+        self.assertEqual(first_uid, after_uninstall["metadata"]["uid"])
+        self.assertEqual(first_data, after_uninstall["data"]["mek.yaml"])
+        self._run_checked([
+            "helm", "install", release, chart, "--namespace", namespace,
+            "--wait", "--wait-for-jobs", "--timeout", "10m", *common,
+        ])
+        after_reinstall = secret_json()
+        self.assertEqual(first_uid, after_reinstall["metadata"]["uid"])
+        self.assertEqual(first_data, after_reinstall["data"]["mek.yaml"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Issue - None
Tracking - OSMO-6594

## What changed

- Read the MEK keyring exclusively from a typed Kubernetes Secret reference at a chart-owned mount path. Vault annotations, ConfigMap rendering, inline key material, and legacy MEK values are no longer supported.
- Load the keyring once at process startup, authenticate the persisted UEK and direct-MEK ciphertext inventory before readiness, and emit a sanitized rollout descriptor containing only key IDs, generation, and bundle digest.
- Add an opt-in, create-only bootstrap Job for disposable installs backed by a new empty database. The Job generates the Secret inside Kubernetes without placing key material in rendered manifests or release state and never overwrites or deletes an existing Secret.
- Add operator-driven `prepare`, `activate`, and `rewrap` lifecycle Jobs. Kubernetes Leases serialize attempts, and Pod ownership plus startup descriptors gate activation and rewrap.
- Support both managed mode, where the lifecycle Jobs create or patch the exact MEK Secret, and external mode, where the operator updates the Secret and the rewrap Job has exact-name read-only `get` access.
- Make rewrap explicit and restartable from the beginning. It compare-and-swap rewraps UEKs and registered direct-MEK configuration, then runs authenticated full inventories. Normal application reads no longer perform MEK rewrap writes.
- Keep every historical MEK in the Secret and reject removal. Rewrap completion is point-in-time evidence, not permission to retire an old key.
- Add unit, real-PostgreSQL, chart-render, deployment-script, and KIND-oriented rotation/bootstrap coverage.

## Design boundary

This implementation stores no MEK material or lifecycle metadata in PostgreSQL. It adds no MEK tables, triggers, functions, DDL, polling loops, or hot reloads. Coordination and rollout evidence are Kubernetes-native: a release-scoped Lease, immutable lifecycle Jobs, and sanitized startup descriptors from the complete Ready Pod cohort.

The database contains only the application ciphertext that already needs the MEK. UEK payloads and user plaintext do not change during rotation; only their encrypted wrappers and registered direct-MEK ciphertext are re-encrypted under the new current MEK.

## Validation

- `bazel test //src/utils/secret_manager/tests:test_secret_manager //src/utils/secret_manager/tests:test_mek_lifecycle //src/utils/connectors/tests:test_mek_reconciliation //src/utils/connectors/tests:test_mek_reconciliation_postgres //deployments/scripts/tests:test_mek_generation_guard`
- Maintained service-chart render suite
- Unified chart render/schema suite with pinned CNPG, Valkey, and RustFS dependencies
- `git diff --check` and shell syntax checks
- Independent security/correctness/lifecycle review approved

## Checklist

- [x] I am familiar with the Contributing Guidelines
- [x] New or existing tests cover these changes
- [x] The documentation is up to date with these changes
