### PR TITLE
feat(skills): route osmo-user through MCP or CLI

### DIFF
--- a/skills/osmo-user/SKILL.md
+++ b/skills/osmo-user/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: osmo-user
 description: >
-  Drive the OSMO CLI for cloud-robotics compute on behalf of an end user:
+  Drive OSMO through its CLI or a connected MCP for cloud-robotics compute on
+  behalf of an end user:
   check resources, submit/monitor/debug/explain workflows, fetch logs and
   Grafana/Kubernetes links, inspect direct data storage, manage workflow apps,
   and set workflow credentials.
@@ -20,9 +21,13 @@ description: >
 Run OSMO CLI workflows from natural-language requests. Keep this file as a
 router: load only the reference files needed for the current task.
 
-## Prerequisites
+## Interface selection and prerequisites
 
-Before the first OSMO command in a conversation:
+Before the first OSMO operation, read `references/interface-routing.md`. It
+chooses one interface per operation and defines the lock, consent, and retry
+rules. An assigned interface always wins.
+
+For a CLI operation:
 
 0. For cancel/delete/force/destructive requests, ask for explicit confirmation
    before running any `osmo` command, including `osmo --version` or query
@@ -34,10 +39,17 @@ Before the first OSMO command in a conversation:
 3. Resource and workflow operations rely on the user's profile and pool access
    (`osmo profile list`, `osmo pool list`).
 
+For an MCP operation, use only tools advertised by the connected OSMO MCP and
+their current schemas. Do not run the CLI, probe a second interface, or use raw
+HTTP. Follow the MCP remediation on authentication failure; do not ask the user
+to run `osmo login`.
+
 ## Operating Rules
 
 - Classify the request using the Reference Routing section below, then load only
   the reference file(s) it names before running commands.
+- Keep each OSMO operation on its selected interface. Do not switch interfaces
+  after an error, capability gap, or authentication failure.
 - Do not guess command names or flags from memory. Use the linked reference for
   the user's use case, then run the commands yourself.
 - Obtain workflow and resource state (status, logs, events, capacity, spec) by
@@ -58,8 +70,8 @@ Before the first OSMO command in a conversation:
 
 ## Default Workflow
 
-1. Complete the Prerequisites above (CLI check, auth, profile/pool access)
-   before the first OSMO command.
+1. Complete the selected interface's prerequisites before the first OSMO
+   operation.
 2. Classify the request and read only the reference file(s) named in the
    Reference Routing section below.
 3. Run the `osmo` commands yourself — cache the query JSON and never infer state
@@ -78,6 +90,12 @@ Classify the request and read only the reference file(s) for the matched intent.
 Each heading is a reference file; the bullets under it are the user intents and
 example wordings that route there. Error and failure cases are listed under the
 reference that handles them. These are routing cues, not complete command recipes.
+The command blocks in these references are the CLI form; when MCP is selected,
+preserve the procedure and use the matching tool in
+`references/interface-routing.md`.
+
+### `references/interface-routing.md`
+Choose and lock CLI or MCP before an OSMO operation.
 
 ### `references/resource-check-format.md`
 Resources, pools, GPUs, nodes, or quota.

--- a/skills/osmo-user/references/interface-routing.md
+++ b/skills/osmo-user/references/interface-routing.md
@@ -1,0 +1,70 @@
+# OSMO Interface Routing
+
+Use this reference to choose and operate one OSMO interface per operation.
+Connected MCP schemas and installed CLI help remain authoritative.
+
+## Route contract
+
+- An assigned interface overrides adaptive selection. Pass that lock to
+  delegates.
+- When unassigned, prefer authenticated CLI for a known one-operation read,
+  validation, local operation, MCP capability gap, or protected-file secret
+  transport. Prefer MCP for supported typed remote writes, recovery, updates,
+  or multi-source diagnosis.
+- If neither interface supports the operation, explain and stop.
+- Never use both interfaces for one operation, fall back to raw HTTP, or switch
+  after an error, capability gap, or authentication failure. A separate phase of
+  an unassigned multi-phase request may choose independently.
+- Verify an ambiguous write on the same route before another authorized write.
+
+## Intent mapping
+
+`—` means the capability is not available through that interface or is not
+documented by this skill.
+
+| Intent | MCP tool | CLI command |
+| --- | --- | --- |
+| Profile defaults | `osmo_get_profile` | `osmo profile list --format-type json` |
+| Update default pool or bucket | `osmo_set_profile` | `osmo profile set pool <pool>` or `osmo profile set bucket <bucket>` |
+| Search pools or capacity | `osmo_search_pools` | `osmo pool list --mode free --format-type json` |
+| Per-node resources | `osmo_list_resources` or `osmo_get_resource` | `osmo resource list --pool <pool> --format-type json` |
+| Recent workflows | `osmo_list_workflows` | `osmo workflow list --format-type json` |
+| Workflow status or dashboard link | `osmo_get_workflow` | `osmo workflow query <workflow_id> --format-type json` |
+| Workflow logs or events | `osmo_get_workflow_logs` or `osmo_get_workflow_events` | `osmo workflow logs <workflow_id>` or `osmo workflow events <workflow_id>` |
+| Workflow spec | `osmo_get_workflow_spec` | `osmo workflow spec <workflow_id> [--template]` |
+| Validate workflow YAML | `osmo_validate_workflow` | `osmo workflow validate <file> --pool <pool>` |
+| Submit workflow YAML | `osmo_submit_workflow` | `osmo workflow submit <file> --pool <pool>` |
+| Restart or cancel workflow | `osmo_restart_workflow` or `osmo_cancel_workflow` | `osmo workflow restart <workflow_id>` or `osmo workflow cancel <workflow_id>` |
+| List or inspect apps | `osmo_list_apps`, `osmo_get_app`, or `osmo_get_app_spec` | `osmo app list`, `osmo app info <name[:version]>`, or `osmo app spec <name[:version]>` |
+| Create, update, or submit an app | `osmo_create_app`, `osmo_update_app`, or `osmo_submit_app` | `osmo app create`, `osmo app update`, or `osmo app submit` |
+| Rename or delete an app | `osmo_rename_app` or `osmo_delete_app` | `osmo app rename` or `osmo app delete` |
+| Credential inventory or mutation | `osmo_list_credentials`, `osmo_set_credential`, or `osmo_delete_credential` | `osmo credential list`, `set`, or `delete` |
+| Upload or download local data | — | `osmo data upload` or `osmo data download` |
+| Exec, rsync, port-forward, tags, login, or version | — | Use the matching installed CLI command |
+
+## MCP execution
+
+Use only advertised OSMO MCP tools and current schemas; never invent a tool or
+use raw HTTP. For a workflow status, dashboard, or progress request, call
+`osmo_get_workflow` once with the supplied ID. Fetch logs, events, or spec only
+when needed.
+
+Read local workflow YAML once and pass its exact text in `workflow_spec`.
+Validation is read-only. For submission, pass exactly one of `workflow_spec` or
+`workflow_id`, preserve pool and priority, pass Jinja overrides as `key=value`,
+set `dry_run=false`, and report the workflow ID.
+
+Follow MCP error and remediation fields. Retry only an explicitly retryable
+read once. Permission denial means missing access. Do not expose secrets through
+MCP unless the current schema documents redaction and non-retention.
+
+## CLI execution
+
+Use the mapped commands directly and prefer JSON reads. If a required flag is
+not documented, inspect only that subcommand's local `--help` once. On an
+authentication failure, ask the user to run `osmo login` and stop. Retry a
+clearly transient read once; do not change interfaces.
+
+Never put secrets in commands, responses, shell history, or inline payloads.
+Use owner-protected `--payload-file` inputs when available and never read their
+contents into chat.

--- a/skills/osmo-user/references/logs-reader.md
+++ b/skills/osmo-user/references/logs-reader.md
@@ -13,6 +13,7 @@ the main agent can use without holding large raw logs in context.
 The main agent will tell you:
 
 - **Workflow ID** — the OSMO workflow identifier (e.g. `my-workflow-abc123`)
+- **Assigned interface** — `MCP` or `CLI`; do not switch or probe the other route
 - **Tasks to read** — either:
   - A list of specific task names (e.g. `["train", "eval"]`)
   - `"all"` — meaning fetch overall (un-split) logs
@@ -22,7 +23,8 @@ The main agent will tell you:
 
 ## Step 1: Determine task list (only when told `"auto"`)
 
-If the main agent said `"auto"`, query the workflow to find its tasks:
+If the main agent said `"auto"`, query the workflow to find its tasks. On MCP,
+use `osmo_get_workflow`; on CLI, run:
 
 ```
 osmo workflow query <workflow_id> --format-type json
@@ -36,8 +38,9 @@ logs (treat as `"all"`).
 
 ## Step 2: Fetch logs
 
-All log-fetching commands stream live output, so **run each with a 5-second
-timeout** and use whatever was captured — do not wait for the stream to end.
+On MCP, use `osmo_get_workflow_logs` with the workflow ID, optional task name,
+and `last_n_lines=10000`. On CLI, log commands stream live output, so **run
+each with a 5-second timeout** and use whatever was captured.
 
 **Overall logs** (when tasks = `"all"` or > 5 tasks):
 

--- a/skills/osmo-user/references/workflow-expert.md
+++ b/skills/osmo-user/references/workflow-expert.md
@@ -10,9 +10,10 @@ lifting — workflow generation, resource selection, submission, and failure
 diagnosis — then return control so the calling agent can monitor inline
 with live status updates visible to the user.
 
-Read `SKILL.md`, then the reference(s) for your use case
+Read `SKILL.md`, `references/interface-routing.md`, then the reference(s) for your use case
 (`references/workflow-submit.md` and any additional files the routing tables
-name). Use those procedures directly; do not reinvent them.
+name). Keep the caller's assigned interface for every OSMO operation. Use those
+procedures directly; do not reinvent them.
 
 ## Mode 1: Setup and Submit (default)
 

--- a/skills/osmo-user/references/workflow-status.md
+++ b/skills/osmo-user/references/workflow-status.md
@@ -4,6 +4,9 @@ Use this reference when the user asks about workflow status, logs, live metrics,
 dashboard links, recent workflows, end-to-end monitoring, or what a workflow
 does.
 
+The command blocks below are the CLI form. When MCP is selected, preserve the
+same procedure and use the matching tool in `interface-routing.md`.
+
 ## List Workflows
 
 Use when the user wants to see all or recent workflows.

--- a/skills/osmo-user/references/workflow-submit.md
+++ b/skills/osmo-user/references/workflow-submit.md
@@ -3,6 +3,9 @@
 Use this reference when the user wants to submit a workflow, generate a
 workflow spec for submission, or choose a pool for submission.
 
+The command blocks below are the CLI form. When MCP is selected, preserve the
+same procedure and use the matching tool in `interface-routing.md`.
+
 ## Generate and Submit a Workflow
 
 Use when the user wants to submit a workflow and does not require live


### PR DESCRIPTION
## Description

Add optional MCP routing for osmo-user while preserving the current CLI-first procedures. The routing reference locks each operation to one interface and updates status, submission, and delegated log/workflow procedures to follow that choice.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting either the OSMO CLI or a connected MCP interface for each operation.
  * Added guidance for mapping workflows across CLI commands and MCP tools.
  * Added MCP-specific authentication, capability, retry, verification, and secret-handling instructions.
* **Documentation**
  * Updated workflow, status, submission, and log-reading guidance to follow the selected interface consistently.
  * Expanded log retrieval guidance for MCP, including support for up to 10,000 lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->