### PR TITLE
ci: make full Azure E2E opt-in and faster

### DIFF
--- a/.github/workflows/deployment-test-init.yaml
+++ b/.github/workflows/deployment-test-init.yaml
@@ -1,0 +1,48 @@
+name: Deployment Test (Azure Init)
+
+# Fast, non-provisioning validation for the Azure example. Keep this separate
+# from the cloud deployment workflow so PR path filters do not restrict the
+# opt-in `ci:azure-deployment` label.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - '.github/workflows/deployment-test-init.yaml'
+      - '.github/workflows/deployment-test.yaml'
+      - 'deployments/scripts/run-deployment-test.sh'
+      - 'deployments/terraform/azure/**'
+
+concurrency:
+  group: azure-terraform-validation-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  init-only:
+    name: init-only
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: deployments/terraform/azure/example
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+
+      - name: terraform init (no Azure auth required)
+        run: terraform init -input=false
+
+      - name: terraform validate
+        run: terraform validate -no-color
+
+      # Existing formatting drift is outside this gate's behavioral contract.
+      - name: terraform fmt -check (informational)
+        run: terraform fmt -check -recursive -no-color || true

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -17,13 +17,12 @@ name: Deployment Test (Azure)
 # Triggers:
 #   - `workflow_dispatch` — once this file lands on the default branch, the
 #     "Run workflow" button in Actions becomes available for all three modes.
-#   - `pull_request` — auto-runs `init-only` on every push that touches the
-#     deployment workflow, source images, scripts, split charts, values, or
-#     Azure terraform module. The two heavier modes are gated behind PR labels
-#     (see below) so they don't burn Azure quota on every push.
+#   - `pull_request` — does nothing automatically. Adding the label below
+#     explicitly starts the validation and full deployment lane.
 #
 # PR-label trigger (works pre-merge when the dispatcher isn't registered yet):
-#   - `ci:azure-deployment` → full-deployment fires on the next PR push
+#   - `ci:azure-deployment` → init-only + full-deployment start immediately.
+#     To test a later commit, remove and re-add the label; pushes do not rerun it.
 # auth-check is workflow_dispatch only — it's a developer-driven smoke for
 # the OIDC chain, not something we want to run automatically per PR.
 #
@@ -31,9 +30,10 @@ name: Deployment Test (Azure)
 #   - Daily at 00:00 UTC = 5pm PDT (16:00 PST during winter — GitHub cron
 #     is UTC, doesn't adjust for DST). github.event_name='schedule' runs
 #     build-images + full-deployment end-to-end on main, the same path
-#     the PR-label gate exercises. Images, scripts, and split charts all come
-#     from the tested checkout. Schedule events fire only from the repo's
-#     default branch (main) — they don't run for forks or feature branches.
+#     the PR-label gate exercises. Images and scripts come from the tested
+#     checkout; charts come from the latest stable public NGC release so the
+#     lane guards the external deployment path. Schedule events fire only from
+#     the repo's default branch (main), not forks or feature branches.
 #
 # Slack notification (failure-only, schedule-only):
 #   - notify-slack-on-azure-deployment-test-failure posts to the channel
@@ -60,27 +60,18 @@ on:
           - full-deployment
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
-    paths:
-      - '.bazelrc'
-      - '.bazelversion'
-      - '.github/workflows/deployment-test.yaml'
-      - 'BUILD'
-      - 'MODULE.bazel'
-      - 'MODULE.bazel.lock'
-      - 'bzl/**'
-      - 'ci/deployment-test/**'
-      - 'deployments/charts/backend-operator/**'
-      - 'deployments/charts/service/**'
-      - 'deployments/scripts/**'
-      - 'deployments/terraform/azure/**'
-      - 'deployments/values/**'
-      - 'src/**'
+    types: [labeled]
   schedule:
     # Daily at 00:00 UTC = 5pm PDT (16:00 PST during winter — GitHub cron
     # is UTC, doesn't track DST). Schedule fires only on main, not on
     # feature branches.
     - cron: '0 0 * * *'
+
+# All full runs share one resource group. Queue overlaps rather than cancelling
+# a run during apply/destroy and risking leaked or cross-deleted resources.
+concurrency:
+  group: deployment-test-azure
+  cancel-in-progress: false
 
 # OIDC federation to Azure — no static secrets in this workflow.
 # `id-token: write` lets the runner mint a JWT that Azure trusts via the
@@ -100,8 +91,10 @@ jobs:
   # API call). terraform validate + fmt are purely local.
   init-only:
     if: >-
-      ${{ github.event_name == 'pull_request'
-          || github.event.inputs.mode == 'init-only' }}
+      ${{ github.event.inputs.mode == 'init-only'
+          || (github.event_name == 'pull_request'
+              && github.event.action == 'labeled'
+              && github.event.label.name == 'ci:azure-deployment') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:
@@ -168,28 +161,56 @@ jobs:
           RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           AZURE_REGION: ${{ vars.AZURE_REGION || 'eastus2' }}
 
+  # Resolve and render the latest stable public charts before starting any
+  # expensive work. This catches known script/image/chart contract gaps in
+  # about a minute instead of discovering them after Azure is provisioned.
+  released-chart-compat:
+    if: >-
+      ${{ github.event_name == 'schedule'
+          || github.event.inputs.mode == 'full-deployment'
+          || (github.event_name == 'pull_request'
+              && github.event.action == 'labeled'
+              && github.event.label.name == 'ci:azure-deployment') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      chart_version: ${{ steps.contract.outputs.chart_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install helm
+        run: |
+          set -euo pipefail
+          HELM_VERSION=v3.16.2
+          HELM_SHA256=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb
+          curl -fsSLo /tmp/helm.tgz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          echo "${HELM_SHA256}  /tmp/helm.tgz" | sha256sum -c -
+          tar -xzf /tmp/helm.tgz -C /tmp linux-amd64/helm
+          sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
+
+      - name: verify latest released chart contract
+        id: contract
+        run: bash ci/deployment-test/check-released-chart-compat.sh
+
   # Build OSMO service + backend images from THIS PR's source and push them
   # to nvcr.io/nvstaging/osmo so the deployment-test below verifies the
   # actual diff, not whatever's currently published at
   # nvcr.io/nvidia/osmo:latest. Without this job the gate is meaningless
   # for service-code PRs (it always tests the published `latest`, never
-  # the proposed change). Sequenced before the deployment jobs via
-  # `needs:`.
+  # the proposed change). After the released-chart preflight, this job runs in
+  # parallel with Azure provisioning; deploy waits for both.
   #
   # Pushes go to `nvcr.io/nvstaging/osmo` — the same team the Jenkins dev
   # pipeline uses (nvcr.io restricts registries to 3 path segments
   # `<org>/<team>/<image>`, so a dedicated `/ci` subpath isn't possible).
-  # CI-built tags are prefixed `pr-<num>-<attempt>-amd64` to visually
-  # separate them from dev's `YYYY.MM.DD.hash.stgN` tags. Cleanup uses
-  # the tag prefix.
+  # CI-built tags include the workflow run ID, so separate label invocations
+  # cannot overwrite each other's images. A rerun keeps the same immutable tag.
   build-images:
-    if: >-
-      ${{ github.event_name == 'schedule'
-          || github.event.inputs.mode == 'full-deployment'
-          || (github.event_name == 'pull_request'
-              && contains(github.event.pull_request.labels.*.name, 'ci:azure-deployment')) }}
+    needs: released-chart-compat
+    if: ${{ needs.released-chart-compat.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    environment: internal-ci
     permissions:
       contents: read
     outputs:
@@ -239,15 +260,14 @@ jobs:
           username: $oauthtoken
           password: ${{ secrets.NGC_API_KEY }}
 
-      # Tag layout: nvcr.io/nvstaging/osmo/<image>:pr-<num>-<attempt>-amd64
+      # Tag layout: nvcr.io/nvstaging/osmo/<image>:e2e-<pr|main>-<run-id>-amd64
       # The `-amd64` suffix is appended by rules_oci's per-arch oci_push;
       # we expose the FULL tag (with suffix) so downstream uses match the
       # actual remote tag.
       - id: tag
         run: |
-          PR_NUM="${{ github.event.pull_request.number || github.run_id }}"
-          ATTEMPT="${{ github.run_attempt }}"
-          TAG_BASE="pr-${PR_NUM}-${ATTEMPT}"
+          SCOPE="${{ github.event.pull_request.number || 'main' }}"
+          TAG_BASE="e2e-${SCOPE}-${GITHUB_RUN_ID}"
           echo "registry=nvcr.io/nvstaging/osmo" >> "$GITHUB_OUTPUT"
           echo "tag_base=${TAG_BASE}"            >> "$GITHUB_OUTPUT"
           echo "tag=${TAG_BASE}-amd64"           >> "$GITHUB_OUTPUT"
@@ -334,8 +354,8 @@ jobs:
   # cross-job job-outputs don't work for masked values (GitHub filters
   # them out, so the receiving job sees an empty string).
   tf-apply:
-    needs: build-images
-    if: ${{ needs.build-images.result == 'success' }}
+    needs: released-chart-compat
+    if: ${{ needs.released-chart-compat.result == 'success' }}
     runs-on: ubuntu-latest
     # ~15 min clean apply + one retry (a failed attempt can poll 20+ min
     # before Azure errors) + pre-apply cleanup of a dirty RG.
@@ -590,8 +610,11 @@ jobs:
   # nvcr.io pull secret, then invokes the wrapper with SKIP_OETF=1 so only
   # bootstrap + deploy stages run.
   deploy-osmo:
-    needs: [build-images, tf-apply]
-    if: ${{ needs.tf-apply.result == 'success' }}
+    needs: [released-chart-compat, build-images, tf-apply]
+    if: >-
+      ${{ !cancelled()
+          && needs.build-images.result == 'success'
+          && needs.tf-apply.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: internal-ci
@@ -603,6 +626,7 @@ jobs:
       RUN_DIR: ${{ github.workspace }}/runs/deployment-test-azure
       OSMO_IMAGE_REGISTRY: ${{ needs.build-images.outputs.image_registry }}
       OSMO_IMAGE_TAG: ${{ needs.build-images.outputs.image_tag }}
+      OSMO_CHART_VERSION: ${{ needs.released-chart-compat.outputs.chart_version }}
       NGC_SECRET_NAME: nvcr-pull
     permissions:
       id-token: write
@@ -737,11 +761,10 @@ jobs:
               | kubectl apply -f -
           done
 
-      # Package the split charts from this checkout into a temporary Helm repo.
-      # deploy-k8s.sh keeps using its normal repository interface, but every
-      # artifact under test now comes from the same source SHA. This gate always
-      # provisions public AKS, so Helm runs on this runner and can reach loopback.
-      - name: deploy OSMO with HEAD charts (chart install + verify-hello)
+      # Use the normal public NGC repository. The compatibility preflight pins
+      # the latest stable version so the chart rendered above is the one
+      # installed here.
+      - name: deploy OSMO with released charts (chart install + verify-hello)
         id: deploy_osmo
         env:
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -754,61 +777,11 @@ jobs:
           # dynamically-created workflow task pods get a docker-registry
           # secret they can use to pull init-container/client from nvcr.io.
           NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
-          OSMO_HELM_REPO_NAME: osmo-head
-          OSMO_HELM_REPO_URL: http://127.0.0.1:8879
           SKIP_OETF: "1"
           SKIP_TEARDOWN: "1"
         run: |
-          set -euo pipefail
-
-          chart_repo_dir="$RUNNER_TEMP/osmo-head-helm-repo"
-          mkdir -p "$chart_repo_dir"
-
-          service_version="$(helm show chart deployments/charts/service \
-            | awk '$1 == "version:" { print $2; exit }')"
-          operator_version="$(helm show chart deployments/charts/backend-operator \
-            | awk '$1 == "version:" { print $2; exit }')"
-          if [[ -z "$service_version" || -z "$operator_version" \
-                || "$service_version" != "$operator_version" ]]; then
-            echo "::error::service ($service_version) and backend-operator ($operator_version) chart versions must match because deploy-k8s.sh uses one OSMO_CHART_VERSION"
-            exit 1
-          fi
-
-          helm lint deployments/charts/service
-          helm lint deployments/charts/backend-operator
-          helm package deployments/charts/service --destination "$chart_repo_dir"
-          helm package deployments/charts/backend-operator --destination "$chart_repo_dir"
-          helm repo index "$chart_repo_dir"
-
-          python3 -m http.server 8879 \
-            --bind 127.0.0.1 \
-            --directory "$chart_repo_dir" \
-            >"$RUNNER_TEMP/osmo-head-helm-repo.log" 2>&1 &
-          chart_repo_pid=$!
-          trap 'kill "$chart_repo_pid" 2>/dev/null || true' EXIT
-
-          chart_repo_ready=""
-          for _ in {1..10}; do
-            if curl -fsS "$OSMO_HELM_REPO_URL/index.yaml" >/dev/null 2>&1; then
-              chart_repo_ready=1
-              break
-            fi
-            sleep 1
-          done
-          if [[ -z "$chart_repo_ready" ]]; then
-            cat "$RUNNER_TEMP/osmo-head-helm-repo.log"
-            echo "::error::HEAD chart repository did not become ready"
-            exit 1
-          fi
-
-          # Pre-add without credentials so deploy-k8s.sh preserves this exact
-          # local repo instead of forwarding NGC credentials to loopback.
-          helm repo add "$OSMO_HELM_REPO_NAME" "$OSMO_HELM_REPO_URL"
-          helm show chart "$OSMO_HELM_REPO_NAME/service" --version "$service_version" >/dev/null
-          helm show chart "$OSMO_HELM_REPO_NAME/backend-operator" --version "$operator_version" >/dev/null
-          export OSMO_CHART_VERSION="$service_version"
-          echo "chart_version=$OSMO_CHART_VERSION" >> "$GITHUB_OUTPUT"
-          echo "::notice::deploy stage starting with HEAD charts $OSMO_CHART_VERSION — expected ~5–15 min"
+          set -o pipefail
+          echo "::notice::deploy stage starting with released charts $OSMO_CHART_VERSION — expected ~5–15 min"
           mkdir -p "$RUN_DIR"
           bash deployments/scripts/run-deployment-test.sh --provider azure
           echo "▶ $(date -u +%H:%M:%S) deploy stage done"
@@ -824,7 +797,7 @@ jobs:
                           | python3 -c 'import json,sys; rs=json.load(sys.stdin); print(rs[0].get("chart","-") if rs else "-")' 2>/dev/null || echo "-")"
           operator_chart="$(helm list -n osmo-operator --output json 2>/dev/null \
                            | python3 -c 'import json,sys; rs=json.load(sys.stdin); print(rs[0].get("chart","-") if rs else "-")' 2>/dev/null || echo "-")"
-          chart_version="HEAD ${{ steps.deploy_osmo.outputs.chart_version || '-' }} (installed: $service_chart, $operator_chart) from ${{ github.sha }}"
+          chart_version="released ${OSMO_CHART_VERSION:-?} (installed: $service_chart, $operator_chart)"
           pod_summary="$(kubectl get pods --all-namespaces --no-headers 2>/dev/null \
                          | awk '$1 == "osmo-minimal" || $1 == "osmo-operator" {print $4}' \
                          | sort | uniq -c | awk '{printf "%s×%s ", $1, $2}' || echo "-")"
@@ -1221,16 +1194,21 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::terraform destroy (streaming)"
-          terraform destroy -input=false -auto-approve -no-color \
-            -var-file="$RUNNER_TEMP/azure.tfvars" \
-            || echo "::warning::terraform destroy failed — orphan resources in $AZURE_RESOURCE_GROUP may remain"
+          destroy_failed=""
+          if ! terraform destroy -input=false -auto-approve -no-color \
+              -var-file="$RUNNER_TEMP/azure.tfvars"; then
+            destroy_failed=1
+            echo "::warning::terraform destroy failed — orphan resources in $AZURE_RESOURCE_GROUP may remain"
+          fi
           echo "::endgroup::"
 
           REMAINING=$(az resource list --resource-group "$AZURE_RESOURCE_GROUP" --query 'length(@)' -o tsv || echo "?")
           echo "  $REMAINING resource(s) still in $AZURE_RESOURCE_GROUP"
 
           icon='✅'
-          [ "$REMAINING" != "0" ] && icon='⚠️'
+          if [[ -n "$destroy_failed" || "$REMAINING" != "0" ]]; then
+            icon='❌'
+          fi
           {
             echo "### Destroy stage ${icon}"
             echo ""
@@ -1241,6 +1219,11 @@ jobs:
               echo "Next run's pre-apply cleanup step will wipe these."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ -n "$destroy_failed" || "$REMAINING" != "0" ]]; then
+            echo "::error::Azure teardown was incomplete"
+            exit 1
+          fi
 
       - name: upload destroy logs + diagnostics
         if: always()
@@ -1261,14 +1244,15 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
 
   notify-slack-on-azure-deployment-test-failure:
-    needs: [build-images, tf-apply, deploy-osmo, oetf, tf-destroy]
+    needs: [released-chart-compat, build-images, tf-apply, deploy-osmo, oetf, tf-destroy]
     # always() so this evaluates even when an upstream `needs:` failed.
     # Fires only on scheduled-run failures — PR-label and workflow_dispatch
     # runs surface their own status interactively.
     if: >-
       ${{ always()
           && github.event_name == 'schedule'
-          && (needs.build-images.result == 'failure'
+          && (needs.released-chart-compat.result == 'failure'
+              || needs.build-images.result == 'failure'
               || needs.tf-apply.result == 'failure'
               || needs.deploy-osmo.result == 'failure'
               || needs.oetf.result == 'failure'
@@ -1380,6 +1364,7 @@ jobs:
           # PR-review channel), which is the wrong audience for deploy-gate
           # failures.
           SLACK_CHANNEL: ${{ vars.CI_SLACK_CHANNEL || 'osmo-slack-test' }}
+          CHART_RESULT: ${{ needs.released-chart-compat.result }}
           BI_RESULT: ${{ needs.build-images.result }}
           APPLY_RESULT: ${{ needs.tf-apply.result }}
           DEPLOY_RESULT: ${{ needs.deploy-osmo.result }}
@@ -1433,6 +1418,7 @@ jobs:
             --arg short_sha     "$SHORT_SHA" \
             --arg author        "$AUTHOR" \
             --arg subject       "$SUBJECT" \
+            --arg chart         "$CHART_RESULT" \
             --arg bi            "$BI_RESULT" \
             --arg apply         "$APPLY_RESULT" \
             --arg deploy        "$DEPLOY_RESULT" \
@@ -1455,6 +1441,7 @@ jobs:
                   text: { type: "plain_text", text: $header_text } },
                 { type: "section",
                   fields: [
+                    { type: "mrkdwn", text: "*released-chart-compat*\n`\($chart)`" },
                     { type: "mrkdwn", text: "*build-images*\n`\($bi)`" },
                     { type: "mrkdwn", text: "*tf-apply*\n`\($apply)`" },
                     { type: "mrkdwn", text: "*deploy-osmo*\n`\($deploy)`" },

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -62,7 +62,13 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
     paths:
+      - '.bazelrc'
+      - '.bazelversion'
       - '.github/workflows/deployment-test.yaml'
+      - 'BUILD'
+      - 'MODULE.bazel'
+      - 'MODULE.bazel.lock'
+      - 'bzl/**'
       - 'ci/deployment-test/**'
       - 'deployments/charts/backend-operator/**'
       - 'deployments/charts/service/**'

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -2,27 +2,25 @@ name: Deployment Test (Azure)
 
 # Cloud deployment-test gate. Runs `deployments/scripts/run-deployment-test.sh`
 # end-to-end against an ephemeral cloud cluster (Azure today; other providers
-# follow). Three modes, each cheaper to set up than the next:
+# follow). Automatic, non-provisioning Terraform validation lives in
+# `deployment-test-init.yaml`; this workflow owns the Azure-facing modes:
 #
-#   1. `init-only` (~30s, no cloud setup): terraform init + validate + fmt
-#      against the Azure example module. Provider-download + HCL syntax check;
-#      ZERO Azure API calls. Use this to shake out the workflow shape before
-#      any cloud-side setup.
-#   2. `auth-check` (~2 min, requires OIDC + Azure App Reg): adds terraform
+#   1. `auth-check` (~2 min, requires OIDC + Azure App Reg): runs terraform
 #      plan. First step that actually touches Azure — confirms the federated-
 #      identity → service-principal → RBAC chain.
-#   3. `full-deployment` (~45 min, requires #2 plus POSTGRES_PASSWORD): runs
+#   2. `full-deployment` (~45 min, requires #1 plus POSTGRES_PASSWORD): runs
 #      `deployments/scripts/run-deployment-test.sh --provider azure` end-to-end.
 #
 # Triggers:
 #   - `workflow_dispatch` — once this file lands on the default branch, the
-#     "Run workflow" button in Actions becomes available for all three modes.
-#   - `pull_request` — auto-runs only the cheap `init-only` validation when a
-#     relevant PR is opened or updated. It never starts cloud provisioning.
+#     "Run workflow" button in Actions becomes available for both modes.
+#   - `pull_request` — listens only for label events. Normal PR updates are
+#     handled by `deployment-test-init.yaml` and never provision cloud.
 #
 # PR-label trigger (works pre-merge when the dispatcher isn't registered yet):
-#   - `ci:azure-deployment` → init-only + full-deployment start immediately.
-#     Later pushes rerun only init-only; remove and re-add the label for full E2E.
+#   - `ci:azure-deployment` → full-deployment starts immediately for any PR.
+#     Later pushes run only automatic validation; remove and re-add the label
+#     to rerun full E2E at the new head.
 # auth-check is workflow_dispatch only — it's a developer-driven smoke for
 # the OIDC chain, not something we want to run automatically per PR.
 #
@@ -53,37 +51,22 @@ on:
         description: 'What to run'
         type: choice
         required: true
-        default: init-only
+        default: auth-check
         options:
-          - init-only
           - auth-check
           - full-deployment
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, labeled]
-    paths:
-      - '.bazelrc'
-      - '.bazelversion'
-      - '.github/workflows/deployment-test.yaml'
-      - 'BUILD'
-      - 'MODULE.bazel'
-      - 'MODULE.bazel.lock'
-      - 'bzl/**'
-      - 'ci/deployment-test/**'
-      - 'deployments/charts/backend-operator/**'
-      - 'deployments/charts/service/**'
-      - 'deployments/scripts/**'
-      - 'deployments/terraform/azure/**'
-      - 'deployments/values/**'
-      - 'src/**'
+    types: [labeled]
   schedule:
     # Daily at 00:00 UTC = 5pm PDT (16:00 PST during winter — GitHub cron
     # is UTC, doesn't track DST). Schedule fires only on main, not on
     # feature branches.
     - cron: '0 0 * * *'
 
-# Full runs share one resource group, so they use one concurrency group. Cheap
-# validation runs get a unique group and never queue behind cloud provisioning.
+# Full runs share one resource group and queue in one concurrency group.
+# Auth checks and non-matching label events use unique groups, so they never
+# wait behind cloud provisioning.
 concurrency:
   group: >-
     ${{ (github.event_name == 'schedule'
@@ -94,6 +77,7 @@ concurrency:
         && 'deployment-test-azure'
         || format('deployment-test-azure-{0}', github.run_id) }}
   cancel-in-progress: false
+  queue: max
 
 # OIDC federation to Azure — no static secrets in this workflow.
 # `id-token: write` lets the runner mint a JWT that Azure trusts via the
@@ -108,37 +92,6 @@ permissions:
   contents: read
 
 jobs:
-  # Cheapest mode — no Azure setup needed. terraform init downloads the
-  # azurerm provider plugin from the Terraform Registry (HTTPS, no Azure
-  # API call). terraform validate + fmt are purely local.
-  init-only:
-    if: >-
-      ${{ github.event_name == 'pull_request'
-          || github.event.inputs.mode == 'init-only' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    defaults:
-      run:
-        working-directory: deployments/terraform/azure/example
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.9.8
-
-      - name: terraform init (no Azure auth required)
-        run: terraform init -input=false
-
-      - name: terraform validate
-        run: terraform validate -no-color
-
-      # fmt is informational only — formatting drift in the existing Azure
-      # example is out of scope for this PR and the run-deployment-test
-      # wrapper doesn't care about cosmetic formatting.
-      - name: terraform fmt -check (informational)
-        run: terraform fmt -check -recursive -no-color || true
-
   # First step that actually talks to Azure — terraform plan reads the
   # resource group via the azurerm_resource_group data source. Requires
   # the full OIDC + App Reg + RBAC setup. Provisions nothing.
@@ -198,15 +151,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: install helm
-        run: |
-          set -euo pipefail
-          HELM_VERSION=v3.16.2
-          HELM_SHA256=9318379b847e333460d33d291d4c088156299a26cd93d570a7f5d0c36e50b5bb
-          curl -fsSLo /tmp/helm.tgz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
-          echo "${HELM_SHA256}  /tmp/helm.tgz" | sha256sum -c -
-          tar -xzf /tmp/helm.tgz -C /tmp linux-amd64/helm
-          sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
+      - name: Set up Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: 'v3.16.2'
 
       - name: verify latest released chart contract
         id: contract
@@ -223,8 +171,8 @@ jobs:
   # Pushes go to `nvcr.io/nvstaging/osmo` — the same team the Jenkins dev
   # pipeline uses (nvcr.io restricts registries to 3 path segments
   # `<org>/<team>/<image>`, so a dedicated `/ci` subpath isn't possible).
-  # CI-built tags include the workflow run ID, so separate label invocations
-  # cannot overwrite each other's images. A rerun keeps the same immutable tag.
+  # Keep the cleanup-compatible `pr-` prefix and include the workflow run ID,
+  # so separate invocations cannot overwrite each other. A rerun reuses it.
   build-images:
     needs: released-chart-compat
     if: ${{ needs.released-chart-compat.result == 'success' }}
@@ -280,16 +228,15 @@ jobs:
           username: $oauthtoken
           password: ${{ secrets.NGC_API_KEY }}
 
-      # Tag layout: nvcr.io/nvstaging/osmo/<image>:e2e-<pr|main>-<run-id>-amd64
+      # Tag layout: nvcr.io/nvstaging/osmo/<image>:pr-<pr|main>-<run-id>-amd64
       # The `-amd64` suffix is appended by rules_oci's per-arch oci_push;
       # we expose the FULL tag (with suffix) so downstream uses match the
       # actual remote tag.
       - id: tag
         run: |
           SCOPE="${{ github.event.pull_request.number || 'main' }}"
-          TAG_BASE="e2e-${SCOPE}-${GITHUB_RUN_ID}"
+          TAG_BASE="pr-${SCOPE}-${GITHUB_RUN_ID}"
           echo "registry=nvcr.io/nvstaging/osmo" >> "$GITHUB_OUTPUT"
-          echo "tag_base=${TAG_BASE}"            >> "$GITHUB_OUTPUT"
           echo "tag=${TAG_BASE}-amd64"           >> "$GITHUB_OUTPUT"
 
       # Minimal --no-gpu image set: 8 service images + client + init-container.
@@ -298,7 +245,7 @@ jobs:
       # per-target oci_push rules directly. Each accepts --repository and
       # --tag at `bazel run` time, so we don't need to mutate the constants
       # repo to redirect from the default nvcr.io/nvidia/osmo path to
-      # nvcr.io/nvstaging/osmo/ci.
+      # nvcr.io/nvstaging/osmo.
       - name: Build and push OSMO images
         env:
           REMOTE_CACHE: ${{ secrets.BAZEL_REMOTE_CACHE_URL }}
@@ -359,7 +306,7 @@ jobs:
             echo "- Source SHA: \`${{ github.sha }}\`"
             echo ""
             echo "Packages pushed:"
-            for img in service logger agent authz-sidecar router worker delayed-job-monitor web-ui init-container client; do
+            for img in service logger agent authz-sidecar router worker delayed-job-monitor web-ui init-container client backend-listener backend-worker; do
               echo "  - \`${{ steps.tag.outputs.registry }}/$img:${{ steps.tag.outputs.tag }}\`"
             done
           } >> "$GITHUB_STEP_SUMMARY"
@@ -1041,18 +988,15 @@ jobs:
           if-no-files-found: warn
 
   # ── Stage 4: terraform destroy + cluster diagnostics ─────────────────────
-  # Downloads the tfstate artifact tf-apply uploaded, captures a final
-  # cluster snapshot before destroy, then tears everything down.
+  # Successful applies wait for the test stages. Failed applies use the same
+  # anchored teardown steps in the early job below without waiting for builds.
   tf-destroy:
     needs: [build-images, tf-apply, deploy-osmo, oetf]
-    # Run whenever tf-apply ran (any result) — a failed apply usually
-    # leaves partial resources to tear down. Skip only if tf-apply never
-    # ran.
-    if: ${{ always() && needs.tf-apply.result != 'skipped' }}
+    if: ${{ always() && needs.tf-apply.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: internal-ci
-    env:
+    env: &azure_destroy_env
       ARM_USE_OIDC: true
       ARM_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
@@ -1063,7 +1007,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    steps:
+    steps: &azure_destroy_steps
       - uses: actions/checkout@v4
 
       - name: azure login (OIDC)
@@ -1253,6 +1197,22 @@ jobs:
           path: runs/deployment-test-azure/**
           retention-days: 14
           if-no-files-found: warn
+  # A failed apply can leave billable partial resources. Start the identical
+  # teardown immediately after its always-upload step, without waiting for build.
+  tf-destroy-apply-failure:
+    needs: [tf-apply]
+    if: >-
+      ${{ always()
+          && needs.tf-apply.result != 'success'
+          && needs.tf-apply.result != 'skipped' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: internal-ci
+    env: *azure_destroy_env
+    permissions:
+      id-token: write
+      contents: read
+    steps: *azure_destroy_steps
 
 
   # ── Slack failure-notification (schedule-only) ───────────────────────────
@@ -1264,7 +1224,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────
 
   notify-slack-on-azure-deployment-test-failure:
-    needs: [released-chart-compat, build-images, tf-apply, deploy-osmo, oetf, tf-destroy]
+    needs: [released-chart-compat, build-images, tf-apply, deploy-osmo, oetf, tf-destroy, tf-destroy-apply-failure]
     # always() so this evaluates even when an upstream `needs:` failed.
     # Fires only on scheduled-run failures — PR-label and workflow_dispatch
     # runs surface their own status interactively.
@@ -1276,7 +1236,8 @@ jobs:
               || needs.tf-apply.result == 'failure'
               || needs.deploy-osmo.result == 'failure'
               || needs.oetf.result == 'failure'
-              || needs.tf-destroy.result == 'failure') }}
+              || needs.tf-destroy.result == 'failure'
+              || needs.tf-destroy-apply-failure.result == 'failure') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -1389,7 +1350,7 @@ jobs:
           APPLY_RESULT: ${{ needs.tf-apply.result }}
           DEPLOY_RESULT: ${{ needs.deploy-osmo.result }}
           OETF_RESULT: ${{ needs.oetf.result }}
-          DESTROY_RESULT: ${{ needs.tf-destroy.result }}
+          DESTROY_RESULT: ${{ needs.tf-destroy.result != 'skipped' && needs.tf-destroy.result || needs.tf-destroy-apply-failure.result }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -18,9 +18,9 @@ name: Deployment Test (Azure)
 #   - `workflow_dispatch` — once this file lands on the default branch, the
 #     "Run workflow" button in Actions becomes available for all three modes.
 #   - `pull_request` — auto-runs `init-only` on every push that touches the
-#     workflow, the wrapper script, or the Azure terraform module. The two
-#     heavier modes are gated behind PR labels (see below) so they don't burn
-#     Azure quota on every push.
+#     deployment workflow, source images, scripts, split charts, values, or
+#     Azure terraform module. The two heavier modes are gated behind PR labels
+#     (see below) so they don't burn Azure quota on every push.
 #
 # PR-label trigger (works pre-merge when the dispatcher isn't registered yet):
 #   - `ci:azure-deployment` → full-deployment fires on the next PR push
@@ -31,9 +31,9 @@ name: Deployment Test (Azure)
 #   - Daily at 00:00 UTC = 5pm PDT (16:00 PST during winter — GitHub cron
 #     is UTC, doesn't adjust for DST). github.event_name='schedule' runs
 #     build-images + full-deployment end-to-end on main, the same path
-#     the PR-label gate exercises. Schedule events fire only from the
-#     repo's default branch (main) — they don't run for forks or
-#     feature branches.
+#     the PR-label gate exercises. Images, scripts, and split charts all come
+#     from the tested checkout. Schedule events fire only from the repo's
+#     default branch (main) — they don't run for forks or feature branches.
 #
 # Slack notification (failure-only, schedule-only):
 #   - notify-slack-on-azure-deployment-test-failure posts to the channel
@@ -63,8 +63,13 @@ on:
     types: [opened, synchronize, reopened, labeled]
     paths:
       - '.github/workflows/deployment-test.yaml'
-      - 'deployments/scripts/run-deployment-test.sh'
+      - 'ci/deployment-test/**'
+      - 'deployments/charts/backend-operator/**'
+      - 'deployments/charts/service/**'
+      - 'deployments/scripts/**'
       - 'deployments/terraform/azure/**'
+      - 'deployments/values/**'
+      - 'src/**'
   schedule:
     # Daily at 00:00 UTC = 5pm PDT (16:00 PST during winter — GitHub cron
     # is UTC, doesn't track DST). Schedule fires only on main, not on
@@ -88,7 +93,7 @@ jobs:
   # azurerm provider plugin from the Terraform Registry (HTTPS, no Azure
   # API call). terraform validate + fmt are purely local.
   init-only:
-    if: >
+    if: >-
       ${{ github.event_name == 'pull_request'
           || github.event.inputs.mode == 'init-only' }}
     runs-on: ubuntu-latest
@@ -172,7 +177,7 @@ jobs:
   # separate them from dev's `YYYY.MM.DD.hash.stgN` tags. Cleanup uses
   # the tag prefix.
   build-images:
-    if: >
+    if: >-
       ${{ github.event_name == 'schedule'
           || github.event.inputs.mode == 'full-deployment'
           || (github.event_name == 'pull_request'
@@ -726,7 +731,11 @@ jobs:
               | kubectl apply -f -
           done
 
-      - name: deploy OSMO (chart install + verify-hello)
+      # Package the split charts from this checkout into a temporary Helm repo.
+      # deploy-k8s.sh keeps using its normal repository interface, but every
+      # artifact under test now comes from the same source SHA. This gate always
+      # provisions public AKS, so Helm runs on this runner and can reach loopback.
+      - name: deploy OSMO with HEAD charts (chart install + verify-hello)
         id: deploy_osmo
         env:
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
@@ -739,11 +748,61 @@ jobs:
           # dynamically-created workflow task pods get a docker-registry
           # secret they can use to pull init-container/client from nvcr.io.
           NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+          OSMO_HELM_REPO_NAME: osmo-head
+          OSMO_HELM_REPO_URL: http://127.0.0.1:8879
           SKIP_OETF: "1"
           SKIP_TEARDOWN: "1"
         run: |
-          set -o pipefail
-          echo "::notice::deploy stage starting — chart install + verify-hello, expected ~5–15 min"
+          set -euo pipefail
+
+          chart_repo_dir="$RUNNER_TEMP/osmo-head-helm-repo"
+          mkdir -p "$chart_repo_dir"
+
+          service_version="$(helm show chart deployments/charts/service \
+            | awk '$1 == "version:" { print $2; exit }')"
+          operator_version="$(helm show chart deployments/charts/backend-operator \
+            | awk '$1 == "version:" { print $2; exit }')"
+          if [[ -z "$service_version" || -z "$operator_version" \
+                || "$service_version" != "$operator_version" ]]; then
+            echo "::error::service ($service_version) and backend-operator ($operator_version) chart versions must match because deploy-k8s.sh uses one OSMO_CHART_VERSION"
+            exit 1
+          fi
+
+          helm lint deployments/charts/service
+          helm lint deployments/charts/backend-operator
+          helm package deployments/charts/service --destination "$chart_repo_dir"
+          helm package deployments/charts/backend-operator --destination "$chart_repo_dir"
+          helm repo index "$chart_repo_dir"
+
+          python3 -m http.server 8879 \
+            --bind 127.0.0.1 \
+            --directory "$chart_repo_dir" \
+            >"$RUNNER_TEMP/osmo-head-helm-repo.log" 2>&1 &
+          chart_repo_pid=$!
+          trap 'kill "$chart_repo_pid" 2>/dev/null || true' EXIT
+
+          chart_repo_ready=""
+          for _ in {1..10}; do
+            if curl -fsS "$OSMO_HELM_REPO_URL/index.yaml" >/dev/null 2>&1; then
+              chart_repo_ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [[ -z "$chart_repo_ready" ]]; then
+            cat "$RUNNER_TEMP/osmo-head-helm-repo.log"
+            echo "::error::HEAD chart repository did not become ready"
+            exit 1
+          fi
+
+          # Pre-add without credentials so deploy-k8s.sh preserves this exact
+          # local repo instead of forwarding NGC credentials to loopback.
+          helm repo add "$OSMO_HELM_REPO_NAME" "$OSMO_HELM_REPO_URL"
+          helm show chart "$OSMO_HELM_REPO_NAME/service" --version "$service_version" >/dev/null
+          helm show chart "$OSMO_HELM_REPO_NAME/backend-operator" --version "$operator_version" >/dev/null
+          export OSMO_CHART_VERSION="$service_version"
+          echo "chart_version=$OSMO_CHART_VERSION" >> "$GITHUB_OUTPUT"
+          echo "::notice::deploy stage starting with HEAD charts $OSMO_CHART_VERSION — expected ~5–15 min"
           mkdir -p "$RUN_DIR"
           bash deployments/scripts/run-deployment-test.sh --provider azure
           echo "▶ $(date -u +%H:%M:%S) deploy stage done"
@@ -755,10 +814,14 @@ jobs:
           AZURE_CLUSTER_NAME: ${{ vars.AZURE_CLUSTER_NAME || 'osmo-deployment-test' }}
         run: |
           set +e
-          chart_version="$(helm list -n osmo --output json 2>/dev/null \
+          service_chart="$(helm list -n osmo-minimal --output json 2>/dev/null \
                           | python3 -c 'import json,sys; rs=json.load(sys.stdin); print(rs[0].get("chart","-") if rs else "-")' 2>/dev/null || echo "-")"
-          pod_summary="$(kubectl get pods -n osmo --no-headers 2>/dev/null \
-                         | awk '{print $3}' | sort | uniq -c | awk '{printf "%s×%s ", $1, $2}' || echo "-")"
+          operator_chart="$(helm list -n osmo-operator --output json 2>/dev/null \
+                           | python3 -c 'import json,sys; rs=json.load(sys.stdin); print(rs[0].get("chart","-") if rs else "-")' 2>/dev/null || echo "-")"
+          chart_version="HEAD ${{ steps.deploy_osmo.outputs.chart_version || '-' }} (installed: $service_chart, $operator_chart) from ${{ github.sha }}"
+          pod_summary="$(kubectl get pods --all-namespaces --no-headers 2>/dev/null \
+                         | awk '$1 == "osmo-minimal" || $1 == "osmo-operator" {print $4}' \
+                         | sort | uniq -c | awk '{printf "%s×%s ", $1, $2}' || echo "-")"
           icon='✅'; verify_text='passed'
           if [ "${{ steps.deploy_osmo.outcome }}" != "success" ]; then icon='❌'; verify_text='failed (see step logs)'; fi
           {
@@ -1196,7 +1259,7 @@ jobs:
     # always() so this evaluates even when an upstream `needs:` failed.
     # Fires only on scheduled-run failures — PR-label and workflow_dispatch
     # runs surface their own status interactively.
-    if: >
+    if: >-
       ${{ always()
           && github.event_name == 'schedule'
           && (needs.build-images.result == 'failure'

--- a/.github/workflows/deployment-test.yaml
+++ b/.github/workflows/deployment-test.yaml
@@ -17,12 +17,12 @@ name: Deployment Test (Azure)
 # Triggers:
 #   - `workflow_dispatch` — once this file lands on the default branch, the
 #     "Run workflow" button in Actions becomes available for all three modes.
-#   - `pull_request` — does nothing automatically. Adding the label below
-#     explicitly starts the validation and full deployment lane.
+#   - `pull_request` — auto-runs only the cheap `init-only` validation when a
+#     relevant PR is opened or updated. It never starts cloud provisioning.
 #
 # PR-label trigger (works pre-merge when the dispatcher isn't registered yet):
 #   - `ci:azure-deployment` → init-only + full-deployment start immediately.
-#     To test a later commit, remove and re-add the label; pushes do not rerun it.
+#     Later pushes rerun only init-only; remove and re-add the label for full E2E.
 # auth-check is workflow_dispatch only — it's a developer-driven smoke for
 # the OIDC chain, not something we want to run automatically per PR.
 #
@@ -60,17 +60,39 @@ on:
           - full-deployment
   pull_request:
     branches: [main]
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - '.bazelrc'
+      - '.bazelversion'
+      - '.github/workflows/deployment-test.yaml'
+      - 'BUILD'
+      - 'MODULE.bazel'
+      - 'MODULE.bazel.lock'
+      - 'bzl/**'
+      - 'ci/deployment-test/**'
+      - 'deployments/charts/backend-operator/**'
+      - 'deployments/charts/service/**'
+      - 'deployments/scripts/**'
+      - 'deployments/terraform/azure/**'
+      - 'deployments/values/**'
+      - 'src/**'
   schedule:
     # Daily at 00:00 UTC = 5pm PDT (16:00 PST during winter — GitHub cron
     # is UTC, doesn't track DST). Schedule fires only on main, not on
     # feature branches.
     - cron: '0 0 * * *'
 
-# All full runs share one resource group. Queue overlaps rather than cancelling
-# a run during apply/destroy and risking leaked or cross-deleted resources.
+# Full runs share one resource group, so they use one concurrency group. Cheap
+# validation runs get a unique group and never queue behind cloud provisioning.
 concurrency:
-  group: deployment-test-azure
+  group: >-
+    ${{ (github.event_name == 'schedule'
+          || github.event.inputs.mode == 'full-deployment'
+          || (github.event_name == 'pull_request'
+              && github.event.action == 'labeled'
+              && github.event.label.name == 'ci:azure-deployment'))
+        && 'deployment-test-azure'
+        || format('deployment-test-azure-{0}', github.run_id) }}
   cancel-in-progress: false
 
 # OIDC federation to Azure — no static secrets in this workflow.
@@ -91,10 +113,8 @@ jobs:
   # API call). terraform validate + fmt are purely local.
   init-only:
     if: >-
-      ${{ github.event.inputs.mode == 'init-only'
-          || (github.event_name == 'pull_request'
-              && github.event.action == 'labeled'
-              && github.event.label.name == 'ci:azure-deployment') }}
+      ${{ github.event_name == 'pull_request'
+          || github.event.inputs.mode == 'init-only' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     defaults:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Before making any code changes in this repo, you MUST:
 
 - Follow existing code patterns and conventions in the codebase
 - Use Bazel for builds and testing
-- Keep cheap, non-provisioning validation automatic; reserve opt-in labels for cloud-provisioning E2E.
+- On pull requests, keep cheap, non-provisioning validation automatic and require an opt-in label for cloud-provisioning E2E.
 - Go code follows standard Go conventions
 - Write self-describing code; avoid redundant comments that simply restate what the code does
 - Copyright headers must keep "All rights reserved." on the same line as "NVIDIA CORPORATION & AFFILIATES"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Before making any code changes in this repo, you MUST:
 
 - Follow existing code patterns and conventions in the codebase
 - Use Bazel for builds and testing
+- Keep cheap, non-provisioning validation automatic; reserve opt-in labels for cloud-provisioning E2E.
 - Go code follows standard Go conventions
 - Write self-describing code; avoid redundant comments that simply restate what the code does
 - Copyright headers must keep "All rights reserved." on the same line as "NVIDIA CORPORATION & AFFILIATES"

--- a/ci/deployment-test/BUILD
+++ b/ci/deployment-test/BUILD
@@ -1,0 +1,25 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+exports_files([
+    "azure-overrides.yaml",
+    "check-released-chart-compat.sh",
+    "fixtures/minio-storage-values.yaml",
+])
+
+sh_test(
+    name = "test_check_released_chart_compat",
+    srcs = ["tests/test_check_released_chart_compat.sh"],
+    size = "small",
+    data = [
+        "azure-overrides.yaml",
+        "check-released-chart-compat.sh",
+        "fixtures/minio-storage-values.yaml",
+        "//deployments:scripts/common.sh",
+        "//deployments:scripts/deploy-k8s.sh",
+        "//deployments:values/backend-operator.yaml",
+        "//deployments:values/service.yaml",
+    ],
+)

--- a/ci/deployment-test/azure-overrides.yaml
+++ b/ci/deployment-test/azure-overrides.yaml
@@ -18,6 +18,32 @@
 # Layering a full values file keeps the merge clean.
 
 services:
+  # Keep the Azure E2E control plane small enough for the test cluster. These
+  # map-only overrides live here (rather than as wrapper --set flags) so the
+  # live install and released-chart compatibility render consume one source.
+  logger:
+    scaling:
+      minReplicas: 1
+    resources:
+      requests:
+        cpu: "100m"
+  service:
+    resources:
+      requests:
+        cpu: "100m"
+  worker:
+    resources:
+      requests:
+        cpu: "100m"
+  agent:
+    resources:
+      requests:
+        cpu: "100m"
+  router:
+    resources:
+      requests:
+        cpu: "100m"
+
   configs:
     podTemplates:
       default_ctrl:

--- a/ci/deployment-test/azure-overrides.yaml
+++ b/ci/deployment-test/azure-overrides.yaml
@@ -19,23 +19,6 @@
 
 services:
   configs:
-    # Since #1155 (Reconcile backend side effects from ConfigMap reloads,
-    # merged 2026-07-06), OSMO's ConfigMap-mode validator requires
-    # `k8s_namespace` on every backend definition — otherwise the service
-    # refuses to start with
-    #   backends.default.k8s_namespace: required in ConfigMap mode
-    # #1155's own chart template auto-fills this from `.Release.Namespace`,
-    # but the deploy path here pulls `latest stable` from the NGC helm repo
-    # (helm.ngc.nvidia.com/nvidia/osmo), which was cut before #1155 landed
-    # and therefore doesn't have the auto-fill yet. The images ARE built
-    # from `refs/pull/*/merge` — i.e. main HEAD — so they carry the strict
-    # check. Set it explicitly here to match the release namespace.
-    # TODO: drop this override once a chart release containing #1155 ships
-    # to helm.ngc.nvidia.com/nvidia/osmo.
-    backends:
-      default:
-        k8s_namespace: osmo-minimal
-
     podTemplates:
       default_ctrl:
         spec:

--- a/ci/deployment-test/check-released-chart-compat.sh
+++ b/ci/deployment-test/check-released-chart-compat.sh
@@ -8,6 +8,9 @@
 
 set -euo pipefail
 
+CHECK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$CHECK_DIR/../.." && pwd)"
+
 HELM_REPO_NAME="${OSMO_HELM_REPO_NAME:-osmo-release-contract}"
 HELM_REPO_URL="${OSMO_HELM_REPO_URL:-https://helm.ngc.nvidia.com/nvidia/osmo}"
 
@@ -28,40 +31,37 @@ if [[ "$service_version" != "$operator_version" ]]; then
     exit 1
 fi
 
-service_render="$(helm template osmo-minimal "$HELM_REPO_NAME/service" \
-    --version "$service_version" \
-    --namespace osmo-minimal \
-    -f deployments/values/service.yaml \
-    -f ci/deployment-test/azure-overrides.yaml \
-    --set global.osmoImageLocation=nvcr.io/nvstaging/osmo \
-    --set global.osmoImageTag=contract-test \
-    --set global.imagePullSecret=nvcr-pull \
-    --set services.postgres.serviceName=example.postgres.database.azure.com \
-    --set services.postgres.port=5432 \
-    --set services.postgres.db=osmo \
-    --set services.postgres.user=osmo \
-    --set services.redis.serviceName=example.redis.azure.net \
-    --set services.redis.port=10000 \
-    --set services.backendApiTokens.enabled=true \
-    --set 'services.backendApiTokens.credentials[0].name=default' \
-    --set 'services.backendApiTokens.credentials[0].existingSecret.name=osmo-operator-token' \
-    --set services.ui.apiHostname=osmo-gateway.osmo-minimal.svc.cluster.local:80 \
-    --set services.configs.service.service_base_url=http://osmo-gateway.osmo-minimal.svc.cluster.local \
-    --set services.configs.backends.default.router_address=ws://osmo-gateway.osmo-minimal.svc.cluster.local \
-    --set services.configs.workflow.backend_images.init=nvcr.io/nvstaging/osmo/init-container:contract-test \
-    --set services.configs.workflow.backend_images.client=nvcr.io/nvstaging/osmo/client:contract-test)"
+# Seed inert connection details, then render through the exact flag builders
+# used by deploy_osmo_service and setup_backend_operator. The storage fixture
+# represents configure-storage.sh's generated MinIO fragment without requiring
+# Kubernetes access.
+PROVIDER=azure
+OSMO_NAMESPACE=osmo-minimal
+OSMO_OPERATOR_NAMESPACE=osmo-operator
+OSMO_WORKFLOWS_NAMESPACE=osmo-workflows
+OSMO_IMAGE_REGISTRY=nvcr.io/nvstaging/osmo
+OSMO_IMAGE_TAG=contract-test
+OSMO_HELM_REPO_NAME="$HELM_REPO_NAME"
+OSMO_HELM_REPO_URL="$HELM_REPO_URL"
+OSMO_CHART_VERSION="$service_version"
+NGC_SECRET_NAME=nvcr-pull
+NGC_API_KEY=contract-test-api-key
+BACKEND_TOKEN_SECRET_NAME=osmo-operator-token
+POSTGRES_HOST=example.postgres.database.azure.com
+POSTGRES_PORT=5432
+POSTGRES_DB_NAME=osmo
+POSTGRES_USERNAME=osmo
+REDIS_HOST=example.redis.azure.net
+REDIS_PORT=10000
+STATIC_VALUES_DIR="$REPO_ROOT/deployments/values"
+STORAGE_VALUES_FILE="$CHECK_DIR/fixtures/minio-storage-values.yaml"
 
-operator_render="$(helm template osmo-operator "$HELM_REPO_NAME/backend-operator" \
-    --version "$operator_version" \
-    --namespace osmo-operator \
-    -f deployments/values/backend-operator.yaml \
-    --set global.osmoImageLocation=nvcr.io/nvstaging/osmo \
-    --set global.osmoImageTag=contract-test \
-    --set global.imagePullSecret=nvcr-pull \
-    --set global.serviceUrl=http://osmo-gateway.osmo-minimal.svc.cluster.local \
-    --set global.agentNamespace=osmo-operator \
-    --set global.backendNamespace=osmo-workflows \
-    --set global.accountTokenSecret=osmo-operator-token)"
+# shellcheck source=../../deployments/scripts/deploy-k8s.sh
+source "$REPO_ROOT/deployments/scripts/deploy-k8s.sh"
+OSMO_SERVICE_HELM_VALUES_FILES=("$CHECK_DIR/azure-overrides.yaml")
+
+service_render="$(render_osmo_service_chart)"
+operator_render="$(render_backend_operator_chart)"
 
 missing_contracts=()
 if ! grep -q 'k8s_namespace: osmo-minimal' <<<"$service_render"; then

--- a/ci/deployment-test/check-released-chart-compat.sh
+++ b/ci/deployment-test/check-released-chart-compat.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Fail before cloud provisioning when the latest stable public charts cannot
+# consume the images and values produced by the current deployment scripts.
+
+set -euo pipefail
+
+HELM_REPO_NAME="${OSMO_HELM_REPO_NAME:-osmo-release-contract}"
+HELM_REPO_URL="${OSMO_HELM_REPO_URL:-https://helm.ngc.nvidia.com/nvidia/osmo}"
+
+helm repo add "$HELM_REPO_NAME" "$HELM_REPO_URL" --force-update >/dev/null
+helm repo update "$HELM_REPO_NAME" >/dev/null
+
+service_version="$(helm show chart "$HELM_REPO_NAME/service" \
+    | awk '$1 == "version:" { print $2; exit }')"
+operator_version="$(helm show chart "$HELM_REPO_NAME/backend-operator" \
+    | awk '$1 == "version:" { print $2; exit }')"
+
+if [[ -z "$service_version" || -z "$operator_version" ]]; then
+    echo "Unable to resolve the latest stable released chart versions" >&2
+    exit 1
+fi
+if [[ "$service_version" != "$operator_version" ]]; then
+    echo "Released chart versions do not match: service=$service_version operator=$operator_version" >&2
+    exit 1
+fi
+
+service_render="$(helm template osmo-minimal "$HELM_REPO_NAME/service" \
+    --version "$service_version" \
+    --namespace osmo-minimal \
+    -f deployments/values/service.yaml \
+    -f ci/deployment-test/azure-overrides.yaml \
+    --set global.osmoImageLocation=nvcr.io/nvstaging/osmo \
+    --set global.osmoImageTag=contract-test \
+    --set global.imagePullSecret=nvcr-pull \
+    --set services.postgres.serviceName=example.postgres.database.azure.com \
+    --set services.postgres.port=5432 \
+    --set services.postgres.db=osmo \
+    --set services.postgres.user=osmo \
+    --set services.redis.serviceName=example.redis.azure.net \
+    --set services.redis.port=10000 \
+    --set services.backendApiTokens.enabled=true \
+    --set 'services.backendApiTokens.credentials[0].name=default' \
+    --set 'services.backendApiTokens.credentials[0].existingSecret.name=osmo-operator-token' \
+    --set services.ui.apiHostname=osmo-gateway.osmo-minimal.svc.cluster.local:80 \
+    --set services.configs.service.service_base_url=http://osmo-gateway.osmo-minimal.svc.cluster.local \
+    --set services.configs.backends.default.router_address=ws://osmo-gateway.osmo-minimal.svc.cluster.local \
+    --set services.configs.workflow.backend_images.init=nvcr.io/nvstaging/osmo/init-container:contract-test \
+    --set services.configs.workflow.backend_images.client=nvcr.io/nvstaging/osmo/client:contract-test)"
+
+operator_render="$(helm template osmo-operator "$HELM_REPO_NAME/backend-operator" \
+    --version "$operator_version" \
+    --namespace osmo-operator \
+    -f deployments/values/backend-operator.yaml \
+    --set global.osmoImageLocation=nvcr.io/nvstaging/osmo \
+    --set global.osmoImageTag=contract-test \
+    --set global.imagePullSecret=nvcr-pull \
+    --set global.serviceUrl=http://osmo-gateway.osmo-minimal.svc.cluster.local \
+    --set global.agentNamespace=osmo-operator \
+    --set global.backendNamespace=osmo-workflows \
+    --set global.accountTokenSecret=osmo-operator-token)"
+
+missing_contracts=()
+if ! grep -q 'k8s_namespace: osmo-minimal' <<<"$service_render"; then
+    missing_contracts+=("backend namespace defaulting")
+fi
+if ! grep -q -- '- --backend_token_directory' <<<"$service_render"; then
+    missing_contracts+=("control-plane backend token argument")
+fi
+if ! grep -Eq 'secretName: ["]?osmo-operator-token["]?' <<<"$service_render"; then
+    missing_contracts+=("control-plane backend token Secret mount")
+fi
+if ! grep -Eq 'secretName: ["]?osmo-operator-token["]?' <<<"$operator_render"; then
+    missing_contracts+=("operator backend token Secret mount")
+fi
+
+if [[ ${#missing_contracts[@]} -gt 0 ]]; then
+    printf 'Latest stable released charts (%s) are incompatible with this checkout:\n' \
+        "$service_version" >&2
+    printf '  - missing %s\n' "${missing_contracts[@]}" >&2
+    echo "Refusing to provision Azure for a deployment that cannot start." >&2
+    exit 1
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "chart_version=$service_version" >> "$GITHUB_OUTPUT"
+fi
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+        echo "### Released chart compatibility passed"
+        echo
+        echo "- service: \`$service_version\`"
+        echo "- backend-operator: \`$operator_version\`"
+        echo "- repository: \`$HELM_REPO_URL\`"
+    } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo "Released charts $service_version satisfy the current deployment contract"

--- a/ci/deployment-test/fixtures/minio-storage-values.yaml
+++ b/ci/deployment-test/fixtures/minio-storage-values.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Representative output from configure-storage.sh --backend minio.
+# Uses inert values so released charts can be rendered without a cluster.
+services:
+  configs:
+    secretRefs:
+      - secretName: nvcr-pull
+      - secretName: osmo-workflow-data-cred
+      - secretName: osmo-workflow-log-cred
+      - secretName: osmo-workflow-app-cred
+    workflow:
+      workflow_data:
+        credential:
+          secretName: osmo-workflow-data-cred
+        base_url: s3://osmo-workflows
+      workflow_log:
+        credential:
+          secretName: osmo-workflow-log-cred
+      workflow_app:
+        credential:
+          secretName: osmo-workflow-app-cred

--- a/ci/deployment-test/tests/test_check_released_chart_compat.sh
+++ b/ci/deployment-test/tests/test_check_released_chart_compat.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+REPO_ROOT="${TEST_SRCDIR}/_main"
+CHECKER="$REPO_ROOT/ci/deployment-test/check-released-chart-compat.sh"
+FAKE_BIN="$(mktemp -d)"
+TEST_TMP="$(mktemp -d)"
+trap 'rm -rf "$FAKE_BIN" "$TEST_TMP"' EXIT
+
+cat > "$FAKE_BIN/helm" <<'FAKE_HELM'
+#!/bin/bash
+set -euo pipefail
+
+case "$1" in
+    repo)
+        exit 0
+        ;;
+    show)
+        chart_name="${3##*/}"
+        if [[ "$chart_name" == "backend-operator" ]]; then
+            printf 'version: %s\n' "${FAKE_OPERATOR_VERSION:-1.3.1}"
+        else
+            printf 'version: %s\n' "${FAKE_SERVICE_VERSION:-1.3.1}"
+        fi
+        ;;
+    template)
+        printf '%s\n' "$*" >> "$FAKE_HELM_LOG"
+        if [[ "${FAKE_CHART_COMPAT:-false}" == "true" ]]; then
+            if [[ "$2" == "osmo-minimal" ]]; then
+                cat <<'SERVICE'
+kind: ConfigMap
+data:
+  config.yaml: |
+    k8s_namespace: osmo-minimal
+---
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - args:
+            - --backend_token_directory
+      volumes:
+        - secret:
+            secretName: osmo-operator-token
+SERVICE
+            else
+                cat <<'OPERATOR'
+kind: Deployment
+spec:
+  template:
+    spec:
+      volumes:
+        - secret:
+            secretName: osmo-operator-token
+OPERATOR
+            fi
+        else
+            printf 'kind: Deployment\nmetadata:\n  name: %s\n' "$2"
+        fi
+        ;;
+    *)
+        echo "unexpected helm invocation: $*" >&2
+        exit 2
+        ;;
+esac
+FAKE_HELM
+chmod +x "$FAKE_BIN/helm"
+
+assert_file_contains() {
+    local description="$1" file="$2" expected="$3"
+    if ! grep -Fq -- "$expected" "$file"; then
+        echo "assertion failed: $description" >&2
+        echo "expected: $expected" >&2
+        exit 1
+    fi
+}
+
+assert_file_not_contains() {
+    local description="$1" file="$2" unexpected="$3"
+    if grep -Fq -- "$unexpected" "$file"; then
+        echo "assertion failed: $description" >&2
+        echo "unexpected sensitive value was present in $file" >&2
+        exit 1
+    fi
+}
+
+incompatible_output="$TEST_TMP/incompatible.out"
+incompatible_log="$TEST_TMP/incompatible-helm.log"
+if PATH="$FAKE_BIN:$PATH" \
+    FAKE_HELM_LOG="$incompatible_log" \
+    FAKE_CHART_COMPAT=false \
+    bash "$CHECKER" >"$incompatible_output" 2>&1; then
+    echo "expected incompatible released charts to fail" >&2
+    exit 1
+fi
+
+assert_file_contains 'reports backend namespace contract' "$incompatible_output" \
+    'missing backend namespace defaulting'
+assert_file_contains 'reports service token argument contract' "$incompatible_output" \
+    'missing control-plane backend token argument'
+assert_file_contains 'reports service token mount contract' "$incompatible_output" \
+    'missing control-plane backend token Secret mount'
+assert_file_contains 'reports operator token mount contract' "$incompatible_output" \
+    'missing operator backend token Secret mount'
+
+assert_file_not_contains 'does not print registry auth' "$incompatible_output" \
+    'contract-test-api-key'
+assert_file_not_contains 'does not print registry username' "$incompatible_output" \
+    '$oauthtoken'
+# The offline preflight must use the same complete values chain as deployment.
+
+assert_file_contains 'uses service base values' "$incompatible_log" \
+    "-f $REPO_ROOT/deployments/values/service.yaml"
+assert_file_contains 'uses generated-storage fixture' "$incompatible_log" \
+    "-f $REPO_ROOT/ci/deployment-test/fixtures/minio-storage-values.yaml"
+assert_file_contains 'uses Azure deployment overrides' "$incompatible_log" \
+    "-f $REPO_ROOT/ci/deployment-test/azure-overrides.yaml"
+assert_file_contains 'uses dynamic backend image credential' "$incompatible_log" \
+    '--set services.configs.workflow.backend_images.credential.auth='
+assert_file_contains 'uses operator base values' "$incompatible_log" \
+    "-f $REPO_ROOT/deployments/values/backend-operator.yaml"
+
+compatible_output="$TEST_TMP/compatible.out"
+compatible_log="$TEST_TMP/compatible-helm.log"
+github_output="$TEST_TMP/github-output"
+github_summary="$TEST_TMP/github-summary"
+PATH="$FAKE_BIN:$PATH" \
+FAKE_HELM_LOG="$compatible_log" \
+FAKE_CHART_COMPAT=true \
+GITHUB_OUTPUT="$github_output" \
+GITHUB_STEP_SUMMARY="$github_summary" \
+bash "$CHECKER" >"$compatible_output" 2>&1
+
+assert_file_contains 'compatible fixture passes' "$compatible_output" \
+    'Released charts 1.3.1 satisfy the current deployment contract'
+assert_file_contains 'emits the pinned chart version' "$github_output" \
+    'chart_version=1.3.1'
+assert_file_contains 'writes the compatibility summary' "$github_summary" \
+    'Released chart compatibility passed'
+assert_file_not_contains 'compatible output does not print registry auth' "$compatible_output" \
+    'contract-test-api-key'

--- a/deployments/BUILD
+++ b/deployments/BUILD
@@ -19,4 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 exports_files([
     "scripts/common.sh",
     "scripts/deploy-k8s.sh",
+    "values/backend-operator.yaml",
+    "values/service.yaml",
 ])

--- a/deployments/scripts/deploy-k8s.sh
+++ b/deployments/scripts/deploy-k8s.sh
@@ -134,7 +134,16 @@ IS_PRIVATE_CLUSTER="${IS_PRIVATE_CLUSTER:-false}"
 # Function references for provider-specific commands
 RUN_KUBECTL="kubectl"
 RUN_KUBECTL_APPLY_STDIN=""
-RUN_HELM="helm"
+
+# Provider Helm wrappers accept a complete command as one string. Keep the
+# local runner on that same interface so render-only consumers can source this
+# file without calling setup_provider or touching a cluster.
+run_helm_locally() {
+    # Intentional word splitting: callers pass a complete Helm command string.
+    # shellcheck disable=SC2086
+    helm $*
+}
+RUN_HELM="run_helm_locally"
 RUN_HELM_WITH_VALUES=""
 
 # Populated by create_database() from the in-pod psql probe. Used by
@@ -752,9 +761,9 @@ create_image_pull_secrets() {
     # Single gate for all NGC pull-secret plumbing. Empty NGC_SECRET_NAME =
     # caller didn't opt in (no --ngc-api-key, no --ngc-secret-name, no env).
     # Skip secret creation + propagation entirely; service_set_flags and
-    # backend_operator_set_flags also gate on this so the helm install
-    # doesn't emit `global.imagePullSecret`, `secretRefs[0]`, or
-    # `backend_images.credential` for a name that resolves to nothing.
+    # backend_operator_set_flags also gate global.imagePullSecret on this.
+    # The workflow-image credential is separate because it requires the API
+    # key itself, not only the name of a pre-created pull Secret.
     if [[ -z "$NGC_SECRET_NAME" ]]; then
         log_info "NGC pull-secret plumbing disabled (no --ngc-api-key, no --ngc-secret-name, no NGC_SECRET_NAME env)"
         log_info "  Workflow + service pods will pull anonymously; works with public images only (e.g. nvcr.io/nvidia/osmo)"
@@ -974,7 +983,14 @@ service_set_flags() {
     # into every workflow Pod spec by the backend-worker — empty fields cause K8s 422.
     sets+=" --set services.configs.workflow.backend_images.init=${OSMO_IMAGE_REGISTRY}/init-container:${OSMO_IMAGE_TAG}"
     sets+=" --set services.configs.workflow.backend_images.client=${OSMO_IMAGE_REGISTRY}/client:${OSMO_IMAGE_TAG}"
-
+    # Dynamic workflow Pods do not inherit the service Deployments'
+    # imagePullSecrets. When an NGC key is available, include the same private
+    # registry credential the deployment path uses to create their pull Secret.
+    if [[ -n "$NGC_API_KEY" ]]; then
+        sets+=" --set services.configs.workflow.backend_images.credential.registry=nvcr.io"
+        sets+=" --set services.configs.workflow.backend_images.credential.username=\$oauthtoken"
+        sets+=" --set services.configs.workflow.backend_images.credential.auth=${NGC_API_KEY}"
+    fi
 
     echo "$sets"
 }
@@ -1117,6 +1133,41 @@ extra_values_flags() {
     echo "$flags"
 }
 
+# Flags shared by `helm upgrade --install` and offline `helm template`.
+# Keeping the complete values chain here ensures compatibility preflights
+# render the same base files, generated fragments, dynamic cluster values, and
+# caller overrides as the real deployment path.
+service_helm_flags() {
+    local flags=""
+    flags+=" --namespace $OSMO_NAMESPACE"
+    flags+="$(chart_version_flag)"
+    flags+=" -f $STATIC_VALUES_DIR/service.yaml"
+    flags+="$(extra_values_flags)"
+    flags+="$(service_set_flags)"
+    flags+="$(helm_user_values_flags service)"
+    flags+="$(helm_user_set_flags service)"
+    echo "$flags"
+}
+
+backend_operator_helm_flags() {
+    local flags=""
+    flags+=" --namespace $OSMO_OPERATOR_NAMESPACE"
+    flags+="$(chart_version_flag)"
+    flags+=" -f $STATIC_VALUES_DIR/backend-operator.yaml"
+    flags+="$(backend_operator_set_flags)"
+    flags+="$(helm_user_values_flags backend-operator)"
+    flags+="$(helm_user_set_flags backend-operator)"
+    echo "$flags"
+}
+
+render_osmo_service_chart() {
+    $RUN_HELM "template osmo-minimal $OSMO_HELM_REPO_NAME/service$(service_helm_flags)"
+}
+
+render_backend_operator_chart() {
+    $RUN_HELM "template osmo-operator $OSMO_HELM_REPO_NAME/backend-operator$(backend_operator_helm_flags)"
+}
+
 # Layer values/gpu-pool.yaml when OSMO_GPU_POOL_ENABLED=true (set automatically
 # by --gpu-node-pool) or when a GPU node is already present. Replaces the
 # 6.2-era `osmo config update` CLI dance — in 6.3 ConfigMap mode the pool
@@ -1179,7 +1230,7 @@ deploy_osmo_service() {
     # + AKS image pulls (~3-5 min) + Postgres + service init can push past 10m
     # on a fresh cluster. Override via HELM_TIMEOUT_SERVICE for slower envs.
     $RUN_HELM \
-        "upgrade --install osmo-minimal $OSMO_HELM_REPO_NAME/service --namespace $OSMO_NAMESPACE --wait --timeout ${HELM_TIMEOUT_SERVICE:-15m}$(chart_version_flag) -f $STATIC_VALUES_DIR/service.yaml$(extra_values_flags)$(service_set_flags)$(helm_user_values_flags service)$(helm_user_set_flags service)"
+        "upgrade --install osmo-minimal $OSMO_HELM_REPO_NAME/service --wait --timeout ${HELM_TIMEOUT_SERVICE:-15m}$(service_helm_flags)"
 
     log_success "OSMO service deployed"
 }
@@ -1196,7 +1247,7 @@ setup_backend_operator() {
     # backend-operator.yaml first, generated per-cluster overrides next, then
     # user overrides last so an explicit caller value always wins.
     $RUN_HELM \
-        "upgrade --install osmo-operator $OSMO_HELM_REPO_NAME/backend-operator --namespace $OSMO_OPERATOR_NAMESPACE --wait --timeout ${HELM_TIMEOUT_OPERATOR:-10m}$(chart_version_flag) -f $STATIC_VALUES_DIR/backend-operator.yaml$(backend_operator_set_flags)$(helm_user_values_flags backend-operator)$(helm_user_set_flags backend-operator)"
+        "upgrade --install osmo-operator $OSMO_HELM_REPO_NAME/backend-operator --wait --timeout ${HELM_TIMEOUT_OPERATOR:-10m}$(backend_operator_helm_flags)"
 
     log_success "Backend Operator deployed"
 }

--- a/deployments/scripts/run-deployment-test.sh
+++ b/deployments/scripts/run-deployment-test.sh
@@ -504,7 +504,8 @@ stage_deploy() {
             # strict-LE rule `USER_CPU LE K8_CPU` rejects every
             # cpu=1 task ("Value 1.0 too high for CPU").
             #
-            # Two reductions:
+            # Two reductions, both owned by azure-overrides.yaml so the live
+            # deployment and offline released-chart preflight share them:
             #   - OSMO-service requests → 100m  (was 1 each → 5 × 1 = 5 CPU)
             #   - osmo-ctrl sidecar request → 100m (was 1 per workflow task)
             # The chart's CPU LIMIT on ctrl/user still tracks USER_CPU,
@@ -522,36 +523,8 @@ stage_deploy() {
                 --cluster-name    "$AZURE_CLUSTER_NAME"
                 --environment     "$ENVIRONMENT"
                 --postgres-password "$POSTGRES_PASSWORD"
-                --helm-set services.logger.scaling.minReplicas=1
-                --helm-set services.logger.resources.requests.cpu=100m
-                --helm-set services.service.resources.requests.cpu=100m
-                --helm-set services.worker.resources.requests.cpu=100m
-                --helm-set services.agent.resources.requests.cpu=100m
-                --helm-set services.router.resources.requests.cpu=100m
-                # default_ctrl pod template override (osmo-ctrl sidecar
-                # requests.cpu → 100m). Has to come via --helm-values not
-                # --helm-set because helm replaces list elements wholesale —
-                # `--set …containers[0]...cpu=100m` wipes the container's
-                # `name` and limits, breaking the configmap loader's schema.
-                --helm-values "${SCRIPT_DIR}/../../ci/deployment-test/azure-overrides.yaml"
+                --service-helm-values "${SCRIPT_DIR}/../../ci/deployment-test/azure-overrides.yaml"
             )
-
-            # If NGC_API_KEY is in env (i.e. images are on a private nvcr.io
-            # path), wire it into services.configs.workflow.backend_images
-            # .credential so OSMO's task-pod scheduler code creates the
-            # per-workflow `<group_uuid>-osmo` docker-registry secret and
-            # attaches it as an imagePullSecret. Without this the dynamic
-            # workflow task pods try to pull the init-container from nvcr.io
-            # anonymously and get 403 (their ServiceAccount's imagePullSecret
-            # from global.imagePullSecret only covers the service-level pods,
-            # not the runtime task pods created by the backend-worker).
-            if [[ -n "${NGC_API_KEY:-}" ]]; then
-                args+=(
-                    --helm-set "services.configs.workflow.backend_images.credential.registry=nvcr.io"
-                    --helm-set 'services.configs.workflow.backend_images.credential.username=$oauthtoken'
-                    --helm-set "services.configs.workflow.backend_images.credential.auth=${NGC_API_KEY}"
-                )
-            fi
             ;;
         *)
             log_error "stage_deploy: provider $PROVIDER not wired"

--- a/deployments/scripts/storage/common.sh
+++ b/deployments/scripts/storage/common.sh
@@ -46,9 +46,10 @@ create_workflow_cred_secrets() {
 # cred secrets so the chart mounts them at /etc/osmo/secrets/<name>/. The NGC
 # pull-secret entry is only included when NGC_SECRET_NAME is non-empty (caller
 # opted in via --ngc-api-key, --ngc-secret-name, or NGC_SECRET_NAME env) —
-# same gate the rest of the script uses for global.imagePullSecret and
-# backend_images.credential, so no-opt-in deploys never reference a secret
-# that won't exist.
+# same gate the rest of the script uses for global.imagePullSecret. The
+# backend_images.credential fields are populated separately when NGC_API_KEY
+# is available, so no-opt-in deploys never reference credentials that do not
+# exist.
 # Args: backend_label (free text for the comment header) base_url
 emit_static_values_fragment() {
     local backend_label="$1" base_url="$2"

--- a/deployments/scripts/tests/BUILD
+++ b/deployments/scripts/tests/BUILD
@@ -20,3 +20,17 @@ sh_test(
         "//deployments:scripts/deploy-k8s.sh",
     ],
 )
+
+sh_test(
+    name = "test_helm_render_path",
+    srcs = ["test_helm_render_path.sh"],
+    size = "small",
+    data = [
+        "//ci/deployment-test:azure-overrides.yaml",
+        "//ci/deployment-test:fixtures/minio-storage-values.yaml",
+        "//deployments:scripts/common.sh",
+        "//deployments:scripts/deploy-k8s.sh",
+        "//deployments:values/backend-operator.yaml",
+        "//deployments:values/service.yaml",
+    ],
+)

--- a/deployments/scripts/tests/test_helm_render_path.sh
+++ b/deployments/scripts/tests/test_helm_render_path.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+REPO_ROOT="${TEST_SRCDIR}/_main"
+
+# shellcheck source=/dev/null
+source "$REPO_ROOT/deployments/scripts/deploy-k8s.sh"
+
+PROVIDER=azure
+OSMO_NAMESPACE=osmo-minimal
+OSMO_OPERATOR_NAMESPACE=osmo-operator
+OSMO_WORKFLOWS_NAMESPACE=osmo-workflows
+OSMO_IMAGE_REGISTRY=nvcr.io/nvstaging/osmo
+OSMO_IMAGE_TAG=contract-test
+OSMO_HELM_REPO_NAME=osmo-release-contract
+OSMO_CHART_VERSION=1.3.1
+NGC_SECRET_NAME=nvcr-pull
+NGC_API_KEY=contract-test-api-key
+BACKEND_TOKEN_SECRET_NAME=osmo-operator-token
+POSTGRES_HOST=example.postgres.database.azure.com
+POSTGRES_PORT=5432
+POSTGRES_DB_NAME=osmo
+POSTGRES_USERNAME=osmo
+REDIS_HOST=example.redis.azure.net
+REDIS_PORT=10000
+STATIC_VALUES_DIR="$REPO_ROOT/deployments/values"
+STORAGE_VALUES_FILE="$REPO_ROOT/ci/deployment-test/fixtures/minio-storage-values.yaml"
+OSMO_SERVICE_HELM_VALUES_FILES=("$REPO_ROOT/ci/deployment-test/azure-overrides.yaml")
+OSMO_SERVICE_HELM_SET_VALUES=(services.ui.enabled=true)
+OSMO_BACKEND_OPERATOR_HELM_SET_VALUES=(services.backendWorker.enabled=true)
+
+CAPTURE_FILE="$(mktemp)"
+trap 'rm -f "$CAPTURE_FILE"' EXIT
+
+capture_helm() {
+    printf '%s\n' "$1" >> "$CAPTURE_FILE"
+    if [[ "$1" == template* ]]; then
+        printf 'kind: List\n'
+    fi
+}
+RUN_HELM=capture_helm
+
+assert_contains() {
+    local description="$1" value="$2" expected="$3"
+    if [[ "$value" != *"$expected"* ]]; then
+        echo "assertion failed: $description" >&2
+        echo "expected: $expected" >&2
+        exit 1
+    fi
+}
+
+service_flags="$(service_helm_flags)"
+operator_flags="$(backend_operator_helm_flags)"
+
+assert_contains 'service namespace' "$service_flags" '--namespace osmo-minimal'
+assert_contains 'service chart version' "$service_flags" '--version 1.3.1'
+assert_contains 'service base values' "$service_flags" \
+    "-f $REPO_ROOT/deployments/values/service.yaml"
+assert_contains 'storage values' "$service_flags" \
+    "-f $REPO_ROOT/ci/deployment-test/fixtures/minio-storage-values.yaml"
+assert_contains 'Azure values' "$service_flags" \
+    "-f $REPO_ROOT/ci/deployment-test/azure-overrides.yaml"
+assert_contains 'private workflow image credential' "$service_flags" \
+    '--set services.configs.workflow.backend_images.credential.username=$oauthtoken'
+assert_contains 'service-specific caller override' "$service_flags" \
+    '--set services.ui.enabled=true'
+
+assert_contains 'operator namespace' "$operator_flags" '--namespace osmo-operator'
+assert_contains 'operator base values' "$operator_flags" \
+    "-f $REPO_ROOT/deployments/values/backend-operator.yaml"
+assert_contains 'operator-specific caller override' "$operator_flags" \
+    '--set services.backendWorker.enabled=true'
+
+render_osmo_service_chart >/dev/null
+deploy_osmo_service >/dev/null
+render_backend_operator_chart >/dev/null
+setup_backend_operator >/dev/null
+
+mapfile -t commands < "$CAPTURE_FILE"
+if [[ "${#commands[@]}" -ne 4 ]]; then
+    echo "assertion failed: expected four Helm commands, got ${#commands[@]}" >&2
+    exit 1
+fi
+
+assert_contains 'service render shares all flags' "${commands[0]}" "$service_flags"
+assert_contains 'service install shares all flags' "${commands[1]}" "$service_flags"
+assert_contains 'operator render shares all flags' "${commands[2]}" "$operator_flags"
+assert_contains 'operator install shares all flags' "${commands[3]}" "$operator_flags"

--- a/deployments/values/service.yaml
+++ b/deployments/values/service.yaml
@@ -72,8 +72,7 @@ services:
       # backend-worker injects into every workflow Pod. The chart has no
       # defaults for `init` / `client` — deploy-k8s.sh --sets them from
       # OSMO_IMAGE_REGISTRY + OSMO_IMAGE_TAG. The `credential` block is also
-      # added via --set, but only when NGC_API_KEY is provided or an existing
-      # pull secret is detected. With public images it is omitted entirely.
+      # added when NGC_API_KEY is provided. With public images it is omitted.
 
       # workflow_data / workflow_log / workflow_app credential blocks are owned
       # entirely by the storage values fragment (configure-storage.sh writes


### PR DESCRIPTION
## Description

The full Azure deployment test takes about an hour and provisions shared cloud resources, so it is no longer an automatic PR check.

This change:

- Moves the existing fast Terraform init/validate check into its own automatic workflow, preserving its original PR path filters.
- Runs full Azure E2E only when `ci:azure-deployment` is added, or by schedule/manual dispatch. Remove and re-add the label to test a newer PR head.
- Keeps the latest released public charts as the external-user guard and renders them through the same Helm values/flags used by the real deployment before Azure is provisioned.
- Builds images and Azure infrastructure in parallel, queues full runs, restores cleanup-compatible image tags, and starts teardown immediately when Terraform apply fails.
- Adds fast offline tests so the compatibility preflight and real Helm install path cannot drift silently.

The current public chart (1.3.1) still fails preflight because it lacks the required backend namespace and token wiring. This is intentional: the lane stops before provisioning until a compatible public chart is released.

Issue - None

## Validation

- `actionlint -ignore 'unexpected key "queue"' .github/workflows/deployment-test.yaml .github/workflows/deployment-test-init.yaml` (v1.7.12; the released linter schema does not yet include GitHub's `queue: max`)
- `terraform init -input=false && terraform validate -no-color`
- `bash -n` on all changed shell scripts and tests
- `bash deployments/charts/service/tests/render-tests.sh`
- `bazel test //ci/deployment-test:test_check_released_chart_compat //deployments/scripts/tests:test_helm_render_path //deployments/scripts/tests:test_backend_token_generation //deployments/scripts/tests:test_private_azure_backend_token`
- Verified public chart 1.3.1 fails with the expected compatibility contracts and no credential output.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
