### PR TITLE
645 - Add backoff and jitter to postgresql reconnect

### DIFF
--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -473,6 +473,7 @@ spec:
           - "--postgres-max-conns={{ $gw.authz.postgres.maxConns }}"
           - "--postgres-min-conns={{ $gw.authz.postgres.minConns }}"
           - "--postgres-max-conn-lifetime={{ $gw.authz.postgres.maxConnLifetimeMin }}"
+          - "--postgres-reconnect-retry={{ $gw.authz.postgres.reconnectRetry }}"
           {{- end }}
           - "--cache-ttl={{ $gw.authz.cache.ttl }}"
           - "--cache-max-size={{ $gw.authz.cache.maxSize }}"

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -473,12 +473,14 @@ spec:
           - "--postgres-max-conns={{ $gw.authz.postgres.maxConns }}"
           - "--postgres-min-conns={{ $gw.authz.postgres.minConns }}"
           - "--postgres-max-conn-lifetime={{ $gw.authz.postgres.maxConnLifetimeMin }}"
-          - "--postgres-reconnect-retry={{ $gw.authz.postgres.reconnectRetry }}"
           {{- end }}
           - "--cache-ttl={{ $gw.authz.cache.ttl }}"
           - "--cache-max-size={{ $gw.authz.cache.maxSize }}"
           {{- with .Values.global.logs.logFormat }}
           - "--log-format={{ . }}"
+          {{- end }}
+          {{- range $gw.authz.extraArgs }}
+          - {{ . | quote }}
           {{- end }}
         env:
           {{- if .Values.services.migration.enabled }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -2158,13 +2158,17 @@ gateway:
     imageTag: ""
     imagePullPolicy: Always
     grpcPort: 50052
+    ## Additional command-line arguments for the authz container.
+    ##
+    extraArgs: []
+    ## Additional environment variables for the authz container.
+    ##
     extraEnv: []
     postgres:
       sslMode: prefer
       maxConns: 10
       minConns: 2
       maxConnLifetimeMin: 5
-      reconnectRetry: 5
     cache:
       ttl: 300
       maxSize: 1000

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -2164,6 +2164,7 @@ gateway:
       maxConns: 10
       minConns: 2
       maxConnLifetimeMin: 5
+      reconnectRetry: 5
     cache:
       ttl: 300
       maxSize: 1000

--- a/src/tests/common/database/postgres_fixture.go
+++ b/src/tests/common/database/postgres_fixture.go
@@ -204,6 +204,7 @@ func StartPostgres(t testing.TB, opts ...PostgresOption) *PostgresFixture {
 		MinConns:        1,
 		MaxConnLifetime: 5 * time.Minute,
 		SSLMode:         "disable",
+		RetryAttempts:   5,
 	}, logger)
 	if err != nil {
 		t.Fatalf("failed to create osmo postgres client: %v", err)

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -26,8 +26,10 @@ import logging
 import math
 import types
 import os
+import random
 import re
 import threading
+import time
 import typing
 from functools import wraps
 from typing import Any, Callable, Dict, Generator, List, Literal, Mapping, Optional, Tuple, Type
@@ -158,7 +160,7 @@ class PostgresConfig(pydantic.BaseModel):
     postgres_reconnect_retry: int = pydantic.Field(
         default=5,
         gt=0,
-        description='Reconnect try count after connection error',
+        description='Maximum total attempts for retryable PostgreSQL errors',
         json_schema_extra={
             'command_line': 'postgres_reconnect_retry',
             'env': 'OSMO_POSTGRES_RECONNECT_RETRY'
@@ -213,6 +215,56 @@ class PostgresConfig(pydantic.BaseModel):
         json_schema_extra={'command_line': 'schema_version', 'env': 'OSMO_SCHEMA_VERSION'})
 
 
+_POSTGRES_RETRY_BASE_DELAY_SECONDS = 0.1
+_POSTGRES_RETRY_MAX_DELAY_SECONDS = 2.0
+_TRANSIENT_TRANSACTION_SQLSTATES = frozenset({'40001', '40P01'})
+
+
+def _get_postgres_sqlstate(error: Exception) -> str | None:
+    sqlstate = getattr(error, 'pgcode', None)
+    return sqlstate if isinstance(sqlstate, str) else None
+
+
+def _get_retry_delay(retry_number: int) -> float:
+    window = min(
+        _POSTGRES_RETRY_MAX_DELAY_SECONDS,
+        _POSTGRES_RETRY_BASE_DELAY_SECONDS * (2 ** (retry_number - 1)),
+    )
+    return window / 2 + random.random() * window / 2
+
+
+def _is_transient_postgres_error(error: Exception) -> bool:
+    if isinstance(error, (psycopg2.InterfaceError, psycopg2.pool.PoolError)):
+        return True
+
+    sqlstate = _get_postgres_sqlstate(error)
+    return sqlstate in _TRANSIENT_TRANSACTION_SQLSTATES or bool(
+        sqlstate and sqlstate.startswith('08'))
+
+
+def _requires_pool_reconnect(error: Exception) -> bool:
+    if isinstance(error, (osmo_errors.OSMOConnectionError, psycopg2.InterfaceError,
+                          psycopg2.pool.PoolError)):
+        return True
+
+    sqlstate = _get_postgres_sqlstate(error)
+    return bool(sqlstate and sqlstate.startswith('08'))
+
+
+def _log_postgres_retry(operation_name: str, attempt_number: int,
+                        maximum_attempts: int, delay: float, error: Exception) -> None:
+    logging.error(
+        'Retrying PostgreSQL operation %s: attempt %d/%d, delay %.3fs, '
+        'exception=%s, sqlstate=%s',
+        operation_name,
+        attempt_number,
+        maximum_attempts,
+        delay,
+        type(error).__name__,
+        _get_postgres_sqlstate(error),
+    )
+
+
 def retry(func=None, *, reconnect: bool = True):
     """
     Retry database operations in case of connection/pool errors.
@@ -226,21 +278,55 @@ def retry(func=None, *, reconnect: bool = True):
         def retry_wrapper(*args, **kwargs):
             self = args[0]
             last_error: Exception | None = None
-            for _ in range(self.config.postgres_reconnect_retry):
+            delay: float | None = None
+            reconnect_pool = False
+            maximum_attempts = self.config.postgres_reconnect_retry
+            for attempt_number in range(1, maximum_attempts + 1):
+                if delay is not None:
+                    time.sleep(delay)
+                    if reconnect_pool:
+                        try:
+                            self.connect()
+                        except osmo_errors.OSMOConnectionError as error:
+                            if attempt_number == maximum_attempts:
+                                raise osmo_errors.OSMODatabaseError(
+                                    f'Error: {str(error)}') from error
+                            last_error = error
+                            delay = _get_retry_delay(attempt_number)
+                            reconnect_pool = True
+                            _log_postgres_retry(
+                                fn.__name__, attempt_number, maximum_attempts, delay, error)
+                            continue
+                        except (psycopg2.InterfaceError, psycopg2.DatabaseError,
+                                psycopg2.pool.PoolError) as error:
+                            if not _is_transient_postgres_error(error) or \
+                                    attempt_number == maximum_attempts:
+                                raise osmo_errors.OSMODatabaseError(
+                                    f'Error: {str(error)}') from error
+                            last_error = error
+                            delay = _get_retry_delay(attempt_number)
+                            reconnect_pool = _requires_pool_reconnect(error)
+                            _log_postgres_retry(
+                                fn.__name__, attempt_number, maximum_attempts, delay, error)
+                            continue
                 try:
                     return fn(*args, **kwargs)
                 except (psycopg2.InterfaceError, psycopg2.DatabaseError,
                         psycopg2.pool.PoolError) as error:
-                    logging.error('Database/pool error, retrying: %s', str(error))
+                    if not _is_transient_postgres_error(error) or \
+                            attempt_number == maximum_attempts:
+                        raise osmo_errors.OSMODatabaseError(f'Error: {str(error)}') from error
                     last_error = error
-                    if reconnect:
-                        self.connect()
+                    delay = _get_retry_delay(attempt_number)
+                    reconnect_pool = reconnect and _requires_pool_reconnect(error)
+                    _log_postgres_retry(
+                        fn.__name__, attempt_number, maximum_attempts, delay, error)
                 except osmo_errors.OSMOError as error:
                     raise error
                 except Exception as error:  # pylint: disable=broad-except
                     raise osmo_errors.OSMODatabaseError(f'Error: {str(error)}')
             if last_error:
-                raise osmo_errors.OSMODatabaseError(f'Error: {str(last_error)}')
+                raise osmo_errors.OSMODatabaseError(f'Error: {str(last_error)}') from last_error
         return retry_wrapper
     if func is None:
         return decorator

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -226,10 +226,11 @@ def _get_postgres_sqlstate(error: Exception) -> str | None:
 
 
 def _get_retry_delay(retry_number: int) -> float:
-    window = min(
-        _POSTGRES_RETRY_MAX_DELAY_SECONDS,
-        _POSTGRES_RETRY_BASE_DELAY_SECONDS * (2 ** (retry_number - 1)),
-    )
+    window = _POSTGRES_RETRY_BASE_DELAY_SECONDS
+    for _ in range(1, retry_number):
+        window = min(_POSTGRES_RETRY_MAX_DELAY_SECONDS, window * 2)
+        if window == _POSTGRES_RETRY_MAX_DELAY_SECONDS:
+            break
     return window / 2 + random.random() * window / 2
 
 
@@ -238,6 +239,8 @@ def _is_transient_postgres_error(error: Exception) -> bool:
         return True
 
     sqlstate = _get_postgres_sqlstate(error)
+    if isinstance(error, psycopg2.OperationalError) and sqlstate is None:
+        return True
     return sqlstate in _TRANSIENT_TRANSACTION_SQLSTATES or bool(
         sqlstate and sqlstate.startswith('08'))
 
@@ -248,6 +251,8 @@ def _requires_pool_reconnect(error: Exception) -> bool:
         return True
 
     sqlstate = _get_postgres_sqlstate(error)
+    if isinstance(error, psycopg2.OperationalError) and sqlstate is None:
+        return True
     return bool(sqlstate and sqlstate.startswith('08'))
 
 
@@ -260,6 +265,19 @@ def _log_postgres_retry(operation_name: str, attempt_number: int,
         attempt_number,
         maximum_attempts,
         delay,
+        type(error).__name__,
+        _get_postgres_sqlstate(error),
+    )
+
+
+def _log_postgres_retry_exhausted(operation_name: str, attempt_number: int,
+                                  maximum_attempts: int, error: Exception) -> None:
+    logging.error(
+        'PostgreSQL retry exhausted: operation=%s, attempt=%d/%d, '
+        'error_type=%s, sqlstate=%s',
+        operation_name,
+        attempt_number,
+        maximum_attempts,
         type(error).__name__,
         _get_postgres_sqlstate(error),
     )
@@ -289,6 +307,8 @@ def retry(func=None, *, reconnect: bool = True):
                             self.connect()
                         except osmo_errors.OSMOConnectionError as error:
                             if attempt_number == maximum_attempts:
+                                _log_postgres_retry_exhausted(
+                                    fn.__name__, attempt_number, maximum_attempts, error)
                                 raise osmo_errors.OSMODatabaseError(
                                     f'Error: {str(error)}') from error
                             last_error = error
@@ -299,8 +319,12 @@ def retry(func=None, *, reconnect: bool = True):
                             continue
                         except (psycopg2.InterfaceError, psycopg2.DatabaseError,
                                 psycopg2.pool.PoolError) as error:
-                            if not _is_transient_postgres_error(error) or \
-                                    attempt_number == maximum_attempts:
+                            if not _is_transient_postgres_error(error):
+                                raise osmo_errors.OSMODatabaseError(
+                                    f'Error: {str(error)}') from error
+                            if attempt_number == maximum_attempts:
+                                _log_postgres_retry_exhausted(
+                                    fn.__name__, attempt_number, maximum_attempts, error)
                                 raise osmo_errors.OSMODatabaseError(
                                     f'Error: {str(error)}') from error
                             last_error = error
@@ -313,8 +337,11 @@ def retry(func=None, *, reconnect: bool = True):
                     return fn(*args, **kwargs)
                 except (psycopg2.InterfaceError, psycopg2.DatabaseError,
                         psycopg2.pool.PoolError) as error:
-                    if not _is_transient_postgres_error(error) or \
-                            attempt_number == maximum_attempts:
+                    if not _is_transient_postgres_error(error):
+                        raise osmo_errors.OSMODatabaseError(f'Error: {str(error)}') from error
+                    if attempt_number == maximum_attempts:
+                        _log_postgres_retry_exhausted(
+                            fn.__name__, attempt_number, maximum_attempts, error)
                         raise osmo_errors.OSMODatabaseError(f'Error: {str(error)}') from error
                     last_error = error
                     delay = _get_retry_delay(attempt_number)

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -305,7 +305,7 @@ def retry(func=None, *, reconnect: bool = True):
                                     f'Error: {str(error)}') from error
                             last_error = error
                             delay = _get_retry_delay(attempt_number)
-                            reconnect_pool = _requires_pool_reconnect(error)
+                            reconnect_pool = True
                             _log_postgres_retry(
                                 fn.__name__, attempt_number, maximum_attempts, delay, error)
                             continue

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -217,6 +217,7 @@ class PostgresConfig(pydantic.BaseModel):
 
 _POSTGRES_RETRY_BASE_DELAY_SECONDS = 0.1
 _POSTGRES_RETRY_MAX_DELAY_SECONDS = 2.0
+_POSTGRES_RETRY_MAX_EXPONENT = 5
 _TRANSIENT_TRANSACTION_SQLSTATES = frozenset({'40001', '40P01'})
 
 
@@ -226,11 +227,10 @@ def _get_postgres_sqlstate(error: Exception) -> str | None:
 
 
 def _get_retry_delay(retry_number: int) -> float:
-    window = _POSTGRES_RETRY_BASE_DELAY_SECONDS
-    for _ in range(1, retry_number):
-        window = min(_POSTGRES_RETRY_MAX_DELAY_SECONDS, window * 2)
-        if window == _POSTGRES_RETRY_MAX_DELAY_SECONDS:
-            break
+    exponent = min(retry_number - 1, _POSTGRES_RETRY_MAX_EXPONENT)
+    window = min(
+        _POSTGRES_RETRY_MAX_DELAY_SECONDS,
+        _POSTGRES_RETRY_BASE_DELAY_SECONDS * 2**exponent)
     return window / 2 + random.random() * window / 2
 
 

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -18,6 +18,17 @@ load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 py_test(
+    name = "test_postgres_retry",
+    srcs = ["test_postgres_retry.py"],
+    deps = [
+        requirement("psycopg2-binary"),
+        "//src/lib/utils:osmo_errors",
+        "//src/utils/connectors:connectors",
+    ],
+    size = "small",
+)
+
+py_test(
     name = "test_resource_spec",
     srcs = [
         "test_resource_spec.py"

--- a/src/utils/connectors/tests/test_postgres_retry.py
+++ b/src/utils/connectors/tests/test_postgres_retry.py
@@ -1,0 +1,194 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import types
+import unittest
+from unittest import mock
+
+import psycopg2  # type: ignore
+
+from src.lib.utils import osmo_errors
+from src.utils.connectors import postgres
+
+
+class _PostgresError(psycopg2.DatabaseError):
+    """A psycopg2 error with a deterministic SQLSTATE for retry tests."""
+
+    def __init__(self, sqlstate: str):
+        super().__init__(f'postgres error {sqlstate}')
+        self._sqlstate = sqlstate
+
+    def __getattribute__(self, name: str) -> object:
+        if name == 'pgcode':
+            return object.__getattribute__(self, '_sqlstate')
+        return super().__getattribute__(name)
+
+
+class _FakePostgres:
+    def __init__(self, outcomes: list[object], attempts: int = 5):
+        self.config = types.SimpleNamespace(postgres_reconnect_retry=attempts)
+        self.outcomes = outcomes
+        self.operation_calls = 0
+        self.connect = mock.Mock()
+
+    def operation(self, *_args: object) -> object:
+        self.operation_calls += 1
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@postgres.retry
+def _retrying_operation(database: _FakePostgres, *arguments: object) -> object:
+    return database.operation(*arguments)
+
+
+class TestPostgresRetry(unittest.TestCase):
+    def _patch_retry_seams(self, random_values: list[float] | None = None):
+        sleep = mock.patch.object(postgres, 'time', create=True)
+        random = mock.patch.object(postgres, 'random', create=True)
+        return sleep, random, random_values or []
+
+    def test_success_does_not_sleep_or_reconnect(self):
+        database = _FakePostgres(['success'])
+
+        sleep, random, random_values = self._patch_retry_seams()
+        with sleep as time_mock, random as random_mock:
+            self.assertEqual(_retrying_operation(database), 'success')
+
+        self.assertEqual(database.operation_calls, 1)
+        time_mock.sleep.assert_not_called()
+        random_mock.random.assert_not_called()
+        database.connect.assert_not_called()
+
+    def test_transient_failures_use_equal_jitter_windows_before_retry(self):
+        database = _FakePostgres([
+            _PostgresError('40001'),
+            _PostgresError('40P01'),
+            _PostgresError('40001'),
+            _PostgresError('40P01'),
+            'success',
+        ])
+
+        sleep, random, random_values = self._patch_retry_seams([0.0, 0.0, 0.0, 0.0])
+        with sleep as time_mock, random as random_mock:
+            random_mock.random.side_effect = random_values
+            self.assertEqual(_retrying_operation(database), 'success')
+
+        self.assertEqual(database.operation_calls, 5)
+        self.assertEqual(time_mock.sleep.call_args_list, [
+            mock.call(0.05),
+            mock.call(0.1),
+            mock.call(0.2),
+            mock.call(0.4),
+        ])
+        database.connect.assert_not_called()
+
+    def test_final_failure_does_not_sleep_or_reconnect(self):
+        database = _FakePostgres([_PostgresError('40001'), _PostgresError('40001')], attempts=2)
+
+        sleep, random, random_values = self._patch_retry_seams([0.0])
+        with sleep as time_mock, random as random_mock:
+            random_mock.random.side_effect = random_values
+            with self.assertRaises(osmo_errors.OSMODatabaseError):
+                _retrying_operation(database)
+
+        self.assertEqual(database.operation_calls, 2)
+        time_mock.sleep.assert_called_once_with(0.05)
+        database.connect.assert_not_called()
+
+    def test_non_transient_database_error_fails_immediately(self):
+        database = _FakePostgres([_PostgresError('23505')])
+
+        sleep, random, random_values = self._patch_retry_seams()
+        with sleep as time_mock, random as random_mock:
+            with self.assertRaises(osmo_errors.OSMODatabaseError):
+                _retrying_operation(database)
+
+        self.assertEqual(database.operation_calls, 1)
+        time_mock.sleep.assert_not_called()
+        random_mock.random.assert_not_called()
+        database.connect.assert_not_called()
+
+    def test_serialization_failure_retries_without_reconnect(self):
+        database = _FakePostgres([_PostgresError('40001'), 'success'])
+
+        sleep, random, random_values = self._patch_retry_seams([0.0])
+        with sleep as time_mock, random as random_mock:
+            random_mock.random.side_effect = random_values
+            self.assertEqual(_retrying_operation(database), 'success')
+
+        time_mock.sleep.assert_called_once_with(0.05)
+        database.connect.assert_not_called()
+
+    def test_connection_failure_sleeps_before_reconnect(self):
+        database = _FakePostgres([_PostgresError('08006'), 'success'])
+
+        sleep, random, random_values = self._patch_retry_seams([0.0])
+        with sleep as time_mock, random as random_mock:
+            random_mock.random.side_effect = random_values
+            self.assertEqual(_retrying_operation(database), 'success')
+
+        time_mock.sleep.assert_called_once_with(0.05)
+        database.connect.assert_called_once_with()
+
+    def test_reconnect_failure_consumes_attempt_budget(self):
+        database = _FakePostgres([_PostgresError('08006'), 'success'], attempts=3)
+        database.connect.side_effect = [
+            osmo_errors.OSMOConnectionError('connection unavailable'),
+            None,
+        ]
+
+        sleep, random, random_values = self._patch_retry_seams([0.0, 0.0])
+        with sleep as time_mock, random as random_mock:
+            random_mock.random.side_effect = random_values
+            self.assertEqual(_retrying_operation(database), 'success')
+
+        self.assertEqual(database.operation_calls, 2)
+        self.assertEqual(time_mock.sleep.call_args_list, [mock.call(0.05), mock.call(0.1)])
+        self.assertEqual(database.connect.call_count, 2)
+
+    def test_one_attempt_disables_retry(self):
+        database = _FakePostgres([_PostgresError('08006')], attempts=1)
+
+        sleep, random, random_values = self._patch_retry_seams()
+        with sleep as time_mock, random as random_mock:
+            with self.assertRaises(osmo_errors.OSMODatabaseError):
+                _retrying_operation(database)
+
+        self.assertEqual(database.operation_calls, 1)
+        time_mock.sleep.assert_not_called()
+        random_mock.random.assert_not_called()
+        database.connect.assert_not_called()
+
+    def test_retry_log_excludes_operation_arguments(self):
+        database = _FakePostgres([_PostgresError('40001'), 'success'], attempts=2)
+
+        sleep, random, random_values = self._patch_retry_seams([0.0])
+        with sleep, random as random_mock, self.assertLogs(level='ERROR') as logs:
+            random_mock.random.side_effect = random_values
+            self.assertEqual(_retrying_operation(database, 'sensitive-operation-argument'), 'success')
+
+        self.assertTrue(any('_retrying_operation' in message for message in logs.output))
+        self.assertTrue(any('attempt 1/2' in message for message in logs.output))
+        self.assertFalse(any('sensitive-operation-argument' in message for message in logs.output))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/utils/connectors/tests/test_postgres_retry.py
+++ b/src/utils/connectors/tests/test_postgres_retry.py
@@ -29,8 +29,21 @@ from src.utils.connectors import postgres
 class _PostgresError(psycopg2.DatabaseError):
     """A psycopg2 error with a deterministic SQLSTATE for retry tests."""
 
-    def __init__(self, sqlstate: str):
-        super().__init__(f'postgres error {sqlstate}')
+    def __init__(self, sqlstate: str | None, message: str | None = None):
+        super().__init__(message if message is not None else f'postgres error {sqlstate}')
+        self._sqlstate = sqlstate
+
+    def __getattribute__(self, name: str) -> object:
+        if name == 'pgcode':
+            return object.__getattribute__(self, '_sqlstate')
+        return super().__getattribute__(name)
+
+
+class _OperationalError(psycopg2.OperationalError):
+    """A psycopg2 operational error with a controllable SQLSTATE."""
+
+    def __init__(self, sqlstate: str | None, message: str | None = None):
+        super().__init__(message if message is not None else f'operational error {sqlstate}')
         self._sqlstate = sqlstate
 
     def __getattribute__(self, name: str) -> object:
@@ -100,6 +113,10 @@ class TestPostgresRetry(unittest.TestCase):
         ])
         database.connect.assert_not_called()
 
+    def test_retry_delay_caps_before_extremely_large_exponent(self):
+        with mock.patch.object(postgres.random, 'random', return_value=0.0):
+            self.assertEqual(postgres._get_retry_delay(1_000_000), 1.0)
+
     def test_final_failure_does_not_sleep_or_reconnect(self):
         database = _FakePostgres([_PostgresError('40001'), _PostgresError('40001')], attempts=2)
 
@@ -113,6 +130,33 @@ class TestPostgresRetry(unittest.TestCase):
         time_mock.sleep.assert_called_once_with(0.05)
         database.connect.assert_not_called()
 
+    def test_retry_exhaustion_logs_terminal_metadata_without_sensitive_values(self):
+        database = _FakePostgres([
+            _PostgresError('40001', 'sensitive SQL from the first failure'),
+            _PostgresError('40001', 'postgresql://user:password@database/osmo'),
+        ], attempts=2)
+
+        sleep, random, random_values = self._patch_retry_seams([0.0])
+        with sleep, random as random_mock, self.assertLogs(level='ERROR') as logs:
+            random_mock.random.side_effect = random_values
+            with self.assertRaises(osmo_errors.OSMODatabaseError):
+                _retrying_operation(database, 'sensitive-operation-argument')
+
+        terminal_logs = [
+            message for message in logs.output if 'PostgreSQL retry exhausted' in message]
+        self.assertEqual(len(terminal_logs), 1)
+        terminal_log = terminal_logs[0]
+        self.assertIn('operation=_retrying_operation', terminal_log)
+        self.assertIn('attempt=2/2', terminal_log)
+        self.assertIn('error_type=_PostgresError', terminal_log)
+        self.assertIn('sqlstate=40001', terminal_log)
+        self.assertNotIn('Retrying PostgreSQL operation', terminal_log)
+        self.assertNotIn('delay', terminal_log)
+        log_output = '\n'.join(logs.output)
+        self.assertNotIn('sensitive SQL from the first failure', log_output)
+        self.assertNotIn('postgresql://user:password@database/osmo', log_output)
+        self.assertNotIn('sensitive-operation-argument', log_output)
+
     def test_non_transient_database_error_fails_immediately(self):
         database = _FakePostgres([_PostgresError('23505')])
 
@@ -125,6 +169,16 @@ class TestPostgresRetry(unittest.TestCase):
         time_mock.sleep.assert_not_called()
         random_mock.random.assert_not_called()
         database.connect.assert_not_called()
+
+    def test_non_transient_database_error_does_not_log_retry_exhaustion(self):
+        database = _FakePostgres([_PostgresError('23505')])
+
+        sleep, random, random_values = self._patch_retry_seams()
+        with sleep, random as random_mock, self.assertNoLogs(level='ERROR'):
+            with self.assertRaises(osmo_errors.OSMODatabaseError):
+                _retrying_operation(database)
+
+        random_mock.random.assert_not_called()
 
     def test_serialization_failure_retries_without_reconnect(self):
         database = _FakePostgres([_PostgresError('40001'), 'success'])
@@ -147,6 +201,79 @@ class TestPostgresRetry(unittest.TestCase):
 
         time_mock.sleep.assert_called_once_with(0.05)
         database.connect.assert_called_once_with()
+
+    def test_operational_error_without_sqlstate_retries_with_reconnect(self):
+        database = _FakePostgres([_OperationalError(None), 'success'], attempts=2)
+
+        sleep, random, random_values = self._patch_retry_seams([0.0])
+        with sleep as time_mock, random as random_mock:
+            random_mock.random.side_effect = random_values
+            self.assertEqual(_retrying_operation(database), 'success')
+
+        self.assertEqual(database.operation_calls, 2)
+        time_mock.sleep.assert_called_once_with(0.05)
+        database.connect.assert_called_once_with()
+
+    def test_operational_error_without_sqlstate_during_reconnect_uses_attempt_budget(self):
+        database = _FakePostgres([_OperationalError(None), 'success'], attempts=3)
+        database.connect.side_effect = [_OperationalError(None), None]
+
+        sleep, random, random_values = self._patch_retry_seams([0.0, 0.0])
+        with sleep as time_mock, random as random_mock:
+            random_mock.random.side_effect = random_values
+            self.assertEqual(_retrying_operation(database), 'success')
+
+        self.assertEqual(database.operation_calls, 2)
+        self.assertEqual(time_mock.sleep.call_args_list, [mock.call(0.05), mock.call(0.1)])
+        self.assertEqual(database.connect.call_count, 2)
+
+    def test_reconnect_exhaustion_logs_terminal_metadata(self):
+        database = _FakePostgres([_OperationalError(None), 'unused'], attempts=2)
+        database.connect.side_effect = _OperationalError(
+            None, 'postgresql://user:password@database/osmo')
+
+        sleep, random, random_values = self._patch_retry_seams([0.0])
+        with sleep, random as random_mock, self.assertLogs(level='ERROR') as logs:
+            random_mock.random.side_effect = random_values
+            with self.assertRaises(osmo_errors.OSMODatabaseError):
+                _retrying_operation(database)
+
+        terminal_logs = [
+            message for message in logs.output if 'PostgreSQL retry exhausted' in message]
+        self.assertEqual(len(terminal_logs), 1)
+        self.assertIn('operation=_retrying_operation', terminal_logs[0])
+        self.assertIn('attempt=2/2', terminal_logs[0])
+        self.assertIn('error_type=_OperationalError', terminal_logs[0])
+        self.assertIn('sqlstate=None', terminal_logs[0])
+        self.assertNotIn('postgresql://user:password@database/osmo', '\n'.join(logs.output))
+        self.assertEqual(database.operation_calls, 1)
+        database.connect.assert_called_once_with()
+
+    def test_operational_error_with_non_transient_sqlstate_fails_immediately(self):
+        database = _FakePostgres([_OperationalError('28P01')])
+
+        sleep, random, random_values = self._patch_retry_seams()
+        with sleep as time_mock, random as random_mock:
+            with self.assertRaises(osmo_errors.OSMODatabaseError):
+                _retrying_operation(database)
+
+        self.assertEqual(database.operation_calls, 1)
+        time_mock.sleep.assert_not_called()
+        random_mock.random.assert_not_called()
+        database.connect.assert_not_called()
+
+    def test_database_error_without_sqlstate_fails_immediately(self):
+        database = _FakePostgres([_PostgresError(None)])
+
+        sleep, random, random_values = self._patch_retry_seams()
+        with sleep as time_mock, random as random_mock:
+            with self.assertRaises(osmo_errors.OSMODatabaseError):
+                _retrying_operation(database)
+
+        self.assertEqual(database.operation_calls, 1)
+        time_mock.sleep.assert_not_called()
+        random_mock.random.assert_not_called()
+        database.connect.assert_not_called()
 
     def test_reconnect_failure_consumes_attempt_budget(self):
         database = _FakePostgres([_PostgresError('08006'), 'success'], attempts=3)
@@ -181,7 +308,7 @@ class TestPostgresRetry(unittest.TestCase):
         database = _FakePostgres([_PostgresError('08006')], attempts=1)
 
         sleep, random, random_values = self._patch_retry_seams()
-        with sleep as time_mock, random as random_mock:
+        with sleep as time_mock, random as random_mock, self.assertLogs(level='ERROR') as logs:
             with self.assertRaises(osmo_errors.OSMODatabaseError):
                 _retrying_operation(database)
 
@@ -189,6 +316,10 @@ class TestPostgresRetry(unittest.TestCase):
         time_mock.sleep.assert_not_called()
         random_mock.random.assert_not_called()
         database.connect.assert_not_called()
+        self.assertEqual(sum(
+            'PostgreSQL retry exhausted' in message for message in logs.output), 1)
+        self.assertFalse(any(
+            'Retrying PostgreSQL operation' in message for message in logs.output))
 
     def test_retry_log_excludes_operation_arguments(self):
         database = _FakePostgres([_PostgresError('40001'), 'success'], attempts=2)

--- a/src/utils/connectors/tests/test_postgres_retry.py
+++ b/src/utils/connectors/tests/test_postgres_retry.py
@@ -164,6 +164,19 @@ class TestPostgresRetry(unittest.TestCase):
         self.assertEqual(time_mock.sleep.call_args_list, [mock.call(0.05), mock.call(0.1)])
         self.assertEqual(database.connect.call_count, 2)
 
+    def test_transient_reconnect_failure_retries_pool_recreation(self):
+        database = _FakePostgres([_PostgresError('08006'), 'success'], attempts=3)
+        database.connect.side_effect = [_PostgresError('40001'), None]
+
+        sleep, random, random_values = self._patch_retry_seams([0.0, 0.0])
+        with sleep as time_mock, random as random_mock:
+            random_mock.random.side_effect = random_values
+            self.assertEqual(_retrying_operation(database), 'success')
+
+        self.assertEqual(database.operation_calls, 2)
+        self.assertEqual(time_mock.sleep.call_args_list, [mock.call(0.05), mock.call(0.1)])
+        self.assertEqual(database.connect.call_count, 2)
+
     def test_one_attempt_disables_retry(self):
         database = _FakePostgres([_PostgresError('08006')], attempts=1)
 

--- a/src/utils/postgres/BUILD
+++ b/src/utils/postgres/BUILD
@@ -26,7 +26,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/utils",
-        "@com_github_jackc_pgx_v5//:go_default_library",
         "@com_github_jackc_pgx_v5//pgconn:go_default_library",
         "@com_github_jackc_pgx_v5//pgxpool:go_default_library",
     ],

--- a/src/utils/postgres/BUILD
+++ b/src/utils/postgres/BUILD
@@ -20,11 +20,14 @@ go_library(
     name = "postgres",
     srcs = [
         "postgres_client.go",
+        "retry.go",
     ],
     importpath = "go.corp.nvidia.com/osmo/utils/postgres",
     visibility = ["//visibility:public"],
     deps = [
         "//src/utils",
+        "@com_github_jackc_pgx_v5//:go_default_library",
+        "@com_github_jackc_pgx_v5//pgconn:go_default_library",
         "@com_github_jackc_pgx_v5//pgxpool:go_default_library",
     ],
 )
@@ -33,9 +36,12 @@ go_test(
     name = "postgres_test",
     srcs = [
         "postgres_client_test.go",
+        "retry_test.go",
     ],
     embed = [":postgres"],
     deps = [
+        "@com_github_jackc_pgx_v5//:go_default_library",
+        "@com_github_jackc_pgx_v5//pgconn:go_default_library",
         "@com_github_jackc_pgx_v5//pgxpool:go_default_library",
     ],
 )

--- a/src/utils/postgres/postgres_client.go
+++ b/src/utils/postgres/postgres_client.go
@@ -105,8 +105,8 @@ func NewPostgresClient(ctx context.Context, config PostgresConfig, logger *slog.
 	defer cancel()
 
 	if err := client.RunWithRetry(pingCtx, "startup ping", ReplayReadOnly,
-		func(operationCtx context.Context) error {
-			return pool.Ping(operationCtx)
+		func(operationCtx context.Context, operationPool *pgxpool.Pool) error {
+			return operationPool.Ping(operationCtx)
 		}); err != nil {
 		pool.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", err)

--- a/src/utils/postgres/postgres_client.go
+++ b/src/utils/postgres/postgres_client.go
@@ -42,16 +42,24 @@ type PostgresConfig struct {
 	MaxConnLifetime time.Duration
 	SSLMode         string
 	SchemaVersion   string
+	RetryAttempts   int
 }
 
 // PostgresClient handles PostgreSQL database operations
 type PostgresClient struct {
-	pool   *pgxpool.Pool
-	logger *slog.Logger
+	pool          *pgxpool.Pool
+	logger        *slog.Logger
+	retryAttempts int
+	randomFloat   func() float64
+	waitForRetry  func(context.Context, time.Duration) error
 }
 
 // NewPostgresClient creates a new PostgreSQL client with connection pooling
 func NewPostgresClient(ctx context.Context, config PostgresConfig, logger *slog.Logger) (*PostgresClient, error) {
+	if config.RetryAttempts < 1 {
+		return nil, fmt.Errorf("retry attempts must be at least 1")
+	}
+
 	// Build connection URL with properly escaped user and password
 	connURL := fmt.Sprintf(
 		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
@@ -84,12 +92,22 @@ func NewPostgresClient(ctx context.Context, config PostgresConfig, logger *slog.
 	if err != nil {
 		return nil, fmt.Errorf("failed to create connection pool: %w", err)
 	}
+	client := &PostgresClient{
+		pool:          pool,
+		logger:        logger,
+		retryAttempts: config.RetryAttempts,
+		randomFloat:   defaultRandomFloat,
+		waitForRetry:  waitForRetry,
+	}
 
 	// Ping to verify connection
 	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	if err := pool.Ping(pingCtx); err != nil {
+	if err := client.RunWithRetry(pingCtx, "startup ping", ReplayReadOnly,
+		func(operationCtx context.Context) error {
+			return pool.Ping(operationCtx)
+		}); err != nil {
 		pool.Close()
 		return nil, fmt.Errorf("failed to ping database: %w", err)
 	}
@@ -100,10 +118,7 @@ func NewPostgresClient(ctx context.Context, config PostgresConfig, logger *slog.
 		slog.String("database", config.Database),
 	)
 
-	return &PostgresClient{
-		pool:   pool,
-		logger: logger,
-	}, nil
+	return client, nil
 }
 
 // Close closes the database connection pool
@@ -139,6 +154,7 @@ type PostgresFlagPointers struct {
 	maxConnLifetimeMin *int
 	sslMode            *string
 	schemaVersion      *string
+	retryAttempts      *int
 }
 
 // RegisterPostgresFlags registers PostgreSQL-related command-line flags
@@ -176,6 +192,11 @@ func RegisterPostgresFlags() *PostgresFlagPointers {
 		schemaVersion: flag.String("postgres-schema-version",
 			utils.GetEnv("OSMO_SCHEMA_VERSION", "public"),
 			"pgroll schema version for search_path"),
+		retryAttempts: flag.Int(
+			"postgres-reconnect-retry",
+			utils.GetEnvInt("OSMO_POSTGRES_RECONNECT_RETRY", 5),
+			"PostgreSQL total connection and operation attempts",
+		),
 	}
 }
 
@@ -193,5 +214,6 @@ func (p *PostgresFlagPointers) ToPostgresConfig() PostgresConfig {
 		MaxConnLifetime: time.Duration(*p.maxConnLifetimeMin) * time.Minute,
 		SSLMode:         *p.sslMode,
 		SchemaVersion:   *p.schemaVersion,
+		RetryAttempts:   *p.retryAttempts,
 	}
 }

--- a/src/utils/postgres/postgres_client_test.go
+++ b/src/utils/postgres/postgres_client_test.go
@@ -19,10 +19,15 @@ SPDX-License-Identifier: Apache-2.0
 package postgres
 
 import (
+	"context"
+	"flag"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -351,6 +356,7 @@ func TestPostgresFlagPointersToPostgresConfig(t *testing.T) {
 	maxConnLifetime := 10
 	sslMode := "require"
 	schemaVersion := "public"
+	retryAttempts := 7
 
 	flagPtrs := &PostgresFlagPointers{
 		host:               &host,
@@ -363,6 +369,7 @@ func TestPostgresFlagPointersToPostgresConfig(t *testing.T) {
 		maxConnLifetimeMin: &maxConnLifetime,
 		sslMode:            &sslMode,
 		schemaVersion:      &schemaVersion,
+		retryAttempts:      &retryAttempts,
 	}
 
 	config := flagPtrs.ToPostgresConfig()
@@ -398,6 +405,54 @@ func TestPostgresFlagPointersToPostgresConfig(t *testing.T) {
 	}
 	if config.SchemaVersion != schemaVersion {
 		t.Errorf("Expected schemaVersion %s, got %s", schemaVersion, config.SchemaVersion)
+	}
+	if config.RetryAttempts != retryAttempts {
+		t.Errorf("Expected RetryAttempts %d, got %d", retryAttempts, config.RetryAttempts)
+	}
+}
+
+func TestPostgresRetryAttemptsDefaultAndEnvironment(t *testing.T) {
+	originalFlagSet := flag.CommandLine
+	t.Cleanup(func() { flag.CommandLine = originalFlagSet })
+
+	testCases := []struct {
+		name        string
+		environment string
+		want        int
+	}{
+		{name: "default", environment: "", want: 5},
+		{name: "environment", environment: "7", want: 7},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("OSMO_POSTGRES_RECONNECT_RETRY", testCase.environment)
+			flag.CommandLine = flag.NewFlagSet(testCase.name, flag.ContinueOnError)
+
+			config := RegisterPostgresFlags().ToPostgresConfig()
+
+			if config.RetryAttempts != testCase.want {
+				t.Errorf("RetryAttempts = %d, want %d", config.RetryAttempts, testCase.want)
+			}
+		})
+	}
+}
+
+func TestNewPostgresClientRejectsRetryAttemptsBelowOne(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	for _, retryAttempts := range []int{0, -1} {
+		t.Run(fmt.Sprintf("attempts_%d", retryAttempts), func(t *testing.T) {
+			_, err := NewPostgresClient(context.Background(), PostgresConfig{
+				RetryAttempts: retryAttempts,
+			}, logger)
+
+			if err == nil {
+				t.Fatal("NewPostgresClient() error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), "retry attempts must be at least 1") {
+				t.Errorf("NewPostgresClient() error = %q, want retry-attempt validation", err)
+			}
+		})
 	}
 }
 

--- a/src/utils/postgres/retry.go
+++ b/src/utils/postgres/retry.go
@@ -22,10 +22,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/rand/v2"
 	"net"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -81,7 +83,21 @@ func (c *PostgresClient) RunWithRetry(
 			}
 			return contextError
 		}
-		if attempt == c.retryAttempts || !canRetry(err, replaySafety) {
+		retryable := canRetry(err, replaySafety)
+		if attempt == c.retryAttempts {
+			if retryable {
+				c.logger.Error("PostgreSQL retry exhausted",
+					slog.String("operation", operationName),
+					slog.Int("attempt", attempt),
+					slog.Int("max_attempts", c.retryAttempts),
+					slog.String("error_type", fmt.Sprintf("%T", err)),
+					slog.String("sqlstate", postgresSQLState(err)),
+					slog.String("replay_safety", replaySafety.String()),
+				)
+			}
+			return err
+		}
+		if !retryable {
 			return err
 		}
 
@@ -132,11 +148,20 @@ func canRetry(err error, replaySafety ReplaySafety) bool {
 	}
 
 	sqlState := postgresSQLState(err)
-	if sqlState == "40001" || sqlState == "40P01" {
+	if isDefinitiveRetryableSQLState(sqlState) {
 		return true
 	}
 
 	return permitsAmbiguousReplay(replaySafety) && isConnectionFailure(err, sqlState)
+}
+
+func isDefinitiveRetryableSQLState(sqlState string) bool {
+	switch sqlState {
+	case "40001", "40P01", "57P01", "57P02", "57P03":
+		return true
+	default:
+		return false
+	}
 }
 
 func permitsAmbiguousReplay(replaySafety ReplaySafety) bool {
@@ -144,7 +169,10 @@ func permitsAmbiguousReplay(replaySafety ReplaySafety) bool {
 }
 
 func isConnectionFailure(err error, sqlState string) bool {
-	if strings.HasPrefix(sqlState, "08") || pgconn.Timeout(err) || errors.Is(err, net.ErrClosed) {
+	if strings.HasPrefix(sqlState, "08") || pgconn.Timeout(err) ||
+		errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EPIPE) {
 		return true
 	}
 

--- a/src/utils/postgres/retry.go
+++ b/src/utils/postgres/retry.go
@@ -35,8 +35,9 @@ import (
 )
 
 const (
-	retryBaseDelay = 100 * time.Millisecond
-	retryMaxDelay  = 2 * time.Second
+	retryBaseDelay   = 100 * time.Millisecond
+	retryMaxDelay    = 2 * time.Second
+	retryMaxExponent = 5
 )
 
 // ReplaySafety describes whether an operation can be safely replayed after an ambiguous failure.
@@ -119,13 +120,8 @@ func (c *PostgresClient) RunWithRetry(
 }
 
 func (c *PostgresClient) retryDelay(attempt int) time.Duration {
-	window := retryBaseDelay
-	for retryNumber := 1; retryNumber < attempt && window < retryMaxDelay; retryNumber++ {
-		window *= 2
-	}
-	if window > retryMaxDelay {
-		window = retryMaxDelay
-	}
+	exponent := min(attempt-1, retryMaxExponent)
+	window := min(retryBaseDelay*time.Duration(1<<exponent), retryMaxDelay)
 	halfWindow := window / 2
 	return halfWindow + time.Duration(c.randomFloat()*float64(halfWindow))
 }

--- a/src/utils/postgres/retry.go
+++ b/src/utils/postgres/retry.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const (
@@ -62,14 +63,15 @@ func (s ReplaySafety) String() string {
 }
 
 // RunWithRetry runs an operation with bounded retries appropriate for its replay safety.
+// Each attempt receives the client's connection pool.
 func (c *PostgresClient) RunWithRetry(
 	ctx context.Context,
 	operationName string,
 	replaySafety ReplaySafety,
-	operation func(context.Context) error,
+	operation func(context.Context, *pgxpool.Pool) error,
 ) error {
 	for attempt := 1; attempt <= c.retryAttempts; attempt++ {
-		err := operation(ctx)
+		err := operation(ctx, c.pool)
 		if err == nil {
 			return nil
 		}

--- a/src/utils/postgres/retry.go
+++ b/src/utils/postgres/retry.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
@@ -140,13 +139,12 @@ func permitsAmbiguousReplay(replaySafety ReplaySafety) bool {
 }
 
 func isConnectionFailure(err error, sqlState string) bool {
-	if strings.HasPrefix(sqlState, "08") || pgconn.Timeout(err) ||
-		errors.Is(err, pgx.ErrTxClosed) || errors.Is(err, net.ErrClosed) {
+	if strings.HasPrefix(sqlState, "08") || pgconn.Timeout(err) || errors.Is(err, net.ErrClosed) {
 		return true
 	}
 
 	var networkError net.Error
-	return errors.As(err, &networkError)
+	return errors.As(err, &networkError) && networkError.Timeout()
 }
 
 func postgresSQLState(err error) string {

--- a/src/utils/postgres/retry.go
+++ b/src/utils/postgres/retry.go
@@ -1,0 +1,162 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+const (
+	retryBaseDelay = 100 * time.Millisecond
+	retryMaxDelay  = 2 * time.Second
+)
+
+// ReplaySafety describes whether an operation can be safely replayed after an ambiguous failure.
+type ReplaySafety int
+
+const (
+	// ReplayReadOnly identifies operations that do not change database state.
+	ReplayReadOnly ReplaySafety = iota
+	// ReplayIdempotent identifies writes whose repeated execution converges to the same state.
+	ReplayIdempotent
+	// ReplaySafeOnly identifies writes that must not be replayed after an ambiguous failure.
+	ReplaySafeOnly
+)
+
+func (s ReplaySafety) String() string {
+	switch s {
+	case ReplayReadOnly:
+		return "read_only"
+	case ReplayIdempotent:
+		return "idempotent"
+	case ReplaySafeOnly:
+		return "safe_only"
+	default:
+		return "unknown"
+	}
+}
+
+// RunWithRetry runs an operation with bounded retries appropriate for its replay safety.
+func (c *PostgresClient) RunWithRetry(
+	ctx context.Context,
+	operationName string,
+	replaySafety ReplaySafety,
+	operation func(context.Context) error,
+) error {
+	for attempt := 1; attempt <= c.retryAttempts; attempt++ {
+		err := operation(ctx)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if attempt == c.retryAttempts || !canRetry(err, replaySafety) {
+			return err
+		}
+
+		delay := c.retryDelay(attempt)
+		c.logger.Warn("retrying PostgreSQL operation",
+			slog.String("operation", operationName),
+			slog.Int("attempt", attempt),
+			slog.Int("max_attempts", c.retryAttempts),
+			slog.Duration("delay", delay),
+			slog.String("error_type", fmt.Sprintf("%T", err)),
+			slog.String("sqlstate", postgresSQLState(err)),
+			slog.String("replay_safety", replaySafety.String()),
+		)
+		if err := c.waitForRetry(ctx, delay); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *PostgresClient) retryDelay(attempt int) time.Duration {
+	window := retryBaseDelay
+	for retryNumber := 1; retryNumber < attempt && window < retryMaxDelay; retryNumber++ {
+		window *= 2
+	}
+	if window > retryMaxDelay {
+		window = retryMaxDelay
+	}
+	halfWindow := window / 2
+	return halfWindow + time.Duration(c.randomFloat()*float64(halfWindow))
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func canRetry(err error, replaySafety ReplaySafety) bool {
+	if pgconn.SafeToRetry(err) {
+		return true
+	}
+
+	sqlState := postgresSQLState(err)
+	if sqlState == "40001" || sqlState == "40P01" {
+		return true
+	}
+
+	return permitsAmbiguousReplay(replaySafety) && isConnectionFailure(err, sqlState)
+}
+
+func permitsAmbiguousReplay(replaySafety ReplaySafety) bool {
+	return replaySafety == ReplayReadOnly || replaySafety == ReplayIdempotent
+}
+
+func isConnectionFailure(err error, sqlState string) bool {
+	if strings.HasPrefix(sqlState, "08") || pgconn.Timeout(err) ||
+		errors.Is(err, pgx.ErrTxClosed) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+
+	var networkError net.Error
+	return errors.As(err, &networkError)
+}
+
+func postgresSQLState(err error) string {
+	var postgresError *pgconn.PgError
+	if errors.As(err, &postgresError) {
+		return postgresError.Code
+	}
+	return ""
+}
+
+func defaultRandomFloat() float64 {
+	return rand.Float64()
+}

--- a/src/utils/postgres/retry.go
+++ b/src/utils/postgres/retry.go
@@ -75,8 +75,11 @@ func (c *PostgresClient) RunWithRetry(
 		if err == nil {
 			return nil
 		}
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if contextError := ctx.Err(); contextError != nil {
+			if errors.Is(err, contextError) {
+				return err
+			}
+			return contextError
 		}
 		if attempt == c.retryAttempts || !canRetry(err, replaySafety) {
 			return err

--- a/src/utils/postgres/retry_test.go
+++ b/src/utils/postgres/retry_test.go
@@ -57,6 +57,20 @@ func (timeoutError) Temporary() bool {
 	return true
 }
 
+type permanentNetworkError struct{}
+
+func (permanentNetworkError) Error() string {
+	return "permanent network error"
+}
+
+func (permanentNetworkError) Timeout() bool {
+	return false
+}
+
+func (permanentNetworkError) Temporary() bool {
+	return false
+}
+
 func newRetryTestClient(attempts int) (*PostgresClient, *[]time.Duration) {
 	delays := []time.Duration{}
 	return &PostgresClient{
@@ -211,7 +225,8 @@ func TestRunWithRetryConnectionFailureRespectsReplaySafety(t *testing.T) {
 		{name: "safe only SQLSTATE 08", error: &pgconn.PgError{Code: "08006"}, replaySafety: ReplaySafeOnly, wantAttempts: 1},
 		{name: "read only timeout", error: timeoutError{}, replaySafety: ReplayReadOnly, wantAttempts: 2},
 		{name: "safe only timeout", error: timeoutError{}, replaySafety: ReplaySafeOnly, wantAttempts: 1},
-		{name: "read only closed transaction", error: pgx.ErrTxClosed, replaySafety: ReplayReadOnly, wantAttempts: 2},
+		{name: "read only permanent network error", error: permanentNetworkError{}, replaySafety: ReplayReadOnly, wantAttempts: 1},
+		{name: "read only closed transaction", error: pgx.ErrTxClosed, replaySafety: ReplayReadOnly, wantAttempts: 1},
 		{name: "safe only closed transaction", error: pgx.ErrTxClosed, replaySafety: ReplaySafeOnly, wantAttempts: 1},
 	}
 

--- a/src/utils/postgres/retry_test.go
+++ b/src/utils/postgres/retry_test.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -220,37 +219,6 @@ func TestRunWithRetryPreservesCallbackErrorWrappingCanceledContext(t *testing.T)
 	}
 	if len(*delays) != 0 {
 		t.Errorf("retry delays = %v, want none", *delays)
-	}
-}
-
-func TestRunWithRetryPublishesOnlySuccessfulAttemptResults(t *testing.T) {
-	client, _ := newRetryTestClient(2)
-	attempts := 0
-	var published []string
-
-	err := client.RunWithRetry(context.Background(), "read role names", ReplayReadOnly,
-		func(context.Context, *pgxpool.Pool) error {
-			attempts++
-			attemptResult := []string{"partial"}
-			if attempts == 1 {
-				attemptResult = append(attemptResult, "failed attempt")
-				return &pgconn.PgError{Code: "40001"}
-			}
-
-			attemptResult = append(attemptResult, "successful attempt")
-			published = attemptResult
-			return nil
-		})
-
-	if err != nil {
-		t.Fatalf("RunWithRetry() error = %v", err)
-	}
-	if attempts != 2 {
-		t.Fatalf("operation calls = %d, want 2", attempts)
-	}
-	want := []string{"partial", "successful attempt"}
-	if !slices.Equal(published, want) {
-		t.Errorf("published result = %v, want %v", published, want)
 	}
 }
 

--- a/src/utils/postgres/retry_test.go
+++ b/src/utils/postgres/retry_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type safeToRetryError struct{}
@@ -111,17 +112,22 @@ func TestRetryDelayUsesEqualJitterAndCap(t *testing.T) {
 
 func TestRunWithRetrySuccessDoesNotDelay(t *testing.T) {
 	client, delays := newRetryTestClient(5)
+	client.pool = &pgxpool.Pool{}
 	type contextKey string
 	ctx := context.WithValue(context.Background(), contextKey("request"), "original")
 	attempts := 0
 
-	err := client.RunWithRetry(ctx, "read roles", ReplayReadOnly, func(operationCtx context.Context) error {
-		attempts++
-		if operationCtx != ctx {
-			t.Errorf("operation context differs from original context")
-		}
-		return nil
-	})
+	err := client.RunWithRetry(ctx, "read roles", ReplayReadOnly,
+		func(operationCtx context.Context, operationPool *pgxpool.Pool) error {
+			attempts++
+			if operationCtx != ctx {
+				t.Errorf("operation context differs from original context")
+			}
+			if operationPool != client.pool {
+				t.Errorf("operation pool differs from client pool")
+			}
+			return nil
+		})
 
 	if err != nil {
 		t.Fatalf("RunWithRetry() error = %v", err)
@@ -142,7 +148,7 @@ func TestRunWithRetryExhaustionHasNoFinalDelay(t *testing.T) {
 	attempts := 0
 
 	err := client.RunWithRetry(context.Background(), "update role", ReplaySafeOnly,
-		func(context.Context) error {
+		func(context.Context, *pgxpool.Pool) error {
 			attempts++
 			return wantErr
 		})
@@ -172,10 +178,11 @@ func TestRunWithRetryCancellationDuringDelay(t *testing.T) {
 	}
 	attempts := 0
 
-	err := client.RunWithRetry(ctx, "read roles", ReplayReadOnly, func(context.Context) error {
-		attempts++
-		return &pgconn.PgError{Code: "08006"}
-	})
+	err := client.RunWithRetry(ctx, "read roles", ReplayReadOnly,
+		func(context.Context, *pgxpool.Pool) error {
+			attempts++
+			return &pgconn.PgError{Code: "08006"}
+		})
 
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("RunWithRetry() error = %v, want context.Canceled", err)
@@ -195,7 +202,7 @@ func TestRunWithRetrySafeToRetryPermitsAllClasses(t *testing.T) {
 			attempts := 0
 
 			err := client.RunWithRetry(context.Background(), "database operation", replaySafety,
-				func(context.Context) error {
+				func(context.Context, *pgxpool.Pool) error {
 					attempts++
 					if attempts == 1 {
 						return safeToRetryError{}
@@ -236,7 +243,7 @@ func TestRunWithRetryConnectionFailureRespectsReplaySafety(t *testing.T) {
 			attempts := 0
 
 			err := client.RunWithRetry(context.Background(), "database operation", testCase.replaySafety,
-				func(context.Context) error {
+				func(context.Context, *pgxpool.Pool) error {
 					attempts++
 					return testCase.error
 				})
@@ -261,7 +268,7 @@ func TestRunWithRetryTransactionAbortCodes(t *testing.T) {
 				attempts := 0
 
 				err := client.RunWithRetry(context.Background(), "database operation", replaySafety,
-					func(context.Context) error {
+					func(context.Context, *pgxpool.Pool) error {
 						attempts++
 						if attempts == 1 {
 							return &pgconn.PgError{Code: sqlState, Message: "sensitive query contents"}
@@ -310,7 +317,7 @@ func TestRunWithRetryRejectsDeterministicPgError(t *testing.T) {
 	attempts := 0
 
 	err := client.RunWithRetry(context.Background(), "insert role", ReplayReadOnly,
-		func(context.Context) error {
+		func(context.Context, *pgxpool.Pool) error {
 			attempts++
 			return wantErr
 		})

--- a/src/utils/postgres/retry_test.go
+++ b/src/utils/postgres/retry_test.go
@@ -23,8 +23,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -192,6 +194,63 @@ func TestRunWithRetryCancellationDuringDelay(t *testing.T) {
 	}
 	if waits != 1 {
 		t.Errorf("retry waits = %d, want 1", waits)
+	}
+}
+
+func TestRunWithRetryPreservesCallbackErrorWrappingCanceledContext(t *testing.T) {
+	client, delays := newRetryTestClient(5)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	attempts := 0
+
+	err := client.RunWithRetry(ctx, "read pool names", ReplayReadOnly,
+		func(operationContext context.Context, _ *pgxpool.Pool) error {
+			attempts++
+			return fmt.Errorf("failed to query pool names: %w", operationContext.Err())
+		})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunWithRetry() error = %v, want wrapped context.Canceled", err)
+	}
+	if got, want := err.Error(), "failed to query pool names: context canceled"; got != want {
+		t.Errorf("RunWithRetry() error = %q, want %q", got, want)
+	}
+	if attempts != 1 {
+		t.Errorf("operation calls = %d, want 1", attempts)
+	}
+	if len(*delays) != 0 {
+		t.Errorf("retry delays = %v, want none", *delays)
+	}
+}
+
+func TestRunWithRetryPublishesOnlySuccessfulAttemptResults(t *testing.T) {
+	client, _ := newRetryTestClient(2)
+	attempts := 0
+	var published []string
+
+	err := client.RunWithRetry(context.Background(), "read role names", ReplayReadOnly,
+		func(context.Context, *pgxpool.Pool) error {
+			attempts++
+			attemptResult := []string{"partial"}
+			if attempts == 1 {
+				attemptResult = append(attemptResult, "failed attempt")
+				return &pgconn.PgError{Code: "40001"}
+			}
+
+			attemptResult = append(attemptResult, "successful attempt")
+			published = attemptResult
+			return nil
+		})
+
+	if err != nil {
+		t.Fatalf("RunWithRetry() error = %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("operation calls = %d, want 2", attempts)
+	}
+	want := []string{"partial", "successful attempt"}
+	if !slices.Equal(published, want) {
+		t.Errorf("published result = %v, want %v", published, want)
 	}
 }
 

--- a/src/utils/postgres/retry_test.go
+++ b/src/utils/postgres/retry_test.go
@@ -26,7 +26,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -71,6 +74,14 @@ func (permanentNetworkError) Timeout() bool {
 
 func (permanentNetworkError) Temporary() bool {
 	return false
+}
+
+func newNetworkOperationError(systemCallError error) error {
+	return &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: &os.SyscallError{Syscall: "read", Err: systemCallError},
+	}
 }
 
 func newRetryTestClient(attempts int) (*PostgresClient, *[]time.Duration) {
@@ -141,11 +152,11 @@ func TestRunWithRetrySuccessDoesNotDelay(t *testing.T) {
 	}
 }
 
-func TestRunWithRetryExhaustionHasNoFinalDelay(t *testing.T) {
+func TestRunWithRetryExhaustionLogsTerminalFailureWithoutFinalDelay(t *testing.T) {
 	var logs bytes.Buffer
 	client, delays := newRetryTestClient(3)
-	client.logger = slog.New(slog.NewTextHandler(&logs, nil))
-	wantErr := &pgconn.PgError{Code: "40001"}
+	client.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+	wantErr := &pgconn.PgError{Code: "40001", Message: "postgresql://user:password@database/osmo"}
 	attempts := 0
 
 	err := client.RunWithRetry(context.Background(), "update role", ReplaySafeOnly,
@@ -163,8 +174,70 @@ func TestRunWithRetryExhaustionHasNoFinalDelay(t *testing.T) {
 	if got := len(*delays); got != 2 {
 		t.Errorf("retry delay count = %d, want 2", got)
 	}
-	if got := strings.Count(logs.String(), "retrying PostgreSQL operation"); got != 2 {
+	logOutput := logs.String()
+	if got := strings.Count(logOutput, "retrying PostgreSQL operation"); got != 2 {
 		t.Errorf("retry log count = %d, want 2", got)
+	}
+	if strings.Contains(logOutput, "postgresql://user:password@database/osmo") {
+		t.Errorf("retry logs contain error message text: %s", logOutput)
+	}
+
+	var terminalFields map[string]any
+	terminalLogCount := 0
+	for _, logLine := range strings.Split(strings.TrimSpace(logOutput), "\n") {
+		var fields map[string]any
+		if err := json.Unmarshal([]byte(logLine), &fields); err != nil {
+			t.Fatalf("retry log is not valid structured JSON: %v", err)
+		}
+		if fields["msg"] == "PostgreSQL retry exhausted" {
+			terminalFields = fields
+			terminalLogCount++
+		}
+	}
+	if terminalLogCount != 1 {
+		t.Fatalf("terminal exhaustion log count = %d, want 1", terminalLogCount)
+	}
+	wantFields := map[string]any{
+		"operation":     "update role",
+		"attempt":       float64(3),
+		"max_attempts":  float64(3),
+		"error_type":    "*pgconn.PgError",
+		"sqlstate":      "40001",
+		"replay_safety": ReplaySafeOnly.String(),
+	}
+	for name, wantValue := range wantFields {
+		if terminalFields[name] != wantValue {
+			t.Errorf("terminal log field %q = %v, want %v", name, terminalFields[name], wantValue)
+		}
+	}
+	if _, ok := terminalFields["delay"]; ok {
+		t.Error("terminal exhaustion log contains a retry delay")
+	}
+}
+
+func TestRunWithRetryOneAttemptTransientFailureLogsOnlyExhaustion(t *testing.T) {
+	var logs bytes.Buffer
+	client, delays := newRetryTestClient(1)
+	client.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+	wantErr := &pgconn.PgError{Code: "40001"}
+
+	err := client.RunWithRetry(context.Background(), "update role", ReplaySafeOnly,
+		func(context.Context, *pgxpool.Pool) error {
+			return wantErr
+		})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("RunWithRetry() error = %v, want original error", err)
+	}
+	if len(*delays) != 0 {
+		t.Errorf("retry delays = %v, want none", *delays)
+	}
+	logOutput := logs.String()
+	if strings.Contains(logOutput, "retrying PostgreSQL operation") {
+		t.Errorf("one-attempt mode logged a scheduled retry: %s", logOutput)
+	}
+	if got := strings.Count(logOutput, "PostgreSQL retry exhausted"); got != 1 {
+		t.Errorf("terminal exhaustion log count = %d, want 1", got)
 	}
 }
 
@@ -260,6 +333,18 @@ func TestRunWithRetryConnectionFailureRespectsReplaySafety(t *testing.T) {
 		{name: "read only timeout", error: timeoutError{}, replaySafety: ReplayReadOnly, wantAttempts: 2},
 		{name: "safe only timeout", error: timeoutError{}, replaySafety: ReplaySafeOnly, wantAttempts: 1},
 		{name: "read only permanent network error", error: permanentNetworkError{}, replaySafety: ReplayReadOnly, wantAttempts: 1},
+		{name: "read only EOF", error: io.EOF, replaySafety: ReplayReadOnly, wantAttempts: 2},
+		{name: "safe only EOF", error: io.EOF, replaySafety: ReplaySafeOnly, wantAttempts: 1},
+		{name: "idempotent unexpected EOF", error: io.ErrUnexpectedEOF, replaySafety: ReplayIdempotent, wantAttempts: 2},
+		{name: "safe only unexpected EOF", error: io.ErrUnexpectedEOF, replaySafety: ReplaySafeOnly, wantAttempts: 1},
+		{name: "read only connection reset", error: newNetworkOperationError(syscall.ECONNRESET), replaySafety: ReplayReadOnly, wantAttempts: 2},
+		{name: "safe only connection reset", error: newNetworkOperationError(syscall.ECONNRESET), replaySafety: ReplaySafeOnly, wantAttempts: 1},
+		{name: "idempotent connection refused", error: newNetworkOperationError(syscall.ECONNREFUSED), replaySafety: ReplayIdempotent, wantAttempts: 2},
+		{name: "safe only connection refused", error: newNetworkOperationError(syscall.ECONNREFUSED), replaySafety: ReplaySafeOnly, wantAttempts: 1},
+		{name: "read only broken pipe", error: newNetworkOperationError(syscall.EPIPE), replaySafety: ReplayReadOnly, wantAttempts: 2},
+		{name: "safe only broken pipe", error: newNetworkOperationError(syscall.EPIPE), replaySafety: ReplaySafeOnly, wantAttempts: 1},
+		{name: "read only permanent DNS error", error: &net.DNSError{Err: "no such host", Name: "database.invalid"}, replaySafety: ReplayReadOnly, wantAttempts: 1},
+		{name: "read only permanent address error", error: &net.AddrError{Err: "missing port", Addr: "database.invalid"}, replaySafety: ReplayReadOnly, wantAttempts: 1},
 		{name: "read only closed transaction", error: pgx.ErrTxClosed, replaySafety: ReplayReadOnly, wantAttempts: 1},
 		{name: "safe only closed transaction", error: pgx.ErrTxClosed, replaySafety: ReplaySafeOnly, wantAttempts: 1},
 	}
@@ -282,6 +367,33 @@ func TestRunWithRetryConnectionFailureRespectsReplaySafety(t *testing.T) {
 				t.Errorf("operation calls = %d, want %d", attempts, testCase.wantAttempts)
 			}
 		})
+	}
+}
+
+func TestRunWithRetryServerShutdownCodesPermitAllReplayClasses(t *testing.T) {
+	for _, sqlState := range []string{"57P01", "57P02", "57P03"} {
+		for _, replaySafety := range []ReplaySafety{ReplayReadOnly, ReplayIdempotent, ReplaySafeOnly} {
+			t.Run(sqlState+"/"+replaySafety.String(), func(t *testing.T) {
+				client, _ := newRetryTestClient(2)
+				attempts := 0
+
+				err := client.RunWithRetry(context.Background(), "database operation", replaySafety,
+					func(context.Context, *pgxpool.Pool) error {
+						attempts++
+						if attempts == 1 {
+							return &pgconn.PgError{Code: sqlState}
+						}
+						return nil
+					})
+
+				if err != nil {
+					t.Fatalf("RunWithRetry() error = %v", err)
+				}
+				if attempts != 2 {
+					t.Errorf("operation calls = %d, want 2", attempts)
+				}
+			})
+		}
 	}
 }
 
@@ -339,8 +451,10 @@ func TestRunWithRetryTransactionAbortCodes(t *testing.T) {
 }
 
 func TestRunWithRetryRejectsDeterministicPgError(t *testing.T) {
+	var logs bytes.Buffer
 	client, delays := newRetryTestClient(5)
-	wantErr := &pgconn.PgError{Code: "23505"}
+	client.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+	wantErr := &pgconn.PgError{Code: "23505", Message: "sensitive SQL contents"}
 	attempts := 0
 
 	err := client.RunWithRetry(context.Background(), "insert role", ReplayReadOnly,
@@ -357,5 +471,8 @@ func TestRunWithRetryRejectsDeterministicPgError(t *testing.T) {
 	}
 	if len(*delays) != 0 {
 		t.Errorf("retry delays = %v, want none", *delays)
+	}
+	if logs.Len() != 0 {
+		t.Errorf("deterministic first-attempt failure produced retry logs: %s", logs.String())
 	}
 }

--- a/src/utils/postgres/retry_test.go
+++ b/src/utils/postgres/retry_test.go
@@ -1,0 +1,312 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type safeToRetryError struct{}
+
+func (safeToRetryError) Error() string {
+	return "safe to retry"
+}
+
+func (safeToRetryError) SafeToRetry() bool {
+	return true
+}
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string {
+	return "database operation timed out"
+}
+
+func (timeoutError) Timeout() bool {
+	return true
+}
+
+func (timeoutError) Temporary() bool {
+	return true
+}
+
+func newRetryTestClient(attempts int) (*PostgresClient, *[]time.Duration) {
+	delays := []time.Duration{}
+	return &PostgresClient{
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		retryAttempts: attempts,
+		randomFloat:   func() float64 { return 0 },
+		waitForRetry: func(_ context.Context, delay time.Duration) error {
+			delays = append(delays, delay)
+			return nil
+		},
+	}, &delays
+}
+
+func TestRetryDelayUsesEqualJitterAndCap(t *testing.T) {
+	randomValues := []float64{0, 0.5, 0, 0, 0, 0, 0}
+	client, _ := newRetryTestClient(8)
+	client.randomFloat = func() float64 {
+		value := randomValues[0]
+		randomValues = randomValues[1:]
+		return value
+	}
+
+	want := []time.Duration{
+		50 * time.Millisecond,
+		150 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+		time.Second,
+		time.Second,
+	}
+	for attempt, wantDelay := range want {
+		if got := client.retryDelay(attempt + 1); got != wantDelay {
+			t.Errorf("retryDelay(%d) = %v, want %v", attempt+1, got, wantDelay)
+		}
+	}
+}
+
+func TestRunWithRetrySuccessDoesNotDelay(t *testing.T) {
+	client, delays := newRetryTestClient(5)
+	type contextKey string
+	ctx := context.WithValue(context.Background(), contextKey("request"), "original")
+	attempts := 0
+
+	err := client.RunWithRetry(ctx, "read roles", ReplayReadOnly, func(operationCtx context.Context) error {
+		attempts++
+		if operationCtx != ctx {
+			t.Errorf("operation context differs from original context")
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("RunWithRetry() error = %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("operation calls = %d, want 1", attempts)
+	}
+	if len(*delays) != 0 {
+		t.Errorf("retry delays = %v, want none", *delays)
+	}
+}
+
+func TestRunWithRetryExhaustionHasNoFinalDelay(t *testing.T) {
+	var logs bytes.Buffer
+	client, delays := newRetryTestClient(3)
+	client.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	wantErr := &pgconn.PgError{Code: "40001"}
+	attempts := 0
+
+	err := client.RunWithRetry(context.Background(), "update role", ReplaySafeOnly,
+		func(context.Context) error {
+			attempts++
+			return wantErr
+		})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("RunWithRetry() error = %v, want original error", err)
+	}
+	if attempts != 3 {
+		t.Errorf("operation calls = %d, want 3", attempts)
+	}
+	if got := len(*delays); got != 2 {
+		t.Errorf("retry delay count = %d, want 2", got)
+	}
+	if got := strings.Count(logs.String(), "retrying PostgreSQL operation"); got != 2 {
+		t.Errorf("retry log count = %d, want 2", got)
+	}
+}
+
+func TestRunWithRetryCancellationDuringDelay(t *testing.T) {
+	client, _ := newRetryTestClient(5)
+	ctx, cancel := context.WithCancel(context.Background())
+	waits := 0
+	client.waitForRetry = func(waitCtx context.Context, delay time.Duration) error {
+		waits++
+		cancel()
+		return waitForRetry(waitCtx, delay)
+	}
+	attempts := 0
+
+	err := client.RunWithRetry(ctx, "read roles", ReplayReadOnly, func(context.Context) error {
+		attempts++
+		return &pgconn.PgError{Code: "08006"}
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunWithRetry() error = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Errorf("operation calls = %d, want 1", attempts)
+	}
+	if waits != 1 {
+		t.Errorf("retry waits = %d, want 1", waits)
+	}
+}
+
+func TestRunWithRetrySafeToRetryPermitsAllClasses(t *testing.T) {
+	for _, replaySafety := range []ReplaySafety{ReplayReadOnly, ReplayIdempotent, ReplaySafeOnly} {
+		t.Run(replaySafety.String(), func(t *testing.T) {
+			client, _ := newRetryTestClient(2)
+			attempts := 0
+
+			err := client.RunWithRetry(context.Background(), "database operation", replaySafety,
+				func(context.Context) error {
+					attempts++
+					if attempts == 1 {
+						return safeToRetryError{}
+					}
+					return nil
+				})
+
+			if err != nil {
+				t.Fatalf("RunWithRetry() error = %v", err)
+			}
+			if attempts != 2 {
+				t.Errorf("operation calls = %d, want 2", attempts)
+			}
+		})
+	}
+}
+
+func TestRunWithRetryConnectionFailureRespectsReplaySafety(t *testing.T) {
+	testCases := []struct {
+		name         string
+		error        error
+		replaySafety ReplaySafety
+		wantAttempts int
+	}{
+		{name: "read only SQLSTATE 08", error: &pgconn.PgError{Code: "08006"}, replaySafety: ReplayReadOnly, wantAttempts: 2},
+		{name: "idempotent SQLSTATE 08", error: &pgconn.PgError{Code: "08006"}, replaySafety: ReplayIdempotent, wantAttempts: 2},
+		{name: "safe only SQLSTATE 08", error: &pgconn.PgError{Code: "08006"}, replaySafety: ReplaySafeOnly, wantAttempts: 1},
+		{name: "read only timeout", error: timeoutError{}, replaySafety: ReplayReadOnly, wantAttempts: 2},
+		{name: "safe only timeout", error: timeoutError{}, replaySafety: ReplaySafeOnly, wantAttempts: 1},
+		{name: "read only closed transaction", error: pgx.ErrTxClosed, replaySafety: ReplayReadOnly, wantAttempts: 2},
+		{name: "safe only closed transaction", error: pgx.ErrTxClosed, replaySafety: ReplaySafeOnly, wantAttempts: 1},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			client, _ := newRetryTestClient(2)
+			attempts := 0
+
+			err := client.RunWithRetry(context.Background(), "database operation", testCase.replaySafety,
+				func(context.Context) error {
+					attempts++
+					return testCase.error
+				})
+
+			if !errors.Is(err, testCase.error) {
+				t.Fatalf("RunWithRetry() error = %v, want original error", err)
+			}
+			if attempts != testCase.wantAttempts {
+				t.Errorf("operation calls = %d, want %d", attempts, testCase.wantAttempts)
+			}
+		})
+	}
+}
+
+func TestRunWithRetryTransactionAbortCodes(t *testing.T) {
+	for _, sqlState := range []string{"40001", "40P01"} {
+		for _, replaySafety := range []ReplaySafety{ReplayReadOnly, ReplayIdempotent, ReplaySafeOnly} {
+			t.Run(sqlState+"/"+replaySafety.String(), func(t *testing.T) {
+				var logs bytes.Buffer
+				client, _ := newRetryTestClient(2)
+				client.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+				attempts := 0
+
+				err := client.RunWithRetry(context.Background(), "database operation", replaySafety,
+					func(context.Context) error {
+						attempts++
+						if attempts == 1 {
+							return &pgconn.PgError{Code: sqlState, Message: "sensitive query contents"}
+						}
+						return nil
+					})
+
+				if err != nil {
+					t.Fatalf("RunWithRetry() error = %v", err)
+				}
+				if attempts != 2 {
+					t.Errorf("operation calls = %d, want 2", attempts)
+				}
+				logOutput := logs.String()
+				if strings.Contains(logOutput, "sensitive query contents") {
+					t.Errorf("retry log contains query contents: %s", logOutput)
+				}
+				var fields map[string]any
+				if err := json.Unmarshal(logs.Bytes(), &fields); err != nil {
+					t.Fatalf("retry log is not valid structured JSON: %v", err)
+				}
+				wantFields := map[string]any{
+					"operation":     "database operation",
+					"attempt":       float64(1),
+					"max_attempts":  float64(2),
+					"error_type":    "*pgconn.PgError",
+					"sqlstate":      sqlState,
+					"replay_safety": replaySafety.String(),
+				}
+				for name, wantValue := range wantFields {
+					if fields[name] != wantValue {
+						t.Errorf("retry log field %q = %v, want %v", name, fields[name], wantValue)
+					}
+				}
+				if _, ok := fields["delay"]; !ok {
+					t.Error("retry log does not contain delay")
+				}
+			})
+		}
+	}
+}
+
+func TestRunWithRetryRejectsDeterministicPgError(t *testing.T) {
+	client, delays := newRetryTestClient(5)
+	wantErr := &pgconn.PgError{Code: "23505"}
+	attempts := 0
+
+	err := client.RunWithRetry(context.Background(), "insert role", ReplayReadOnly,
+		func(context.Context) error {
+			attempts++
+			return wantErr
+		})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("RunWithRetry() error = %v, want original error", err)
+	}
+	if attempts != 1 {
+		t.Errorf("operation calls = %d, want 1", attempts)
+	}
+	if len(*delays) != 0 {
+		t.Errorf("retry delays = %v, want none", *delays)
+	}
+}

--- a/src/utils/roles/BUILD
+++ b/src/utils/roles/BUILD
@@ -23,6 +23,7 @@ go_library(
         "file_loader.go",
         "pool_access.go",
         "role_cache.go",
+        "retry_result.go",
         "roles.go",
         "user_role_sync.go",
     ],
@@ -46,7 +47,11 @@ go_test(
         "roles_test.go",
     ],
     embed = [":roles"],
-    deps = [],
+    deps = [
+        "//src/utils/postgres",
+        "@com_github_jackc_pgx_v5//pgconn:go_default_library",
+        "@com_github_jackc_pgx_v5//pgxpool:go_default_library",
+    ],
 )
 
 go_test(

--- a/src/utils/roles/BUILD
+++ b/src/utils/roles/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//src/utils",
         "//src/utils/postgres",
         "@com_github_hashicorp_golang_lru_v2//expirable:go_default_library",
+        "@com_github_jackc_pgx_v5//pgxpool:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",
     ],
 )

--- a/src/utils/roles/pool_access.go
+++ b/src/utils/roles/pool_access.go
@@ -33,11 +33,11 @@ func GetAllPoolNames(ctx context.Context, client *postgres.PostgresClient) ([]st
 	query := `SELECT name FROM pools ORDER BY name`
 
 	var names []string
-	err := client.RunWithRetry(ctx, "get all pool names", postgres.ReplayReadOnly,
-		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+	err := runWithRetryResult(ctx, client, "get all pool names", postgres.ReplayReadOnly, &names,
+		func(attemptContext context.Context, pool *pgxpool.Pool) ([]string, error) {
 			rows, err := pool.Query(attemptContext, query)
 			if err != nil {
-				return fmt.Errorf("failed to query pool names: %w", err)
+				return nil, fmt.Errorf("failed to query pool names: %w", err)
 			}
 			defer rows.Close()
 
@@ -45,17 +45,16 @@ func GetAllPoolNames(ctx context.Context, client *postgres.PostgresClient) ([]st
 			for rows.Next() {
 				var name string
 				if err := rows.Scan(&name); err != nil {
-					return fmt.Errorf("failed to scan pool name: %w", err)
+					return nil, fmt.Errorf("failed to scan pool name: %w", err)
 				}
 				attemptNames = append(attemptNames, name)
 			}
 
 			if err := rows.Err(); err != nil {
-				return fmt.Errorf("error iterating pool names: %w", err)
+				return nil, fmt.Errorf("error iterating pool names: %w", err)
 			}
 
-			names = attemptNames
-			return nil
+			return attemptNames, nil
 		})
 	if err != nil {
 		return nil, err

--- a/src/utils/roles/pool_access.go
+++ b/src/utils/roles/pool_access.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"go.corp.nvidia.com/osmo/utils/postgres"
 )
 
@@ -31,23 +32,33 @@ var poolResourcePrefix = string(ResourceTypePool) + "/"
 func GetAllPoolNames(ctx context.Context, client *postgres.PostgresClient) ([]string, error) {
 	query := `SELECT name FROM pools ORDER BY name`
 
-	rows, err := client.Pool().Query(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query pool names: %w", err)
-	}
-	defer rows.Close()
-
 	var names []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, fmt.Errorf("failed to scan pool name: %w", err)
-		}
-		names = append(names, name)
-	}
+	err := client.RunWithRetry(ctx, "get all pool names", postgres.ReplayReadOnly,
+		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+			rows, err := pool.Query(attemptContext, query)
+			if err != nil {
+				return fmt.Errorf("failed to query pool names: %w", err)
+			}
+			defer rows.Close()
 
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating pool names: %w", err)
+			var attemptNames []string
+			for rows.Next() {
+				var name string
+				if err := rows.Scan(&name); err != nil {
+					return fmt.Errorf("failed to scan pool name: %w", err)
+				}
+				attemptNames = append(attemptNames, name)
+			}
+
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("error iterating pool names: %w", err)
+			}
+
+			names = attemptNames
+			return nil
+		})
+	if err != nil {
+		return nil, err
 	}
 
 	return names, nil

--- a/src/utils/roles/pool_access_test.go
+++ b/src/utils/roles/pool_access_test.go
@@ -19,9 +19,65 @@ SPDX-License-Identifier: Apache-2.0
 package roles
 
 import (
+	"context"
 	"reflect"
 	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.corp.nvidia.com/osmo/utils/postgres"
 )
+
+type twoAttemptRetryRunner struct {
+	afterFailedAttempt func()
+}
+
+func (r *twoAttemptRetryRunner) RunWithRetry(
+	ctx context.Context,
+	_ string,
+	_ postgres.ReplaySafety,
+	operation func(context.Context, *pgxpool.Pool) error,
+) error {
+	if err := operation(ctx, nil); err != nil {
+		r.afterFailedAttempt()
+		return operation(ctx, nil)
+	}
+	return nil
+}
+
+func TestRunWithRetryResultPublishesOnlySuccessfulAttempt(t *testing.T) {
+	var published []string
+	runner := &twoAttemptRetryRunner{
+		afterFailedAttempt: func() {
+			if published != nil {
+				t.Errorf("result after failed attempt = %v, want nil", published)
+			}
+		},
+	}
+	attempts := 0
+
+	err := runWithRetryResult(context.Background(), runner, "get all pool names",
+		postgres.ReplayReadOnly, &published,
+		func(context.Context, *pgxpool.Pool) ([]string, error) {
+			attempts++
+			attemptResult := []string{"partial"}
+			if attempts == 1 {
+				return attemptResult, &pgconn.PgError{Code: "40001"}
+			}
+			return append(attemptResult, "complete"), nil
+		})
+
+	if err != nil {
+		t.Fatalf("runWithRetryResult() error = %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("operation calls = %d, want 2", attempts)
+	}
+	want := []string{"partial", "complete"}
+	if !reflect.DeepEqual(published, want) {
+		t.Errorf("published result = %v, want %v", published, want)
+	}
+}
 
 func TestGetAllowedPools(t *testing.T) {
 	allPools := []string{"default", "dev", "production", "staging", "restricted"}

--- a/src/utils/roles/retry_result.go
+++ b/src/utils/roles/retry_result.go
@@ -1,0 +1,54 @@
+/*
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package roles
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.corp.nvidia.com/osmo/utils/postgres"
+)
+
+type retryResultRunner interface {
+	RunWithRetry(
+		context.Context,
+		string,
+		postgres.ReplaySafety,
+		func(context.Context, *pgxpool.Pool) error,
+	) error
+}
+
+func runWithRetryResult[T any](
+	ctx context.Context,
+	runner retryResultRunner,
+	operationName string,
+	replaySafety postgres.ReplaySafety,
+	result *T,
+	operation func(context.Context, *pgxpool.Pool) (T, error),
+) error {
+	return runner.RunWithRetry(ctx, operationName, replaySafety,
+		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+			attemptResult, err := operation(attemptContext, pool)
+			if err != nil {
+				return err
+			}
+			*result = attemptResult
+			return nil
+		})
+}

--- a/src/utils/roles/roles.go
+++ b/src/utils/roles/roles.go
@@ -178,15 +178,15 @@ func GetRoles(ctx context.Context, client *postgres.PostgresClient, roleNames []
 	)
 
 	var result []*Role
-	err := client.RunWithRetry(ctx, "get roles", postgres.ReplayReadOnly,
-		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+	err := runWithRetryResult(ctx, client, "get roles", postgres.ReplayReadOnly, &result,
+		func(attemptContext context.Context, pool *pgxpool.Pool) ([]*Role, error) {
 			rows, err := pool.Query(attemptContext, query, roleNames)
 			if err != nil {
 				logger.Error("failed to query roles",
 					slog.String("error", err.Error()),
 					slog.Any("role_names", roleNames),
 				)
-				return fmt.Errorf("failed to query roles: %w", err)
+				return nil, fmt.Errorf("failed to query roles: %w", err)
 			}
 			defer rows.Close()
 
@@ -200,7 +200,7 @@ func GetRoles(ctx context.Context, client *postgres.PostgresClient, roleNames []
 					logger.Error("failed to scan role",
 						slog.String("error", err.Error()),
 					)
-					return fmt.Errorf("failed to scan role: %w", err)
+					return nil, fmt.Errorf("failed to scan role: %w", err)
 				}
 
 				policiesJSON := []byte(policiesStr)
@@ -214,7 +214,7 @@ func GetRoles(ctx context.Context, client *postgres.PostgresClient, roleNames []
 						slog.String("role", role.Name),
 						slog.String("raw_json", string(policiesJSON)),
 					)
-					return fmt.Errorf("failed to unmarshal policies for role %s: %w", role.Name, err)
+					return nil, fmt.Errorf("failed to unmarshal policies for role %s: %w", role.Name, err)
 				}
 
 				// Parse each policy
@@ -228,7 +228,7 @@ func GetRoles(ctx context.Context, client *postgres.PostgresClient, roleNames []
 							slog.String("role", role.Name),
 							slog.String("policy_raw", string(policyRaw)),
 						)
-						return fmt.Errorf("failed to unmarshal policy for role %s: %w", role.Name, err)
+						return nil, fmt.Errorf("failed to unmarshal policy for role %s: %w", role.Name, err)
 					}
 					// Default effect to Allow when not specified (backward compatibility)
 					if policy.Effect == "" {
@@ -253,11 +253,10 @@ func GetRoles(ctx context.Context, client *postgres.PostgresClient, roleNames []
 				logger.Error("error iterating rows",
 					slog.String("error", err.Error()),
 				)
-				return fmt.Errorf("error iterating rows: %w", err)
+				return nil, fmt.Errorf("error iterating rows: %w", err)
 			}
 
-			result = attemptResult
-			return nil
+			return attemptResult, nil
 		})
 	if err != nil {
 		return nil, err
@@ -282,11 +281,11 @@ func GetAllRoleNames(ctx context.Context, client *postgres.PostgresClient) ([]st
 	query := `SELECT name FROM roles ORDER BY name`
 
 	var roleNames []string
-	err := client.RunWithRetry(ctx, "get all role names", postgres.ReplayReadOnly,
-		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+	err := runWithRetryResult(ctx, client, "get all role names", postgres.ReplayReadOnly, &roleNames,
+		func(attemptContext context.Context, pool *pgxpool.Pool) ([]string, error) {
 			rows, err := pool.Query(attemptContext, query)
 			if err != nil {
-				return fmt.Errorf("failed to query role names: %w", err)
+				return nil, fmt.Errorf("failed to query role names: %w", err)
 			}
 			defer rows.Close()
 
@@ -294,17 +293,16 @@ func GetAllRoleNames(ctx context.Context, client *postgres.PostgresClient) ([]st
 			for rows.Next() {
 				var name string
 				if err := rows.Scan(&name); err != nil {
-					return fmt.Errorf("failed to scan role name: %w", err)
+					return nil, fmt.Errorf("failed to scan role name: %w", err)
 				}
 				attemptRoleNames = append(attemptRoleNames, name)
 			}
 
 			if err := rows.Err(); err != nil {
-				return fmt.Errorf("error iterating role names: %w", err)
+				return nil, fmt.Errorf("error iterating role names: %w", err)
 			}
 
-			roleNames = attemptRoleNames
-			return nil
+			return attemptRoleNames, nil
 		})
 	if err != nil {
 		return nil, err
@@ -321,14 +319,13 @@ func GetPoolForWorkflow(
 	query := `SELECT pool FROM workflows WHERE workflow_id = $1`
 
 	var pool string
-	err := client.RunWithRetry(ctx, "get pool for workflow", postgres.ReplayReadOnly,
-		func(attemptContext context.Context, databasePool *pgxpool.Pool) error {
+	err := runWithRetryResult(ctx, client, "get pool for workflow", postgres.ReplayReadOnly, &pool,
+		func(attemptContext context.Context, databasePool *pgxpool.Pool) (string, error) {
 			var attemptPool string
 			if err := databasePool.QueryRow(attemptContext, query, workflowID).Scan(&attemptPool); err != nil {
-				return err
+				return "", err
 			}
-			pool = attemptPool
-			return nil
+			return attemptPool, nil
 		})
 	if err != nil {
 		return "", fmt.Errorf("failed to get pool for workflow %s: %w", workflowID, err)

--- a/src/utils/roles/roles.go
+++ b/src/utils/roles/roles.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"go.corp.nvidia.com/osmo/utils/postgres"
 )
 
@@ -176,80 +177,90 @@ func GetRoles(ctx context.Context, client *postgres.PostgresClient, roleNames []
 		slog.Any("roles", roleNames),
 	)
 
-	rows, err := client.Pool().Query(ctx, query, roleNames)
-	if err != nil {
-		logger.Error("failed to query roles",
-			slog.String("error", err.Error()),
-			slog.Any("role_names", roleNames),
-		)
-		return nil, fmt.Errorf("failed to query roles: %w", err)
-	}
-	defer rows.Close()
-
 	var result []*Role
-	for rows.Next() {
-		var role Role
-		var policiesStr string // Scan as string first to handle PostgreSQL's JSONB representation
-
-		err := rows.Scan(&role.Name, &role.Description, &policiesStr, &role.Immutable)
-		if err != nil {
-			logger.Error("failed to scan role",
-				slog.String("error", err.Error()),
-			)
-			return nil, fmt.Errorf("failed to scan role: %w", err)
-		}
-
-		policiesJSON := []byte(policiesStr)
-
-		// Parse policies JSON array (converted from JSONB[] via array_to_json)
-		var policiesArray []json.RawMessage
-		err = json.Unmarshal(policiesJSON, &policiesArray)
-		if err != nil {
-			logger.Error("failed to unmarshal policies array",
-				slog.String("error", err.Error()),
-				slog.String("role", role.Name),
-				slog.String("raw_json", string(policiesJSON)),
-			)
-			return nil, fmt.Errorf("failed to unmarshal policies for role %s: %w", role.Name, err)
-		}
-
-		// Parse each policy
-		role.Policies = make([]RolePolicy, 0, len(policiesArray))
-		for _, policyRaw := range policiesArray {
-			var policy RolePolicy
-			err = json.Unmarshal(policyRaw, &policy)
+	err := client.RunWithRetry(ctx, "get roles", postgres.ReplayReadOnly,
+		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+			rows, err := pool.Query(attemptContext, query, roleNames)
 			if err != nil {
-				logger.Error("failed to unmarshal policy",
+				logger.Error("failed to query roles",
 					slog.String("error", err.Error()),
-					slog.String("role", role.Name),
-					slog.String("policy_raw", string(policyRaw)),
+					slog.Any("role_names", roleNames),
 				)
-				return nil, fmt.Errorf("failed to unmarshal policy for role %s: %w", role.Name, err)
+				return fmt.Errorf("failed to query roles: %w", err)
 			}
-			// Default effect to Allow when not specified (backward compatibility)
-			if policy.Effect == "" {
-				policy.Effect = EffectAllow
+			defer rows.Close()
+
+			var attemptResult []*Role
+			for rows.Next() {
+				var role Role
+				var policiesStr string // Scan as string first to handle PostgreSQL's JSONB representation
+
+				err := rows.Scan(&role.Name, &role.Description, &policiesStr, &role.Immutable)
+				if err != nil {
+					logger.Error("failed to scan role",
+						slog.String("error", err.Error()),
+					)
+					return fmt.Errorf("failed to scan role: %w", err)
+				}
+
+				policiesJSON := []byte(policiesStr)
+
+				// Parse policies JSON array (converted from JSONB[] via array_to_json)
+				var policiesArray []json.RawMessage
+				err = json.Unmarshal(policiesJSON, &policiesArray)
+				if err != nil {
+					logger.Error("failed to unmarshal policies array",
+						slog.String("error", err.Error()),
+						slog.String("role", role.Name),
+						slog.String("raw_json", string(policiesJSON)),
+					)
+					return fmt.Errorf("failed to unmarshal policies for role %s: %w", role.Name, err)
+				}
+
+				// Parse each policy
+				role.Policies = make([]RolePolicy, 0, len(policiesArray))
+				for _, policyRaw := range policiesArray {
+					var policy RolePolicy
+					err = json.Unmarshal(policyRaw, &policy)
+					if err != nil {
+						logger.Error("failed to unmarshal policy",
+							slog.String("error", err.Error()),
+							slog.String("role", role.Name),
+							slog.String("policy_raw", string(policyRaw)),
+						)
+						return fmt.Errorf("failed to unmarshal policy for role %s: %w", role.Name, err)
+					}
+					// Default effect to Allow when not specified (backward compatibility)
+					if policy.Effect == "" {
+						policy.Effect = EffectAllow
+					}
+					// Ensure Resources is never nil (always an empty list if not specified)
+					if policy.Resources == nil {
+						policy.Resources = []string{}
+					}
+					role.Policies = append(role.Policies, policy)
+				}
+
+				attemptResult = append(attemptResult, &role)
+
+				logger.Debug("loaded role",
+					slog.String("name", role.Name),
+					slog.Int("policies", len(role.Policies)),
+				)
 			}
-			// Ensure Resources is never nil (always an empty list if not specified)
-			if policy.Resources == nil {
-				policy.Resources = []string{}
+
+			if err := rows.Err(); err != nil {
+				logger.Error("error iterating rows",
+					slog.String("error", err.Error()),
+				)
+				return fmt.Errorf("error iterating rows: %w", err)
 			}
-			role.Policies = append(role.Policies, policy)
-		}
 
-		result = append(result, &role)
-
-		logger.Debug("loaded role",
-			slog.String("name", role.Name),
-			slog.Int("policies", len(role.Policies)),
-		)
-	}
-
-	if err := rows.Err(); err != nil {
-		logger.Error("error iterating rows",
-			slog.String("error", err.Error()),
-		)
-		return nil, fmt.Errorf("error iterating rows: %w", err)
+			result = attemptResult
+			return nil
+		})
+	if err != nil {
+		return nil, err
 	}
 
 	loaded := make([]string, len(result))
@@ -270,23 +281,33 @@ func GetRoles(ctx context.Context, client *postgres.PostgresClient, roleNames []
 func GetAllRoleNames(ctx context.Context, client *postgres.PostgresClient) ([]string, error) {
 	query := `SELECT name FROM roles ORDER BY name`
 
-	rows, err := client.Pool().Query(ctx, query)
-	if err != nil {
-		return nil, fmt.Errorf("failed to query role names: %w", err)
-	}
-	defer rows.Close()
-
 	var roleNames []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, fmt.Errorf("failed to scan role name: %w", err)
-		}
-		roleNames = append(roleNames, name)
-	}
+	err := client.RunWithRetry(ctx, "get all role names", postgres.ReplayReadOnly,
+		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+			rows, err := pool.Query(attemptContext, query)
+			if err != nil {
+				return fmt.Errorf("failed to query role names: %w", err)
+			}
+			defer rows.Close()
 
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("error iterating role names: %w", err)
+			var attemptRoleNames []string
+			for rows.Next() {
+				var name string
+				if err := rows.Scan(&name); err != nil {
+					return fmt.Errorf("failed to scan role name: %w", err)
+				}
+				attemptRoleNames = append(attemptRoleNames, name)
+			}
+
+			if err := rows.Err(); err != nil {
+				return fmt.Errorf("error iterating role names: %w", err)
+			}
+
+			roleNames = attemptRoleNames
+			return nil
+		})
+	if err != nil {
+		return nil, err
 	}
 
 	return roleNames, nil
@@ -300,7 +321,15 @@ func GetPoolForWorkflow(
 	query := `SELECT pool FROM workflows WHERE workflow_id = $1`
 
 	var pool string
-	err := client.Pool().QueryRow(ctx, query, workflowID).Scan(&pool)
+	err := client.RunWithRetry(ctx, "get pool for workflow", postgres.ReplayReadOnly,
+		func(attemptContext context.Context, databasePool *pgxpool.Pool) error {
+			var attemptPool string
+			if err := databasePool.QueryRow(attemptContext, query, workflowID).Scan(&attemptPool); err != nil {
+				return err
+			}
+			pool = attemptPool
+			return nil
+		})
 	if err != nil {
 		return "", fmt.Errorf("failed to get pool for workflow %s: %w", workflowID, err)
 	}
@@ -327,7 +356,11 @@ func UpdateRolePolicies(
 	// PostgreSQL expects JSONB[] which we construct from individual JSON values
 	query := `UPDATE roles SET policies = $1::jsonb[] WHERE name = $2`
 
-	_, err := client.Pool().Exec(ctx, query, policiesJSON, role.Name)
+	err := client.RunWithRetry(ctx, "update role policies", postgres.ReplayIdempotent,
+		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+			_, err := pool.Exec(attemptContext, query, policiesJSON, role.Name)
+			return err
+		})
 	if err != nil {
 		logger.Error("failed to update role policies",
 			slog.String("role", role.Name),

--- a/src/utils/roles/user_role_sync.go
+++ b/src/utils/roles/user_role_sync.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"go.corp.nvidia.com/osmo/utils/postgres"
 )
 
@@ -84,8 +85,11 @@ func upsertUser(ctx context.Context, client *postgres.PostgresClient, userName s
 	query := `INSERT INTO users (id, created_at, created_by)
 	          VALUES ($1, NOW(), $1)
 	          ON CONFLICT (id) DO NOTHING`
-	_, err := client.Pool().Exec(ctx, query, userName)
-	return err
+	return client.RunWithRetry(ctx, "upsert user", postgres.ReplayIdempotent,
+		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+			_, err := pool.Exec(attemptContext, query, userName)
+			return err
+		})
 }
 
 type syncResult struct {
@@ -166,28 +170,41 @@ func syncAndReturnRoles(
 		  AND role_name NOT IN (SELECT role_name FROM inserted)
 		  AND role_name NOT IN (SELECT role_name FROM deleted)`
 
-	rows, err := client.Pool().Query(
-		ctx, query, userName, externalRoles, SyncModeIgnore, idpSyncAssigner)
-	if err != nil {
-		return nil, fmt.Errorf("exec sync query: %w", err)
-	}
-	defer rows.Close()
+	var result *syncResult
+	err := client.RunWithRetry(ctx, "sync user roles", postgres.ReplayIdempotent,
+		func(attemptContext context.Context, pool *pgxpool.Pool) error {
+			rows, err := pool.Query(
+				attemptContext, query, userName, externalRoles, SyncModeIgnore, idpSyncAssigner)
+			if err != nil {
+				return fmt.Errorf("exec sync query: %w", err)
+			}
+			defer rows.Close()
 
-	res := &syncResult{}
-	for rows.Next() {
-		var name, changeType string
-		if err := rows.Scan(&name, &changeType); err != nil {
-			return nil, fmt.Errorf("scan sync result: %w", err)
-		}
-		switch changeType {
-		case "added":
-			res.Added = append(res.Added, name)
-			res.RoleNames = append(res.RoleNames, name)
-		case "removed":
-			res.Removed = append(res.Removed, name)
-		case "existing":
-			res.RoleNames = append(res.RoleNames, name)
-		}
+			attemptResult := &syncResult{}
+			for rows.Next() {
+				var name, changeType string
+				if err := rows.Scan(&name, &changeType); err != nil {
+					return fmt.Errorf("scan sync result: %w", err)
+				}
+				switch changeType {
+				case "added":
+					attemptResult.Added = append(attemptResult.Added, name)
+					attemptResult.RoleNames = append(attemptResult.RoleNames, name)
+				case "removed":
+					attemptResult.Removed = append(attemptResult.Removed, name)
+				case "existing":
+					attemptResult.RoleNames = append(attemptResult.RoleNames, name)
+				}
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+
+			result = attemptResult
+			return nil
+		})
+	if err != nil {
+		return nil, err
 	}
-	return res, rows.Err()
+	return result, nil
 }

--- a/src/utils/roles/user_role_sync_integration_test.go
+++ b/src/utils/roles/user_role_sync_integration_test.go
@@ -281,7 +281,8 @@ func TestSyncUserRoles_Integration_NoChanges_ReturnsExistingRole(t *testing.T) {
 
 // TestSyncUserRoles_Integration_CanceledContext_UpsertError covers the error
 // wrap "upsert user: <err>" returned by SyncUserRoles when upsertUser's
-// Pool().Exec call fails. A canceled context fails the Exec immediately.
+// retry callback returns an error. A canceled context fails its database
+// operation immediately.
 func TestSyncUserRoles_Integration_CanceledContext_UpsertError(t *testing.T) {
 	fixture := database.StartPostgresWithSchema(t)
 


### PR DESCRIPTION
## Description
Add backoff and jitter to postgresl reconnect to avoid all services overwhelming postgres after a DB outage

Issue #645

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable PostgreSQL retry attempts, defaulting to five.
  * Added automatic retries for transient database and connection failures.
  * Added bounded, jittered backoff with context-aware cancellation.
  * Extended retry protection across authorization, roles, pool access, and user-role synchronization.
  * Added configurable extra arguments for the authorization gateway.

* **Bug Fixes**
  * Improved resilience during temporary outages and reconnects.
  * Prevented partial results from failed attempts from being returned.
  * Improved retry logging while excluding sensitive operation details.

* **Tests**
  * Added comprehensive coverage for retries, cancellation, replay safety, logging, and exhaustion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->