### PR TITLE
Close Redis log readers when clients disconnect

### DIFF
--- a/src/service/core/workflow/BUILD
+++ b/src/service/core/workflow/BUILD
@@ -29,6 +29,7 @@ osmo_py_library(
     ],
     deps = [
         requirement("fastapi"),
+        requirement("starlette"),
         requirement("redis"),
         requirement("pyjwt"),
         requirement("kubernetes"),

--- a/src/service/core/workflow/tests/BUILD
+++ b/src/service/core/workflow/tests/BUILD
@@ -76,6 +76,7 @@ py_test(
         "//src/lib/utils:osmo_errors",
         "//src/service/core/workflow",
         "//src/utils/job",
+        osmo_requirement("starlette"),
     ],
 )
 

--- a/src/service/core/workflow/tests/test_workflow_service_units.py
+++ b/src/service/core/workflow/tests/test_workflow_service_units.py
@@ -21,7 +21,10 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import ClientDisconnect
+from starlette.routing import Route
 
 from src.lib.utils import osmo_errors
 from src.service.core.workflow import objects, workflow_service
@@ -2066,6 +2069,101 @@ class TestRedisLogDisconnect(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(
             formatter_closed.is_set(),
             'Redis log formatter was not closed after the client disconnected.',
+        )
+
+    async def test_redis_disconnect_before_first_log_closes_formatter(self):
+        formatter_started = asyncio.Event()
+        formatter_closed = asyncio.Event()
+
+        async def tracked_formatter():
+            try:
+                formatter_started.set()
+                await asyncio.Future()
+                yield 'unreachable\n'
+            finally:
+                formatter_closed.set()
+
+        async def receive():
+            await formatter_started.wait()
+            return {'type': 'http.disconnect'}
+
+        async def send(_message):
+            return None
+
+        response = workflow_service._ClosingStreamingResponse(tracked_formatter())  # pylint: disable=protected-access
+        await asyncio.wait_for(
+            response(
+                {
+                    'type': 'http',
+                    'asgi': {'version': '3.0', 'spec_version': '2.4'},
+                },
+                receive,
+                send,
+            ),
+            timeout=1,
+        )
+
+        self.assertTrue(
+            formatter_closed.is_set(),
+            'Redis log formatter was not closed before its first log line.',
+        )
+
+    async def test_redis_disconnect_closes_formatter_through_http_middleware(self):
+        formatter_started = asyncio.Event()
+        formatter_closed = asyncio.Event()
+        request_count = 0
+
+        async def tracked_formatter():
+            try:
+                formatter_started.set()
+                await asyncio.Future()
+                yield 'unreachable\n'
+            finally:
+                formatter_closed.set()
+
+        async def endpoint(_request):
+            return workflow_service._ClosingStreamingResponse(tracked_formatter())  # pylint: disable=protected-access
+
+        async def pass_through_middleware(request, call_next):
+            return await call_next(request)
+
+        async def receive():
+            nonlocal request_count
+            if request_count == 0:
+                request_count += 1
+                return {'type': 'http.request', 'body': b'', 'more_body': False}
+            await formatter_started.wait()
+            return {'type': 'http.disconnect'}
+
+        async def send(_message):
+            return None
+
+        app = Starlette(routes=[Route('/logs', endpoint)])
+        app.add_middleware(BaseHTTPMiddleware, dispatch=pass_through_middleware)
+        await asyncio.wait_for(
+            app(
+                {
+                    'type': 'http',
+                    'asgi': {'version': '3.0', 'spec_version': '2.3'},
+                    'http_version': '1.1',
+                    'method': 'GET',
+                    'scheme': 'http',
+                    'path': '/logs',
+                    'raw_path': b'/logs',
+                    'query_string': b'',
+                    'headers': [],
+                    'client': ('127.0.0.1', 12345),
+                    'server': ('testserver', 80),
+                },
+                receive,
+                send,
+            ),
+            timeout=1,
+        )
+
+        self.assertTrue(
+            formatter_closed.is_set(),
+            'Redis log formatter was not closed through HTTP middleware.',
         )
 
 

--- a/src/service/core/workflow/tests/test_workflow_service_units.py
+++ b/src/service/core/workflow/tests/test_workflow_service_units.py
@@ -2108,6 +2108,30 @@ class TestRedisLogDisconnect(unittest.IsolatedAsyncioTestCase):
             'Redis log formatter was not closed before its first log line.',
         )
 
+    async def test_redis_reader_oserror_is_not_a_client_disconnect(self):
+
+        async def failing_formatter():
+            if False:
+                yield 'unreachable\n'
+            raise OSError('redis read failed')
+
+        async def receive():
+            await asyncio.Future()
+
+        async def send(_message):
+            return None
+
+        response = workflow_service._ClosingStreamingResponse(failing_formatter())  # pylint: disable=protected-access
+        with self.assertRaisesRegex(OSError, 'redis read failed'):
+            await response(
+                {
+                    'type': 'http',
+                    'asgi': {'version': '3.0', 'spec_version': '2.4'},
+                },
+                receive,
+                send,
+            )
+
     async def test_redis_disconnect_closes_formatter_through_http_middleware(self):
         formatter_started = asyncio.Event()
         formatter_closed = asyncio.Event()
@@ -2144,7 +2168,7 @@ class TestRedisLogDisconnect(unittest.IsolatedAsyncioTestCase):
             app(
                 {
                     'type': 'http',
-                    'asgi': {'version': '3.0', 'spec_version': '2.3'},
+                    'asgi': {'version': '3.0', 'spec_version': '2.4'},
                     'http_version': '1.1',
                     'method': 'GET',
                     'scheme': 'http',

--- a/src/service/core/workflow/tests/test_workflow_service_units.py
+++ b/src/service/core/workflow/tests/test_workflow_service_units.py
@@ -15,10 +15,13 @@ limitations under the License.
 
 SPDX-License-Identifier: Apache-2.0
 """
+import asyncio
 import http
 import unittest
 from types import SimpleNamespace
 from unittest import mock
+
+from starlette.requests import ClientDisconnect
 
 from src.lib.utils import osmo_errors
 from src.service.core.workflow import objects, workflow_service
@@ -2015,6 +2018,55 @@ class TestGetFileInfo(unittest.TestCase):
                 storage_client=mock.Mock(),
                 last_n_lines=10)
         self.assertIsNotNone(response)
+
+
+class TestRedisLogDisconnect(unittest.IsolatedAsyncioTestCase):
+    """Covers cleanup when a Redis-backed log response loses its client."""
+
+    async def test_redis_disconnect_closes_formatter(self):
+        context = mock.Mock()
+        log_info = SimpleNamespace(logs='redis://localhost/wf-1')
+        formatter_closed = asyncio.Event()
+
+        async def tracked_formatter(*_args):
+            try:
+                yield 'first log line\n'
+                await asyncio.Future()
+            finally:
+                formatter_closed.set()
+
+        async def receive():
+            await asyncio.Future()
+
+        async def send(message):
+            if message['type'] == 'http.response.body':
+                raise OSError('client disconnected')
+
+        with mock.patch.object(workflow_service.objects.WorkflowServiceContext,
+                               'get', return_value=context), \
+             mock.patch.object(workflow_service.workflow.LogInfo,
+                               'fetch_log_info_from_db',
+                               return_value=log_info), \
+             mock.patch.object(workflow_service.connectors,
+                               'redis_log_formatter',
+                               side_effect=tracked_formatter):
+            response = workflow_service.get_file_info(
+                'wf-1', 'redis-key', 'log.txt', storage_client=mock.Mock())
+
+            with self.assertRaises(ClientDisconnect):
+                await response(
+                    {
+                        'type': 'http',
+                        'asgi': {'version': '3.0', 'spec_version': '2.4'},
+                    },
+                    receive,
+                    send,
+                )
+
+        self.assertTrue(
+            formatter_closed.is_set(),
+            'Redis log formatter was not closed after the client disconnected.',
+        )
 
 
 class TestGetWorkflowSpec(unittest.TestCase):

--- a/src/service/core/workflow/workflow_service.py
+++ b/src/service/core/workflow/workflow_service.py
@@ -33,6 +33,7 @@ import yaml
 import fastapi
 import fastapi.responses
 import fastapi.staticfiles
+from starlette.requests import ClientDisconnect
 
 from src.lib.data import storage
 from src.lib.utils import common, credentials, login, osmo_errors, priority as wf_priority
@@ -55,8 +56,19 @@ class _ClosingStreamingResponse(fastapi.responses.StreamingResponse):
     """Streaming response that closes its async body iterator on teardown."""
 
     async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        # Starlette relies only on send failures for ASGI 2.4 responses. Redis
+        # streams can be quiet indefinitely, so keep its disconnect listener
+        # active even when there is no log body to send.
+        disconnect_scope = dict(scope)
+        disconnect_scope['asgi'] = {
+            **scope.get('asgi', {}),
+            'spec_version': '2.3',
+        }
         try:
-            await super().__call__(scope, receive, send)
+            try:
+                await super().__call__(disconnect_scope, receive, send)
+            except OSError as exc:
+                raise ClientDisconnect() from exc
         finally:
             close = getattr(self.body_iterator, 'aclose', None)
             if close:

--- a/src/service/core/workflow/workflow_service.py
+++ b/src/service/core/workflow/workflow_service.py
@@ -64,11 +64,15 @@ class _ClosingStreamingResponse(fastapi.responses.StreamingResponse):
             **scope.get('asgi', {}),
             'spec_version': '2.3',
         }
-        try:
+
+        async def send_with_disconnect(message: Any) -> None:
             try:
-                await super().__call__(disconnect_scope, receive, send)
+                await send(message)
             except OSError as exc:
                 raise ClientDisconnect() from exc
+
+        try:
+            await super().__call__(disconnect_scope, receive, send_with_disconnect)
         finally:
             close = getattr(self.body_iterator, 'aclose', None)
             if close:

--- a/src/service/core/workflow/workflow_service.py
+++ b/src/service/core/workflow/workflow_service.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import collections
+import contextlib
 import dataclasses
 import datetime
 import enum
@@ -48,6 +49,19 @@ router_pool = fastapi.APIRouter(tags = ['Pool API'])
 
 
 FETCH_TASK_LIMIT = 1000
+
+
+class _ClosingStreamingResponse(fastapi.responses.StreamingResponse):
+    """Streaming response that closes its async body iterator on teardown."""
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        try:
+            await super().__call__(scope, receive, send)
+        finally:
+            close = getattr(self.body_iterator, 'aclose', None)
+            if close:
+                await close()
+
 
 class ActionType(enum.Enum):
     EXEC = 'exec'
@@ -771,10 +785,11 @@ def get_file_info(name: str, redis_name: str, file_name: str,
     async def async_filter_log(log_generator: AsyncGenerator[str, None])\
         -> AsyncGenerator[str, None]:
         ''' Returns whether to send the log '''
-        async for line in log_generator:
-            if not regexes or \
-                all(compiled_regex.search(line) for compiled_regex in compiled_regexes):
-                yield line
+        async with contextlib.aclosing(log_generator):
+            async for line in log_generator:
+                if not regexes or \
+                    all(compiled_regex.search(line) for compiled_regex in compiled_regexes):
+                    yield line
 
     def filter_log(log_generator: storage.LinesStream) -> Generator[str, None, None]:
         ''' Returns whether to send the log '''
@@ -783,8 +798,9 @@ def get_file_info(name: str, redis_name: str, file_name: str,
                 all(compiled_regex.search(line) for compiled_regex in compiled_regexes):
                 yield line
 
+    response: fastapi.responses.StreamingResponse
     if parsed_result.scheme in ('redis', 'rediss') and not download:
-        response = fastapi.responses.StreamingResponse(
+        response = _ClosingStreamingResponse(
             async_filter_log(
                 connectors.redis_log_formatter(log_info.logs, redis_name, last_n_lines)))
     else:

--- a/src/utils/connectors/BUILD
+++ b/src/utils/connectors/BUILD
@@ -5,6 +5,7 @@ osmo_py_library(
     name = "connectors",
     srcs = glob(["*.py"]),
     deps = [
+        requirement("anyio"),
         requirement("fastapi"),
         requirement("jwcrypto"),
         requirement("kombu"),

--- a/src/utils/connectors/redis.py
+++ b/src/utils/connectors/redis.py
@@ -17,6 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import asyncio
+import contextlib
 import datetime
 import enum
 import logging
@@ -241,20 +242,21 @@ async def redis_log_formatter(url: str, name: str, last_n_lines: int | None = No
     Yields:
         Iterator[AsyncGenerator[str]]: Formatted logs.
     """
-    async for line in redis_log_streamer(url, name, last_n_lines):
-        # Align Lines
-        date = str(line.time.replace(tzinfo=None, microsecond=0)).replace('-', '/')
-        if line.io_type.ctrl_logs():
-            # Occassionally CTRL may send an empty string due to tdqm
-            if line.text:
-                if line.retry_id > 0:
-                    yield f'{date} [{line.source} retry-{line.retry_id}][osmo] {line.text}\n'
-                else:
-                    yield f'{date} [{line.source}][osmo] {line.text}\n'
-        elif line.io_type == IOType.DUMP:
-            yield f'{line.text}\n'
-        else:
-            if line.retry_id > 0:
+    async with contextlib.aclosing(
+            redis_log_streamer(url, name, last_n_lines)) as log_stream:
+        async for line in log_stream:
+            # Align Lines
+            date = str(line.time.replace(tzinfo=None, microsecond=0)).replace('-', '/')
+            if line.io_type.ctrl_logs():
+                # Occassionally CTRL may send an empty string due to tdqm
+                if line.text:
+                    if line.retry_id > 0:
+                        yield f'{date} [{line.source} retry-{line.retry_id}][osmo] {line.text}\n'
+                    else:
+                        yield f'{date} [{line.source}][osmo] {line.text}\n'
+            elif line.io_type == IOType.DUMP:
+                yield f'{line.text}\n'
+            elif line.retry_id > 0:
                 yield f'{date} [{line.source} retry-{line.retry_id}] {line.text}\n'
             else:
                 yield f'{date} [{line.source}] {line.text}\n'

--- a/src/utils/connectors/redis.py
+++ b/src/utils/connectors/redis.py
@@ -24,6 +24,7 @@ import logging
 from typing import AsyncGenerator, Dict, Optional
 
 import aiofiles  # type: ignore
+import anyio
 import kombu  # type: ignore
 import pydantic
 import redis.asyncio  # type: ignore
@@ -204,7 +205,8 @@ async def redis_log_streamer(
     Yields:
         AsyncGenerator[connectors.LogStreamBody]: The logs line.
     """
-    async with redis.asyncio.from_url(url) as redis_client:
+    redis_client = redis.asyncio.from_url(url)
+    try:
         # Continue to fetch log lines until the end control message is met
         start_id = 0
         skip_streaming = False
@@ -228,6 +230,9 @@ async def redis_log_streamer(
                 yield log
             except IndexError:  # No new line
                 await asyncio.sleep(1)  # Otherwise the stream will hang
+    finally:
+        with anyio.CancelScope(shield=True):
+            await redis_client.aclose()
 
 
 async def redis_log_formatter(url: str, name: str, last_n_lines: int | None = None) -> \

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -21,6 +21,7 @@ py_test(
     name = "test_redis",
     srcs = ["test_redis.py"],
     deps = [
+        requirement("anyio"),
         "//src/utils/connectors:connectors",
     ],
     size = "small",

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -18,6 +18,15 @@ load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 py_test(
+    name = "test_redis",
+    srcs = ["test_redis.py"],
+    deps = [
+        "//src/utils/connectors:connectors",
+    ],
+    size = "small",
+)
+
+py_test(
     name = "test_resource_spec",
     srcs = [
         "test_resource_spec.py"

--- a/src/utils/connectors/tests/test_redis.py
+++ b/src/utils/connectors/tests/test_redis.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import datetime
+import unittest
+from unittest import mock
+
+from src.utils.connectors import redis
+
+
+class RedisLogFormatterTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_closing_formatter_closes_redis_reader(self):
+        reader_closed = asyncio.Event()
+
+        async def tracked_reader(*_args):
+            try:
+                yield redis.LogStreamBody(
+                    source='task-1',
+                    retry_id=0,
+                    time=datetime.datetime(2026, 8, 19),
+                    text='first log line',
+                    io_type=redis.IOType.STDOUT,
+                )
+                await asyncio.Future()
+            finally:
+                reader_closed.set()
+
+        with mock.patch.object(redis, 'redis_log_streamer',
+                               side_effect=tracked_reader):
+            formatter = redis.redis_log_formatter(
+                'redis://localhost', 'workflow-logs')
+            self.assertIn('first log line', await anext(formatter))
+            await formatter.aclose()
+
+        self.assertTrue(
+            reader_closed.is_set(),
+            'Redis log reader was not closed when its formatter was closed.',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/utils/connectors/tests/test_redis.py
+++ b/src/utils/connectors/tests/test_redis.py
@@ -19,10 +19,51 @@ import datetime
 import unittest
 from unittest import mock
 
+import anyio
+
 from src.utils.connectors import redis
 
 
 class RedisLogFormatterTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_cancellation_does_not_interrupt_redis_client_cleanup(self):
+        read_started = asyncio.Event()
+        client_closed = asyncio.Event()
+
+        class TrackedRedisClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                await self.aclose()
+
+            async def xread(self, *_args, **_kwargs):
+                read_started.set()
+                await asyncio.Future()
+
+            async def aclose(self):
+                await asyncio.sleep(0)
+                client_closed.set()
+
+        redis_client = TrackedRedisClient()
+
+        async def consume():
+            async for _ in redis.redis_log_streamer(
+                'redis://localhost', 'workflow-logs'
+            ):
+                pass
+
+        with mock.patch.object(redis.redis.asyncio, 'from_url',
+                               return_value=redis_client):
+            async with anyio.create_task_group() as task_group:
+                task_group.start_soon(consume)
+                await read_started.wait()
+                task_group.cancel_scope.cancel()
+
+        self.assertTrue(
+            client_closed.is_set(),
+            'Redis client cleanup was cancelled before it completed.',
+        )
 
     async def test_closing_formatter_closes_redis_reader(self):
         reader_closed = asyncio.Event()


### PR DESCRIPTION
## Description

Issue - None

Close Redis-backed log response iterators on every response teardown path, and propagate generator closure through the log filter and formatter to the Redis reader. Keep an active `http.disconnect` listener for quiet Redis streams, including when the server advertises ASGI 2.4, while translating only downstream send failures to `ClientDisconnect`; Redis/read failures remain operational errors.

File-backed completed-log responses are unchanged.

## Root cause

Starlette's ASGI 2.4 streaming path detects disconnects only when a body send fails. A quiet Redis `XREAD` stream may not emit another body chunk after the client leaves, so the request coroutine and its Redis client remain alive indefinitely. Closing the outer response alone was also insufficient because closure did not propagate through both wrapping async generators.

## Performance impact

The formatted-log hot loop is unchanged. The fix adds one disconnect-listener task per active Redis log stream and teardown-only `aclose()` calls; it adds no per-line network request, lock, copy, sleep, buffer, or formatting work.

## Validation

- `bazel test //src/service/core/workflow/tests:all //src/utils/connectors/tests:all //src/service/core/workflow:workflow-pylint //src/utils/connectors:connectors-pylint --test_tag_filters=-requires-network --test_output=errors --cache_test_results=no` — 15/15 passed
- OETF `logger-connectivity` against the patched KIND deployment — passed end to end
- Leak reproduction: baseline retained 20 active `XREAD` clients after 20 disconnected streams; the patched direct Uvicorn path retained 0 after 5 disconnected quiet streams
- Independent code review completed with no remaining Critical or Important findings

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming log handling when a client disconnects, ensuring resources are cleaned up promptly.
  - Prevented disconnected log streams from leaving background readers, formatters, or Redis connections open.
  - Preserved underlying connection errors so failures are reported accurately.
  - Improved reliability for log streaming through middleware and during early client disconnects.
  - Ensured cleanup completes even when streaming tasks are cancelled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->