### PR TITLE
Add KIND regression for Redis reader cleanup

### DIFF
--- a/test/oetf/bzl/oetf.bzl
+++ b/test/oetf/bzl/oetf.bzl
@@ -67,6 +67,7 @@ def oetf_scenario_test(
         workflow_data = ["@osmo_workspace//test/workflow:all_workflow_yamls"],
         tags = [],
         test_filter = None,
+        env_inherit = [],
         size = "large",
         timeout = "long"):
     """A scenario test — submits a workflow and asserts outcome.
@@ -94,6 +95,7 @@ def oetf_scenario_test(
       test_filter: optional "ClassName.test_method" — emitted as an argv arg
         so `unittest` only runs the one method. Used to split slow files
         into per-test Bazel targets for parallelism.
+      env_inherit: host environment variables required by the scenario.
       size: Bazel size. Default large (workflows take minutes).
       timeout: Bazel timeout class. Default long (900s). Use "eternal" for load tests.
     """
@@ -120,6 +122,7 @@ def oetf_scenario_test(
         main = main,
         data = data,
         args = [test_filter] if test_filter else [],
+        env_inherit = env_inherit,
         deps = [
             "@osmo_workspace//test/oetf:runner_fixture",
             "@osmo_workspace//test/oetf:fixture_base",

--- a/test/scenarios/BUILD
+++ b/test/scenarios/BUILD
@@ -19,6 +19,13 @@ oetf_scenario_test(
 )
 
 oetf_scenario_test(
+    name = "redis-reader-cleanup",
+    env_inherit = ["HOME", "KUBECONFIG"],
+    test_dir = "redis_reader_cleanup",
+    tags = ["logger", "redis", "positive", "kind", "exclusive"],
+)
+
+oetf_scenario_test(
     name = "task-runtime-environment",
     test_dir = "task_runtime_environment",
     tags = ["task-env", "positive", "kind"],

--- a/test/scenarios/redis_reader_cleanup/spec.yaml
+++ b/test/scenarios/redis_reader_cleanup/spec.yaml
@@ -1,0 +1,30 @@
+#####################################################################################
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto. Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#####################################################################################
+
+version: 2
+workflow:
+  name: oetf-redis-reader-cleanup-{{test_id}}
+  timeout:
+    exec_timeout: 5m
+    queue_timeout: 30m
+  resources:
+    default:
+      cpu: 1
+      memory: 1Gi
+      storage: 1Gi
+  tasks:
+  - name: quiet-logger
+    image: python:3.10-slim
+    command: ["python3"]
+    args: ["/tmp/oetf/task.py"]
+    resource: default
+
+default-values:
+  test_id: "0"

--- a/test/scenarios/redis_reader_cleanup/task.py
+++ b/test/scenarios/redis_reader_cleanup/task.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+NVIDIA CORPORATION and its licensors retain all intellectual property
+and proprietary rights in and to this software, related documentation
+and any modifications thereto. Any use, reproduction, disclosure or
+distribution of this software and related documentation without an express
+license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""
+
+import time
+
+from task_fixture import TaskFixture
+
+
+class QuietLogger(TaskFixture):
+    """Emit one line, then stay quiet while clients disconnect."""
+
+    def run_checks(self):
+        print("OETF_REDIS_READER_READY", flush=True)
+        self.record_pass("log:ready", "quiet log stream is available")
+        time.sleep(240)
+
+
+if __name__ == "__main__":
+    QuietLogger().execute()

--- a/test/scenarios/redis_reader_cleanup/test_runner.py
+++ b/test/scenarios/redis_reader_cleanup/test_runner.py
@@ -1,0 +1,135 @@
+"""
+Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+NVIDIA CORPORATION and its licensors retain all intellectual property
+and proprietary rights in and to this software, related documentation
+and any modifications thereto. Any use, reproduction, disclosure or
+distribution of this software and related documentation without an express
+license agreement from NVIDIA CORPORATION is strictly prohibited.
+"""
+
+import os
+import subprocess
+import time
+import unittest
+
+from test.oetf.runner_fixture import RunnerFixture
+
+
+KUBE_CONTEXT = "kind-osmo"
+NAMESPACE = "osmo"
+DISCONNECT_COUNT = 20
+TASK_NAME = "quiet-logger"
+
+
+def _kubectl(*args: str, timeout: int = 30) -> str:
+    result = subprocess.run(
+        ["kubectl", "--context", KUBE_CONTEXT, "-n", NAMESPACE, *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.stdout.strip()
+
+
+def _redis_topology() -> tuple[set[str], str, str]:
+    service_ips = set(_kubectl(
+        "get", "pods", "-l", "app=osmo-service",
+        "-o", "jsonpath={range .items[*]}{.status.podIP}{'\\n'}{end}",
+    ).splitlines())
+    if not service_ips:
+        raise RuntimeError("no osmo-service pod IPs found")
+
+    redis_pod = _kubectl(
+        "get", "pods", "-l", "app=redis",
+        "-o", "jsonpath={.items[0].metadata.name}",
+    )
+    service_pod = _kubectl(
+        "get", "pods", "-l", "app=osmo-service",
+        "-o", "jsonpath={.items[0].metadata.name}",
+    )
+    return service_ips, redis_pod, service_pod
+
+
+def _redis_xread_clients_from_service(
+    service_ips: set[str], redis_pod: str,
+) -> int:
+    clients = _kubectl("exec", redis_pod, "--", "redis-cli", "CLIENT", "LIST")
+    return sum(
+        1 for line in clients.splitlines()
+        if "cmd=xread" in line
+        and any(f"addr={service_ip}:" in line for service_ip in service_ips)
+    )
+
+
+def _disconnect_local_log_streams(
+    service_pod: str, workflow_id: str, username: str,
+) -> None:
+    script = """
+import http.client
+import sys
+
+for _ in range(int(sys.argv[3])):
+    connection = http.client.HTTPConnection("127.0.0.1", 8000, timeout=2)
+    connection.request(
+        "GET",
+        f"/api/workflow/{sys.argv[1]}/logs",
+        headers={"x-osmo-user": sys.argv[2]},
+    )
+    response = connection.getresponse()
+    if response.status != 200:
+        raise RuntimeError(f"live log request returned HTTP {response.status}")
+    try:
+        response.read()
+    except TimeoutError:
+        pass
+    else:
+        raise RuntimeError("live log request ended before the forced disconnect")
+    finally:
+        connection.close()
+"""
+    _kubectl(
+        "exec", service_pod, "-c", "osmo-service", "--",
+        "python3", "-c", script, workflow_id, username, str(DISCONNECT_COUNT),
+        timeout=60,
+    )
+
+
+class RedisReaderCleanup(RunnerFixture):
+    """Disconnected live-log clients do not retain Redis readers."""
+
+    timeout = "5m"
+
+    def test_disconnected_log_streams_release_redis_readers(self):
+        if os.environ.get("OETF_ENV") != "kind":
+            self.skipTest("Redis client inspection is available only in KIND")
+
+        handle = self.workflow("spec.yaml").submit()
+        try:
+            handle.wait_for_task_running(TASK_NAME)
+            service_ips, redis_pod, service_pod = _redis_topology()
+            baseline = _redis_xread_clients_from_service(service_ips, redis_pod)
+
+            _disconnect_local_log_streams(
+                service_pod, handle.workflow_id, self.config.auth_username,
+            )
+
+            deadline = time.monotonic() + 30
+            observed = _redis_xread_clients_from_service(service_ips, redis_pod)
+            while observed != baseline and time.monotonic() < deadline:
+                time.sleep(1)
+                observed = _redis_xread_clients_from_service(service_ips, redis_pod)
+
+            self.assertLessEqual(
+                observed,
+                baseline,
+                f"{observed - baseline} additional Redis XREAD clients remained after "
+                f"{DISCONNECT_COUNT} live-log clients disconnected",
+            )
+        finally:
+            handle.cancel()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Issue #None

Add a KIND-only regression scenario for the Redis log-reader cleanup fixed by #1315.

The scenario submits a quiet logger workflow, opens and forcibly disconnects 20 direct live-log clients, and verifies that the service returns to its baseline number of Redis `XREAD` clients. It is marked exclusive because it measures a shared Redis client count. The scenario macro now supports inheriting `HOME` and `KUBECONFIG` so the test can perform read-only KIND inspection.

This PR is stacked on #1315 and should be merged after the base fix.

Validation:

- `bazel run //test/oetf:run -- --env kind --tags redis` — 1/1 passed in 55.93s
- Without the owner-level cancellation shield from #1315, the regression retained 4 additional Redis `XREAD` clients after 20 disconnects.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
