### PR TITLE
build: deduplicate progress check image dependencies

### DIFF
--- a/bzl/py.bzl
+++ b/bzl/py.bzl
@@ -115,18 +115,14 @@ def osmo_py_test(
         **kwargs
     )
 
-def osmo_python_wrapper(
+def _osmo_python_wrapper_script(
         name,
         bin_name,
         main,
         runfiles_dir,
-        package_dir = "/usr/bin",
         python_interpreter = "/usr/bin/python3"):
-
-    # Generate the wrapper script
-    wrapper_target = name + "_script"
     native.genrule(
-        name = wrapper_target,
+        name = name,
         outs = [bin_name],
         cmd = """
             cat > $@ << 'EOF'
@@ -166,11 +162,46 @@ EOF
         ),
     )
 
+    return name
+
+def osmo_python_wrapper(
+        name,
+        bin_name,
+        main,
+        runfiles_dir,
+        package_dir = "/usr/bin",
+        python_interpreter = "/usr/bin/python3",
+        include_progress_check = False):
+
+    wrapper_targets = [
+        _osmo_python_wrapper_script(
+            name = name + "_script",
+            bin_name = bin_name,
+            main = main,
+            runfiles_dir = runfiles_dir,
+            python_interpreter = python_interpreter,
+        ),
+    ]
+    if include_progress_check:
+        progress_check_bin_name = name + "_progress_check"
+        wrapper_targets.append(
+            _osmo_python_wrapper_script(
+                name = name + "_progress_check_script",
+                bin_name = progress_check_bin_name,
+                main = "/src/utils/progress_check/progress_check.py",
+                runfiles_dir = runfiles_dir,
+                python_interpreter = python_interpreter,
+            ),
+        )
+
     # Package the wrapper into a tarball
     pkg_tar(
         name = name,
         extension = "tgz",
-        srcs = [wrapper_target],
+        srcs = wrapper_targets,
         mode = "0755",
         package_dir = package_dir,
+        remap_paths = {
+            "/" + progress_check_bin_name: "/progress_check",
+        } if include_progress_check else {},
     )

--- a/bzl/tests/oci_image_contract_test.py
+++ b/bzl/tests/oci_image_contract_test.py
@@ -49,6 +49,29 @@ def _read_json_blob(layout: pathlib.Path, digest: str) -> dict[str, Any]:
     return json.loads((layout / "blobs" / algorithm / value).read_text())
 
 
+def _read_progress_check_contract(
+    layout: pathlib.Path,
+) -> tuple[set[str], bytes | None]:
+    index = json.loads((layout / "index.json").read_text())
+    manifest = _read_json_blob(layout, index["manifests"][0]["digest"])
+    member_names: set[str] = set()
+    progress_check_wrapper: bytes | None = None
+
+    for layer in manifest["layers"]:
+        algorithm, value = layer["digest"].split(":", maxsplit=1)
+        with tarfile.open(layout / "blobs" / algorithm / value, mode="r:*") as archive:
+            for member in archive.getmembers():
+                name = member.name.removeprefix("./").removeprefix("/")
+                member_names.add(name)
+                if name == "usr/bin/progress_check" and member.isfile():
+                    extracted = archive.extractfile(member)
+                    if extracted is None:
+                        raise ValueError("Could not read progress_check wrapper")
+                    progress_check_wrapper = extracted.read()
+
+    return member_names, progress_check_wrapper
+
+
 class OCIImageContractTest(unittest.TestCase):
     """Checks the command and process environment exposed to callers."""
 
@@ -97,6 +120,26 @@ class OCIImageContractTest(unittest.TestCase):
             self.assertIn(path, final_members)
             self.assertTrue(final_members[path].issym())
             self.assertEqual(final_members[path].linkname, target)
+
+    def test_progress_check_uses_service_runfiles(self) -> None:
+        member_names, progress_check_wrapper = _read_progress_check_contract(
+            pathlib.Path(sys.argv[1])
+        )
+
+        if progress_check_wrapper is None:
+            self.fail("Image does not contain /usr/bin/progress_check")
+        self.assertIn(
+            b"/src/service/router/router_binary.runfiles",
+            progress_check_wrapper,
+        )
+        self.assertIn(
+            "src/service/router/router_binary.runfiles/_main/"
+            "src/utils/progress_check/progress_check.py",
+            member_names,
+        )
+        self.assertFalse(
+            any("progress_check_binary.runfiles" in name for name in member_names)
+        )
 
 
 if __name__ == "__main__":

--- a/src/operator/BUILD
+++ b/src/operator/BUILD
@@ -69,6 +69,7 @@ osmo_python_wrapper(
     bin_name = "backend_listener",
     main = "/src/operator/backend_listener.py",
     runfiles_dir = "/src/operator/backend_listener_binary.runfiles",
+    include_progress_check = True,
 )
 
 filegroup(
@@ -89,7 +90,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_amd64",
     tars = [
         ":backend_listener_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -130,7 +130,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_arm64",
     tars = [
         ":backend_listener_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -203,6 +202,7 @@ osmo_python_wrapper(
     bin_name = "backend_worker",
     main = "/src/operator/backend_worker.py",
     runfiles_dir = "/src/operator/backend_worker_binary.runfiles",
+    include_progress_check = True,
 )
 
 filegroup(
@@ -223,7 +223,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_amd64",
     tars = [
         ":backend_worker_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -264,7 +263,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_arm64",
     tars = [
         ":backend_worker_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [

--- a/src/service/agent/BUILD
+++ b/src/service/agent/BUILD
@@ -60,6 +60,7 @@ osmo_python_wrapper(
     bin_name = "agent_service",
     main = "/src/service/agent/agent_service.py",
     runfiles_dir = "/src/service/agent/agent_service_binary.runfiles",
+    include_progress_check = True,
 )
 
 filegroup(
@@ -104,7 +105,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_amd64",
     tars = [
         ":agent_service_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -143,7 +143,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_arm64",
     tars = [
         ":agent_service_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [

--- a/src/service/core/BUILD
+++ b/src/service/core/BUILD
@@ -45,6 +45,7 @@ osmo_py_library(
         "//src/service/core/workflow",
         "//src/service/logger:ctrl_websocket",
         "//src/utils:ssl_init",
+        "//src/utils/progress_check:progress_check_lib",
     ],
     data = [
         "//src/lib/utils:version.yaml",
@@ -69,6 +70,7 @@ osmo_python_wrapper(
     bin_name = "service",
     main = "/src/service/core/service.py",
     runfiles_dir = "/src/service/core/service_binary.runfiles",
+    include_progress_check = True,
 )
 
 filegroup(
@@ -89,7 +91,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_amd64",
     tars = [
         ":service_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -130,7 +131,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_arm64",
     tars = [
         ":service_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [

--- a/src/service/delayed_job_monitor/BUILD
+++ b/src/service/delayed_job_monitor/BUILD
@@ -61,6 +61,7 @@ osmo_python_wrapper(
     bin_name = "delayed_job_monitor",
     main = "/src/service/delayed_job_monitor/delayed_job_monitor.py",
     runfiles_dir = "/src/service/delayed_job_monitor/delayed_job_monitor_binary.runfiles",
+    include_progress_check = True,
 )
 
 filegroup(
@@ -81,7 +82,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_amd64",
     tars = [
         ":delayed_job_monitor_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -120,7 +120,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_arm64",
     tars = [
         ":delayed_job_monitor_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [

--- a/src/service/logger/BUILD
+++ b/src/service/logger/BUILD
@@ -76,6 +76,7 @@ osmo_python_wrapper(
     bin_name = "logger",
     main = "/src/service/logger/logger.py",
     runfiles_dir = "/src/service/logger/logger_binary.runfiles",
+    include_progress_check = True,
 )
 
 filegroup(
@@ -96,7 +97,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_amd64",
     tars = [
         ":logger_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -135,7 +135,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_arm64",
     tars = [
         ":logger_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     target_compatible_with = [
         "@platforms//cpu:arm64",

--- a/src/service/router/BUILD
+++ b/src/service/router/BUILD
@@ -39,6 +39,7 @@ osmo_py_library(
         "//src/utils:ssl_config",
         "//src/utils:ssl_init",
         "//src/utils:static_config",
+        "//src/utils/progress_check:progress_check_lib",
     ],
     visibility = ["//visibility:public"],
 )
@@ -60,6 +61,7 @@ osmo_python_wrapper(
     bin_name = "router",
     main = "/src/service/router/router.py",
     runfiles_dir = "/src/service/router/router_binary.runfiles",
+    include_progress_check = True,
 )
 
 filegroup(
@@ -80,7 +82,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_amd64",
     tars = [
         ":router_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -119,7 +120,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_arm64",
     tars = [
         ":router_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [

--- a/src/service/worker/BUILD
+++ b/src/service/worker/BUILD
@@ -66,6 +66,7 @@ osmo_python_wrapper(
     bin_name = "worker",
     main = "/src/service/worker/worker.py",
     runfiles_dir = "/src/service/worker/worker_binary.runfiles",
+    include_progress_check = True,
 )
 
 filegroup(
@@ -86,7 +87,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_amd64",
     tars = [
         ":worker_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [
@@ -127,7 +127,6 @@ oci_image(
     base = "//src:osmo_docker_distroless_image_arm64",
     tars = [
         ":worker_image_layers",
-        "//src/utils/progress_check:progress_check_image_layers",
     ],
     visibility = ["//visibility:public"],
     target_compatible_with = [

--- a/src/utils/progress_check/BUILD
+++ b/src/utils/progress_check/BUILD
@@ -14,8 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-load("@aspect_rules_py//py:defs.bzl", "py_image_layer")
-load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_library", "osmo_python_wrapper")
+load("//bzl:py.bzl", "osmo_py_library")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_library(
@@ -28,37 +27,6 @@ osmo_py_library(
         requirement("pydantic"),
         requirement("aiofiles"),
         "//src/utils:static_config",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-osmo_py_binary(
-    name = "progress_check_binary",
-    srcs = ["progress_check.py"],
-    main = "progress_check.py",
-    deps = [
-        ":progress_check_lib",
-    ],
-)
-
-py_image_layer(
-    name = "progress_check_layer",
-    binary = ":progress_check_binary",
-)
-
-osmo_python_wrapper(
-    name = "progress_check_wrapper",
-    bin_name = "progress_check",
-    main = "/src/utils/progress_check/progress_check.py",
-    runfiles_dir = "/src/utils/progress_check/progress_check_binary.runfiles",
-)
-
-filegroup(
-    name = "progress_check_image_layers",
-    srcs = [
-        ":progress_check_layer_default",
-        ":progress_check_layer_packages",
-        ":progress_check_wrapper",
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Each Python service image separately packaged a `progress_check` binary, runfiles tree, and wheels that were already present in the main application, duplicating dependencies and OCI layers.

This change makes `progress_check_lib` part of each main binary's runfiles and generates `/usr/bin/progress_check` from that shared tree, removing the standalone binary and layers.

For the Core service image, this removes 3 layers and 449 duplicate runfiles paths, saving 3.69 MB compressed (3.39%) and 12.07 MB uncompressed (3.86%). Fresh-build actions dropped from 111 to 88

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Progress-check support is now bundled directly into service, worker, listener, agent, logger, and delayed-job-monitor images.
  - The progress-check executable is available at `/usr/bin/progress_check`.

- **Bug Fixes**
  - Progress checks now use the service’s bundled runtime files, improving reliability across supported image architectures.
  - Removed legacy progress-check paths and separate image layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
