### PR TITLE
Show log search results in context

### DIFF
--- a/src/ui/e2e/journeys/log-viewer-content.spec.ts
+++ b/src/ui/e2e/journeys/log-viewer-content.spec.ts
@@ -42,6 +42,7 @@ import { setupDefaultMocks, setupProfile } from "@/e2e/utils/mock-setup";
  */
 
 const CT_JSON = "application/json";
+const WRAPPED_LOG_SUFFIX = " wrapped-log-segment".repeat(24);
 
 function createWorkflowForLogs(name: string) {
   const now = new Date();
@@ -109,6 +110,25 @@ function createWorkflowForLogs(name: string) {
     app_version: null,
     plugins: { rsync: false },
   };
+}
+
+function createLogsWithSearchContext(): string {
+  return Array.from({ length: 60 }, (_, index) => {
+    const minute = String(index).padStart(2, "0");
+    const message =
+      index === 0
+        ? "needle first match"
+        : index === 2
+          ? "context immediately before target"
+          : index === 3
+            ? `needle selected target${WRAPPED_LOG_SUFFIX}`
+            : index === 4
+              ? "context immediately after target"
+              : index >= 6
+                ? `needle filler match ${index}`
+                : `ordinary log line ${index}`;
+    return `2026/01/15 10:${minute}:00 [train-task] ${message}`;
+  }).join("\n");
 }
 
 test.describe("Log Viewer Content Page", () => {
@@ -237,5 +257,94 @@ test.describe("Log Viewer Content Page", () => {
 
     // ASSERT — workflow name appears somewhere on the page (breadcrumb or title)
     await expect(page.getByText(wfName).first()).toBeVisible();
+  });
+
+  test("shows the selected search result in its surrounding log context", async ({ page }) => {
+    const contextWfName = "log-viewer-show-context-wf";
+    const data = createWorkflowForLogs(contextWfName);
+    await page.route(`**/api/workflow/${contextWfName}*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: CT_JSON,
+        body: JSON.stringify(data),
+      }),
+    );
+    await page.route(`**/api/workflow/${contextWfName}/logs*`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/plain",
+        body: createLogsWithSearchContext(),
+      }),
+    );
+
+    await page.goto(`/log-viewer?workflow=${contextWfName}&f=source:user`);
+    await page.waitForLoadState("networkidle");
+
+    const searchInput = page.getByRole("combobox", { name: /search and filter/i });
+    await searchInput.fill("needle");
+    await searchInput.press("Enter");
+
+    await expect.poll(() => new URL(page.url()).searchParams.getAll("f")).toEqual(["source:user", "text:needle"]);
+    const firstMatch = page.getByText("needle first match", { exact: true });
+    const selectedTarget = page.getByText(/^needle selected target/);
+    const contextBeforeTarget = page.getByText(/^context immediately before target/);
+    const contextAfterTarget = page.getByText(/^context immediately after target/);
+    await expect(firstMatch).toBeVisible();
+    await expect(selectedTarget).toBeVisible();
+    await expect(contextBeforeTarget).not.toBeVisible();
+    await expect(contextAfterTarget).not.toBeVisible();
+
+    // Enable wrapping after filtering so the tall measurement exists only at
+    // the target's search-result index, not its later full-list index.
+    await page.getByRole("button", { name: "Enable line wrap" }).click();
+    await expect(page.getByRole("button", { name: "Disable line wrap" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    // A keyboard-only user can focus a result and open the same action.
+    const keyboardTarget = page.getByRole("row").filter({ hasText: "needle selected target" });
+    // Seed a real dynamic-height measurement before the row moves to a new index.
+    // This also guards against the test passing with a single-line fixture.
+    await expect.poll(async () => (await keyboardTarget.boundingBox())?.height ?? 0).toBeGreaterThan(64);
+    await keyboardTarget.focus();
+    await expect(keyboardTarget).toBeFocused();
+    await keyboardTarget.press("Shift+F10");
+    await expect(page.getByRole("menuitem", { name: "Show in context" })).toBeEnabled();
+    await page.keyboard.press("Escape");
+
+    // Keep the first result selected to prove the action targets the right-clicked row.
+    await firstMatch.click();
+    await selectedTarget.click({ button: "right" });
+    const showInContext = page.getByRole("menuitem", { name: "Show in context" });
+    await expect(showInContext).toBeVisible();
+    await showInContext.click();
+
+    // The text search is removed while the structured source filter is preserved.
+    await expect.poll(() => new URL(page.url()).searchParams.getAll("f")).toEqual(["source:user"]);
+    await expect(page.getByText("source: user", { exact: true })).toBeVisible();
+
+    const contextTarget = page.getByRole("row").filter({ hasText: "needle selected target" });
+    await expect(contextTarget).toBeVisible();
+    await expect(contextTarget).toHaveAttribute("aria-current", "true");
+    await expect(contextBeforeTarget).toBeVisible();
+    await expect(contextAfterTarget).toBeVisible();
+
+    // The next absolute row must start below the unchanged wrapped target.
+    // Index-keyed measurement caches position it inside the target instead.
+    const contextAfterRow = page.getByRole("row").filter({ hasText: "context immediately after target" });
+    await expect
+      .poll(async () => {
+        const [targetBox, nextBox] = await Promise.all([
+          contextTarget.boundingBox(),
+          contextAfterRow.boundingBox(),
+        ]);
+        if (!targetBox || !nextBox) return Number.NEGATIVE_INFINITY;
+        return nextBox.y - (targetBox.y + targetBox.height);
+      })
+      .toBeGreaterThanOrEqual(-0.5);
+
+    await contextTarget.click({ button: "right" });
+    await expect(page.getByRole("menuitem", { name: "Show in context" })).toHaveCount(0);
   });
 });

--- a/src/ui/e2e/journeys/log-viewer-content.spec.ts
+++ b/src/ui/e2e/journeys/log-viewer-content.spec.ts
@@ -43,6 +43,12 @@ import { setupDefaultMocks, setupProfile } from "@/e2e/utils/mock-setup";
 
 const CT_JSON = "application/json";
 const WRAPPED_LOG_SUFFIX = " wrapped-log-segment".repeat(24);
+const SEARCH_CONTEXT_MESSAGE_BY_INDEX = new Map<number, string>([
+  [0, "needle first match"],
+  [2, "context immediately before target"],
+  [3, `needle selected target${WRAPPED_LOG_SUFFIX}`],
+  [4, "context immediately after target"],
+]);
 
 function createWorkflowForLogs(name: string) {
   const now = new Date();
@@ -116,17 +122,8 @@ function createLogsWithSearchContext(): string {
   return Array.from({ length: 60 }, (_, index) => {
     const minute = String(index).padStart(2, "0");
     const message =
-      index === 0
-        ? "needle first match"
-        : index === 2
-          ? "context immediately before target"
-          : index === 3
-            ? `needle selected target${WRAPPED_LOG_SUFFIX}`
-            : index === 4
-              ? "context immediately after target"
-              : index >= 6
-                ? `needle filler match ${index}`
-                : `ordinary log line ${index}`;
+      SEARCH_CONTEXT_MESSAGE_BY_INDEX.get(index) ??
+      (index >= 6 ? `needle filler match ${index}` : `ordinary log line ${index}`);
     return `2026/01/15 10:${minute}:00 [train-task] ${message}`;
   }).join("\n");
 }

--- a/src/ui/src/components/log-viewer/components/log-entry-row.tsx
+++ b/src/ui/src/components/log-viewer/components/log-entry-row.tsx
@@ -35,6 +35,10 @@ export interface LogEntryRowProps {
   showTask: boolean;
   /** Whether this row is part of the active selection */
   isSelected?: boolean;
+  /** Whether this row is the line currently shown in context */
+  isContextTarget?: boolean;
+  /** Whether the row should be reachable for keyboard context-menu actions */
+  isKeyboardActionable?: boolean;
   /** Whether this row is individually expanded (only relevant when wrapLines is off) */
   isExpanded?: boolean;
   /** Callback to toggle expansion for this row */
@@ -54,6 +58,8 @@ function LogEntryRowInner({
   wrapLines,
   showTask,
   isSelected = false,
+  isContextTarget = false,
+  isKeyboardActionable = false,
   isExpanded = false,
   onToggleExpand,
   style,
@@ -98,10 +104,17 @@ function LogEntryRowInner({
   return (
     <div
       role="row"
+      tabIndex={isKeyboardActionable ? 0 : undefined}
       data-entry-id={entry.id}
+      data-context-target={isContextTarget || undefined}
+      aria-current={isContextTarget || undefined}
       className={cn(
         "group relative px-3 py-0.5",
-        isSelected ? "bg-primary/10 hover:bg-primary/20" : "hover:bg-muted/50",
+        isContextTarget
+          ? "border-l-nvidia bg-nvidia-bg dark:bg-nvidia-bg-dark border-l-2 hover:brightness-95"
+          : isSelected
+            ? "bg-primary/10 hover:bg-primary/20"
+            : "hover:bg-muted/50",
         "transition-colors duration-75",
         "select-none",
         "focus-visible:ring-ring focus:outline-none focus-visible:ring-2 focus-visible:ring-inset",

--- a/src/ui/src/components/log-viewer/components/log-list.tsx
+++ b/src/ui/src/components/log-viewer/components/log-list.tsx
@@ -289,7 +289,12 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
   // effect so the selected line wins once the full list is ready, then acknowledge
   // the one-shot request so streaming appends do not keep re-centering the viewer.
   useLayoutEffect(() => {
-    if (!revealEntryId || revealEntryIndex === -1) return;
+    if (!revealEntryId) return;
+
+    if (revealEntryIndex === -1) {
+      onEntryRevealed?.(revealEntryId);
+      return;
+    }
 
     isAutoScrollingRef.current = true;
     virtualizer.scrollToIndex(revealEntryIndex, { align: "center" });

--- a/src/ui/src/components/log-viewer/components/log-list.tsx
+++ b/src/ui/src/components/log-viewer/components/log-list.tsx
@@ -247,12 +247,13 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
   // TanStack Virtual caches measured heights by item key. Entries can move to
   // different indices when a filtered result is expanded back into the full
   // log, so index-based keys would attach a wrapped row's height to the wrong
-  // item. Keep the virtualizer and React keyed to the same logical identity.
+  // item. Separators have fixed height, so include their group index to keep
+  // repeated date groups unique.
   const getItemKey = useCallback(
     (index: number) => {
       const item = flatItems[index];
       if (!item) return index;
-      return item.type === "separator" ? `separator:${item.dateKey}` : `entry:${item.entry.id}`;
+      return item.type === "separator" ? `separator:${item.dateKey}:${item.index}` : `entry:${item.entry.id}`;
     },
     [flatItems],
   );

--- a/src/ui/src/components/log-viewer/components/log-list.tsx
+++ b/src/ui/src/components/log-viewer/components/log-list.tsx
@@ -63,6 +63,8 @@ export interface LogListHandle {
 export interface LogListProps {
   /** Log entries to display */
   entries: LogEntry[];
+  /** Stable key for the filters/time range that produced `entries`. */
+  entriesResetKey: string;
   /** Additional CSS classes */
   className?: string;
   /**
@@ -82,6 +84,16 @@ export interface LogListProps {
    * Used when scoped to a single task where the tag is redundant.
    */
   hideTask?: boolean;
+  /** Entry with the persistent context highlight. */
+  contextTargetId?: string | null;
+  /** One-shot request to center an entry after the expanded list is ready. */
+  revealEntryId?: string | null;
+  /** Acknowledge that a reveal request has been handled. */
+  onEntryRevealed?: (entryId: string) => void;
+  /** Whether the current entries are text-search results. */
+  canShowInContext?: boolean;
+  /** Show the selected search-result entry in the regular log view. */
+  onShowInContext?: (entryId: string) => void;
 }
 
 // =============================================================================
@@ -168,12 +180,26 @@ function findEntryId(element: Element | null): string | null {
 // =============================================================================
 
 const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInner(
-  { entries, className, isPinnedToBottom = false, onScrollAwayFromBottom, isStale = false, hideTask = false },
+  {
+    entries,
+    entriesResetKey,
+    className,
+    isPinnedToBottom = false,
+    onScrollAwayFromBottom,
+    isStale = false,
+    hideTask = false,
+    contextTargetId,
+    revealEntryId,
+    onEntryRevealed,
+    canShowInContext = false,
+    onShowInContext,
+  },
   ref,
 ) {
   const parentRef = useRef<HTMLDivElement>(null);
   const { clipboard } = useServices();
   const copyShortcut = useFormattedHotkey("mod+c");
+  const [contextMenuEntryId, setContextMenuEntryId] = useState<string | null>(null);
 
   // Track programmatic scrolls to avoid unpinning during auto-scroll
   const isAutoScrollingRef = useRef(false);
@@ -201,7 +227,7 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
 
   // Flatten entries with date separators using incremental algorithm
   // O(k) for streaming appends where k = new entries, O(n) for full replacement
-  const { items: flatItems, separators, resetCount } = useIncrementalFlatten(entries);
+  const { items: flatItems, separators, resetCount } = useIncrementalFlatten(entries, entriesResetKey);
 
   // Keep flatItems in a ref to allow stable estimateSize callback
   // This prevents virtualizer from resetting on every flatItems change
@@ -218,11 +244,25 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
     return item.type === "separator" ? DATE_SEPARATOR_HEIGHT : ROW_HEIGHT_ESTIMATE;
   }, []);
 
+  // TanStack Virtual caches measured heights by item key. Entries can move to
+  // different indices when a filtered result is expanded back into the full
+  // log, so index-based keys would attach a wrapped row's height to the wrong
+  // item. Keep the virtualizer and React keyed to the same logical identity.
+  const getItemKey = useCallback(
+    (index: number) => {
+      const item = flatItems[index];
+      if (!item) return index;
+      return item.type === "separator" ? `separator:${item.dateKey}` : `entry:${item.entry.id}`;
+    },
+    [flatItems],
+  );
+
   // Single virtualizer for entire list
   const virtualizer = useVirtualizerCompat({
     count: flatItems.length,
     getScrollElement: useCallback(() => parentRef.current, []),
     estimateSize,
+    getItemKey,
     overscan: OVERSCAN_COUNT,
   });
 
@@ -238,6 +278,31 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
       parentRef.current.scrollTop = 0;
     }
   }, [resetCount]);
+
+  const revealEntryIndex = useMemo(() => {
+    if (!revealEntryId) return -1;
+    return flatItems.findIndex((item) => item.type === "entry" && item.entry.id === revealEntryId);
+  }, [flatItems, revealEntryId]);
+
+  // A context transition replaces the filtered list. Run after the reset-to-top
+  // effect so the selected line wins once the full list is ready, then acknowledge
+  // the one-shot request so streaming appends do not keep re-centering the viewer.
+  useLayoutEffect(() => {
+    if (!revealEntryId || revealEntryIndex === -1) return;
+
+    isAutoScrollingRef.current = true;
+    virtualizer.scrollToIndex(revealEntryIndex, { align: "center" });
+
+    const timer = setTimeout(() => {
+      isAutoScrollingRef.current = false;
+      onEntryRevealed?.(revealEntryId);
+    }, 150);
+
+    return () => {
+      clearTimeout(timer);
+      isAutoScrollingRef.current = false;
+    };
+  }, [onEntryRevealed, revealEntryId, revealEntryIndex, virtualizer]);
 
   // Expose scrollToBottom and focus methods via ref
   useImperativeHandle(
@@ -321,9 +386,14 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
-      if (e.button !== 0) return;
       // elementFromPoint resolves the actual element even after pointer capture
       const id = findEntryId(document.elementFromPoint(e.clientX, e.clientY));
+      // Radix opens touch/pen context menus from a long press, which may not
+      // emit a browser contextmenu event. Capture that row on pointerdown too.
+      if (e.pointerType !== "mouse" || e.button === 2) {
+        setContextMenuEntryId(id);
+      }
+      if (e.button !== 0) return;
       if (!id) {
         setSelection(null);
         anchorIdxRef.current = { idx: -1, epoch: resetCount };
@@ -362,6 +432,20 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
     if (e.button !== 0) return;
     (e.currentTarget as HTMLDivElement).releasePointerCapture(e.pointerId);
   }, []);
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const pointerTargetId = e.target instanceof Element ? findEntryId(e.target) : null;
+      const keyboardTargetId = effectiveSelection ? entries[effectiveSelection.focusIdx]?.id : null;
+      setContextMenuEntryId(pointerTargetId ?? keyboardTargetId ?? null);
+    },
+    [effectiveSelection, entries],
+  );
+
+  const handleShowInContext = useCallback(() => {
+    if (!contextMenuEntryId) return;
+    onShowInContext?.(contextMenuEntryId);
+  }, [contextMenuEntryId, onShowInContext]);
 
   // Refs so the global keydown handler always reads fresh values without
   // being recreated on every selection/entries change (avoids add/remove churn).
@@ -497,6 +581,7 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}
           onPointerUp={handlePointerUp}
+          onContextMenuCapture={handleContextMenu}
         >
           {/* CSS sticky header - simple date display, swaps instantly */}
           {showStickyHeader && <StickyHeader date={currentDate} />}
@@ -522,10 +607,7 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
 
                 return (
                   <div
-                    // Use dateKey + index to ensure unique keys across filter changes.
-                    // Without the index, React may reuse DOM elements when the same date
-                    // appears in different positions, causing phantom separator artifacts.
-                    key={`${item.dateKey}-${item.index}`}
+                    key={virtualRow.key}
                     data-index={virtualRow.index}
                     ref={virtualizer.measureElement}
                     className="bg-card absolute top-0 left-0 w-full"
@@ -549,7 +631,7 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
 
               return (
                 <div
-                  key={item.entry.id}
+                  key={virtualRow.key}
                   data-index={virtualRow.index}
                   ref={virtualizer.measureElement}
                   className="absolute top-0 left-0 w-full"
@@ -563,6 +645,8 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
                     wrapLines={wrapLines}
                     showTask={showTask}
                     isSelected={isSelected}
+                    isContextTarget={item.entry.id === contextTargetId}
+                    isKeyboardActionable={canShowInContext}
                     isExpanded={expandedIds.has(item.entry.id)}
                     onToggleExpand={handleToggleExpand}
                   />
@@ -574,6 +658,14 @@ const LogListInner = forwardRef<LogListHandle, LogListProps>(function LogListInn
       </ContextMenuTrigger>
 
       <ContextMenuContent>
+        {canShowInContext && onShowInContext && (
+          <ContextMenuItem
+            onSelect={handleShowInContext}
+            disabled={!contextMenuEntryId}
+          >
+            Show in context
+          </ContextMenuItem>
+        )}
         <ContextMenuItem
           onClick={copySelection}
           disabled={!effectiveSelection}

--- a/src/ui/src/components/log-viewer/components/log-viewer.tsx
+++ b/src/ui/src/components/log-viewer/components/log-viewer.tsx
@@ -41,6 +41,7 @@ import { LogViewerSkeleton } from "@/components/log-viewer/components/log-viewer
 import { useLogViewerStore } from "@/components/log-viewer/store/log-viewer-store";
 import { HISTOGRAM_BUCKET_JUMP_WINDOW_MS } from "@/components/log-viewer/lib/constants";
 import { DEFAULT_HEIGHT } from "@/components/log-viewer/lib/timeline-constants";
+import { getContextFilterChips, hasTextSearch } from "@/components/log-viewer/lib/show-in-context";
 import type {
   LogViewerDataProps,
   LogViewerFilterProps,
@@ -264,6 +265,9 @@ function LogViewerInner({ data, filter, timeline, className, showTimeline = true
 
   // Local pin state (ephemeral UI state, not persisted)
   const [isPinnedToBottom, setIsPinnedToBottom] = useState(false);
+  // The context target is intentionally ephemeral rather than URL-synced.
+  const [contextTargetId, setContextTargetId] = useState<string | null>(null);
+  const [pendingRevealEntryId, setPendingRevealEntryId] = useState<string | null>(null);
 
   // Wrap toggle handlers with View Transitions for smooth visual updates
   const toggleWrapLines = useCallback(() => {
@@ -281,8 +285,7 @@ function LogViewerInner({ data, filter, timeline, className, showTimeline = true
     };
   }, [reset]);
 
-  // Handle filter chip changes with View Transition for smooth visual updates
-  const handleFilterChipsChange = useCallback(
+  const applyFilterChips = useCallback(
     (newChips: SearchChip[]) => {
       // Use View Transition API for smooth crossfade when available
       // Falls back to immediate update if not supported
@@ -295,12 +298,63 @@ function LogViewerInner({ data, filter, timeline, className, showTimeline = true
     [onFilterChipsChange],
   );
 
-  // Use deferred value to prevent blocking UI during streaming updates
-  // React 19 will keep showing previous results while computing new ones
-  const deferredEntries = useDeferredValue(filteredEntries);
+  // Normal filter edits start a new result set and clear any prior context target.
+  const handleFilterChipsChange = useCallback(
+    (newChips: SearchChip[]) => {
+      setContextTargetId(null);
+      setPendingRevealEntryId(null);
+      applyFilterChips(newChips);
+    },
+    [applyFilterChips],
+  );
+
+  const handleShowInContext = useCallback(
+    (entryId: string) => {
+      setContextTargetId(entryId);
+      setPendingRevealEntryId(entryId);
+      setIsPinnedToBottom(false);
+      applyFilterChips(getContextFilterChips(filterChips));
+      announcer.announce("Showing log line in context", "polite");
+    },
+    [announcer, applyFilterChips, filterChips],
+  );
+
+  const handleEntryRevealed = useCallback((entryId: string) => {
+    setPendingRevealEntryId((pendingEntryId) => (pendingEntryId === entryId ? null : pendingEntryId));
+  }, []);
+
+  // Defer entries and their query generation together. LogList uses the key to
+  // distinguish a filter replacement from an append without scanning the full
+  // existing log prefix on every streaming update.
+  const filterStartTimeMs = timeline?.filterStartTime?.getTime() ?? null;
+  const filterEndTimeMs = timeline?.filterEndTime?.getTime() ?? null;
+  const entriesResetKey = useMemo(
+    () =>
+      JSON.stringify({
+        scope,
+        chips: filterChips.map(({ field, value }) => [field, value]),
+        start: filterStartTimeMs,
+        end: filterEndTimeMs,
+      }),
+    [filterChips, filterStartTimeMs, filterEndTimeMs, scope],
+  );
+  const isTextSearchActive = hasTextSearch(filterChips);
+  const filteredView = useMemo(
+    () => ({ entries: filteredEntries, isTextSearch: isTextSearchActive, resetKey: entriesResetKey }),
+    [entriesResetKey, filteredEntries, isTextSearchActive],
+  );
+  const deferredView = useDeferredValue(filteredView);
+  const deferredEntries = deferredView.entries;
 
   // Track if we're showing stale data (deferred value hasn't caught up)
-  const isStale = deferredEntries !== filteredEntries || isFetching;
+  const isStale = deferredView !== filteredView || isFetching;
+  const isCurrentDeferredQuery = deferredView.resetKey === entriesResetKey;
+  // URL back/forward can replace chips without going through FilterBar's
+  // callback. Never expose the regular-view highlight in search results.
+  const visibleContextTargetId =
+    !isTextSearchActive && !deferredView.isTextSearch && isCurrentDeferredQuery ? contextTargetId : null;
+  const revealEntryId = visibleContextTargetId ? pendingRevealEntryId : null;
+  const canShowInContext = isTextSearchActive && deferredView.isTextSearch && isCurrentDeferredQuery;
 
   // Handle histogram bucket click - jump to that time
   const handleBucketClick = useCallback(
@@ -665,10 +719,16 @@ function LogViewerInner({ data, filter, timeline, className, showTimeline = true
         <LogList
           ref={logListRef}
           entries={deferredEntries}
+          entriesResetKey={deferredView.resetKey}
           isPinnedToBottom={isPinnedToBottom}
           onScrollAwayFromBottom={handleScrollAwayFromBottom}
           isStale={isStale}
           hideTask={scope === "task"}
+          contextTargetId={visibleContextTargetId}
+          revealEntryId={revealEntryId}
+          onEntryRevealed={handleEntryRevealed}
+          canShowInContext={canShowInContext}
+          onShowInContext={handleShowInContext}
         />
       </div>
     </div>

--- a/src/ui/src/components/log-viewer/lib/show-in-context.test.ts
+++ b/src/ui/src/components/log-viewer/lib/show-in-context.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import type { SearchChip } from "@/components/filter-bar/lib/types";
+import { getContextFilterChips, hasTextSearch } from "@/components/log-viewer/lib/show-in-context";
+
+const chips: SearchChip[] = [
+  { field: "source", value: "user", label: "source:user" },
+  { field: "text", value: "failed", label: "failed" },
+  { field: "task", value: "train", label: "task:train" },
+  { field: "text", value: "timeout", label: "timeout" },
+];
+
+describe("show in context filters", () => {
+  it("detects text-search result views", () => {
+    expect(hasTextSearch(chips)).toBe(true);
+    expect(hasTextSearch(chips.filter((chip) => chip.field !== "text"))).toBe(false);
+  });
+
+  it("removes every text search while preserving structured filters", () => {
+    expect(getContextFilterChips(chips)).toEqual([
+      { field: "source", value: "user", label: "source:user" },
+      { field: "task", value: "train", label: "task:train" },
+    ]);
+  });
+});

--- a/src/ui/src/components/log-viewer/lib/show-in-context.ts
+++ b/src/ui/src/components/log-viewer/lib/show-in-context.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SearchChip } from "@/components/filter-bar/lib/types";
+
+/** Whether the current log view is narrowed by at least one text search. */
+export function hasTextSearch(chips: SearchChip[]): boolean {
+  return chips.some((chip) => chip.field === "text");
+}
+
+/** Preserve structured filters while returning from search results to log context. */
+export function getContextFilterChips(chips: SearchChip[]): SearchChip[] {
+  return chips.filter((chip) => chip.field !== "text");
+}

--- a/src/ui/src/components/log-viewer/lib/use-incremental-flatten.test.ts
+++ b/src/ui/src/components/log-viewer/lib/use-incremental-flatten.test.ts
@@ -26,6 +26,9 @@ import {
 } from "@/components/log-viewer/lib/use-incremental-flatten";
 import type { LogEntry } from "@/lib/api/log-adapter/types";
 
+// React's concurrent act() requires an explicit test-environment opt-in.
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
 /**
  * Create a mock log entry for testing.
  */

--- a/src/ui/src/components/log-viewer/lib/use-incremental-flatten.test.ts
+++ b/src/ui/src/components/log-viewer/lib/use-incremental-flatten.test.ts
@@ -15,7 +15,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "vitest";
-import { getDateKey, fullFlatten, appendFlatten } from "@/components/log-viewer/lib/use-incremental-flatten";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  appendFlatten,
+  classifyEntriesChange,
+  fullFlatten,
+  getDateKey,
+  useIncrementalFlatten,
+} from "@/components/log-viewer/lib/use-incremental-flatten";
 import type { LogEntry } from "@/lib/api/log-adapter/types";
 
 /**
@@ -45,6 +53,98 @@ function createMockEntry(id: string, timestamp: Date): LogEntry {
 function localDate(year: number, month: number, day: number, hour = 12): Date {
   return new Date(year, month - 1, day, hour, 0, 0);
 }
+
+describe("classifyEntriesChange", () => {
+  const timestamp = localDate(2024, 1, 15);
+
+  it("recognizes a streaming append that preserves the previous prefix", () => {
+    const first = createMockEntry("first", timestamp);
+    const target = createMockEntry("target", timestamp);
+    const after = createMockEntry("after", timestamp);
+
+    expect(classifyEntriesChange([first, target], [first, target, after], "all", "all")).toBe("append");
+  });
+
+  it("treats search-result expansion with the same first entry as a replacement", () => {
+    const first = createMockEntry("first", timestamp);
+    const beforeTarget = createMockEntry("before-target", timestamp);
+    const target = createMockEntry("target", timestamp);
+    const afterTarget = createMockEntry("after-target", timestamp);
+
+    expect(classifyEntriesChange([first, target], [first, beforeTarget, target, afterTarget], "search", "all")).toBe(
+      "replace",
+    );
+  });
+
+  it("detects an equal-length replacement when its boundary entries change", () => {
+    const first = createMockEntry("first", timestamp);
+    const oldMiddle = createMockEntry("old-middle", timestamp);
+    const newMiddle = createMockEntry("new-middle", timestamp);
+    const oldLast = createMockEntry("old-last", timestamp);
+    const newLast = createMockEntry("new-last", timestamp);
+
+    expect(classifyEntriesChange([first, oldMiddle, oldLast], [first, newMiddle, newLast], "all", "all")).toBe(
+      "replace",
+    );
+  });
+
+  it("forces a replacement when a new query preserves the old prefix boundary", () => {
+    const first = createMockEntry("first", timestamp);
+    const oldMiddle = createMockEntry("old-middle", timestamp);
+    const newMiddle = createMockEntry("new-middle", timestamp);
+    const oldLast = createMockEntry("old-last", timestamp);
+    const appended = createMockEntry("appended", timestamp);
+
+    expect(
+      classifyEntriesChange([first, oldMiddle, oldLast], [first, newMiddle, oldLast, appended], "text:old", "text:new"),
+    ).toBe("replace");
+  });
+
+  it("recognizes the same entries array without scanning it", () => {
+    const entries = [createMockEntry("first", timestamp)];
+
+    expect(classifyEntriesChange(entries, entries, "all", "all")).toBe("unchanged");
+  });
+});
+
+describe("useIncrementalFlatten", () => {
+  it("replaces expanded search results once, then appends without another reset", () => {
+    const timestamp = localDate(2024, 1, 15);
+    const first = createMockEntry("first", timestamp);
+    const before = createMockEntry("before", timestamp);
+    const target = createMockEntry("target", timestamp);
+    const after = createMockEntry("after", timestamp);
+    const appended = createMockEntry("appended", timestamp);
+    let latest: ReturnType<typeof useIncrementalFlatten> | undefined;
+
+    function Probe({ entries, resetKey }: { entries: LogEntry[]; resetKey: string }) {
+      latest = useIncrementalFlatten(entries, resetKey);
+      return null;
+    }
+
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    const entryIds = () => latest?.items.flatMap((item) => (item.type === "entry" ? [item.entry.id] : [])) ?? [];
+
+    try {
+      act(() => root.render(createElement(Probe, { entries: [first, target], resetKey: "search" })));
+      expect(entryIds()).toEqual(["first", "target"]);
+      expect(latest?.resetCount).toBe(0);
+
+      act(() => root.render(createElement(Probe, { entries: [first, before, target, after], resetKey: "context" })));
+      expect(entryIds()).toEqual(["first", "before", "target", "after"]);
+      expect(latest?.resetCount).toBe(1);
+
+      act(() =>
+        root.render(createElement(Probe, { entries: [first, before, target, after, appended], resetKey: "context" })),
+      );
+      expect(entryIds()).toEqual(["first", "before", "target", "after", "appended"]);
+      expect(latest?.resetCount).toBe(1);
+    } finally {
+      act(() => root.unmount());
+    }
+  });
+});
 
 // =============================================================================
 // getDateKey Tests

--- a/src/ui/src/components/log-viewer/lib/use-incremental-flatten.ts
+++ b/src/ui/src/components/log-viewer/lib/use-incremental-flatten.ts
@@ -85,6 +85,10 @@ export type EntriesChangeType = "unchanged" | "append" | "replace";
  * Classify an entry update without scanning the full prefix on streaming appends.
  * The previous tail must remain at the same prefix boundary; expanding a filtered
  * subsequence therefore becomes a replacement instead of a false append.
+ *
+ * While resetKey is unchanged, entries must be immutable and order-preserving;
+ * producers may only append entries and/or evict a prefix. Any other replacement
+ * must change resetKey.
  */
 export function classifyEntriesChange(
   previousEntries: LogEntry[],

--- a/src/ui/src/components/log-viewer/lib/use-incremental-flatten.ts
+++ b/src/ui/src/components/log-viewer/lib/use-incremental-flatten.ts
@@ -72,11 +72,57 @@ export function getDateKey(date: Date): string {
 
 /** State for tracking previous entries and cached flatten result */
 interface PrevEntriesState {
-  firstEntryId: string | undefined;
-  length: number;
+  entries: LogEntry[];
+  resetKey: string;
   resetCount: number;
   lastFlattenedResult: FlattenResultInternal;
   lastDateKey: string | null;
+}
+
+export type EntriesChangeType = "unchanged" | "append" | "replace";
+
+/**
+ * Classify an entry update without scanning the full prefix on streaming appends.
+ * The previous tail must remain at the same prefix boundary; expanding a filtered
+ * subsequence therefore becomes a replacement instead of a false append.
+ */
+export function classifyEntriesChange(
+  previousEntries: LogEntry[],
+  entries: LogEntry[],
+  previousResetKey: string,
+  resetKey: string,
+): EntriesChangeType {
+  if (resetKey !== previousResetKey) {
+    return "replace";
+  }
+
+  if (entries === previousEntries) {
+    return "unchanged";
+  }
+
+  if (entries.length === previousEntries.length) {
+    if (entries.length === 0) return "unchanged";
+
+    // The log stream is immutable: existing entry objects are preserved for
+    // appends/caps, while reconnect replacements create new boundary objects.
+    // Query replacements are distinguished by resetKey. Checking boundaries
+    // keeps filtered no-match stream updates O(1) instead of rescanning up to
+    // 100K entries on every RAF batch.
+    if (entries[0] === previousEntries[0] && entries[entries.length - 1] === previousEntries[entries.length - 1]) {
+      return "unchanged";
+    }
+  }
+
+  if (
+    previousEntries.length > 0 &&
+    entries.length > previousEntries.length &&
+    entries[0] === previousEntries[0] &&
+    entries[previousEntries.length - 1] === previousEntries[previousEntries.length - 1]
+  ) {
+    return "append";
+  }
+
+  return "replace";
 }
 
 /**
@@ -85,28 +131,26 @@ interface PrevEntriesState {
  * Optimized for streaming: detects appends and only processes new entries (O(k))
  * instead of re-flattening the entire array (O(n)).
  *
- * The hook detects reset scenarios (when the first entry changes) and
- * increments resetCount accordingly. This helps consumers know when
- * to invalidate caches like virtualizer measurements.
+ * The hook detects reset scenarios from the query generation or replaced
+ * entries and increments resetCount accordingly. This helps consumers know
+ * when to invalidate caches like virtualizer measurements.
  *
  * @param entries - Log entries array
+ * @param resetKey - Stable identity for the filters and time range producing entries
  * @returns Flattened items and separator metadata
  */
-export function useIncrementalFlatten(entries: LogEntry[]): FlattenResult {
+export function useIncrementalFlatten(entries: LogEntry[], resetKey: string): FlattenResult {
   // Track previous entries state and cached flattened result
   const [prevState, setPrevState] = useState<PrevEntriesState>({
-    firstEntryId: undefined,
-    length: 0,
+    entries: [],
+    resetKey: "",
     resetCount: 0,
     lastFlattenedResult: { items: [], separators: [] },
     lastDateKey: null,
   });
 
   // Extract current state
-  const entriesLength = entries.length;
-  const firstEntryId = entries[0]?.id;
-
-  // Detect if this is a reset (first entry changed) vs append or no-change
+  // Detect if this is a reset (filter/replacement) vs append or no-change.
   // Use the "updating state during render" pattern recommended by React
   let resetCount = prevState.resetCount;
   let newState = prevState;
@@ -117,13 +161,14 @@ export function useIncrementalFlatten(entries: LogEntry[]): FlattenResult {
   // CRITICAL: Must handle the empty-to-empty case (both length 0). Without this,
   // fullFlatten([]) creates a new object every render, the reference check on line 154
   // always triggers setPrevState, and React hits "Too many re-renders."
-  const isNoChange = entriesLength === prevState.length && firstEntryId === prevState.firstEntryId;
-  const isAppend = entriesLength > prevState.length && firstEntryId === prevState.firstEntryId && prevState.length > 0;
+  const changeType = classifyEntriesChange(prevState.entries, entries, prevState.resetKey, resetKey);
+  const isNoChange = changeType === "unchanged";
+  const isAppend = changeType === "append";
   // A reset is anything that's not an append or no-change (filter applied, entries replaced, etc.).
   // The old condition only checked firstEntryId changes, missing the case where a filter keeps
   // the same first entry but reduces the count — leaving measurementsCache stale and causing
   // incorrect separator positions (hidden separators creating visual gaps).
-  const isReset = !isNoChange && !isAppend && prevState.length > 0;
+  const isReset = changeType === "replace" && prevState.entries.length > 0;
 
   if (isReset) {
     resetCount = prevState.resetCount + 1;
@@ -136,7 +181,7 @@ export function useIncrementalFlatten(entries: LogEntry[]): FlattenResult {
     flattenedResult = prevState.lastFlattenedResult;
   } else if (isAppend) {
     // Append path: only flatten new entries (O(k) where k = new entries)
-    const newEntries = entries.slice(prevState.length);
+    const newEntries = entries.slice(prevState.entries.length);
     flattenedResult = appendFlatten(prevState.lastFlattenedResult, newEntries, prevState.lastDateKey);
   } else {
     // Reset path or initial: full flatten (O(n))
@@ -150,15 +195,10 @@ export function useIncrementalFlatten(entries: LogEntry[]): FlattenResult {
       : null;
 
   // Update state if anything changed
-  if (
-    firstEntryId !== prevState.firstEntryId ||
-    entriesLength !== prevState.length ||
-    resetCount !== prevState.resetCount ||
-    flattenedResult !== prevState.lastFlattenedResult
-  ) {
+  if (!isNoChange) {
     newState = {
-      firstEntryId,
-      length: entriesLength,
+      entries,
+      resetKey,
       resetCount,
       lastFlattenedResult: flattenedResult,
       lastDateKey,


### PR DESCRIPTION
## Description

Add a **Show in context** action to text-search results in the log viewer. The mouse and keyboard context menu action removes text-search filters while preserving structured filters and the selected time range, returns to the full log stream, centers the selected entry, and keeps it highlighted.

This also fixes a wrapped-line rendering bug exposed by the context transition. TanStack Virtual cached measured row heights by numeric index while React keyed rows by entry identity. When a filtered result moved to a different index, its wrapped height could be reused by another row, causing overlapping text and row boxes. The virtualizer and React now share stable entry and separator keys, and query replacements are distinguished from streaming appends with an explicit reset key.

There are no backend or API changes.

Issue - None

### Validation

- The browser regression reproduces on the pre-fix build with about 80 px of overlap and passes with this change.
- Log-viewer Playwright journey: 5/5 passed.
- Focused Vitest suite: 23/23 passed.
- Full UI Vitest suite: 52 files, 1,038/1,038 tests passed.
- `pnpm type-check`, `pnpm lint`, `pnpm format:check`, and `pnpm build` passed.
- Verified after rollout on a dev instance.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Show in context” for matching log entries through keyboard and context-menu actions.
  - Highlights selected entries and reveals surrounding log lines while preserving structured filters.
  - Improved wrapped-log search results, context navigation, and virtualized row positioning.
  - Added accessible keyboard focus and state indicators for actionable log entries.

- **Bug Fixes**
  - Prevented stale highlighting and list positioning when filters, queries, or time ranges change.

- **Tests**
  - Added end-to-end and unit coverage for context filtering, wrapping, navigation, and incremental log updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->