### PR TITLE
Osmo umbrella chart quickstart profile

### DIFF
--- a/deployments/charts/BUILD
+++ b/deployments/charts/BUILD
@@ -44,3 +44,9 @@ sh_test(
     srcs = ["osmo/tests/test_mek_bootstrap.sh"],
     data = ["osmo/files/mek-bootstrap.sh"],
 )
+
+sh_test(
+    name = "osmo_object_storage_bootstrap_test",
+    srcs = ["osmo/tests/test_object_storage_bootstrap.sh"],
+    data = ["osmo/files/object-storage-bootstrap.sh"],
+)

--- a/deployments/charts/README.md
+++ b/deployments/charts/README.md
@@ -24,48 +24,32 @@ compute templates. The legacy `service` and standalone `backend-operator`
 charts remain available for existing deployments; neither is a dependency of
 the unified chart.
 
-## Local kind example
+## Quick start
 
-The development flow assumes KAI Scheduler is already installed. Install the
-CloudNativePG operator separately, then install one unified OSMO release:
+For an existing development cluster with KAI Scheduler, the CloudNativePG
+operator, and a default dynamic StorageClass, install the complete browser,
+CLI, API, and CPU workflow experience with one unified OSMO release:
 
 ```bash
-helm repo add cnpg https://cloudnative-pg.github.io/charts
-helm repo update cnpg
-helm --kube-context kind-osmo upgrade --install cnpg cnpg/cloudnative-pg \
-  --version 0.29.0 \
-  --namespace cnpg-system \
-  --create-namespace \
-  --wait \
-  --timeout 10m
-
 helm dependency build deployments/charts/osmo
 helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
   --namespace osmo \
   --create-namespace \
-  --values deployments/charts/osmo/profiles/kind-self-contained.yaml \
+  --values deployments/charts/osmo/profiles/quickstart.yaml \
   --set-string compute.backendName=default \
   --wait \
   --timeout 20m
 ```
 
-The profile deploys the control and compute planes, a CloudNativePG Cluster,
-Valkey, and RustFS. It generates retained development credentials, creates the
-workflow/log/app buckets, and connects the backend with no manual Secret copy.
-It is not a production identity or high-availability profile.
+The profile deploys the UI, gateway, control and compute planes, a CloudNativePG
+Cluster, persistent Valkey, and persistent RustFS. It generates development
+credentials, creates the workflow/log/app buckets, and connects the backend
+without a manual Secret copy. The UI and API are exposed through gateway
+NodePort `30080`.
 
-Forward the gateway and submit the repository smoke workflow:
-
-```bash
-kubectl --context kind-osmo --namespace osmo \
-  port-forward service/osmo-gateway 8080:80
-osmo login http://127.0.0.1:8080 --method=dev --username=testuser
-osmo workflow submit deployments/workflows/verify-hello.yaml --pool default
-```
-
-See [`osmo/README.md`](osmo/README.md) for readiness checks, workflow status,
-credential recovery, uninstall behavior, and the split-compute external URL and
-Secret interface.
+See the [`osmo` quick-start guide](osmo/README.md#quick-start) for prerequisite
+installation, browser and CLI access, a hello-world workflow, capacity,
+troubleshooting, cleanup, and the profile's non-production limitations.
 
 ## Production Shape
 

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -19,19 +19,54 @@ credentials without Vault agent injection. The standalone `backend-operator`
 chart remains available for existing two-chart installations, but it is not a
 dependency of this chart.
 
-## Minimal quick start
+## Quick start
 
-The `quickstart.yaml` profile is a development-only path to a complete OSMO
-control plane, compute plane, and CPU hello-world workflow. Before installation,
-KAI Scheduler and the CloudNativePG operator must be healthy, and the cluster
-must have a working default dynamic StorageClass. These prerequisites are not
-installed by the profile.
+The `quickstart.yaml` profile is a development-only path to trying the complete
+OSMO browser, CLI, API, and CPU workflow experience in one converged release.
+It installs:
 
-Install OSMO with the single quick-start values file:
+- the Envoy gateway and browser UI;
+- the API, worker, router, logger, agent, and delayed-job monitor;
+- the compute backend listener and worker;
+- persistent CloudNativePG, Valkey, and RustFS instances;
+- generated development credentials, object-storage buckets, configuration,
+  and a CPU-only default pool.
+
+### Prerequisites
+
+Use Kubernetes 1.30 or newer with enough capacity for the resources described
+below. The cluster must have a default dynamic StorageClass. Install Helm,
+`kubectl`, KAI Scheduler, and the CloudNativePG operator before OSMO. The
+examples use the `kind-osmo` context; replace it if your development cluster has
+a different context.
+
+```bash
+kubectl --context kind-osmo get storageclass
+
+helm --kube-context kind-osmo upgrade --install kai-scheduler \
+  https://github.com/NVIDIA/KAI-Scheduler/releases/download/v0.14.0/kai-scheduler-v0.14.0.tgz \
+  --namespace kai-scheduler \
+  --create-namespace \
+  --wait \
+  --timeout 10m
+
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update cnpg
+helm --kube-context kind-osmo upgrade --install cnpg cnpg/cloudnative-pg \
+  --version 0.29.0 \
+  --namespace cnpg-system \
+  --create-namespace \
+  --wait \
+  --timeout 10m
+```
+
+### Install OSMO
+
+Install the unified chart with the single quick-start values file:
 
 ```bash
 helm dependency build deployments/charts/osmo
-helm --kube-context kind-osmo install osmo deployments/charts/osmo \
+helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
   --namespace osmo \
   --create-namespace \
   --values deployments/charts/osmo/profiles/quickstart.yaml \
@@ -40,27 +75,75 @@ helm --kube-context kind-osmo install osmo deployments/charts/osmo \
   --timeout 20m
 ```
 
-Forward the gateway in one terminal:
+Inspect the release without reading generated Secret values:
+
+```bash
+kubectl --context kind-osmo --namespace osmo get pods,pvc,services,jobs
+kubectl --context kind-osmo --namespace osmo get service osmo-gateway
+```
+
+### Open the UI and use the CLI
+
+The gateway exposes the UI and API on NodePort `30080`. Set `OSMO_URL` from a
+reachable node address, then open the same URL in a browser:
+
+```bash
+export OSMO_NODE_ADDRESS="$(kubectl --context kind-osmo get nodes \
+  --output jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
+export OSMO_URL="http://${OSMO_NODE_ADDRESS}:30080"
+curl --fail "$OSMO_URL/api/version"
+```
+
+For a kind cluster whose `extraPortMappings` maps container port `30080` to
+host port `80`, use this URL instead:
+
+```bash
+export OSMO_URL=http://127.0.0.1
+```
+
+If the NodePort is not reachable from the workstation, run a port-forward in
+one terminal:
 
 ```bash
 kubectl --context kind-osmo --namespace osmo \
   port-forward service/osmo-gateway 8080:80
 ```
 
-In another terminal, verify the API, log in, and submit the canonical smoke
-workflow:
+Then select the forwarded URL in the terminal where you use the CLI:
 
 ```bash
-curl --fail http://127.0.0.1:8080/api/version
-osmo login http://127.0.0.1:8080 --method=dev --username=testuser
+export OSMO_URL=http://127.0.0.1:8080
+```
+
+Install the CLI if needed, log in with the development identity, and submit the
+canonical smoke workflow:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/install.sh | bash
+osmo login "$OSMO_URL" --method=dev --username=testuser
 osmo workflow submit deployments/workflows/verify-hello.yaml \
   --pool default \
   --format-type json
 osmo workflow query <workflow-id> --format-type json
 ```
 
-Repeat the query until the workflow status is `COMPLETED`. Clean up only the
-quick-start release and namespace:
+Repeat the query until the workflow status is `COMPLETED`.
+
+### Troubleshooting and cleanup
+
+If installation does not become ready, inspect pods, recent events, and the
+UI. A `Pending` database, Valkey, or RustFS PVC usually means the cluster has no
+working default StorageClass. A `Pending` workflow commonly means KAI is not
+healthy or the cluster lacks the workflow capacity described below.
+
+```bash
+kubectl --context kind-osmo --namespace osmo get pods,pvc,jobs
+kubectl --context kind-osmo --namespace osmo get events \
+  --sort-by=.lastTimestamp
+kubectl --context kind-osmo --namespace osmo logs deployment/osmo-ui
+```
+
+Clean up only the quick-start release and namespace:
 
 ```bash
 helm --kube-context kind-osmo uninstall osmo --namespace osmo --wait
@@ -69,24 +152,27 @@ kubectl --context kind-osmo delete namespace osmo \
   --timeout=10m
 ```
 
-The profile runs one replica of every required OSMO service, including the
-delayed-job monitor, and uses persistent volumes for PostgreSQL (1 GiB), Valkey
-(512 MiB), and RustFS (1 GiB). PostgreSQL requests 1 CPU and 2 GiB, while Valkey
-and RustFS each request 500 millicores and 1 GiB. The eight OSMO services request
-100 millicores and 256 MiB each, and the gateway requests 50 millicores and
-64 MiB. Those long-running pods reserve approximately 2.85 CPU and 6.1 GiB
+### Capacity and limitations
+
+The profile runs one replica of every required OSMO service, including the UI
+and delayed-job monitor, and uses persistent volumes for PostgreSQL (1 GiB),
+Valkey (512 MiB), and RustFS (1 GiB). PostgreSQL requests 1 CPU and 2 GiB, while
+Valkey and RustFS each request 500 millicores and 1 GiB. The nine OSMO services
+request 100 millicores and 256 MiB each, and the gateway requests 50 millicores
+and 64 MiB. Those long-running pods reserve approximately 2.95 CPU and 6.4 GiB
 before Kubernetes, KAI, and CloudNativePG operator overhead.
 
 The canonical hello-world pod additionally requests 1 CPU, 1 GiB of memory, and
 1 GiB of ephemeral storage for both its user container and its `osmo-ctrl`
 container. Ensure an eligible worker has at least 2 CPU, 2 GiB of memory, and
 2 GiB of ephemeral storage available for that workflow. The profile disables
-the UI, MCP, optional gateway authentication and rate limiting, TLS, ingress,
+MCP, optional gateway authentication and rate limiting, TLS, ingress,
 monitoring, autoscaling, disruption budgets, backups, and HA behavior.
 
-This profile uses development authentication and is not a production security or
-availability configuration. Use a production profile with managed credentials,
-TLS, authorization, backups, suitable resource sizing, and HA dependencies for
+This profile uses development authentication and exposes an administrator
+identity through a NodePort. It is not a production security or availability
+configuration. Use a production profile with managed credentials, TLS,
+authorization, backups, suitable resource sizing, and HA dependencies for
 long-lived environments.
 
 ## Full kind development profile

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -19,7 +19,69 @@ credentials without Vault agent injection. The standalone `backend-operator`
 chart remains available for existing two-chart installations, but it is not a
 dependency of this chart.
 
-## Self-contained kind quick start
+## Minimal quick start
+
+The `quickstart.yaml` profile is a development-only path to a complete OSMO
+control plane, compute plane, and CPU hello-world workflow. Before installation,
+KAI Scheduler and the CloudNativePG operator must be healthy, and the cluster
+must have a working default dynamic StorageClass. These prerequisites are not
+installed by the profile.
+
+Install OSMO with the single quick-start values file:
+
+```bash
+helm dependency build deployments/charts/osmo
+helm --kube-context kind-osmo install osmo deployments/charts/osmo \
+  --namespace osmo \
+  --create-namespace \
+  --values deployments/charts/osmo/profiles/quickstart.yaml \
+  --set-string compute.backendName=default \
+  --wait \
+  --timeout 20m
+```
+
+Forward the gateway in one terminal:
+
+```bash
+kubectl --context kind-osmo --namespace osmo \
+  port-forward service/osmo-gateway 8080:80
+```
+
+In another terminal, verify the API, log in, and submit the canonical smoke
+workflow:
+
+```bash
+curl --fail http://127.0.0.1:8080/api/version
+osmo login http://127.0.0.1:8080 --method=dev --username=testuser
+osmo workflow submit deployments/workflows/verify-hello.yaml \
+  --pool default \
+  --format-type json
+osmo workflow query <workflow-id> --format-type json
+```
+
+Repeat the query until the workflow status is `COMPLETED`. Clean up only the
+quick-start release and namespace:
+
+```bash
+helm --kube-context kind-osmo uninstall osmo --namespace osmo --wait
+kubectl --context kind-osmo delete namespace osmo \
+  --wait=true \
+  --timeout=10m
+```
+
+The profile runs one replica of every required OSMO service, including the
+delayed-job monitor, and uses persistent volumes for PostgreSQL (1 GiB), Valkey
+(512 MiB), and RustFS (1 GiB). OSMO service requests are generally 100 millicores
+and 256 MiB; the gateway requests 50 millicores and 64 MiB. It disables the UI,
+MCP, optional gateway authentication and rate limiting, TLS, ingress, monitoring,
+autoscaling, disruption budgets, backups, and HA behavior.
+
+This profile uses development authentication and is not a production security or
+availability configuration. Use a production profile with managed credentials,
+TLS, authorization, backups, suitable resource sizing, and HA dependencies for
+long-lived environments.
+
+## Full kind development profile
 
 The `kind-self-contained.yaml` profile is for development only. It expects an
 existing cluster with KAI Scheduler installed. CloudNativePG is intentionally a

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -71,10 +71,18 @@ kubectl --context kind-osmo delete namespace osmo \
 
 The profile runs one replica of every required OSMO service, including the
 delayed-job monitor, and uses persistent volumes for PostgreSQL (1 GiB), Valkey
-(512 MiB), and RustFS (1 GiB). OSMO service requests are generally 100 millicores
-and 256 MiB; the gateway requests 50 millicores and 64 MiB. It disables the UI,
-MCP, optional gateway authentication and rate limiting, TLS, ingress, monitoring,
-autoscaling, disruption budgets, backups, and HA behavior.
+(512 MiB), and RustFS (1 GiB). PostgreSQL requests 1 CPU and 2 GiB, while Valkey
+and RustFS each request 500 millicores and 1 GiB. The eight OSMO services request
+100 millicores and 256 MiB each, and the gateway requests 50 millicores and
+64 MiB. Those long-running pods reserve approximately 2.85 CPU and 6.1 GiB
+before Kubernetes, KAI, and CloudNativePG operator overhead.
+
+The canonical hello-world pod additionally requests 1 CPU, 1 GiB of memory, and
+1 GiB of ephemeral storage for both its user container and its `osmo-ctrl`
+container. Ensure an eligible worker has at least 2 CPU, 2 GiB of memory, and
+2 GiB of ephemeral storage available for that workflow. The profile disables
+the UI, MCP, optional gateway authentication and rate limiting, TLS, ingress,
+monitoring, autoscaling, disruption budgets, backups, and HA behavior.
 
 This profile uses development authentication and is not a production security or
 availability configuration. Use a production profile with managed credentials,

--- a/deployments/charts/osmo/files/object-storage-bootstrap.sh
+++ b/deployments/charts/osmo/files/object-storage-bootstrap.sh
@@ -36,7 +36,8 @@ s3 =
 EOF
 
 attempt=1
-while ! aws s3api list-buckets >/dev/null 2>&1; do
+while ! existing_buckets=$(aws s3api list-buckets \
+    --query 'Buckets[].Name' --output text 2>/dev/null); do
     if [ "$attempt" -ge "$attempts" ]; then
         echo "object storage endpoint was not ready after $attempts attempts" >&2
         exit 1
@@ -58,7 +59,14 @@ $bucket
     seen_buckets="${seen_buckets}${bucket}
 "
 
-    if aws s3api head-bucket --bucket "$bucket" >/dev/null 2>&1; then
+    bucket_exists=false
+    for existing_bucket in $existing_buckets; do
+        if [ "$existing_bucket" = "$bucket" ]; then
+            bucket_exists=true
+            break
+        fi
+    done
+    if [ "$bucket_exists" = true ]; then
         continue
     fi
     aws s3api create-bucket --bucket "$bucket"

--- a/deployments/charts/osmo/profiles/README.md
+++ b/deployments/charts/osmo/profiles/README.md
@@ -17,8 +17,9 @@ values take precedence.
 | `split-plane-compute.yaml` | Base overlay | A control-plane `externalUrl`, a compute authentication Secret, and `compute.backendName` set explicitly at install time |
 
 The quick-start profile is the smallest complete control-and-compute deployment
-for a CPU hello-world verification. It omits the UI and other optional services.
-The kind profile retains a broader local-development surface. Both profiles are
+for browser, CLI, and CPU hello-world verification. It exposes the UI and API
+through gateway NodePort `30080` while omitting other optional services. The kind
+profile retains a broader local-development surface. Both profiles are
 development-only and intentionally use `latest` OSMO images, one replica per
 component, generated credentials, and embedded stateful dependencies. The split
 profiles contain example names and endpoints; copy them into an environment

--- a/deployments/charts/osmo/profiles/README.md
+++ b/deployments/charts/osmo/profiles/README.md
@@ -11,14 +11,18 @@ values take precedence.
 
 | File | Directly installable | Required environment input |
 | --- | --- | --- |
+| `quickstart.yaml` | Yes, on a development cluster | KAI Scheduler, the CloudNativePG operator, and a default dynamic StorageClass installed separately; `compute.backendName` set explicitly at install time |
 | `kind-self-contained.yaml` | Yes, on kind | KAI Scheduler and the CloudNativePG operator installed separately; `compute.backendName` set explicitly at install time |
 | `split-plane-control.yaml` | Base overlay | PostgreSQL, Valkey, and object-storage endpoints; Kubernetes Secrets; and `externalUrl` |
 | `split-plane-compute.yaml` | Base overlay | A control-plane `externalUrl`, a compute authentication Secret, and `compute.backendName` set explicitly at install time |
 
-The kind profile is development-only and intentionally uses `latest` OSMO
-images, one replica per component, retained generated credentials, and embedded
-stateful dependencies. The split profiles contain example names and endpoints;
-copy them into an environment values file before installation.
+The quick-start profile is the smallest complete control-and-compute deployment
+for a CPU hello-world verification. It omits the UI and other optional services.
+The kind profile retains a broader local-development surface. Both profiles are
+development-only and intentionally use `latest` OSMO images, one replica per
+component, generated credentials, and embedded stateful dependencies. The split
+profiles contain example names and endpoints; copy them into an environment
+values file before installation.
 
 KAI Scheduler is a prerequisite for every profile that enables the compute
 plane. The unified chart does not install or manage KAI. CloudNativePG must also

--- a/deployments/charts/osmo/profiles/quickstart.yaml
+++ b/deployments/charts/osmo/profiles/quickstart.yaml
@@ -46,7 +46,20 @@ secrets:
 
 services:
   ui:
-    enabled: false
+    enabled: true
+    replicas: 1
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
   mcp:
     enabled: false
   api:
@@ -183,6 +196,9 @@ gateway:
       user: testuser
       roles: osmo-admin
       allowedPools: default
+    service:
+      type: NodePort
+      nodePort: 30080
     resources:
       requests:
         cpu: 50m
@@ -201,7 +217,7 @@ gateway:
     enabled: false
   upstreams:
     ui:
-      enabled: false
+      enabled: true
 
 monitoring:
   podMonitor:

--- a/deployments/charts/osmo/profiles/quickstart.yaml
+++ b/deployments/charts/osmo/profiles/quickstart.yaml
@@ -1,0 +1,286 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Development-only converged profile for the shortest path to a working OSMO
+# control plane, compute plane, and CPU workflow runtime.
+planes:
+  control:
+    enabled: true
+  compute:
+    enabled: true
+
+fullnameOverride: osmo
+
+imageTag: latest
+runtimeImage:
+  tag: latest
+
+externalUrl: http://osmo-gateway
+
+embeddedDependencies:
+  postgresql:
+    enabled: true
+  valkey:
+    enabled: true
+  objectStorage:
+    enabled: true
+
+secrets:
+  postgresql:
+    existingSecret: ''
+  valkey:
+    generate: true
+    existingSecret: ''
+  objectStorage:
+    generate: true
+    existingSecret: ''
+  backendApiTokens:
+    enabled: true
+    credentials:
+    - name: default
+      managedSecret:
+        name: osmo-backend-token
+  masterEncryptionKey:
+    generate: true
+    existingSecret: ''
+
+services:
+  ui:
+    enabled: false
+  mcp:
+    enabled: false
+  api:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
+  worker:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
+  router:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
+  logger:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  agent:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  delayedJobMonitor:
+    replicas: 1
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
+  backendListener:
+    replicas: 1
+    image:
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  backendWorker:
+    replicas: 1
+    image:
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  backendTestRunner:
+    enabled: false
+
+gateway:
+  envoy:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    defaultIdentity:
+      user: testuser
+      roles: osmo-admin
+      allowedPools: default
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
+  oauth2Proxy:
+    enabled: false
+  authz:
+    enabled: false
+  rateLimit:
+    enabled: false
+  tls:
+    enabled: false
+  upstreams:
+    ui:
+      enabled: false
+
+monitoring:
+  podMonitor:
+    control:
+      enabled: false
+    compute:
+      enabled: false
+
+configuration:
+  enabled: true
+  podTemplates:
+    # KAI treats even a zero-valued nvidia.com/gpu resource key as a GPU pod
+    # and injects the NVIDIA RuntimeClass. This CPU-only profile omits the key.
+    default_user:
+      spec:
+        containers:
+        - name: '{{USER_CONTAINER_NAME}}'
+          resources:
+            limits:
+              cpu: '{{USER_CPU}}'
+              memory: '{{USER_MEMORY}}'
+              ephemeral-storage: '{{USER_STORAGE}}'
+            requests:
+              cpu: '{{USER_CPU}}'
+              memory: '{{USER_MEMORY}}'
+              ephemeral-storage: '{{USER_STORAGE}}'
+    kind_dev_auth:
+      spec:
+        containers:
+        - name: '{{USER_CONTAINER_NAME}}'
+          env:
+          - name: OSMO_LOGIN_DEV
+            value: "true"
+        - name: osmo-ctrl
+          env:
+          - name: OSMO_LOGIN_DEV
+            value: "true"
+  pools:
+    default:
+      common_pod_template:
+      - default_ctrl
+      - default_user
+      - kind_dev_auth
+
+postgresql:
+  fullnameOverride: osmo-pg
+  cluster:
+    instances: 1
+    storage:
+      size: 1Gi
+    affinity:
+      podAntiAffinityType: ""
+    enablePDB: false
+    postgresql:
+      synchronous: null
+  backups:
+    enabled: false
+
+valkey:
+  fullnameOverride: osmo-valkey
+  dataStorage:
+    requestedSize: 512Mi
+  replica:
+    enabled: false
+    minReplicasToWrite: 0
+  podDisruptionBudget:
+    enabled: false
+
+rustfs:
+  fullnameOverride: osmo-rustfs
+  affinity:
+    podAntiAffinity:
+      enabled: false
+  storageclass:
+    dataStorageSize: 1Gi
+
+compute:
+  workloadNamespace: ''
+  backendTestNamespace: ''
+  authentication:
+    existingSecret: osmo-backend-token
+    tokenKey: token

--- a/deployments/charts/osmo/tests/test_object_storage_bootstrap.sh
+++ b/deployments/charts/osmo/tests/test_object_storage_bootstrap.sh
@@ -53,6 +53,9 @@ if [ "$1" = "s3api" ] && [ "$2" = "list-buckets" ]; then
     if [ "$attempts" -le "${AWS_FAKE_READINESS_FAILURES:-0}" ]; then
         exit 1
     fi
+    if [ -s "$FAKE_AWS_STATE/buckets" ]; then
+        paste -sd '\t' "$FAKE_AWS_STATE/buckets"
+    fi
     exit 0
 fi
 
@@ -122,18 +125,16 @@ fi
 
 run_bootstrap 2 3
 require_call_count "s3api list-buckets" 3
+require_call_count "s3api list-buckets --query Buckets[].Name --output text" 3
 require_file_contains "$FAKE_AWS_STATE/aws-config" "addressing_style = path"
-require_call_count "s3api head-bucket --bucket existing-workflows" 1
-require_call_count "s3api head-bucket --bucket missing-logs" 1
-require_call_count "s3api head-bucket --bucket missing-apps" 1
+require_call_count "s3api head-bucket" 0
 require_call_count "s3api create-bucket --bucket missing-logs" 1
 require_call_count "s3api create-bucket --bucket missing-apps" 1
 
 : >"$FAKE_AWS_STATE/calls"
 printf '%s\n' existing-workflows >"$FAKE_AWS_STATE/buckets"
 run_bootstrap 0 3 existing-workflows shared-bucket shared-bucket
-require_call_count "s3api head-bucket --bucket existing-workflows" 1
-require_call_count "s3api head-bucket --bucket shared-bucket" 1
+require_call_count "s3api head-bucket" 0
 require_call_count "s3api create-bucket --bucket shared-bucket" 1
 
 : >"$FAKE_AWS_STATE/calls"
@@ -141,9 +142,7 @@ printf '%s\n' existing-workflows >"$FAKE_AWS_STATE/buckets"
 printf '%s\n' missing-logs >>"$FAKE_AWS_STATE/buckets"
 printf '%s\n' missing-apps >>"$FAKE_AWS_STATE/buckets"
 run_bootstrap 0 3
-require_call_count "s3api head-bucket --bucket existing-workflows" 1
-require_call_count "s3api head-bucket --bucket missing-logs" 1
-require_call_count "s3api head-bucket --bucket missing-apps" 1
+require_call_count "s3api head-bucket" 0
 require_call_count "s3api create-bucket" 0
 
 : >"$FAKE_AWS_STATE/calls"

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -634,7 +634,7 @@ test_control_umbrella() {
         >"$TEST_DIRECTORY/quickstart.yaml"
     local quickstart_deployment
     for quickstart_deployment in \
-            api worker router logger agent delayed-job-monitor gateway-envoy \
+            ui api worker router logger agent delayed-job-monitor gateway-envoy \
             backend-listener backend-worker valkey rustfs; do
         require_deployment "$TEST_DIRECTORY/quickstart.yaml" \
             "osmo-$quickstart_deployment"
@@ -668,7 +668,17 @@ test_control_umbrella() {
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job "osmo-mek-bootstrap"
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
         "osmo-object-storage-bootstrap"
-    require_no_deployment "$TEST_DIRECTORY/quickstart.yaml" "osmo-ui"
+    resource_document "$TEST_DIRECTORY/quickstart.yaml" Service \
+        "osmo-gateway" >"$TEST_DIRECTORY/quickstart-gateway-service.yaml"
+    require_contains "$TEST_DIRECTORY/quickstart-gateway-service.yaml" \
+        "type: NodePort"
+    require_contains "$TEST_DIRECTORY/quickstart-gateway-service.yaml" \
+        "nodePort: 30080"
+    resource_document "$TEST_DIRECTORY/quickstart.yaml" ConfigMap \
+        "osmo-gateway-envoy-config" \
+        >"$TEST_DIRECTORY/quickstart-gateway-config.yaml"
+    require_contains "$TEST_DIRECTORY/quickstart-gateway-config.yaml" \
+        "cluster: osmo-ui"
     require_no_deployment "$TEST_DIRECTORY/quickstart.yaml" "osmo-mcp"
     require_no_deployment "$TEST_DIRECTORY/quickstart.yaml" \
         "osmo-gateway-oauth2-proxy"
@@ -709,7 +719,7 @@ test_control_umbrella() {
     require_contains "$charts_copy/osmo/README.md" \
         "deployments/charts/osmo/profiles/quickstart.yaml"
     require_contains "$charts_copy/osmo/README.md" \
-        "helm --kube-context kind-osmo install osmo"
+        "helm --kube-context kind-osmo upgrade --install osmo"
     require_contains "$charts_copy/osmo/README.md" \
         "kubectl --context kind-osmo"
     require_contains "$charts_copy/osmo/README.md" \
@@ -717,7 +727,7 @@ test_control_umbrella() {
     require_contains "$charts_copy/osmo/README.md" \
         "PostgreSQL requests 1 CPU and 2 GiB"
     require_contains "$charts_copy/osmo/README.md" \
-        "approximately 2.85 CPU and 6.1 GiB"
+        "approximately 2.95 CPU and 6.4 GiB"
 
     if helm_template_with_backend mismatched-converged-backend-token "$charts_copy/osmo" \
             --namespace osmo \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -649,8 +649,20 @@ test_control_umbrella() {
             "topologySpreadConstraints:"
     done
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Cluster "osmo-pg"
+    resource_document "$TEST_DIRECTORY/quickstart.yaml" Cluster "osmo-pg" \
+        >"$TEST_DIRECTORY/quickstart-postgresql.yaml"
+    require_contains "$TEST_DIRECTORY/quickstart-postgresql.yaml" "instances: 1"
+    require_contains "$TEST_DIRECTORY/quickstart-postgresql.yaml" "size: 1Gi"
     require_resource "$TEST_DIRECTORY/quickstart.yaml" PersistentVolumeClaim \
         "osmo-valkey"
+    resource_document "$TEST_DIRECTORY/quickstart.yaml" PersistentVolumeClaim \
+        "osmo-valkey" >"$TEST_DIRECTORY/quickstart-valkey-pvc.yaml"
+    require_contains "$TEST_DIRECTORY/quickstart-valkey-pvc.yaml" "storage: 512Mi"
+    require_resource "$TEST_DIRECTORY/quickstart.yaml" PersistentVolumeClaim \
+        "osmo-rustfs-data"
+    resource_document "$TEST_DIRECTORY/quickstart.yaml" PersistentVolumeClaim \
+        "osmo-rustfs-data" >"$TEST_DIRECTORY/quickstart-rustfs-pvc.yaml"
+    require_contains "$TEST_DIRECTORY/quickstart-rustfs-pvc.yaml" "storage: 1Gi"
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
         "osmo-backend-token-bootstrap"
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job "osmo-mek-bootstrap"
@@ -702,6 +714,10 @@ test_control_umbrella() {
         "kubectl --context kind-osmo"
     require_contains "$charts_copy/osmo/README.md" \
         "deployments/workflows/verify-hello.yaml"
+    require_contains "$charts_copy/osmo/README.md" \
+        "PostgreSQL requests 1 CPU and 2 GiB"
+    require_contains "$charts_copy/osmo/README.md" \
+        "approximately 2.85 CPU and 6.1 GiB"
 
     if helm_template_with_backend mismatched-converged-backend-token "$charts_copy/osmo" \
             --namespace osmo \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -627,6 +627,71 @@ test_control_umbrella() {
     require_not_contains "$TEST_DIRECTORY/kind-self-contained-ui.yaml" \
         "scheme: HTTPS"
 
+    helm_template_with_backend quick-start "$charts_copy/osmo" \
+        --namespace osmo \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$charts_copy/osmo/profiles/quickstart.yaml" \
+        >"$TEST_DIRECTORY/quickstart.yaml"
+    local quickstart_deployment
+    for quickstart_deployment in \
+            api worker router logger agent delayed-job-monitor gateway-envoy \
+            backend-listener backend-worker valkey rustfs; do
+        require_deployment "$TEST_DIRECTORY/quickstart.yaml" \
+            "osmo-$quickstart_deployment"
+        resource_document "$TEST_DIRECTORY/quickstart.yaml" Deployment \
+            "osmo-$quickstart_deployment" \
+            >"$TEST_DIRECTORY/quickstart-$quickstart_deployment.yaml"
+        require_contains "$TEST_DIRECTORY/quickstart-$quickstart_deployment.yaml" \
+            "replicas: 1"
+        require_contains "$TEST_DIRECTORY/quickstart-$quickstart_deployment.yaml" \
+            "imagePullPolicy: IfNotPresent"
+        require_not_contains "$TEST_DIRECTORY/quickstart-$quickstart_deployment.yaml" \
+            "topologySpreadConstraints:"
+    done
+    require_resource "$TEST_DIRECTORY/quickstart.yaml" Cluster "osmo-pg"
+    require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
+        "osmo-backend-token-bootstrap"
+    require_resource "$TEST_DIRECTORY/quickstart.yaml" Job "osmo-mek-bootstrap"
+    require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
+        "osmo-object-storage-bootstrap"
+    require_no_deployment "$TEST_DIRECTORY/quickstart.yaml" "osmo-ui"
+    require_no_deployment "$TEST_DIRECTORY/quickstart.yaml" "osmo-mcp"
+    require_no_deployment "$TEST_DIRECTORY/quickstart.yaml" \
+        "osmo-gateway-oauth2-proxy"
+    require_no_deployment "$TEST_DIRECTORY/quickstart.yaml" "osmo-gateway-authz"
+    require_no_deployment "$TEST_DIRECTORY/quickstart.yaml" \
+        "osmo-gateway-ratelimit"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" \
+        "backend-test-runner"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" \
+        "kind: HorizontalPodAutoscaler"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" \
+        "kind: PodDisruptionBudget"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "kind: PodMonitor"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "kind: Ingress"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "kind: HTTPRoute"
+    require_contains "$TEST_DIRECTORY/quickstart.yaml" "OSMO_LOGIN_DEV"
+    require_contains "$TEST_DIRECTORY/quickstart.yaml" "http://osmo-gateway"
+    require_contains "$TEST_DIRECTORY/quickstart.yaml" \
+        "secretName: osmo-backend-token"
+    resource_document "$TEST_DIRECTORY/quickstart.yaml" ConfigMap \
+        "osmo-api-config" >"$TEST_DIRECTORY/quickstart-config.yaml"
+    require_contains "$TEST_DIRECTORY/quickstart-config.yaml" \
+        "cpu: '{{USER_CPU}}'"
+    require_not_contains "$TEST_DIRECTORY/quickstart-config.yaml" \
+        "nvidia.com/gpu"
+    local quickstart_osmo_image
+    for quickstart_osmo_image in \
+            agent service backend-listener backend-worker delayed-job-monitor \
+            logger router worker; do
+        require_contains "$TEST_DIRECTORY/quickstart.yaml" \
+            "image: nvcr.io/nvidia/osmo/$quickstart_osmo_image:latest"
+    done
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "hostPath:"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "kind-osmo"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "/home/"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "currentMek:"
+
     if helm_template_with_backend mismatched-converged-backend-token "$charts_copy/osmo" \
             --namespace osmo \
             --api-versions postgresql.cnpg.io/v1 \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -649,6 +649,8 @@ test_control_umbrella() {
             "topologySpreadConstraints:"
     done
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Cluster "osmo-pg"
+    require_resource "$TEST_DIRECTORY/quickstart.yaml" PersistentVolumeClaim \
+        "osmo-valkey"
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
         "osmo-backend-token-bootstrap"
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job "osmo-mek-bootstrap"
@@ -691,6 +693,15 @@ test_control_umbrella() {
     require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "kind-osmo"
     require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "/home/"
     require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "currentMek:"
+    require_contains "$charts_copy/osmo/profiles/README.md" "quickstart.yaml"
+    require_contains "$charts_copy/osmo/README.md" \
+        "deployments/charts/osmo/profiles/quickstart.yaml"
+    require_contains "$charts_copy/osmo/README.md" \
+        "helm --kube-context kind-osmo install osmo"
+    require_contains "$charts_copy/osmo/README.md" \
+        "kubectl --context kind-osmo"
+    require_contains "$charts_copy/osmo/README.md" \
+        "deployments/workflows/verify-hello.yaml"
 
     if helm_template_with_backend mismatched-converged-backend-token "$charts_copy/osmo" \
             --namespace osmo \


### PR DESCRIPTION
## Description
Add a quickstart profile to the osmo umbrella chart to replace the existing quickstart chart

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a development quick-start profile for deploying the complete OSMO control plane, UI, CLI, API, and CPU workflow experience.
  * Enabled bundled local PostgreSQL, Valkey, object storage, persistence, generated credentials, and gateway access through NodePort 30080.
  * Added streamlined installation, troubleshooting, cleanup, and capacity guidance for local development environments.

* **Bug Fixes**
  * Improved object-storage initialization by reliably detecting existing buckets without repeated per-bucket checks.

* **Documentation**
  * Updated chart documentation with prerequisites, configuration requirements, security limitations, and quick-start workflow guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->