### PR TITLE
Take the MCP token-verification JWKS URI from OIDC discovery

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -105,13 +105,10 @@ destination, but it cannot validate external DNS.
 | `services.mcp.extraVolumeMounts` | Additional MCP container volume mounts, including Vault-injected credential files. | `[]` |
 | `services.mcp.extraVolumes` | Additional MCP pod volumes. | `[]` |
 | `services.mcp.oidcProxy.enabled` | Enable FastMCP's built-in OIDC proxy inside the existing MCP process. It advertises CIMD and retains DCR as a compatibility fallback. | `false` |
-| `services.mcp.oidcProxy.scope` | Full delegated scope URI advertised to MCP clients and requested upstream, normally `<resourceUrl>/access_as_user`. | `""` |
-| `services.mcp.oidcProxy.trustedHttpsRedirectOrigins` | Exact HTTPS origins allowed for pre-registered web-client redirects; native clients use loopback redirects. | `[]` |
 | `services.mcp.oidcProxy.oidc.configUrl` | Upstream OIDC discovery URL. | `""` |
 | `services.mcp.oidcProxy.oidc.clientId` | Administrator-managed confidential OIDC application client ID. | `""` |
 | `services.mcp.oidcProxy.oidc.clientSecretFile` | Mounted file containing the upstream OIDC client secret. | `/etc/osmo/mcp-auth/client-secret` |
 | `services.mcp.oidcProxy.oidc.accessTokenIssuer` | Exact issuer required on upstream API access tokens. | `""` |
-| `services.mcp.oidcProxy.oidc.accessTokenAudience` | Exact OSMO MCP resource audience required on upstream API access tokens; must equal `resourceUrl`. | `""` |
 | `services.mcp.oidcProxy.oidc.accessTokenJwksUrl` | HTTPS JWKS URL used to verify upstream API access tokens. | `""` |
 | `services.mcp.oidcProxy.oidc.accessTokenRequiredScope` | Short scope value required in the upstream access token's `scp` claim. | `access_as_user` |
 | `services.mcp.oidcProxy.redis` | Redis connection used by FastMCP for registrations, authorization state, and encrypted upstream tokens; blank host/port inherit `services.redis`. | See `values.yaml` |
@@ -123,7 +120,7 @@ destination, but it cannot validate external DNS.
 The in-process proxy follows OSMO's OIDC profile: a full delegated scope URI is requested
 from the upstream provider while its short suffix is enforced in the verified
 API access token. Register the single stable upstream redirect URI
-`<resourceUrl origin>/auth/callback`. MCP clients still configure only `resourceUrl`.
+`<resourceUrl origin>/mcp/auth/callback`. MCP clients still configure only `resourceUrl`.
 CIMD-capable clients identify themselves with a hosted metadata document;
 older clients can use FastMCP's `/register` DCR endpoint. Both paths use
 authorization-code flow with PKCE and end in the same OSMO Gateway and semantic

--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -109,7 +109,6 @@ destination, but it cannot validate external DNS.
 | `services.mcp.oidcProxy.oidc.clientId` | Administrator-managed confidential OIDC application client ID. | `""` |
 | `services.mcp.oidcProxy.oidc.clientSecretFile` | Mounted file containing the upstream OIDC client secret. | `/etc/osmo/mcp-auth/client-secret` |
 | `services.mcp.oidcProxy.oidc.accessTokenIssuer` | Exact issuer required on upstream API access tokens. | `""` |
-| `services.mcp.oidcProxy.oidc.accessTokenJwksUrl` | HTTPS JWKS URL used to verify upstream API access tokens. | `""` |
 | `services.mcp.oidcProxy.oidc.accessTokenRequiredScope` | Short scope value required in the upstream access token's `scp` claim. | `access_as_user` |
 | `services.mcp.oidcProxy.redis` | Redis connection used by FastMCP for registrations, authorization state, and encrypted upstream tokens; blank host/port inherit `services.redis`. | See `values.yaml` |
 | `services.mcp.oidcProxy.accessTokenTtlSeconds` | Lifetime of proxy access tokens, from 60 through 3600 seconds. | `600` |

--- a/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
+++ b/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
@@ -27,7 +27,6 @@ services:
         configUrl: https://login.example.com/example-tenant/v2.0/.well-known/openid-configuration
         clientId: example-mcp-proxy-client
         accessTokenIssuer: https://sts.example.com/example-tenant/
-        accessTokenJwksUrl: https://login.example.com/example-tenant/discovery/v2.0/keys
         accessTokenRequiredScope: access_as_user
       redis:
         serviceName: proxy-redis.example.internal

--- a/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
+++ b/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
@@ -23,14 +23,10 @@ services:
     - http://localhost:6274
     oidcProxy:
       enabled: true
-      scope: https://osmo.example.com/mcp/access_as_user
-      trustedHttpsRedirectOrigins:
-      - https://trusted-client.example.com
       oidc:
         configUrl: https://login.example.com/example-tenant/v2.0/.well-known/openid-configuration
         clientId: example-mcp-proxy-client
         accessTokenIssuer: https://sts.example.com/example-tenant/
-        accessTokenAudience: https://osmo.example.com/mcp
         accessTokenJwksUrl: https://login.example.com/example-tenant/discovery/v2.0/keys
         accessTokenRequiredScope: access_as_user
       redis:

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -170,7 +170,6 @@ for expected in \
     'name: OSMO_MCP_AUTH_OIDC_CLIENT_ID' \
     'name: OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE' \
     'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER' \
-    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL' \
     'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE' \
     'name: OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS' \
     'secretName: mcp-oidc-proxy-secrets'; do

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -162,9 +162,7 @@ assert_env_value "$MCP_MANIFEST" OSMO_MCP_AUTH_ENABLED false
 assert_route_omits "$RENDERED_MANIFEST" osmo-mcp 'typed_per_filter_config:'
 
 for expected in \
-    'name: OSMO_MCP_AUTH_ISSUER_URL' \
     'name: OSMO_MCP_AUTH_RESOURCE_URL' \
-    'name: OSMO_MCP_AUTH_SCOPE' \
     'name: OSMO_MCP_AUTH_REDIS_URL' \
     'name: OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS' \
     'name: OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS' \
@@ -172,7 +170,6 @@ for expected in \
     'name: OSMO_MCP_AUTH_OIDC_CLIENT_ID' \
     'name: OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE' \
     'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER' \
-    'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE' \
     'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL' \
     'name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE' \
     'name: OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS' \
@@ -208,9 +205,7 @@ assert_route_contains "$PROXY_RENDERED_MANIFEST" mcp-health-not-public \
 assert_route_contains "$PROXY_RENDERED_MANIFEST" mcp-health-not-public \
   'envoy.filters.http.ext_authz:'
 assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_ENABLED true
-assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_ISSUER_URL https://osmo.example.com
 assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_RESOURCE_URL https://osmo.example.com/mcp
-assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_SCOPE https://osmo.example.com/mcp/access_as_user
 assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_REDIS_URL rediss://proxy-redis.example.internal:6380/14
 
 # FastMCP advertises its endpoints under /mcp; the gateway publishes that
@@ -316,16 +311,6 @@ expect_render_failure "$PROXY_VALUES_FILE" \
   --set 'services.mcp.oidcProxy.upstreamTimeoutSeconds=61'
 
 expect_render_failure "$PROXY_VALUES_FILE" \
-  'OIDC access-token audience mismatch' \
-  'services.mcp.oidcProxy.oidc.accessTokenAudience must equal services.mcp.resourceUrl' \
-  --set 'services.mcp.oidcProxy.oidc.accessTokenAudience=https://other.example.com/mcp'
-
-expect_render_failure "$PROXY_VALUES_FILE" \
-  'OIDC full scope mismatch' \
-  'services.mcp.oidcProxy.scope must equal services.mcp.resourceUrl followed by oidc.accessTokenRequiredScope' \
-  --set 'services.mcp.oidcProxy.scope=https://other.example.com/access_as_user'
-
-expect_render_failure "$PROXY_VALUES_FILE" \
   'relative OIDC client-secret path' \
   'services.mcp.oidcProxy.oidc.clientSecretFile must be an absolute path' \
   --set 'services.mcp.oidcProxy.oidc.clientSecretFile=client-secret'
@@ -346,13 +331,8 @@ expect_render_failure "$PROXY_VALUES_FILE" \
   --set 'services.mcp.oidcProxy.redis.passwordFile=/other/redis-password'
 
 expect_render_failure "$PROXY_VALUES_FILE" \
-  'untrusted redirect origin with a path' \
-  'trustedHttpsRedirectOrigins entries must be exact HTTPS origins' \
-  --set 'services.mcp.oidcProxy.trustedHttpsRedirectOrigins[0]=https://trusted.example.com/callback'
-
-expect_render_failure "$PROXY_VALUES_FILE" \
   'managed OIDC proxy issuer override' \
-  'services.mcp.extraEnv must not override managed variable OSMO_MCP_AUTH_ISSUER_URL' \
-  --set-json 'services.mcp.extraEnv=[{"name":"OSMO_MCP_AUTH_ISSUER_URL","value":"https://evil.example.com"}]'
+  'services.mcp.extraEnv must not override managed variable OSMO_MCP_AUTH_OIDC_CLIENT_ID' \
+  --set-json 'services.mcp.extraEnv=[{"name":"OSMO_MCP_AUTH_OIDC_CLIENT_ID","value":"evil-client"}]'
 
 echo 'MCP chart validation passed'

--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -29,7 +29,6 @@
 {{- $oidcClientId := "" }}
 {{- $oidcClientSecretFile := "" }}
 {{- $oidcAccessTokenIssuer := "" }}
-{{- $oidcAccessTokenJwksUrl := "" }}
 {{- $oidcAccessTokenRequiredScope := "" }}
 {{- $redisKeyPrefix := "" }}
 {{- $redisUrl := "" }}
@@ -41,7 +40,6 @@
 {{- $oidcClientId = required "services.mcp.oidcProxy.oidc.clientId is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientId }}
 {{- $oidcClientSecretFile = required "services.mcp.oidcProxy.oidc.clientSecretFile is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientSecretFile }}
 {{- $oidcAccessTokenIssuer = required "services.mcp.oidcProxy.oidc.accessTokenIssuer is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenIssuer }}
-{{- $oidcAccessTokenJwksUrl = required "services.mcp.oidcProxy.oidc.accessTokenJwksUrl is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenJwksUrl }}
 {{- $oidcAccessTokenRequiredScope = required "services.mcp.oidcProxy.oidc.accessTokenRequiredScope is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenRequiredScope }}
 {{- if not (regexMatch "^[A-Za-z0-9:._~-]{1,128}$" $oidcAccessTokenRequiredScope) }}
 {{- fail "services.mcp.oidcProxy.oidc.accessTokenRequiredScope must be one non-empty scope" }}
@@ -53,10 +51,7 @@
 {{- if not (regexMatch $oidcHttpsUrlPattern $oidcAccessTokenIssuer) }}
 {{- fail "services.mcp.oidcProxy.oidc.accessTokenIssuer must be an absolute HTTPS issuer without query or fragment" }}
 {{- end }}
-{{- if not (regexMatch $oidcHttpsUrlPattern $oidcAccessTokenJwksUrl) }}
-{{- fail "services.mcp.oidcProxy.oidc.accessTokenJwksUrl must be an absolute HTTPS URL without query or fragment" }}
-{{- end }}
-{{- range $name, $url := dict "configUrl" $oidcConfigUrl "accessTokenIssuer" $oidcAccessTokenIssuer "accessTokenJwksUrl" $oidcAccessTokenJwksUrl }}
+{{- range $name, $url := dict "configUrl" $oidcConfigUrl "accessTokenIssuer" $oidcAccessTokenIssuer }}
 {{- $portMatch := regexFind ":[0-9]+(/|$)" $url }}
 {{- if $portMatch }}
 {{- $urlPort := trimSuffix "/" (trimPrefix ":" $portMatch) | int }}
@@ -146,7 +141,6 @@
       "OSMO_MCP_AUTH_OIDC_CLIENT_ID"
       "OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE"
       "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER"
-      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL"
       "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE"
       "OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS"
       "OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS"
@@ -248,8 +242,6 @@ spec:
           value: {{ $oidcClientSecretFile | quote }}
         - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER
           value: {{ $oidcAccessTokenIssuer | quote }}
-        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL
-          value: {{ $oidcAccessTokenJwksUrl | quote }}
         - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE
           value: {{ $oidcAccessTokenRequiredScope | quote }}
         - name: OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS

--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -25,12 +25,10 @@
 {{- if not (regexMatch "^([1-9]|[1-5][0-9]|60)$" $requestTimeoutSeconds) }}
 {{- fail "services.mcp.requestTimeoutSeconds must be between 1 and 60" }}
 {{- end }}
-{{- $scope := "" }}
 {{- $oidcConfigUrl := "" }}
 {{- $oidcClientId := "" }}
 {{- $oidcClientSecretFile := "" }}
 {{- $oidcAccessTokenIssuer := "" }}
-{{- $oidcAccessTokenAudience := "" }}
 {{- $oidcAccessTokenJwksUrl := "" }}
 {{- $oidcAccessTokenRequiredScope := "" }}
 {{- $redisKeyPrefix := "" }}
@@ -39,40 +37,14 @@
 {{- if ne (int $mcp.replicas) 1 }}
 {{- fail "services.mcp.replicas must be 1 when services.mcp.oidcProxy.enabled=true" }}
 {{- end }}
-{{- if not (kindIs "slice" $oidcProxy.trustedHttpsRedirectOrigins) }}
-{{- fail "services.mcp.oidcProxy.trustedHttpsRedirectOrigins must be a list" }}
-{{- end }}
-{{- range $origin := $oidcProxy.trustedHttpsRedirectOrigins }}
-{{- if or (not (kindIs "string" $origin)) (not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?$" $origin)) }}
-{{- fail "services.mcp.oidcProxy.trustedHttpsRedirectOrigins entries must be exact HTTPS origins" }}
-{{- end }}
-{{- $originPortSuffix := regexFind ":[0-9]+$" $origin }}
-{{- if $originPortSuffix }}
-{{- $originPort := trimPrefix ":" $originPortSuffix | int }}
-{{- if or (lt $originPort 1) (gt $originPort 65535) }}
-{{- fail "services.mcp.oidcProxy.trustedHttpsRedirectOrigins ports must be between 1 and 65535" }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- $scope = required "services.mcp.oidcProxy.scope is required when the OIDC proxy is enabled" $oidcProxy.scope }}
 {{- $oidcConfigUrl = required "services.mcp.oidcProxy.oidc.configUrl is required when the OIDC proxy is enabled" $oidcProxy.oidc.configUrl }}
 {{- $oidcClientId = required "services.mcp.oidcProxy.oidc.clientId is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientId }}
 {{- $oidcClientSecretFile = required "services.mcp.oidcProxy.oidc.clientSecretFile is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientSecretFile }}
 {{- $oidcAccessTokenIssuer = required "services.mcp.oidcProxy.oidc.accessTokenIssuer is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenIssuer }}
-{{- $oidcAccessTokenAudience = required "services.mcp.oidcProxy.oidc.accessTokenAudience is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenAudience }}
 {{- $oidcAccessTokenJwksUrl = required "services.mcp.oidcProxy.oidc.accessTokenJwksUrl is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenJwksUrl }}
 {{- $oidcAccessTokenRequiredScope = required "services.mcp.oidcProxy.oidc.accessTokenRequiredScope is required when the OIDC proxy is enabled" $oidcProxy.oidc.accessTokenRequiredScope }}
 {{- if not (regexMatch "^[A-Za-z0-9:._~-]{1,128}$" $oidcAccessTokenRequiredScope) }}
 {{- fail "services.mcp.oidcProxy.oidc.accessTokenRequiredScope must be one non-empty scope" }}
-{{- end }}
-{{- if or (gt (len $oidcAccessTokenAudience) 2048) (not (regexMatch "^[^[:space:][:cntrl:]]+$" $oidcAccessTokenAudience)) }}
-{{- fail "services.mcp.oidcProxy.oidc.accessTokenAudience must be one non-empty value without whitespace or control characters" }}
-{{- end }}
-{{- if ne $oidcAccessTokenAudience $mcpResourceUrl }}
-{{- fail "services.mcp.oidcProxy.oidc.accessTokenAudience must equal services.mcp.resourceUrl" }}
-{{- end }}
-{{- if ne $scope (printf "%s/%s" $mcpResourceUrl $oidcAccessTokenRequiredScope) }}
-{{- fail "services.mcp.oidcProxy.scope must equal services.mcp.resourceUrl followed by oidc.accessTokenRequiredScope" }}
 {{- end }}
 {{- $oidcHttpsUrlPattern := "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?(/[A-Za-z0-9._~%!$&'()*+,;=:@/-]*)?$" }}
 {{- if not (regexMatch $oidcHttpsUrlPattern $oidcConfigUrl) }}
@@ -164,10 +136,7 @@
       "OSMO_MCP_REQUEST_TIMEOUT_SECONDS"
       "OSMO_MCP_ALLOWED_ORIGINS"
       "OSMO_MCP_AUTH_ENABLED"
-      "OSMO_MCP_AUTH_ISSUER_URL"
       "OSMO_MCP_AUTH_RESOURCE_URL"
-      "OSMO_MCP_AUTH_SCOPE"
-      "OSMO_MCP_AUTH_TRUSTED_HTTPS_REDIRECT_ORIGINS"
       "OSMO_MCP_AUTH_REDIS_URL"
       "OSMO_MCP_AUTH_REDIS_PASSWORD_FILE"
       "OSMO_MCP_AUTH_REDIS_KEY_PREFIX"
@@ -177,7 +146,6 @@
       "OSMO_MCP_AUTH_OIDC_CLIENT_ID"
       "OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE"
       "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER"
-      "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE"
       "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL"
       "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE"
       "OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS"
@@ -258,14 +226,8 @@ spec:
         - name: OSMO_MCP_AUTH_ENABLED
           value: {{ $oidcProxyEnabled | quote }}
         {{- if $oidcProxyEnabled }}
-        - name: OSMO_MCP_AUTH_ISSUER_URL
-          value: {{ $gatewayUrl | quote }}
         - name: OSMO_MCP_AUTH_RESOURCE_URL
           value: {{ $mcpResourceUrl | quote }}
-        - name: OSMO_MCP_AUTH_SCOPE
-          value: {{ $scope | quote }}
-        - name: OSMO_MCP_AUTH_TRUSTED_HTTPS_REDIRECT_ORIGINS
-          value: {{ join "," $oidcProxy.trustedHttpsRedirectOrigins | quote }}
         - name: OSMO_MCP_AUTH_REDIS_URL
           value: {{ $redisUrl | quote }}
         {{- if $oidcProxy.redis.passwordFile }}
@@ -286,8 +248,6 @@ spec:
           value: {{ $oidcClientSecretFile | quote }}
         - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER
           value: {{ $oidcAccessTokenIssuer | quote }}
-        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE
-          value: {{ $oidcAccessTokenAudience | quote }}
         - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL
           value: {{ $oidcAccessTokenJwksUrl | quote }}
         - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -176,25 +176,14 @@ services:
     oidcProxy:
       enabled: false
 
-      ## Full delegated scope URI advertised to MCP clients and requested from
-      ## the upstream provider, normally <resourceUrl>/access_as_user.
-      ##
-      scope: ""
-
-      ## Public HTTPS redirect origins allowed for pre-registered web clients.
-      ## Native clients use dynamically allocated loopback redirects.
-      ##
-      trustedHttpsRedirectOrigins: []
-
       ## Upstream OpenID Connect provider. Register the fixed redirect URL
-      ## <resourceUrl origin>/auth/callback on this confidential application.
+      ## <resourceUrl origin>/mcp/auth/callback on this confidential application.
       ##
       oidc:
         configUrl: ""
         clientId: ""
         clientSecretFile: /etc/osmo/mcp-auth/client-secret
         accessTokenIssuer: ""
-        accessTokenAudience: ""
         accessTokenJwksUrl: ""
         accessTokenRequiredScope: access_as_user
 

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -184,7 +184,6 @@ services:
         clientId: ""
         clientSecretFile: /etc/osmo/mcp-auth/client-secret
         accessTokenIssuer: ""
-        accessTokenJwksUrl: ""
         accessTokenRequiredScope: access_as_user
 
       ## Redis stores proxy registrations, authorization state, and encrypted

--- a/docs/deployment_guide/advanced_config/mcp.rst
+++ b/docs/deployment_guide/advanced_config/mcp.rst
@@ -86,6 +86,7 @@ Register the Upstream Application
 
 Configure one confidential application in the identity provider with:
 
+* An Application ID URI of exactly ``https://<osmo-host>/mcp``.
 * The exact redirect URL ``https://<osmo-host>/mcp/auth/callback``.
 * Authorization code flow and the ``client_secret_post`` token authentication
   method.
@@ -93,6 +94,19 @@ Configure one confidential application in the identity provider with:
   ``https://<osmo-host>/mcp/access_as_user``.
 * User or group assignments and administrator consent appropriate for the
   deployment.
+
+.. important::
+
+   The application is per host, not per deployment fleet. OSMO derives the
+   audience it validates from ``services.mcp.resourceUrl``, and that audience
+   must exist as an Application ID URI on the registered application, so
+   enabling MCP on a second host requires either a second application or an
+   additional Application ID URI on the existing one.
+
+   Prefer a separate application for a new environment. Editing
+   ``identifierUris`` or ``redirectUris`` on an application that other
+   environments already depend on can break sign-in for those environments;
+   check every consumer before changing a shared registration.
 
 ``access_as_user`` permits delegated MCP access as the signed-in user. It does
 not grant workflow, application, credential, or pool permissions; each tool's
@@ -112,8 +126,7 @@ compatibility before using another provider.
 
    Do not confuse the fixed upstream ``/mcp/auth/callback`` URL with a native MCP
    client's temporary localhost callback. FastMCP accepts native loopback
-   callbacks automatically. Browser-hosted clients require separately
-   configured HTTPS redirect origins.
+   callbacks automatically; only loopback client redirects are accepted.
 
 Provide Redis and Secrets
 -------------------------
@@ -167,13 +180,11 @@ to the deployment:
        resourceUrl: https://osmo.example.com/mcp
        oidcProxy:
          enabled: true
-         scope: https://osmo.example.com/mcp/access_as_user
          oidc:
            configUrl: https://idp.example.com/.well-known/openid-configuration
            clientId: <confidential-oidc-client-id>
            clientSecretFile: /etc/osmo/mcp-auth/client-secret
            accessTokenIssuer: https://issuer.example.com/
-           accessTokenAudience: https://osmo.example.com/mcp
            accessTokenJwksUrl: https://idp.example.com/jwks
            accessTokenRequiredScope: access_as_user
          redis:
@@ -192,13 +203,9 @@ while the proxy is enabled. Keep ``services.mcp.replicas`` at ``1`` because
 the current refresh lock is process-local and does not serialize refreshes
 across replicas.
 
-Native clients normally omit ``Origin`` and need neither of the following
-settings. For a browser-hosted MCP client, configure both concepts separately:
-
-* ``services.mcp.allowedOrigins`` controls which browser origins can call
-  ``/mcp`` through CORS.
-* ``services.mcp.oidcProxy.trustedHttpsRedirectOrigins`` controls which exact
-  HTTPS origins can receive OAuth callbacks for browser-hosted clients.
+Native clients normally omit ``Origin`` and need no extra configuration. For a
+browser-hosted MCP client, ``services.mcp.allowedOrigins`` controls which
+browser origins may call ``/mcp``.
 
 How the Proxy Flow Works
 ------------------------

--- a/docs/deployment_guide/advanced_config/mcp.rst
+++ b/docs/deployment_guide/advanced_config/mcp.rst
@@ -185,7 +185,6 @@ to the deployment:
            clientId: <confidential-oidc-client-id>
            clientSecretFile: /etc/osmo/mcp-auth/client-secret
            accessTokenIssuer: https://issuer.example.com/
-           accessTokenJwksUrl: https://idp.example.com/jwks
            accessTokenRequiredScope: access_as_user
          redis:
            dbNumber: 0

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -222,7 +222,6 @@ services:
         clientId: <oidc-application-client-id>
         clientSecretFile: /etc/osmo/mcp-auth/client-secret
         accessTokenIssuer: https://sts.windows.net/<tenant-id>/
-        accessTokenJwksUrl: https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys
         accessTokenRequiredScope: access_as_user
       redis:
         dbNumber: <dedicated-database-number>

--- a/src/service/mcp/README.md
+++ b/src/service/mcp/README.md
@@ -217,13 +217,11 @@ services:
     replicas: 1
     oidcProxy:
       enabled: true
-      scope: https://<osmo-host>/mcp/access_as_user
       oidc:
         configUrl: https://login.microsoftonline.com/<tenant-id>/v2.0/.well-known/openid-configuration
         clientId: <oidc-application-client-id>
         clientSecretFile: /etc/osmo/mcp-auth/client-secret
         accessTokenIssuer: https://sts.windows.net/<tenant-id>/
-        accessTokenAudience: https://<osmo-host>/mcp
         accessTokenJwksUrl: https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys
         accessTokenRequiredScope: access_as_user
       redis:

--- a/src/service/mcp/auth.py
+++ b/src/service/mcp/auth.py
@@ -24,7 +24,6 @@ from cryptography.fernet import Fernet
 from fastmcp.server.auth.jwt_issuer import derive_jwt_key
 from fastmcp.server.auth.oidc_proxy import OIDCProxy
 from fastmcp.server.auth.providers.jwt import JWTVerifier
-import httpx
 from key_value.aio.protocols import AsyncKeyValue
 from key_value.aio.stores.redis import RedisStore
 from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
@@ -33,13 +32,58 @@ import pydantic
 from redis import asyncio as redis_asyncio
 
 _UPSTREAM_OIDC_SCOPES = ('openid', 'profile', 'email', 'offline_access')
+
+
+class _OSMOOIDCProxy(OIDCProxy):
+    """OIDC proxy that verifies access tokens against a configured issuer.
+
+    An Entra resource application configured for v1 access tokens issues them
+    from ``https://sts.windows.net/<tenant>/`` even when its discovery document
+    advertises the v2.0 issuer, and no discovery document can express that. The
+    JWKS URI is still taken from discovery.
+    """
+
+    def __init__(
+        self,
+        *,
+        access_token_issuer: str,
+        access_token_audience: str,
+        **kwargs: object,
+    ) -> None:
+        self._access_token_issuer = access_token_issuer
+        self._access_token_audience = access_token_audience
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+
+    def get_token_verifier(  # pylint: disable=unused-argument
+        self,
+        *,
+        algorithm: str | None = None,
+        audience: str | None = None,
+        required_scopes: list[str] | None = None,
+        timeout_seconds: int | None = None,
+    ) -> JWTVerifier:
+        """Build the verifier, keeping the base signature FastMCP calls with.
+
+        ``audience`` and ``timeout_seconds`` are accepted to match the hook
+        FastMCP invokes but are not used: the audience comes from OSMO's own
+        configuration for the reason below, and JWTVerifier has no timeout.
+        """
+        # audience is deliberately not taken from the caller: OIDCProxy's own
+        # audience argument is forwarded to the provider's authorize and token
+        # endpoints (oidc_proxy.py:432-434), which Entra does not accept.
+        return JWTVerifier(
+            jwks_uri=str(self.oidc_config.jwks_uri),
+            issuer=self._access_token_issuer,
+            algorithm=algorithm,
+            audience=self._access_token_audience,
+            required_scopes=required_scopes,
+        )
 _REQUIRED_WHEN_AUTH_ENABLED = (
     'resource_url',
     'redis_url',
     'oidc_config_url',
     'oidc_client_id',
     'oidc_client_secret_file',
-    'oidc_access_token_jwks_url',
     'oidc_access_token_issuer',
 )
 
@@ -81,10 +125,6 @@ class MCPAuthConfig(pydantic.BaseModel):
     oidc_client_secret_file: str | None = pydantic.Field(
         default=None,
         json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE'},
-    )
-    oidc_access_token_jwks_url: str | None = pydantic.Field(
-        default=None,
-        json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_JWKS_URL'},
     )
     oidc_access_token_issuer: str | None = pydantic.Field(
         default=None,
@@ -146,9 +186,6 @@ class MCPAuthConfig(pydantic.BaseModel):
             raise ValueError('resource_url must end with /mcp')
         self.resource_url = resource
         self.oidc_config_url = _https_url(cast(str, self.oidc_config_url))
-        self.oidc_access_token_jwks_url = _https_url(
-            cast(str, self.oidc_access_token_jwks_url)
-        )
         self.oidc_access_token_issuer = _https_url(
             cast(str, self.oidc_access_token_issuer),
             preserve_trailing_slash=True,
@@ -181,13 +218,9 @@ class MCPAuthRuntime:
 
     provider: OIDCProxy
     redis_client: redis_asyncio.Redis
-    http_client: httpx.AsyncClient
 
     async def aclose(self) -> None:
-        try:
-            await self.http_client.aclose()
-        finally:
-            await self.redis_client.aclose()
+        await self.redis_client.aclose()
 
 
 def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
@@ -215,26 +248,16 @@ def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
         fernet=Fernet(_storage_encryption_key(client_secret)),
         raise_on_decryption_error=False,
     )
-    http_client = httpx.AsyncClient(
-        timeout=config.upstream_timeout_seconds,
-        follow_redirects=False,
-    )
     mcp_url = cast(str, config.resource_url)
-    verifier = JWTVerifier(
-        jwks_uri=cast(str, config.oidc_access_token_jwks_url),
-        issuer=cast(str, config.oidc_access_token_issuer),
-        audience=mcp_url,
-        algorithm='RS256',
-        required_scopes=[config.oidc_access_token_required_scope],
-        http_client=http_client,
-    )
     requested_scope = config.auth_scope
     upstream_scope = ' '.join((requested_scope, *_UPSTREAM_OIDC_SCOPES))
-    provider = OIDCProxy(
+    provider = _OSMOOIDCProxy(
         config_url=cast(str, config.oidc_config_url),
         client_id=cast(str, config.oidc_client_id),
         client_secret=client_secret,
-        token_verifier=verifier,
+        access_token_issuer=cast(str, config.oidc_access_token_issuer),
+        access_token_audience=mcp_url,
+        required_scopes=[config.oidc_access_token_required_scope],
         # FastMCP builds its operational OAuth endpoints from base_url and its
         # RFC 9728 resource identity from resource_base_url plus the MCP path.
         # Publishing base_url at the MCP URL therefore keeps authorize, token,
@@ -264,7 +287,7 @@ def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
     # Entra returns the short `scp` claim that the verifier enforces, while MCP
     # clients must discover and request the full API scope URI.
     provider.update_default_scopes([requested_scope])
-    return MCPAuthRuntime(provider, redis_client, http_client)
+    return MCPAuthRuntime(provider, redis_client)
 
 
 def _storage_encryption_key(client_secret: str) -> bytes:

--- a/src/service/mcp/auth.py
+++ b/src/service/mcp/auth.py
@@ -33,6 +33,15 @@ import pydantic
 from redis import asyncio as redis_asyncio
 
 _UPSTREAM_OIDC_SCOPES = ('openid', 'profile', 'email', 'offline_access')
+_REQUIRED_WHEN_AUTH_ENABLED = (
+    'resource_url',
+    'redis_url',
+    'oidc_config_url',
+    'oidc_client_id',
+    'oidc_client_secret_file',
+    'oidc_access_token_jwks_url',
+    'oidc_access_token_issuer',
+)
 
 
 class MCPAuthConfig(pydantic.BaseModel):
@@ -44,17 +53,9 @@ class MCPAuthConfig(pydantic.BaseModel):
         default=False,
         json_schema_extra={'env': 'OSMO_MCP_AUTH_ENABLED'},
     )
-    issuer_url: str | None = pydantic.Field(
-        default=None,
-        json_schema_extra={'env': 'OSMO_MCP_AUTH_ISSUER_URL'},
-    )
     resource_url: str | None = pydantic.Field(
         default=None,
         json_schema_extra={'env': 'OSMO_MCP_AUTH_RESOURCE_URL'},
-    )
-    auth_scope: str | None = pydantic.Field(
-        default=None,
-        json_schema_extra={'env': 'OSMO_MCP_AUTH_SCOPE'},
     )
     redis_url: str | None = pydantic.Field(
         default=None,
@@ -89,21 +90,11 @@ class MCPAuthConfig(pydantic.BaseModel):
         default=None,
         json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER'},
     )
-    oidc_access_token_audience: str | None = pydantic.Field(
-        default=None,
-        json_schema_extra={'env': 'OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_AUDIENCE'},
-    )
     oidc_access_token_required_scope: str = pydantic.Field(
         default='access_as_user',
         pattern=r'^[A-Za-z0-9:._~-]{1,128}$',
         json_schema_extra={
             'env': 'OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE',
-        },
-    )
-    trusted_https_redirect_origins: str = pydantic.Field(
-        default='',
-        json_schema_extra={
-            'env': 'OSMO_MCP_AUTH_TRUSTED_HTTPS_REDIRECT_ORIGINS',
         },
     )
     access_token_ttl_seconds: int = pydantic.Field(
@@ -141,41 +132,19 @@ class MCPAuthConfig(pydantic.BaseModel):
     def _validate_auth_config(self) -> 'MCPAuthConfig':
         if not self.auth_enabled:
             return self
-        required = {
-            name: getattr(self, name)
-            for name in (
-                'issuer_url',
-                'resource_url',
-                'auth_scope',
-                'redis_url',
-                'oidc_config_url',
-                'oidc_client_id',
-                'oidc_client_secret_file',
-                'oidc_access_token_jwks_url',
-                'oidc_access_token_issuer',
-                'oidc_access_token_audience',
-            )
-        }
-        missing = sorted(name for name, value in required.items() if not value)
+        missing = sorted(
+            name for name in _REQUIRED_WHEN_AUTH_ENABLED
+            if not getattr(self, name)
+        )
         if missing:
             raise ValueError(
                 'Enabled MCP auth is missing: ' + ', '.join(missing)
             )
 
-        issuer = _https_url(cast(str, self.issuer_url), root_only=True)
         resource = _https_url(cast(str, self.resource_url))
-        scope = _https_url(cast(str, self.auth_scope))
-        if resource != f'{issuer}/mcp':
-            raise ValueError('resource_url must be issuer_url followed by /mcp')
-        if scope != f'{resource}/{self.oidc_access_token_required_scope}':
-            raise ValueError(
-                'auth_scope must be resource_url followed by the token scope'
-            )
-        if self.oidc_access_token_audience != resource:
-            raise ValueError('oidc_access_token_audience must match resource_url')
-        self.issuer_url = issuer
+        if not resource.endswith('/mcp'):
+            raise ValueError('resource_url must end with /mcp')
         self.resource_url = resource
-        self.auth_scope = scope
         self.oidc_config_url = _https_url(cast(str, self.oidc_config_url))
         self.oidc_access_token_jwks_url = _https_url(
             cast(str, self.oidc_access_token_jwks_url)
@@ -189,26 +158,20 @@ class MCPAuthConfig(pydantic.BaseModel):
             raise ValueError('redis_url must be an absolute Redis URL')
         if redis_url.password is not None:
             raise ValueError('Redis password must be provided through its file')
-        for origin in self.trusted_redirect_origins:
-            if _https_url(origin, root_only=True) != origin:
-                raise ValueError('trusted redirect origins must be normalized')
         return self
 
     @property
-    def trusted_redirect_origins(self) -> tuple[str, ...]:
-        return tuple(
-            item.strip().rstrip('/')
-            for item in self.trusted_https_redirect_origins.split(',')
-            if item.strip()
-        )
+    def auth_scope(self) -> str:
+        """The delegated scope clients request for this resource."""
+        return f'{self.resource_url}/{self.oidc_access_token_required_scope}'
 
     @property
     def allowed_client_redirect_uris(self) -> list[str]:
+        """Native MCP clients redirect to a dynamically allocated loopback port."""
         return [
             'http://localhost:*',
             'http://127.0.0.1:*',
             'http://[::1]:*',
-            *self.trusted_redirect_origins,
         ]
 
 
@@ -256,16 +219,16 @@ def create_auth_runtime(config: MCPAuthConfig) -> MCPAuthRuntime:
         timeout=config.upstream_timeout_seconds,
         follow_redirects=False,
     )
+    mcp_url = cast(str, config.resource_url)
     verifier = JWTVerifier(
         jwks_uri=cast(str, config.oidc_access_token_jwks_url),
         issuer=cast(str, config.oidc_access_token_issuer),
-        audience=cast(str, config.oidc_access_token_audience),
+        audience=mcp_url,
         algorithm='RS256',
         required_scopes=[config.oidc_access_token_required_scope],
         http_client=http_client,
     )
-    mcp_url = cast(str, config.resource_url)
-    requested_scope = cast(str, config.auth_scope)
+    requested_scope = config.auth_scope
     upstream_scope = ' '.join((requested_scope, *_UPSTREAM_OIDC_SCOPES))
     provider = OIDCProxy(
         config_url=cast(str, config.oidc_config_url),
@@ -331,7 +294,6 @@ def _read_optional_secret(path: str | None) -> str | None:
 def _https_url(
     value: str,
     *,
-    root_only: bool = False,
     preserve_trailing_slash: bool = False,
 ) -> str:
     parsed = parse.urlsplit(value)
@@ -349,6 +311,4 @@ def _https_url(
     ):
         raise ValueError('OAuth URLs must be absolute HTTPS URLs')
     path = parsed.path if preserve_trailing_slash else parsed.path.rstrip('/')
-    if root_only and path:
-        raise ValueError('OAuth issuer and redirect origins must be origins')
     return parse.urlunsplit((parsed.scheme, parsed.netloc, path, '', ''))

--- a/src/service/mcp/tests/test_auth.py
+++ b/src/service/mcp/tests/test_auth.py
@@ -42,18 +42,34 @@ class MCPAuthConfigTest(unittest.TestCase):
         ):
             auth.MCPAuthConfig(auth_enabled=True)
 
+    def test_dependent_urls_derive_from_the_resource_url(self) -> None:
+        """Only the resource URL is supplied; the rest follow from it."""
+        config = auth.MCPAuthConfig(
+            auth_enabled=True,
+            resource_url='https://osmo.example/mcp',
+            redis_url='rediss://redis.example:6379/7',
+            oidc_config_url=(
+                'https://login.example/tenant/.well-known/openid-configuration'
+            ),
+            oidc_client_id='oidc-client',
+            oidc_client_secret_file='/secret',
+            oidc_access_token_jwks_url='https://sts.example/tenant/keys',
+            oidc_access_token_issuer='https://sts.example/tenant/',
+        )
+        self.assertEqual(
+            config.auth_scope, 'https://osmo.example/mcp/access_as_user')
+
     def test_enabled_auth_normalizes_and_validates_scope_contract(self) -> None:
         config = _config()
-        self.assertEqual(config.issuer_url, 'https://osmo.example')
         self.assertEqual(
             config.allowed_client_redirect_uris,
             ['http://localhost:*', 'http://127.0.0.1:*', 'http://[::1]:*'],
         )
         with self.assertRaisesRegex(
             pydantic.ValidationError,
-            'auth_scope must be',
+            'resource_url must end with /mcp',
         ):
-            _config(auth_scope='https://osmo.example/mcp/wrong')
+            _config(resource_url='https://osmo.example/not-mcp')
 
         service_config = server.MCPServiceConfig(
             gateway_url='https://gateway.example',
@@ -68,9 +84,14 @@ class MCPAuthConfigTest(unittest.TestCase):
             {'env': 'OSMO_MCP_AUTH_ENABLED'},
         )
         self.assertEqual(
-            auth.MCPAuthConfig.model_fields['auth_scope'].json_schema_extra,
-            {'env': 'OSMO_MCP_AUTH_SCOPE'},
+            auth.MCPAuthConfig.model_fields['resource_url'].json_schema_extra,
+            {'env': 'OSMO_MCP_AUTH_RESOURCE_URL'},
         )
+        # The derived values are no longer configuration inputs.
+        for derived in (
+            'issuer_url', 'auth_scope', 'oidc_access_token_audience',
+        ):
+            self.assertNotIn(derived, auth.MCPAuthConfig.model_fields)
 
 
 class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
@@ -338,9 +359,7 @@ class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
 def _config(**overrides: object) -> auth.MCPAuthConfig:
     values: dict[str, object] = {
         'auth_enabled': True,
-        'issuer_url': 'https://osmo.example/',
         'resource_url': 'https://osmo.example/mcp',
-        'auth_scope': 'https://osmo.example/mcp/access_as_user',
         'redis_url': 'rediss://redis.example:6379/7',
         'oidc_config_url': (
             'https://login.example/tenant/.well-known/openid-configuration'
@@ -349,7 +368,6 @@ def _config(**overrides: object) -> auth.MCPAuthConfig:
         'oidc_client_secret_file': '/secret',
         'oidc_access_token_jwks_url': 'https://sts.example/tenant/keys',
         'oidc_access_token_issuer': 'https://sts.example/tenant/',
-        'oidc_access_token_audience': 'https://osmo.example/mcp',
     }
     values.update(overrides)
     return auth.MCPAuthConfig(**values)

--- a/src/service/mcp/tests/test_auth.py
+++ b/src/service/mcp/tests/test_auth.py
@@ -23,6 +23,7 @@ import unittest
 from unittest import mock
 
 from fastmcp.server.auth.oidc_proxy import OIDCConfiguration, OIDCProxy
+from fastmcp.server.auth.providers.jwt import JWTVerifier
 from fastmcp.server.auth.oauth_proxy.models import UpstreamTokenSet
 import httpx
 from key_value.aio.stores.memory import MemoryStore
@@ -147,7 +148,9 @@ class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
 
             try:
                 provider = runtime.provider
-                self.assertIs(type(provider), OIDCProxy)
+                # The subclass exists only to keep the configured access-token
+                # issuer; everything else is stock OIDCProxy behaviour.
+                self.assertIsInstance(provider, OIDCProxy)
                 self.assertEqual(
                     provider._jwt_signing_key,  # pylint: disable=protected-access
                     auth.derive_jwt_key(
@@ -155,6 +158,16 @@ class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
                         salt='fastmcp-jwt-signing-key',
                     ),
                 )
+                # The JWKS URI comes from the discovery document; only the
+                # access-token issuer, which no discovery document can supply
+                # for an Entra v1 resource app, stays configured.
+                verifier = provider._token_validator  # pylint: disable=protected-access
+                assert isinstance(verifier, JWTVerifier)
+                self.assertEqual(
+                    verifier.jwks_uri,
+                    'https://login.example/tenant/discovery/v2.0/keys',
+                )
+                self.assertEqual(verifier.issuer, 'https://sts.example/tenant/')
                 self.assertEqual(provider.required_scopes, ['access_as_user'])
                 self.assertEqual(
                     provider._token_validator.required_scopes,  # pylint: disable=protected-access
@@ -315,22 +328,6 @@ class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
             finally:
                 await runtime.aclose()
             redis_client.aclose.assert_awaited_once()
-
-    async def test_close_releases_redis_when_http_close_fails(self) -> None:
-        provider = mock.create_autospec(OIDCProxy, instance=True)
-        redis_client = mock.create_autospec(
-            auth.redis_asyncio.Redis,
-            instance=True,
-        )
-        http_client = mock.create_autospec(httpx.AsyncClient, instance=True)
-        http_client.aclose.side_effect = RuntimeError('HTTP close failed')
-        runtime = auth.MCPAuthRuntime(provider, redis_client, http_client)
-
-        with self.assertRaisesRegex(RuntimeError, 'HTTP close failed'):
-            await runtime.aclose()
-
-        http_client.aclose.assert_awaited_once_with()
-        redis_client.aclose.assert_awaited_once_with()
 
     def test_storage_key_matches_fastmcp_default_and_is_deterministic(self) -> None:
         first = auth._storage_encryption_key(  # pylint: disable=protected-access


### PR DESCRIPTION
Stacked on #1329. Third of the MCP authentication simplification stack.

Issue #None

## Problem

Deployers supplied `accessTokenJwksUrl` — a value every OIDC discovery document publishes as `jwks_uri`, and which FastMCP already fetches at startup. OSMO hand-built a `JWTVerifier` purely to pin that URL, and carried a process-lifetime `httpx` client to serve it.

## Change

Let `OIDCProxy` build the verifier (`oidc_proxy.py:381-395`) and override only what discovery cannot supply. An Entra resource application configured for v1 access tokens issues them from `https://sts.windows.net/<tenant>/` even when its discovery document advertises the v2.0 issuer, so `accessTokenIssuer` stays configured — the JWKS URI now comes from discovery.

**Required OIDC-proxy values: 7 → 6.**

## One subtlety worth reviewer attention

The audience is applied *inside* the override rather than through `OIDCProxy`'s own `audience` argument. That argument is forwarded to the provider's authorize **and token** endpoints (`oidc_proxy.py:432-434`) — an Auth0-style parameter that Entra does not accept.

I got this wrong first. An existing assertion that no extra token parameters are sent caught it:

```
AssertionError: {'audience': 'https://osmo.example/mcp'} != {}
```

That test was written to prevent exactly this class of mistake, and it worked.

## Also removed

The `http_close_fails` test, which existed solely to verify the `try/finally` ordering between the httpx client and Redis — both the client and the ordering are gone.

## Verification

- `bazel test //src/service/mcp/...` — 72/72 pass, including a new assertion that the verifier's `jwks_uri` comes from the mocked discovery document while its `issuer` stays the configured one
- `render-tests.sh`, `validate-mcp-chart.sh` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
