### PR TITLE
docs: refine workflow-label documentation

### DIFF
--- a/docs/deployment_guide/advanced_config/index.rst
+++ b/docs/deployment_guide/advanced_config/index.rst
@@ -70,6 +70,12 @@ This section provides additional advanced configurations to customize and optimi
 
           Grant shared cloud bucket access to every workflow in a pool, so team members don't supply credentials per workflow.
 
+      .. grid-item-card:: :octicon:`tag` Workflow Labels
+          :link: ./workflow_labels
+          :link-type: doc
+
+          Require and constrain workflow label keys, and namespace the label keys stamped onto task pods.
+
       .. grid-item-card:: :octicon:`plug` MCP
           :link: ./mcp
           :link-type: doc

--- a/docs/deployment_guide/advanced_config/workflow_labels.rst
+++ b/docs/deployment_guide/advanced_config/workflow_labels.rst
@@ -104,11 +104,11 @@ Rolling Out a Requirement
         **2. Watch** 📊
         ^^^
 
-        Track ``osmo_label_validation_total``
+        Check the :ref:`validation metrics <workflow_labels_metrics>`
 
         +++
 
-        The ``missing`` and ``invalid`` outcomes show who is affected
+        See who is still missing the key before it starts rejecting
 
     .. grid-item-card::
         :class-header: sd-bg-success sd-text-white
@@ -150,6 +150,8 @@ The prefix is an opaque string, not an assumed DNS prefix: it is joined to the l
 
    Set a prefix when task pods share a cluster with unrelated workloads. Pod labels are exported by key name, so a short key such as ``team`` can match an identically named label on another pod.
 
+
+.. _workflow_labels_metrics:
 
 Metrics
 =======

--- a/docs/deployment_guide/advanced_config/workflow_labels.rst
+++ b/docs/deployment_guide/advanced_config/workflow_labels.rst
@@ -1,0 +1,178 @@
+..
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+
+
+.. _workflow_labels_config:
+
+=======================================================
+Workflow Labels
+=======================================================
+
+Users attach labels to a workflow to record who owns it and what it is for. Label syntax is checked on every submission even when nothing is configured here; a policy adds requirements on top, so you can decide which keys must be present and which values are accepted.
+
+See :ref:`workflow_spec_labels` for how users set labels, and :ref:`workflow_submission` for the CLI flags and list filters. Field definitions are in :ref:`workflow_config`.
+
+
+Why Configure a Policy?
+=======================
+
+✓ **Attribute usage**
+  Require a key such as ``team`` or ``cost-center`` so every workflow can be traced back to an owner.
+
+✓ **Keep values consistent**
+  An allow-list rejects typos and near-duplicates, which keeps reports and dashboards aligned.
+
+✓ **Roll out gradually**
+  Warn before you enforce, so users see what to change while their submissions still succeed.
+
+
+Enforcement Modes
+=================
+
+Each entry in ``policy`` controls one key independently.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 15 85
+
+   * - **Mode**
+     - **Behavior when the key is missing, or its value is outside a non-empty allow-list**
+   * - ``"off"``
+     - Accepted, with no warning. Same as omitting the key from ``policy``.
+   * - ``warn``
+     - Accepted, and the submit response carries a warning.
+   * - ``enforce``
+     - Rejected. No workflow row and no stored specification are created.
+
+.. code-block:: yaml
+
+   labels_config:
+     policy:
+     - key: team
+       allow_list:
+       - robotics
+       - simulation
+       enforcement: warn
+     - key: cost-center
+       allow_list: []
+       enforcement: enforce
+
+An empty ``allow_list`` accepts any well-formed value, so the key becomes required without constraining what it holds.
+
+.. note::
+
+   Quote ``"off"``. Unquoted YAML ``off`` parses as boolean false.
+
+The same policy applies to new submissions, resubmission by ID, restart, and validation-only requests. Warnings are recomputed from the stored labels and the current policy, so a workflow always shows the warnings its policy would produce today, including after it completes.
+
+
+Rolling Out a Requirement
+=========================
+
+.. grid:: 3
+    :gutter: 2
+
+    .. grid-item-card::
+        :class-header: sd-bg-info sd-text-white
+
+        **1. Announce** 📣
+        ^^^
+
+        Add the key with ``enforcement: warn``
+
+        +++
+
+        Submissions succeed; users see what to add
+
+    .. grid-item-card::
+        :class-header: sd-bg-warning sd-text-white
+
+        **2. Watch** 📊
+        ^^^
+
+        Track ``osmo_label_validation_total``
+
+        +++
+
+        The ``missing`` and ``invalid`` outcomes show who is affected
+
+    .. grid-item-card::
+        :class-header: sd-bg-success sd-text-white
+
+        **3. Enforce** ✅
+        ^^^
+
+        Switch to ``enforcement: enforce``
+
+        +++
+
+        Remaining violations are rejected at submission
+
+Changing a policy leaves existing and in-flight workflows untouched. To roll back, set ``enforcement: warn``; to disable the key entirely, set ``enforcement: "off"`` or remove the entry. In ConfigMap mode, an invalid edit is rejected and the previous valid snapshot stays active.
+
+.. warning::
+
+   Removing a value from an allow-list while the key is in ``enforce`` mode rejects every later submission that uses it, including restarts of workflows that were accepted earlier. Soak the change in ``warn`` first.
+
+
+Prefixing Pod Labels
+====================
+
+``pod_label_prefix`` is prepended to every workflow label key when labels are stamped onto task pods, and nowhere else:
+
+.. code-block:: yaml
+
+   labels_config:
+     pod_label_prefix: example.com/
+     policy:
+     - key: team
+       enforcement: warn
+
+A workflow submitted with ``team: robotics`` then carries ``example.com/team=robotics`` on its pods. Everywhere else keeps the bare ``team`` key: the stored specification, the workflow API, list filters, the CLI, and the metric attributes below. Users never type or query the prefix.
+
+The prefix is an opaque string, not an assumed DNS prefix: it is joined to the label key, and the merged key is validated as a Kubernetes label key at submission, in the same check as the policy. An invalid merged key is rejected with an error reporting the original key, the prefix, and the result.
+
+.. tip::
+
+   Set a prefix when task pods share a cluster with unrelated workloads. Pod labels are exported by key name, so a short key such as ``team`` can match an identically named label on another pod.
+
+
+Metrics
+=======
+
+Only configured policy keys become workflow-label dimensions on ``osmo_tasks_count``. Attribute names start with ``workflow_label_``. Letters and numbers are unchanged; ``_``, ``-``, ``.``, and ``/`` are encoded as ``__``, ``_dash_``, ``_dot_``, and ``_slash_`` respectively. For example, ``project`` is exported as ``workflow_label_project``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - **Exported value**
+     - **When**
+   * - The value itself
+     - The value is in the configured allow-list.
+   * - ``<other>``
+     - The key is present with a value outside that list. An empty allow-list exports every value this way.
+   * - ``<missing>``
+     - The key is absent.
+
+This bounds the series count to the allow-list plus two sentinels per key, so keep the policy list small to control cardinality.
+
+Admission also emits ``osmo_label_validation_total{key, outcome}``, where ``outcome`` is ``ok``, ``missing``, ``invalid``, or ``rejected``. The counter covers rejected submissions that never create a workflow row.
+
+.. seealso::
+
+   Exporting a Pod label through ``kube_pod_labels`` is a separate kube-state-metrics allow-list decision; see :ref:`adding_observability`.

--- a/docs/deployment_guide/index.rst
+++ b/docs/deployment_guide/index.rst
@@ -149,6 +149,7 @@ An OSMO deployment consists of two main components:
   advanced_config/scheduler
   advanced_config/rsync
   advanced_config/workflow_pod_workload_identity
+  advanced_config/workflow_labels
   advanced_config/mcp
 
 .. toctree::

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -249,6 +249,10 @@ Workflow Labels
 ===============
 
 Workflow labels are optional and format-checked even when no label is required.
+See :ref:`workflow_spec_labels` for how users set labels in a workflow
+specification, and :ref:`workflow_submission` for the CLI flags and list
+filters.
+
 The default configuration applies no label policies:
 
 .. code-block:: yaml
@@ -326,9 +330,9 @@ stamped onto task pods, and nowhere else:
        enforcement: warn
 
 A workflow submitted with ``team: robotics`` then carries
-``example.com/team=robotics`` on its pods. The stored specification, workflow
-API, list filters, CLI, and the metric attributes below keep the bare ``team``
-key, so users never type or query the prefix.
+``example.com/team=robotics`` on its pods. Everywhere else keeps the bare
+``team`` key: the stored specification, the workflow API, list filters, the
+CLI, and the metric attributes below. Users never type or query the prefix.
 
 .. list-table::
    :header-rows: 1
@@ -345,12 +349,18 @@ key, so users never type or query the prefix.
        break, or exceeds 253 characters.
      - ``""``
 
-The prefix is an opaque string, not an assumed DNS prefix: it is joined to the
-key, and the merged key is validated as a Kubernetes label key during
-submission, in the same check as the policy above. A key that already carries
-its own ``/`` prefix therefore forms an invalid two-slash key and is rejected,
-naming the key, the prefix, and the result. Since the store keeps bare keys,
-stamping a pod again on restart or retry yields the same key.
+The prefix is an opaque string, not an assumed DNS prefix. It is joined to the
+label key, and the result is validated as a Kubernetes label key in the same
+submission check as the policy above.
+
+This matters when a key already contains a ``/``. With
+``pod_label_prefix: example.com/``, the key ``team.example.com/role`` merges to
+``example.com/team.example.com/role``. That key has two slashes, so it is not a
+valid Kubernetes label key and the submission is rejected. The error reports the
+original key, the configured prefix, and the merged key.
+
+Restart and retry stamp pods from the stored labels, which keep their bare keys,
+so a pod always receives the same prefixed key.
 
 Set this when task pods share a cluster with unrelated workloads: pod labels
 are exported by key name, so a short key such as ``team`` can match an

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -248,10 +248,11 @@ Workflow Information
 Workflow Labels
 ===============
 
-Workflow labels are optional and format-checked even when no label is required.
-See :ref:`workflow_spec_labels` for how users set labels in a workflow
-specification, and :ref:`workflow_submission` for the CLI flags and list
-filters.
+Label syntax is checked on every submission, even when no policy is
+configured. Policies add requirements on top: which keys must be present and
+which values are accepted. See :ref:`workflow_spec_labels` for how users set
+labels in a workflow specification, and :ref:`workflow_submission` for the CLI
+flags and list filters.
 
 The default configuration applies no label policies:
 
@@ -301,19 +302,16 @@ key from ``policy`` to disable both warnings and enforcement for that key:
      - ``"off"``
 
 The same policy applies to new submissions, resubmission by ID, restart, and
-validation-only requests. An ``enforcement: enforce`` rejection creates
-neither a workflow row nor a stored specification. Submit responses carry
-warnings from that admission check. Warnings are not stored with the
-workflow: detail responses recompute warn-mode violations from the stored
-labels and the current configuration, so displayed warnings track policy
-changes even for completed workflows.
+validation-only requests. An ``enforce`` rejection creates neither a workflow
+row nor a stored specification. Warnings are recomputed from the stored labels
+and the current policy, so a workflow always shows the warnings its policy
+would produce today, including after it completes.
 
-To roll back enforcement immediately, use ``enforcement: warn``. To disable both
-warnings and enforcement, use ``enforcement: "off"`` (quoted: unquoted YAML
-``off`` parses as boolean false) or remove the policy entry.
-Existing and in-flight workflows are not modified, although their detail-page
-warnings always reflect the current warn policy. In ConfigMap mode, an invalid
-edit is rejected and the previous valid snapshot remains active.
+Changing a policy leaves existing and in-flight workflows untouched. To roll
+back enforcement, use ``enforcement: warn``; to disable it entirely, use
+``enforcement: "off"`` (quoted, because unquoted YAML ``off`` parses as boolean
+false) or remove the entry. In ConfigMap mode, an invalid edit is rejected and
+the previous valid snapshot stays active.
 
 Prefixing Pod Labels
 --------------------
@@ -358,15 +356,17 @@ Set this when task pods share a cluster with unrelated workloads: pod labels
 are exported by key name, so a short key such as ``team`` can match an
 identically named label on another pod.
 
+Label Metrics
+-------------
+
 Only configured policy keys become workflow-label dimensions on
 ``osmo_tasks_count``. Attribute names start with ``workflow_label_``. Letters
 and numbers are unchanged; ``_``, ``-``, ``.``, and ``/`` are encoded as
 ``__``, ``_dash_``, ``_dot_``, and ``_slash_`` respectively. For example,
 ``project`` is exported as ``workflow_label_project``. Values in the configured
 allow-list are exported verbatim; a present value outside that list is clamped
-to ``<other>``, and a missing key is reported as ``<missing>``. Angle
-brackets are not valid in label values, so the sentinels never collide with
-real values. An empty allow-list exports every present value as ``<other>``.
+to ``<other>``, and a missing key is reported as ``<missing>``. An empty
+allow-list exports every present value as ``<other>``.
 This keeps the number of series bounded to the allow-list plus two sentinels
 per key.
 

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -73,7 +73,7 @@ Top-Level Configuration
    * - ``labels_config``
      - `Workflow Labels`_
      - Workflow-label policies, accepted values, staged enforcement, and the
-       optional prefix applied to label keys on task pods.
+       optional pod-label prefix.
      - ``policy: []``
    * - ``max_num_tasks``
      - Integer
@@ -314,8 +314,8 @@ edit is rejected and the previous valid snapshot remains active.
 Prefixing Pod Labels
 --------------------
 
-``pod_label_prefix`` is prepended to every workflow label key at the moment the
-labels are stamped onto task pods, and nowhere else:
+``pod_label_prefix`` is prepended to every workflow label key when labels are
+stamped onto task pods, and nowhere else:
 
 .. code-block:: yaml
 
@@ -325,10 +325,10 @@ labels are stamped onto task pods, and nowhere else:
      - key: team
        enforcement: warn
 
-With the setting above, a workflow submitted with ``team: robotics`` carries
-``example.com/team=robotics`` on its pods, while the stored specification, the
-workflow API, list filters, the CLI, and the metric attributes described below
-all keep the bare ``team`` key. Users neither type nor query the prefix.
+A workflow submitted with ``team: robotics`` then carries
+``example.com/team=robotics`` on its pods. The stored specification, workflow
+API, list filters, CLI, and the metric attributes below keep the bare ``team``
+key, so users never type or query the prefix.
 
 .. list-table::
    :header-rows: 1
@@ -341,23 +341,20 @@ all keep the bare ``team`` key. Users neither type nor query the prefix.
    * - ``pod_label_prefix``
      - String
      - Prepended to each workflow label key on task pods only. Empty disables
-       the behavior. Rejected at configuration time if it contains a space,
-       tab, or line break, or exceeds 253 characters.
+       it. Rejected at configuration time if it contains a space, tab, or line
+       break, or exceeds 253 characters.
      - ``""``
 
-The prefix is treated as an opaque string rather than an assumed DNS prefix:
-the key and prefix are concatenated first, and the merged key is then validated
-as a Kubernetes label key during submission, in the same admission check as the
-policy above. A user key that already carries its own ``/`` prefix therefore
-produces an invalid two-slash key and is rejected with an error naming the
-original key, the configured prefix, and the resulting key. Because the store
-keeps bare keys, stamping the pod again on restart or retry produces the same
-prefixed key.
+The prefix is an opaque string, not an assumed DNS prefix: it is joined to the
+key, and the merged key is validated as a Kubernetes label key during
+submission, in the same check as the policy above. A key that already carries
+its own ``/`` prefix therefore forms an invalid two-slash key and is rejected,
+naming the key, the prefix, and the result. Since the store keeps bare keys,
+stamping a pod again on restart or retry yields the same key.
 
-Set this when task pods share a cluster with unrelated workloads. Pod labels
-are exported by key name, so a short key such as ``team`` risks matching an
-identically named label on an unrelated pod; a prefixed key keeps that
-selection precise.
+Set this when task pods share a cluster with unrelated workloads: pod labels
+are exported by key name, so a short key such as ``team`` can match an
+identically named label on another pod.
 
 Only configured policy keys become workflow-label dimensions on
 ``osmo_tasks_count``. Attribute names start with ``workflow_label_``. Letters

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -341,8 +341,8 @@ all keep the bare ``team`` key. Users neither type nor query the prefix.
    * - ``pod_label_prefix``
      - String
      - Prepended to each workflow label key on task pods only. Empty disables
-       the behavior. Rejected at configuration time if it contains whitespace
-       or exceeds 253 characters.
+       the behavior. Rejected at configuration time if it contains a space,
+       tab, or line break, or exceeds 253 characters.
      - ``""``
 
 The prefix is treated as an opaque string rather than an assumed DNS prefix:

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -248,34 +248,31 @@ Workflow Information
 Workflow Labels
 ===============
 
-Label syntax is checked on every submission, even when no policy is
-configured. Policies add requirements on top: which keys must be present and
-which values are accepted. See :ref:`workflow_spec_labels` for how users set
-labels in a workflow specification, and :ref:`workflow_submission` for the CLI
-flags and list filters.
+Policy and prefix behavior, enforcement rollout, and the exported metrics are
+described in :ref:`workflow_labels_config`.
 
-The default configuration applies no label policies:
+.. list-table::
+   :header-rows: 1
+   :widths: 25 12 43 20
 
-.. code-block:: yaml
+   * - **Field**
+     - **Type**
+     - **Description**
+     - **Default Values**
+   * - ``policy``
+     - List of `Label Policy`_
+     - One entry per label key to check. At most 16 entries; duplicate keys are
+       rejected.
+     - ``[]``
+   * - ``pod_label_prefix``
+     - String
+     - Prepended to each workflow label key on task pods only. Empty disables
+       it. Rejected at configuration time if it contains a space, tab, or line
+       break, or exceeds 253 characters.
+     - ``""``
 
-   labels_config:
-     policy: []
-
-Each entry in ``policy`` controls one key independently. Use ``off`` or omit a
-key from ``policy`` to disable both warnings and enforcement for that key:
-
-.. code-block:: yaml
-
-   labels_config:
-     policy:
-     - key: team
-       allow_list:
-       - robotics
-       - simulation
-       enforcement: warn
-     - key: cost-center
-       allow_list: []
-       enforcement: enforce
+Label Policy
+============
 
 .. list-table::
    :header-rows: 1
@@ -287,8 +284,7 @@ key from ``policy`` to disable both warnings and enforcement for that key:
      - **Default Values**
    * - ``key``
      - String
-     - Kubernetes label key to check. Duplicate policy keys are rejected,
-       and at most 16 keys can be configured.
+     - Kubernetes label key to check.
      - Required
    * - ``allow_list``
      - List of Strings
@@ -296,87 +292,10 @@ key from ``policy`` to disable both warnings and enforcement for that key:
      - ``[]``
    * - ``enforcement``
      - String (``"off"``, ``warn``, ``enforce``)
-     - ``off`` accepts without policy warnings. ``warn`` accepts but warns
-       when the key is missing or its value is outside a non-empty allow-list.
+     - ``off`` accepts without policy warnings. ``warn`` accepts but warns when
+       the key is missing or its value is outside a non-empty allow-list.
        ``enforce`` rejects those violations.
      - ``"off"``
-
-The same policy applies to new submissions, resubmission by ID, restart, and
-validation-only requests. An ``enforce`` rejection creates neither a workflow
-row nor a stored specification. Warnings are recomputed from the stored labels
-and the current policy, so a workflow always shows the warnings its policy
-would produce today, including after it completes.
-
-Changing a policy leaves existing and in-flight workflows untouched. To roll
-back enforcement, use ``enforcement: warn``; to disable it entirely, use
-``enforcement: "off"`` (quoted, because unquoted YAML ``off`` parses as boolean
-false) or remove the entry. In ConfigMap mode, an invalid edit is rejected and
-the previous valid snapshot stays active.
-
-Prefixing Pod Labels
---------------------
-
-``pod_label_prefix`` is prepended to every workflow label key when labels are
-stamped onto task pods, and nowhere else:
-
-.. code-block:: yaml
-
-   labels_config:
-     pod_label_prefix: example.com/
-     policy:
-     - key: team
-       enforcement: warn
-
-A workflow submitted with ``team: robotics`` then carries
-``example.com/team=robotics`` on its pods. Everywhere else keeps the bare
-``team`` key: the stored specification, the workflow API, list filters, the
-CLI, and the metric attributes below. Users never type or query the prefix.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 25 12 43 20
-
-   * - **Field**
-     - **Type**
-     - **Description**
-     - **Default Values**
-   * - ``pod_label_prefix``
-     - String
-     - Prepended to each workflow label key on task pods only. Empty disables
-       it. Rejected at configuration time if it contains a space, tab, or line
-       break, or exceeds 253 characters.
-     - ``""``
-
-The prefix is an opaque string, not an assumed DNS prefix: it is joined to the
-label key, and the merged key is validated as a Kubernetes label key at
-submission, in the same check as the policy above. An invalid merged key is
-rejected with an error reporting the original key, the prefix, and the result.
-
-Set this when task pods share a cluster with unrelated workloads: pod labels
-are exported by key name, so a short key such as ``team`` can match an
-identically named label on another pod.
-
-Label Metrics
--------------
-
-Only configured policy keys become workflow-label dimensions on
-``osmo_tasks_count``. Attribute names start with ``workflow_label_``. Letters
-and numbers are unchanged; ``_``, ``-``, ``.``, and ``/`` are encoded as
-``__``, ``_dash_``, ``_dot_``, and ``_slash_`` respectively. For example,
-``project`` is exported as ``workflow_label_project``. Values in the configured
-allow-list are exported verbatim; a present value outside that list is clamped
-to ``<other>``, and a missing key is reported as ``<missing>``. An empty
-allow-list exports every present value as ``<other>``.
-This keeps the number of series bounded to the allow-list plus two sentinels
-per key.
-
-Admission also emits
-``osmo_label_validation_total{key, outcome}``, where ``outcome`` is ``ok``,
-``missing``, ``invalid``, or ``rejected``. The counter covers rejected
-submissions that do not create a workflow row. Keep the policy list small to
-control metric cardinality. Exporting a Pod label through ``kube_pod_labels`` is a
-separate kube-state-metrics allow-list decision; see
-:ref:`adding_observability`.
 
 Backend Images
 ==============

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -349,18 +349,10 @@ CLI, and the metric attributes below. Users never type or query the prefix.
        break, or exceeds 253 characters.
      - ``""``
 
-The prefix is an opaque string, not an assumed DNS prefix. It is joined to the
-label key, and the result is validated as a Kubernetes label key in the same
-submission check as the policy above.
-
-This matters when a key already contains a ``/``. With
-``pod_label_prefix: example.com/``, the key ``team.example.com/role`` merges to
-``example.com/team.example.com/role``. That key has two slashes, so it is not a
-valid Kubernetes label key and the submission is rejected. The error reports the
-original key, the configured prefix, and the merged key.
-
-Restart and retry stamp pods from the stored labels, which keep their bare keys,
-so a pod always receives the same prefixed key.
+The prefix is an opaque string, not an assumed DNS prefix: it is joined to the
+label key, and the merged key is validated as a Kubernetes label key at
+submission, in the same check as the policy above. An invalid merged key is
+rejected with an error reporting the original key, the prefix, and the result.
 
 Set this when task pods share a cluster with unrelated workloads: pod labels
 are exported by key name, so a short key such as ``team`` can match an

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -72,7 +72,8 @@ Top-Level Configuration
      - See Plugins section
    * - ``labels_config``
      - `Workflow Labels`_
-     - Workflow-label policies, accepted values, and staged enforcement.
+     - Workflow-label policies, accepted values, staged enforcement, and the
+       optional prefix applied to label keys on task pods.
      - ``policy: []``
    * - ``max_num_tasks``
      - Integer
@@ -309,6 +310,54 @@ warnings and enforcement, use ``enforcement: "off"`` (quoted: unquoted YAML
 Existing and in-flight workflows are not modified, although their detail-page
 warnings always reflect the current warn policy. In ConfigMap mode, an invalid
 edit is rejected and the previous valid snapshot remains active.
+
+Prefixing Pod Labels
+--------------------
+
+``pod_label_prefix`` is prepended to every workflow label key at the moment the
+labels are stamped onto task pods, and nowhere else:
+
+.. code-block:: yaml
+
+   labels_config:
+     pod_label_prefix: example.com/
+     policy:
+     - key: team
+       enforcement: warn
+
+With the setting above, a workflow submitted with ``team: robotics`` carries
+``example.com/team=robotics`` on its pods, while the stored specification, the
+workflow API, list filters, the CLI, and the metric attributes described below
+all keep the bare ``team`` key. Users neither type nor query the prefix.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 12 43 20
+
+   * - **Field**
+     - **Type**
+     - **Description**
+     - **Default Values**
+   * - ``pod_label_prefix``
+     - String
+     - Prepended to each workflow label key on task pods only. Empty disables
+       the behavior. Rejected at configuration time if it contains whitespace
+       or exceeds 253 characters.
+     - ``""``
+
+The prefix is treated as an opaque string rather than an assumed DNS prefix:
+the key and prefix are concatenated first, and the merged key is then validated
+as a Kubernetes label key during submission, in the same admission check as the
+policy above. A user key that already carries its own ``/`` prefix therefore
+produces an invalid two-slash key and is rejected with an error naming the
+original key, the configured prefix, and the resulting key. Because the store
+keeps bare keys, stamping the pod again on restart or retry produces the same
+prefixed key.
+
+Set this when task pods share a cluster with unrelated workloads. Pod labels
+are exported by key name, so a short key such as ``team`` risks matching an
+identically named label on an unrelated pod; a prefixed key keeps that
+selection precise.
 
 Only configured policy keys become workflow-label dimensions on
 ``osmo_tasks_count``. Attribute names start with ``workflow_label_``. Letters

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -248,6 +248,7 @@ preflight
 Preflight
 prem
 prepend
+prepended
 Preprocess
 programmatically
 prometheus

--- a/docs/user_guide/workflows/specification/index.rst
+++ b/docs/user_guide/workflows/specification/index.rst
@@ -69,13 +69,13 @@ Workflow
 Workflow Labels
 ---------------
 
-Labels identify a workflow independently of mutable tags. Keys and values use
-Kubernetes label syntax, values must be non-empty, and a workflow can define
-at most 16 labels. Labels are stored with the submitted specification and
-copied only to task pods, not to Services, Secrets, scheduler groups, or
-other objects. Any syntactically valid key is accepted; where a workflow
-label collides with a system-owned pod label (the ``osmo.`` selectors or
-scheduler queue labels), the system value wins on the pod.
+Labels are fixed metadata for a workflow, unlike tags, which can change after
+submission. Keys and values use Kubernetes label syntax, values must be
+non-empty, and a workflow can define at most 16 labels. Labels are stored with
+the submitted specification and copied to task pods only. Any syntactically
+valid key is accepted; if a key collides with a system-owned pod label (an
+``osmo.`` selector or a scheduler queue label), the system value wins on the
+pod.
 
 .. code-block:: yaml
 
@@ -90,15 +90,15 @@ scheduler queue labels), the system value wins on the pod.
        command: [bash]
        args: [-lc, "echo training"]
 
-Your administrator may configure particular keys in ``off``, ``warn``, or
-``enforce`` mode. A submission can succeed and still print a warning while an
-administrator is rolling out a requirement. Use :ref:`workflow_submission` to
-validate and override labels without editing a shared specification.
+Your administrator may require particular keys. In ``warn`` mode a submission
+succeeds but prints a warning, so a requirement can be announced before it is
+enforced; in ``enforce`` mode it is rejected. Use :ref:`workflow_submission` to
+validate labels, or to override them without editing a shared specification.
 
-An administrator may also configure a prefix added to label keys on task pods,
-so a pod can show ``example.com/team`` where the specification said ``team``.
-Only the pod is affected; stored labels, the detail view, and the filters in
-:ref:`workflow_submission` use the key as written here.
+Your administrator may also configure a prefix added to label keys on task
+pods, so a pod can show ``example.com/team`` where the specification said
+``team``. Only the pod is affected; stored labels, the detail view, and the
+filters in :ref:`workflow_submission` use the key as written here.
 
 .. _workflow_spec_task:
 

--- a/docs/user_guide/workflows/specification/index.rst
+++ b/docs/user_guide/workflows/specification/index.rst
@@ -96,8 +96,7 @@ validate labels, or to override them without editing a shared specification.
 
 Your administrator may also configure a prefix added to label keys on task
 pods, so a pod can show ``example.com/team`` where the specification said
-``team``. Only the pod is affected; stored labels, the detail view, and the
-filters in :ref:`workflow_submission` use the key as written here.
+``team``.
 
 .. _workflow_spec_task:
 

--- a/docs/user_guide/workflows/specification/index.rst
+++ b/docs/user_guide/workflows/specification/index.rst
@@ -69,13 +69,12 @@ Workflow
 Workflow Labels
 ---------------
 
-Labels are fixed metadata for a workflow, unlike tags, which can change after
-submission. Keys and values use Kubernetes label syntax, values must be
-non-empty, and a workflow can define at most 16 labels. Labels are stored with
-the submitted specification and copied to task pods only. Any syntactically
-valid key is accepted; if a key collides with a system-owned pod label (an
-``osmo.`` selector or a scheduler queue label), the system value wins on the
-pod.
+Labels are immutable metadata for a workflow, set at submission. Keys and
+values use Kubernetes label syntax, values must be non-empty, and a workflow
+can define at most 16 labels. Labels are stored with the submitted
+specification and copied to task pods only. Any syntactically valid key is
+accepted; if a key collides with a system-owned pod label (an ``osmo.``
+selector or a scheduler queue label), the system value wins on the pod.
 
 .. code-block:: yaml
 

--- a/docs/user_guide/workflows/specification/index.rst
+++ b/docs/user_guide/workflows/specification/index.rst
@@ -95,11 +95,10 @@ Your administrator may configure particular keys in ``off``, ``warn``, or
 administrator is rolling out a requirement. Use :ref:`workflow_submission` to
 validate and override labels without editing a shared specification.
 
-An administrator may also configure a prefix that is added to label keys on
-task pods, so a pod can show ``example.com/team`` where the specification said
-``team``. Only the pod is affected: the stored specification, the workflow
-detail view, and the label filters described in :ref:`workflow_submission` all
-use the key exactly as written here.
+An administrator may also configure a prefix added to label keys on task pods,
+so a pod can show ``example.com/team`` where the specification said ``team``.
+Only the pod is affected; stored labels, the detail view, and the filters in
+:ref:`workflow_submission` use the key as written here.
 
 .. _workflow_spec_task:
 

--- a/docs/user_guide/workflows/specification/index.rst
+++ b/docs/user_guide/workflows/specification/index.rst
@@ -95,6 +95,12 @@ Your administrator may configure particular keys in ``off``, ``warn``, or
 administrator is rolling out a requirement. Use :ref:`workflow_submission` to
 validate and override labels without editing a shared specification.
 
+An administrator may also configure a prefix that is added to label keys on
+task pods, so a pod can show ``example.com/team`` where the specification said
+``team``. Only the pod is affected: the stored specification, the workflow
+detail view, and the label filters described in :ref:`workflow_submission` all
+use the key exactly as written here.
+
 .. _workflow_spec_task:
 
 Task

--- a/docs/user_guide/workflows/submission.rst
+++ b/docs/user_guide/workflows/submission.rst
@@ -223,18 +223,16 @@ or a missing key:
    $ osmo workflow list --label 'team=robotics_(a|b)'
    $ osmo workflow list --no-label team
 
-Label selectors are case-sensitive. In a glob selector, ``*`` matches zero or
-more characters; every other character, including ``_``, is literal. A
-parenthesized ``|`` group can appear within a selector and matches any one of
-its alternatives. Alternatives can contain ``*`` wildcards. Groups are flat
-(not nested), each group must contain at least two non-empty alternatives,
-and the alternatives in a selector may multiply out to at most 32
-combinations. Quote pattern selectors so the shell does not interpret them.
+Label selectors are case-sensitive. ``*`` matches zero or more characters;
+every other character, including ``_``, is literal. A parenthesized ``|`` group
+matches any one of its alternatives, which can themselves contain ``*``. Groups
+cannot nest, each needs at least two alternatives, and one selector can expand
+to at most 32 combinations. Quote selectors so the shell does not interpret
+them.
 
-Repeated ``--label`` filters are combined with AND, so every supplied
-selector must match. Alternatives within one selector are combined with OR. Pattern syntax
-applies only to workflow list filters; submission and validation labels must
-still contain exact Kubernetes label values.
+Repeated ``--label`` filters combine with AND; alternatives within one selector
+combine with OR. Pattern syntax applies only to list filters: submission and
+validation still require exact Kubernetes label values.
 
 Dry Run Validation
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Summary

Issue - None

`labels_config.pod_label_prefix` shipped without documentation. Writing that section turned into a review of all workflow-label docs, and then a move of the label configuration to where admins look for it.

**Adds an Advanced Configuration page.** Label configuration lived only in the config reference, where an admin finds it by already knowing the field name. `advanced_config/workflow_labels.rst` now covers why to configure a policy, the enforcement modes, the warn-then-enforce rollout, the pod-label prefix, and the exported metrics — using the formatting the neighbouring pages use (tables, a card grid, note/tip/seealso). It also documents an edge that was previously unwritten: removing a value from an allow-list under `enforce` rejects restarts of workflows that were accepted earlier.

**Trims the config reference to tables.** `/api/configs/workflow` keeps a `labels_config` table, a `Label Policy` table for the nested fields, and a pointer to the new page, matching the surrounding sections. 683 → 194 words.

**Documents the pod-label prefix.** What it applies to (task pods only — the stored specification, workflow API, list filters, CLI, and metrics keep the bare key), its validation, and the merged-key check at submission. The user guide gets a note so someone finding `example.com/team` on a pod knows why it differs from their spec.

**Fixes section nesting.** The metrics paragraphs rendered underneath the prefix subsection, because RST nests until the next same-level heading.

**Reviews the existing label docs.** Removes content a reader cannot act on, merges a duplicated explanation of recomputed warnings, makes the `warn` and `enforce` modes explicit rather than just named, drops a reference to tags (being deprecated), and tightens the list-selector rules.

Also adds `prepended` to the spelling wordlist.

## Verification

`make -C docs build` and `make -C docs spelling` are clean, with no diagnostics on any changed file. The new page builds, is linked from the Advanced Configuration landing page, and its cross-references resolve into the user guide.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive guidance for configuring workflow label policies, including `off`, `warn`, and `enforce` modes.
  - Documented label validation, allow-list behavior, rollout and rollback procedures, metrics, and task-pod label prefixes.
  - Clarified label syntax, wildcard and alternation behavior, expansion limits, quoting, and Kubernetes constraints.
  - Added workflow labels to the Advanced Configuration documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->