### PR TITLE
Shrink docker images

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -163,6 +163,11 @@ python.single_version_platform_override(
         "https://github.com/astral-sh/python-build-standalone/releases/download/20260610/cpython-3.14.6+20260610-aarch64-apple-darwin-install_only.tar.gz",
     ],
 )
+use_repo(
+    python,
+    "python_3_14_6_aarch64-unknown-linux-gnu",
+    "python_3_14_6_x86_64-unknown-linux-gnu",
+)
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 
@@ -365,9 +370,9 @@ apt.install(
 )
 
 oci.pull(
-    name = "distroless_python3_14",
-    digest = "sha256:0897284378754fcf98fa722801a06a52fdb24260eb90b88fcb0c1bc8555d8646",
-    image = BASE_DISTROLESS_IMAGE_URL + "python:3.14-v4.0.10",
+    name = "distroless_cc",
+    digest = "sha256:d1f0fd42719120badb6e6773a518b7fadc9c19d2c94d0d2ccb7695a69d91a5c6",
+    image = BASE_DISTROLESS_IMAGE_URL + "cc:v4.0.9",
     platforms = [
         "linux/arm64/v8",
         "linux/amd64",
@@ -396,9 +401,9 @@ oci.pull(
 )
 use_repo(
     oci,
-    "distroless_python3_14",
-    "distroless_python3_14_linux_amd64",
-    "distroless_python3_14_linux_arm64_v8",
+    "distroless_cc",
+    "distroless_cc_linux_amd64",
+    "distroless_cc_linux_arm64_v8",
     # "distroless_python3_14_dev",
     # "distroless_python3_14_dev_linux_amd64",
     # "distroless_python3_14_dev_linux_arm64_v8",

--- a/bzl/python_runtime.bzl
+++ b/bzl/python_runtime.bzl
@@ -1,0 +1,53 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+
+Rules for selecting the runtime-only portion of a rules_python toolchain.
+"""
+
+def _python_runtime_files_impl(ctx):
+    if ctx.attr.component == "binary":
+        selected = [
+            file
+            for file in ctx.files.runtime
+            if file.short_path.endswith("/bin/python3.14")
+        ]
+        if len(selected) != 1:
+            fail("expected one bin/python3.14, found {}".format(len(selected)))
+    else:
+        selected = [
+            file
+            for file in ctx.files.runtime
+            if "/lib/python3.14/" in file.short_path
+        ]
+        if not selected:
+            fail("expected files beneath lib/python3.14")
+
+    return [DefaultInfo(files = depset(selected))]
+
+python_runtime_files = rule(
+    implementation = _python_runtime_files_impl,
+    attrs = {
+        "component": attr.string(
+            mandatory = True,
+            values = ["binary", "stdlib"],
+        ),
+        "runtime": attr.label(
+            mandatory = True,
+            allow_files = True,
+        ),
+    },
+)

--- a/bzl/tests/BUILD
+++ b/bzl/tests/BUILD
@@ -27,3 +27,10 @@ py_test(
     args = ["$(rootpath //src/service/router:router_image_x86_64)"],
     data = ["//src/service/router:router_image_x86_64"],
 )
+
+py_test(
+    name = "oci_image_contract_test",
+    srcs = ["oci_image_contract_test.py"],
+    args = ["$(rootpath //src/service/router:router_image_x86_64)"],
+    data = ["//src/service/router:router_image_x86_64"],
+)

--- a/bzl/tests/BUILD
+++ b/bzl/tests/BUILD
@@ -20,3 +20,10 @@ py_test(
     args = ["$(rootpath //src:python_runtime_tar_amd64)"],
     data = ["//src:python_runtime_tar_amd64"],
 )
+
+py_test(
+    name = "python_image_runtime_dedup_test",
+    srcs = ["python_image_runtime_dedup_test.py"],
+    args = ["$(rootpath //src/service/router:router_image_x86_64)"],
+    data = ["//src/service/router:router_image_x86_64"],
+)

--- a/bzl/tests/BUILD
+++ b/bzl/tests/BUILD
@@ -24,8 +24,22 @@ py_test(
 py_test(
     name = "python_image_runtime_dedup_test",
     srcs = ["python_image_runtime_dedup_test.py"],
-    args = ["$(rootpath //src/service/router:router_image_x86_64)"],
+    args = [
+        "$(rootpath //src/service/router:router_image_x86_64)",
+        "1",
+    ],
     data = ["//src/service/router:router_image_x86_64"],
+)
+
+py_test(
+    name = "non_python_image_runtime_test",
+    srcs = ["python_image_runtime_dedup_test.py"],
+    args = [
+        "$(rootpath //src/service/authz_sidecar:authz_sidecar_image_x86_64)",
+        "0",
+    ],
+    data = ["//src/service/authz_sidecar:authz_sidecar_image_x86_64"],
+    main = "python_image_runtime_dedup_test.py",
 )
 
 py_test(

--- a/bzl/tests/BUILD
+++ b/bzl/tests/BUILD
@@ -17,8 +17,28 @@
 py_test(
     name = "python_runtime_tar_test",
     srcs = ["python_runtime_tar_test.py"],
-    args = ["$(rootpath //src:python_runtime_tar_amd64)"],
-    data = ["//src:python_runtime_tar_amd64"],
+    args = [
+        "$(rootpath //src:python_runtime_tar_amd64)",
+        "$(rootpath //src:python_runtime_binary_amd64)",
+    ],
+    data = [
+        "//src:python_runtime_binary_amd64",
+        "//src:python_runtime_tar_amd64",
+    ],
+)
+
+py_test(
+    name = "python_runtime_tar_arm64_test",
+    srcs = ["python_runtime_tar_test.py"],
+    args = [
+        "$(rootpath //src:python_runtime_tar_arm64)",
+        "$(rootpath //src:python_runtime_binary_arm64)",
+    ],
+    data = [
+        "//src:python_runtime_binary_arm64",
+        "//src:python_runtime_tar_arm64",
+    ],
+    main = "python_runtime_tar_test.py",
 )
 
 py_test(

--- a/bzl/tests/BUILD
+++ b/bzl/tests/BUILD
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+py_test(
+    name = "python_runtime_tar_test",
+    srcs = ["python_runtime_tar_test.py"],
+    args = ["$(rootpath //src:python_runtime_tar_amd64)"],
+    data = ["//src:python_runtime_tar_amd64"],
+)

--- a/bzl/tests/oci_image_contract_test.py
+++ b/bzl/tests/oci_image_contract_test.py
@@ -27,12 +27,14 @@ from typing import Any
 
 _REQUIRED_ENVIRONMENT = {
     "LANG=C.UTF-8",
-    "PIP_BREAK_SYSTEM_PACKAGES=1",
     "PYTHONNOUSERSITE=1",
-    "PYTHONPATH=/usr/local/lib/python3.14/dist-packages:/app:",
     "PYTHONUNBUFFERED=1",
-    "PY_VERSION=3.14",
 }
+_OMITTED_ENVIRONMENT_PREFIXES = (
+    "PIP_BREAK_SYSTEM_PACKAGES=",
+    "PYTHONPATH=",
+    "PY_VERSION=",
+)
 _PYTHON_SYMLINKS = {
     "usr/bin/python": "/opt/osmo-python/bin/python3.14",
     "usr/bin/python3": "/opt/osmo-python/bin/python3.14",
@@ -63,6 +65,19 @@ class OCIImageContractTest(unittest.TestCase):
         self.assertEqual(config["WorkingDir"], "/app")
         self.assertLessEqual(_REQUIRED_ENVIRONMENT, set(config["Env"]))
         self.assertFalse(any(value.startswith("PYTHONHOME=") for value in config["Env"]))
+
+    def test_omits_build_time_and_legacy_python_environment(self) -> None:
+        layout = pathlib.Path(sys.argv[1])
+        index = json.loads((layout / "index.json").read_text())
+        manifest = _read_json_blob(layout, index["manifests"][0]["digest"])
+        image = _read_json_blob(layout, manifest["config"]["digest"])
+
+        self.assertFalse(
+            any(
+                value.startswith(_OMITTED_ENVIRONMENT_PREFIXES)
+                for value in image["config"]["Env"]
+            )
+        )
 
     def test_preserves_python_executable_paths(self) -> None:
         layout = pathlib.Path(sys.argv[1])

--- a/bzl/tests/oci_image_contract_test.py
+++ b/bzl/tests/oci_image_contract_test.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# pylint: disable=line-too-long
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Locks the public OCI configuration of OSMO Python service images."""
+
+import json
+import pathlib
+import sys
+import unittest
+from typing import Any
+
+
+_REQUIRED_ENVIRONMENT = {
+    "LANG=C.UTF-8",
+    "PIP_BREAK_SYSTEM_PACKAGES=1",
+    "PYTHONNOUSERSITE=1",
+    "PYTHONPATH=/usr/local/lib/python3.14/dist-packages:/app:",
+    "PYTHONUNBUFFERED=1",
+    "PY_VERSION=3.14",
+}
+
+
+def _read_json_blob(layout: pathlib.Path, digest: str) -> dict[str, Any]:
+    algorithm, value = digest.split(":", maxsplit=1)
+    return json.loads((layout / "blobs" / algorithm / value).read_text())
+
+
+class OCIImageContractTest(unittest.TestCase):
+    """Checks the command and process environment exposed to callers."""
+
+    def test_preserves_service_image_contract(self) -> None:
+        layout = pathlib.Path(sys.argv[1])
+        index = json.loads((layout / "index.json").read_text())
+        manifest = _read_json_blob(layout, index["manifests"][0]["digest"])
+        image = _read_json_blob(layout, manifest["config"]["digest"])
+        config = image["config"]
+
+        self.assertEqual(config["Entrypoint"], ["/usr/bin/shelless_ulimit"])
+        self.assertIsNone(config.get("Cmd"))
+        self.assertEqual(config["User"], "osmo")
+        self.assertEqual(config["WorkingDir"], "/app")
+        self.assertLessEqual(_REQUIRED_ENVIRONMENT, set(config["Env"]))
+        self.assertFalse(any(value.startswith("PYTHONHOME=") for value in config["Env"]))
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/bzl/tests/oci_image_contract_test.py
+++ b/bzl/tests/oci_image_contract_test.py
@@ -20,6 +20,7 @@
 import json
 import pathlib
 import sys
+import tarfile
 import unittest
 from typing import Any
 
@@ -31,6 +32,13 @@ _REQUIRED_ENVIRONMENT = {
     "PYTHONPATH=/usr/local/lib/python3.14/dist-packages:/app:",
     "PYTHONUNBUFFERED=1",
     "PY_VERSION=3.14",
+}
+_PYTHON_SYMLINKS = {
+    "usr/bin/python": "/opt/osmo-python/bin/python3.14",
+    "usr/bin/python3": "/opt/osmo-python/bin/python3.14",
+    "usr/local/bin/python": "/opt/osmo-python/bin/python3.14",
+    "usr/local/bin/python3": "/opt/osmo-python/bin/python3.14",
+    "usr/local/bin/python3.14": "/opt/osmo-python/bin/python3.14",
 }
 
 
@@ -55,6 +63,25 @@ class OCIImageContractTest(unittest.TestCase):
         self.assertEqual(config["WorkingDir"], "/app")
         self.assertLessEqual(_REQUIRED_ENVIRONMENT, set(config["Env"]))
         self.assertFalse(any(value.startswith("PYTHONHOME=") for value in config["Env"]))
+
+    def test_preserves_python_executable_paths(self) -> None:
+        layout = pathlib.Path(sys.argv[1])
+        index = json.loads((layout / "index.json").read_text())
+        manifest = _read_json_blob(layout, index["manifests"][0]["digest"])
+        final_members: dict[str, tarfile.TarInfo] = {}
+
+        for layer in manifest["layers"]:
+            algorithm, value = layer["digest"].split(":", maxsplit=1)
+            with tarfile.open(layout / "blobs" / algorithm / value, mode="r:*") as archive:
+                for member in archive.getmembers():
+                    name = member.name.removeprefix("./").removeprefix("/")
+                    if name in _PYTHON_SYMLINKS:
+                        final_members[name] = member
+
+        for path, target in _PYTHON_SYMLINKS.items():
+            self.assertIn(path, final_members)
+            self.assertTrue(final_members[path].issym())
+            self.assertEqual(final_members[path].linkname, target)
 
 
 if __name__ == "__main__":

--- a/bzl/tests/python_image_runtime_dedup_test.py
+++ b/bzl/tests/python_image_runtime_dedup_test.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# pylint: disable=line-too-long
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests that a final Python image contains only one interpreter runtime."""
+
+import json
+import pathlib
+import sys
+import tarfile
+from typing import Any
+import unittest
+
+
+_EXPECTED_BINARY = "opt/osmo-python/bin/python3.14"
+
+
+def _read_json_blob(layout: pathlib.Path, digest: str) -> dict[str, Any]:
+    algorithm, value = digest.split(":", maxsplit=1)
+    return json.loads((layout / "blobs" / algorithm / value).read_text())
+
+
+class PythonImageRuntimeDedupTest(unittest.TestCase):
+    """Checks runtime files across the actual OCI layer graph."""
+
+    def test_has_one_python_runtime(self) -> None:
+        layout = pathlib.Path(sys.argv[1])
+        index = json.loads((layout / "index.json").read_text())
+        manifest_descriptor = index["manifests"][0]
+        manifest = _read_json_blob(layout, manifest_descriptor["digest"])
+        python_binaries: list[str] = []
+        libpython_files: list[str] = []
+
+        for layer in manifest["layers"]:
+            algorithm, value = layer["digest"].split(":", maxsplit=1)
+            with tarfile.open(layout / "blobs" / algorithm / value, mode="r:*") as archive:
+                for member in archive.getmembers():
+                    name = member.name.removeprefix("./").removeprefix("/")
+                    if name.endswith("/bin/python3.14"):
+                        python_binaries.append(name)
+                    if "/lib/libpython3.14" in name:
+                        libpython_files.append(name)
+
+        self.assertEqual(python_binaries, [_EXPECTED_BINARY])
+        self.assertEqual(libpython_files, [])
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/bzl/tests/python_image_runtime_dedup_test.py
+++ b/bzl/tests/python_image_runtime_dedup_test.py
@@ -36,8 +36,9 @@ def _read_json_blob(layout: pathlib.Path, digest: str) -> dict[str, Any]:
 class PythonImageRuntimeDedupTest(unittest.TestCase):
     """Checks runtime files across the actual OCI layer graph."""
 
-    def test_has_one_python_runtime(self) -> None:
+    def test_has_expected_python_runtime_count(self) -> None:
         layout = pathlib.Path(sys.argv[1])
+        expected_runtime_count = int(sys.argv[2])
         index = json.loads((layout / "index.json").read_text())
         manifest_descriptor = index["manifests"][0]
         manifest = _read_json_blob(layout, manifest_descriptor["digest"])
@@ -49,12 +50,12 @@ class PythonImageRuntimeDedupTest(unittest.TestCase):
             with tarfile.open(layout / "blobs" / algorithm / value, mode="r:*") as archive:
                 for member in archive.getmembers():
                     name = member.name.removeprefix("./").removeprefix("/")
-                    if name.endswith("/bin/python3.14"):
+                    if name.endswith("/bin/python3.14") and member.isfile():
                         python_binaries.append(name)
                     if "/lib/libpython3.14" in name:
                         libpython_files.append(name)
 
-        self.assertEqual(python_binaries, [_EXPECTED_BINARY])
+        self.assertEqual(python_binaries, [_EXPECTED_BINARY] * expected_runtime_count)
         self.assertEqual(libpython_files, [])
 
 

--- a/bzl/tests/python_image_runtime_dedup_test.py
+++ b/bzl/tests/python_image_runtime_dedup_test.py
@@ -21,8 +21,8 @@ import json
 import pathlib
 import sys
 import tarfile
-from typing import Any
 import unittest
+from typing import Any
 
 
 _EXPECTED_BINARY = "opt/osmo-python/bin/python3.14"

--- a/bzl/tests/python_runtime_tar_test.py
+++ b/bzl/tests/python_runtime_tar_test.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# pylint: disable=line-too-long
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests the runtime-only CPython image layer."""
+
+import hashlib
+import pathlib
+import sys
+import tarfile
+import unittest
+
+
+_BINARY_PATH = "opt/osmo-python/bin/python3.14"
+_STDLIB_PREFIX = "opt/osmo-python/lib/python3.14/"
+_MAXIMUM_UNPACKED_SIZE = 160_000_000
+
+
+class PythonRuntimeTarTest(unittest.TestCase):
+    """Validates the shared runtime layer's contents and interpreter identity."""
+
+    def setUp(self) -> None:
+        self.archive = tarfile.open(sys.argv[1])
+        self.members = {
+            member.name.removeprefix("./"): member for member in self.archive.getmembers()
+        }
+
+    def tearDown(self) -> None:
+        self.archive.close()
+
+    def test_contains_runtime_without_development_files(self) -> None:
+        self.assertIn(_BINARY_PATH, self.members)
+        self.assertIn(_STDLIB_PREFIX + "os.py", self.members)
+        self.assertTrue(
+            any(name.startswith(_STDLIB_PREFIX + "lib-dynload/") for name in self.members)
+        )
+        self.assertNotIn("opt/osmo-python/bin/python", self.members)
+        self.assertNotIn("opt/osmo-python/bin/python3", self.members)
+        self.assertFalse(any("/include/" in name for name in self.members))
+        self.assertFalse(
+            any(name.startswith("opt/osmo-python/lib/libpython") for name in self.members)
+        )
+        self.assertLess(
+            sum(member.size for member in self.members.values()),
+            _MAXIMUM_UNPACKED_SIZE,
+        )
+
+    def test_contains_executable_used_by_bazel(self) -> None:
+        runtime_binary = self.archive.extractfile(self.members[_BINARY_PATH])
+        if runtime_binary is None:
+            self.fail(f"{_BINARY_PATH} is not a regular file")
+
+        image_digest = hashlib.sha256(runtime_binary.read()).digest()
+        bazel_digest = hashlib.sha256(pathlib.Path(sys.executable).resolve().read_bytes()).digest()
+
+        self.assertNotEqual(self.members[_BINARY_PATH].mode & 0o111, 0)
+        self.assertEqual(image_digest, bazel_digest)
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/bzl/tests/python_runtime_tar_test.py
+++ b/bzl/tests/python_runtime_tar_test.py
@@ -26,6 +26,7 @@ import unittest
 
 _BINARY_PATH = "opt/osmo-python/bin/python3.14"
 _STDLIB_PREFIX = "opt/osmo-python/lib/python3.14/"
+_MAXIMUM_COMPRESSED_SIZE = 60_000_000
 _MAXIMUM_UNPACKED_SIZE = 160_000_000
 
 
@@ -57,6 +58,9 @@ class PythonRuntimeTarTest(unittest.TestCase):
             sum(member.size for member in self.members.values()),
             _MAXIMUM_UNPACKED_SIZE,
         )
+
+    def test_is_compressed_for_registry_transfer(self) -> None:
+        self.assertLess(pathlib.Path(sys.argv[1]).stat().st_size, _MAXIMUM_COMPRESSED_SIZE)
 
     def test_contains_executable_used_by_bazel(self) -> None:
         runtime_binary = self.archive.extractfile(self.members[_BINARY_PATH])

--- a/bzl/tests/python_runtime_tar_test.py
+++ b/bzl/tests/python_runtime_tar_test.py
@@ -62,16 +62,16 @@ class PythonRuntimeTarTest(unittest.TestCase):
     def test_is_compressed_for_registry_transfer(self) -> None:
         self.assertLess(pathlib.Path(sys.argv[1]).stat().st_size, _MAXIMUM_COMPRESSED_SIZE)
 
-    def test_contains_executable_used_by_bazel(self) -> None:
+    def test_contains_expected_interpreter(self) -> None:
         runtime_binary = self.archive.extractfile(self.members[_BINARY_PATH])
         if runtime_binary is None:
             self.fail(f"{_BINARY_PATH} is not a regular file")
 
         image_digest = hashlib.sha256(runtime_binary.read()).digest()
-        bazel_digest = hashlib.sha256(pathlib.Path(sys.executable).resolve().read_bytes()).digest()
+        expected_digest = hashlib.sha256(pathlib.Path(sys.argv[2]).read_bytes()).digest()
 
         self.assertNotEqual(self.members[_BINARY_PATH].mode & 0o111, 0)
-        self.assertEqual(image_digest, bazel_digest)
+        self.assertEqual(image_digest, expected_digest)
 
 
 if __name__ == "__main__":

--- a/src/BUILD
+++ b/src/BUILD
@@ -218,11 +218,8 @@ oci_image(
     entrypoint = ["/usr/bin/shelless_ulimit"],
     env = {
         "LANG": "C.UTF-8",
-        "PIP_BREAK_SYSTEM_PACKAGES": "1",
         "PYTHONNOUSERSITE": "1",
-        "PYTHONPATH": "/usr/local/lib/python3.14/dist-packages:/app:",
         "PYTHONUNBUFFERED": "1",
-        "PY_VERSION": "3.14",
     },
     target_compatible_with = [
         "@platforms//cpu:x86_64",
@@ -242,11 +239,8 @@ oci_image(
     entrypoint = ["/usr/bin/shelless_ulimit"],
     env = {
         "LANG": "C.UTF-8",
-        "PIP_BREAK_SYSTEM_PACKAGES": "1",
         "PYTHONNOUSERSITE": "1",
-        "PYTHONPATH": "/usr/local/lib/python3.14/dist-packages:/app:",
         "PYTHONUNBUFFERED": "1",
-        "PY_VERSION": "3.14",
     },
     target_compatible_with = [
         "@platforms//cpu:arm64",

--- a/src/BUILD
+++ b/src/BUILD
@@ -15,9 +15,83 @@
 # SPDX-License-Identifier: Apache-2.0
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//bzl:python_runtime.bzl", "python_runtime_files")
 
 package(default_visibility = ["//visibility:public"])
+
+python_runtime_files(
+    name = "python_runtime_binary_amd64",
+    component = "binary",
+    runtime = "@python_3_14_6_x86_64-unknown-linux-gnu//:files",
+)
+
+python_runtime_files(
+    name = "python_runtime_stdlib_amd64",
+    component = "stdlib",
+    runtime = "@python_3_14_6_x86_64-unknown-linux-gnu//:files",
+)
+
+pkg_files(
+    name = "python_runtime_binary_package_amd64",
+    srcs = [":python_runtime_binary_amd64"],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "/opt/osmo-python",
+    strip_prefix = strip_prefix.from_root(),
+)
+
+pkg_files(
+    name = "python_runtime_stdlib_package_amd64",
+    srcs = [":python_runtime_stdlib_amd64"],
+    attributes = pkg_attributes(mode = "0644"),
+    prefix = "/opt/osmo-python",
+    strip_prefix = strip_prefix.from_root(),
+)
+
+pkg_tar(
+    name = "python_runtime_tar_amd64",
+    srcs = [
+        ":python_runtime_binary_package_amd64",
+        ":python_runtime_stdlib_package_amd64",
+    ],
+)
+
+python_runtime_files(
+    name = "python_runtime_binary_arm64",
+    component = "binary",
+    runtime = "@python_3_14_6_aarch64-unknown-linux-gnu//:files",
+)
+
+python_runtime_files(
+    name = "python_runtime_stdlib_arm64",
+    component = "stdlib",
+    runtime = "@python_3_14_6_aarch64-unknown-linux-gnu//:files",
+)
+
+pkg_files(
+    name = "python_runtime_binary_package_arm64",
+    srcs = [":python_runtime_binary_arm64"],
+    attributes = pkg_attributes(mode = "0755"),
+    prefix = "/opt/osmo-python",
+    strip_prefix = strip_prefix.from_root(),
+)
+
+pkg_files(
+    name = "python_runtime_stdlib_package_arm64",
+    srcs = [":python_runtime_stdlib_arm64"],
+    attributes = pkg_attributes(mode = "0644"),
+    prefix = "/opt/osmo-python",
+    strip_prefix = strip_prefix.from_root(),
+)
+
+pkg_tar(
+    name = "python_runtime_tar_arm64",
+    srcs = [
+        ":python_runtime_binary_package_arm64",
+        ":python_runtime_stdlib_package_arm64",
+    ],
+)
 
 genrule(
     name = "osmo_group",
@@ -80,8 +154,8 @@ pkg_tar(
 pkg_tar(
     name = "python_symlinks_tar",
     symlinks = {
-        "/usr/bin/python": "/usr/local/bin/python",
-        "/usr/bin/python3": "/usr/local/bin/python3",
+        "/usr/bin/python": "/opt/osmo-python/bin/python3.14",
+        "/usr/bin/python3": "/opt/osmo-python/bin/python3.14",
     },
 )
 
@@ -101,47 +175,73 @@ pkg_tar(
 
 oci_image(
     name = "osmo_docker_distroless_image_amd64",
-    base = "@distroless_python3_14_linux_amd64",
+    base = "@distroless_cc_linux_amd64",
+    entrypoint = ["/usr/bin/shelless_ulimit"],
+    env = {
+        "LANG": "C.UTF-8",
+        "PIP_BREAK_SYSTEM_PACKAGES": "1",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONPATH": "/usr/local/lib/python3.14/dist-packages:/app:",
+        "PYTHONUNBUFFERED": "1",
+        "PY_VERSION": "3.14",
+    },
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
     tars = [
         "//src:group_tar",
         "//src:passwd_tar",
         "//src:osmo_run_tar",
         "//src:python_symlinks_tar",
+        "//src:python_runtime_tar_amd64",
     ],
-    env = {
-        "PYTHONUNBUFFERED": "1",
-    },
-    workdir = "/app",
     user = "osmo",
     visibility = ["//visibility:public"],
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
-    ],
+    workdir = "/app",
 )
 
 oci_image(
     name = "osmo_docker_distroless_image_arm64",
-    base = "@distroless_python3_14_linux_arm64_v8",
+    base = "@distroless_cc_linux_arm64_v8",
+    entrypoint = ["/usr/bin/shelless_ulimit"],
+    env = {
+        "LANG": "C.UTF-8",
+        "PIP_BREAK_SYSTEM_PACKAGES": "1",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONPATH": "/usr/local/lib/python3.14/dist-packages:/app:",
+        "PYTHONUNBUFFERED": "1",
+        "PY_VERSION": "3.14",
+    },
+    target_compatible_with = [
+        "@platforms//cpu:arm64",
+    ],
     tars = [
         "//src:group_tar",
         "//src:passwd_tar",
         "//src:osmo_run_tar",
         "//src:python_symlinks_tar",
+        "//src:python_runtime_tar_arm64",
     ],
-    env = {
-        "PYTHONUNBUFFERED": "1",
-    },
-    workdir = "/app",
     user = "osmo",
     visibility = ["//visibility:public"],
-    target_compatible_with = [
-        "@platforms//cpu:arm64",
-    ],
+    workdir = "/app",
 )
 
 oci_image(
     name = "osmo_docker_client_image_amd64",
-    base = "@distroless_python3_14_linux_amd64",
+    base = "@distroless_cc_linux_amd64",
+    entrypoint = ["/usr/bin/shelless_ulimit"],
+    env = {
+        "LANG": "C.UTF-8",
+        "PIP_BREAK_SYSTEM_PACKAGES": "1",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONPATH": "/usr/local/lib/python3.14/dist-packages:/app:",
+        "PYTHONUNBUFFERED": "1",
+        "PY_VERSION": "3.14",
+    },
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
     tars = [
         # Client base packages (tree, ca-certificates, /osmo dir)
         "@debian_packages//tree/amd64:data",
@@ -153,16 +253,11 @@ oci_image(
         "//src:osmo_run_tar",
         "//src:osmo_home_tar",
         "//src:python_symlinks_tar",
+        "//src:python_runtime_tar_amd64",
     ],
-    env = {
-        "PYTHONUNBUFFERED": "1",
-    },
-    workdir = "/home/osmo",
     user = "osmo",
     visibility = ["//visibility:public"],
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
-    ],
+    workdir = "/home/osmo",
 )
 
 # Local testing for the optimized client image
@@ -177,7 +272,19 @@ oci_image(
 
 oci_image(
     name = "osmo_docker_client_image_arm64",
-    base = "@distroless_python3_14_linux_arm64_v8",
+    base = "@distroless_cc_linux_arm64_v8",
+    entrypoint = ["/usr/bin/shelless_ulimit"],
+    env = {
+        "LANG": "C.UTF-8",
+        "PIP_BREAK_SYSTEM_PACKAGES": "1",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONPATH": "/usr/local/lib/python3.14/dist-packages:/app:",
+        "PYTHONUNBUFFERED": "1",
+        "PY_VERSION": "3.14",
+    },
+    target_compatible_with = [
+        "@platforms//cpu:arm64",
+    ],
     tars = [
         # Client base packages (tree, ca-certificates, /osmo dir)
         "@debian_packages_arm64//tree/arm64:data",
@@ -189,16 +296,11 @@ oci_image(
         "//src:osmo_run_tar",
         "//src:osmo_home_tar",
         "//src:python_symlinks_tar",
+        "//src:python_runtime_tar_arm64",
     ],
-    env = {
-        "PYTHONUNBUFFERED": "1",
-    },
-    workdir = "/home/osmo",
     user = "osmo",
     visibility = ["//visibility:public"],
-    target_compatible_with = [
-        "@platforms//cpu:arm64",
-    ],
+    workdir = "/home/osmo",
 )
 
 # Local testing for the optimized client image (arm64)

--- a/src/BUILD
+++ b/src/BUILD
@@ -51,6 +51,7 @@ pkg_files(
 
 pkg_tar(
     name = "python_runtime_tar_amd64",
+    extension = "tar.gz",
     srcs = [
         ":python_runtime_binary_package_amd64",
         ":python_runtime_stdlib_package_amd64",
@@ -87,6 +88,7 @@ pkg_files(
 
 pkg_tar(
     name = "python_runtime_tar_arm64",
+    extension = "tar.gz",
     srcs = [
         ":python_runtime_binary_package_arm64",
         ":python_runtime_stdlib_package_arm64",

--- a/src/BUILD
+++ b/src/BUILD
@@ -158,6 +158,9 @@ pkg_tar(
     symlinks = {
         "/usr/bin/python": "/opt/osmo-python/bin/python3.14",
         "/usr/bin/python3": "/opt/osmo-python/bin/python3.14",
+        "/usr/local/bin/python": "/opt/osmo-python/bin/python3.14",
+        "/usr/local/bin/python3": "/opt/osmo-python/bin/python3.14",
+        "/usr/local/bin/python3.14": "/opt/osmo-python/bin/python3.14",
     },
 )
 
@@ -176,8 +179,42 @@ pkg_tar(
 )
 
 oci_image(
-    name = "osmo_docker_distroless_image_amd64",
+    name = "osmo_docker_distroless_cc_image_amd64",
     base = "@distroless_cc_linux_amd64",
+    entrypoint = ["/usr/bin/shelless_ulimit"],
+    target_compatible_with = [
+        "@platforms//cpu:x86_64",
+    ],
+    tars = [
+        "//src:group_tar",
+        "//src:passwd_tar",
+        "//src:osmo_run_tar",
+    ],
+    user = "osmo",
+    visibility = ["//visibility:public"],
+    workdir = "/app",
+)
+
+oci_image(
+    name = "osmo_docker_distroless_cc_image_arm64",
+    base = "@distroless_cc_linux_arm64_v8",
+    entrypoint = ["/usr/bin/shelless_ulimit"],
+    target_compatible_with = [
+        "@platforms//cpu:arm64",
+    ],
+    tars = [
+        "//src:group_tar",
+        "//src:passwd_tar",
+        "//src:osmo_run_tar",
+    ],
+    user = "osmo",
+    visibility = ["//visibility:public"],
+    workdir = "/app",
+)
+
+oci_image(
+    name = "osmo_docker_distroless_image_amd64",
+    base = ":osmo_docker_distroless_cc_image_amd64",
     entrypoint = ["/usr/bin/shelless_ulimit"],
     env = {
         "LANG": "C.UTF-8",
@@ -191,9 +228,6 @@ oci_image(
         "@platforms//cpu:x86_64",
     ],
     tars = [
-        "//src:group_tar",
-        "//src:passwd_tar",
-        "//src:osmo_run_tar",
         "//src:python_symlinks_tar",
         "//src:python_runtime_tar_amd64",
     ],
@@ -204,7 +238,7 @@ oci_image(
 
 oci_image(
     name = "osmo_docker_distroless_image_arm64",
-    base = "@distroless_cc_linux_arm64_v8",
+    base = ":osmo_docker_distroless_cc_image_arm64",
     entrypoint = ["/usr/bin/shelless_ulimit"],
     env = {
         "LANG": "C.UTF-8",
@@ -218,9 +252,6 @@ oci_image(
         "@platforms//cpu:arm64",
     ],
     tars = [
-        "//src:group_tar",
-        "//src:passwd_tar",
-        "//src:osmo_run_tar",
         "//src:python_symlinks_tar",
         "//src:python_runtime_tar_arm64",
     ],
@@ -231,16 +262,7 @@ oci_image(
 
 oci_image(
     name = "osmo_docker_client_image_amd64",
-    base = "@distroless_cc_linux_amd64",
-    entrypoint = ["/usr/bin/shelless_ulimit"],
-    env = {
-        "LANG": "C.UTF-8",
-        "PIP_BREAK_SYSTEM_PACKAGES": "1",
-        "PYTHONNOUSERSITE": "1",
-        "PYTHONPATH": "/usr/local/lib/python3.14/dist-packages:/app:",
-        "PYTHONUNBUFFERED": "1",
-        "PY_VERSION": "3.14",
-    },
+    base = ":osmo_docker_distroless_image_amd64",
     target_compatible_with = [
         "@platforms//cpu:x86_64",
     ],
@@ -249,13 +271,7 @@ oci_image(
         "@debian_packages//tree/amd64:data",
         "@debian_packages//ca-certificates/amd64:data",
         "//src:osmo_client_dir_tar",
-        # User and system setup
-        "//src:group_tar",
-        "//src:passwd_tar",
-        "//src:osmo_run_tar",
         "//src:osmo_home_tar",
-        "//src:python_symlinks_tar",
-        "//src:python_runtime_tar_amd64",
     ],
     user = "osmo",
     visibility = ["//visibility:public"],
@@ -274,16 +290,7 @@ oci_image(
 
 oci_image(
     name = "osmo_docker_client_image_arm64",
-    base = "@distroless_cc_linux_arm64_v8",
-    entrypoint = ["/usr/bin/shelless_ulimit"],
-    env = {
-        "LANG": "C.UTF-8",
-        "PIP_BREAK_SYSTEM_PACKAGES": "1",
-        "PYTHONNOUSERSITE": "1",
-        "PYTHONPATH": "/usr/local/lib/python3.14/dist-packages:/app:",
-        "PYTHONUNBUFFERED": "1",
-        "PY_VERSION": "3.14",
-    },
+    base = ":osmo_docker_distroless_image_arm64",
     target_compatible_with = [
         "@platforms//cpu:arm64",
     ],
@@ -292,13 +299,7 @@ oci_image(
         "@debian_packages_arm64//tree/arm64:data",
         "@debian_packages_arm64//ca-certificates/arm64:data",
         "//src:osmo_client_dir_tar",
-        # User and system setup
-        "//src:group_tar",
-        "//src:passwd_tar",
-        "//src:osmo_run_tar",
         "//src:osmo_home_tar",
-        "//src:python_symlinks_tar",
-        "//src:python_runtime_tar_arm64",
     ],
     user = "osmo",
     visibility = ["//visibility:public"],

--- a/src/operator/BUILD
+++ b/src/operator/BUILD
@@ -75,7 +75,6 @@ filegroup(
     name = "backend_listener_image_layers",
     srcs = [
         ":backend_listener_layer_default",
-        ":backend_listener_layer_interpreter",
         ":backend_listener_layer_packages",
         ":backend_listener_wrapper",
     ],
@@ -210,7 +209,6 @@ filegroup(
     name = "backend_worker_image_layers",
     srcs = [
         ":backend_worker_layer_default",
-        ":backend_worker_layer_interpreter",
         ":backend_worker_layer_packages",
         ":backend_worker_wrapper",
     ],

--- a/src/operator/backend_test_runner/BUILD
+++ b/src/operator/backend_test_runner/BUILD
@@ -64,7 +64,6 @@ filegroup(
     name = "backend_test_runner_image_layers",
     srcs = [
         ":backend_test_runner_layer_default",
-        ":backend_test_runner_layer_interpreter",
         ":backend_test_runner_layer_packages",
         ":backend_test_runner_wrapper",
     ],

--- a/src/operator/utils/node_validation_test/BUILD
+++ b/src/operator/utils/node_validation_test/BUILD
@@ -83,7 +83,6 @@ filegroup(
     name = "resource_validator_image_layers",
     srcs = [
         ":resource_validator_layer_default",
-        ":resource_validator_layer_interpreter",
         ":resource_validator_layer_packages",
         ":resource_validator_wrapper",
     ],
@@ -213,7 +212,6 @@ filegroup(
     name = "lfs_validator_image_layers",
     srcs = [
         ":lfs_validator_layer_default",
-        ":lfs_validator_layer_interpreter",
         ":lfs_validator_layer_packages",
         ":lfs_validator_wrapper",
     ],
@@ -347,7 +345,6 @@ filegroup(
     name = "connection_validator_image_layers",
     srcs = [
         ":connection_validator_layer_default",
-        ":connection_validator_layer_interpreter",
         ":connection_validator_layer_packages",
         ":connection_validator_wrapper",
     ],

--- a/src/runtime/BUILD
+++ b/src/runtime/BUILD
@@ -43,7 +43,6 @@ filegroup(
     name = "init_image_layers",
     srcs = [
         ":init_layer_default",
-        ":init_layer_interpreter",
         ":init_layer_packages",
         ":init_wrapper",
     ],

--- a/src/service/agent/BUILD
+++ b/src/service/agent/BUILD
@@ -66,7 +66,6 @@ filegroup(
     name = "agent_service_image_layers",
     srcs = [
         ":agent_service_layer_default",
-        ":agent_service_layer_interpreter",
         ":agent_service_layer_packages",
         ":agent_service_wrapper",
     ],

--- a/src/service/authz_sidecar/BUILD
+++ b/src/service/authz_sidecar/BUILD
@@ -66,7 +66,7 @@ pkg_tar(
 
 oci_image(
     name = "authz_sidecar_image_x86_64",
-    base = "//src:osmo_docker_distroless_image_amd64",
+    base = "//src:osmo_docker_distroless_cc_image_amd64",
     tars = [":authz_sidecar_pkg_x86_64"],
     entrypoint = ["/osmo/authz_sidecar"],
     visibility = ["//visibility:public"],
@@ -122,7 +122,7 @@ pkg_tar(
 
 oci_image(
     name = "authz_sidecar_image_arm64",
-    base = "//src:osmo_docker_distroless_image_arm64",
+    base = "//src:osmo_docker_distroless_cc_image_arm64",
     tars = [":authz_sidecar_pkg_arm64"],
     entrypoint = ["/osmo/authz_sidecar"],
     visibility = ["//visibility:public"],

--- a/src/service/core/BUILD
+++ b/src/service/core/BUILD
@@ -75,7 +75,6 @@ filegroup(
     name = "service_image_layers",
     srcs = [
         ":service_layer_default",
-        ":service_layer_interpreter",
         ":service_layer_packages",
         ":service_wrapper",
     ],

--- a/src/service/delayed_job_monitor/BUILD
+++ b/src/service/delayed_job_monitor/BUILD
@@ -67,7 +67,6 @@ filegroup(
     name = "delayed_job_monitor_image_layers",
     srcs = [
         ":delayed_job_monitor_layer_default",
-        ":delayed_job_monitor_layer_interpreter",
         ":delayed_job_monitor_layer_packages",
         ":delayed_job_monitor_wrapper",
     ],

--- a/src/service/logger/BUILD
+++ b/src/service/logger/BUILD
@@ -82,7 +82,6 @@ filegroup(
     name = "logger_image_layers",
     srcs = [
         ":logger_layer_default",
-        ":logger_layer_interpreter",
         ":logger_layer_packages",
         ":logger_wrapper",
     ],

--- a/src/service/router/BUILD
+++ b/src/service/router/BUILD
@@ -66,7 +66,6 @@ filegroup(
     name = "router_image_layers",
     srcs = [
         ":router_layer_default",
-        ":router_layer_interpreter",
         ":router_layer_packages",
         ":router_wrapper",
     ],

--- a/src/service/worker/BUILD
+++ b/src/service/worker/BUILD
@@ -72,7 +72,6 @@ filegroup(
     name = "worker_image_layers",
     srcs = [
         ":worker_layer_default",
-        ":worker_layer_interpreter",
         ":worker_layer_packages",
         ":worker_wrapper",
     ],

--- a/src/utils/progress_check/BUILD
+++ b/src/utils/progress_check/BUILD
@@ -57,7 +57,6 @@ filegroup(
     name = "progress_check_image_layers",
     srcs = [
         ":progress_check_layer_default",
-        ":progress_check_layer_interpreter",
         ":progress_check_layer_packages",
         ":progress_check_wrapper",
     ],


### PR DESCRIPTION
## Summary

Reduce a representative OSMO Python service image by approximately **80% unpacked** (**~1.39 GiB → ~284 MiB**) and **79% compressed** (**~479 MiB → ~103 MiB**).

Previously, each service image contained three Python interpreter payloads:

- NVIDIA distroless Python base: approximately **40.5 MiB unpacked / 17.3 MiB compressed** of Python-specific content beyond the equivalent C/C++ base.
- Main application `rules_python` interpreter layer: approximately **616 MiB unpacked / 205 MiB compressed**, including redundant toolchain files.
- `progress_check` `rules_python` interpreter layer: another approximately **616 MiB unpacked / 205 MiB compressed** copy.

Images now contain one interpreter:

- Digest-pinned `nvcr.io/nvidia/distroless/cc:v4.0.9` base, with no Python interpreter: approximately **31.5 MiB unpacked / 14.4 MiB compressed**.
- One architecture-specific `rules_python` CPython runtime layer: approximately **136 MiB unpacked / 50.6 MiB compressed** on amd64.

The shared runtime contains the exact CPython executable used by Bazel plus its required standard library, while excluding duplicate launchers, headers, development files, and `libpython`. Python leaf images no longer package per-target interpreter layers, and Go-only images do not inherit Python.

This also makes `bazel run` and the corresponding container execute the same CPython bytes. Existing image entrypoints, commands/arguments, users, working directories, wrapper paths, Helm commands, and probes remain unchanged.

## Validation

- Artifact tests verify one interpreter in Python images and none in the Go Authz image.
- amd64 production images and representative arm64 images build successfully.
- CPython, native extensions, and `progress_check` execute successfully on both architectures.
- Service and backend-operator Helm renders remain byte-identical.

Issue - None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added architecture-specific Python 3.14 runtime packaging for amd64 and arm64.
  * Updated container images to use C/C++ distroless bases with integrated Python runtimes.
  * Client images now share runtime content, reducing duplication.

* **Bug Fixes**
  * Preserved service image settings, executable paths, permissions, and runtime contents.

* **Tests**
  * Added coverage for runtime archives, image contracts, runtime deduplication, and supported Python files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->