### PR TITLE
Release streaming response resources on client disconnect

### DIFF
--- a/src/service/core/BUILD
+++ b/src/service/core/BUILD
@@ -23,6 +23,16 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push", "oci_load")
 load("@osmo_constants//:constants.bzl", "BASE_IMAGE_URL", "IMAGE_TAG")
 
 osmo_py_library(
+    name = "responses",
+    srcs = ["responses.py"],
+    deps = [
+        requirement("fastapi"),
+        requirement("starlette"),
+    ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_library(
     name = "service_lib",
     srcs = [
         "service.py",

--- a/src/service/core/responses.py
+++ b/src/service/core/responses.py
@@ -1,0 +1,62 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import asyncio
+from typing import AsyncGenerator, cast
+
+import fastapi.responses
+from starlette.types import Receive, Scope, Send
+
+
+class ClosingStreamingResponse(fastapi.responses.StreamingResponse):
+    """Streaming response that ends and releases its body when the client leaves.
+
+    Starlette only installs a disconnect listener for ASGI servers older than
+    spec 2.4; on 2.4 and later it infers a disconnect from a failed body send.
+    Uvicorn advertises 2.4, so a body that never sends -- a log tail on a quiet
+    workflow -- is never told the client is gone, and the request runs forever.
+
+    This restores the listener unconditionally and closes the body afterwards,
+    so whatever the body holds open is released with the response. Use it for a
+    body that can stay idle; a body that always has a next chunk does not need
+    it, because its next send will fail and end the request anyway.
+    """
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope['type'] != 'http':
+            await super().__call__(scope, receive, send)
+            return
+
+        streaming = asyncio.ensure_future(self.stream_response(send))
+        watching = asyncio.ensure_future(self.listen_for_disconnect(receive))
+        try:
+            await asyncio.wait((streaming, watching), return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            streaming.cancel()
+            watching.cancel()
+            # Both have to finish unwinding before the body can be closed, or
+            # aclose() lands on a generator that is still running.
+            await asyncio.wait((streaming, watching))
+            await cast(AsyncGenerator[bytes, None], self.body_iterator).aclose()
+
+        if not streaming.cancelled():
+            # Surface a body failure; a cancelled stream means the client left.
+            streaming.result()
+
+        if self.background is not None:
+            await self.background()

--- a/src/service/core/tests/BUILD
+++ b/src/service/core/tests/BUILD
@@ -60,6 +60,17 @@ osmo_py_test(
 )
 
 osmo_py_test(
+    name = "test_responses",
+    srcs = ["test_responses.py"],
+    deps = [
+        "//src/service/core:responses",
+        osmo_requirement("starlette"),
+    ],
+    size = "small",
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_test(
     name = "test_asyncio_startup",
     srcs = ["test_asyncio_startup.py"],
     deps = [

--- a/src/service/core/tests/test_responses.py
+++ b/src/service/core/tests/test_responses.py
@@ -1,0 +1,170 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import asyncio
+import unittest
+
+from starlette.applications import Starlette
+from starlette.background import BackgroundTask
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.routing import Route
+
+from src.service.core import responses
+
+
+def _scope(spec_version: str = '2.4') -> dict:
+    """Minimal ASGI HTTP scope for calling a response directly."""
+    return {'type': 'http', 'asgi': {'version': '3.0', 'spec_version': spec_version}}
+
+
+async def _idle_receive():
+    """ASGI receive for a client that stays connected and sends nothing further."""
+    await asyncio.Future()
+
+
+async def _discard_send(message) -> None:  # pylint: disable=unused-argument
+    """ASGI send that drops every message."""
+
+
+def _disconnect_once(after: asyncio.Event):
+    """ASGI receive that reports a disconnect once `after` is set."""
+
+    async def receive():
+        await after.wait()
+        return {'type': 'http.disconnect'}
+
+    return receive
+
+
+def _quiet_body(started: asyncio.Event, closed: asyncio.Event):
+    """Body that blocks before its first chunk, recording start and closure."""
+
+    async def body():
+        try:
+            started.set()
+            await asyncio.Future()
+            yield 'unreachable\n'
+        finally:
+            closed.set()
+
+    return body()
+
+
+class TestClosingStreamingResponse(unittest.IsolatedAsyncioTestCase):
+    """Covers release of an idle body when the client disconnects."""
+
+    async def test_quiet_body_is_closed_when_client_disconnects(self):
+        for spec_version in ('2.3', '2.4'):
+            with self.subTest(spec_version=spec_version):
+                started, closed = asyncio.Event(), asyncio.Event()
+                response = responses.ClosingStreamingResponse(_quiet_body(started, closed))
+                await asyncio.wait_for(
+                    response(_scope(spec_version), _disconnect_once(started), _discard_send),
+                    timeout=1,
+                )
+                self.assertTrue(closed.is_set(), 'A quiet body outlived its client.')
+
+    async def test_body_is_closed_after_it_is_fully_sent(self):
+        closed = asyncio.Event()
+        sent = []
+
+        async def body():
+            try:
+                yield 'one\n'
+                yield 'two\n'
+            finally:
+                closed.set()
+
+        async def collecting_send(message):
+            if message['type'] == 'http.response.body':
+                sent.append(message['body'])
+
+        response = responses.ClosingStreamingResponse(body())
+        await asyncio.wait_for(
+            response(_scope(), _idle_receive, collecting_send), timeout=1)
+
+        self.assertEqual(b''.join(sent), b'one\ntwo\n')
+        self.assertTrue(closed.is_set(), 'The body was not closed after a full send.')
+
+    async def test_body_failure_propagates(self):
+
+        async def failing_body():
+            # The unreachable yield is what makes this an async generator; the
+            # raise fires on the first __anext__.
+            if False:  # pylint: disable=using-constant-test
+                yield 'unreachable\n'
+            raise OSError('backend read failed')
+
+        response = responses.ClosingStreamingResponse(failing_body())
+        with self.assertRaisesRegex(OSError, 'backend read failed'):
+            await asyncio.wait_for(
+                response(_scope(), _idle_receive, _discard_send), timeout=1)
+
+    async def test_background_task_runs_after_the_body_is_closed(self):
+        order = []
+
+        async def body():
+            try:
+                yield 'one\n'
+            finally:
+                order.append('body closed')
+
+        async def background():
+            order.append('background')
+
+        response = responses.ClosingStreamingResponse(
+            body(), background=BackgroundTask(background))
+        await asyncio.wait_for(
+            response(_scope(), _idle_receive, _discard_send), timeout=1)
+
+        self.assertEqual(order, ['body closed', 'background'])
+
+    async def test_quiet_body_is_closed_behind_http_middleware(self):
+        """The core service wraps requests in BaseHTTPMiddleware; it must not
+        prevent the disconnect from reaching the response."""
+        started, closed = asyncio.Event(), asyncio.Event()
+        request_sent = False
+
+        async def endpoint(request):  # pylint: disable=unused-argument
+            return responses.ClosingStreamingResponse(_quiet_body(started, closed))
+
+        async def pass_through(request, call_next):
+            return await call_next(request)
+
+        async def receive():
+            nonlocal request_sent
+            if not request_sent:
+                request_sent = True
+                return {'type': 'http.request', 'body': b'', 'more_body': False}
+            await started.wait()
+            return {'type': 'http.disconnect'}
+
+        app = Starlette(routes=[Route('/logs', endpoint)])
+        app.add_middleware(BaseHTTPMiddleware, dispatch=pass_through)
+        await asyncio.wait_for(
+            app({**_scope(), 'http_version': '1.1', 'method': 'GET', 'scheme': 'http',
+                 'path': '/logs', 'raw_path': b'/logs', 'query_string': b'', 'headers': [],
+                 'client': ('127.0.0.1', 12345), 'server': ('testserver', 80)},
+                receive, _discard_send),
+            timeout=1,
+        )
+
+        self.assertTrue(closed.is_set(), 'A quiet body was not closed through HTTP middleware.')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/core/workflow/BUILD
+++ b/src/service/core/workflow/BUILD
@@ -41,6 +41,7 @@ osmo_py_library(
         "//src/lib/utils:osmo_errors",
         "//src/lib/utils:redact",
         "//src/lib/utils:validation",
+        "//src/service/core:responses",
         "//src/service/core/config:configmap_loader_lib",
         "//src/utils:ssl_config",
         "//src/utils:static_config",

--- a/src/service/core/workflow/workflow_service.py
+++ b/src/service/core/workflow/workflow_service.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import collections
+import contextlib
 import dataclasses
 import datetime
 import enum
@@ -37,6 +38,7 @@ from src.lib.data import storage
 from src.lib.utils import common, credentials, login, osmo_errors, priority as wf_priority
 from src.lib.utils.redact import redact_secrets
 from src.utils.job import common as job_common, jobs, workflow, task
+from src.service.core import responses
 from src.service.core.workflow import helpers, objects
 from src.utils import connectors
 
@@ -771,10 +773,11 @@ def get_file_info(name: str, redis_name: str, file_name: str,
     async def async_filter_log(log_generator: AsyncGenerator[str, None])\
         -> AsyncGenerator[str, None]:
         ''' Returns whether to send the log '''
-        async for line in log_generator:
-            if not regexes or \
-                all(compiled_regex.search(line) for compiled_regex in compiled_regexes):
-                yield line
+        async with contextlib.aclosing(log_generator) as log_stream:
+            async for line in log_stream:
+                if not regexes or \
+                    all(compiled_regex.search(line) for compiled_regex in compiled_regexes):
+                    yield line
 
     def filter_log(log_generator: storage.LinesStream) -> Generator[str, None, None]:
         ''' Returns whether to send the log '''
@@ -783,8 +786,9 @@ def get_file_info(name: str, redis_name: str, file_name: str,
                 all(compiled_regex.search(line) for compiled_regex in compiled_regexes):
                 yield line
 
+    response: fastapi.responses.StreamingResponse
     if parsed_result.scheme in ('redis', 'rediss') and not download:
-        response = fastapi.responses.StreamingResponse(
+        response = responses.ClosingStreamingResponse(
             async_filter_log(
                 connectors.redis_log_formatter(log_info.logs, redis_name, last_n_lines)))
     else:

--- a/src/utils/connectors/BUILD
+++ b/src/utils/connectors/BUILD
@@ -13,6 +13,7 @@ osmo_py_library(
         requirement("pydantic"),
         requirement("redis"),
         requirement("aiofiles"),
+        requirement("anyio"),
         requirement("pyyaml"),
         "//src/lib/data/storage",
         "//src/lib/data/storage/constants",

--- a/src/utils/connectors/redis.py
+++ b/src/utils/connectors/redis.py
@@ -17,12 +17,14 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import asyncio
+import contextlib
 import datetime
 import enum
 import logging
 from typing import AsyncGenerator, Dict, Optional
 
 import aiofiles  # type: ignore
+import anyio
 import kombu  # type: ignore
 import pydantic
 import redis.asyncio  # type: ignore
@@ -203,7 +205,8 @@ async def redis_log_streamer(
     Yields:
         AsyncGenerator[connectors.LogStreamBody]: The logs line.
     """
-    async with redis.asyncio.from_url(url) as redis_client:
+    redis_client = redis.asyncio.from_url(url)
+    try:
         # Continue to fetch log lines until the end control message is met
         start_id = 0
         skip_streaming = False
@@ -227,6 +230,12 @@ async def redis_log_streamer(
                 yield log
             except IndexError:  # No new line
                 await asyncio.sleep(1)  # Otherwise the stream will hang
+    finally:
+        # A client disconnect closes this generator by cancelling the task that
+        # drives it, and cancellation lands on the sleep above. An unshielded
+        # await here would be cancelled in turn, leaving the connection open.
+        with anyio.CancelScope(shield=True):
+            await redis_client.aclose()
 
 
 async def redis_log_formatter(url: str, name: str, last_n_lines: int | None = None) -> \
@@ -241,23 +250,24 @@ async def redis_log_formatter(url: str, name: str, last_n_lines: int | None = No
     Yields:
         Iterator[AsyncGenerator[str]]: Formatted logs.
     """
-    async for line in redis_log_streamer(url, name, last_n_lines):
-        # Align Lines
-        date = str(line.time.replace(tzinfo=None, microsecond=0)).replace('-', '/')
-        if line.io_type.ctrl_logs():
-            # Occassionally CTRL may send an empty string due to tdqm
-            if line.text:
-                if line.retry_id > 0:
-                    yield f'{date} [{line.source} retry-{line.retry_id}][osmo] {line.text}\n'
-                else:
-                    yield f'{date} [{line.source}][osmo] {line.text}\n'
-        elif line.io_type == IOType.DUMP:
-            yield f'{line.text}\n'
-        else:
-            if line.retry_id > 0:
-                yield f'{date} [{line.source} retry-{line.retry_id}] {line.text}\n'
+    async with contextlib.aclosing(redis_log_streamer(url, name, last_n_lines)) as log_stream:
+        async for line in log_stream:
+            # Align Lines
+            date = str(line.time.replace(tzinfo=None, microsecond=0)).replace('-', '/')
+            if line.io_type.ctrl_logs():
+                # Occassionally CTRL may send an empty string due to tdqm
+                if line.text:
+                    if line.retry_id > 0:
+                        yield f'{date} [{line.source} retry-{line.retry_id}][osmo] {line.text}\n'
+                    else:
+                        yield f'{date} [{line.source}][osmo] {line.text}\n'
+            elif line.io_type == IOType.DUMP:
+                yield f'{line.text}\n'
             else:
-                yield f'{date} [{line.source}] {line.text}\n'
+                if line.retry_id > 0:
+                    yield f'{date} [{line.source} retry-{line.retry_id}] {line.text}\n'
+                else:
+                    yield f'{date} [{line.source}] {line.text}\n'
 
 
 async def write_redis_log_to_disk(url: str, name: str, file_path: str):

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -14,8 +14,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library")
+load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
+
+osmo_py_test(
+    name = "test_redis",
+    srcs = ["test_redis.py"],
+    deps = [
+        "//src/utils/connectors:connectors",
+        requirement("anyio"),
+    ],
+    size = "small",
+)
 
 py_test(
     name = "test_resource_spec",

--- a/src/utils/connectors/tests/test_redis.py
+++ b/src/utils/connectors/tests/test_redis.py
@@ -1,0 +1,109 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+import asyncio
+import datetime
+import unittest
+from unittest import mock
+
+import anyio
+
+from src.utils.connectors import redis
+
+
+def _log_line(text: str) -> redis.LogStreamBody:
+    """One STDOUT log entry as redis_log_streamer would yield it."""
+    return redis.LogStreamBody(
+        source='task-1',
+        retry_id=0,
+        time=datetime.datetime(2026, 8, 19),
+        text=text,
+        io_type=redis.IOType.STDOUT,
+    )
+
+
+class TestRedisLogFormatter(unittest.IsolatedAsyncioTestCase):
+    """Covers closure propagation from the log formatter to the Redis reader."""
+
+    async def test_closing_formatter_closes_redis_reader(self):
+        reader_closed = asyncio.Event()
+
+        async def tracked_reader(*args):  # pylint: disable=unused-argument
+            try:
+                yield _log_line('first log line')
+                await asyncio.Future()
+            finally:
+                reader_closed.set()
+
+        with mock.patch.object(redis, 'redis_log_streamer',
+                               side_effect=tracked_reader):
+            formatter = redis.redis_log_formatter(
+                'redis://localhost', 'workflow-logs')
+            self.assertIn('first log line', await anext(formatter))
+            await formatter.aclose()
+
+        self.assertTrue(
+            reader_closed.is_set(),
+            'Redis log reader was not closed when its formatter was closed.',
+        )
+
+
+class TestRedisLogStreamer(unittest.IsolatedAsyncioTestCase):
+    """Covers release of the Redis client when the reader is cancelled."""
+
+    async def test_client_is_closed_even_when_the_reader_is_cancelled(self):
+        """A disconnect cancels the task driving the reader, and cancellation
+        lands inside it. The close must still complete or the socket leaks."""
+        closed = asyncio.Event()
+
+        class _FakeClient:
+            async def xread(self, *args, **kwargs):  # pylint: disable=unused-argument
+                return []
+
+            async def aclose(self):
+                # Any real close awaits; an unshielded one would be cancelled here.
+                await asyncio.sleep(0)
+                closed.set()
+
+        async def drain():
+            async with anyio.create_task_group() as task_group:
+
+                async def read():
+                    stream = redis.redis_log_streamer('redis://localhost', 'logs')
+                    try:
+                        await anext(stream)
+                    except StopAsyncIteration:
+                        pass
+                    finally:
+                        await stream.aclose()
+
+                task_group.start_soon(read)
+                await asyncio.sleep(0.05)
+                task_group.cancel_scope.cancel()
+
+        with mock.patch.object(redis.redis.asyncio, 'from_url',
+                               return_value=_FakeClient()):
+            await asyncio.wait_for(drain(), timeout=5)
+
+        self.assertTrue(
+            closed.is_set(),
+            'The Redis client was not closed when the reader was cancelled.',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Issue - None

Tailing a workflow's live logs (`GET /api/workflow/{name}/logs`) opens a Redis client that polls `XREAD` once a second. If the client goes away while the workflow is quiet, nothing tells the server, and that Redis connection is never released. Enough abandoned log windows and the service exhausts Redis connections.

## Root cause

Two independent defects. Closing only the first still leaks.

**1. The request never ends.** Starlette installs a disconnect listener only for ASGI servers reporting spec version < 2.4 (`starlette/responses.py`, `StreamingResponse.__call__`). On >= 2.4 — which uvicorn advertises — it instead infers a disconnect from a failed body send. A body with nothing to send never fails, so `redis_log_streamer` keeps polling and the request coroutine lives until the process restarts.

**2. The close is cancelled.** The disconnect tears the reader down by cancelling the task driving it. Cancellation lands on the `asyncio.sleep(1)` *inside* `redis_log_streamer`, unwinding it and running its `finally` — but that `finally` awaits `redis_client.aclose()`, and an await inside an already-cancelled scope is cancelled immediately. The generator ends; the socket does not close.

## Design

**`src/service/core/responses.py` — `ClosingStreamingResponse` (62 lines).** Races the body against `listen_for_disconnect(receive)` and closes the body in a `finally`, restoring the listener regardless of the server's advertised spec version. Uses plain `asyncio.wait` rather than an anyio task group, which avoids vendoring Starlette's private exception-group collapsing helper.

Applied to **one** call site: the `redis://` branch of `get_file_info`. The other streaming endpoints serve finite object-store reads — they always have a next chunk, so their next send fails promptly and the existing >= 2.4 path already ends them. They are deliberately left alone.

**`src/utils/connectors/redis.py` — shielded close.** `redis_log_streamer` now owns its client explicitly and closes it under `anyio.CancelScope(shield=True)`, so the close completes despite the cancellation that triggered it.

**`contextlib.aclosing` at the two chain links** (`redis_log_formatter`, and `async_filter_log` in `workflow_service.py`) so closure reaches the streamer at all — closing an async generator does not close one it is iterating.

## Validation

Dev-instance A/B using fresh service pods and the same 100 live-log client disconnects:

| Code | Redis `XREAD` delta | PID 1 RSS delta | Cgroup memory delta |
|---|---:|---:|---:|
| No fix (`08a56212`) | +100 | +102.3 MiB | +104.0 MiB |
| **PR head (`e7b21e4c`)** | **0** | **+17.1 MiB** | **+17.8 MiB** |

All 100 requests returned 200 and neither pod restarted. With the fix, `XREAD` stayed at zero and cgroup growth plateaued to +0.9 MiB over the final 50 disconnects (versus +52.6 MiB without it).

KIND also left 0/20 readers in two full-fix runs (no fix: 4/20; response-only: 2/20 twice). Twenty-four unit, integration, and lint targets pass, including the core service and workflow service suites.

## Scope

Deliberately limited to the measured leak. Split out of an earlier, larger version of this PR:

- **Converting the other five streaming endpoints.** Three serve finite object-store reads and cannot exhibit this defect. The two router endpoints (`stream_chunked` / `stream_content`) *do* — `stream_chunked` loops on `ws.receive_bytes()` unbounded and never signals `close` when torn down early, leaking the backend WebSocket and its `connections[]` entry. That is a real leak in a different service and will get its own PR with its own measurement.
- **Rewriting `check_client_version` from `BaseHTTPMiddleware` to pure ASGI.** Was included on the belief that `BaseHTTPMiddleware` swallows the disconnect signal. It does swallow the *send-failure* signal, but this fix detects disconnects via `receive()`, which `BaseHTTPMiddleware` forwards intact — `test_quiet_body_is_closed_behind_http_middleware` asserts exactly that. The rewrite is a worthwhile change on its own merits (measured ~94.7 µs/req -> ~2.5 µs/req on every core-service request) and will be proposed separately.

## Known gap

CI cannot catch a regression of this bug. The KIND job runs an explicit allowlist of negative scenarios that never launch a workload; a scenario for this leak fails on GitHub runners with `FAILED_IMAGE_PULL` and insufficient CPU. The scenario exists at `refs/pull/1318/head` and can be recovered with `git fetch origin pull/1318/head`. Closing the gap needs image preloading in the KIND job or a scheduled dev-instance run.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

