### PR TITLE
Fix ConfigMap role validation for service accounts

### DIFF
--- a/deployments/charts/service/migrations/008_v6_4_0_configmap_user_roles.json
+++ b/deployments/charts/service/migrations/008_v6_4_0_configmap_user_roles.json
@@ -1,0 +1,16 @@
+{
+  "operations": [
+    {
+      "drop_multicolumn_constraint": {
+        "table": "user_roles",
+        "name": "fk_user_roles_role",
+        "up": {
+          "role_name": "role_name"
+        },
+        "down": {
+          "role_name": "role_name"
+        }
+      }
+    }
+  ]
+}

--- a/src/service/core/auth/auth_service.py
+++ b/src/service/core/auth/auth_service.py
@@ -27,7 +27,7 @@ import fastapi
 from src.lib.utils import common, osmo_errors
 from src.utils.job import task as task_lib
 from src.service.core.auth import backend_secret_auth, objects
-from src.utils import auth, connectors
+from src.utils import auth, configmap_state, connectors
 
 
 router = fastapi.APIRouter(
@@ -462,6 +462,23 @@ def _validate_role_exists(postgres: connectors.PostgresConnector, role_name: str
     connectors.Role.fetch_from_db(postgres, role_name)
 
 
+def _insert_user_role(postgres: connectors.PostgresConnector, user_id: str,
+                      role_name: str, assigned_by: str,
+                      assigned_at: datetime.datetime) -> List[dict]:
+    if configmap_state.get_snapshot() is not None:
+        _validate_role_exists(postgres, role_name)
+        insert_cmd = '''
+            INSERT INTO user_roles (user_id, role_name, assigned_by, assigned_at)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (user_id, role_name) DO UPDATE SET user_id = EXCLUDED.user_id
+            RETURNING id, assigned_by, assigned_at;
+        '''
+        return postgres.execute_fetch_command(
+            insert_cmd, (user_id, role_name, assigned_by, assigned_at), True)
+
+    return postgres.assign_user_role(user_id, role_name, assigned_by, assigned_at)
+
+
 def _validate_user_exists(postgres: connectors.PostgresConnector, user_id: str):
     """Validate that a user exists in the database."""
     if not _get_user_from_db(postgres, user_id):
@@ -638,13 +655,7 @@ def create_user(
     # Assign initial roles if provided
     if request.roles:
         for role_name in request.roles:
-            assign_cmd = '''
-                INSERT INTO user_roles (user_id, role_name, assigned_by, assigned_at)
-                VALUES (%s, %s, %s, %s)
-                ON CONFLICT (user_id, role_name) DO NOTHING;
-            '''
-            postgres.execute_commit_command(
-                assign_cmd, (request.id, role_name, created_by, now))
+            _insert_user_role(postgres, request.id, role_name, created_by, now)
 
     row = result[0]
     return objects.User(
@@ -751,24 +762,17 @@ def assign_role_to_user(
     _validate_user_id_not_empty(user_id)
     postgres = connectors.PostgresConnector.get_instance()
 
-    # Validate role exists (user existence is enforced by FK constraint on user_roles)
-    _validate_role_exists(postgres, request.role_name)
-
     now = datetime.datetime.now(datetime.timezone.utc)
 
-    # Insert role assignment (idempotent - returns existing if already assigned)
-    # FK constraint on user_id will reject if user doesn't exist
-    insert_cmd = '''
-        INSERT INTO user_roles (user_id, role_name, assigned_by, assigned_at)
-        VALUES (%s, %s, %s, %s)
-        ON CONFLICT (user_id, role_name) DO UPDATE SET user_id = EXCLUDED.user_id
-        RETURNING id, assigned_by, assigned_at;
-    '''
     try:
-        result = postgres.execute_fetch_command(
-            insert_cmd, (user_id, request.role_name, assigned_by, now), True)
+        result = _insert_user_role(
+            postgres, user_id, request.role_name, assigned_by, now)
     except osmo_errors.OSMODatabaseError as err:
         raise osmo_errors.OSMOUserError(f'User {user_id} not found') from err
+
+    if not result:
+        raise osmo_errors.OSMOUserError(
+            f'Role {request.role_name} does not exist.')
 
     row = result[0]
     return objects.UserRoleAssignment(
@@ -885,15 +889,12 @@ def bulk_assign_role(
         if existing:
             already_assigned.append(user_id)
         else:
-            # Assign role
-            insert_cmd = '''
-                INSERT INTO user_roles (user_id, role_name, assigned_by, assigned_at)
-                VALUES (%s, %s, %s, %s)
-                ON CONFLICT (user_id, role_name) DO NOTHING;
-            '''
-            postgres.execute_commit_command(
-                insert_cmd, (user_id, role_name, assigned_by, now))
-            assigned.append(user_id)
+            result = _insert_user_role(
+                postgres, user_id, role_name, assigned_by, now)
+            if result:
+                assigned.append(user_id)
+            else:
+                raise osmo_errors.OSMOUserError(f'Role {role_name} does not exist.')
 
     return objects.BulkAssignResponse(
         role_name=role_name,

--- a/src/service/core/auth/auth_service.py
+++ b/src/service/core/auth/auth_service.py
@@ -458,11 +458,8 @@ def _get_user_role_names(postgres: connectors.PostgresConnector,
 
 
 def _validate_role_exists(postgres: connectors.PostgresConnector, role_name: str):
-    """Validate that a role exists in the database."""
-    fetch_cmd = 'SELECT 1 FROM roles WHERE name = %s;'
-    rows = postgres.execute_fetch_command(fetch_cmd, (role_name,), True)
-    if not rows:
-        raise osmo_errors.OSMOUserError(f'Role {role_name} does not exist')
+    """Validate that a role exists in the active config source."""
+    connectors.Role.fetch_from_db(postgres, role_name)
 
 
 def _validate_user_exists(postgres: connectors.PostgresConnector, user_id: str):

--- a/src/service/core/auth/auth_service.py
+++ b/src/service/core/auth/auth_service.py
@@ -655,7 +655,10 @@ def create_user(
     # Assign initial roles if provided
     if request.roles:
         for role_name in request.roles:
-            _insert_user_role(postgres, request.id, role_name, created_by, now)
+            assignment_result = _insert_user_role(
+                postgres, request.id, role_name, created_by, now)
+            if not assignment_result:
+                raise osmo_errors.OSMOUserError(f'Role {role_name} does not exist.')
 
     row = result[0]
     return objects.User(

--- a/src/service/core/auth/auth_service.py
+++ b/src/service/core/auth/auth_service.py
@@ -20,7 +20,7 @@ import logging
 import re
 import secrets
 import time
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import fastapi
 
@@ -464,7 +464,7 @@ def _validate_role_exists(postgres: connectors.PostgresConnector, role_name: str
 
 def _insert_user_role(postgres: connectors.PostgresConnector, user_id: str,
                       role_name: str, assigned_by: str,
-                      assigned_at: datetime.datetime) -> List[dict]:
+                      assigned_at: datetime.datetime) -> List[Dict[str, Any]]:
     if configmap_state.get_snapshot() is not None:
         _validate_role_exists(postgres, role_name)
         insert_cmd = '''

--- a/src/service/core/auth/tests/BUILD
+++ b/src/service/core/auth/tests/BUILD
@@ -35,6 +35,7 @@ osmo_py_test(
         "//src/service/core/auth:auth",
         "//src/service/core/tests:fixture",
         "//src/tests/common",
+        "//src/utils:configmap_state",
         "//src/utils/connectors",
     ],
     size = "large",

--- a/src/service/core/auth/tests/test_auth_service.py
+++ b/src/service/core/auth/tests/test_auth_service.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional
 
 from src.service.core.auth import objects
 from src.service.core.tests import fixture
-from src.utils import connectors
+from src.utils import configmap_state, connectors
 from src.tests.common import runner
 
 
@@ -32,6 +32,8 @@ class AuthServiceTestCase(fixture.ServiceTestFixture):
 
     def setUp(self):
         super().setUp()
+        configmap_state.set_configmap_mode(False)
+        configmap_state.set_parsed_configs(None)
         # Set default auth header to TEST_USER
         self.client.headers['x-osmo-user'] = self.TEST_USER
         # Clean up test users from previous tests to ensure isolation
@@ -41,6 +43,11 @@ class AuthServiceTestCase(fixture.ServiceTestFixture):
         self._create_test_role('osmo-admin', 'Admin role')
         self._create_test_role('osmo-ml-team', 'ML team role')
         self._create_test_role('osmo-dev-team', 'Dev team role')
+
+    def tearDown(self):
+        configmap_state.set_configmap_mode(False)
+        configmap_state.set_parsed_configs(None)
+        super().tearDown()
 
     def _cleanup_test_users(self):
         """Clean up test users to ensure test isolation."""
@@ -168,6 +175,29 @@ class AuthServiceTestCase(fixture.ServiceTestFixture):
         role_names = [r['role_name'] for r in user_details['roles']]
         self.assertIn('osmo-user', role_names)
         self.assertIn('osmo-ml-team', role_names)
+
+    def test_create_user_with_configmap_only_role(self):
+        postgres = connectors.PostgresConnector.get_instance()
+        postgres.execute_commit_command(
+            'DELETE FROM roles WHERE name = %s;', ('configmap-only-role',))
+        configmap_state.set_parsed_configs({
+            'roles': {
+                'configmap-only-role': {
+                    'description': 'ConfigMap-only role',
+                    'policies': [],
+                },
+            },
+        })
+        configmap_state.set_configmap_mode(True)
+
+        self._create_user(
+            'configmap-role-user@example.com', roles=['configmap-only-role'])
+
+        user_details = self._get_user('configmap-role-user@example.com')
+        self.assertEqual(
+            [role['role_name'] for role in user_details['roles']],
+            ['configmap-only-role'],
+        )
 
     def test_create_user_duplicate_fails(self):
         """Test that creating a duplicate user fails."""

--- a/src/service/core/auth/tests/test_auth_service.py
+++ b/src/service/core/auth/tests/test_auth_service.py
@@ -425,6 +425,29 @@ class AuthServiceTestCase(fixture.ServiceTestFixture):
         self.assertIn('osmo-user', token_roles)
         self.assertIn('osmo-ml-team', token_roles)
 
+    def test_delete_role_removes_assignments_and_access_token_grants(self):
+        self._create_user(self.TEST_USER, roles=['osmo-admin'])
+        self._create_access_token('deleted-role-token')
+        postgres = connectors.PostgresConnector.get_instance()
+
+        connectors.Role.delete_from_db(postgres, 'osmo-admin')
+
+        self.assertNotIn(
+            'osmo-admin',
+            [role['role_name'] for role in self._get_user(self.TEST_USER)['roles']])
+        self.assertNotIn(
+            'osmo-admin',
+            self._get_access_token_roles(self.TEST_USER, 'deleted-role-token'))
+
+        self._create_test_role('osmo-admin', 'Recreated admin role')
+
+        self.assertNotIn(
+            'osmo-admin',
+            [role['role_name'] for role in self._get_user(self.TEST_USER)['roles']])
+        self.assertNotIn(
+            'osmo-admin',
+            self._get_access_token_roles(self.TEST_USER, 'deleted-role-token'))
+
     def test_remove_role_cascades_to_multiple_access_tokens(self):
         """Test that removing a role cascades to all of user's access tokens."""
         self._create_user(self.TEST_USER, roles=['osmo-user', 'osmo-admin'])

--- a/src/service/core/auth/tests/test_auth_service.py
+++ b/src/service/core/auth/tests/test_auth_service.py
@@ -19,7 +19,9 @@ SPDX-License-Identifier: Apache-2.0
 # pylint: disable=protected-access
 
 import threading
+import time
 from typing import Any, Dict, List, Optional
+from unittest import mock
 
 from src.lib.utils import osmo_errors
 from src.service.core.auth import auth_service, objects
@@ -452,11 +454,50 @@ class AuthServiceTestCase(fixture.ServiceTestFixture):
             'osmo-admin',
             self._get_access_token_roles(self.TEST_USER, 'deleted-role-token'))
 
-    def test_assignment_waiting_on_role_deletion_cannot_create_orphan(self):
+    def test_role_deletion_waits_for_assignment_before_cleanup(self):
+        user_id = 'race@example.com'
+        self._create_user(user_id)
+        postgres = connectors.PostgresConnector.get_instance()
+        deletion_outcome: List[Any] = []
+
+        def delete_role():
+            try:
+                connectors.Role.delete_from_db(postgres, 'osmo-admin')
+            except Exception as error:  # pylint: disable=broad-except
+                deletion_outcome.append(error)
+
+        with postgres._get_connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                'SELECT name FROM roles WHERE name = %s FOR KEY SHARE;', ('osmo-admin',))
+            deletion_thread = threading.Thread(target=delete_role)
+            deletion_thread.start()
+            time.sleep(0.2)
+            self.assertTrue(deletion_thread.is_alive())
+
+            cursor.execute('''
+                INSERT INTO user_roles (user_id, role_name, assigned_by)
+                VALUES (%s, %s, %s);
+            ''', (user_id, 'osmo-admin', 'test'))
+            connection.commit()
+
+        deletion_thread.join(timeout=5)
+        self.assertFalse(deletion_thread.is_alive())
+        self.assertEqual(deletion_outcome, [])
+        rows = postgres.execute_fetch_command(
+            'SELECT 1 FROM user_roles WHERE role_name = %s;', ('osmo-admin',), True)
+        self.assertEqual(rows, [])
+
+    def test_assignment_waits_for_role_deletion(self):
         user_id = 'race@example.com'
         self._create_user(user_id)
         postgres = connectors.PostgresConnector.get_instance()
         assignment_outcome: List[Any] = []
+        delete_commands = postgres.execute_commit_commands
+
+        def delete_with_pause(commands):
+            commands.insert(1, ('SELECT pg_sleep(0.5);', ()))
+            return delete_commands(commands)
 
         def assign_role():
             try:
@@ -465,20 +506,19 @@ class AuthServiceTestCase(fixture.ServiceTestFixture):
             except Exception as error:  # pylint: disable=broad-except
                 assignment_outcome.append(error)
 
-        with postgres._get_connection() as connection:
-            cursor = connection.cursor()
-            cursor.execute(
-                'SELECT name FROM roles WHERE name = %s FOR UPDATE;', ('osmo-admin',))
+        with mock.patch.object(
+                postgres, 'execute_commit_commands', side_effect=delete_with_pause):
+            deletion_thread = threading.Thread(
+                target=connectors.Role.delete_from_db,
+                args=(postgres, 'osmo-admin'))
+            deletion_thread.start()
+            time.sleep(0.2)
             assignment_thread = threading.Thread(target=assign_role)
             assignment_thread.start()
-            assignment_thread.join(timeout=0.2)
-            self.assertTrue(assignment_thread.is_alive())
+            deletion_thread.join(timeout=5)
+            assignment_thread.join(timeout=5)
 
-            cursor.execute('DELETE FROM user_roles WHERE role_name = %s;', ('osmo-admin',))
-            cursor.execute('DELETE FROM roles WHERE name = %s;', ('osmo-admin',))
-            connection.commit()
-
-        assignment_thread.join(timeout=5)
+        self.assertFalse(deletion_thread.is_alive())
         self.assertFalse(assignment_thread.is_alive())
         self.assertEqual(len(assignment_outcome), 1)
         self.assertIsInstance(assignment_outcome[0], osmo_errors.OSMOUserError)

--- a/src/service/core/auth/tests/test_auth_service.py
+++ b/src/service/core/auth/tests/test_auth_service.py
@@ -16,9 +16,13 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+# pylint: disable=protected-access
+
+import threading
 from typing import Any, Dict, List, Optional
 
-from src.service.core.auth import objects
+from src.lib.utils import osmo_errors
+from src.service.core.auth import auth_service, objects
 from src.service.core.tests import fixture
 from src.utils import configmap_state, connectors
 from src.tests.common import runner
@@ -447,6 +451,40 @@ class AuthServiceTestCase(fixture.ServiceTestFixture):
         self.assertNotIn(
             'osmo-admin',
             self._get_access_token_roles(self.TEST_USER, 'deleted-role-token'))
+
+    def test_assignment_waiting_on_role_deletion_cannot_create_orphan(self):
+        user_id = 'race@example.com'
+        self._create_user(user_id)
+        postgres = connectors.PostgresConnector.get_instance()
+        assignment_outcome: List[Any] = []
+
+        def assign_role():
+            try:
+                assignment_outcome.append(auth_service.assign_role_to_user(
+                    user_id, objects.AssignRoleRequest(role_name='osmo-admin'), 'test'))
+            except Exception as error:  # pylint: disable=broad-except
+                assignment_outcome.append(error)
+
+        with postgres._get_connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                'SELECT name FROM roles WHERE name = %s FOR UPDATE;', ('osmo-admin',))
+            assignment_thread = threading.Thread(target=assign_role)
+            assignment_thread.start()
+            assignment_thread.join(timeout=0.2)
+            self.assertTrue(assignment_thread.is_alive())
+
+            cursor.execute('DELETE FROM user_roles WHERE role_name = %s;', ('osmo-admin',))
+            cursor.execute('DELETE FROM roles WHERE name = %s;', ('osmo-admin',))
+            connection.commit()
+
+        assignment_thread.join(timeout=5)
+        self.assertFalse(assignment_thread.is_alive())
+        self.assertEqual(len(assignment_outcome), 1)
+        self.assertIsInstance(assignment_outcome[0], osmo_errors.OSMOUserError)
+        rows = postgres.execute_fetch_command(
+            'SELECT 1 FROM user_roles WHERE role_name = %s;', ('osmo-admin',), True)
+        self.assertEqual(rows, [])
 
     def test_remove_role_cascades_to_multiple_access_tokens(self):
         """Test that removing a role cascades to all of user's access tokens."""

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -276,15 +276,22 @@ class ConfigMapWatcher:
         logging.info(
             'ConfigMap configs loaded from %s', self._config_file_path)
         if self._enable_reconciliation:
+            roles_reconciled = False
+            backends_reconciled = False
             try:
-                reconciled = _reconcile_backend_side_effects(
-                    reconciliation_baseline, managed_configs, self._postgres,
+                roles_reconciled = _reconcile_user_role_assignments(
+                    managed_configs, self._postgres)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.exception('ConfigMap user role reconciliation failed')
+            try:
+                backends_reconciled = _reconcile_backend_side_effects(
+                    reconciliation_baseline, managed_configs,
                     self._backend_queue_updater, self._backend_test_updater)
-                if reconciled:
-                    self._last_reconciled_snapshot = copy.deepcopy(managed_configs)
             except Exception:  # pylint: disable=broad-exception-caught
                 logging.exception(
                     'ConfigMap backend side-effect reconciliation failed')
+            if roles_reconciled and backends_reconciled:
+                self._last_reconciled_snapshot = copy.deepcopy(managed_configs)
         self._record_success()
 
         return LoadResult.SUCCESS
@@ -562,21 +569,10 @@ def _affected_backends_for_test_sync(
 def _reconcile_backend_side_effects(
     previous: Dict[str, Any] | None,
     current: Dict[str, Any],
-    postgres: connectors.PostgresConnector | None,
     backend_queue_updater: Callable[..., bool] | None,
     backend_test_updater: Callable[..., bool] | None,
 ) -> bool:
     """Queue backend sync jobs for ConfigMap-driven config changes."""
-    if postgres is None:
-        logging.warning(
-            'ConfigMap backend reconciliation enabled without Postgres')
-        return False
-
-    role_names = list(current.get('roles', {}))
-    postgres.execute_commit_command(
-        'DELETE FROM user_roles WHERE NOT (role_name = ANY(%s));',
-        (role_names,))
-
     if backend_queue_updater is None or backend_test_updater is None:
         logging.warning(
             'ConfigMap backend reconciliation enabled without enqueue callbacks')
@@ -671,6 +667,24 @@ def _reconcile_backend_side_effects(
                 backend_name)
 
     return success
+
+
+def _reconcile_user_role_assignments(
+    current: Dict[str, Any], postgres: connectors.PostgresConnector | None,
+) -> bool:
+    """Remove assignments for roles absent from the current ConfigMap."""
+    if postgres is None:
+        logging.warning(
+            'ConfigMap user role reconciliation enabled without Postgres')
+        return False
+
+    roles = current.get('roles')
+    role_names = [role_name for role_name in roles
+                  if isinstance(role_name, str)] if isinstance(roles, dict) else []
+    postgres.execute_commit_command(
+        'DELETE FROM user_roles WHERE NOT (role_name = ANY(%s::text[]));',
+        (role_names,))
+    return True
 
 
 def _resolve_backend_test_computed_fields(managed_configs: Dict[str, Any]) -> None:

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -278,7 +278,7 @@ class ConfigMapWatcher:
         if self._enable_reconciliation:
             try:
                 reconciled = _reconcile_backend_side_effects(
-                    reconciliation_baseline, managed_configs,
+                    reconciliation_baseline, managed_configs, self._postgres,
                     self._backend_queue_updater, self._backend_test_updater)
                 if reconciled:
                     self._last_reconciled_snapshot = copy.deepcopy(managed_configs)
@@ -562,10 +562,21 @@ def _affected_backends_for_test_sync(
 def _reconcile_backend_side_effects(
     previous: Dict[str, Any] | None,
     current: Dict[str, Any],
+    postgres: connectors.PostgresConnector | None,
     backend_queue_updater: Callable[..., bool] | None,
     backend_test_updater: Callable[..., bool] | None,
 ) -> bool:
     """Queue backend sync jobs for ConfigMap-driven config changes."""
+    if postgres is None:
+        logging.warning(
+            'ConfigMap backend reconciliation enabled without Postgres')
+        return False
+
+    role_names = list(current.get('roles', {}))
+    postgres.execute_commit_command(
+        'DELETE FROM user_roles WHERE NOT (role_name = ANY(%s));',
+        (role_names,))
+
     if backend_queue_updater is None or backend_test_updater is None:
         logging.warning(
             'ConfigMap backend reconciliation enabled without enqueue callbacks')

--- a/src/service/core/config/tests/test_configmap_loader_integration.py
+++ b/src/service/core/config/tests/test_configmap_loader_integration.py
@@ -266,6 +266,25 @@ class ConfigMapModeReadIntegrationTest(fixture.ServiceTestFixture):
         self.assertEqual(
             result, ['role-b', 'role-default', 'role-empty', 'role-null'])
 
+    def test_scalar_external_roles_uses_default_mapping_from_snapshot(self):
+        postgres = self._get_postgres()
+        self._activate_configmap_mode({
+            'roles': {
+                'role-scalar': {
+                    'description': 'Scalar mapping',
+                    'policies': [],
+                    'external_roles': 'external-scalar',
+                },
+            },
+        })
+
+        self.assertEqual(
+            connectors.Role.get_roles_by_external_roles(postgres, ['a']), [])
+        self.assertEqual(
+            connectors.Role.get_roles_by_external_roles(
+                postgres, ['role-scalar']),
+            ['role-scalar'])
+
     def test_backend_list_from_snapshot(self):
         """Backend.list_from_db returns backends from snapshot."""
         postgres = self._get_postgres()

--- a/src/service/core/config/tests/test_configmap_loader_integration.py
+++ b/src/service/core/config/tests/test_configmap_loader_integration.py
@@ -406,6 +406,18 @@ class ConfigMapModeReadIntegrationTest(fixture.ServiceTestFixture):
             INSERT INTO user_roles (user_id, role_name, assigned_by)
             VALUES (%s, %s, %s), (%s, %s, %s);
         ''', (user_id, 'current-role', 'test', user_id, 'stale-role', 'test'))
+        role_rows = postgres.execute_fetch_command(
+            'SELECT id, role_name FROM user_roles WHERE user_id = %s;',
+            (user_id,), True)
+        role_ids = {row['role_name']: row['id'] for row in role_rows}
+        postgres.execute_commit_command('''
+            INSERT INTO access_token (user_name, token_name, access_token)
+            VALUES (%s, %s, %s);
+            INSERT INTO access_token_roles (user_name, token_name, user_role_id, assigned_by)
+            VALUES (%s, %s, %s, %s), (%s, %s, %s, %s);
+        ''', (user_id, 'configmap-token', b'token',
+              user_id, 'configmap-token', role_ids['current-role'], 'test',
+              user_id, 'configmap-token', role_ids['stale-role'], 'test'))
         with tempfile.NamedTemporaryFile(
                 mode='w', suffix='.yaml', delete=False) as temp_file:
             yaml.dump(_with_service_auth({
@@ -423,6 +435,12 @@ class ConfigMapModeReadIntegrationTest(fixture.ServiceTestFixture):
             rows = postgres.execute_fetch_command(
                 'SELECT role_name FROM user_roles WHERE user_id = %s;',
                 (user_id,), True)
+            self.assertEqual([row['role_name'] for row in rows], ['current-role'])
+            rows = postgres.execute_fetch_command('''
+                SELECT ur.role_name FROM access_token_roles atr
+                JOIN user_roles ur ON ur.id = atr.user_role_id
+                WHERE atr.user_name = %s AND atr.token_name = %s;
+            ''', (user_id, 'configmap-token'), True)
             self.assertEqual([row['role_name'] for row in rows], ['current-role'])
 
             with open(temp_file.name, 'w', encoding='utf-8') as config_file:

--- a/src/service/core/config/tests/test_configmap_loader_integration.py
+++ b/src/service/core/config/tests/test_configmap_loader_integration.py
@@ -242,13 +242,29 @@ class ConfigMapModeReadIntegrationTest(fixture.ServiceTestFixture):
                     'policies': [],
                     'external_roles': ['external-b'],
                 },
+                'role-default': {
+                    'description': 'Default mapping',
+                    'policies': [],
+                },
+                'role-null': {
+                    'description': 'Null mapping',
+                    'policies': [],
+                    'external_roles': None,
+                },
+                'role-empty': {
+                    'description': 'Empty mapping',
+                    'policies': [],
+                    'external_roles': [],
+                },
             },
         })
 
         result = connectors.Role.get_roles_by_external_roles(
-            postgres, ['external-b'])
+            postgres, [
+                'external-b', 'role-default', 'role-null', 'role-empty'])
 
-        self.assertEqual(result, ['role-b'])
+        self.assertEqual(
+            result, ['role-b', 'role-default', 'role-empty', 'role-null'])
 
     def test_backend_list_from_snapshot(self):
         """Backend.list_from_db returns backends from snapshot."""

--- a/src/service/core/config/tests/test_configmap_loader_integration.py
+++ b/src/service/core/config/tests/test_configmap_loader_integration.py
@@ -228,6 +228,28 @@ class ConfigMapModeReadIntegrationTest(fixture.ServiceTestFixture):
         names = {r.name for r in result}
         self.assertEqual(names, {'role-a', 'role-b'})
 
+    def test_roles_by_external_roles_from_snapshot(self):
+        postgres = self._get_postgres()
+        self._activate_configmap_mode({
+            'roles': {
+                'role-a': {
+                    'description': 'A',
+                    'policies': [],
+                    'external_roles': ['external-a'],
+                },
+                'role-b': {
+                    'description': 'B',
+                    'policies': [],
+                    'external_roles': ['external-b'],
+                },
+            },
+        })
+
+        result = connectors.Role.get_roles_by_external_roles(
+            postgres, ['external-b'])
+
+        self.assertEqual(result, ['role-b'])
+
     def test_backend_list_from_snapshot(self):
         """Backend.list_from_db returns backends from snapshot."""
         postgres = self._get_postgres()

--- a/src/service/core/config/tests/test_configmap_loader_integration.py
+++ b/src/service/core/config/tests/test_configmap_loader_integration.py
@@ -396,6 +396,70 @@ class ConfigMapModeReadIntegrationTest(fixture.ServiceTestFixture):
         finally:
             os.unlink(temp_file.name)
 
+    def test_api_watcher_reconciles_user_roles_from_snapshot(self):
+        postgres = self._get_postgres()
+        user_id = 'configmap-roles@example.com'
+        postgres.execute_commit_command(
+            'INSERT INTO users (id, created_by) VALUES (%s, %s);',
+            (user_id, 'test'))
+        postgres.execute_commit_command('''
+            INSERT INTO user_roles (user_id, role_name, assigned_by)
+            VALUES (%s, %s, %s), (%s, %s, %s);
+        ''', (user_id, 'current-role', 'test', user_id, 'stale-role', 'test'))
+        with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.yaml', delete=False) as temp_file:
+            yaml.dump(_with_service_auth({
+                'roles': {
+                    'current-role': {'description': 'current', 'policies': []},
+                },
+            }), temp_file)
+        try:
+            watcher = configmap_loader.ConfigMapWatcher(
+                temp_file.name, postgres, enable_reconciliation=True,
+                backend_queue_updater=lambda *_args, **_kwargs: True,
+                backend_test_updater=lambda *_args, **_kwargs: True)
+            self.assertEqual(
+                watcher._load_and_apply(), configmap_loader.LoadResult.SUCCESS)
+            rows = postgres.execute_fetch_command(
+                'SELECT role_name FROM user_roles WHERE user_id = %s;',
+                (user_id,), True)
+            self.assertEqual([row['role_name'] for row in rows], ['current-role'])
+
+            with open(temp_file.name, 'w', encoding='utf-8') as config_file:
+                yaml.dump(_with_service_auth({'roles': {}}), config_file)
+            self.assertEqual(
+                watcher._load_and_apply(), configmap_loader.LoadResult.SUCCESS)
+            rows = postgres.execute_fetch_command(
+                'SELECT role_name FROM user_roles WHERE user_id = %s;',
+                (user_id,), True)
+            self.assertEqual(rows, [])
+        finally:
+            os.unlink(temp_file.name)
+
+    def test_non_api_watcher_does_not_reconcile_user_roles(self):
+        postgres = self._get_postgres()
+        user_id = 'non-api-configmap-roles@example.com'
+        postgres.execute_commit_command(
+            'INSERT INTO users (id, created_by) VALUES (%s, %s);',
+            (user_id, 'test'))
+        postgres.execute_commit_command('''
+            INSERT INTO user_roles (user_id, role_name, assigned_by)
+            VALUES (%s, %s, %s);
+        ''', (user_id, 'stale-role', 'test'))
+        with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.yaml', delete=False) as temp_file:
+            yaml.dump(_with_service_auth({'roles': {}}), temp_file)
+        try:
+            watcher = configmap_loader.ConfigMapWatcher(temp_file.name, postgres)
+            self.assertEqual(
+                watcher._load_and_apply(), configmap_loader.LoadResult.SUCCESS)
+            rows = postgres.execute_fetch_command(
+                'SELECT role_name FROM user_roles WHERE user_id = %s;',
+                (user_id,), True)
+            self.assertEqual([row['role_name'] for row in rows], ['stale-role'])
+        finally:
+            os.unlink(temp_file.name)
+
     def test_watcher_resolves_pool_parsed_fields(self):
         """ConfigMapWatcher resolves parsed_pod_template from references."""
         config = {

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -1910,6 +1910,22 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_user_role_reconcile_normalizes_invalid_role_keys(self):
+        postgres = mock.MagicMock()
+
+        self.assertTrue(configmap_loader._reconcile_user_role_assignments(
+            {'roles': {None: {}, 1: {}, 'current-role': {}}}, postgres))
+        self.assertTrue(configmap_loader._reconcile_user_role_assignments(
+            {'roles': None}, postgres))
+        self.assertTrue(configmap_loader._reconcile_user_role_assignments(
+            {}, postgres))
+
+        calls = postgres.execute_commit_command.call_args_list
+        self.assertEqual(calls[0].args[1], (['current-role'],))
+        self.assertEqual(calls[1].args[1], ([],))
+        self.assertEqual(calls[2].args[1], ([],))
+        self.assertIn('%s::text[]', calls[0].args[0])
+
     def test_api_reconcile_removed_backend_queues_cleanup(self):
         now = datetime.datetime.now(datetime.timezone.utc)
         old_snapshot: Dict[str, Any] = {

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -1885,6 +1885,31 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_api_user_role_reconcile_failure_retries_without_failing_reload(self):
+        path = self._write_config_file(_with_service_auth({
+            'roles': {
+                'current-role': {'description': 'current', 'policies': []},
+            },
+        }))
+        try:
+            postgres = _postgres_with_service_auth()
+            postgres.execute_commit_command.side_effect = [
+                RuntimeError('database unavailable'), None]
+            watcher = configmap_loader.ConfigMapWatcher(
+                path, postgres, enable_reconciliation=True,
+                backend_queue_updater=mock.MagicMock(return_value=True),
+                backend_test_updater=mock.MagicMock(return_value=True))
+
+            self.assertEqual(
+                watcher._load_and_apply(), configmap_loader.LoadResult.SUCCESS)
+            self.assertIsNone(watcher._last_reconciled_snapshot)
+            self.assertEqual(
+                watcher._load_and_apply(), configmap_loader.LoadResult.SUCCESS)
+            self.assertIsNotNone(watcher._last_reconciled_snapshot)
+            self.assertEqual(postgres.execute_commit_command.call_count, 2)
+        finally:
+            os.unlink(path)
+
     def test_api_reconcile_removed_backend_queues_cleanup(self):
         now = datetime.datetime.now(datetime.timezone.utc)
         old_snapshot: Dict[str, Any] = {

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -399,13 +399,8 @@ def setup_default_admin(postgres: connectors.PostgresConnector,
 
     # Assign the osmo-admin role if not already assigned
     now = common.current_time()
-    assign_role_cmd = '''
-        INSERT INTO user_roles (user_id, role_name, assigned_by, assigned_at)
-        VALUES (%s, %s, %s, %s)
-        ON CONFLICT (user_id, role_name) DO NOTHING;
-    '''
-    postgres.execute_commit_command(
-        assign_role_cmd, (admin_username, 'osmo-admin', 'System', now))
+    postgres.assign_user_role(
+        admin_username, 'osmo-admin', 'System', now)
 
     # Check if token already exists and compare hashed values
     check_token_cmd = '''

--- a/src/tests/common/database/testdata/schema.sql
+++ b/src/tests/common/database/testdata/schema.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS roles (
 CREATE TABLE IF NOT EXISTS user_roles (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    role_name TEXT NOT NULL REFERENCES roles(name) ON DELETE CASCADE,
+    role_name TEXT NOT NULL,
     assigned_by TEXT NOT NULL DEFAULT '',
     assigned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE (user_id, role_name)
@@ -65,4 +65,3 @@ CREATE TABLE IF NOT EXISTS workflows (
 
 CREATE INDEX IF NOT EXISTS workflow_labels_gin_idx
     ON workflows USING gin (labels jsonb_ops);
-

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -4631,7 +4631,8 @@ class Role(role.Role):
                 role_name
                 for role_name, role_data in snapshot.get('roles', {}).items()
                 if isinstance(role_data, dict)
-                and requested_roles.intersection(role_data.get('external_roles', []))
+                and requested_roles.intersection(
+                    role_data.get('external_roles') or [role_name])
             )
 
         fetch_cmd = '''

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -553,6 +553,46 @@ class PostgresConnector:
                 if cur is not None:
                     cur.close()
 
+    @retry
+    def assign_user_role(self, user_id: str, role_name: str, assigned_by: str,
+                         assigned_at: datetime.datetime) -> List[Dict[str, Any]]:
+        with self._get_connection() as conn:
+            cur = None
+            try:
+                cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+                cur.execute(
+                    'SELECT name FROM roles WHERE name = %s FOR KEY SHARE;',
+                    (role_name,))
+                if not cur.fetchone():
+                    conn.commit()
+                    return []
+
+                cur.execute('''
+                    INSERT INTO user_roles (user_id, role_name, assigned_by, assigned_at)
+                    VALUES (%s, %s, %s, %s)
+                    ON CONFLICT (user_id, role_name)
+                    DO UPDATE SET user_id = EXCLUDED.user_id
+                    RETURNING id, assigned_by, assigned_at;
+                ''', (user_id, role_name, assigned_by, assigned_at))
+                rows = cur.fetchall()
+                cur.close()
+                conn.commit()
+                return rows
+            except (psycopg2.DatabaseError, psycopg2.InterfaceError) as error:
+                try:
+                    if cur is not None:
+                        cur.close()
+                    conn.rollback()
+                except Exception:  # pylint: disable=broad-except
+                    pass
+                raise error
+            except Exception as error:  # pylint: disable=broad-except
+                raise osmo_errors.OSMODatabaseError(
+                    f'Error during assigning user role: {error}')
+            finally:
+                if cur is not None:
+                    cur.close()
+
     @retry(reconnect=False)
     def execute_autocommit_command(self, command: str, args: Tuple):
         """
@@ -4628,7 +4668,8 @@ class Role(role.Role):
         if snapshot is not None:
             requested_roles = set(external_roles)
 
-            def mapped_external_roles(role_name: str, role_data: Dict) -> List[str]:
+            def mapped_external_roles(role_name: str,
+                                      role_data: Dict[str, Any]) -> List[str]:
                 configured_roles = role_data.get('external_roles')
                 if isinstance(configured_roles, list) and configured_roles:
                     return configured_roles
@@ -4655,6 +4696,7 @@ class Role(role.Role):
         cls.fetch_from_db(database, name)
 
         database.execute_commit_commands([
+            ('SELECT name FROM roles WHERE name = %s FOR UPDATE;', (name,)),
             ('DELETE FROM user_roles WHERE role_name = %s;', (name,)),
             ('DELETE FROM roles WHERE name = %s;', (name,)),
         ])

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -1163,7 +1163,7 @@ class PostgresConnector:
             CREATE TABLE IF NOT EXISTS user_roles (
                 id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
                 user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-                role_name TEXT NOT NULL REFERENCES roles(name) ON DELETE CASCADE,
+                role_name TEXT NOT NULL,
                 assigned_by TEXT NOT NULL,
                 assigned_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
                 UNIQUE (user_id, role_name)
@@ -4623,6 +4623,16 @@ class Role(role.Role):
         """
         if not external_roles:
             return []
+
+        snapshot = configmap_state.get_snapshot()
+        if snapshot is not None:
+            requested_roles = set(external_roles)
+            return sorted(
+                role_name
+                for role_name, role_data in snapshot.get('roles', {}).items()
+                if isinstance(role_data, dict)
+                and requested_roles.intersection(role_data.get('external_roles', []))
+            )
 
         fetch_cmd = '''
             SELECT DISTINCT role_name FROM role_external_mappings

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -4627,12 +4627,19 @@ class Role(role.Role):
         snapshot = configmap_state.get_snapshot()
         if snapshot is not None:
             requested_roles = set(external_roles)
+
+            def mapped_external_roles(role_name: str, role_data: Dict) -> List[str]:
+                configured_roles = role_data.get('external_roles')
+                if isinstance(configured_roles, list) and configured_roles:
+                    return configured_roles
+                return [role_name]
+
             return sorted(
                 role_name
                 for role_name, role_data in snapshot.get('roles', {}).items()
                 if isinstance(role_data, dict)
                 and requested_roles.intersection(
-                    role_data.get('external_roles') or [role_name])
+                    mapped_external_roles(role_name, role_data))
             )
 
         fetch_cmd = '''
@@ -4647,10 +4654,10 @@ class Role(role.Role):
     def delete_from_db(cls, database: PostgresConnector, name: str):
         cls.fetch_from_db(database, name)
 
-        delete_cmd = '''
-            DELETE FROM roles WHERE name = %s;
-            '''
-        database.execute_commit_command(delete_cmd, (name,))
+        database.execute_commit_commands([
+            ('DELETE FROM user_roles WHERE role_name = %s;', (name,)),
+            ('DELETE FROM roles WHERE name = %s;', (name,)),
+        ])
 
     def insert_into_db(self, database: PostgresConnector, force: bool = False):
         """

--- a/src/utils/roles/user_role_sync.go
+++ b/src/utils/roles/user_role_sync.go
@@ -109,6 +109,22 @@ func syncAndReturnRoles(
 	userName string,
 	externalRoles []string,
 ) (*syncResult, error) {
+	tx, err := client.Pool().Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin sync transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	lockRows, err := tx.Query(ctx, `
+		SELECT name FROM roles WHERE sync_mode != $1 FOR KEY SHARE`, SyncModeIgnore)
+	if err != nil {
+		return nil, fmt.Errorf("lock sync roles: %w", err)
+	}
+	lockRows.Close()
+	if err := lockRows.Err(); err != nil {
+		return nil, fmt.Errorf("lock sync roles: %w", err)
+	}
+
 	// Each row comes back as (role_name, change_type) where change_type is
 	// 'added', 'removed', or 'existing'.
 	query := `
@@ -166,13 +182,11 @@ func syncAndReturnRoles(
 		  AND role_name NOT IN (SELECT role_name FROM inserted)
 		  AND role_name NOT IN (SELECT role_name FROM deleted)`
 
-	rows, err := client.Pool().Query(
+	rows, err := tx.Query(
 		ctx, query, userName, externalRoles, SyncModeIgnore, idpSyncAssigner)
 	if err != nil {
 		return nil, fmt.Errorf("exec sync query: %w", err)
 	}
-	defer rows.Close()
-
 	res := &syncResult{}
 	for rows.Next() {
 		var name, changeType string
@@ -189,5 +203,12 @@ func syncAndReturnRoles(
 			res.RoleNames = append(res.RoleNames, name)
 		}
 	}
-	return res, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	rows.Close()
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit sync transaction: %w", err)
+	}
+	return res, nil
 }

--- a/src/utils/roles/user_role_sync.go
+++ b/src/utils/roles/user_role_sync.go
@@ -101,34 +101,28 @@ type syncResult struct {
 //  3. Applies the inserts and deletes.
 //  4. Returns which roles were added, removed, and the final set.
 //
-// Because the entire operation is one statement, concurrent calls for the same
-// user serialise naturally via PostgreSQL row-level locks; no TOCTOU gap exists.
+// The locked CTE takes a KEY SHARE lock on roles eligible for insertion, so a
+// concurrent role deletion either removes the assignment or prevents its insert.
 func syncAndReturnRoles(
 	ctx context.Context,
 	client *postgres.PostgresClient,
 	userName string,
 	externalRoles []string,
 ) (*syncResult, error) {
-	tx, err := client.Pool().Begin(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("begin sync transaction: %w", err)
-	}
-	defer tx.Rollback(ctx)
-
-	lockRows, err := tx.Query(ctx, `
-		SELECT name FROM roles WHERE sync_mode != $1 FOR KEY SHARE`, SyncModeIgnore)
-	if err != nil {
-		return nil, fmt.Errorf("lock sync roles: %w", err)
-	}
-	lockRows.Close()
-	if err := lockRows.Err(); err != nil {
-		return nil, fmt.Errorf("lock sync roles: %w", err)
-	}
-
 	// Each row comes back as (role_name, change_type) where change_type is
 	// 'added', 'removed', or 'existing'.
 	query := `
-		WITH sync_info AS (
+		WITH locked AS (
+			SELECT r.name
+			FROM roles r
+			WHERE r.sync_mode != $3
+			  AND EXISTS (
+				  SELECT 1 FROM role_external_mappings rem
+				  WHERE rem.role_name = r.name AND rem.external_role = ANY($2)
+			  )
+			FOR KEY SHARE
+		),
+		sync_info AS (
 			SELECT
 				r.name,
 				r.sync_mode,
@@ -151,6 +145,7 @@ func syncAndReturnRoles(
 			WHERE si.in_header
 			  AND si.sync_mode IN ('import', 'force')
 			  AND si.name NOT IN (SELECT role_name FROM current_roles)
+			  AND si.name IN (SELECT name FROM locked)
 		),
 		to_remove AS (
 			SELECT si.name
@@ -182,7 +177,7 @@ func syncAndReturnRoles(
 		  AND role_name NOT IN (SELECT role_name FROM inserted)
 		  AND role_name NOT IN (SELECT role_name FROM deleted)`
 
-	rows, err := tx.Query(
+	rows, err := client.Pool().Query(
 		ctx, query, userName, externalRoles, SyncModeIgnore, idpSyncAssigner)
 	if err != nil {
 		return nil, fmt.Errorf("exec sync query: %w", err)
@@ -207,8 +202,5 @@ func syncAndReturnRoles(
 		return nil, err
 	}
 	rows.Close()
-	if err := tx.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("commit sync transaction: %w", err)
-	}
 	return res, nil
 }

--- a/src/utils/roles/user_role_sync_integration_test.go
+++ b/src/utils/roles/user_role_sync_integration_test.go
@@ -309,8 +309,8 @@ func TestSyncUserRoles_Integration_CanceledContext_UpsertError(t *testing.T) {
 func TestSyncUserRoles_Integration_SyncQueryError(t *testing.T) {
 	fixture := database.StartPostgresWithSchema(t)
 
-	// CASCADE also drops user_roles and role_external_mappings (both FK into
-	// roles), so syncAndReturnRoles' query references missing tables.
+	// CASCADE drops role_external_mappings, so syncAndReturnRoles' query
+	// references a missing table.
 	fixture.ExecSQL(t, `DROP TABLE roles CASCADE`)
 
 	result, err := roles.SyncUserRoles(context.Background(), fixture.Client,

--- a/src/utils/roles/user_role_sync_integration_test.go
+++ b/src/utils/roles/user_role_sync_integration_test.go
@@ -162,14 +162,6 @@ func TestSyncUserRoles_Integration_RoleDeletionPreventsOrphan(t *testing.T) {
 		t.Fatalf("lock role for deletion: %v", err)
 	}
 
-	done := make(chan error, 1)
-	go func() {
-		_, syncErr := roles.SyncUserRoles(context.Background(), fixture.Client,
-			"alice", []string{"idp-admins"}, silentLogger())
-		done <- syncErr
-	}()
-
-	time.Sleep(200 * time.Millisecond)
 	if _, err := tx.Exec(context.Background(),
 		`DELETE FROM role_external_mappings WHERE role_name = $1`, "osmo-admin"); err != nil {
 		t.Fatalf("delete role mappings: %v", err)
@@ -182,6 +174,19 @@ func TestSyncUserRoles_Integration_RoleDeletionPreventsOrphan(t *testing.T) {
 		`DELETE FROM roles WHERE name = $1`, "osmo-admin"); err != nil {
 		t.Fatalf("delete role: %v", err)
 	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, syncErr := roles.SyncUserRoles(context.Background(), fixture.Client,
+			"alice", []string{"idp-admins"}, silentLogger())
+		done <- syncErr
+	}()
+	select {
+	case syncErr := <-done:
+		t.Fatalf("sync completed before role deletion committed: %v", syncErr)
+	case <-time.After(200 * time.Millisecond):
+	}
+
 	if err := tx.Commit(context.Background()); err != nil {
 		t.Fatalf("commit deletion: %v", err)
 	}

--- a/src/utils/roles/user_role_sync_integration_test.go
+++ b/src/utils/roles/user_role_sync_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"go.corp.nvidia.com/osmo/tests/common/database"
 	"go.corp.nvidia.com/osmo/utils/roles"
@@ -143,6 +144,54 @@ func TestSyncUserRoles_Integration_ImportMode_AddsMappedRole(t *testing.T) {
 	if !containsString(stored, "osmo-admin") {
 		t.Errorf("expected user_roles to contain %q after sync, got: %v",
 			"osmo-admin", stored)
+	}
+}
+
+func TestSyncUserRoles_Integration_RoleDeletionPreventsOrphan(t *testing.T) {
+	fixture := database.StartPostgresWithSchema(t)
+	insertRoleWithSyncMode(t, fixture, "osmo-admin", roles.SyncModeImport)
+	insertRoleMapping(t, fixture, "osmo-admin", "idp-admins")
+
+	tx, err := fixture.Pool.Begin(context.Background())
+	if err != nil {
+		t.Fatalf("begin deletion transaction: %v", err)
+	}
+	defer tx.Rollback(context.Background())
+	if _, err := tx.Exec(context.Background(),
+		`SELECT name FROM roles WHERE name = $1 FOR UPDATE`, "osmo-admin"); err != nil {
+		t.Fatalf("lock role for deletion: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, syncErr := roles.SyncUserRoles(context.Background(), fixture.Client,
+			"alice", []string{"idp-admins"}, silentLogger())
+		done <- syncErr
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	if _, err := tx.Exec(context.Background(),
+		`DELETE FROM role_external_mappings WHERE role_name = $1`, "osmo-admin"); err != nil {
+		t.Fatalf("delete role mappings: %v", err)
+	}
+	if _, err := tx.Exec(context.Background(),
+		`DELETE FROM user_roles WHERE role_name = $1`, "osmo-admin"); err != nil {
+		t.Fatalf("delete role assignments: %v", err)
+	}
+	if _, err := tx.Exec(context.Background(),
+		`DELETE FROM roles WHERE name = $1`, "osmo-admin"); err != nil {
+		t.Fatalf("delete role: %v", err)
+	}
+	if err := tx.Commit(context.Background()); err != nil {
+		t.Fatalf("commit deletion: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("sync roles: %v", err)
+	}
+
+	stored := readUserRoleNames(t, fixture, "alice")
+	if containsString(stored, "osmo-admin") {
+		t.Errorf("orphan role assignment survived deletion: %v", stored)
 	}
 }
 


### PR DESCRIPTION
## Description
Use ConfigMap role definitions during service-account role validation and decouple runtime user-role assignments from database-backed role definitions. This allows ConfigMap-only roles to be assigned while retaining user and token lifecycle constraints.

- Revoke assigned user roles when their ConfigMap role is deleted.
- Serialize role assignment and deletion to prevent races.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roles defined in configuration can now be recognized when creating users, even when they are not stored in the database.
  * External role mappings support configuration-based role resolution, including default handling for simplified mappings.
* **Bug Fixes**
  * Improved role validation and lookup for configuration-managed roles.
  * Deleting a role now removes associated user assignments and access-token permissions.
  * Improved consistency during concurrent role assignment and deletion.
  * Configuration synchronization now retries failed role updates and avoids publishing incomplete state.
* **Tests**
  * Added coverage for configuration-based roles, external mappings, synchronization, and role deletion cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->