### PR TITLE
Share OSMO's Redis for MCP proxy state and allow scaling out

### DIFF
--- a/deployments/charts/service/README.md
+++ b/deployments/charts/service/README.md
@@ -100,7 +100,7 @@ destination, but it cannot validate external DNS.
 | `services.mcp.scopes` | OAuth scopes advertised in direct-provider mode; ignored when `oidcProxy.enabled` is true. | `[]` |
 | `services.mcp.allowedOrigins` | Exact browser origins permitted on `/mcp`; native clients normally omit `Origin`. | `[]` |
 | `services.mcp.requestTimeoutSeconds` | Total timeout for each MCP-initiated Gateway request, from 1 through 60 seconds. | `10` |
-| `services.mcp.replicas` | Number of MCP replicas. Must remain `1` with `oidcProxy.enabled` because FastMCP 3.4.7 refresh serialization is process-local. | `1` |
+| `services.mcp.replicas` | Number of MCP replicas. The OIDC proxy keeps its state in Redis, so it scales out. | `1` |
 | `services.mcp.extraEnv` | Additional non-managed environment variables. It cannot override MCP host, port, Gateway origin, or request timeout. | `[]` |
 | `services.mcp.extraVolumeMounts` | Additional MCP container volume mounts, including Vault-injected credential files. | `[]` |
 | `services.mcp.extraVolumes` | Additional MCP pod volumes. | `[]` |
@@ -110,7 +110,7 @@ destination, but it cannot validate external DNS.
 | `services.mcp.oidcProxy.oidc.clientSecretFile` | Mounted file containing the upstream OIDC client secret. | `/etc/osmo/mcp-auth/client-secret` |
 | `services.mcp.oidcProxy.oidc.accessTokenIssuer` | Exact issuer required on upstream API access tokens. | `""` |
 | `services.mcp.oidcProxy.oidc.accessTokenRequiredScope` | Short scope value required in the upstream access token's `scp` claim. | `access_as_user` |
-| `services.mcp.oidcProxy.redis` | Redis connection used by FastMCP for registrations, authorization state, and encrypted upstream tokens; blank host/port inherit `services.redis`. | See `values.yaml` |
+| `services.mcp.oidcProxy.redis.dbNumber` | Logical Redis database for proxy state. Host, port and TLS come from `services.redis`. | `1` |
 | `services.mcp.oidcProxy.accessTokenTtlSeconds` | Lifetime of proxy access tokens, from 60 through 3600 seconds. | `600` |
 | `services.mcp.oidcProxy.refreshTokenTtlSeconds` | Lifetime of proxy refresh tokens, from 300 through 604800 seconds. | `28800` |
 | `services.mcp.oidcProxy.upstreamTimeoutSeconds` | Timeout for upstream OIDC requests, from 1 through 60 seconds. | `10` |

--- a/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
+++ b/deployments/charts/service/ci/mcp-oidc-proxy-values.yaml
@@ -29,10 +29,7 @@ services:
         accessTokenIssuer: https://sts.example.com/example-tenant/
         accessTokenRequiredScope: access_as_user
       redis:
-        serviceName: proxy-redis.example.internal
-        port: 6380
         dbNumber: 14
-        tlsEnabled: true
         passwordFile: /etc/osmo/mcp-auth/redis-password
         keyPrefix: test:mcp-auth
       existingSecret:

--- a/deployments/charts/service/ci/validate-mcp-chart.sh
+++ b/deployments/charts/service/ci/validate-mcp-chart.sh
@@ -205,7 +205,13 @@ assert_route_contains "$PROXY_RENDERED_MANIFEST" mcp-health-not-public \
   'envoy.filters.http.ext_authz:'
 assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_ENABLED true
 assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_RESOURCE_URL https://osmo.example.com/mcp
-assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_REDIS_URL rediss://proxy-redis.example.internal:6380/14
+assert_env_value "$PROXY_MCP_MANIFEST" OSMO_MCP_AUTH_REDIS_URL rediss://redis:6379/14
+
+# The proxy keeps all state in Redis, so scaling out must render.
+if ! helm template test-release "$CHART_DIR" -f "$PROXY_VALUES_FILE" \
+    --set 'services.mcp.replicas=2' >/dev/null 2>&1; then
+  fail "MCP OIDC proxy with two replicas failed to render"
+fi
 
 # FastMCP advertises its endpoints under /mcp; the gateway publishes that
 # prefix and rewrites it off before forwarding to the root paths the MCP SDK
@@ -253,16 +259,6 @@ expect_render_failure "$PROXY_VALUES_FILE" \
   'OIDC proxy without MCP' \
   'services.mcp.oidcProxy.enabled requires services.mcp.enabled=true' \
   --set 'services.mcp.enabled=false'
-
-expect_render_failure "$PROXY_VALUES_FILE" \
-  'OIDC proxy with multiple replicas' \
-  'services.mcp.replicas must be 1 when services.mcp.oidcProxy.enabled=true' \
-  --set 'services.mcp.replicas=2'
-
-expect_render_failure "$PROXY_VALUES_FILE" \
-  'invalid OIDC proxy Redis port' \
-  'services.mcp.oidcProxy.redis.port must be between 1 and 65535' \
-  --set 'services.mcp.oidcProxy.redis.port=0'
 
 expect_render_failure "$PROXY_VALUES_FILE" \
   'OIDC proxy Redis database below range' \

--- a/deployments/charts/service/templates/mcp-service.yaml
+++ b/deployments/charts/service/templates/mcp-service.yaml
@@ -33,9 +33,6 @@
 {{- $redisKeyPrefix := "" }}
 {{- $redisUrl := "" }}
 {{- if $oidcProxyEnabled }}
-{{- if ne (int $mcp.replicas) 1 }}
-{{- fail "services.mcp.replicas must be 1 when services.mcp.oidcProxy.enabled=true" }}
-{{- end }}
 {{- $oidcConfigUrl = required "services.mcp.oidcProxy.oidc.configUrl is required when the OIDC proxy is enabled" $oidcProxy.oidc.configUrl }}
 {{- $oidcClientId = required "services.mcp.oidcProxy.oidc.clientId is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientId }}
 {{- $oidcClientSecretFile = required "services.mcp.oidcProxy.oidc.clientSecretFile is required when the OIDC proxy is enabled" $oidcProxy.oidc.clientSecretFile }}
@@ -63,14 +60,8 @@
 {{- if not (hasPrefix "/" $oidcClientSecretFile) }}
 {{- fail "services.mcp.oidcProxy.oidc.clientSecretFile must be an absolute path" }}
 {{- end }}
-{{- $redisHost := $oidcProxy.redis.serviceName | default .Values.services.redis.serviceName | required "services.mcp.oidcProxy.redis.serviceName or services.redis.serviceName is required" }}
+{{- $redisHost := .Values.services.redis.serviceName | required "services.redis.serviceName is required when the MCP OIDC proxy is enabled" }}
 {{- $redisPort := .Values.services.redis.port }}
-{{- if not (kindIs "invalid" $oidcProxy.redis.port) }}
-{{- $redisPort = $oidcProxy.redis.port }}
-{{- end }}
-{{- if or (lt (int $redisPort) 1) (gt (int $redisPort) 65535) }}
-{{- fail "services.mcp.oidcProxy.redis.port must be between 1 and 65535" }}
-{{- end }}
 {{- if or (lt (int $oidcProxy.redis.dbNumber) 0) (gt (int $oidcProxy.redis.dbNumber) 15) }}
 {{- fail "services.mcp.oidcProxy.redis.dbNumber must be between 0 and 15" }}
 {{- end }}
@@ -113,7 +104,7 @@
 {{- fail "services.mcp.oidcProxy.existingSecret.redisPasswordKey is required when redis.passwordFile is configured" }}
 {{- end }}
 {{- end }}
-{{- $redisScheme := ternary "rediss" "redis" $oidcProxy.redis.tlsEnabled }}
+{{- $redisScheme := ternary "rediss" "redis" .Values.services.redis.tlsEnabled }}
 {{- $redisUrl = printf "%s://%s:%v/%v" $redisScheme $redisHost $redisPort $oidcProxy.redis.dbNumber }}
 {{- end }}
 {{- if not (kindIs "slice" $mcp.allowedOrigins) }}

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -120,8 +120,8 @@ services:
     ##
     enabled: false
 
-    ## Number of MCP replicas. Keep this at 1 while oidcProxy is enabled;
-    ## FastMCP 3.4.7 serializes refreshes within one process.
+    ## Number of MCP replicas. The OIDC proxy keeps all of its state in Redis,
+    ## so more than one replica is supported.
     ##
     replicas: 1
 
@@ -187,13 +187,12 @@ services:
         accessTokenRequiredScope: access_as_user
 
       ## Redis stores proxy registrations, authorization state, and encrypted
-      ## upstream tokens. Empty serviceName/port inherit services.redis.
+      ## upstream tokens. Host, port and TLS come from services.redis; only the
+      ## logical database is chosen here, so proxy state stays isolated from
+      ## OSMO's other Redis users.
       ##
       redis:
-        serviceName: ""
-        port: null
-        dbNumber: 0
-        tlsEnabled: true
+        dbNumber: 1
         passwordFile: ""
         keyPrefix: osmo:mcp-fastmcp
         connectTimeoutSeconds: 3


### PR DESCRIPTION
Stacked on #1330. Fourth of the MCP authentication simplification stack.

Issue #None

## Two fixes

**1. The single-replica rule was based on a misreading of FastMCP.**

The chart hard-failed on `replicas != 1` with the OIDC proxy enabled, citing process-local refresh serialization. FastMCP says the opposite:

> All state is stored in the configured `client_storage` backend (Redis, disk, etc.) **enabling horizontal scaling across multiple instances**
> — `oauth_proxy/proxy.py:212-213`

and `:1903-1912` handles the distributed refresh race explicitly ("another worker may have already refreshed and rotated the token"). The rule was also self-contradictory: sharing state through Redis only matters across replicas the chart forbade from existing.

**2. `oidcProxy.redis.tlsEnabled` did not inherit — and that one can CrashLoop the pod.**

`serviceName` and `port` already fell back to `services.redis`, but `tlsEnabled` did not. A deployment whose Redis requires TLS could satisfy every other OSMO service and still fail on MCP, with a connection error rather than a config error. All three now come from `services.redis`.

Only `dbNumber` stays MCP-local, which is its actual job — isolating proxy state from OSMO's other Redis users. Its default moves off `0` for the same reason.

## Test change

The negative test asserting the replica ban is replaced by a positive assertion that two replicas render. I negative-tested the replacement by reintroducing a ban and confirming the check fails:

```
MCP chart validation failed: MCP OIDC proxy with two replicas failed to render
```

## Verification

- `bazel test //src/service/mcp/...` — 72/72 pass
- `render-tests.sh`, `validate-mcp-chart.sh` — pass
- Rendered Redis URL inherits correctly: `rediss://redis:6379/14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
