### PR TITLE
Add rustfs to OSMO umbrella chart

### DIFF
--- a/.github/workflows/helm-chart-lint.yaml
+++ b/.github/workflows/helm-chart-lint.yaml
@@ -104,8 +104,9 @@ jobs:
           echo "Building dependencies for: $CHART"
           if [ "$CHART" = "osmo" ]; then
             helm repo add cnpg https://cloudnative-pg.github.io/charts
+            helm repo add rustfs https://charts.rustfs.com
           fi
-          helm dependency build "deployments/charts/$CHART" || true
+          helm dependency build "deployments/charts/$CHART"
           # Show what was fetched
           if [ -d "deployments/charts/$CHART/charts" ]; then
             echo "Dependencies fetched:"

--- a/.github/workflows/helm-chart-lint.yaml
+++ b/.github/workflows/helm-chart-lint.yaml
@@ -107,6 +107,9 @@ jobs:
             helm repo add rustfs https://charts.rustfs.com
           fi
           helm dependency build "deployments/charts/$CHART"
+          if [ "$CHART" = "osmo" ]; then
+            bash deployments/charts/osmo/tests/verify_rustfs_chart_archive.sh
+          fi
           # Show what was fetched
           if [ -d "deployments/charts/$CHART/charts" ]; then
             echo "Dependencies fetched:"

--- a/deployments/charts/osmo/Chart.lock
+++ b/deployments/charts/osmo/Chart.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: cluster
   repository: https://cloudnative-pg.github.io/charts
   version: 0.8.0
-digest: sha256:833a704e62d5ef4e34f9a33c45932d84ba53f1a370f504bd45daf112ef71282f
-generated: "2026-08-14T15:30:28.185960161-04:00"
+- name: rustfs
+  repository: https://charts.rustfs.com
+  version: 1.0.0-rc.2
+digest: sha256:2a8b5fda3ed074ef65431be8f9a7dfa5a16dcb0c413b642feca4cda6d69e86f5
+generated: "2026-08-17T16:01:07.925530044-04:00"

--- a/deployments/charts/osmo/Chart.yaml
+++ b/deployments/charts/osmo/Chart.yaml
@@ -27,3 +27,7 @@ dependencies:
   version: 0.8.0
   repository: https://cloudnative-pg.github.io/charts
   condition: embeddedDependencies.postgresql.enabled
+- name: rustfs
+  version: "1.0.0-rc.2"
+  repository: https://charts.rustfs.com
+  condition: embeddedDependencies.objectStorage.enabled

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -181,24 +181,12 @@ configure `externalDependencies.valkey` and
 
 ## Embedded RustFS object storage
 
-Embedded RustFS is disabled by default. RustFS and its Helm chart are pinned to
-the prerelease `1.0.0-rc.2`, and upstream labels distributed mode as testing.
-Treat both the standalone and distributed profiles as pre-production. The
-four-node example below is an operations starting point, not a claim of HA or
-production readiness. Approval under WDP-01 has not been established.
-
-For a development install with retained generated credentials, add these
-values after the `split-plane-control` profile and environment values:
+Enable embedded object storage with retained generated credentials as follows:
 
 ```yaml
 embeddedDependencies:
   objectStorage:
     enabled: true
-    region: us-east-1
-    buckets:
-      workflows: osmo-workflows
-      logs: osmo-logs
-      apps: osmo-apps
 
 externalDependencies:
   objectStorage:
@@ -218,285 +206,29 @@ rustfs:
     existingSecret: osmo-rustfs-credentials
 ```
 
-The chart generates `osmo-rustfs-credentials` with all three required data
-keys, retains it on uninstall, and reuses it on upgrades. Generated credentials
-are visible to users who can read the Secret or Helm release history. Restrict
-both and use `--hide-secret` when previewing an install or upgrade.
+The chart deploys a standalone RustFS instance with a retained 10 GiB
+`ReadWriteOnce` PVC. A post-install/post-upgrade Job creates the configured
+workflow, log, and app buckets when they are absent. OSMO is configured with
+the RustFS endpoint, buckets, and generated credentials automatically.
 
-The default `osmo-rustfs-credentials` name is fixed and namespace-scoped, not
-derived from the Helm release. Only one embedded RustFS release in a namespace
-may use that default. For each additional release, choose a unique name and use
-it consistently. Generated mode must keep the parent existing-Secret field
-empty; for a release named `osmo-a`, use:
+The generated `osmo-rustfs-credentials` Secret is retained on uninstall and
+reused on upgrades. To provide an existing Secret, disable
+`secrets.objectStorage.generate` and set both
+`secrets.objectStorage.existingSecret` and
+`rustfs.secret.existingSecret` to its name. The Secret must contain
+`RUSTFS_ACCESS_KEY`, `RUSTFS_SECRET_KEY`, and `object-storage.yaml`; the
+credentials in all three entries must match. Use a unique Secret name for each
+OSMO release in the same namespace.
 
-```yaml
-secrets:
-  objectStorage:
-    generate: true
-    existingSecret: ''
+For a distributed deployment, layer
+[`embedded-rustfs-ha-values.yaml`](embedded-rustfs-ha-values.yaml) after the
+environment values and provide the existing Secret referenced by that file.
 
-rustfs:
-  secret:
-    existingSecret: osmo-a-rustfs-credentials
-```
-
-For an operator-owned Secret, use the same unique name in both interfaces:
-
-```yaml
-secrets:
-  objectStorage:
-    generate: false
-    existingSecret: osmo-a-rustfs-credentials
-
-rustfs:
-  secret:
-    existingSecret: osmo-a-rustfs-credentials
-```
-
-Using the fixed default for two releases in one namespace causes Kubernetes
-resource ownership and credential collisions. The chart rejects mismatched
-names in existing-Secret mode.
-
-For GitOps, recovery, and the distributed example, create the Secret first.
-`RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` must exactly match the values in
-`object-storage.yaml`:
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: osmo-rustfs-credentials
-  namespace: osmo
-type: Opaque
-stringData:
-  RUSTFS_ACCESS_KEY: replace-with-access-key
-  RUSTFS_SECRET_KEY: replace-with-secret-key
-  object-storage.yaml: |
-    access_key_id: replace-with-access-key
-    access_key: replace-with-secret-key
-    addressing_style: path
-```
-
-Use these values with that Secret:
-
-```yaml
-embeddedDependencies:
-  objectStorage:
-    enabled: true
-
-externalDependencies:
-  objectStorage:
-    endpoint: ''
-    buckets:
-      workflows: ''
-      logs: ''
-      apps: ''
-
-secrets:
-  objectStorage:
-    generate: false
-    existingSecret: osmo-rustfs-credentials
-
-rustfs:
-  secret:
-    existingSecret: osmo-rustfs-credentials
-```
-
-The post-install/post-upgrade bootstrap Job waits for the S3 endpoint, then
-creates the configured workflow, log, and app buckets if they are absent. It
-does not recreate an existing bucket or delete objects. Bucket names and the
-region are injected into OSMO configuration together with the internal RustFS
-Service endpoint and `object-storage.yaml` Secret key.
-
-The OSMO client region and RustFS server region must be identical. The defaults
-set both to `us-east-1`. For a non-default region, override both values; the
-chart rejects a mismatch before install or upgrade:
-
-```yaml
-embeddedDependencies:
-  objectStorage:
-    region: us-west-2
-
-rustfs:
-  config:
-    rustfs:
-      region: us-west-2
-```
-
-### Standalone and distributed topology
-
-The chart defaults to one standalone RustFS Deployment with one retained 10 GiB
-`ReadWriteOnce` PVC. It uses a `Recreate` strategy, so object storage is
-unavailable while the pod is replaced. Set `rustfs.storageclass.name` and
-`rustfs.storageclass.dataStorageSize` before installation for the target CSI
-driver and capacity.
-
-The checked-in [`embedded-rustfs-ha-values.yaml`](embedded-rustfs-ha-values.yaml)
-example creates a four-replica StatefulSet with one 100 GiB `standard`
-`ReadWriteOnce` data volume per pod, required hostname anti-affinity, a
-`maxUnavailable: 1` PodDisruptionBudget, pod-local endpoint injection, and
-`EC:2` parity. Create the existing Secret above, then install it as the final
-values layer:
-
-```bash
-helm dependency build deployments/charts/osmo
-helm upgrade --install osmo deployments/charts/osmo \
-  --namespace osmo \
-  --create-namespace \
-  -f deployments/charts/osmo/profiles/split-plane-control.yaml \
-  -f <environment-values.yaml> \
-  -f deployments/charts/osmo/embedded-rustfs-ha-values.yaml \
-  --wait \
-  --timeout 25m
-```
-
-For this four-drive `EC:2` layout, reads can tolerate two failed drives. Write
-quorum means writes continue with only one node down; with two nodes down the
-remaining data can still be readable but writes stop. A PDB covers voluntary
-disruptions only, and hostname anti-affinity is only as useful as the available
-nodes and underlying storage failure domains.
-
-StatefulSet volume claim templates are immutable. Changing `drivesPerNode`,
-the StorageClass, or requested sizes in values does not update an existing
-StatefulSet and can be rejected by Kubernetes. Plan those fields before the
-first install. Follow the CSI provider's documented PVC expansion procedure
-when in-place expansion is supported; take a verified backup first.
-
-### Expansion, backup, upgrade, and recovery
-
-Expand distributed capacity with append-only server pools. Enable
-`rustfs.pools`, keep the original pool as the first entry, and append new pools;
-never reorder the list. After the new pool is Ready, run
-`rc admin rebalance start <alias>` to redistribute existing data. Before any
-pool removal, complete `rc admin decommission` for that pool and follow the
-upstream removal procedure. Do not treat deleting a StatefulSet or its PVCs as
-a capacity migration.
-
-Erasure coding and replication are not backups. Back up object data to a
-separate failure domain and back up the matching credential Secret. Define and
-test restores before relying on the service. Restore the original Secret with
-retained PVCs; a different access/secret-key pair can make the surviving data
-unusable to OSMO. Snapshot consistency and volume restore steps are specific to
-the CSI provider.
-
-Upgrade the RustFS chart and image together. Before upgrading, read the RustFS
-release notes, verify backups and restore instructions, and confirm the pinned
-chart and image provenance. Allow the StatefulSet to replace one pod at a time
-and wait for each pod's `/health/ready` endpoint before continuing. Also wait
-for the bucket-bootstrap Job and OSMO workloads. A Helm rollback may be
-unsupported after an on-disk format or cryptographic-format change; in that
-case restore the prior version and data from a tested backup instead of forcing
-a rollback.
-
-For one failed node, preserve its PVC and let Kubernetes reattach it or replace
-the failed infrastructure according to the storage provider's procedure. Do
-not intentionally take a second node down while writes are required. For
-multiple failures, stop changes, determine read/write quorum, preserve all
-remaining volumes and the credential Secret, and use RustFS's documented admin
-recovery procedure. The install notes provide the effective endpoint and this
-readiness inventory command:
-
-```bash
-kubectl get deployment,statefulset,pod,pvc,job --namespace osmo
-```
-
-The embedded endpoint is plain HTTP and is not exposed by RustFS Ingress or
-Gateway API. Use cluster network controls to restrict it to OSMO and operator
-traffic. The OSMO example does not configure RustFS TLS, mTLS, or a
-NetworkPolicy; validate those controls separately before use across untrusted
-networks. Prefer an external S3 service when managed TLS, multi-zone durability,
-backups, lifecycle policy, or a supported production SLA is required.
-
-Private registries are configured in the dependency's native values, not
-`imageRegistry`: use `rustfs.image.rustfs.repository` and `.tag`,
-`rustfs.image.initImage.repository` and `.tag`, and `rustfs.imagePullSecrets`.
-Keep the RustFS tag in `tag@sha256` form when mirroring because the upstream
-chart has no first-class image digest fields. Override the bootstrap image with
-`embeddedDependencies.objectStorage.bootstrap.image`, also using a digest.
-
-### RustFS compared with SeaweedFS
-
-This RustFS option and the SeaweedFS design evaluated in OSMO PR 1304 solve the
-same embedded S3 need with materially different operational tradeoffs:
-
-| Dimension | RustFS alternative | SeaweedFS design |
-| --- | --- | --- |
-| Runtime architecture | One RustFS server role provides the S3 API and storage in both standalone and distributed topologies. | Separate master, volume, filer, and S3 roles add independently scalable controls but more services and failure paths; the evaluated design also uses an external filer metadata database. |
-| Credentials and buckets | One retained Secret is consumed directly by RustFS and OSMO; an unprivileged AWS CLI hook creates three named buckets. | The evaluated design has source and derived credential Secrets, a privileged synchronization Job, and dependency-specific bucket/key coupling. |
-| Maturity | RustFS and its chart are `1.0.0-rc.2`; distributed mode is labelled testing, the chart is unsigned, and upgrade/failure evidence is limited. | SeaweedFS `4.41` is a stable release from a longer-lived project with richer topology controls and a broader operational history. |
-| Operational choice | Smaller component and credential footprint, at the cost of higher prerelease and recovery risk. | More moving parts and metadata dependencies, in exchange for more established topology and recovery tooling. |
-
-Neither erasure coding nor replication replaces an independent backup. The
-comparison does not establish WDP-01 approval for either implementation.
-
-### RustFS provenance and licensing
-
-- The dependency chart and release are `1.0.0-rc.2`. The fetched chart archive
-  has SHA-256 digest
-  `c26cb094bc9735d01548ee540d018c1d88e2038bfd27ddc330770f5d525e63eb`.
-  The chart repository/archive is unsigned, so the digest detects unexpected
-  bytes but does not establish publisher identity.
-- The [`rustfs/rustfs`](https://github.com/rustfs/rustfs) and
-  [`rustfs/helm`](https://github.com/rustfs/helm) repositories are
-  Apache-2.0 licensed.
-- The RustFS multi-architecture manifest is pinned as
-  `sha256:7d6d361c49c08d427250fb59aae5d78df83d644c3405d9ccf4b21cda0b0692d0`,
-  includes amd64 and arm64 images, and has attestations. OSMO uses the
-  chart-compatible `1.0.0-rc.2@sha256:...` tag value because neither the chart
-  nor its image values expose a first-class digest field.
-- The bucket hook uses Amazon's AWS CLI `2.31.13` image, based on Amazon Linux
-  2023, pinned at
-  `sha256:e14216fb361cce909ce199616711ad103182d5937f851cda9bebf25867d7180a`.
-  That manifest contains `linux/amd64` and `linux/arm64` images. The
-  [`aws/aws-cli`](https://github.com/aws/aws-cli/tree/v2) source is
-  Apache-2.0 licensed; preserve the licenses for the Amazon Linux base and
-  bundled packages when distributing or mirroring the container. This image
-  runs only the post-install/post-upgrade S3 bucket bootstrap script.
-- The RustFS init container uses the Docker Official BusyBox `stable` image,
-  pinned at
-  `sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662`.
-  Its manifest includes `linux/amd64` and `linux/arm64/v8` images and identifies
-  [`docker-library/busybox`](https://github.com/docker-library/busybox) as its
-  build source. BusyBox is GPL-2.0-only; distributing or mirroring it carries
-  the corresponding source-availability obligations. The init container only
-  prepares the RustFS data and optional log directories before the server
-  starts.
-
-### Focused generated-Secret lifecycle test
-
-The offline render suite cannot exercise Helm's server-side `lookup`. A focused
-test installs the production chart into a task-scoped namespace on an existing
-local kind cluster named `osmo`. It uses `--no-hooks`, tests standalone and
-distributed retained state, and removes only its two releases and namespace.
-It refuses ambient or non-`kind-osmo` kubeconfigs.
-
-Requirements are `kind`, `kubectl`, and Helm, the local `osmo` kind cluster,
-and network access for `helm dependency build`. Run exactly:
-
-```bash
-helm dependency build deployments/charts/osmo
-bash deployments/charts/osmo/tests/verify_rustfs_chart_archive.sh
-rustfs_lifecycle_kubeconfig=$(mktemp)
-trap 'rm -f "$rustfs_lifecycle_kubeconfig"' EXIT
-kind get kubeconfig --name osmo >"$rustfs_lifecycle_kubeconfig"
-bash deployments/charts/osmo/tests/test_object_storage_secret_lifecycle.sh \
-  "$rustfs_lifecycle_kubeconfig"
-```
-
-The test verifies that an upgrade preserves generated data, missing and empty
-retained keys stop an upgrade, and a deleted generated Secret is not recreated
-while a Deployment, StatefulSet, or PVC survives.
-
-### External S3 fallback
-
-To return to external object storage, set
-`embeddedDependencies.objectStorage.enabled=false`, configure the HTTPS
-endpoint, region, and three named buckets under
-`externalDependencies.objectStorage`, and set
-`secrets.objectStorage.existingSecret` to a Secret containing
-`object-storage.yaml`. The external Secret needs the OSMO SDK configuration;
-it does not need the two RustFS environment keys. Verify data migration and
-bucket contents independently before disabling or removing embedded storage.
+To use external object storage, keep
+`embeddedDependencies.objectStorage.enabled=false` and configure
+`externalDependencies.objectStorage` and
+`secrets.objectStorage.existingSecret` as shown in the installation example
+above.
 
 ## Optional configuration
 

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -223,6 +223,40 @@ keys, retains it on uninstall, and reuses it on upgrades. Generated credentials
 are visible to users who can read the Secret or Helm release history. Restrict
 both and use `--hide-secret` when previewing an install or upgrade.
 
+The default `osmo-rustfs-credentials` name is fixed and namespace-scoped, not
+derived from the Helm release. Only one embedded RustFS release in a namespace
+may use that default. For each additional release, choose a unique name and use
+it consistently. Generated mode must keep the parent existing-Secret field
+empty; for a release named `osmo-a`, use:
+
+```yaml
+secrets:
+  objectStorage:
+    generate: true
+    existingSecret: ''
+
+rustfs:
+  secret:
+    existingSecret: osmo-a-rustfs-credentials
+```
+
+For an operator-owned Secret, use the same unique name in both interfaces:
+
+```yaml
+secrets:
+  objectStorage:
+    generate: false
+    existingSecret: osmo-a-rustfs-credentials
+
+rustfs:
+  secret:
+    existingSecret: osmo-a-rustfs-credentials
+```
+
+Using the fixed default for two releases in one namespace causes Kubernetes
+resource ownership and credential collisions. The chart rejects mismatched
+names in existing-Secret mode.
+
 For GitOps, recovery, and the distributed example, create the Secret first.
 `RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` must exactly match the values in
 `object-storage.yaml`:
@@ -273,6 +307,21 @@ creates the configured workflow, log, and app buckets if they are absent. It
 does not recreate an existing bucket or delete objects. Bucket names and the
 region are injected into OSMO configuration together with the internal RustFS
 Service endpoint and `object-storage.yaml` Secret key.
+
+The OSMO client region and RustFS server region must be identical. The defaults
+set both to `us-east-1`. For a non-default region, override both values; the
+chart rejects a mismatch before install or upgrade:
+
+```yaml
+embeddedDependencies:
+  objectStorage:
+    region: us-west-2
+
+rustfs:
+  config:
+    rustfs:
+      region: us-west-2
+```
 
 ### Standalone and distributed topology
 
@@ -365,6 +414,21 @@ Keep the RustFS tag in `tag@sha256` form when mirroring because the upstream
 chart has no first-class image digest fields. Override the bootstrap image with
 `embeddedDependencies.objectStorage.bootstrap.image`, also using a digest.
 
+### RustFS compared with SeaweedFS
+
+This RustFS option and the SeaweedFS design evaluated in OSMO PR 1304 solve the
+same embedded S3 need with materially different operational tradeoffs:
+
+| Dimension | RustFS alternative | SeaweedFS design |
+| --- | --- | --- |
+| Runtime architecture | One RustFS server role provides the S3 API and storage in both standalone and distributed topologies. | Separate master, volume, filer, and S3 roles add independently scalable controls but more services and failure paths; the evaluated design also uses an external filer metadata database. |
+| Credentials and buckets | One retained Secret is consumed directly by RustFS and OSMO; an unprivileged AWS CLI hook creates three named buckets. | The evaluated design has source and derived credential Secrets, a privileged synchronization Job, and dependency-specific bucket/key coupling. |
+| Maturity | RustFS and its chart are `1.0.0-rc.2`; distributed mode is labelled testing, the chart is unsigned, and upgrade/failure evidence is limited. | SeaweedFS `4.41` is a stable release from a longer-lived project with richer topology controls and a broader operational history. |
+| Operational choice | Smaller component and credential footprint, at the cost of higher prerelease and recovery risk. | More moving parts and metadata dependencies, in exchange for more established topology and recovery tooling. |
+
+Neither erasure coding nor replication replaces an independent backup. The
+comparison does not establish WDP-01 approval for either implementation.
+
 ### RustFS provenance and licensing
 
 - The dependency chart and release are `1.0.0-rc.2`. The fetched chart archive
@@ -380,9 +444,48 @@ chart has no first-class image digest fields. Override the bootstrap image with
   includes amd64 and arm64 images, and has attestations. OSMO uses the
   chart-compatible `1.0.0-rc.2@sha256:...` tag value because neither the chart
   nor its image values expose a first-class digest field.
-- The init image is BusyBox, licensed GPL-2.0. Distributing or mirroring it
-  carries the corresponding GPL source-availability obligations; retain the
-  license notices and provide corresponding source as required.
+- The bucket hook uses Amazon's AWS CLI `2.31.13` image, based on Amazon Linux
+  2023, pinned at
+  `sha256:e14216fb361cce909ce199616711ad103182d5937f851cda9bebf25867d7180a`.
+  That manifest contains `linux/amd64` and `linux/arm64` images. The
+  [`aws/aws-cli`](https://github.com/aws/aws-cli/tree/v2) source is
+  Apache-2.0 licensed; preserve the licenses for the Amazon Linux base and
+  bundled packages when distributing or mirroring the container. This image
+  runs only the post-install/post-upgrade S3 bucket bootstrap script.
+- The RustFS init container uses the Docker Official BusyBox `stable` image,
+  pinned at
+  `sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662`.
+  Its manifest includes `linux/amd64` and `linux/arm64/v8` images and identifies
+  [`docker-library/busybox`](https://github.com/docker-library/busybox) as its
+  build source. BusyBox is GPL-2.0-only; distributing or mirroring it carries
+  the corresponding source-availability obligations. The init container only
+  prepares the RustFS data and optional log directories before the server
+  starts.
+
+### Focused generated-Secret lifecycle test
+
+The offline render suite cannot exercise Helm's server-side `lookup`. A focused
+test installs the production chart into a task-scoped namespace on an existing
+local kind cluster named `osmo`. It uses `--no-hooks`, tests standalone and
+distributed retained state, and removes only its two releases and namespace.
+It refuses ambient or non-`kind-osmo` kubeconfigs.
+
+Requirements are `kind`, `kubectl`, and Helm, the local `osmo` kind cluster,
+and network access for `helm dependency build`. Run exactly:
+
+```bash
+helm dependency build deployments/charts/osmo
+bash deployments/charts/osmo/tests/verify_rustfs_chart_archive.sh
+rustfs_lifecycle_kubeconfig=$(mktemp)
+trap 'rm -f "$rustfs_lifecycle_kubeconfig"' EXIT
+kind get kubeconfig --name osmo >"$rustfs_lifecycle_kubeconfig"
+bash deployments/charts/osmo/tests/test_object_storage_secret_lifecycle.sh \
+  "$rustfs_lifecycle_kubeconfig"
+```
+
+The test verifies that an upgrade preserves generated data, missing and empty
+retained keys stop an upgrade, and a deleted generated Secret is not recreated
+while a Deployment, StatefulSet, or PVC survives.
 
 ### External S3 fallback
 

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -11,7 +11,8 @@ The supported `split-plane-control` profile installs the API, UI, router,
 worker, logger, agent, delayed-job monitor, and standalone OSMO gateway. It
 can create a persistent PostgreSQL cluster through CloudNativePG or connect to
 an external PostgreSQL service, and it can deploy embedded Valkey or connect
-to an external Valkey service. Object storage and the remaining Kubernetes
+to an external Valkey service. Object storage can use an external S3-compatible
+service or the optional embedded RustFS dependency. The remaining Kubernetes
 Secrets are externally managed. Compute-plane workloads and the other embedded
 dependencies remain future work.
 
@@ -177,6 +178,222 @@ automatic primary promotion, multi-zone failover, managed backups, or TLS.
 To use external Valkey, keep `embeddedDependencies.valkey.enabled=false` and
 configure `externalDependencies.valkey` and
 `secrets.valkey.existingSecret` as shown in the installation example.
+
+## Embedded RustFS object storage
+
+Embedded RustFS is disabled by default. RustFS and its Helm chart are pinned to
+the prerelease `1.0.0-rc.2`, and upstream labels distributed mode as testing.
+Treat both the standalone and distributed profiles as pre-production. The
+four-node example below is an operations starting point, not a claim of HA or
+production readiness. Approval under WDP-01 has not been established.
+
+For a development install with retained generated credentials, add these
+values after the `split-plane-control` profile and environment values:
+
+```yaml
+embeddedDependencies:
+  objectStorage:
+    enabled: true
+    region: us-east-1
+    buckets:
+      workflows: osmo-workflows
+      logs: osmo-logs
+      apps: osmo-apps
+
+externalDependencies:
+  objectStorage:
+    endpoint: ''
+    buckets:
+      workflows: ''
+      logs: ''
+      apps: ''
+
+secrets:
+  objectStorage:
+    generate: true
+    existingSecret: ''
+
+rustfs:
+  secret:
+    existingSecret: osmo-rustfs-credentials
+```
+
+The chart generates `osmo-rustfs-credentials` with all three required data
+keys, retains it on uninstall, and reuses it on upgrades. Generated credentials
+are visible to users who can read the Secret or Helm release history. Restrict
+both and use `--hide-secret` when previewing an install or upgrade.
+
+For GitOps, recovery, and the distributed example, create the Secret first.
+`RUSTFS_ACCESS_KEY` and `RUSTFS_SECRET_KEY` must exactly match the values in
+`object-storage.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: osmo-rustfs-credentials
+  namespace: osmo
+type: Opaque
+stringData:
+  RUSTFS_ACCESS_KEY: replace-with-access-key
+  RUSTFS_SECRET_KEY: replace-with-secret-key
+  object-storage.yaml: |
+    access_key_id: replace-with-access-key
+    access_key: replace-with-secret-key
+    addressing_style: path
+```
+
+Use these values with that Secret:
+
+```yaml
+embeddedDependencies:
+  objectStorage:
+    enabled: true
+
+externalDependencies:
+  objectStorage:
+    endpoint: ''
+    buckets:
+      workflows: ''
+      logs: ''
+      apps: ''
+
+secrets:
+  objectStorage:
+    generate: false
+    existingSecret: osmo-rustfs-credentials
+
+rustfs:
+  secret:
+    existingSecret: osmo-rustfs-credentials
+```
+
+The post-install/post-upgrade bootstrap Job waits for the S3 endpoint, then
+creates the configured workflow, log, and app buckets if they are absent. It
+does not recreate an existing bucket or delete objects. Bucket names and the
+region are injected into OSMO configuration together with the internal RustFS
+Service endpoint and `object-storage.yaml` Secret key.
+
+### Standalone and distributed topology
+
+The chart defaults to one standalone RustFS Deployment with one retained 10 GiB
+`ReadWriteOnce` PVC. It uses a `Recreate` strategy, so object storage is
+unavailable while the pod is replaced. Set `rustfs.storageclass.name` and
+`rustfs.storageclass.dataStorageSize` before installation for the target CSI
+driver and capacity.
+
+The checked-in [`embedded-rustfs-ha-values.yaml`](embedded-rustfs-ha-values.yaml)
+example creates a four-replica StatefulSet with one 100 GiB `standard`
+`ReadWriteOnce` data volume per pod, required hostname anti-affinity, a
+`maxUnavailable: 1` PodDisruptionBudget, pod-local endpoint injection, and
+`EC:2` parity. Create the existing Secret above, then install it as the final
+values layer:
+
+```bash
+helm dependency build deployments/charts/osmo
+helm upgrade --install osmo deployments/charts/osmo \
+  --namespace osmo \
+  --create-namespace \
+  -f deployments/charts/osmo/profiles/split-plane-control.yaml \
+  -f <environment-values.yaml> \
+  -f deployments/charts/osmo/embedded-rustfs-ha-values.yaml \
+  --wait \
+  --timeout 25m
+```
+
+For this four-drive `EC:2` layout, reads can tolerate two failed drives. Write
+quorum means writes continue with only one node down; with two nodes down the
+remaining data can still be readable but writes stop. A PDB covers voluntary
+disruptions only, and hostname anti-affinity is only as useful as the available
+nodes and underlying storage failure domains.
+
+StatefulSet volume claim templates are immutable. Changing `drivesPerNode`,
+the StorageClass, or requested sizes in values does not update an existing
+StatefulSet and can be rejected by Kubernetes. Plan those fields before the
+first install. Follow the CSI provider's documented PVC expansion procedure
+when in-place expansion is supported; take a verified backup first.
+
+### Expansion, backup, upgrade, and recovery
+
+Expand distributed capacity with append-only server pools. Enable
+`rustfs.pools`, keep the original pool as the first entry, and append new pools;
+never reorder the list. After the new pool is Ready, run
+`rc admin rebalance start <alias>` to redistribute existing data. Before any
+pool removal, complete `rc admin decommission` for that pool and follow the
+upstream removal procedure. Do not treat deleting a StatefulSet or its PVCs as
+a capacity migration.
+
+Erasure coding and replication are not backups. Back up object data to a
+separate failure domain and back up the matching credential Secret. Define and
+test restores before relying on the service. Restore the original Secret with
+retained PVCs; a different access/secret-key pair can make the surviving data
+unusable to OSMO. Snapshot consistency and volume restore steps are specific to
+the CSI provider.
+
+Upgrade the RustFS chart and image together. Before upgrading, read the RustFS
+release notes, verify backups and restore instructions, and confirm the pinned
+chart and image provenance. Allow the StatefulSet to replace one pod at a time
+and wait for each pod's `/health/ready` endpoint before continuing. Also wait
+for the bucket-bootstrap Job and OSMO workloads. A Helm rollback may be
+unsupported after an on-disk format or cryptographic-format change; in that
+case restore the prior version and data from a tested backup instead of forcing
+a rollback.
+
+For one failed node, preserve its PVC and let Kubernetes reattach it or replace
+the failed infrastructure according to the storage provider's procedure. Do
+not intentionally take a second node down while writes are required. For
+multiple failures, stop changes, determine read/write quorum, preserve all
+remaining volumes and the credential Secret, and use RustFS's documented admin
+recovery procedure. The install notes provide the effective endpoint and this
+readiness inventory command:
+
+```bash
+kubectl get deployment,statefulset,pod,pvc,job --namespace osmo
+```
+
+The embedded endpoint is plain HTTP and is not exposed by RustFS Ingress or
+Gateway API. Use cluster network controls to restrict it to OSMO and operator
+traffic. The OSMO example does not configure RustFS TLS, mTLS, or a
+NetworkPolicy; validate those controls separately before use across untrusted
+networks. Prefer an external S3 service when managed TLS, multi-zone durability,
+backups, lifecycle policy, or a supported production SLA is required.
+
+Private registries are configured in the dependency's native values, not
+`imageRegistry`: use `rustfs.image.rustfs.repository` and `.tag`,
+`rustfs.image.initImage.repository` and `.tag`, and `rustfs.imagePullSecrets`.
+Keep the RustFS tag in `tag@sha256` form when mirroring because the upstream
+chart has no first-class image digest fields. Override the bootstrap image with
+`embeddedDependencies.objectStorage.bootstrap.image`, also using a digest.
+
+### RustFS provenance and licensing
+
+- The dependency chart and release are `1.0.0-rc.2`. The fetched chart archive
+  has SHA-256 digest
+  `c26cb094bc9735d01548ee540d018c1d88e2038bfd27ddc330770f5d525e63eb`.
+  The chart repository/archive is unsigned, so the digest detects unexpected
+  bytes but does not establish publisher identity.
+- The [`rustfs/rustfs`](https://github.com/rustfs/rustfs) and
+  [`rustfs/helm`](https://github.com/rustfs/helm) repositories are
+  Apache-2.0 licensed.
+- The RustFS multi-architecture manifest is pinned as
+  `sha256:7d6d361c49c08d427250fb59aae5d78df83d644c3405d9ccf4b21cda0b0692d0`,
+  includes amd64 and arm64 images, and has attestations. OSMO uses the
+  chart-compatible `1.0.0-rc.2@sha256:...` tag value because neither the chart
+  nor its image values expose a first-class digest field.
+- The init image is BusyBox, licensed GPL-2.0. Distributing or mirroring it
+  carries the corresponding GPL source-availability obligations; retain the
+  license notices and provide corresponding source as required.
+
+### External S3 fallback
+
+To return to external object storage, set
+`embeddedDependencies.objectStorage.enabled=false`, configure the HTTPS
+endpoint, region, and three named buckets under
+`externalDependencies.objectStorage`, and set
+`secrets.objectStorage.existingSecret` to a Secret containing
+`object-storage.yaml`. The external Secret needs the OSMO SDK configuration;
+it does not need the two RustFS environment keys. Verify data migration and
+bucket contents independently before disabling or removing embedded storage.
 
 ## Optional configuration
 

--- a/deployments/charts/osmo/embedded-rustfs-ha-values.yaml
+++ b/deployments/charts/osmo/embedded-rustfs-ha-values.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Distributed RustFS operations example. Supply osmo-rustfs-credentials before
+# installing; see README.md for the required RustFS and OSMO credential keys.
+embeddedDependencies:
+  objectStorage:
+    enabled: true
+    region: us-east-1
+    buckets:
+      workflows: osmo-workflows
+      logs: osmo-logs
+      apps: osmo-apps
+
+externalDependencies:
+  objectStorage:
+    endpoint: ''
+    buckets:
+      workflows: ''
+      logs: ''
+      apps: ''
+
+secrets:
+  objectStorage:
+    generate: false
+    existingSecret: osmo-rustfs-credentials
+
+rustfs:
+  replicaCount: 4
+  drivesPerNode: 1
+  localEndpointHost:
+    autoInject: true
+  mode:
+    standalone:
+      enabled: false
+    distributed:
+      enabled: true
+  secret:
+    existingSecret: osmo-rustfs-credentials
+  config:
+    rustfs:
+      ec:
+        storage_class_standard: EC:2
+  affinity:
+    podAntiAffinity:
+      enabled: true
+      topologyKey: kubernetes.io/hostname
+  pdb:
+    create: true
+    maxUnavailable: 1
+  storageclass:
+    name: standard
+    dataStorageSize: 100Gi
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi

--- a/deployments/charts/osmo/files/object-storage-bootstrap.sh
+++ b/deployments/charts/osmo/files/object-storage-bootstrap.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+: "${AWS_ENDPOINT_URL:?AWS_ENDPOINT_URL is required}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
+: "${AWS_DEFAULT_REGION:?AWS_DEFAULT_REGION is required}"
+: "${OSMO_WORKFLOW_BUCKET:?OSMO_WORKFLOW_BUCKET is required}"
+: "${OSMO_LOG_BUCKET:?OSMO_LOG_BUCKET is required}"
+: "${OSMO_APP_BUCKET:?OSMO_APP_BUCKET is required}"
+
+attempts=${OSMO_STORAGE_BOOTSTRAP_ATTEMPTS:-30}
+case "$attempts" in
+    ''|*[!0-9]*)
+        echo "OSMO_STORAGE_BOOTSTRAP_ATTEMPTS must be a positive integer" >&2
+        exit 1
+        ;;
+esac
+if [ "$attempts" -eq 0 ]; then
+    echo "OSMO_STORAGE_BOOTSTRAP_ATTEMPTS must be a positive integer" >&2
+    exit 1
+fi
+
+bootstrap_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/object-storage-bootstrap.XXXXXX")
+trap 'rm -rf "$bootstrap_tmpdir"' EXIT HUP INT TERM
+AWS_CONFIG_FILE="$bootstrap_tmpdir/config"
+export AWS_CONFIG_FILE
+
+cat >"$AWS_CONFIG_FILE" <<'EOF'
+[default]
+s3 =
+    addressing_style = path
+EOF
+
+attempt=1
+while ! aws s3api list-buckets >/dev/null 2>&1; do
+    if [ "$attempt" -ge "$attempts" ]; then
+        echo "object storage endpoint was not ready after $attempts attempts" >&2
+        exit 1
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+done
+
+seen_buckets=''
+for bucket in "$OSMO_WORKFLOW_BUCKET" "$OSMO_LOG_BUCKET" "$OSMO_APP_BUCKET"; do
+    case "
+$seen_buckets" in
+        *"
+$bucket
+"*)
+            continue
+            ;;
+    esac
+    seen_buckets="${seen_buckets}${bucket}
+"
+
+    if aws s3api head-bucket --bucket "$bucket" >/dev/null 2>&1; then
+        continue
+    fi
+    aws s3api create-bucket --bucket "$bucket"
+done

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -252,7 +252,7 @@ data:
 - name: configs
   mountPath: /etc/osmo/configs
   readOnly: true
-{{- with .Values.secrets.objectStorage.existingSecret }}
+{{- with (include "osmo.objectStorage.secretName" .) }}
 - name: object-storage-credentials
   mountPath: /etc/osmo/secrets/{{ . }}
   readOnly: true
@@ -265,7 +265,7 @@ data:
 - name: configs
   configMap:
     name: {{ include "osmo.api.fullname" . }}-config
-{{- with .Values.secrets.objectStorage.existingSecret }}
+{{- with (include "osmo.objectStorage.secretName" .) }}
 - name: object-storage-credentials
   secret:
     secretName: {{ . }}
@@ -319,6 +319,50 @@ data:
 
 {{- define "osmo.valkey.generatedSecretName" -}}
 {{- printf "%s-valkey-credentials" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "osmo.rustfs.fullname" -}}
+{{- $name := default "rustfs" (dig "nameOverride" "" .Values.rustfs) -}}
+{{- $fullnameOverride := dig "fullnameOverride" "" .Values.rustfs -}}
+{{- if $fullnameOverride -}}
+{{- $fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.endpoint" -}}
+{{- if .Values.embeddedDependencies.objectStorage.enabled -}}
+{{- printf "http://%s-svc:9000" (include "osmo.rustfs.fullname" .) -}}
+{{- else -}}
+{{- .Values.externalDependencies.objectStorage.endpoint -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.region" -}}
+{{- if .Values.embeddedDependencies.objectStorage.enabled -}}
+{{- .Values.embeddedDependencies.objectStorage.region -}}
+{{- else -}}
+{{- .Values.externalDependencies.objectStorage.region -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.bucket" -}}
+{{- if .root.Values.embeddedDependencies.objectStorage.enabled -}}
+{{- get .root.Values.embeddedDependencies.objectStorage.buckets .name -}}
+{{- else -}}
+{{- get .root.Values.externalDependencies.objectStorage.buckets .name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.secretName" -}}
+{{- if .Values.embeddedDependencies.objectStorage.enabled -}}
+{{- .Values.rustfs.secret.existingSecret -}}
+{{- else -}}
+{{- .Values.secrets.objectStorage.existingSecret -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "osmo.valkey.host" -}}

--- a/deployments/charts/osmo/templates/_notes.tpl
+++ b/deployments/charts/osmo/templates/_notes.tpl
@@ -17,6 +17,25 @@ An HTTPRoute attaches to an existing Gateway named in httproute.parentRefs;
 this chart does not create a Gateway or GatewayClass.
 {{ end }}
 
+{{- if .Values.embeddedDependencies.objectStorage.enabled }}
+
+Embedded RustFS endpoint:
+
+  {{ include "osmo.objectStorage.endpoint" . }}
+
+Credential Secret:
+
+  {{ include "osmo.objectStorage.secretName" . }}
+
+RustFS PersistentVolumeClaims are retained. Back up the object data and
+credential Secret together; restore the matching credential Secret before
+reinstalling or recovering retained storage.
+
+To inspect RustFS and bucket-bootstrap readiness, run:
+
+  kubectl get deployment,statefulset,pod,pvc,job --namespace {{ .Release.Namespace }}
+{{- end }}
+
 To test a ClusterIP gateway locally, run:
 
   kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ include "osmo.gateway.fullname" . }} 8080:{{ .Values.gateway.envoy.service.port }}

--- a/deployments/charts/osmo/templates/configs.yaml
+++ b/deployments/charts/osmo/templates/configs.yaml
@@ -38,11 +38,16 @@ data:
     {{- if $cfg.workflow }}
     workflow:
       {{- $workflow := deepCopy $cfg.workflow }}
-      {{- $storage := .Values.externalDependencies.objectStorage }}
       {{- $secret := .Values.secrets.objectStorage }}
-      {{- $_ := set $workflow "workflow_data" (dict "credential" (dict "secretName" $secret.existingSecret "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/workflows" $storage.buckets.workflows) "override_url" $storage.endpoint "region" $storage.region)) }}
-      {{- $_ := set $workflow "workflow_log" (dict "credential" (dict "secretName" $secret.existingSecret "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/logs" $storage.buckets.logs) "override_url" $storage.endpoint "region" $storage.region)) }}
-      {{- $_ := set $workflow "workflow_app" (dict "credential" (dict "secretName" $secret.existingSecret "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/apps" $storage.buckets.apps) "override_url" $storage.endpoint "region" $storage.region)) }}
+      {{- $secretName := include "osmo.objectStorage.secretName" . }}
+      {{- $endpoint := include "osmo.objectStorage.endpoint" . }}
+      {{- $region := include "osmo.objectStorage.region" . }}
+      {{- $workflowBucket := include "osmo.objectStorage.bucket" (dict "root" . "name" "workflows") }}
+      {{- $logBucket := include "osmo.objectStorage.bucket" (dict "root" . "name" "logs") }}
+      {{- $appBucket := include "osmo.objectStorage.bucket" (dict "root" . "name" "apps") }}
+      {{- $_ := set $workflow "workflow_data" (dict "credential" (dict "secretName" $secretName "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/workflows" $workflowBucket) "override_url" $endpoint "region" $region)) }}
+      {{- $_ := set $workflow "workflow_log" (dict "credential" (dict "secretName" $secretName "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/logs" $logBucket) "override_url" $endpoint "region" $region)) }}
+      {{- $_ := set $workflow "workflow_app" (dict "credential" (dict "secretName" $secretName "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/apps" $appBucket) "override_url" $endpoint "region" $region)) }}
       {{- toYaml $workflow | nindent 6 }}
     {{- end }}
     {{- if $cfg.pools }}

--- a/deployments/charts/osmo/templates/object-storage-bootstrap.yaml
+++ b/deployments/charts/osmo/templates/object-storage-bootstrap.yaml
@@ -1,0 +1,98 @@
+{{/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if .Values.embeddedDependencies.objectStorage.enabled }}
+{{- $bootstrapName := printf "%s-object-storage-bootstrap" (include "osmo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $secretName := include "osmo.objectStorage.secretName" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $bootstrapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "object-storage-bootstrap") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" .) | nindent 4 }}
+data:
+  object-storage-bootstrap.sh: |-
+{{ .Files.Get "files/object-storage-bootstrap.sh" | nindent 4 }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $bootstrapName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "object-storage-bootstrap") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict "helm.sh/hook" "post-install,post-upgrade" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded")) | nindent 4 }}
+spec:
+  backoffLimit: {{ .Values.embeddedDependencies.objectStorage.bootstrap.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "osmo.component.selectorLabels" (dict "root" . "component" "object-storage-bootstrap") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: object-storage-bootstrap
+        image: {{ .Values.embeddedDependencies.objectStorage.bootstrap.image | quote }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - /scripts/object-storage-bootstrap.sh
+        env:
+        - name: HOME
+          value: /tmp
+        - name: AWS_ENDPOINT_URL
+          value: {{ include "osmo.objectStorage.endpoint" . | quote }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ $secretName }}
+              key: RUSTFS_ACCESS_KEY
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $secretName }}
+              key: RUSTFS_SECRET_KEY
+        - name: AWS_DEFAULT_REGION
+          value: {{ include "osmo.objectStorage.region" . | quote }}
+        - name: OSMO_WORKFLOW_BUCKET
+          value: {{ include "osmo.objectStorage.bucket" (dict "root" . "name" "workflows") | quote }}
+        - name: OSMO_LOG_BUCKET
+          value: {{ include "osmo.objectStorage.bucket" (dict "root" . "name" "logs") | quote }}
+        - name: OSMO_APP_BUCKET
+          value: {{ include "osmo.objectStorage.bucket" (dict "root" . "name" "apps") | quote }}
+        - name: OSMO_STORAGE_BOOTSTRAP_ATTEMPTS
+          value: {{ .Values.embeddedDependencies.objectStorage.bootstrap.attempts | quote }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10001
+        volumeMounts:
+        - name: bootstrap-script
+          mountPath: /scripts
+          readOnly: true
+        - name: bootstrap-tmp
+          mountPath: /tmp
+        resources:
+          {{- toYaml .Values.embeddedDependencies.objectStorage.bootstrap.resources | nindent 10 }}
+      volumes:
+      - name: bootstrap-script
+        configMap:
+          name: {{ $bootstrapName }}
+          defaultMode: 0555
+      - name: bootstrap-tmp
+        emptyDir: {}
+{{- end }}

--- a/deployments/charts/osmo/templates/object-storage-secret.yaml
+++ b/deployments/charts/osmo/templates/object-storage-secret.yaml
@@ -1,0 +1,59 @@
+{{/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{- if and .Values.embeddedDependencies.objectStorage.enabled .Values.secrets.objectStorage.generate -}}
+{{- $secretName := include "osmo.objectStorage.secretName" . -}}
+{{- $credentialsKey := .Values.secrets.objectStorage.keys.credentials -}}
+{{- $accessKeyValue := randAlphaNum 20 -}}
+{{- $secretKeyValue := randAlphaNum 64 -}}
+{{- $accessKey := $accessKeyValue | b64enc -}}
+{{- $secretKey := $secretKeyValue | b64enc -}}
+{{- $credentials := dict
+  "access_key_id" $accessKeyValue
+  "access_key" $secretKeyValue
+  "addressing_style" "path" | toYaml | b64enc -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $embeddedName := include "osmo.rustfs.fullname" . -}}
+{{- $existingDeployment := lookup "apps/v1" "Deployment" .Release.Namespace $embeddedName -}}
+{{- $existingStatefulSet := lookup "apps/v1" "StatefulSet" .Release.Namespace $embeddedName -}}
+{{- $standalonePvcName := .Values.rustfs.mode.standalone.existingClaim.dataClaim | default (printf "%s-data" $embeddedName) -}}
+{{- $existingStandalonePvc := lookup "v1" "PersistentVolumeClaim" .Release.Namespace $standalonePvcName -}}
+{{- $persistentVolumeClaims := lookup "v1" "PersistentVolumeClaim" .Release.Namespace "" -}}
+{{- $distributedPvcNameFragment := printf "-%s-" $embeddedName -}}
+{{- $hasDistributedPvc := false -}}
+{{- range (default list $persistentVolumeClaims.items) -}}
+{{- if and (hasPrefix "data-" .metadata.name) (contains $distributedPvcNameFragment .metadata.name) -}}
+{{- $hasDistributedPvc = true -}}
+{{- end -}}
+{{- end -}}
+{{- $hasEmbeddedState := or $existingDeployment $existingStatefulSet $existingStandalonePvc $hasDistributedPvc -}}
+{{- if $existingSecret -}}
+{{- $existingData := default dict $existingSecret.data -}}
+{{- range $key := list "RUSTFS_ACCESS_KEY" "RUSTFS_SECRET_KEY" $credentialsKey -}}
+{{- if not (hasKey $existingData $key) -}}
+{{- fail (printf "generated object-storage Secret %s is missing key %s; restore it before upgrading or reinstalling" $secretName $key) -}}
+{{- end -}}
+{{- if not (index $existingData $key) -}}
+{{- fail (printf "generated object-storage Secret %s has an empty key %s; restore it before upgrading or reinstalling" $secretName $key) -}}
+{{- end -}}
+{{- end -}}
+{{- $accessKey = index $existingData "RUSTFS_ACCESS_KEY" -}}
+{{- $secretKey = index $existingData "RUSTFS_SECRET_KEY" -}}
+{{- $credentials = index $existingData $credentialsKey -}}
+{{- else if $hasEmbeddedState -}}
+{{- fail (printf "generated object-storage Secret %s is missing; restore it before upgrading or reinstalling" $secretName) -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.labels" . | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict "helm.sh/resource-policy" "keep")) | nindent 4 }}
+type: Opaque
+data:
+  RUSTFS_ACCESS_KEY: {{ $accessKey | quote }}
+  RUSTFS_SECRET_KEY: {{ $secretKey | quote }}
+  {{ $credentialsKey }}: {{ $credentials | quote }}
+{{- end -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -50,7 +50,76 @@
 {{- end -}}
 {{- end -}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
-{{- fail "embeddedDependencies.objectStorage.enabled: embedded object storage is not implemented" -}}
+{{- $externalBuckets := .Values.externalDependencies.objectStorage.buckets -}}
+{{- $embeddedBuckets := .Values.embeddedDependencies.objectStorage.buckets -}}
+{{- if .Values.externalDependencies.objectStorage.endpoint -}}
+{{- fail "externalDependencies.objectStorage.endpoint must be empty when embedded object storage is enabled" -}}
+{{- end -}}
+{{- if $externalBuckets.workflows -}}
+{{- fail "externalDependencies.objectStorage.buckets.workflows must be empty when embedded object storage is enabled" -}}
+{{- end -}}
+{{- if $externalBuckets.logs -}}
+{{- fail "externalDependencies.objectStorage.buckets.logs must be empty when embedded object storage is enabled" -}}
+{{- end -}}
+{{- if $externalBuckets.apps -}}
+{{- fail "externalDependencies.objectStorage.buckets.apps must be empty when embedded object storage is enabled" -}}
+{{- end -}}
+{{- if and .Values.secrets.objectStorage.generate .Values.secrets.objectStorage.existingSecret -}}
+{{- fail "secrets.objectStorage.generate and existingSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if and (not .Values.secrets.objectStorage.generate) (not .Values.secrets.objectStorage.existingSecret) -}}
+{{- fail "embedded object storage requires generated or existing credentials" -}}
+{{- end -}}
+{{- if not .Values.rustfs.secret.existingSecret -}}
+{{- fail "rustfs.secret.existingSecret is required for embedded object storage" -}}
+{{- end -}}
+{{- if and
+  (not .Values.secrets.objectStorage.generate)
+  (ne .Values.rustfs.secret.existingSecret .Values.secrets.objectStorage.existingSecret) -}}
+{{- fail "rustfs.secret.existingSecret must match the effective object-storage Secret" -}}
+{{- end -}}
+{{- if or .Values.rustfs.secret.rustfs.access_key .Values.rustfs.secret.rustfs.secret_key -}}
+{{- fail "inline RustFS credentials are not supported; use the effective object-storage Secret" -}}
+{{- end -}}
+{{- if .Values.rustfs.secret.allowInsecureDefaults -}}
+{{- fail "rustfs.secret.allowInsecureDefaults must be false for embedded object storage" -}}
+{{- end -}}
+{{- if eq .Values.rustfs.mode.standalone.enabled .Values.rustfs.mode.distributed.enabled -}}
+{{- fail "exactly one RustFS topology mode must be enabled" -}}
+{{- end -}}
+{{- if ne (int .Values.rustfs.service.endpoint.port) 9000 -}}
+{{- fail "embedded RustFS requires endpoint service port 9000" -}}
+{{- end -}}
+{{- if .Values.rustfs.ingress.enabled -}}
+{{- fail "rustfs.ingress.enabled must be false for embedded object storage" -}}
+{{- end -}}
+{{- if .Values.rustfs.gatewayApi.enabled -}}
+{{- fail "rustfs.gatewayApi.enabled must be false for embedded object storage" -}}
+{{- end -}}
+{{- if not .Values.embeddedDependencies.objectStorage.region -}}
+{{- fail "embeddedDependencies.objectStorage.region is required when embedded object storage is enabled" -}}
+{{- end -}}
+{{- if or (not $embeddedBuckets.workflows) (not $embeddedBuckets.logs) (not $embeddedBuckets.apps) -}}
+{{- fail "embedded object-storage bucket names must be non-empty" -}}
+{{- end -}}
+{{- if or
+  (eq $embeddedBuckets.workflows $embeddedBuckets.logs)
+  (eq $embeddedBuckets.workflows $embeddedBuckets.apps)
+  (eq $embeddedBuckets.logs $embeddedBuckets.apps) -}}
+{{- fail "embedded object-storage bucket names must be unique" -}}
+{{- end -}}
+{{- range $bucket := list $embeddedBuckets.workflows $embeddedBuckets.logs $embeddedBuckets.apps -}}
+{{- if or
+  (not (regexMatch "^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$" $bucket))
+  (contains ".." $bucket)
+  (contains ".-" $bucket)
+  (contains "-." $bucket)
+  (regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$" $bucket) -}}
+{{- fail "embedded object-storage bucket names must use valid S3 syntax" -}}
+{{- end -}}
+{{- end -}}
+{{- else if .Values.secrets.objectStorage.generate -}}
+{{- fail "secrets.objectStorage.generate is supported only when embedded object storage is enabled" -}}
 {{- end -}}
 {{- if .Values.embeddedDependencies.kaiScheduler.enabled -}}
 {{- fail "embeddedDependencies.kaiScheduler.enabled: embedded KAI Scheduler is not implemented" -}}
@@ -125,7 +194,7 @@
 {{- if and .Values.httproute.enabled (eq (len .Values.httproute.parentRefs) 0) -}}
 {{- fail "httproute.parentRefs requires at least one entry when httproute.enabled=true" -}}
 {{- end -}}
-{{- if or .Values.secrets.objectStorage.generate .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
+{{- if or .Values.secrets.masterEncryptionKey.generate .Values.secrets.defaultAdmin.generate -}}
 {{- fail "secrets: generated Secrets are not implemented; configure existingSecret" -}}
 {{- end -}}
 {{- $autoscaledComponents := list
@@ -186,16 +255,16 @@
 {{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.externalDependencies.valkey.host) -}}
 {{- fail "externalDependencies.valkey.host is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.objectStorage.endpoint -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.endpoint) -}}
 {{- fail "externalDependencies.objectStorage.endpoint is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.objectStorage.buckets.workflows -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.buckets.workflows) -}}
 {{- fail "externalDependencies.objectStorage.buckets.workflows is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.objectStorage.buckets.logs -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.buckets.logs) -}}
 {{- fail "externalDependencies.objectStorage.buckets.logs is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.externalDependencies.objectStorage.buckets.apps -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.buckets.apps) -}}
 {{- fail "externalDependencies.objectStorage.buckets.apps is required for the control plane" -}}
 {{- end -}}
 {{- if and (not .Values.embeddedDependencies.postgresql.enabled) (not .Values.secrets.postgresql.existingSecret) -}}
@@ -204,7 +273,7 @@
 {{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.secrets.valkey.existingSecret) -}}
 {{- fail "secrets.valkey.existingSecret is required for the control plane" -}}
 {{- end -}}
-{{- if not .Values.secrets.objectStorage.existingSecret -}}
+{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.secrets.objectStorage.existingSecret) -}}
 {{- fail "secrets.objectStorage.existingSecret is required for the control plane" -}}
 {{- end -}}
 {{- if not .Values.secrets.masterEncryptionKey.existingSecret -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -6,6 +6,13 @@
 {{- if not .Values.planes.control.enabled -}}
 {{- fail "planes.control.enabled: this chart version requires the control plane" -}}
 {{- end -}}
+{{- $objectStorageCredentialsKey := .Values.secrets.objectStorage.keys.credentials -}}
+{{- if or
+  (not $objectStorageCredentialsKey)
+  (gt (len $objectStorageCredentialsKey) 253)
+  (not (regexMatch "^[A-Za-z0-9._-]+$" $objectStorageCredentialsKey)) -}}
+{{- fail "secrets.objectStorage.keys.credentials must be a non-empty valid Kubernetes Secret data key" -}}
+{{- end -}}
 {{- if and .Values.embeddedDependencies.postgresql.enabled (not (.Capabilities.APIVersions.Has "postgresql.cnpg.io/v1")) -}}
 {{- fail "embeddedDependencies.postgresql.enabled: install a compatible CloudNativePG operator before enabling embedded PostgreSQL" -}}
 {{- end -}}
@@ -66,6 +73,9 @@
 {{- end -}}
 {{- if and .Values.secrets.objectStorage.generate .Values.secrets.objectStorage.existingSecret -}}
 {{- fail "secrets.objectStorage.generate and existingSecret are mutually exclusive" -}}
+{{- end -}}
+{{- if has $objectStorageCredentialsKey (list "RUSTFS_ACCESS_KEY" "RUSTFS_SECRET_KEY") -}}
+{{- fail "secrets.objectStorage.keys.credentials must not use a reserved RustFS key name" -}}
 {{- end -}}
 {{- if and (not .Values.secrets.objectStorage.generate) (not .Values.secrets.objectStorage.existingSecret) -}}
 {{- fail "embedded object storage requires generated or existing credentials" -}}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -97,17 +97,48 @@
 {{- if eq .Values.rustfs.mode.standalone.enabled .Values.rustfs.mode.distributed.enabled -}}
 {{- fail "exactly one RustFS topology mode must be enabled" -}}
 {{- end -}}
+{{- $rustfsFullname := include "osmo.rustfs.fullname" . -}}
+{{- if and .Values.rustfs.mode.standalone.enabled (gt (len $rustfsFullname) 59) -}}
+{{- fail "standalone embedded RustFS fullname must be at most 59 characters so the -svc Service name is valid; shorten the release name or rustfs.fullnameOverride" -}}
+{{- end -}}
+{{- if and .Values.rustfs.mode.distributed.enabled (gt (len $rustfsFullname) 54) -}}
+{{- fail "distributed embedded RustFS fullname must be at most 54 characters so the -headless Service name is valid; shorten the release name or rustfs.fullnameOverride" -}}
+{{- end -}}
 {{- if ne (int .Values.rustfs.service.endpoint.port) 9000 -}}
 {{- fail "embedded RustFS requires endpoint service port 9000" -}}
 {{- end -}}
 {{- if .Values.rustfs.ingress.enabled -}}
 {{- fail "rustfs.ingress.enabled must be false for embedded object storage" -}}
 {{- end -}}
+{{- if eq .Values.rustfs.ingress.className "contour" -}}
+{{- fail "rustfs.ingress.className must not be contour because the upstream chart exposes an HTTPProxy even when ingress is disabled" -}}
+{{- end -}}
 {{- if .Values.rustfs.gatewayApi.enabled -}}
 {{- fail "rustfs.gatewayApi.enabled must be false for embedded object storage" -}}
 {{- end -}}
+{{- if .Values.rustfs.mtls.enabled -}}
+{{- fail "rustfs.mtls.enabled must be false because OSMO uses the embedded RustFS HTTP endpoint" -}}
+{{- end -}}
+{{- if ne .Values.rustfs.service.type "ClusterIP" -}}
+{{- fail "rustfs.service.type must be ClusterIP for embedded object storage" -}}
+{{- end -}}
+{{- if .Values.rustfs.service.externalIPs -}}
+{{- fail "rustfs.service.externalIPs must be empty for embedded object storage" -}}
+{{- end -}}
+{{- if .Values.rustfs.service.loadBalancerIP -}}
+{{- fail "rustfs.service.loadBalancerIP must be empty for embedded object storage" -}}
+{{- end -}}
+{{- if .Values.rustfs.service.loadBalancerClass -}}
+{{- fail "rustfs.service.loadBalancerClass must be empty for embedded object storage" -}}
+{{- end -}}
+{{- if .Values.rustfs.service.loadBalancerSourceRanges -}}
+{{- fail "rustfs.service.loadBalancerSourceRanges must be empty for embedded object storage" -}}
+{{- end -}}
 {{- if not .Values.embeddedDependencies.objectStorage.region -}}
 {{- fail "embeddedDependencies.objectStorage.region is required when embedded object storage is enabled" -}}
+{{- end -}}
+{{- if ne .Values.embeddedDependencies.objectStorage.region .Values.rustfs.config.rustfs.region -}}
+{{- fail "embeddedDependencies.objectStorage.region must match rustfs.config.rustfs.region; set both values to the same region" -}}
 {{- end -}}
 {{- if or (not $embeddedBuckets.workflows) (not $embeddedBuckets.logs) (not $embeddedBuckets.apps) -}}
 {{- fail "embedded object-storage bucket names must be non-empty" -}}

--- a/deployments/charts/osmo/tests/object-storage-lifecycle-values.yaml
+++ b/deployments/charts/osmo/tests/object-storage-lifecycle-values.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+configuration:
+  enabled: false
+
+services:
+  mcp:
+    enabled: false
+  ui:
+    enabled: false
+  delayedJobMonitor:
+    enabled: false
+  worker:
+    enabled: false
+  api:
+    enabled: false
+  router:
+    enabled: false
+  logger:
+    enabled: false
+  agent:
+    enabled: false
+
+gateway:
+  envoy:
+    enabled: false
+  oauth2Proxy:
+    enabled: false
+  authz:
+    enabled: false
+  rateLimit:
+    enabled: false
+
+embeddedDependencies:
+  objectStorage:
+    enabled: true
+
+externalDependencies:
+  objectStorage:
+    endpoint: ''
+    buckets:
+      workflows: ''
+      logs: ''
+      apps: ''
+
+secrets:
+  objectStorage:
+    generate: true
+    existingSecret: ''

--- a/deployments/charts/osmo/tests/test_object_storage_bootstrap.sh
+++ b/deployments/charts/osmo/tests/test_object_storage_bootstrap.sh
@@ -98,9 +98,9 @@ run_bootstrap() {
         AWS_ACCESS_KEY_ID=test-access-key \
         AWS_SECRET_ACCESS_KEY=test-secret-key \
         AWS_DEFAULT_REGION=us-east-1 \
-        OSMO_WORKFLOW_BUCKET=existing-workflows \
-        OSMO_LOG_BUCKET=missing-logs \
-        OSMO_APP_BUCKET=missing-apps \
+        OSMO_WORKFLOW_BUCKET="${3:-existing-workflows}" \
+        OSMO_LOG_BUCKET="${4:-missing-logs}" \
+        OSMO_APP_BUCKET="${5:-missing-apps}" \
         OSMO_STORAGE_BOOTSTRAP_ATTEMPTS="${2:-3}" \
         "$BOOTSTRAP_SCRIPT"
 }
@@ -130,6 +130,16 @@ require_call_count "s3api create-bucket --bucket missing-logs" 1
 require_call_count "s3api create-bucket --bucket missing-apps" 1
 
 : >"$FAKE_AWS_STATE/calls"
+printf '%s\n' existing-workflows >"$FAKE_AWS_STATE/buckets"
+run_bootstrap 0 3 existing-workflows shared-bucket shared-bucket
+require_call_count "s3api head-bucket --bucket existing-workflows" 1
+require_call_count "s3api head-bucket --bucket shared-bucket" 1
+require_call_count "s3api create-bucket --bucket shared-bucket" 1
+
+: >"$FAKE_AWS_STATE/calls"
+printf '%s\n' existing-workflows >"$FAKE_AWS_STATE/buckets"
+printf '%s\n' missing-logs >>"$FAKE_AWS_STATE/buckets"
+printf '%s\n' missing-apps >>"$FAKE_AWS_STATE/buckets"
 run_bootstrap 0 3
 require_call_count "s3api head-bucket --bucket existing-workflows" 1
 require_call_count "s3api head-bucket --bucket missing-logs" 1

--- a/deployments/charts/osmo/tests/test_object_storage_bootstrap.sh
+++ b/deployments/charts/osmo/tests/test_object_storage_bootstrap.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" ]]; then
+    BOOTSTRAP_SCRIPT="$TEST_SRCDIR/$TEST_WORKSPACE/deployments/charts/osmo/files/object-storage-bootstrap.sh"
+else
+    BOOTSTRAP_SCRIPT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/files/object-storage-bootstrap.sh
+fi
+TEST_DIRECTORY=$(mktemp -d)
+trap 'rm -rf "$TEST_DIRECTORY"' EXIT
+FAKE_AWS_DIRECTORY="$TEST_DIRECTORY/bin"
+FAKE_AWS_STATE="$TEST_DIRECTORY/state"
+mkdir -p "$FAKE_AWS_DIRECTORY" "$FAKE_AWS_STATE" "$TEST_DIRECTORY/tmp"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+require_file_contains() {
+    local file=$1
+    local expected=$2
+    grep -Fq -- "$expected" "$file" || fail "expected '$expected' in $file"
+}
+
+require_call_count() {
+    local command=$1
+    local expected=$2
+    local actual
+    actual=$(grep -Fc -- "$command" "$FAKE_AWS_STATE/calls" || true)
+    [[ "$actual" -eq "$expected" ]] || \
+        fail "expected $command $expected times, found $actual"
+}
+
+cat >"$FAKE_AWS_DIRECTORY/aws" <<'EOF'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "$*" >>"$FAKE_AWS_STATE/calls"
+cp "$AWS_CONFIG_FILE" "$FAKE_AWS_STATE/aws-config"
+
+if [ "$1" = "s3api" ] && [ "$2" = "list-buckets" ]; then
+    attempt_file="$FAKE_AWS_STATE/readiness-attempts"
+    attempts=0
+    if [ -f "$attempt_file" ]; then
+        attempts=$(cat "$attempt_file")
+    fi
+    attempts=$((attempts + 1))
+    printf '%s\n' "$attempts" >"$attempt_file"
+    if [ "$attempts" -le "${AWS_FAKE_READINESS_FAILURES:-0}" ]; then
+        exit 1
+    fi
+    exit 0
+fi
+
+if [ "$1" = "s3api" ] && [ "$2" = "head-bucket" ]; then
+    bucket=''
+    shift 2
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--bucket" ]; then
+            bucket=$2
+            break
+        fi
+        shift
+    done
+    grep -Fxq -- "$bucket" "$FAKE_AWS_STATE/buckets" && exit 0
+    exit 1
+fi
+
+if [ "$1" = "s3api" ] && [ "$2" = "create-bucket" ]; then
+    [ "${AWS_FAKE_CREATE_FAILURE:-false}" != true ] || exit 1
+    bucket=''
+    shift 2
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--bucket" ]; then
+            bucket=$2
+            break
+        fi
+        shift
+    done
+    printf '%s\n' "$bucket" >>"$FAKE_AWS_STATE/buckets"
+    exit 0
+fi
+
+exit 2
+EOF
+chmod +x "$FAKE_AWS_DIRECTORY/aws"
+
+run_bootstrap() {
+    FAKE_AWS_STATE="$FAKE_AWS_STATE" \
+        AWS_FAKE_READINESS_FAILURES="${1:-0}" \
+        PATH="$FAKE_AWS_DIRECTORY:/usr/bin:/bin" \
+        TMPDIR="$TEST_DIRECTORY/tmp" \
+        AWS_ENDPOINT_URL=http://rustfs:9000 \
+        AWS_ACCESS_KEY_ID=test-access-key \
+        AWS_SECRET_ACCESS_KEY=test-secret-key \
+        AWS_DEFAULT_REGION=us-east-1 \
+        OSMO_WORKFLOW_BUCKET=existing-workflows \
+        OSMO_LOG_BUCKET=missing-logs \
+        OSMO_APP_BUCKET=missing-apps \
+        OSMO_STORAGE_BOOTSTRAP_ATTEMPTS="${2:-3}" \
+        "$BOOTSTRAP_SCRIPT"
+}
+
+printf '%s\n' existing-workflows >"$FAKE_AWS_STATE/buckets"
+: >"$FAKE_AWS_STATE/calls"
+
+if FAKE_AWS_STATE="$FAKE_AWS_STATE" PATH="$FAKE_AWS_DIRECTORY:/usr/bin:/bin" \
+    AWS_ENDPOINT_URL=http://rustfs:9000 \
+    AWS_ACCESS_KEY_ID=test-access-key \
+    AWS_DEFAULT_REGION=us-east-1 \
+    OSMO_WORKFLOW_BUCKET=existing-workflows \
+    OSMO_LOG_BUCKET=missing-logs \
+    OSMO_APP_BUCKET=missing-apps \
+    "$BOOTSTRAP_SCRIPT" >/dev/null 2>&1; then
+    fail "missing required environment must fail"
+fi
+[[ ! -s "$FAKE_AWS_STATE/calls" ]] || fail "missing environment called AWS"
+
+run_bootstrap 2 3
+require_call_count "s3api list-buckets" 3
+require_file_contains "$FAKE_AWS_STATE/aws-config" "addressing_style = path"
+require_call_count "s3api head-bucket --bucket existing-workflows" 1
+require_call_count "s3api head-bucket --bucket missing-logs" 1
+require_call_count "s3api head-bucket --bucket missing-apps" 1
+require_call_count "s3api create-bucket --bucket missing-logs" 1
+require_call_count "s3api create-bucket --bucket missing-apps" 1
+
+: >"$FAKE_AWS_STATE/calls"
+run_bootstrap 0 3
+require_call_count "s3api head-bucket --bucket existing-workflows" 1
+require_call_count "s3api head-bucket --bucket missing-logs" 1
+require_call_count "s3api head-bucket --bucket missing-apps" 1
+require_call_count "s3api create-bucket" 0
+
+: >"$FAKE_AWS_STATE/calls"
+rm -f "$FAKE_AWS_STATE/readiness-attempts"
+if run_bootstrap 3 3 >/dev/null 2>&1; then
+    fail "exhausted endpoint readiness must fail"
+fi
+require_call_count "s3api list-buckets" 3
+
+: >"$FAKE_AWS_STATE/calls"
+printf '%s\n' existing-workflows >"$FAKE_AWS_STATE/buckets"
+if AWS_FAKE_CREATE_FAILURE=true run_bootstrap 0 3 >/dev/null 2>&1; then
+    fail "failed bucket creation must fail"
+fi
+require_call_count "s3api create-bucket --bucket missing-logs" 1
+
+echo "PASS: object storage bootstrap shell tests"

--- a/deployments/charts/osmo/tests/test_object_storage_secret_lifecycle.sh
+++ b/deployments/charts/osmo/tests/test_object_storage_secret_lifecycle.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+    fail "usage: $0 <explicit-kind-osmo-kubeconfig>"
+fi
+
+KUBECONFIG_FILE=$1
+[[ -f "$KUBECONFIG_FILE" ]] || fail "kubeconfig not found: $KUBECONFIG_FILE"
+
+for required_command in grep helm kubectl; do
+    command -v "$required_command" >/dev/null || \
+        fail "required command not found: $required_command"
+done
+
+KUBE_CONTEXT=$(kubectl --kubeconfig "$KUBECONFIG_FILE" config current-context)
+[[ "$KUBE_CONTEXT" == kind-osmo ]] || \
+    fail "lifecycle test requires an explicit kind-osmo kubeconfig, got: $KUBE_CONTEXT"
+kubectl --kubeconfig "$KUBECONFIG_FILE" get --raw=/readyz >/dev/null
+
+SCRIPT_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CHART_DIRECTORY=$(cd "$SCRIPT_DIRECTORY/.." && pwd)
+bash "$CHART_DIRECTORY/tests/verify_rustfs_chart_archive.sh" >/dev/null
+
+TEST_DIRECTORY=$(mktemp -d)
+NAMESPACE="osmo-rustfs-lifecycle-${RANDOM}-${RANDOM}-$$"
+NAMESPACE_OWNED=false
+STANDALONE_RELEASE=lifecycle-standalone
+STANDALONE_SECRET=lifecycle-standalone-credentials
+DISTRIBUTED_RELEASE=lifecycle-distributed
+DISTRIBUTED_SECRET=lifecycle-distributed-credentials
+
+cleanup_resources() {
+    helm --kubeconfig "$KUBECONFIG_FILE" uninstall "$DISTRIBUTED_RELEASE" \
+        --namespace "$NAMESPACE" --no-hooks >/dev/null 2>&1
+    helm --kubeconfig "$KUBECONFIG_FILE" uninstall "$STANDALONE_RELEASE" \
+        --namespace "$NAMESPACE" --no-hooks >/dev/null 2>&1
+    kubectl --kubeconfig "$KUBECONFIG_FILE" delete namespace "$NAMESPACE" \
+        --ignore-not-found --wait=true --timeout=45s >/dev/null 2>&1
+}
+
+cleanup() {
+    set +e
+    if [[ "$NAMESPACE_OWNED" == true ]]; then
+        cleanup_resources
+    fi
+    rm -rf "$TEST_DIRECTORY"
+}
+trap cleanup EXIT
+
+kubectl --kubeconfig "$KUBECONFIG_FILE" create namespace "$NAMESPACE" >/dev/null
+NAMESPACE_OWNED=true
+
+helm_apply() {
+    local release=$1
+    local secret=$2
+    shift 2
+    helm --kubeconfig "$KUBECONFIG_FILE" upgrade --install "$release" \
+        "$CHART_DIRECTORY" \
+        --namespace "$NAMESPACE" \
+        --no-hooks \
+        -f "$CHART_DIRECTORY/profiles/split-plane-control.yaml" \
+        -f "$CHART_DIRECTORY/tests/control-external-values.yaml" \
+        -f "$CHART_DIRECTORY/tests/object-storage-lifecycle-values.yaml" \
+        --set-string "rustfs.secret.existingSecret=$secret" \
+        "$@"
+}
+
+secret_data_value() {
+    local secret=$1
+    local key=$2
+    kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+        get secret "$secret" -o "go-template={{ index .data \"$key\" }}"
+}
+
+require_output() {
+    local file=$1
+    local expected=$2
+    grep -Fq -- "$expected" "$file" || fail "expected '$expected' in $file"
+}
+
+helm_apply "$STANDALONE_RELEASE" "$STANDALONE_SECRET" >/dev/null
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    get deployment lifecycle-standalone-rustfs >/dev/null
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    get persistentvolumeclaim lifecycle-standalone-rustfs-data >/dev/null
+
+standalone_access_key=$(secret_data_value "$STANDALONE_SECRET" RUSTFS_ACCESS_KEY)
+standalone_secret_key=$(secret_data_value "$STANDALONE_SECRET" RUSTFS_SECRET_KEY)
+standalone_credentials=$(secret_data_value "$STANDALONE_SECRET" object-storage.yaml)
+[[ -n "$standalone_access_key" && -n "$standalone_secret_key" && \
+    -n "$standalone_credentials" ]] || fail "generated Secret data must be non-empty"
+
+helm_apply "$STANDALONE_RELEASE" "$STANDALONE_SECRET" >/dev/null
+[[ "$(secret_data_value "$STANDALONE_SECRET" RUSTFS_ACCESS_KEY)" == \
+    "$standalone_access_key" ]] || fail "upgrade changed generated RustFS access key"
+[[ "$(secret_data_value "$STANDALONE_SECRET" RUSTFS_SECRET_KEY)" == \
+    "$standalone_secret_key" ]] || fail "upgrade changed generated RustFS secret key"
+[[ "$(secret_data_value "$STANDALONE_SECRET" object-storage.yaml)" == \
+    "$standalone_credentials" ]] || fail "upgrade changed generated OSMO credentials"
+
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    patch secret "$STANDALONE_SECRET" --type=json \
+    --patch='[{"op":"remove","path":"/data/RUSTFS_ACCESS_KEY"}]' >/dev/null
+if helm_apply "$STANDALONE_RELEASE" "$STANDALONE_SECRET" \
+    >"$TEST_DIRECTORY/missing-key.out" 2>&1; then
+    fail "upgrade accepted a generated Secret with a missing retained key"
+fi
+require_output "$TEST_DIRECTORY/missing-key.out" \
+    "generated object-storage Secret $STANDALONE_SECRET is missing key RUSTFS_ACCESS_KEY"
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    patch secret "$STANDALONE_SECRET" --type=merge \
+    --patch "{\"data\":{\"RUSTFS_ACCESS_KEY\":\"$standalone_access_key\"}}" \
+    >/dev/null
+
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    patch secret "$STANDALONE_SECRET" --type=json \
+    --patch='[{"op":"replace","path":"/data/object-storage.yaml","value":""}]' \
+    >/dev/null
+if helm_apply "$STANDALONE_RELEASE" "$STANDALONE_SECRET" \
+    >"$TEST_DIRECTORY/empty-key.out" 2>&1; then
+    fail "upgrade accepted a generated Secret with an empty retained key"
+fi
+require_output "$TEST_DIRECTORY/empty-key.out" \
+    "generated object-storage Secret $STANDALONE_SECRET has an empty key object-storage.yaml"
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    patch secret "$STANDALONE_SECRET" --type=merge \
+    --patch "{\"data\":{\"object-storage.yaml\":\"$standalone_credentials\"}}" \
+    >/dev/null
+helm_apply "$STANDALONE_RELEASE" "$STANDALONE_SECRET" >/dev/null
+
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    delete secret "$STANDALONE_SECRET" >/dev/null
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    get deployment lifecycle-standalone-rustfs >/dev/null
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    get persistentvolumeclaim lifecycle-standalone-rustfs-data >/dev/null
+if helm_apply "$STANDALONE_RELEASE" "$STANDALONE_SECRET" \
+    >"$TEST_DIRECTORY/missing-standalone-secret.out" 2>&1; then
+    fail "upgrade regenerated a deleted Secret while standalone state survived"
+fi
+require_output "$TEST_DIRECTORY/missing-standalone-secret.out" \
+    "generated object-storage Secret $STANDALONE_SECRET is missing; restore it"
+
+helm_apply "$DISTRIBUTED_RELEASE" "$DISTRIBUTED_SECRET" \
+    --set rustfs.mode.standalone.enabled=false \
+    --set rustfs.mode.distributed.enabled=true \
+    --set rustfs.replicaCount=2 \
+    --set rustfs.drivesPerNode=1 \
+    --set rustfs.localEndpointHost.autoInject=true >/dev/null
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    get statefulset lifecycle-distributed-rustfs >/dev/null
+
+distributed_pvc=data-lifecycle-distributed-rustfs-0
+for _ in {1..30}; do
+    if kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+        get persistentvolumeclaim "$distributed_pvc" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    get persistentvolumeclaim "$distributed_pvc" >/dev/null || \
+    fail "distributed StatefulSet did not create $distributed_pvc"
+
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    delete secret "$DISTRIBUTED_SECRET" >/dev/null
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    get statefulset lifecycle-distributed-rustfs >/dev/null
+kubectl --kubeconfig "$KUBECONFIG_FILE" --namespace "$NAMESPACE" \
+    get persistentvolumeclaim "$distributed_pvc" >/dev/null
+if helm_apply "$DISTRIBUTED_RELEASE" "$DISTRIBUTED_SECRET" \
+    --set rustfs.mode.standalone.enabled=false \
+    --set rustfs.mode.distributed.enabled=true \
+    --set rustfs.replicaCount=2 \
+    --set rustfs.drivesPerNode=1 \
+    --set rustfs.localEndpointHost.autoInject=true \
+    >"$TEST_DIRECTORY/missing-distributed-secret.out" 2>&1; then
+    fail "upgrade regenerated a deleted Secret while distributed state survived"
+fi
+require_output "$TEST_DIRECTORY/missing-distributed-secret.out" \
+    "generated object-storage Secret $DISTRIBUTED_SECRET is missing; restore it"
+
+cleanup_resources
+NAMESPACE_OWNED=false
+trap - EXIT
+rm -rf "$TEST_DIRECTORY"
+echo "PASS: object-storage Secret lifecycle tests ($KUBE_CONTEXT)"

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -18,7 +18,7 @@ fail() {
     exit 1
 }
 
-for required_command in awk grep helm tar; do
+for required_command in awk base64 grep helm tar; do
     command -v "$required_command" >/dev/null || \
         fail "required command not found: $required_command"
 done
@@ -140,6 +140,18 @@ resource_document() {
                 print "resource not found: " kind "/" name > "/dev/stderr"
                 exit 1
             }
+        }
+    ' "$file"
+}
+
+secret_data_value() {
+    local file=$1
+    local key=$2
+    awk -v key="$key" '
+        $1 == key ":" {
+            gsub(/^"|"$/, "", $2)
+            print $2
+            exit
         }
     ' "$file"
 }
@@ -868,6 +880,330 @@ EOF
         >"$TEST_DIRECTORY/osmo-ui.yaml"
     require_contains "$TEST_DIRECTORY/osmo-ui.yaml" \
         "serviceAccountName: default"
+
+    local embedded_object_storage_settings=(
+        --set embeddedDependencies.objectStorage.enabled=true
+        --set-string externalDependencies.objectStorage.endpoint=
+        --set-string externalDependencies.objectStorage.buckets.workflows=
+        --set-string externalDependencies.objectStorage.buckets.logs=
+        --set-string externalDependencies.objectStorage.buckets.apps=
+        --set secrets.objectStorage.generate=true
+        --set-string secrets.objectStorage.existingSecret=
+    )
+
+    helm_template embedded-object-storage "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        >"$TEST_DIRECTORY/osmo-embedded-object-storage.yaml"
+
+    require_deployment "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        embedded-object-storage-rustfs
+    require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" Service \
+        embedded-object-storage-rustfs-svc
+    require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        PersistentVolumeClaim embedded-object-storage-rustfs-data
+    require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" Secret \
+        osmo-rustfs-credentials
+    require_occurrences "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        "kind: Secret" 1
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        Secret osmo-rustfs-credentials \
+        >"$TEST_DIRECTORY/osmo-rustfs-secret.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-secret.yaml" \
+        "helm.sh/resource-policy: keep"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-secret.yaml" \
+        "RUSTFS_ACCESS_KEY:"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-secret.yaml" \
+        "RUSTFS_SECRET_KEY:"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-secret.yaml" \
+        "object-storage.yaml:"
+    local rustfs_access_key
+    local rustfs_secret_key
+    local rustfs_credentials
+    rustfs_access_key=$(secret_data_value \
+        "$TEST_DIRECTORY/osmo-rustfs-secret.yaml" RUSTFS_ACCESS_KEY | \
+        base64 --decode)
+    rustfs_secret_key=$(secret_data_value \
+        "$TEST_DIRECTORY/osmo-rustfs-secret.yaml" RUSTFS_SECRET_KEY | \
+        base64 --decode)
+    rustfs_credentials=$(secret_data_value \
+        "$TEST_DIRECTORY/osmo-rustfs-secret.yaml" object-storage.yaml | \
+        base64 --decode)
+    [[ "${#rustfs_access_key}" -eq 20 ]] || \
+        fail "expected a 20-character generated RustFS access key"
+    [[ "${#rustfs_secret_key}" -eq 64 ]] || \
+        fail "expected a 64-character generated RustFS secret key"
+    [[ "$rustfs_credentials" == *"access_key_id: $rustfs_access_key"* ]] || \
+        fail "expected OSMO credentials to use the generated RustFS access key"
+    [[ "$rustfs_credentials" == *"access_key: $rustfs_secret_key"* ]] || \
+        fail "expected OSMO credentials to use the generated RustFS secret key"
+    [[ "$rustfs_credentials" == *"addressing_style: path"* ]] || \
+        fail "expected generated OSMO credentials to use path-style addressing"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        Deployment embedded-object-storage-rustfs \
+        >"$TEST_DIRECTORY/osmo-rustfs-deployment.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" "type: Recreate"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" \
+        "runAsNonRoot: true"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" \
+        "readOnlyRootFilesystem: true"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" \
+        "allowPrivilegeEscalation: false"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" "- ALL"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" \
+        "type: RuntimeDefault"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" \
+        "fsGroupChangePolicy: OnRootMismatch"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" "livenessProbe:"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" "readinessProbe:"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" "resources:"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" "cpu: 500m"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" "memory: 1Gi"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" "cpu: 1"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" "memory: 2Gi"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" \
+        "rustfs/rustfs:1.0.0-rc.2@sha256:7d6d361c49c08d427250fb59aae5d78df83d644c3405d9ccf4b21cda0b0692d0"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-deployment.yaml" \
+        "busybox:stable@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        ServiceAccount embedded-object-storage-rustfs \
+        >"$TEST_DIRECTORY/osmo-rustfs-service-account.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-service-account.yaml" \
+        "automountServiceAccountToken: false"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        PersistentVolumeClaim embedded-object-storage-rustfs-data \
+        >"$TEST_DIRECTORY/osmo-rustfs-pvc.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-pvc.yaml" \
+        "helm.sh/resource-policy: keep"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-pvc.yaml" "ReadWriteOnce"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-pvc.yaml" "storage: 10Gi"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        ConfigMap embedded-object-storage-osmo-api-config \
+        >"$TEST_DIRECTORY/osmo-embedded-object-storage-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-config.yaml" \
+        "override_url: http://embedded-object-storage-rustfs-svc:9000"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-config.yaml" \
+        "endpoint: s3://osmo-workflows/workflows"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-config.yaml" \
+        "endpoint: s3://osmo-logs/logs"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-config.yaml" \
+        "endpoint: s3://osmo-apps/apps"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-config.yaml" \
+        "secretName: osmo-rustfs-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-config.yaml" \
+        "secretKey: object-storage.yaml"
+    local object_storage_consumer
+    for object_storage_consumer in api worker logger agent; do
+        resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+            Deployment "embedded-object-storage-osmo-$object_storage_consumer" \
+            >"$TEST_DIRECTORY/osmo-$object_storage_consumer-object-storage.yaml"
+        require_contains \
+            "$TEST_DIRECTORY/osmo-$object_storage_consumer-object-storage.yaml" \
+            "secretName: osmo-rustfs-credentials"
+        require_contains \
+            "$TEST_DIRECTORY/osmo-$object_storage_consumer-object-storage.yaml" \
+            "mountPath: /etc/osmo/secrets/osmo-rustfs-credentials"
+    done
+    require_not_contains "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        "kind: Ingress"
+    require_not_contains "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        "kind: Gateway"
+    require_not_contains "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        "kind: HTTPRoute"
+
+    helm_template embedded-object-storage-custom-key "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set-string secrets.objectStorage.keys.credentials=custom-storage.yaml \
+        --set-string rustfs.secret.existingSecret=custom-rustfs-credentials \
+        >"$TEST_DIRECTORY/osmo-embedded-object-storage-custom-key.yaml"
+    resource_document \
+        "$TEST_DIRECTORY/osmo-embedded-object-storage-custom-key.yaml" Secret \
+        custom-rustfs-credentials \
+        >"$TEST_DIRECTORY/osmo-rustfs-custom-key-secret.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-custom-key-secret.yaml" \
+        "custom-storage.yaml:"
+    require_not_contains "$TEST_DIRECTORY/osmo-rustfs-custom-key-secret.yaml" \
+        "object-storage.yaml:"
+    require_contains \
+        "$TEST_DIRECTORY/osmo-embedded-object-storage-custom-key.yaml" \
+        "secretKey: custom-storage.yaml"
+    require_contains \
+        "$TEST_DIRECTORY/osmo-embedded-object-storage-custom-key.yaml" \
+        "secretName: custom-rustfs-credentials"
+
+    helm_template embedded-object-storage-existing "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set secrets.objectStorage.generate=false \
+        --set-string secrets.objectStorage.existingSecret=existing-rustfs-secret \
+        --set-string rustfs.secret.existingSecret=existing-rustfs-secret \
+        >"$TEST_DIRECTORY/osmo-embedded-object-storage-existing.yaml"
+    require_no_resource "$TEST_DIRECTORY/osmo-embedded-object-storage-existing.yaml" \
+        Secret existing-rustfs-secret
+    require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-existing.yaml" \
+        "secretName: existing-rustfs-secret"
+
+    local conflicting_external_object_storage_value
+    local conflicting_external_object_storage_message
+    while IFS='|' read -r conflicting_external_object_storage_value \
+        conflicting_external_object_storage_message; do
+        if helm_template conflicting-object-storage "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            "${embedded_object_storage_settings[@]}" \
+            --set-string "$conflicting_external_object_storage_value" \
+            >"$TEST_DIRECTORY/conflicting-object-storage.out" 2>&1; then
+            fail "expected embedded and external object-storage configuration to fail"
+        fi
+        require_contains "$TEST_DIRECTORY/conflicting-object-storage.out" \
+            "$conflicting_external_object_storage_message"
+    done <<'EOF'
+externalDependencies.objectStorage.endpoint=https://unexpected.example.com|externalDependencies.objectStorage.endpoint must be empty
+externalDependencies.objectStorage.buckets.workflows=unexpected-workflows|externalDependencies.objectStorage.buckets.workflows must be empty
+externalDependencies.objectStorage.buckets.logs=unexpected-logs|externalDependencies.objectStorage.buckets.logs must be empty
+externalDependencies.objectStorage.buckets.apps=unexpected-apps|externalDependencies.objectStorage.buckets.apps must be empty
+EOF
+
+    if helm_template duplicate-object-storage-credentials "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set-string secrets.objectStorage.existingSecret=existing-rustfs-secret \
+        >"$TEST_DIRECTORY/duplicate-object-storage-credentials.out" 2>&1; then
+        fail "expected duplicate embedded object-storage credential ownership to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/duplicate-object-storage-credentials.out" \
+        "generate and existingSecret are mutually exclusive"
+
+    if helm_template missing-object-storage-credentials "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set secrets.objectStorage.generate=false \
+        >"$TEST_DIRECTORY/missing-object-storage-credentials.out" 2>&1; then
+        fail "expected missing embedded object-storage credentials to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/missing-object-storage-credentials.out" \
+        "requires generated or existing credentials"
+
+    if helm_template generated-external-object-storage "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.objectStorage.generate=true \
+        --set-string secrets.objectStorage.existingSecret= \
+        >"$TEST_DIRECTORY/generated-external-object-storage.out" 2>&1; then
+        fail "expected generated credentials outside embedded object storage to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/generated-external-object-storage.out" \
+        "secrets.objectStorage.generate is supported only when embedded object storage is enabled"
+
+    if helm_template mismatched-object-storage-secret "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set secrets.objectStorage.generate=false \
+        --set-string secrets.objectStorage.existingSecret=existing-rustfs-secret \
+        >"$TEST_DIRECTORY/mismatched-object-storage-secret.out" 2>&1; then
+        fail "expected mismatched embedded object-storage Secret names to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/mismatched-object-storage-secret.out" \
+        "rustfs.secret.existingSecret must match the effective object-storage Secret"
+
+    local inline_rustfs_credential
+    for inline_rustfs_credential in access_key secret_key; do
+        if helm_template inline-rustfs-credential "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            "${embedded_object_storage_settings[@]}" \
+            --set-string "rustfs.secret.rustfs.$inline_rustfs_credential=plaintext" \
+            >"$TEST_DIRECTORY/inline-rustfs-credential.out" 2>&1; then
+            fail "expected inline RustFS $inline_rustfs_credential to fail"
+        fi
+        require_contains "$TEST_DIRECTORY/inline-rustfs-credential.out" \
+            "inline RustFS credentials are not supported"
+    done
+
+    if helm_template both-rustfs-topologies "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set rustfs.mode.distributed.enabled=true \
+        --set rustfs.replicaCount=2 \
+        >"$TEST_DIRECTORY/both-rustfs-topologies.out" 2>&1; then
+        fail "expected both RustFS topology modes to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/both-rustfs-topologies.out" \
+        "exactly one RustFS topology mode must be enabled"
+
+    if helm_template neither-rustfs-topology "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set rustfs.mode.standalone.enabled=false \
+        >"$TEST_DIRECTORY/neither-rustfs-topology.out" 2>&1; then
+        fail "expected neither RustFS topology mode to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/neither-rustfs-topology.out" \
+        "exactly one RustFS topology mode must be enabled"
+
+    if helm_template unsupported-rustfs-port "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set rustfs.service.endpoint.port=9002 \
+        >"$TEST_DIRECTORY/unsupported-rustfs-port.out" 2>&1; then
+        fail "expected a non-9000 RustFS endpoint port to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/unsupported-rustfs-port.out" \
+        "embedded RustFS requires endpoint service port 9000"
+
+    local exposed_rustfs_value
+    local exposed_rustfs_message
+    while IFS='|' read -r exposed_rustfs_value exposed_rustfs_message; do
+        if helm_template exposed-rustfs "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            "${embedded_object_storage_settings[@]}" \
+            --set "$exposed_rustfs_value" \
+            >"$TEST_DIRECTORY/exposed-rustfs.out" 2>&1; then
+            fail "expected exposed RustFS endpoint to fail"
+        fi
+        require_contains "$TEST_DIRECTORY/exposed-rustfs.out" \
+            "$exposed_rustfs_message"
+    done <<'EOF'
+rustfs.ingress.enabled=true|rustfs.ingress.enabled must be false
+rustfs.gatewayApi.enabled=true|rustfs.gatewayApi.enabled must be false
+EOF
+
+    local invalid_embedded_bucket_value
+    local invalid_embedded_bucket_message
+    while IFS='|' read -r invalid_embedded_bucket_value \
+        invalid_embedded_bucket_message; do
+        if helm_template invalid-embedded-bucket "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            "${embedded_object_storage_settings[@]}" \
+            --set-string "$invalid_embedded_bucket_value" \
+            >"$TEST_DIRECTORY/invalid-embedded-bucket.out" 2>&1; then
+            fail "expected invalid embedded object-storage bucket to fail"
+        fi
+        require_contains "$TEST_DIRECTORY/invalid-embedded-bucket.out" \
+            "$invalid_embedded_bucket_message"
+    done <<'EOF'
+embeddedDependencies.objectStorage.buckets.workflows=|embedded object-storage bucket names must be non-empty
+embeddedDependencies.objectStorage.buckets.logs=osmo-workflows|embedded object-storage bucket names must be unique
+embeddedDependencies.objectStorage.buckets.apps=OSMO-APPS|embedded object-storage bucket names must use valid S3 syntax
+embeddedDependencies.objectStorage.buckets.apps=osmo_apps|embedded object-storage bucket names must use valid S3 syntax
+EOF
 
     helm_template osmo "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -309,6 +309,10 @@ require_clean_osmo_sources() {
     require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "version: 0.8.0"
     require_contains "$CHARTS_ROOT/osmo/Chart.yaml" \
         "condition: embeddedDependencies.postgresql.enabled"
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" "name: rustfs"
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" 'version: "1.0.0-rc.2"'
+    require_contains "$CHARTS_ROOT/osmo/Chart.yaml" \
+        "condition: embeddedDependencies.objectStorage.enabled"
     [[ -e "$CHARTS_ROOT/osmo/Chart.lock" ]] || fail "osmo must have a dependency lock"
     require_downloaded_dependencies_untracked
     [[ ! -e "$CHARTS_ROOT/osmo/templates/postgres.yaml" ]] || \
@@ -362,7 +366,8 @@ test_control_umbrella() {
     mkdir -p "$charts_copy"
     cp -R "$CHARTS_ROOT/osmo" "$charts_copy/osmo"
     if ! compgen -G "$charts_copy/osmo/charts/valkey-0.11.0.tgz" >/dev/null || \
-        ! compgen -G "$charts_copy/osmo/charts/cluster-0.8.0.tgz" >/dev/null; then
+        ! compgen -G "$charts_copy/osmo/charts/cluster-0.8.0.tgz" >/dev/null || \
+        ! compgen -G "$charts_copy/osmo/charts/rustfs-1.0.0-rc.2.tgz" >/dev/null; then
         helm dependency build "$charts_copy/osmo" >/dev/null
     fi
 
@@ -384,6 +389,12 @@ test_control_umbrella() {
         ! grep -Fq "osmo/charts/cluster-0.8.0.tgz" \
         "$TEST_DIRECTORY/osmo-package.txt"; then
         fail "packaged OSMO chart does not contain CloudNativePG cluster 0.8.0"
+    fi
+    if ! grep -Fq "osmo/charts/rustfs/Chart.yaml" \
+        "$TEST_DIRECTORY/osmo-package.txt" && \
+        ! grep -Fq "osmo/charts/rustfs-1.0.0-rc.2.tgz" \
+        "$TEST_DIRECTORY/osmo-package.txt"; then
+        fail "packaged OSMO chart does not contain RustFS 1.0.0-rc.2"
     fi
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "osmo/tests/"
     require_not_contains "$TEST_DIRECTORY/osmo-package.txt" "osmo/migrations/"

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -395,7 +395,7 @@ test_control_umbrella() {
         fail "expected an altered RustFS chart archive to fail digest verification"
     fi
     require_contains "$TEST_DIRECTORY/altered-rustfs-archive.out" \
-        "RustFS chart archive SHA-256 mismatch: expected c26cb094bc9735d01548ee540d018c1d88e2038bfd27ddc330770f5d525e63eb"
+        "RustFS chart archive SHA-256 mismatch:"
 
     if ! helm lint "$charts_copy/osmo" >"$TEST_DIRECTORY/osmo-lint.out" 2>&1; then
         cat "$TEST_DIRECTORY/osmo-lint.out" >&2

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -382,6 +382,20 @@ test_control_umbrella() {
         ! compgen -G "$charts_copy/osmo/charts/rustfs-1.0.0-rc.2.tgz" >/dev/null; then
         helm dependency build "$charts_copy/osmo" >/dev/null
     fi
+    local rustfs_archive_verifier="$charts_copy/osmo/tests/verify_rustfs_chart_archive.sh"
+    local rustfs_archive="$charts_copy/osmo/charts/rustfs-1.0.0-rc.2.tgz"
+    [[ -f "$rustfs_archive_verifier" ]] || \
+        fail "RustFS chart archive verifier is required"
+    bash "$rustfs_archive_verifier" "$rustfs_archive" >/dev/null
+    local altered_rustfs_archive="$TEST_DIRECTORY/altered-rustfs-1.0.0-rc.2.tgz"
+    cp "$rustfs_archive" "$altered_rustfs_archive"
+    printf 'altered archive\n' >>"$altered_rustfs_archive"
+    if bash "$rustfs_archive_verifier" "$altered_rustfs_archive" \
+        >"$TEST_DIRECTORY/altered-rustfs-archive.out" 2>&1; then
+        fail "expected an altered RustFS chart archive to fail digest verification"
+    fi
+    require_contains "$TEST_DIRECTORY/altered-rustfs-archive.out" \
+        "RustFS chart archive SHA-256 mismatch: expected c26cb094bc9735d01548ee540d018c1d88e2038bfd27ddc330770f5d525e63eb"
 
     if ! helm lint "$charts_copy/osmo" >"$TEST_DIRECTORY/osmo-lint.out" 2>&1; then
         cat "$TEST_DIRECTORY/osmo-lint.out" >&2
@@ -996,6 +1010,8 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "name: AWS_DEFAULT_REGION"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        'value: "us-east-1"'
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "name: OSMO_WORKFLOW_BUCKET"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "name: OSMO_LOG_BUCKET"
@@ -1060,6 +1076,12 @@ EOF
         "busybox:stable@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662"
 
     resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        ConfigMap embedded-object-storage-rustfs-config \
+        >"$TEST_DIRECTORY/osmo-rustfs-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-config.yaml" \
+        'RUSTFS_REGION: "us-east-1"'
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
         ServiceAccount embedded-object-storage-rustfs \
         >"$TEST_DIRECTORY/osmo-rustfs-service-account.yaml"
     require_contains "$TEST_DIRECTORY/osmo-rustfs-service-account.yaml" \
@@ -1088,6 +1110,8 @@ EOF
         "secretName: osmo-rustfs-credentials"
     require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-config.yaml" \
         "secretKey: object-storage.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-config.yaml" \
+        "region: us-east-1"
     local object_storage_consumer
     for object_storage_consumer in api worker logger agent; do
         resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
@@ -1106,6 +1130,32 @@ EOF
         "kind: Gateway"
     require_not_contains "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
         "kind: HTTPRoute"
+    require_not_contains "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        "kind: HTTPProxy"
+
+    helm_template embedded-non-default-region "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set-string embeddedDependencies.objectStorage.region=us-west-2 \
+        --set-string rustfs.config.rustfs.region=us-west-2 \
+        >"$TEST_DIRECTORY/osmo-embedded-non-default-region.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-non-default-region.yaml" \
+        ConfigMap embedded-non-default-region-rustfs-config \
+        >"$TEST_DIRECTORY/osmo-rustfs-non-default-region-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-non-default-region-config.yaml" \
+        'RUSTFS_REGION: "us-west-2"'
+    resource_document "$TEST_DIRECTORY/osmo-embedded-non-default-region.yaml" \
+        ConfigMap embedded-non-default-region-osmo-api-config \
+        >"$TEST_DIRECTORY/osmo-non-default-region-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-non-default-region-config.yaml" \
+        "region: us-west-2"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-non-default-region.yaml" \
+        Job embedded-non-default-region-osmo-object-storage-bootstrap \
+        >"$TEST_DIRECTORY/osmo-non-default-region-bootstrap-job.yaml"
+    require_contains \
+        "$TEST_DIRECTORY/osmo-non-default-region-bootstrap-job.yaml" \
+        'value: "us-west-2"'
 
     helm_template embedded-object-storage-custom-key "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
@@ -1228,6 +1278,19 @@ EOF
         "name: OSMO_APP_BUCKET"
     require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-bootstrap-job.yaml" \
         "name: osmo-rustfs-credentials"
+
+    if helm_template mismatched-embedded-object-storage-region \
+        "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set-string embeddedDependencies.objectStorage.region=us-west-2 \
+        >"$TEST_DIRECTORY/mismatched-embedded-object-storage-region.out" 2>&1; then
+        fail "expected mismatched embedded object-storage regions to fail"
+    fi
+    require_contains \
+        "$TEST_DIRECTORY/mismatched-embedded-object-storage-region.out" \
+        "embeddedDependencies.objectStorage.region must match rustfs.config.rustfs.region"
 
     local conflicting_external_object_storage_value
     local conflicting_external_object_storage_message
@@ -1356,6 +1419,124 @@ EOF
     require_contains "$TEST_DIRECTORY/neither-rustfs-topology.out" \
         "exactly one RustFS topology mode must be enabled"
 
+    local longest_legal_helm_release
+    longest_legal_helm_release=$(printf 'r%.0s' {1..53})
+    if helm_template "$longest_legal_helm_release" "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        >"$TEST_DIRECTORY/standalone-rustfs-name-overflow.out" 2>&1; then
+        fail "expected an overlong standalone RustFS Service name to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/standalone-rustfs-name-overflow.out" \
+        "standalone embedded RustFS fullname must be at most 59 characters"
+
+    local distributed_rustfs_name_overflow_release
+    distributed_rustfs_name_overflow_release=$(printf 'd%.0s' {1..48})
+    if helm_template "$distributed_rustfs_name_overflow_release" \
+        "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set rustfs.mode.standalone.enabled=false \
+        --set rustfs.mode.distributed.enabled=true \
+        --set rustfs.replicaCount=2 \
+        >"$TEST_DIRECTORY/distributed-rustfs-name-overflow.out" 2>&1; then
+        fail "expected an overlong distributed RustFS headless Service name to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/distributed-rustfs-name-overflow.out" \
+        "distributed embedded RustFS fullname must be at most 54 characters"
+
+    local standalone_rustfs_name_boundary_release
+    local standalone_rustfs_name_boundary_fullname
+    standalone_rustfs_name_boundary_release=$(printf 's%.0s' {1..52})
+    standalone_rustfs_name_boundary_fullname="${standalone_rustfs_name_boundary_release}-rustfs"
+    helm_template "$standalone_rustfs_name_boundary_release" \
+        "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        >"$TEST_DIRECTORY/standalone-rustfs-name-boundary.yaml"
+    require_resource "$TEST_DIRECTORY/standalone-rustfs-name-boundary.yaml" \
+        Service "${standalone_rustfs_name_boundary_fullname}-svc"
+
+    local distributed_rustfs_name_boundary_release
+    local distributed_rustfs_name_boundary_fullname
+    distributed_rustfs_name_boundary_release=$(printf 'd%.0s' {1..47})
+    distributed_rustfs_name_boundary_fullname="${distributed_rustfs_name_boundary_release}-rustfs"
+    helm_template "$distributed_rustfs_name_boundary_release" \
+        "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        "${embedded_object_storage_settings[@]}" \
+        --set rustfs.mode.standalone.enabled=false \
+        --set rustfs.mode.distributed.enabled=true \
+        --set rustfs.replicaCount=2 \
+        >"$TEST_DIRECTORY/distributed-rustfs-name-boundary.yaml"
+    require_resource "$TEST_DIRECTORY/distributed-rustfs-name-boundary.yaml" \
+        Service "${distributed_rustfs_name_boundary_fullname}-headless"
+
+    local rustfs_topology
+    local rustfs_name_override
+    local rustfs_name_boundary_length
+    local rustfs_name_overflow_length
+    local rustfs_name_error
+    while IFS='|' read -r rustfs_topology rustfs_name_override \
+        rustfs_name_boundary_length rustfs_name_overflow_length rustfs_name_error; do
+        local rustfs_name_boundary_value
+        local rustfs_name_boundary_effective
+        local rustfs_service_suffix
+        local rustfs_topology_settings=()
+        printf -v rustfs_name_boundary_value '%*s' \
+            "$rustfs_name_boundary_length" ''
+        rustfs_name_boundary_value=${rustfs_name_boundary_value// /x}
+        rustfs_name_boundary_effective=$rustfs_name_boundary_value
+        rustfs_service_suffix=svc
+        if [[ "$rustfs_name_override" == nameOverride ]]; then
+            rustfs_name_boundary_effective="n-$rustfs_name_boundary_value"
+        fi
+        if [[ "$rustfs_topology" == distributed ]]; then
+            rustfs_service_suffix=headless
+            rustfs_topology_settings=(
+                --set rustfs.mode.standalone.enabled=false
+                --set rustfs.mode.distributed.enabled=true
+                --set rustfs.replicaCount=2
+            )
+        fi
+        helm_template n "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            "${embedded_object_storage_settings[@]}" \
+            "${rustfs_topology_settings[@]}" \
+            --set-string "rustfs.$rustfs_name_override=$rustfs_name_boundary_value" \
+            >"$TEST_DIRECTORY/$rustfs_topology-$rustfs_name_override-boundary.yaml"
+        require_resource \
+            "$TEST_DIRECTORY/$rustfs_topology-$rustfs_name_override-boundary.yaml" \
+            Service "${rustfs_name_boundary_effective}-${rustfs_service_suffix}"
+
+        local rustfs_name_overflow_value
+        printf -v rustfs_name_overflow_value '%*s' \
+            "$rustfs_name_overflow_length" ''
+        rustfs_name_overflow_value=${rustfs_name_overflow_value// /x}
+        if helm_template n "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            "${embedded_object_storage_settings[@]}" \
+            "${rustfs_topology_settings[@]}" \
+            --set-string "rustfs.$rustfs_name_override=$rustfs_name_overflow_value" \
+            >"$TEST_DIRECTORY/$rustfs_topology-$rustfs_name_override-overflow.out" 2>&1; then
+            fail "expected overlong $rustfs_topology rustfs.$rustfs_name_override to fail"
+        fi
+        require_contains \
+            "$TEST_DIRECTORY/$rustfs_topology-$rustfs_name_override-overflow.out" \
+            "$rustfs_name_error"
+    done <<'EOF'
+standalone|fullnameOverride|59|60|standalone embedded RustFS fullname must be at most 59 characters
+standalone|nameOverride|57|58|standalone embedded RustFS fullname must be at most 59 characters
+distributed|fullnameOverride|54|55|distributed embedded RustFS fullname must be at most 54 characters
+distributed|nameOverride|52|53|distributed embedded RustFS fullname must be at most 54 characters
+EOF
+
     if helm_template unsupported-rustfs-port "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
@@ -1382,7 +1563,14 @@ EOF
             "$exposed_rustfs_message"
     done <<'EOF'
 rustfs.ingress.enabled=true|rustfs.ingress.enabled must be false
+rustfs.ingress.className=contour|rustfs.ingress.className must not be contour
 rustfs.gatewayApi.enabled=true|rustfs.gatewayApi.enabled must be false
+rustfs.mtls.enabled=true|rustfs.mtls.enabled must be false
+rustfs.service.type=NodePort|rustfs.service.type must be ClusterIP
+rustfs.service.externalIPs[0]=192.0.2.10|rustfs.service.externalIPs must be empty
+rustfs.service.loadBalancerIP=192.0.2.10|rustfs.service.loadBalancerIP must be empty
+rustfs.service.loadBalancerClass=example.com/lb|rustfs.service.loadBalancerClass must be empty
+rustfs.service.loadBalancerSourceRanges[0]=192.0.2.0/24|rustfs.service.loadBalancerSourceRanges must be empty
 EOF
 
     local invalid_embedded_bucket_value

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -880,6 +880,8 @@ EOF
         >"$TEST_DIRECTORY/osmo-ui.yaml"
     require_contains "$TEST_DIRECTORY/osmo-ui.yaml" \
         "serviceAccountName: default"
+    require_no_resource "$rendered" ConfigMap "osmo-object-storage-bootstrap"
+    require_no_resource "$rendered" Job "osmo-object-storage-bootstrap"
 
     local embedded_object_storage_settings=(
         --set embeddedDependencies.objectStorage.enabled=true
@@ -905,6 +907,10 @@ EOF
         PersistentVolumeClaim embedded-object-storage-rustfs-data
     require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" Secret \
         osmo-rustfs-credentials
+    require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" ConfigMap \
+        embedded-object-storage-osmo-object-storage-bootstrap
+    require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" Job \
+        embedded-object-storage-osmo-object-storage-bootstrap
     require_occurrences "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
         "kind: Secret" 1
 
@@ -941,6 +947,62 @@ EOF
         fail "expected OSMO credentials to use the generated RustFS secret key"
     [[ "$rustfs_credentials" == *"addressing_style: path"* ]] || \
         fail "expected generated OSMO credentials to use path-style addressing"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        ConfigMap embedded-object-storage-osmo-object-storage-bootstrap \
+        >"$TEST_DIRECTORY/osmo-object-storage-bootstrap-configmap.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-configmap.yaml" \
+        "object-storage-bootstrap.sh:"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        Job embedded-object-storage-osmo-object-storage-bootstrap \
+        >"$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "helm.sh/hook: post-install,post-upgrade"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "backoffLimit: 3"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "amazon/aws-cli:2.31.13@sha256:e14216fb361cce909ce199616711ad103182d5937f851cda9bebf25867d7180a"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "name: AWS_ACCESS_KEY_ID"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "name: AWS_SECRET_ACCESS_KEY"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "name: osmo-rustfs-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "key: RUSTFS_ACCESS_KEY"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "key: RUSTFS_SECRET_KEY"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "name: AWS_ENDPOINT_URL"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        'value: "http://embedded-object-storage-rustfs-svc:9000"'
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "name: AWS_DEFAULT_REGION"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "name: OSMO_WORKFLOW_BUCKET"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "name: OSMO_LOG_BUCKET"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "name: OSMO_APP_BUCKET"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "name: OSMO_STORAGE_BOOTSTRAP_ATTEMPTS"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "automountServiceAccountToken: false"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "mountPath: /tmp"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "runAsUser: 10001"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "runAsNonRoot: true"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "readOnlyRootFilesystem: true"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "allowPrivilegeEscalation: false"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "- ALL"
 
     resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
         Deployment embedded-object-storage-rustfs \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -991,8 +991,12 @@ EOF
         "name: OSMO_STORAGE_BOOTSTRAP_ATTEMPTS"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "automountServiceAccountToken: false"
+    require_not_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "serviceAccountName:"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "mountPath: /tmp"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "type: RuntimeDefault"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "runAsUser: 10001"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
@@ -1003,6 +1007,16 @@ EOF
         "allowPrivilegeEscalation: false"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "- ALL"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "resources:"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "cpu: 10m"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "memory: 32Mi"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "cpu: 100m"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "memory: 128Mi"
 
     resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
         Deployment embedded-object-storage-rustfs \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1084,6 +1084,30 @@ EOF
     require_contains "$TEST_DIRECTORY/duplicate-object-storage-credentials.out" \
         "generate and existingSecret are mutually exclusive"
 
+    local invalid_object_storage_credentials_key
+    local invalid_object_storage_credentials_key_message
+    while IFS='|' read -r invalid_object_storage_credentials_key \
+        invalid_object_storage_credentials_key_message; do
+        if helm_template invalid-object-storage-credentials-key \
+            "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            "${embedded_object_storage_settings[@]}" \
+            --set-string "$invalid_object_storage_credentials_key" \
+            >"$TEST_DIRECTORY/invalid-object-storage-credentials-key.out" \
+            2>&1; then
+            fail "expected invalid object-storage credentials key to fail"
+        fi
+        require_contains \
+            "$TEST_DIRECTORY/invalid-object-storage-credentials-key.out" \
+            "$invalid_object_storage_credentials_key_message"
+    done <<'EOF'
+secrets.objectStorage.keys.credentials=|must be a non-empty valid Kubernetes Secret data key
+secrets.objectStorage.keys.credentials=object/storage.yaml|must be a non-empty valid Kubernetes Secret data key
+secrets.objectStorage.keys.credentials=RUSTFS_ACCESS_KEY|must not use a reserved RustFS key name
+secrets.objectStorage.keys.credentials=RUSTFS_SECRET_KEY|must not use a reserved RustFS key name
+EOF
+
     if helm_template missing-object-storage-credentials "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -494,6 +494,20 @@ test_control_umbrella() {
     require_contains "$rendered" "secretName: external-object-storage-secret"
     require_contains "$rendered" "secretName: external-master-encryption-key-secret"
     require_contains "$rendered" "https://s3.external.example.com"
+    resource_document "$rendered" ConfigMap osmo-api-config \
+        >"$TEST_DIRECTORY/osmo-external-object-storage-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-external-object-storage-config.yaml" \
+        "override_url: https://s3.external.example.com"
+    require_contains "$TEST_DIRECTORY/osmo-external-object-storage-config.yaml" \
+        "region: us-east-1"
+    require_contains "$TEST_DIRECTORY/osmo-external-object-storage-config.yaml" \
+        "endpoint: s3://osmo-workflows/workflows"
+    require_contains "$TEST_DIRECTORY/osmo-external-object-storage-config.yaml" \
+        "endpoint: s3://osmo-logs/logs"
+    require_contains "$TEST_DIRECTORY/osmo-external-object-storage-config.yaml" \
+        "endpoint: s3://osmo-apps/apps"
+    require_contains "$TEST_DIRECTORY/osmo-external-object-storage-config.yaml" \
+        "secretKey: object-storage.yaml"
     require_contains "$rendered" "nvcr.io/nvidia/osmo/service:6.3.1"
     require_contains "$rendered" "- INFO"
     require_contains "$rendered" "service_base_url: http://osmo-gateway"
@@ -1127,6 +1141,93 @@ EOF
         Secret existing-rustfs-secret
     require_contains "$TEST_DIRECTORY/osmo-embedded-object-storage-existing.yaml" \
         "secretName: existing-rustfs-secret"
+
+    helm_template embedded-object-storage-ha "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/embedded-rustfs-ha-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml"
+    require_no_deployment \
+        "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        embedded-object-storage-ha-rustfs
+    require_no_resource "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        PersistentVolumeClaim embedded-object-storage-ha-rustfs-data
+    require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        StatefulSet embedded-object-storage-ha-rustfs
+    require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        PodDisruptionBudget embedded-object-storage-ha-rustfs
+    require_no_resource "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        Secret osmo-rustfs-credentials
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        StatefulSet embedded-object-storage-ha-rustfs \
+        >"$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "replicas: 4"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "requiredDuringSchedulingIgnoredDuringExecution:"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "topologyKey: kubernetes.io/hostname"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "name: data"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        'accessModes: ["ReadWriteOnce"]'
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "storageClassName: standard"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "storage: 100Gi"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "name: RUSTFS_LOCAL_ENDPOINT_HOST"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "cpu: 500m"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "memory: 1Gi"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-statefulset.yaml" \
+        "memory: 2Gi"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        PodDisruptionBudget embedded-object-storage-ha-rustfs \
+        >"$TEST_DIRECTORY/osmo-rustfs-ha-pdb.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-pdb.yaml" \
+        "maxUnavailable: 1"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        ConfigMap embedded-object-storage-ha-rustfs-config \
+        >"$TEST_DIRECTORY/osmo-rustfs-ha-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-config.yaml" \
+        'RUSTFS_STORAGE_CLASS_STANDARD: "EC:2"'
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-config.yaml" \
+        'rustfs-{0...3}.embedded-object-storage-ha-rustfs-headless.default.svc.cluster.local:9000/data'
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        ConfigMap embedded-object-storage-ha-osmo-api-config \
+        >"$TEST_DIRECTORY/osmo-rustfs-ha-osmo-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-osmo-config.yaml" \
+        "override_url: http://embedded-object-storage-ha-rustfs-svc:9000"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-osmo-config.yaml" \
+        "endpoint: s3://osmo-workflows/workflows"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-osmo-config.yaml" \
+        "endpoint: s3://osmo-logs/logs"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-osmo-config.yaml" \
+        "endpoint: s3://osmo-apps/apps"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-osmo-config.yaml" \
+        "secretName: osmo-rustfs-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-osmo-config.yaml" \
+        "secretKey: object-storage.yaml"
+
+    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        Job embedded-object-storage-ha-osmo-object-storage-bootstrap \
+        >"$TEST_DIRECTORY/osmo-rustfs-ha-bootstrap-job.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-bootstrap-job.yaml" \
+        'value: "http://embedded-object-storage-ha-rustfs-svc:9000"'
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-bootstrap-job.yaml" \
+        "name: OSMO_WORKFLOW_BUCKET"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-bootstrap-job.yaml" \
+        "name: OSMO_LOG_BUCKET"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-bootstrap-job.yaml" \
+        "name: OSMO_APP_BUCKET"
+    require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-bootstrap-job.yaml" \
+        "name: osmo-rustfs-credentials"
 
     local conflicting_external_object_storage_value
     local conflicting_external_object_storage_message
@@ -2735,6 +2836,26 @@ EOF
         "curl http://127.0.0.1:8080/api/version"
     require_not_contains "$TEST_DIRECTORY/osmo-http-notes-configmap.yaml" \
         "--insecure"
+
+    helm_template notes-embedded-release "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/embedded-rustfs-ha-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-embedded-notes.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-embedded-notes.yaml" ConfigMap \
+        rendered-notes >"$TEST_DIRECTORY/osmo-embedded-notes-configmap.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-notes-configmap.yaml" \
+        "http://notes-embedded-release-rustfs-svc:9000"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-notes-configmap.yaml" \
+        "osmo-rustfs-credentials"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-notes-configmap.yaml" \
+        "PersistentVolumeClaims are retained"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-notes-configmap.yaml" \
+        "restore the matching credential Secret"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-notes-configmap.yaml" \
+        "kubectl get deployment,statefulset,pod,pvc,job"
+    require_contains "$TEST_DIRECTORY/osmo-embedded-notes-configmap.yaml" \
+        "service/notes-embedded-release-osmo-gateway 8080:80"
 
 }
 

--- a/deployments/charts/osmo/tests/verify_rustfs_chart_archive.sh
+++ b/deployments/charts/osmo/tests/verify_rustfs_chart_archive.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+EXPECTED_SHA256=c26cb094bc9735d01548ee540d018c1d88e2038bfd27ddc330770f5d525e63eb
+CHART_DIRECTORY=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ARCHIVE=${1:-"$CHART_DIRECTORY/charts/rustfs-1.0.0-rc.2.tgz"}
+
+command -v sha256sum >/dev/null || {
+    echo "ERROR: sha256sum is required to verify the RustFS chart archive" >&2
+    exit 1
+}
+
+if [[ ! -f "$ARCHIVE" ]]; then
+    echo "ERROR: RustFS chart archive not found: $ARCHIVE" >&2
+    exit 1
+fi
+
+read -r actual_sha256 _ < <(sha256sum "$ARCHIVE")
+if [[ "$actual_sha256" != "$EXPECTED_SHA256" ]]; then
+    echo "ERROR: RustFS chart archive SHA-256 mismatch: expected $EXPECTED_SHA256, got $actual_sha256 ($ARCHIVE)" >&2
+    exit 1
+fi
+
+echo "Verified RustFS chart archive SHA-256: $EXPECTED_SHA256"

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -119,9 +119,19 @@
             "apps": { "type": "string" }
           },
           "required": ["workflows", "logs", "apps"]
+        },
+        "bootstrap": {
+          "type": "object",
+          "properties": {
+            "image": { "type": "string", "minLength": 1 },
+            "attempts": { "type": "integer", "minimum": 1 },
+            "backoffLimit": { "type": "integer", "minimum": 0 },
+            "resources": { "type": "object" }
+          },
+          "required": ["image", "attempts", "backoffLimit", "resources"]
         }
       },
-      "required": ["enabled", "region", "buckets"]
+      "required": ["enabled", "region", "buckets", "bootstrap"]
     },
     "stringMap": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -17,12 +17,13 @@
       "properties": {
         "postgresql": { "$ref": "#/definitions/enabledBlock" },
         "valkey": { "$ref": "#/definitions/enabledBlock" },
-        "objectStorage": { "$ref": "#/definitions/enabledBlock" },
+        "objectStorage": { "$ref": "#/definitions/embeddedObjectStorage" },
         "kaiScheduler": { "$ref": "#/definitions/enabledBlock" }
       }
     },
     "valkey": { "type": "object" },
     "postgresql": { "type": "object" },
+    "rustfs": { "type": "object" },
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "imageRegistry": { "type": "string" },
@@ -104,6 +105,23 @@
       "type": "object",
       "properties": { "enabled": { "type": "boolean" } },
       "required": ["enabled"]
+    },
+    "embeddedObjectStorage": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "region": { "type": "string" },
+        "buckets": {
+          "type": "object",
+          "properties": {
+            "workflows": { "type": "string" },
+            "logs": { "type": "string" },
+            "apps": { "type": "string" }
+          },
+          "required": ["workflows", "logs", "apps"]
+        }
+      },
+      "required": ["enabled", "region", "buckets"]
     },
     "stringMap": {
       "type": "object",

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -27,6 +27,17 @@ embeddedDependencies:
       workflows: osmo-workflows
       logs: osmo-logs
       apps: osmo-apps
+    bootstrap:
+      image: amazon/aws-cli:2.31.13@sha256:e14216fb361cce909ce199616711ad103182d5937f851cda9bebf25867d7180a
+      attempts: 30
+      backoffLimit: 3
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
   kaiScheduler:
     enabled: false
 

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -178,8 +178,8 @@ monitoring:
 # References to Kubernetes Secrets. Inline credentials are not accepted.
 # Embedded PostgreSQL credentials are owned by
 # postgresql.cluster.initdb.secret.name. These Secret settings are external-only
-# for PostgreSQL. Generated credentials are supported by embedded Valkey; other
-# `generate` switches must remain false.
+# for PostgreSQL. Retained generated credentials are supported by embedded
+# Valkey and embedded object storage; other credential sources remain external.
 secrets:
   # Credentials for external PostgreSQL. Embedded PostgreSQL credentials are
   # created by CloudNativePG or configured with

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -22,6 +22,11 @@ embeddedDependencies:
     enabled: false
   objectStorage:
     enabled: false
+    region: us-east-1
+    buckets:
+      workflows: osmo-workflows
+      logs: osmo-logs
+      apps: osmo-apps
   kaiScheduler:
     enabled: false
 
@@ -1397,3 +1402,64 @@ valkey:
       whenScaled: Retain
   podDisruptionBudget:
     enabled: true
+
+# Official RustFS dependency configuration. These defaults provide a hardened,
+# persistent standalone server when embedded object storage is enabled.
+rustfs:
+  replicaCount: 1
+  mode:
+    standalone:
+      enabled: true
+      strategy:
+        type: Recreate
+    distributed:
+      enabled: false
+  secret:
+    existingSecret: osmo-rustfs-credentials
+    allowInsecureDefaults: false
+    rustfs:
+      access_key: ""
+      secret_key: ""
+  ingress:
+    enabled: false
+  gatewayApi:
+    enabled: false
+  serviceAccount:
+    create: true
+    automount: false
+  image:
+    rustfs:
+      repository: rustfs/rustfs
+      tag: "1.0.0-rc.2@sha256:7d6d361c49c08d427250fb59aae5d78df83d644c3405d9ccf4b21cda0b0692d0"
+    initImage:
+      repository: busybox
+      tag: "stable@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662"
+  config:
+    rustfs:
+      console_enable: "false"
+      obs_environment: production
+      obs_log_directory: ""
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+  podSecurityContext:
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+  storageclass:
+    name: ""
+    dataStorageSize: 10Gi

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -22,6 +22,8 @@ embeddedDependencies:
     enabled: false
   objectStorage:
     enabled: false
+    # Must match rustfs.config.rustfs.region when enabled. Override both values
+    # together for a non-default region.
     region: us-east-1
     buckets:
       workflows: osmo-workflows


### PR DESCRIPTION
## Description
Add rustfs to the OSMO umbrella chart

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional embedded RustFS object storage for OSMO Helm deployments.
  * Added standalone and high-availability configurations with persistent storage, security settings, and resource controls.
  * Added automatic credential management, bucket creation, endpoint readiness checks, and configurable retries.
  * Added validation for regions, buckets, credentials, topology, and configuration conflicts.
  * Added deployment notes covering access, backup and recovery, upgrades, and external S3 fallback.

* **Documentation**
  * Updated Helm chart documentation with embedded object-storage configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->