### PR TITLE
OSMO-6648 - Move service auth identity to Kubernetes Secret

### DIFF
--- a/bzl/tests/BUILD
+++ b/bzl/tests/BUILD
@@ -87,6 +87,19 @@ py_test(
 )
 
 py_test(
+    name = "service_auth_bootstrap_python_runfiles_dedup_test",
+    srcs = ["python_image_runfiles_dedup_test.py"],
+    args = [
+        "$(rootpath //src/service/core:service_image_x86_64)",
+        "src/service/core/service_binary.runfiles",
+        "usr/bin/service-auth-bootstrap",
+        "src/service/core/service_auth_bootstrap.py",
+    ],
+    data = ["//src/service/core:service_image_x86_64"],
+    main = "python_image_runfiles_dedup_test.py",
+)
+
+py_test(
     name = "mcp_python_runfiles_dedup_test",
     srcs = ["python_image_runfiles_dedup_test.py"],
     args = [

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -796,7 +796,8 @@ kubectl annotate secret osmo-service-auth \
 ```
 
 Upgrade with `secrets.serviceAuth.existingSecret.name=osmo-service-auth` and
-`secrets.serviceAuth.migration.enabled=true`. A pre-upgrade Job reads and
+`secrets.serviceAuth.migration.enabled=true`. A Helm pre-upgrade or Argo CD
+PreSync Job reads and
 decrypts the legacy DB identity, validates every public/private keypair, and
 writes canonical plaintext JSON into the authorized placeholder. It then reads
 the DB identity again and aborts if the stable authority changed during the

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -30,7 +30,8 @@ It installs:
 - the compute backend listener and worker;
 - persistent CloudNativePG, Valkey, and RustFS instances;
 - generated development credentials, object-storage buckets, configuration,
-  and a CPU-only default pool.
+  and a CPU-only default pool. Service auth is generated explicitly before
+  installation so every process uses the same identity.
 
 ### Prerequisites
 
@@ -62,9 +63,22 @@ helm --kube-context kind-osmo upgrade --install cnpg cnpg/cloudnative-pg \
 
 ### Install OSMO
 
-Install the unified chart with the single quick-start values file:
+Generate the shared development service-auth identity, create its Secret, then
+install the unified chart with the single quick-start values file:
 
 ```bash
+OSMO_SERVICE_AUTH_DIRECTORY="$(mktemp -d)"
+docker run --rm --user "$(id -u):$(id -g)" \
+  --entrypoint service-auth-bootstrap \
+  --volume "${OSMO_SERVICE_AUTH_DIRECTORY}:/output" \
+  nvcr.io/nvidia/osmo/service:latest \
+  generate --output /output/authentication-config.json
+kubectl --context kind-osmo create namespace osmo \
+  --dry-run=client --output=yaml | kubectl --context kind-osmo apply -f -
+kubectl --context kind-osmo --namespace osmo create secret generic \
+  osmo-service-auth \
+  --from-file="authentication-config.json=${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
+
 helm dependency build deployments/charts/osmo
 helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
   --namespace osmo \
@@ -88,6 +102,9 @@ helm --kube-context kind-osmo upgrade osmo deployments/charts/osmo \
   --set secrets.masterEncryptionKey.bootstrap.enabled=false \
   --wait \
   --timeout 20m
+
+rm "${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
+rmdir "${OSMO_SERVICE_AUTH_DIRECTORY}"
 ```
 
 Inspect the release without reading generated Secret values:
@@ -233,6 +250,15 @@ kubectl create namespace osmo
 kubectl --namespace osmo create secret generic osmo-oauth2-proxy \
   --from-literal=client_secret='<oidc-client-secret>' \
   --from-literal=cookie_secret='<32-byte-random-cookie-secret>'
+OSMO_SERVICE_AUTH_DIRECTORY="$(mktemp -d)"
+docker run --rm --user "$(id -u):$(id -g)" \
+  --entrypoint service-auth-bootstrap \
+  --volume "${OSMO_SERVICE_AUTH_DIRECTORY}:/output" \
+  nvcr.io/nvidia/osmo/service:latest \
+  generate --output /output/authentication-config.json
+kubectl --namespace osmo create secret generic \
+  osmo-service-auth \
+  --from-file="authentication-config.json=${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
 helm dependency build deployments/charts/osmo
 cp deployments/charts/osmo/examples/self-contained-environment-values.yaml \
   self-contained-environment-values.yaml
@@ -244,6 +270,9 @@ helm upgrade --install osmo deployments/charts/osmo \
   --wait \
   --wait-for-jobs \
   --timeout 30m
+
+rm "${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
+rmdir "${OSMO_SERVICE_AUTH_DIRECTORY}"
 ```
 
 The first installation bootstraps the retained
@@ -303,7 +332,7 @@ kubectl --namespace osmo wait \
 kubectl --namespace osmo get pods,pvc,services,jobs,poddisruptionbudgets
 kubectl --namespace osmo get secret \
   osmo-backend-token osmo-master-encryption-key osmo-valkey-credentials \
-  osmo-rustfs-credentials
+  osmo-rustfs-credentials osmo-service-auth
 ```
 
 The release creates the workflow, log, and app buckets and wires the RustFS
@@ -661,6 +690,7 @@ may reference a separate Secret. The defaults expect these keys:
 | `secrets.objectStorage` | `object-storage.yaml` | Workflow data, logs, and apps |
 | `secrets.masterEncryptionKey` | `mek.yaml` | OSMO encryption-key configuration |
 | `secrets.backendApiTokens.credentials[]` | `token`, optional `previous-token` | Backend authentication |
+| `secrets.serviceAuth` | `authentication-config.json` | Stable JWT signing identity |
 | `secrets.defaultAdmin` | `password` | Optional administrator bootstrap |
 | `secrets.oauthClientSecret` | `client_secret` | OAuth2 proxy client authentication |
 | `secrets.oauthCookieSecret` | `cookie_secret` | OAuth2 proxy sessions |
@@ -695,6 +725,114 @@ postgresql:
       secret:
         name: osmo-postgresql-credentials
 ```
+
+### Service auth identity
+
+The OSMO JWT signing identity is installation-scoped secret material. Every
+control-plane installation requires an externally persisted Kubernetes Secret
+containing canonical `AuthenticationConfig` JSON under
+`authentication-config.json`. The chart references and mounts this Secret but
+never renders its private key into Helm values or release state. Runtime
+services do not read or write `service_auth` through PostgreSQL.
+
+For a fresh installation, generate the identity offline with the service image,
+then create the Secret before installing the chart:
+
+```bash
+OSMO_SERVICE_AUTH_DIRECTORY="$(mktemp -d)"
+docker run --rm --user "$(id -u):$(id -g)" \
+  --entrypoint service-auth-bootstrap \
+  --volume "${OSMO_SERVICE_AUTH_DIRECTORY}:/output" \
+  <service-image> \
+  generate --output /output/authentication-config.json
+kubectl create secret generic osmo-service-auth --namespace <namespace> \
+  --from-file="authentication-config.json=${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
+rm "${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
+rmdir "${OSMO_SERVICE_AUTH_DIRECTORY}"
+```
+
+The generator creates the output with mode `0600`, refuses to overwrite an
+existing file, validates the keypair, and never writes private material to
+stdout. Store and back up the Secret through the installation's normal secret
+management system.
+
+For an existing PostgreSQL-backed installation, first establish a maintenance
+window that prevents the old configuration API from changing `service_auth`.
+Delete its HPA, scale the old API deployment to zero, and verify that no old API
+pod remains before starting the upgrade. Replace the example release and
+namespace if needed.
+
+```bash
+OSMO_RELEASE_NAME=osmo
+OSMO_NAMESPACE=osmo
+OSMO_API_SELECTOR="app.kubernetes.io/instance=${OSMO_RELEASE_NAME},app.kubernetes.io/component=api"
+OSMO_API_DEPLOYMENT="$(kubectl --namespace "${OSMO_NAMESPACE}" get deployment \
+  --selector "${OSMO_API_SELECTOR}" \
+  --output=jsonpath='{.items[0].metadata.name}')"
+test -n "${OSMO_API_DEPLOYMENT}"
+kubectl --namespace "${OSMO_NAMESPACE}" delete hpa \
+  --selector "${OSMO_API_SELECTOR}" --ignore-not-found
+kubectl --namespace "${OSMO_NAMESPACE}" scale deployment \
+  "${OSMO_API_DEPLOYMENT}" --replicas=0
+kubectl --namespace "${OSMO_NAMESPACE}" rollout status deployment \
+  "${OSMO_API_DEPLOYMENT}" --timeout=5m
+if kubectl --namespace "${OSMO_NAMESPACE}" get pods \
+  --selector "${OSMO_API_SELECTOR}" \
+  --output=name | grep -q .; then
+  echo "old API pods still exist; do not continue" >&2
+  exit 1
+fi
+```
+
+With writers stopped, pre-provision an empty Secret and authorize it for the
+exact Helm release:
+
+```bash
+kubectl create secret generic osmo-service-auth \
+  --namespace "${OSMO_NAMESPACE}"
+kubectl annotate secret osmo-service-auth \
+  --namespace "${OSMO_NAMESPACE}" \
+  "osmo.nvidia.com/service-auth-db-migration-placeholder=${OSMO_RELEASE_NAME}"
+```
+
+Upgrade with `secrets.serviceAuth.existingSecret.name=osmo-service-auth` and
+`secrets.serviceAuth.migration.enabled=true`. A pre-upgrade Job reads and
+decrypts the legacy DB identity, validates every public/private keypair, and
+writes canonical plaintext JSON into the authorized placeholder. It then reads
+the DB identity again and aborts if the stable authority changed during the
+migration. An already populated Secret is preserved only when its complete
+stable identity matches. Temporary hook RBAC grants only `get` and `update` on
+that named Secret and is removed after the hook completes.
+
+This Job is transitional upgrade compatibility for installations coming from
+DB-backed releases. It remains disabled by default and should stay in the chart
+until direct upgrades from those releases are no longer supported; it does not
+create a persistent runtime component.
+
+The 6.4 workloads start only after the hook succeeds and read the copied
+identity exclusively from the mounted Secret, so existing tokens remain valid.
+Wait for the Secret-backed API deployment to become ready and confirm that Helm
+has recreated its HPA when autoscaling is enabled. After the successful upgrade,
+disable `migration.enabled`. Retain the legacy DB row and its MEK through the
+rollback window so an older binary can still use the same identity; 6.4 runtime
+services ignore that row.
+
+```bash
+kubectl --namespace "${OSMO_NAMESPACE}" rollout status deployment \
+  "${OSMO_API_DEPLOYMENT}" --timeout=10m
+kubectl --namespace "${OSMO_NAMESPACE}" get hpa \
+  --selector "${OSMO_API_SELECTOR}"
+```
+
+The migration uses `secrets.masterEncryptionKey` to decrypt legacy MEK/JWE
+values. Missing, malformed, changing, or mismatched identity data fails closed
+without generating a replacement key. `login_info` remains deployment-derived
+and is overlaid only in memory.
+
+Intentional key rotation requires a staged keyset rollout: add the new key,
+roll all consumers, switch `active_key`, retain the old verification key until
+all tokens it signed have expired, and remove it in a later rollout. Change
+`rolloutNonce` on each Secret update.
 
 The MEK is mounted through the typed
 `secrets.masterEncryptionKey.existingSecret.{name,key}` reference. Set

--- a/deployments/charts/osmo/profiles/README.md
+++ b/deployments/charts/osmo/profiles/README.md
@@ -11,8 +11,8 @@ values take precedence.
 
 | File | Directly installable | Required environment input |
 | --- | --- | --- |
-| `quickstart.yaml` | Yes, on a development cluster | KAI Scheduler, the CloudNativePG operator, and a default dynamic StorageClass installed separately; `compute.backendName` set explicitly at install time |
-| `self-contained.yaml` | Yes, with production inputs | KAI Scheduler, the CloudNativePG operator, a default dynamic StorageClass, at least four schedulable nodes, a NetworkPolicy-enforcing CNI, an OIDC client and Secret with role assignments, a TLS edge and public `externalUrl`, IPv4 cluster CIDRs, and `compute.backendName` |
+| `quickstart.yaml` | Yes, on a development cluster | KAI Scheduler, the CloudNativePG operator, and a default dynamic StorageClass installed separately; `osmo-service-auth` generated and created as documented; `compute.backendName` set explicitly at install time |
+| `self-contained.yaml` | Yes, with production inputs | KAI Scheduler, the CloudNativePG operator, a default dynamic StorageClass, at least four schedulable nodes, a NetworkPolicy-enforcing CNI, an OIDC client and Secret with role assignments, an `osmo-service-auth` Secret generated as documented, a TLS edge and public `externalUrl`, IPv4 cluster CIDRs, and `compute.backendName` |
 | `split-plane-control.yaml` | Base overlay | PostgreSQL, Valkey, and object-storage endpoints; Kubernetes Secrets; and `externalUrl` |
 | `split-plane-compute.yaml` | Base overlay | A control-plane `externalUrl`, a compute authentication Secret, and `compute.backendName` set explicitly at install time |
 
@@ -20,7 +20,8 @@ The quick-start profile is the smallest complete control-and-compute deployment
 for browser, CLI, and CPU hello-world verification. It exposes the UI and API
 through gateway NodePort `30080` while omitting optional production behavior.
 It intentionally uses `latest` OSMO images, one replica per component,
-development authentication, and small single-node stateful dependencies.
+development authentication, explicitly generated service auth, and small
+single-node stateful dependencies.
 The quick-start installation path uses the chart's default image settings and
 does not require application Secrets or an image-pull Secret to be created
 beforehand. Configure top-level `imagePullSecrets` only when using a registry

--- a/deployments/charts/osmo/profiles/quickstart.yaml
+++ b/deployments/charts/osmo/profiles/quickstart.yaml
@@ -43,6 +43,10 @@ secrets:
       key: mek.yaml
     bootstrap:
       enabled: true
+  serviceAuth:
+    existingSecret:
+      name: osmo-service-auth
+      key: authentication-config.json
 
 services:
   ui:

--- a/deployments/charts/osmo/profiles/self-contained.yaml
+++ b/deployments/charts/osmo/profiles/self-contained.yaml
@@ -60,6 +60,10 @@ secrets:
     # rotation phase so the one-time Secret-creation permission is removed.
     bootstrap:
       enabled: true
+  serviceAuth:
+    existingSecret:
+      name: osmo-service-auth
+      key: authentication-config.json
 
 gateway:
   envoy:

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -425,6 +425,33 @@ osmo.nvidia.com/mek-rollout: {{ . | quote }}
 {{- end }}
 {{- end -}}
 
+{{- define "osmo.secrets.serviceAuthRolloutAnnotation" -}}
+osmo.nvidia.com/service-auth-rollout: {{ .Values.secrets.serviceAuth.rolloutNonce | quote }}
+{{- end -}}
+
+{{- define "osmo.secrets.serviceAuthArgs" -}}
+- --service_auth_file
+- /etc/osmo/service-auth/authentication-config.json
+{{- end -}}
+
+{{- define "osmo.secrets.serviceAuthVolumeMount" -}}
+- name: service-auth
+  mountPath: /etc/osmo/service-auth/authentication-config.json
+  subPath: authentication-config.json
+  readOnly: true
+{{- end -}}
+
+{{- define "osmo.secrets.serviceAuthVolume" -}}
+{{- $serviceAuth := .Values.secrets.serviceAuth -}}
+- name: service-auth
+  secret:
+    defaultMode: 292
+    secretName: {{ required "secrets.serviceAuth.existingSecret.name is required for the control plane" $serviceAuth.existingSecret.name | quote }}
+    items:
+    - key: {{ required "secrets.serviceAuth.existingSecret.key is required" $serviceAuth.existingSecret.key | quote }}
+      path: authentication-config.json
+{{- end -}}
+
 {{- define "osmo.valkey.fullname" -}}
 {{- $name := default "valkey" (dig "nameOverride" "" .Values.valkey) -}}
 {{- $fullnameOverride := dig "fullnameOverride" "" .Values.valkey -}}
@@ -620,6 +647,7 @@ osmo.nvidia.com/postgresql-secret-rollout: {{ .Values.secrets.postgresql.rollout
 osmo.nvidia.com/valkey-secret-rollout: {{ .Values.secrets.valkey.rolloutNonce | quote }}
 osmo.nvidia.com/object-storage-secret-rollout: {{ .Values.secrets.objectStorage.rolloutNonce | quote }}
 {{- include "osmo.secrets.mekRolloutAnnotation" . }}
+{{ include "osmo.secrets.serviceAuthRolloutAnnotation" . }}
 {{- end -}}
 
 {{- define "osmo.externalDependencies.caVolumeMounts" -}}

--- a/deployments/charts/osmo/templates/agent-service.yaml
+++ b/deployments/charts/osmo/templates/agent-service.yaml
@@ -126,6 +126,7 @@ spec:
         - {{ .Values.logging.logFormat | default "text" }}
         {{- end }}
         {{- include "osmo.configuration.args" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthArgs" . | nindent 8 }}
         {{- range $arg := .Values.services.agent.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
@@ -145,6 +146,7 @@ spec:
           name: mek-volume
           readOnly: true
         {{- end }}
+        {{- include "osmo.secrets.serviceAuthVolumeMount" . | nindent 8 }}
         {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
         {{- include "osmo.component.extraVolumeMounts" .Values.services.agent | nindent 8 }}
@@ -184,6 +186,7 @@ spec:
         {{- include "osmo.pod.extraVolumes" .Values.services.agent | nindent 8 }}
         {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "agent"))) | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthVolume" . | nindent 8 }}
         {{- include "osmo.configuration.volumes" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 

--- a/deployments/charts/osmo/templates/api-service.yaml
+++ b/deployments/charts/osmo/templates/api-service.yaml
@@ -157,6 +157,7 @@ spec:
         - /etc/osmo/backend-tokens
         {{- end }}
         {{- include "osmo.configuration.args" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthArgs" . | nindent 8 }}
         {{- range $arg := .Values.services.api.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
@@ -188,6 +189,7 @@ spec:
           name: mek-volume
           readOnly: true
         {{- end }}
+        {{- include "osmo.secrets.serviceAuthVolumeMount" . | nindent 8 }}
         {{- if .Values.secrets.backendApiTokens.enabled }}
         {{- range .Values.secrets.backendApiTokens.credentials }}
         - name: backend-token-{{ .name }}
@@ -222,6 +224,7 @@ spec:
         {{- include "osmo.pod.extraVolumes" .Values.services.api | nindent 8 }}
         {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "api"))) | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthVolume" . | nindent 8 }}
         {{- include "osmo.configuration.volumes" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
         {{- if .Values.secrets.backendApiTokens.enabled }}

--- a/deployments/charts/osmo/templates/delayed-job-monitor.yaml
+++ b/deployments/charts/osmo/templates/delayed-job-monitor.yaml
@@ -115,6 +115,7 @@ spec:
         - --log_format
         - {{ .Values.logging.logFormat | default "text" }}
         {{- end }}
+        {{- include "osmo.secrets.serviceAuthArgs" . | nindent 8 }}
         - --enable_metrics
         {{- range $arg := .Values.services.delayedJobMonitor.extraArgs }}
         - {{ $arg | quote }}
@@ -133,6 +134,7 @@ spec:
           name: mek-volume
           readOnly: true
         {{- end }}
+        {{- include "osmo.secrets.serviceAuthVolumeMount" . | nindent 8 }}
         {{- include "osmo.component.extraVolumeMounts" .Values.services.delayedJobMonitor | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
 
@@ -158,6 +160,7 @@ spec:
           emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.delayedJobMonitor | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthVolume" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/deployments/charts/osmo/templates/logger-service.yaml
+++ b/deployments/charts/osmo/templates/logger-service.yaml
@@ -121,6 +121,7 @@ spec:
         - {{ .Values.logging.logFormat | default "text" }}
         {{- end }}
         {{- include "osmo.configuration.args" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthArgs" . | nindent 8 }}
         {{- range $arg := .Values.services.logger.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
@@ -140,6 +141,7 @@ spec:
           name: mek-volume
           readOnly: true
         {{- end }}
+        {{- include "osmo.secrets.serviceAuthVolumeMount" . | nindent 8 }}
         {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
         {{- include "osmo.component.extraVolumeMounts" .Values.services.logger | nindent 8 }}
@@ -187,6 +189,7 @@ spec:
         {{- include "osmo.pod.extraVolumes" .Values.services.logger | nindent 8 }}
         {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "logger"))) | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthVolume" . | nindent 8 }}
         {{- include "osmo.configuration.volumes" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 

--- a/deployments/charts/osmo/templates/mek-bootstrap.yaml
+++ b/deployments/charts/osmo/templates/mek-bootstrap.yaml
@@ -175,6 +175,7 @@ spec:
         - {{ include "osmo.postgresql.database" . | quote }}
         - --postgres_user
         - {{ include "osmo.postgresql.username" . | quote }}
+        {{- include "osmo.secrets.serviceAuthArgs" . | nindent 8 }}
         {{- end }}
         - --active_deadline_seconds
         - {{ ternary $mek.bootstrap.activeDeadlineSeconds $mek.rotation.activeDeadlineSeconds $mek.bootstrap.enabled | quote }}
@@ -195,6 +196,7 @@ spec:
           readOnly: true
         {{- end }}
         {{- if $needsDatabase }}
+        {{- include "osmo.secrets.serviceAuthVolumeMount" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
         {{- end }}
         - name: kubernetes-api
@@ -221,6 +223,7 @@ spec:
             path: "mek.yaml"
       {{- end }}
       {{- if $needsDatabase }}
+      {{- include "osmo.secrets.serviceAuthVolume" . | nindent 6 }}
       {{- include "osmo.externalDependencies.caVolumes" . | nindent 6 }}
       {{- end }}
       - name: kubernetes-api

--- a/deployments/charts/osmo/templates/router-service.yaml
+++ b/deployments/charts/osmo/templates/router-service.yaml
@@ -108,6 +108,7 @@ spec:
         - --log_format
         - {{ .Values.logging.logFormat | default "text" }}
         {{- end }}
+        {{- include "osmo.secrets.serviceAuthArgs" . | nindent 8 }}
         {{- with .Values.services.router.extraArgs }}
         {{- range . }}
         - {{ . }}
@@ -149,6 +150,7 @@ spec:
           name: mek-volume
           readOnly: true
         {{- end }}
+        {{- include "osmo.secrets.serviceAuthVolumeMount" . | nindent 8 }}
         {{- with .Values.services.router.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -179,6 +181,7 @@ spec:
         - name: osmo-runtime-tmp
           emptyDir: {}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthVolume" . | nindent 8 }}
         {{- with .Values.services.router.pod.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deployments/charts/osmo/templates/service-auth-db-migration.yaml
+++ b/deployments/charts/osmo/templates/service-auth-db-migration.yaml
@@ -1,0 +1,164 @@
+{{- if and .Values.planes.control.enabled .Values.secrets.serviceAuth.migration.enabled -}}
+{{- if not .Release.IsUpgrade -}}
+{{- fail "secrets.serviceAuth.migration.enabled is only valid during an upgrade" -}}
+{{- end -}}
+{{- $serviceAuth := .Values.secrets.serviceAuth -}}
+{{- $secretName := required "secrets.serviceAuth.existingSecret.name is required during migration" $serviceAuth.existingSecret.name -}}
+{{- $secretKey := required "secrets.serviceAuth.existingSecret.key is required during migration" $serviceAuth.existingSecret.key -}}
+{{- $migrationName := include "osmo.component.fullname" (dict "root" . "suffix" "service-auth-db-migration") -}}
+{{- $rbacAnnotations := dict
+      "helm.sh/hook" "pre-upgrade"
+      "helm.sh/hook-weight" "-20"
+      "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded,hook-failed" -}}
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $migrationName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "service-auth-db-migration") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" $rbacAnnotations) | nindent 4 }}
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $migrationName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "service-auth-db-migration") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" $rbacAnnotations) | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: [{{ $secretName | quote }}]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $migrationName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "service-auth-db-migration") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" $rbacAnnotations) | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ $migrationName | quote }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $migrationName | quote }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $migrationName | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osmo.component.labels" (dict "root" . "component" "service-auth-db-migration") | nindent 4 }}
+  annotations:
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict "helm.sh/hook" "pre-upgrade" "helm.sh/hook-weight" "-10" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded")) | nindent 4 }}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- include "osmo.component.standardLabels" (dict "root" . "component" "service-auth-db-migration") | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $migrationName | quote }}
+      automountServiceAccountToken: false
+      {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      {{- with $serviceAuth.migration.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $serviceAuth.migration.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: migrate-service-auth
+        image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.api) }}
+        imagePullPolicy: {{ include "osmo.component.imagePullPolicy" (dict "root" . "component" .Values.services.api) }}
+        command: ["service-auth-bootstrap"]
+        args:
+        - migrate
+        - --postgres-host
+        - {{ include "osmo.postgresql.host" . | quote }}
+        - --postgres-port
+        - {{ include "osmo.postgresql.port" . | quote }}
+        - --postgres-database
+        - {{ include "osmo.postgresql.database" . | quote }}
+        - --postgres-user
+        - {{ include "osmo.postgresql.username" . | quote }}
+        - --mek-file
+        - {{ include "osmo.secrets.mekFile" . | quote }}
+        - --namespace
+        - {{ .Release.Namespace | quote }}
+        - --release-name
+        - {{ .Release.Name | quote }}
+        - --target-secret
+        - {{ $secretName | quote }}
+        - --target-key
+        - {{ $secretKey | quote }}
+        env:
+        - name: OSMO_POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "osmo.postgresql.secretName" . | quote }}
+              key: {{ include "osmo.postgresql.passwordKey" . | quote }}
+        {{- if or .Values.embeddedDependencies.postgresql.enabled .Values.externalDependencies.postgresql.tls.enabled }}
+        - name: PGSSLMODE
+          value: verify-full
+        - name: PGSSLROOTCERT
+          value: /etc/osmo/ca/postgresql/ca.crt
+        {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - name: mek-volume
+          mountPath: {{ include "osmo.secrets.mekMountPath" . | quote }}
+          readOnly: true
+        {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
+        - name: kubernetes-api
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+        {{- with $serviceAuth.migration.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      volumes:
+      - name: mek-volume
+        secret:
+          secretName: {{ .Values.secrets.masterEncryptionKey.existingSecret.name | quote }}
+          items:
+          - key: {{ .Values.secrets.masterEncryptionKey.existingSecret.key | quote }}
+            path: mek.yaml
+      {{- include "osmo.externalDependencies.caVolumes" . | nindent 6 }}
+      - name: kubernetes-api
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 600
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+              - key: ca.crt
+                path: ca.crt
+{{- end }}

--- a/deployments/charts/osmo/templates/service-auth-db-migration.yaml
+++ b/deployments/charts/osmo/templates/service-auth-db-migration.yaml
@@ -1,7 +1,4 @@
 {{- if and .Values.planes.control.enabled .Values.secrets.serviceAuth.migration.enabled -}}
-{{- if not .Release.IsUpgrade -}}
-{{- fail "secrets.serviceAuth.migration.enabled is only valid during an upgrade" -}}
-{{- end -}}
 {{- $serviceAuth := .Values.secrets.serviceAuth -}}
 {{- $secretName := required "secrets.serviceAuth.existingSecret.name is required during migration" $serviceAuth.existingSecret.name -}}
 {{- $secretKey := required "secrets.serviceAuth.existingSecret.key is required during migration" $serviceAuth.existingSecret.key -}}
@@ -9,7 +6,17 @@
 {{- $rbacAnnotations := dict
       "helm.sh/hook" "pre-upgrade"
       "helm.sh/hook-weight" "-20"
-      "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded,hook-failed" -}}
+      "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded,hook-failed"
+      "argocd.argoproj.io/hook" "PreSync"
+      "argocd.argoproj.io/sync-wave" "-20"
+      "argocd.argoproj.io/hook-delete-policy" "BeforeHookCreation,HookSucceeded,HookFailed" -}}
+{{- $jobAnnotations := dict
+      "helm.sh/hook" "pre-upgrade"
+      "helm.sh/hook-weight" "-10"
+      "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded"
+      "argocd.argoproj.io/hook" "PreSync"
+      "argocd.argoproj.io/sync-wave" "-10"
+      "argocd.argoproj.io/hook-delete-policy" "BeforeHookCreation,HookSucceeded" -}}
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
@@ -64,7 +71,7 @@ metadata:
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "service-auth-db-migration") | nindent 4 }}
   annotations:
-    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict "helm.sh/hook" "pre-upgrade" "helm.sh/hook-weight" "-10" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded")) | nindent 4 }}
+    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" $jobAnnotations) | nindent 4 }}
 spec:
   backoffLimit: 0
   template:

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -118,6 +118,7 @@ spec:
         - {{ .Values.logging.logFormat | default "text" }}
         {{- end }}
         {{- include "osmo.configuration.args" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthArgs" . | nindent 8 }}
         {{- range $arg := .Values.services.worker.extraArgs }}
         - {{ $arg | quote }}
         {{- end }}
@@ -133,6 +134,7 @@ spec:
           name: mek-volume
           readOnly: true
         {{- end }}
+        {{- include "osmo.secrets.serviceAuthVolumeMount" . | nindent 8 }}
         {{- include "osmo.configuration.volumeMounts" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumeMounts" . | nindent 8 }}
         {{- include "osmo.component.extraVolumeMounts" .Values.services.worker | nindent 8 }}
@@ -162,6 +164,7 @@ spec:
           emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.worker | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}
+        {{- include "osmo.secrets.serviceAuthVolume" . | nindent 8 }}
         {{- include "osmo.configuration.volumes" . | nindent 8 }}
         {{- include "osmo.externalDependencies.caVolumes" . | nindent 8 }}
 

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -2052,7 +2052,6 @@ EOF
         "service-auth-osmo-service-auth-db-migration"
 
     helm_template service-auth-migration "$charts_copy/osmo" \
-        --is-upgrade \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         --set secrets.serviceAuth.existingSecret.name=osmo-service-auth \
@@ -2076,6 +2075,12 @@ EOF
     require_not_contains "$TEST_DIRECTORY/service-auth-role.yaml" '"create"'
     require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
         'helm.sh/hook: pre-upgrade'
+    require_occurrences "$TEST_DIRECTORY/service-auth-migration.yaml" \
+        'argocd.argoproj.io/hook: PreSync' 4
+    require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
+        'argocd.argoproj.io/sync-wave: "-20"'
+    require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
+        'argocd.argoproj.io/sync-wave: "-10"'
     require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
         'command: ["service-auth-bootstrap"]'
     require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
@@ -2086,17 +2091,6 @@ EOF
         "expirationSeconds: 600"
     require_no_resource "$TEST_DIRECTORY/service-auth-migration.yaml" Secret \
         "osmo-service-auth"
-
-    if helm_template install-service-auth-migration "$charts_copy/osmo" \
-            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
-            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
-            --set secrets.serviceAuth.existingSecret.name=osmo-service-auth \
-            --set secrets.serviceAuth.migration.enabled=true \
-            >"$TEST_DIRECTORY/install-service-auth-migration.out" 2>&1; then
-        fail "service auth migration was accepted during a fresh install"
-    fi
-    require_contains "$TEST_DIRECTORY/install-service-auth-migration.out" \
-        "migration.enabled is only valid during an upgrade"
 
     if helm_template missing-service-auth-secret "$charts_copy/osmo" \
             -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1808,6 +1808,9 @@ EOF
         >"$TEST_DIRECTORY/mek-bootstrap.yaml"
     require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'command: ["mek-lifecycle"]'
     require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" '- "bootstrap"'
+    require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" '--service_auth_file'
+    require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" \
+        'secretName: "osmo-service-auth"'
     require_not_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'kind: Lease'
     require_no_resource "$TEST_DIRECTORY/mek-bootstrap.yaml" Secret \
         external-master-encryption-key-secret
@@ -2027,6 +2030,94 @@ EOF
     ' "$rendered"; then
         fail 'Helm rendered non-empty Secret material into release state'
     fi
+
+    helm_template service-auth "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.serviceAuth.existingSecret.name=osmo-service-auth \
+        --set secrets.serviceAuth.existingSecret.key=auth.json \
+        --set secrets.serviceAuth.rolloutNonce=auth-v1 \
+        >"$TEST_DIRECTORY/service-auth.yaml"
+    require_occurrences "$TEST_DIRECTORY/service-auth.yaml" \
+        "--service_auth_file" 6
+    require_occurrences "$TEST_DIRECTORY/service-auth.yaml" \
+        'secretName: "osmo-service-auth"' 6
+    require_occurrences "$TEST_DIRECTORY/service-auth.yaml" \
+        'osmo.nvidia.com/service-auth-rollout: "auth-v1"' 6
+    require_no_resource "$TEST_DIRECTORY/service-auth.yaml" Secret \
+        "osmo-service-auth"
+    require_not_contains "$TEST_DIRECTORY/service-auth.yaml" \
+        "service_auth_database_write_lock"
+    require_not_contains "$TEST_DIRECTORY/service-auth.yaml" \
+        "service-auth-osmo-service-auth-db-migration"
+
+    helm_template service-auth-migration "$charts_copy/osmo" \
+        --is-upgrade \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set secrets.serviceAuth.existingSecret.name=osmo-service-auth \
+        --set secrets.serviceAuth.migration.enabled=true \
+        >"$TEST_DIRECTORY/service-auth-migration.yaml"
+    require_resource "$TEST_DIRECTORY/service-auth-migration.yaml" ServiceAccount \
+        "service-auth-migration-osmo-service-auth-db-migration"
+    require_resource "$TEST_DIRECTORY/service-auth-migration.yaml" Role \
+        "service-auth-migration-osmo-service-auth-db-migration"
+    require_resource "$TEST_DIRECTORY/service-auth-migration.yaml" RoleBinding \
+        "service-auth-migration-osmo-service-auth-db-migration"
+    require_resource "$TEST_DIRECTORY/service-auth-migration.yaml" Job \
+        "service-auth-migration-osmo-service-auth-db-migration"
+    resource_document "$TEST_DIRECTORY/service-auth-migration.yaml" Role \
+        "service-auth-migration-osmo-service-auth-db-migration" \
+        >"$TEST_DIRECTORY/service-auth-role.yaml"
+    require_contains "$TEST_DIRECTORY/service-auth-role.yaml" \
+        'resourceNames: ["osmo-service-auth"]'
+    require_contains "$TEST_DIRECTORY/service-auth-role.yaml" \
+        'verbs: ["get", "update"]'
+    require_not_contains "$TEST_DIRECTORY/service-auth-role.yaml" '"create"'
+    require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
+        'helm.sh/hook: pre-upgrade'
+    require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
+        'command: ["service-auth-bootstrap"]'
+    require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
+        "- migrate"
+    require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
+        "--target-secret"
+    require_contains "$TEST_DIRECTORY/service-auth-migration.yaml" \
+        "expirationSeconds: 600"
+    require_no_resource "$TEST_DIRECTORY/service-auth-migration.yaml" Secret \
+        "osmo-service-auth"
+
+    if helm_template install-service-auth-migration "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set secrets.serviceAuth.existingSecret.name=osmo-service-auth \
+            --set secrets.serviceAuth.migration.enabled=true \
+            >"$TEST_DIRECTORY/install-service-auth-migration.out" 2>&1; then
+        fail "service auth migration was accepted during a fresh install"
+    fi
+    require_contains "$TEST_DIRECTORY/install-service-auth-migration.out" \
+        "migration.enabled is only valid during an upgrade"
+
+    if helm_template missing-service-auth-secret "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set-string secrets.serviceAuth.existingSecret.name= \
+            >"$TEST_DIRECTORY/missing-service-auth-secret.out" 2>&1; then
+        fail "control plane was accepted without a service auth Secret"
+    fi
+    require_contains "$TEST_DIRECTORY/missing-service-auth-secret.out" \
+        "existingSecret.name is required for the control plane"
+
+    if helm_template invalid-service-auth-secret-key "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set secrets.serviceAuth.existingSecret.name=osmo-service-auth \
+            --set-string secrets.serviceAuth.existingSecret.key= \
+            >"$TEST_DIRECTORY/invalid-service-auth-secret-key.out" 2>&1; then
+        fail "expected an empty service auth Secret key to fail schema validation"
+    fi
+    require_schema_path "$TEST_DIRECTORY/invalid-service-auth-secret-key.out" \
+        "secrets.serviceAuth.existingSecret.key"
     require_contains "$rendered" "https://s3.external.example.com"
     resource_document "$rendered" ConfigMap osmo-api-config \
         >"$TEST_DIRECTORY/osmo-external-object-storage-config.yaml"

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -72,6 +72,7 @@
         "objectStorage": { "$ref": "#/definitions/objectStorageSecretReference" },
         "backendApiTokens": { "$ref": "#/definitions/backendApiTokens" },
         "masterEncryptionKey": { "$ref": "#/definitions/masterEncryptionKeyReference" },
+        "serviceAuth": { "$ref": "#/definitions/serviceAuthReference" },
         "defaultAdmin": { "$ref": "#/definitions/adminSecretReference" },
         "oauthClientSecret": { "$ref": "#/definitions/existingValueSecretReference" },
         "oauthCookieSecret": { "$ref": "#/definitions/generatedValueSecretReference" }
@@ -1260,6 +1261,34 @@
         }
       },
       "required": ["managementMode", "existingSecret", "bootstrap", "rotation"]
+    },
+    "serviceAuthReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingSecret": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "key": { "type": "string", "minLength": 1 }
+          },
+          "required": ["name", "key"]
+        },
+        "rolloutNonce": { "type": "string" },
+        "migration": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "nodeSelector": { "$ref": "#/definitions/stringMap" },
+            "tolerations": { "type": "array" },
+            "resources": { "type": "object" }
+          },
+          "required": ["enabled", "nodeSelector", "tolerations", "resources"]
+        }
+      },
+      "required": ["existingSecret", "rolloutNonce", "migration"]
     },
     "postgresqlSecretReference": {
       "type": "object",

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -317,6 +317,25 @@ secrets:
       rolloutRevision: ''
       imagePullPolicy: IfNotPresent
       activeDeadlineSeconds: 900
+  # Stable JWT signing identity. Production installations should provision
+  # this Secret outside Helm so private key material is not stored in Helm
+  # values or release state.
+  serviceAuth:
+    existingSecret:
+      name: osmo-service-auth
+      key: authentication-config.json
+    # Change after intentionally updating the externally managed Secret.
+    rolloutNonce: ''
+    migration:
+      # Transitional compatibility hook for upgrades from DB-backed releases.
+      # It performs a one-time pre-upgrade export from the legacy configs row
+      # into the pre-provisioned existingSecret. The hook has read-only DB
+      # access and target-scoped Secret update permission. Disable after
+      # migration. Remove only when DB-backed upgrades are no longer supported.
+      enabled: false
+      nodeSelector: {}
+      tolerations: []
+      resources: {}
   # Optional password used to bootstrap the named administrator account.
   defaultAdmin:
     generate: false

--- a/run/start_service_bazel.py
+++ b/run/start_service_bazel.py
@@ -36,6 +36,7 @@ from run.run_command import run_command_with_logging, cleanup_registered_process
 
 
 logger = logging.getLogger()
+_DEV_SERVICE_AUTH_FILE = '/tmp/osmo/service/authentication-config.json'
 
 
 def _get_env():
@@ -78,6 +79,23 @@ def _wait_for_http_service(url: str, service_name: str, timeout: int = 60) -> bo
 
     logger.error('❌ %s failed to become ready within %d seconds', service_name, timeout)
     return False
+
+
+def _ensure_dev_service_auth_file() -> None:
+    """Generate one persistent development identity shared by every service."""
+    if os.path.exists(_DEV_SERVICE_AUTH_FILE):
+        return
+    os.makedirs(os.path.dirname(_DEV_SERVICE_AUTH_FILE), mode=0o700, exist_ok=True)
+    process = run_command_with_logging(
+        [
+            'bazel', 'run',
+            '@osmo_workspace//src/service/core:service_auth_bootstrap_binary',
+            '--', 'generate', '--output', _DEV_SERVICE_AUTH_FILE,
+        ],
+        'Generating shared development service auth identity',
+    )
+    if process.has_failed():
+        raise RuntimeError('Failed to generate shared development service auth identity')
 
 
 def _handle_existing_container(container_name: str, display_name: str) -> bool:
@@ -294,6 +312,7 @@ def _start_core_service():
         '--',
         '--host', f'http://{host_ip}:8000',
         '--method=dev',
+        '--service_auth_file', _DEV_SERVICE_AUTH_FILE,
         '--progress_file', '/tmp/osmo/service/last_progress_core'
     ]
 
@@ -315,6 +334,7 @@ def _start_service_worker():
         'bazel', 'run', '@osmo_workspace//src/service/worker:worker_binary',
         '--',
         '--method=dev',
+        '--service_auth_file', _DEV_SERVICE_AUTH_FILE,
         '--progress_file', '/tmp/osmo/service/last_progress_worker'
     ]
 
@@ -387,6 +407,7 @@ def _start_delayed_job_monitor():
         '@osmo_workspace//src/service/delayed_job_monitor:delayed_job_monitor_binary',
         '--',
         '--method=dev',
+        '--service_auth_file', _DEV_SERVICE_AUTH_FILE,
         '--progress_file', '/tmp/osmo/service/last_progress_delayed_job_monitor'
     ]
 
@@ -413,7 +434,8 @@ def _start_router_service():
         'bazel', 'run', '@osmo_workspace//src/service/router:router_binary',
         '--',
         '--host', f'http://{host_ip}:8001',
-        '--method=dev'
+        '--method=dev',
+        '--service_auth_file', _DEV_SERVICE_AUTH_FILE,
     ]
 
     run_command_with_logging(
@@ -436,6 +458,7 @@ def start_service_bazel():
         _start_postgres()
         _start_localstack_s3()
         _create_localstack_buckets()
+        _ensure_dev_service_auth_file()
 
         _start_core_service()
         _start_service_worker()

--- a/src/service/core/BUILD
+++ b/src/service/core/BUILD
@@ -69,9 +69,32 @@ osmo_py_binary(
     main = "service.py",
     srcs = ["service.py"],
     deps = [
+        ":service_auth_bootstrap_lib",
         ":service_lib",
         "//src/utils/secret_manager:mek_lifecycle_lib",
     ],
+)
+
+osmo_py_binary(
+    name = "service_auth_bootstrap_binary",
+    main = "service_auth_bootstrap.py",
+    srcs = ["service_auth_bootstrap.py"],
+    deps = [":service_auth_bootstrap_lib"],
+)
+
+osmo_py_library(
+    name = "service_auth_bootstrap_lib",
+    srcs = ["service_auth_bootstrap.py"],
+    deps = [
+        requirement("jwcrypto"),
+        requirement("kubernetes"),
+        requirement("psycopg2-binary"),
+        requirement("pydantic"),
+        "//src/lib/utils:osmo_errors",
+        "//src/utils:auth",
+        "//src/utils/secret_manager",
+    ],
+    visibility = ["//visibility:public"],
 )
 
 py_image_layer(
@@ -94,9 +117,17 @@ osmo_python_wrapper(
     runfiles_dir = "/src/service/core/service_binary.runfiles",
 )
 
+osmo_python_wrapper(
+    name = "service_auth_bootstrap_wrapper",
+    bin_name = "service-auth-bootstrap",
+    main = "/src/service/core/service_auth_bootstrap.py",
+    runfiles_dir = "/src/service/core/service_binary.runfiles",
+)
+
 filegroup(
     name = "service_image_layers",
     srcs = [
+        ":service_auth_bootstrap_wrapper",
         ":service_layer_default",
         ":service_layer_packages",
         ":service_wrapper",

--- a/src/service/core/config/BUILD
+++ b/src/service/core/config/BUILD
@@ -33,6 +33,7 @@ osmo_py_library(
         requirement("pyyaml"),
         requirement("watchdog"),
         "//src/lib/utils:common",
+        "//src/utils:auth",
         "//src/utils:configmap_state",
         "//src/utils/connectors",
     ],

--- a/src/service/core/config/config_history_helpers.py
+++ b/src/service/core/config/config_history_helpers.py
@@ -16,6 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import copy
 from typing import Any, Tuple
 
 from src.lib.utils import config_history
@@ -115,7 +116,17 @@ def transform_config_data(postgres: connectors.PostgresConnector, config_type: s
     Transform the config data for returning to the client with obfuscated credentials
     """
     if config_type == config_history.ConfigHistoryType.SERVICE.value.lower():
-        return connectors.ServiceConfig.deserialize(data, postgres)
+        if not postgres.service_auth_is_external:
+            return connectors.ServiceConfig.deserialize(data, postgres)
+        data = copy.deepcopy(data)
+        data.pop('service_auth', None)
+        service_config = connectors.ServiceConfig.deserialize(
+            data,
+            postgres,
+            runtime_overrides={'service_auth': postgres.get_service_auth()},
+            persist_secret_updates=False,
+        )
+        return service_config.model_dump(exclude={'service_auth'})
     elif config_type == config_history.ConfigHistoryType.WORKFLOW.value.lower():
         return connectors.WorkflowConfig.deserialize(data, postgres)
     # ROLE and other types: return data as-is (already the right shape)

--- a/src/service/core/config/config_service.py
+++ b/src/service/core/config/config_service.py
@@ -16,11 +16,13 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import copy
 import enum
 import re
 from typing import Annotated, Any, Dict, List, Mapping
 
 import fastapi
+from fastapi import encoders, responses
 import pydantic
 
 from src.lib.utils import common, osmo_errors
@@ -61,10 +63,14 @@ def _check_config_name(name: str, name_type: ConfigNameType):
     '/api/configs/service',
     response_model=connectors.ServiceConfig,
 )
-def read_service_configs() -> connectors.ServiceConfig:
+def read_service_configs() -> connectors.ServiceConfig | responses.JSONResponse:
     """Read all the service configurations"""
     postgres = connectors.PostgresConnector.get_instance()
-    return postgres.get_service_configs()
+    service_configs = postgres.get_service_configs()
+    if postgres.service_auth_is_external:
+        return responses.JSONResponse(content=encoders.jsonable_encoder(
+            service_configs, exclude={'service_auth'}))
+    return service_configs
 
 
 @router.put('/api/configs/service')
@@ -124,16 +130,23 @@ def create_clean_config_api(app: fastapi.FastAPI):
         # TODO: Make this clean all the configs
         service_configs_dict = postgres.get_service_configs().plaintext_dict(
             by_alias=True, exclude_unset=True)
+        if postgres.service_auth_is_external:
+            service_configs_dict.pop('service_auth', None)
 
         try:
             configs = connectors.ServiceConfig.from_db(service_configs_dict)
             updated_configs = configs.serialize(postgres)
+            if postgres.service_auth_is_external:
+                updated_configs.pop('service_auth', None)
             for key, value in updated_configs.items():
-                postgres.set_config(key, value)
+                postgres.set_config(key, value, connectors.ConfigType.SERVICE)
         except pydantic.ValidationError as err:
             raise osmo_errors.OSMOUsageError(f'{err}') from err
-        return postgres.get_service_configs().model_dump(by_alias=True,
-                                                        exclude_unset=True)
+        cleaned_configs = postgres.get_service_configs().model_dump(
+            by_alias=True, exclude_unset=True)
+        if postgres.service_auth_is_external:
+            cleaned_configs.pop('service_auth', None)
+        return cleaned_configs
 
     app.add_api_route('/api/configs/service/clean', clean_configs,  # type: ignore
                       description='Clean service configurations',
@@ -1089,9 +1102,12 @@ def rollback_config(
 
     config_type_value = request.config_type.value
     if config_type_value == connectors.ConfigHistoryType.SERVICE.value:
+        service_history_data = copy.deepcopy(history_entry['data'])
+        if postgres.service_auth_is_external:
+            service_history_data.pop('service_auth', None)
         helpers.put_configs(
             objects.PutConfigsRequest(
-                configs=connectors.ServiceConfig.from_db(history_entry['data']),
+                configs=connectors.ServiceConfig.from_db(service_history_data),
                 description=description,
                 tags=request.tags
             ),

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -35,7 +35,7 @@ from watchdog import events, observers
 from src.lib.utils import jinja_sandbox, osmo_errors
 from src.lib.utils.common import merge_lists_on_name, recursive_dict_update
 from src.service.core.config import configmap_events, configmap_guard
-from src.utils import connectors
+from src.utils import auth, connectors
 
 
 # Cold-start retry: kubelet may take up to ~60s to project a freshly-created
@@ -133,7 +133,7 @@ class ConfigMapWatcher:
     ):
         self._config_file_path = config_file_path
         self._postgres = postgres
-        self._db_service_auth: Dict[str, Any] | None = None
+        self._stable_service_auth: auth.AuthenticationConfig | None = None
         self._event_recorder = event_recorder
         self._enable_reconciliation = enable_reconciliation
         self._backend_queue_updater = backend_queue_updater
@@ -238,7 +238,7 @@ class ConfigMapWatcher:
         # Dataset config is deprecated; tolerate stale ConfigMap blocks without loading them.
         managed_configs.pop('dataset', None)
 
-        # JWT signing identity is PostgreSQL-owned. Discard ConfigMap input before
+        # JWT signing identity is externally owned. Discard ConfigMap input before
         # resolving secret references so it is never interpreted as runtime auth.
         service_config = managed_configs.get('service')
         if isinstance(service_config, dict):
@@ -299,24 +299,18 @@ class ConfigMapWatcher:
     def _hydrate_service_auth(
         self, managed_configs: Dict[str, Any],
     ) -> None:
-        """Hydrate the stable JWT signing identity from Postgres."""
+        """Hydrate the stable JWT signing identity from its configured source."""
         service_config = managed_configs.setdefault('service', {})
         if not isinstance(service_config, dict):
             return
 
-        if self._db_service_auth is None and self._postgres is not None:
-            persisted_service_config = self._postgres.get_service_configs()
-            persisted_service_config_dict = (
-                persisted_service_config.plaintext_dict(
-                    by_alias=True, exclude_unset=True))
-            persisted_service_auth = persisted_service_config_dict.get(
-                'service_auth')
-            if isinstance(persisted_service_auth, dict):
-                self._db_service_auth = copy.deepcopy(persisted_service_auth)
+        if self._stable_service_auth is None and self._postgres is not None:
+            self._stable_service_auth = self._postgres.get_service_auth().model_copy(
+                deep=True)
 
-        if self._db_service_auth is not None:
-            service_config['service_auth'] = copy.deepcopy(
-                self._db_service_auth)
+        if self._stable_service_auth is not None:
+            service_config['service_auth'] = (
+                self._stable_service_auth.plaintext_dict())
 
 
 def start_config_watcher(
@@ -343,8 +337,8 @@ def start_config_watcher(
 
     ConfigMap mode is authoritative for managed config except service auth.
     ConfigMap-supplied service auth is ignored. On the first load, the watcher
-    recovers the stable signing identity from Postgres; reloads preserve only
-    that watcher-local, DB-derived identity.
+    obtains the stable signing identity from its configured source; reloads
+    preserve that watcher-local identity.
     """
     if not config_file:
         return None
@@ -789,7 +783,7 @@ def _validate_configmap_runtime_contract(
     if (not isinstance(service_config, dict)
             or 'service_auth' not in service_config):
         errors.append(
-            'service.service_auth: required from PostgreSQL in ConfigMap mode')
+            'service.service_auth: required from the configured auth source')
 
     backends = managed_configs.get('backends', {})
     if isinstance(backends, dict):

--- a/src/service/core/config/helpers.py
+++ b/src/service/core/config/helpers.py
@@ -33,6 +33,25 @@ from src.service.core.workflow import objects
 from src.utils import connectors
 
 
+def _reject_service_auth_write(
+    postgres: connectors.PostgresConnector,
+    config_type: connectors.ConfigType,
+    *,
+    explicit_fields: set[str] | None = None,
+    patch: Dict[str, Any] | None = None,
+) -> None:
+    """Reject service-auth mutations through the dynamic configuration API."""
+    if (config_type != connectors.ConfigType.SERVICE
+            or not postgres.service_auth_is_external):
+        return
+    if ('service_auth' in (explicit_fields or set())
+            or (patch is not None and 'service_auth' in patch)):
+        raise osmo_errors.OSMOUserError(
+            'service_auth is managed through its Kubernetes Secret, not the '
+            'service configuration API.',
+            status_code=409)
+
+
 def update_backend_queues(current_backend: connectors.Backend,
     prev_backend: connectors.Backend | None = None,
     job_id: str | None = None) -> bool:
@@ -129,6 +148,8 @@ def put_configs(
     configmap_guard.reject_if_configmap_mode(username)
 
     postgres = connectors.PostgresConnector.get_instance()
+    _reject_service_auth_write(
+        postgres, config_type, explicit_fields=request.configs.model_fields_set)
     if should_serialize:
         updated_configs = request.configs.serialize(postgres)
     else:
@@ -137,6 +158,9 @@ def put_configs(
         for key, value in updated_configs.items():
             if isinstance(value, (dict, list)):
                 updated_configs[key] = json.dumps(value)
+    if (config_type == connectors.ConfigType.SERVICE
+            and postgres.service_auth_is_external):
+        updated_configs.pop('service_auth', None)
 
     for key, value in updated_configs.items():
         postgres.set_config(key, value, config_type)
@@ -152,6 +176,9 @@ def put_configs(
         or f'Set complete {config_type.value.lower()} configuration',
         tags=request.tags,
     )
+    if (config_type == connectors.ConfigType.SERVICE
+            and postgres.service_auth_is_external):
+        configs_dict.pop('service_auth', None)
     return configs_dict
 
 
@@ -179,6 +206,7 @@ def patch_configs(
     configmap_guard.reject_if_configmap_mode(username)
 
     postgres = connectors.PostgresConnector.get_instance()
+    _reject_service_auth_write(postgres, config_type, patch=request.configs_dict)
     current_configs_dict = postgres.get_configs(config_type).plaintext_dict(
         by_alias=True, exclude_unset=True)
 

--- a/src/service/core/config/tests/BUILD
+++ b/src/service/core/config/tests/BUILD
@@ -44,6 +44,7 @@ osmo_py_test(
     name = "test_configmap_loader_unit",
     srcs = ["test_configmap_loader_unit.py"],
     deps = [
+        requirement("fastapi"),
         requirement("pyyaml"),
         "//src/service/core/config:config",
     ],

--- a/src/service/core/config/tests/test_config_history.py
+++ b/src/service/core/config/tests/test_config_history.py
@@ -113,6 +113,10 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
 
     def test_service_config_history(self):
         """Test history entries for service config operations."""
+        response = self.client.get('/api/configs/service')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('service_auth', response.json())
+
         self._verify_initial_config_entry('SERVICE')
 
         # Test first service config update
@@ -159,6 +163,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
             expected_tags=first_tags,
         )
         config = history['configs'][-2]['data']
+        self.assertNotIn('service_auth', config)
         self.assertEqual(config['cli_config']['latest_version'], '1.0.0')
         self.assertEqual(config['cli_config']
                          ['min_supported_version'], '1.0.0')
@@ -170,6 +175,7 @@ class ConfigHistoryTestCase(fixture.ServiceTestFixture):
             expected_tags=second_tags,
         )
         config = history['configs'][-1]['data']
+        self.assertNotIn('service_auth', config)
         self.assertEqual(config['cli_config']['latest_version'], '2.0.0')
         self.assertEqual(config['cli_config']
                          ['min_supported_version'], '2.0.0')

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -31,13 +31,15 @@ import unittest
 from typing import Any, Dict
 from unittest import mock
 
+from fastapi import responses
 import yaml
 
 from src.lib.utils import osmo_errors
 from src.service.core.config import (
-    configmap_events, configmap_guard, configmap_loader, helpers,
+    config_service, configmap_events, configmap_guard, configmap_loader, helpers,
+    objects as config_objects,
 )
-from src.utils import auth, configmap_state
+from src.utils import auth, configmap_state, connectors
 
 _DEFAULT_SERVICE_AUTH_CONFIG: Dict[str, Any] | None = None
 
@@ -62,14 +64,9 @@ def _with_service_auth(config: Dict[str, Any]) -> Dict[str, Any]:
 
 def _postgres_with_service_auth(
         service_auth: Dict[str, Any] | None = None) -> mock.MagicMock:
-    persisted_service_config = mock.MagicMock()
-    persisted_service_config.plaintext_dict.return_value = {
-        'service_auth': (
-            service_auth if service_auth is not None
-            else _service_auth_config()),
-    }
     postgres = mock.MagicMock()
-    postgres.get_service_configs.return_value = persisted_service_config
+    postgres.get_service_auth.return_value = auth.AuthenticationConfig.model_validate(
+        service_auth if service_auth is not None else _service_auth_config())
     return postgres
 
 
@@ -135,6 +132,71 @@ class TestConfigmapState(unittest.TestCase):
         new_snapshot = configmap_state.get_snapshot()
         assert new_snapshot is not None
         self.assertEqual(new_snapshot['service']['version'], 2)
+
+
+class TestServiceAuthSecretManagement(unittest.TestCase):
+    """Tests for rejecting writes to Secret-managed service auth."""
+
+    def test_service_config_response_omits_external_identity(self):
+        postgres = mock.MagicMock()
+        postgres.service_auth_is_external = True
+        postgres.get_service_configs.return_value = connectors.ServiceConfig(
+            service_auth=auth.AuthenticationConfig.generate_default())
+
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance', return_value=postgres,
+        ):
+            response = config_service.read_service_configs()
+
+        assert isinstance(response, responses.JSONResponse)
+        self.assertNotIn('service_auth', json.loads(response.body))
+
+    def test_service_config_response_preserves_legacy_identity(self):
+        postgres = mock.MagicMock()
+        postgres.service_auth_is_external = False
+        service_configs = connectors.ServiceConfig(
+            service_auth=auth.AuthenticationConfig.generate_default())
+        postgres.get_service_configs.return_value = service_configs
+
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance', return_value=postgres,
+        ):
+            response = config_service.read_service_configs()
+
+        assert isinstance(response, connectors.ServiceConfig)
+        self.assertIs(response, service_configs)
+        self.assertIn('service_auth', response.model_dump())
+
+    def test_explicit_service_auth_patch_is_rejected_before_database_access(self):
+        postgres = mock.MagicMock()
+        request = config_objects.PatchConfigRequest(
+            configs_dict={'service_auth': {'issuer': 'replacement'}})
+
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance', return_value=postgres,
+        ):
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                helpers.patch_configs(
+                    request, connectors.ConfigType.SERVICE, username='admin')
+
+        self.assertEqual(context.exception.status_code, 409)
+        postgres.get_configs.assert_not_called()
+
+    def test_explicit_service_auth_put_is_rejected_before_database_access(self):
+        postgres = mock.MagicMock()
+        request = config_objects.PutServiceRequest(
+            configs=connectors.ServiceConfig(
+                service_auth=auth.AuthenticationConfig.generate_default()))
+
+        with mock.patch.object(
+            connectors.PostgresConnector, 'get_instance', return_value=postgres,
+        ):
+            with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                helpers.put_configs(
+                    request, connectors.ConfigType.SERVICE, username='admin')
+
+        self.assertEqual(context.exception.status_code, 409)
+        postgres.set_config.assert_not_called()
 
 
 class TestResolveSecretFileReferences(unittest.TestCase):
@@ -1001,14 +1063,11 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_cold_load_hydrates_service_auth_from_postgres(self):
+    def test_cold_load_hydrates_service_auth_from_configured_source(self):
         persisted_auth = _service_auth_config()
-        persisted_service_config = mock.MagicMock()
-        persisted_service_config.plaintext_dict.return_value = {
-            'service_auth': persisted_auth,
-        }
         postgres = mock.MagicMock()
-        postgres.get_service_configs.return_value = persisted_service_config
+        postgres.get_service_auth.return_value = (
+            auth.AuthenticationConfig.model_validate(persisted_auth))
         config: Dict[str, Any] = {
             'service': {
                 'max_pod_restart_limit': '30m',
@@ -1035,9 +1094,63 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
         finally:
             os.unlink(path)
 
-    def test_reload_carries_forward_db_service_auth(self):
+    def test_secret_backed_load_succeeds_without_database_identity_access(self):
+        stable_service_auth = auth.AuthenticationConfig.generate_default()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            service_auth_path = os.path.join(
+                temporary_directory, 'authentication-config.json')
+            with open(service_auth_path, 'w', encoding='utf-8') as service_auth_file:
+                service_auth_file.write(
+                    stable_service_auth.canonical_json(include_login_info=False))
+
+            postgres = connectors.PostgresConnector.__new__(
+                connectors.PostgresConnector)
+            untyped_postgres: Any = postgres
+            untyped_postgres.config = connectors.PostgresConfig(
+                postgres_password='unused',
+                service_auth_file=service_auth_path,
+            )
+            untyped_postgres._service_auth = (
+                auth.load_authentication_config_file(service_auth_path))
+            untyped_postgres._runtime_service_auth_login_info = None
+            untyped_postgres.execute_fetch_command = mock.Mock(
+                side_effect=AssertionError(
+                    'must not read service_auth from database'))
+            untyped_postgres.execute_commit_command = mock.Mock(
+                side_effect=AssertionError(
+                    'must not write service_auth to database'))
+
+            path = self._write_config_file({
+                'service': {
+                    'max_pod_restart_limit': '30m',
+                },
+            })
+            try:
+                with mock.patch.object(
+                    auth.AuthenticationConfig,
+                    'generate_default',
+                    side_effect=AssertionError(
+                        'must not generate a replacement identity'),
+                ) as generate_default:
+                    watcher = configmap_loader.ConfigMapWatcher(path, postgres)
+                    result = watcher._load_and_apply()
+                    service_config = postgres.get_service_configs()
+
+                self.assertEqual(result, configmap_loader.LoadResult.SUCCESS)
+                self.assertEqual(
+                    service_config.service_auth.canonical_json(
+                        include_login_info=False),
+                    stable_service_auth.canonical_json(include_login_info=False),
+                )
+                generate_default.assert_not_called()
+                untyped_postgres.execute_fetch_command.assert_not_called()
+                untyped_postgres.execute_commit_command.assert_not_called()
+            finally:
+                os.unlink(path)
+
+    def test_reload_carries_forward_stable_service_auth(self):
         persisted_auth = _service_auth_config()
-        persisted_auth['issuer'] = 'postgres-issuer'
+        persisted_auth['issuer'] = 'stable-source-issuer'
         configmap_auth = _service_auth_config()
         configmap_auth['issuer'] = 'configmap-issuer'
         postgres = _postgres_with_service_auth(persisted_auth)
@@ -1068,16 +1181,16 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
             self.assertEqual(service_config['service_auth'], persisted_auth)
             self.assertEqual(
                 service_config['max_pod_restart_limit'], '45m')
-            postgres.get_service_configs.assert_called_once_with()
+            postgres.get_service_auth.assert_called_once_with()
         finally:
             os.unlink(path)
 
-    def test_configmap_service_auth_cannot_override_postgres(self):
+    def test_configmap_service_auth_cannot_override_stable_source(self):
         configmap_auth = {
             'secret_file': '/configmap/service-auth-must-not-be-read',
         }
         persisted_auth = _service_auth_config()
-        persisted_auth['issuer'] = 'postgres-issuer'
+        persisted_auth['issuer'] = 'stable-source-issuer'
         postgres = _postgres_with_service_auth(persisted_auth)
         path = self._write_config_file({
             'service': {
@@ -1095,15 +1208,15 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
                 snapshot['service']['service_auth'], persisted_auth)
             self.assertNotEqual(
                 snapshot['service']['service_auth'], configmap_auth)
-            postgres.get_service_configs.assert_called_once_with()
+            postgres.get_service_auth.assert_called_once_with()
         finally:
             os.unlink(path)
 
-    def test_new_watcher_hydrates_service_auth_from_postgres(self):
+    def test_new_watcher_hydrates_service_auth_from_configured_source(self):
         previous_auth = _service_auth_config()
         previous_auth['issuer'] = 'previous-issuer'
         persisted_auth = _service_auth_config()
-        persisted_auth['issuer'] = 'postgres-issuer'
+        persisted_auth['issuer'] = 'stable-source-issuer'
         configmap_state.set_parsed_configs({
             'service': {'service_auth': previous_auth},
         })
@@ -1123,7 +1236,7 @@ class TestConfigMapWatcherLoadAndApply(unittest.TestCase):
                 snapshot['service']['service_auth'], persisted_auth)
             self.assertNotEqual(
                 snapshot['service']['service_auth'], previous_auth)
-            postgres.get_service_configs.assert_called_once_with()
+            postgres.get_service_auth.assert_called_once_with()
         finally:
             os.unlink(path)
 
@@ -2540,8 +2653,8 @@ class TestStartConfigWatcher(unittest.TestCase):
         self.assertIsNone(watcher)
         self.assertFalse(configmap_state.is_configmap_mode())
 
-    def test_non_api_service_hydrates_db_auth_without_event_recorder(self):
-        """All services hydrate DB auth; non-API replicas skip K8s events."""
+    def test_non_api_service_hydrates_auth_without_event_recorder(self):
+        """All services hydrate auth; non-API replicas skip K8s events."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             config_path = os.path.join(tmp_dir, 'config.yaml')
             with open(config_path, 'w', encoding='utf-8') as f:
@@ -2557,7 +2670,7 @@ class TestStartConfigWatcher(unittest.TestCase):
                 try:
                     self.assertIsNone(watcher._event_recorder)
                     mock_recorder.assert_not_called()
-                    postgres.get_service_configs.assert_called_once_with()
+                    postgres.get_service_auth.assert_called_once_with()
                 finally:
                     watcher.stop()
 

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -453,37 +453,34 @@ def configure_app(target_app: fastapi.FastAPI, config: objects.WorkflowServiceCo
         objects.WorkflowServiceContext(config=config, database=postgres))
     backend_secret_auth.configure(config.backend_token_directory)
 
+    login_info = auth.LoginInfo(
+        device_endpoint=config.device_endpoint,
+        device_client_id=config.device_client_id,
+        browser_endpoint=config.browser_endpoint,
+        browser_client_id=config.browser_client_id,
+        token_endpoint=config.token_endpoint,
+        logout_endpoint=config.logout_endpoint,
+    )
     if not config.config_file:
-        service_configs_dict = postgres.get_service_configs()
-
-        configs_dict = {}
-        login_info = auth.LoginInfo(
-            device_endpoint=config.device_endpoint,
-            device_client_id=config.device_client_id,
-            browser_endpoint=config.browser_endpoint,
-            browser_client_id=config.browser_client_id,
-            token_endpoint=config.token_endpoint,
-            logout_endpoint=config.logout_endpoint,
-        )
-        if login_info != service_configs_dict.service_auth.login_info:
-            configs_dict['service_auth'] = {
-                'login_info': login_info.model_dump()
-            }
-
-        if configs_dict:
+        service_configs = postgres.get_service_configs()
+        if (not postgres.service_auth_is_external
+                and login_info != service_configs.service_auth.login_info):
             config_helpers.patch_configs(
                 request=config_objects.PatchConfigRequest(
-                    configs_dict=configs_dict,
+                    configs_dict={
+                        'service_auth': {'login_info': login_info.model_dump()},
+                    },
                     description='Updated service auth',
                 ),
                 config_type=connectors.ConfigType.SERVICE,
                 username='',
             )
-
         create_default_pool(postgres)
         set_default_backend_images(postgres)
         set_client_install_url(postgres, config)
         set_default_service_url(postgres)
+
+    postgres.set_runtime_service_auth_login_info(login_info)
 
     setup_default_admin(postgres, config)
 

--- a/src/service/core/service_auth_bootstrap.py
+++ b/src/service/core/service_auth_bootstrap.py
@@ -1,0 +1,293 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import argparse
+import base64
+import binascii
+import json
+import logging
+import os
+from typing import Any, NoReturn
+
+from jwcrypto import jwe  # type: ignore
+from jwcrypto.common import JWException  # type: ignore
+from kubernetes import client, config as kube_config  # type: ignore
+from kubernetes.client.exceptions import ApiException  # type: ignore
+import psycopg2  # type: ignore
+import pydantic
+
+from src.lib.utils import osmo_errors
+from src.utils import auth
+from src.utils.secret_manager import Encrypted, SecretManager
+
+
+_PLACEHOLDER_ANNOTATION = 'osmo.nvidia.com/service-auth-db-migration-placeholder'
+_CREDENTIAL_SOURCE_ANNOTATION = 'osmo.nvidia.com/credential-source'
+
+
+def _unexpected_user_key_access(*_args: Any) -> NoReturn:
+    raise RuntimeError('Service auth must use the master encryption key directly')
+
+
+def _decrypt_legacy_service_auth(
+    payload: str, secret_manager: SecretManager,
+) -> auth.AuthenticationConfig:
+    """Decode the legacy DB representation without modifying PostgreSQL."""
+    try:
+        raw_config = json.loads(payload)
+        keys = raw_config['keys']
+        if not isinstance(keys, dict) or not keys:
+            raise ValueError('missing keys')
+        for key_pair in keys.values():
+            private_key = key_pair['private_key']
+            if not isinstance(private_key, str):
+                raise ValueError('invalid private key')
+            token = jwe.JWE()
+            try:
+                token.deserialize(private_key)
+            except JWException:
+                continue
+            key_pair['private_key'] = secret_manager.decrypt(
+                Encrypted(private_key), '', lambda _value: None).value
+
+        service_auth = auth.AuthenticationConfig.model_validate(raw_config)
+        service_auth.validate_key_pairs()
+        return service_auth
+    except Exception:
+        raise osmo_errors.OSMOError(
+            'Legacy service_auth is missing, malformed, or cannot be decrypted.') from None
+
+
+def _read_legacy_service_auth(arguments: argparse.Namespace) -> auth.AuthenticationConfig:
+    password = os.environ.get('OSMO_POSTGRES_PASSWORD')
+    if password is None:
+        raise osmo_errors.OSMOError('OSMO_POSTGRES_PASSWORD is required.')
+
+    try:
+        with psycopg2.connect(
+            host=arguments.postgres_host,
+            port=arguments.postgres_port,
+            dbname=arguments.postgres_database,
+            user=arguments.postgres_user,
+            password=password,
+        ) as connection:
+            connection.set_session(readonly=True)
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    'SELECT value FROM configs '
+                    "WHERE key = 'service_auth' AND type = 'SERVICE'")
+                row = cursor.fetchone()
+    except psycopg2.Error:
+        raise osmo_errors.OSMOError(
+            'Unable to read legacy service_auth from PostgreSQL.') from None
+
+    if row is None or not isinstance(row[0], str) or not row[0]:
+        raise osmo_errors.OSMOError(
+            'Legacy service_auth is missing from PostgreSQL.')
+
+    secret_manager = SecretManager(
+        arguments.mek_file,
+        _unexpected_user_key_access,
+        _unexpected_user_key_access,
+        _unexpected_user_key_access,
+        _unexpected_user_key_access,
+    )
+    return _decrypt_legacy_service_auth(row[0], secret_manager)
+
+
+def _decode_existing_secret(
+    secret: client.V1Secret,
+    secret_key: str,
+) -> auth.AuthenticationConfig:
+    encoded_payload = (secret.data or {}).get(secret_key)
+    if not encoded_payload:
+        raise osmo_errors.OSMOError(
+            f'Existing service auth Secret is missing key {secret_key}.')
+    try:
+        payload = base64.b64decode(encoded_payload, validate=True).decode('utf-8')
+        parsed_payload = json.loads(payload)
+        service_auth = auth.AuthenticationConfig.model_validate(parsed_payload)
+        service_auth.validate_key_pairs()
+        return service_auth
+    except (JWException, binascii.Error, UnicodeError, json.JSONDecodeError,
+            TypeError, ValueError, pydantic.ValidationError):
+        raise osmo_errors.OSMOError(
+            'Existing service auth Secret is invalid.') from None
+
+
+def _same_stable_authority(
+    first: auth.AuthenticationConfig,
+    second: auth.AuthenticationConfig,
+) -> bool:
+    return first.canonical_json(include_login_info=False) == second.canonical_json(
+        include_login_info=False)
+
+
+def _read_secret(
+    core_api: client.CoreV1Api,
+    namespace: str,
+    secret_name: str,
+) -> client.V1Secret | None:
+    try:
+        return core_api.read_namespaced_secret(secret_name, namespace)
+    except ApiException as error:
+        if error.status == 404:
+            return None
+        raise osmo_errors.OSMOError(
+            f'Unable to read service auth Secret {secret_name}.') from None
+
+
+def _verify_existing_secret(
+    secret: client.V1Secret,
+    secret_key: str,
+    legacy_auth: auth.AuthenticationConfig,
+) -> None:
+    existing_auth = _decode_existing_secret(secret, secret_key)
+    if not _same_stable_authority(existing_auth, legacy_auth):
+        raise osmo_errors.OSMOError(
+            'Existing service auth Secret does not match the legacy identity.')
+
+
+def _populate_or_verify_secret(
+    arguments: argparse.Namespace,
+    legacy_auth: auth.AuthenticationConfig,
+) -> None:
+    kube_config.load_incluster_config()
+    core_api = client.CoreV1Api()
+    existing = _read_secret(core_api, arguments.namespace, arguments.target_secret)
+    if existing is None:
+        raise osmo_errors.OSMOError(
+            f'Pre-provisioned service auth Secret {arguments.target_secret} is not found.')
+
+    if (existing.data or {}).get(arguments.target_key):
+        _verify_existing_secret(existing, arguments.target_key, legacy_auth)
+        logging.info('Existing service auth Secret is valid; preserving it')
+        return
+
+    metadata = existing.metadata
+    annotations = dict(metadata.annotations or {}) if metadata is not None else {}
+    if (existing.data or metadata is None
+            or annotations.get(_PLACEHOLDER_ANNOTATION) != arguments.release_name):
+        raise osmo_errors.OSMOError(
+            'Existing service auth Secret is neither a complete matching identity '
+            'nor an authorized empty migration placeholder.')
+
+    canonical_payload = legacy_auth.canonical_json(include_login_info=False)
+    existing.data = {
+        arguments.target_key: base64.b64encode(
+            canonical_payload.encode('utf-8')).decode('ascii'),
+    }
+    annotations.pop(_PLACEHOLDER_ANNOTATION)
+    annotations[_CREDENTIAL_SOURCE_ANNOTATION] = 'legacy-db-migration'
+    metadata.annotations = annotations
+    labels = dict(metadata.labels or {})
+    labels['app.kubernetes.io/managed-by'] = 'osmo-service-auth-db-migration'
+    labels['app.kubernetes.io/instance'] = arguments.release_name
+    metadata.labels = labels
+    try:
+        core_api.replace_namespaced_secret(
+            arguments.target_secret, arguments.namespace, existing)
+        logging.info('Populated service auth Secret %s', arguments.target_secret)
+    except ApiException as error:
+        if error.status != 409:
+            raise osmo_errors.OSMOError(
+                f'Unable to update service auth Secret {arguments.target_secret}.') from None
+        existing = _read_secret(core_api, arguments.namespace, arguments.target_secret)
+        if existing is None:
+            raise osmo_errors.OSMOError(
+                f'Unable to verify service auth Secret {arguments.target_secret}.')
+        _verify_existing_secret(existing, arguments.target_key, legacy_auth)
+        logging.info('Service auth Secret was updated concurrently; preserving it')
+
+
+def _generate_service_auth_file(output_path: str) -> None:
+    """Generate a fresh canonical identity without writing secret material to stdout."""
+    service_auth = auth.AuthenticationConfig.generate_default()
+    service_auth.validate_key_pairs()
+    payload = service_auth.canonical_json(include_login_info=False)
+    try:
+        descriptor = os.open(
+            output_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+    except FileExistsError:
+        raise osmo_errors.OSMOError(
+            f'Refusing to overwrite existing service auth file {output_path}.') from None
+    except OSError:
+        raise osmo_errors.OSMOError(
+            f'Unable to create service auth file {output_path}.') from None
+
+    try:
+        with os.fdopen(descriptor, 'w', encoding='utf-8') as output_file:
+            output_file.write(payload)
+            output_file.write('\n')
+    except OSError:
+        raise osmo_errors.OSMOError(
+            f'Unable to write service auth file {output_path}.') from None
+    logging.info('Generated service auth file %s', output_path)
+
+
+def _migrate_service_auth(arguments: argparse.Namespace) -> None:
+    """Copy and then recheck the stable legacy identity before cutover."""
+    legacy_auth = _read_legacy_service_auth(arguments)
+    _populate_or_verify_secret(arguments, legacy_auth)
+    confirmed_auth = _read_legacy_service_auth(arguments)
+    if not _same_stable_authority(legacy_auth, confirmed_auth):
+        raise osmo_errors.OSMOError(
+            'Legacy service_auth changed during migration; refusing cutover.')
+
+
+def _parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Provision the stable OSMO service auth identity.')
+    commands = parser.add_subparsers(dest='command', required=True)
+
+    generate = commands.add_parser(
+        'generate', description='Generate a fresh offline service auth file.')
+    generate.add_argument('--output', required=True)
+
+    migrate = commands.add_parser(
+        'migrate', description='Copy the legacy DB identity to a Kubernetes Secret.')
+    migrate.add_argument('--postgres-host', required=True)
+    migrate.add_argument('--postgres-port', type=int, required=True)
+    migrate.add_argument('--postgres-database', required=True)
+    migrate.add_argument('--postgres-user', required=True)
+    migrate.add_argument('--mek-file', required=True)
+    migrate.add_argument('--namespace', required=True)
+    migrate.add_argument('--release-name', required=True)
+    migrate.add_argument('--target-secret', required=True)
+    migrate.add_argument('--target-key', required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format='%(levelname)s %(message)s')
+    try:
+        arguments = _parse_arguments()
+        if arguments.command == 'generate':
+            _generate_service_auth_file(arguments.output)
+        else:
+            _migrate_service_auth(arguments)
+    except osmo_errors.OSMOError as error:
+        logging.error('%s', error)
+        raise SystemExit(1) from None
+
+
+if __name__ == '__main__':
+    main()

--- a/src/service/core/tests/BUILD
+++ b/src/service/core/tests/BUILD
@@ -81,6 +81,20 @@ osmo_py_test(
     visibility = ["//visibility:public"],
 )
 
+osmo_py_test(
+    name = "test_service_auth_bootstrap",
+    srcs = ["test_service_auth_bootstrap.py"],
+    deps = [
+        osmo_requirement("jwcrypto"),
+        osmo_requirement("kubernetes"),
+        osmo_requirement("pyyaml"),
+        "//src/lib/utils:osmo_errors",
+        "//src/service/core:service_auth_bootstrap_lib",
+        "//src/utils:auth",
+        "//src/utils/secret_manager",
+    ],
+)
+
 osmo_py_library(
     name = "fixture",
     srcs = ["fixture.py"],

--- a/src/service/core/tests/fixture.py
+++ b/src/service/core/tests/fixture.py
@@ -19,7 +19,7 @@ SPDX-License-Identifier: Apache-2.0
 import logging
 import io
 import time
-from typing import Any, Dict
+from typing import Any, Dict, IO
 
 from fastapi import testclient
 
@@ -52,10 +52,12 @@ class ServiceTestFixture(fixtures.PostgresFixture,
     """
 
     client: testclient.TestClient
+    service_auth_file: IO[str]
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.service_auth_file = fixtures.create_service_auth_file()
 
         # Prepare a bucket in S3 storage
         cls.s3_client.create_bucket(Bucket=TEST_BUCKET_NAME)
@@ -76,6 +78,7 @@ class ServiceTestFixture(fixtures.PostgresFixture,
                 redis_db_number=cls.redis_params.db_number,
                 redis_tls_enable=False,
                 method='dev',
+                service_auth_file=cls.service_auth_file.name,
             ),
         )
         cls.client = testclient.TestClient(service.app)
@@ -103,6 +106,7 @@ class ServiceTestFixture(fixtures.PostgresFixture,
             # Close TestClient
             if hasattr(cls, 'client'):
                 cls.client.close()
+            cls.service_auth_file.close()
         finally:
             super().tearDownClass()
 

--- a/src/service/core/tests/test_service.py
+++ b/src/service/core/tests/test_service.py
@@ -90,7 +90,7 @@ class ServiceTestCase(service_fixture.ServiceTestFixture):
             config_objects.PatchConfigRequest(
                 configs_dict=connectors.postgres.ServiceConfig(
                     cli_config=connectors.postgres.CliConfig(latest_version=str(test_version)),
-                ).model_dump(),
+                ).model_dump(exclude_unset=True),
             ),
             config_type=connectors.ConfigType.SERVICE,
             username='test@nvidia.com',
@@ -477,7 +477,7 @@ class ServiceTestCase(service_fixture.ServiceTestFixture):
                         latest_version=latest_version,
                         min_supported_version=min_supported_version,
                     ),
-                ).model_dump(),
+                ).model_dump(exclude_unset=True),
             ),
             config_type=connectors.ConfigType.SERVICE,
             username='test@nvidia.com',

--- a/src/service/core/tests/test_service_auth_bootstrap.py
+++ b/src/service/core/tests/test_service_auth_bootstrap.py
@@ -1,0 +1,326 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.  # pylint: disable=line-too-long
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# pylint: disable=protected-access
+
+import argparse
+import base64
+import json
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from jwcrypto import jwk
+from kubernetes import client
+from kubernetes.client.exceptions import ApiException
+import yaml
+
+from src.lib.utils import osmo_errors
+from src.service.core import service_auth_bootstrap
+from src.utils import auth
+from src.utils.secret_manager import SecretManager
+
+
+def _authentication_config() -> auth.AuthenticationConfig:
+    key_name = 'installation-key'
+    key = jwk.JWK.generate(kty='RSA', kid=key_name, size=2048)
+    return auth.AuthenticationConfig(
+        keys={
+            key_name: auth.AsymmetricKeyPair(
+                public_key=key.export_public(),
+                private_key=key.export_private(),
+            ),
+        },
+        active_key=key_name,
+        issuer='osmo',
+        audience='osmo',
+    )
+
+
+def _write_mek_file(path: str, current_key: jwk.JWK, keys: list[jwk.JWK]) -> None:
+    with open(path, 'w', encoding='utf-8') as mek_file:
+        yaml.safe_dump({
+            'currentMek': current_key.key_id,
+            'meks': {
+                key.key_id: base64.b64encode(
+                    key.export().encode('utf-8')).decode('ascii')
+                for key in keys
+            },
+        }, mek_file)
+
+
+def _secret_manager(path: str) -> SecretManager:
+    unexpected = mock.Mock(side_effect=RuntimeError('unexpected user key access'))
+    return SecretManager(path, unexpected, unexpected, unexpected, unexpected)
+
+
+class ServiceAuthBootstrapTest(unittest.TestCase):
+
+    def test_legacy_database_read_uses_read_only_session(self):
+        arguments = argparse.Namespace(
+            postgres_host='postgres',
+            postgres_port=5432,
+            postgres_database='osmo',
+            postgres_user='osmo',
+            mek_file='/mek.yaml',
+        )
+        connection = mock.MagicMock()
+        cursor = connection.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = ('legacy-payload',)
+        connect = mock.MagicMock()
+        connect.return_value.__enter__.return_value = connection
+        expected = _authentication_config()
+
+        with mock.patch.dict(
+            os.environ, {'OSMO_POSTGRES_PASSWORD': 'password'}, clear=False,
+        ), mock.patch.object(
+            service_auth_bootstrap.psycopg2, 'connect', connect,
+        ), mock.patch.object(
+            service_auth_bootstrap, 'SecretManager', return_value=mock.MagicMock(),
+        ), mock.patch.object(
+            service_auth_bootstrap, '_decrypt_legacy_service_auth',
+            return_value=expected,
+        ):
+            actual = service_auth_bootstrap._read_legacy_service_auth(arguments)
+
+        self.assertIs(actual, expected)
+        connection.set_session.assert_called_once_with(readonly=True)
+        cursor.execute.assert_called_once()
+
+    def test_generate_writes_valid_canonical_identity_with_private_permissions(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = os.path.join(
+                temporary_directory, 'authentication-config.json')
+
+            service_auth_bootstrap._generate_service_auth_file(output_path)
+
+            generated = auth.load_authentication_config_file(output_path)
+            generated.validate_key_pairs()
+            with open(output_path, encoding='utf-8') as output_file:
+                self.assertEqual(
+                    output_file.read().strip(),
+                    generated.canonical_json(include_login_info=False),
+                )
+            self.assertEqual(os.stat(output_path).st_mode & 0o777, 0o600)
+
+    def test_generate_refuses_to_overwrite_existing_file(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output_path = os.path.join(
+                temporary_directory, 'authentication-config.json')
+            with open(output_path, 'w', encoding='utf-8') as output_file:
+                output_file.write('sentinel')
+
+            with self.assertRaisesRegex(osmo_errors.OSMOError, 'Refusing to overwrite'):
+                service_auth_bootstrap._generate_service_auth_file(output_path)
+
+            with open(output_path, encoding='utf-8') as output_file:
+                self.assertEqual(output_file.read(), 'sentinel')
+
+    def test_migration_rechecks_legacy_identity_after_populating_secret(self):
+        service_auth = _authentication_config()
+        changed_auth = _authentication_config()
+        arguments = argparse.Namespace()
+
+        with mock.patch.object(
+            service_auth_bootstrap,
+            '_read_legacy_service_auth',
+            side_effect=[service_auth, changed_auth],
+        ), mock.patch.object(
+            service_auth_bootstrap, '_populate_or_verify_secret',
+        ) as populate, self.assertRaisesRegex(
+            osmo_errors.OSMOError, 'changed during migration',
+        ):
+            service_auth_bootstrap._migrate_service_auth(arguments)
+
+        populate.assert_called_once_with(arguments, service_auth)
+
+    def test_plaintext_legacy_identity_is_validated_without_decryption(self):
+        service_auth = _authentication_config()
+        secret_manager = mock.MagicMock()
+
+        migrated = service_auth_bootstrap._decrypt_legacy_service_auth(
+            service_auth.canonical_json(), secret_manager)
+
+        self.assertEqual(
+            migrated.canonical_json(include_login_info=False),
+            service_auth.canonical_json(include_login_info=False),
+        )
+        secret_manager.decrypt.assert_not_called()
+
+    def test_old_mek_ciphertext_is_decrypted_to_canonical_plaintext(self):
+        service_auth = _authentication_config()
+        old_mek = jwk.JWK.generate(kty='oct', kid='old-mek', size=256)
+        current_mek = jwk.JWK.generate(kty='oct', kid='current-mek', size=256)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            old_path = os.path.join(temporary_directory, 'old-mek.yaml')
+            current_path = os.path.join(temporary_directory, 'current-mek.yaml')
+            _write_mek_file(old_path, old_mek, [old_mek])
+            _write_mek_file(current_path, current_mek, [current_mek, old_mek])
+
+            encrypted_payload = service_auth.plaintext_dict()
+            active_key = encrypted_payload['active_key']
+            encrypted_payload['keys'][active_key]['private_key'] = (
+                _secret_manager(old_path).encrypt(
+                    encrypted_payload['keys'][active_key]['private_key'], '').value)
+
+            migrated = service_auth_bootstrap._decrypt_legacy_service_auth(
+                json.dumps(encrypted_payload), _secret_manager(current_path))
+
+        self.assertEqual(
+            migrated.canonical_json(include_login_info=False),
+            service_auth.canonical_json(include_login_info=False),
+        )
+        self.assertNotIn('old-mek', migrated.canonical_json())
+
+    def test_invalid_legacy_payload_does_not_leak_private_value(self):
+        sentinel = 'private-key-sentinel'
+        payload = json.dumps({
+            'keys': {'bad': {'public_key': '{}', 'private_key': sentinel}},
+            'active_key': 'bad',
+            'issuer': 'osmo',
+            'audience': 'osmo',
+        })
+
+        with self.assertRaises(osmo_errors.OSMOError) as context:
+            service_auth_bootstrap._decrypt_legacy_service_auth(
+                payload, mock.MagicMock())
+
+        self.assertNotIn(sentinel, str(context.exception))
+
+    def test_existing_secret_compares_full_stable_identity(self):
+        service_auth = _authentication_config()
+        existing = client.V1Secret(data={
+            'authentication-config.json': base64.b64encode(
+                service_auth.canonical_json(
+                    include_login_info=False).encode('utf-8')).decode('ascii'),
+        })
+
+        service_auth_bootstrap._verify_existing_secret(
+            existing, 'authentication-config.json', service_auth)
+
+        different_identity = service_auth.model_copy(
+            deep=True, update={'audience': 'different-audience'})
+        with self.assertRaises(osmo_errors.OSMOError):
+            service_auth_bootstrap._verify_existing_secret(
+                existing, 'authentication-config.json', different_identity)
+
+    def test_preprovisioned_secret_is_populated_with_canonical_stable_identity(self):
+        service_auth = _authentication_config().model_copy(
+            deep=True,
+            update={'login_info': auth.LoginInfo(device_client_id='runtime-only')},
+        )
+        core_api = mock.MagicMock()
+        core_api.read_namespaced_secret.return_value = client.V1Secret(
+            metadata=client.V1ObjectMeta(
+                name='osmo-service-auth',
+                namespace='osmo',
+                resource_version='1',
+                annotations={
+                    'osmo.nvidia.com/service-auth-db-migration-placeholder': 'prod',
+                },
+            ),
+            type='Opaque',
+        )
+        arguments = argparse.Namespace(
+            namespace='osmo',
+            target_secret='osmo-service-auth',
+            target_key='authentication-config.json',
+            release_name='prod',
+        )
+
+        with mock.patch.object(service_auth_bootstrap.kube_config,
+                               'load_incluster_config'), mock.patch.object(
+                service_auth_bootstrap.client, 'CoreV1Api', return_value=core_api):
+            service_auth_bootstrap._populate_or_verify_secret(arguments, service_auth)
+
+        updated_secret = core_api.replace_namespaced_secret.call_args.args[2]
+        encoded_payload = updated_secret.data['authentication-config.json']
+        payload = base64.b64decode(encoded_payload).decode('utf-8')
+        self.assertEqual(
+            payload,
+            service_auth.canonical_json(include_login_info=False),
+        )
+        self.assertNotIn('runtime-only', payload)
+        self.assertNotIn(
+            'osmo.nvidia.com/service-auth-db-migration-placeholder',
+            updated_secret.metadata.annotations,
+        )
+        self.assertNotIn(
+            'osmo.nvidia.com/service-auth-bootstrap-placeholder',
+            updated_secret.metadata.annotations,
+        )
+        self.assertEqual(
+            updated_secret.metadata.annotations['osmo.nvidia.com/credential-source'],
+            'legacy-db-migration',
+        )
+        self.assertEqual(
+            updated_secret.metadata.labels['app.kubernetes.io/managed-by'],
+            'osmo-service-auth-db-migration',
+        )
+        self.assertNotIn(
+            'osmo-service-auth-bootstrap',
+            updated_secret.metadata.labels.values(),
+        )
+        core_api.create_namespaced_secret.assert_not_called()
+
+    def test_missing_preprovisioned_secret_fails_closed(self):
+        core_api = mock.MagicMock()
+        core_api.read_namespaced_secret.side_effect = ApiException(status=404)
+        arguments = argparse.Namespace(
+            namespace='osmo',
+            target_secret='osmo-service-auth',
+            target_key='authentication-config.json',
+            release_name='prod',
+        )
+
+        with mock.patch.object(service_auth_bootstrap.kube_config,
+                               'load_incluster_config'), mock.patch.object(
+                service_auth_bootstrap.client, 'CoreV1Api', return_value=core_api), \
+                self.assertRaisesRegex(osmo_errors.OSMOError, 'is not found'):
+            service_auth_bootstrap._populate_or_verify_secret(
+                arguments, _authentication_config())
+
+        core_api.replace_namespaced_secret.assert_not_called()
+
+    def test_unmarked_empty_secret_fails_closed(self):
+        core_api = mock.MagicMock()
+        core_api.read_namespaced_secret.return_value = client.V1Secret(
+            metadata=client.V1ObjectMeta(name='osmo-service-auth'),
+            type='Opaque',
+        )
+        arguments = argparse.Namespace(
+            namespace='osmo',
+            target_secret='osmo-service-auth',
+            target_key='authentication-config.json',
+            release_name='prod',
+        )
+
+        with mock.patch.object(service_auth_bootstrap.kube_config,
+                               'load_incluster_config'), mock.patch.object(
+                service_auth_bootstrap.client, 'CoreV1Api', return_value=core_api), \
+                self.assertRaisesRegex(osmo_errors.OSMOError, 'authorized empty'):
+            service_auth_bootstrap._populate_or_verify_secret(
+                arguments, _authentication_config())
+
+        core_api.replace_namespaced_secret.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/core/workflow/tests/test_workflow_label_filters_db.py
+++ b/src/service/core/workflow/tests/test_workflow_label_filters_db.py
@@ -17,6 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 from types import SimpleNamespace
+from typing import IO
 import unittest
 from unittest import mock
 
@@ -37,9 +38,12 @@ class WorkflowLabelFiltersFixture(
     layering prevents sharing the class across the two test trees.
     """
 
+    service_auth_file: IO[str]
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.service_auth_file = fixtures.create_service_auth_file()
         postgres.PostgresConnector(
             postgres.PostgresConfig(
                 postgres_host=cls.postgres_container.get_container_host_ip(),
@@ -48,6 +52,7 @@ class WorkflowLabelFiltersFixture(
                 postgres_database_name=cls.postgres_container.dbname,
                 postgres_user=cls.postgres_container.username,
                 method='dev',
+                service_auth_file=cls.service_auth_file.name,
             ))
 
     @classmethod
@@ -57,6 +62,7 @@ class WorkflowLabelFiltersFixture(
                 postgres.PostgresConnector._instance.close()  # pylint: disable=protected-access
                 postgres.PostgresConnector._instance = None  # pylint: disable=protected-access
         finally:
+            cls.service_auth_file.close()
             super().tearDownClass()
 
     @property

--- a/src/service/core/workflow/tests/test_workflow_service.py
+++ b/src/service/core/workflow/tests/test_workflow_service.py
@@ -21,6 +21,7 @@ Functional tests for APIs defined in workflow_service.py
 import concurrent.futures
 import logging
 import threading
+from typing import IO
 
 from fastapi import testclient
 
@@ -53,10 +54,13 @@ class WorkflowServiceTestCase(
     TEST_IMAGE_NAME = 'test_image'
 
     client: testclient.TestClient
+    service_auth_file: IO[str]
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.service_auth_file = fixtures.create_service_auth_file()
+        cls.addClassCleanup(cls.service_auth_file.close)
 
         # Setup the service application and correponding TestClient
         service.configure_app(
@@ -75,6 +79,7 @@ class WorkflowServiceTestCase(
                 redis_db_number=cls.redis_params.db_number,
                 redis_tls_enable=False,
                 method='dev',
+                service_auth_file=cls.service_auth_file.name,
             ),
         )
         cls.client = testclient.TestClient(service.app)

--- a/src/tests/common/BUILD
+++ b/src/tests/common/BUILD
@@ -26,6 +26,7 @@ osmo_py_library(
         "//src/tests/common/envoy",
         "//src/tests/common/registry",
         "//src/tests/common/storage",
+        "//src/utils:auth",
     ],
     visibility = ["//visibility:public"],
 )

--- a/src/tests/common/fixtures.py
+++ b/src/tests/common/fixtures.py
@@ -16,6 +16,9 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
+import tempfile
+from typing import IO
+
 from src.tests.common.core.network import NetworkFixture
 from src.tests.common.core.reaper import ReaperFixture
 from src.tests.common.database.postgres import PostgresFixture, PostgresTestIsolationFixture
@@ -24,6 +27,7 @@ from src.tests.common.registry.registry import DockerRegistryFixture
 from src.tests.common.storage.swift import SwiftStorageFixture
 from src.tests.common.storage.s3 import S3StorageFixture
 from src.tests.common.storage.redis import RedisStorageFixture
+from src.utils import auth
 
 __all__ = [
     "DockerRegistryFixture",
@@ -35,7 +39,19 @@ __all__ = [
     "SslProxyFixture",
     "SwiftStorageFixture",
     "S3StorageFixture",
+    "create_service_auth_file",
 ]
+
+
+def create_service_auth_file() -> IO[str]:
+    """Create an explicit file-backed identity for an isolated test process."""
+    service_auth_file = tempfile.NamedTemporaryFile(  # pylint: disable=consider-using-with
+        mode="w+", encoding="utf-8")
+    service_auth_file.write(
+        auth.AuthenticationConfig.generate_default().canonical_json(
+            include_login_info=False))
+    service_auth_file.flush()
+    return service_auth_file
 
 
 class OsmoTestFixture(ReaperFixture, NetworkFixture):

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -17,12 +17,14 @@ SPDX-License-Identifier: Apache-2.0
 """
 import hashlib
 import json
+import logging
 from typing import Any, Dict, List
 import uuid
 import time
 
 import pydantic
 from jwcrypto import jwk  # type: ignore
+from jwcrypto.common import JWException  # type: ignore
 import jwt  # type: ignore
 
 from src.lib.utils import common, osmo_errors
@@ -131,6 +133,58 @@ class AuthenticationConfig(pydantic.BaseModel):
     def get_current_key(self) -> AsymmetricKeyPair:
         return self.keys[self.active_key]
 
+    def validate_key_pairs(self) -> None:
+        """Validate that every stored public key matches its private key."""
+        for key_name, key_pair in self.keys.items():
+            try:
+                public_key = jwk.JWK.from_json(key_pair.public_key)
+                private_key = jwk.JWK.from_json(
+                    key_pair.private_key.get_secret_value())
+                public_values = {
+                    field: public_key.get(field) for field in ('kty', 'n', 'e')
+                }
+                private_values = {
+                    field: private_key.get(field) for field in ('kty', 'n', 'e')
+                }
+                if public_values != private_values:
+                    raise ValueError('public and private keys do not match')
+
+                test_token = key_pair.create_jwt({'sub': 'service-auth-validation'})
+                jwt.decode(
+                    test_token,
+                    key=public_key.export_to_pem(),
+                    algorithms=['RS256'],
+                    options={
+                        'verify_aud': False,
+                        'verify_exp': False,
+                    },
+                )
+            except Exception as error:
+                raise ValueError(
+                    f'Authentication key pair {key_name!r} is invalid') from error
+
+    def plaintext_dict(self, *, include_login_info: bool = True) -> Dict[str, Any]:
+        """Return an unmasked representation suitable for a Secret file."""
+        data = self.model_dump(mode='python')
+        for key_name, key_pair in self.keys.items():
+            data['keys'][key_name]['private_key'] = (
+                key_pair.private_key.get_secret_value())
+        if not include_login_info:
+            data.pop('login_info', None)
+        return data
+
+    def canonical_json(self, *, include_login_info: bool = True) -> str:
+        """Return stable plaintext JSON for persistence in a Kubernetes Secret."""
+        data = self.plaintext_dict(include_login_info=include_login_info)
+        for key_pair in data['keys'].values():
+            key_pair['public_key'] = json.dumps(
+                json.loads(key_pair['public_key']), sort_keys=True,
+                separators=(',', ':'))
+            key_pair['private_key'] = json.dumps(
+                json.loads(key_pair['private_key']), sort_keys=True,
+                separators=(',', ':'))
+        return json.dumps(data, sort_keys=True, separators=(',', ':'))
+
     def create_idtoken_jwt(self, expire_timestamp: int, username: str,
                            roles: List[str],
                            token_name: str | None = None,
@@ -166,7 +220,25 @@ class AuthenticationConfig(pydantic.BaseModel):
         return key.create_jwt(payload)
 
 
+def load_authentication_config_file(path: str) -> AuthenticationConfig:
+    """Load and validate canonical plaintext service auth from a mounted Secret."""
+    try:
+        with open(path, encoding='utf-8') as auth_file:
+            payload = json.load(auth_file)
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        raise osmo_errors.OSMOError(
+            f'Service auth file {path} is missing or invalid.') from None
+
+    try:
+        service_auth = AuthenticationConfig.model_validate(payload)
+        service_auth.validate_key_pairs()
+        return service_auth
+    except (JWException, TypeError, ValueError, pydantic.ValidationError):
+        logging.error('Service auth file validation failed for %s', path)
+        raise osmo_errors.OSMOError(
+            f'Service auth file {path} is invalid.') from None
+
+
 def hash_access_token(access_token: str) -> bytes:
     """ Hash the access token """
     return hashlib.sha256(access_token.encode()).digest()
-

--- a/src/utils/connectors/postgres.py
+++ b/src/utils/connectors/postgres.py
@@ -181,6 +181,15 @@ class PostgresConfig(pydantic.BaseModel):
         default='/opt/osmo/mek/mek.yaml',
         description='Path to the file that stores master encryption keys',
         json_schema_extra={'command_line': 'mek_file', 'env': 'OSMO_MEK_FILE'})
+    service_auth_file: str | None = pydantic.Field(
+        default=None,
+        description=(
+            'Path to canonical service auth JSON. An absent path retains the '
+            'legacy chart database mode until that deployment path is retired.'),
+        json_schema_extra={
+            'command_line': 'service_auth_file',
+            'env': 'OSMO_SERVICE_AUTH_FILE',
+        })
     method: Literal['dev'] | None = pydantic.Field(
         default=None,
         description='If set to "dev", use the default local mek file'
@@ -432,6 +441,10 @@ class PostgresConnector:
                 'generation': self.secret_manager.generation,
                 'digest': self.secret_manager.fingerprint_bundle_digest(),
             }, separators=(',', ':'), sort_keys=True))
+        self._service_auth: auth.AuthenticationConfig | None = (
+            auth.load_authentication_config_file(config.service_auth_file)
+            if config.service_auth_file else None)
+        self._runtime_service_auth_login_info: auth.LoginInfo | None = None
         logging.debug('Secret manager initialized')
 
         logging.debug('Initializing tables')
@@ -707,7 +720,11 @@ class PostgresConnector:
             return self._get_configs_from_snapshot(
                 config_type, snapshot)
 
+        uses_external_service_auth = (
+            config_type == ConfigType.SERVICE and self.service_auth_is_external)
         cmd = 'SELECT * FROM configs WHERE type = %s;'
+        if uses_external_service_auth:
+            cmd = "SELECT * FROM configs WHERE type = %s AND key != 'service_auth';"
         result = self.execute_fetch_command(cmd, (config_type.value,))
         if not result:
             raise osmo_errors.OSMODatabaseError('Configs are not found.')
@@ -728,12 +745,25 @@ class PostgresConnector:
         for model in result:
             if model.key not in hints:
                 continue
+            if uses_external_service_auth and model.key == 'service_auth':
+                continue
             item_type = hints[model.key]
             if item_type in primative_types:
                 result_dicts[model.key] = model.value
             else:
                 result_dicts[model.key] = json.loads(model.value)
-        return config_class.deserialize(result_dicts, self)
+        runtime_overrides = None
+        if uses_external_service_auth:
+            runtime_overrides = {'service_auth': self.get_service_auth()}
+        dynamic_config = config_class.deserialize(
+            result_dicts, self, runtime_overrides=runtime_overrides)
+        if (config_type == ConfigType.SERVICE
+                and self._runtime_service_auth_login_info is not None):
+            dynamic_config.service_auth = dynamic_config.service_auth.model_copy(
+                deep=True,
+                update={'login_info': self._runtime_service_auth_login_info},
+            )
+        return dynamic_config
 
     def _get_configs_from_snapshot(self, config_type: ConfigType,
                                    snapshot: dict):
@@ -748,6 +778,50 @@ class PostgresConnector:
 
     def get_service_configs(self) -> 'ServiceConfig':
         return self.get_configs(ConfigType.SERVICE)
+
+    @property
+    def service_auth_is_external(self) -> bool:
+        """Whether this process uses the mounted identity instead of legacy DB mode."""
+        return bool(self.config.service_auth_file)
+
+    def set_runtime_service_auth_login_info(self, login_info: auth.LoginInfo) -> None:
+        """Overlay deployment-derived login endpoints without persisting them."""
+        self._runtime_service_auth_login_info = login_info.model_copy(deep=True)
+
+    def get_service_auth(self) -> auth.AuthenticationConfig:
+        """Return the mounted identity, or the unmodified legacy-chart DB identity."""
+        if self._service_auth is not None:
+            service_auth = self._service_auth.model_copy(deep=True)
+        else:
+            rows = self.execute_fetch_command(
+                'SELECT value FROM configs '
+                "WHERE key = 'service_auth' AND type = 'SERVICE';",
+                (),
+                return_raw=True,
+            )
+            if not rows or not isinstance(rows[0]['value'], str):
+                raise osmo_errors.OSMODatabaseError('Service auth is not found.')
+            try:
+                service_auth_data = json.loads(rows[0]['value'])
+                service_auth = ServiceConfig.deserialize(
+                    {'service_auth': service_auth_data}, self).service_auth
+                service_auth.validate_key_pairs()
+            except (JWException, json.JSONDecodeError, pydantic.ValidationError, ValueError):
+                raise osmo_errors.OSMODatabaseError(
+                    'Persisted service auth is invalid.') from None
+
+        if self._runtime_service_auth_login_info is not None:
+            service_auth = service_auth.model_copy(
+                deep=True,
+                update={'login_info': self._runtime_service_auth_login_info},
+            )
+        return service_auth
+
+    def prepare_service_auth_history_data(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Exclude externally managed service auth from configuration history."""
+        history_data = copy.deepcopy(data)
+        history_data.pop('service_auth', None)
+        return history_data
 
     def get_workflow_configs(self) -> 'WorkflowConfig':
         return self.get_configs(ConfigType.WORKFLOW)
@@ -793,6 +867,11 @@ class PostgresConnector:
 
     def set_config(self, key: str, value: str | None, config_type: ConfigType):
         """ Set the config value for the given key. """
+        if (key == 'service_auth' and config_type == ConfigType.SERVICE
+                and self.service_auth_is_external):
+            raise osmo_errors.OSMOUserError(
+                'service_auth is managed outside PostgreSQL.',
+                status_code=409)
         cmd = 'UPDATE configs SET value = %s WHERE key = %s and type = %s;'
         return self.execute_commit_command(cmd, (value, key, config_type.value))
 
@@ -1381,6 +1460,9 @@ class PostgresConnector:
 
         def set_default_values(configs: 'DynamicConfig', config_type: ConfigType):
             for key, value in configs.serialize(self, exclude_unset=False).items():
+                if (key == 'service_auth' and config_type == ConfigType.SERVICE
+                        and self.service_auth_is_external):
+                    continue
                 if isinstance(value, str):
                     self._set_default_config(key, value, config_type)
                 else:
@@ -1446,6 +1528,10 @@ class PostgresConnector:
                 raise ValueError(
                     f'Invalid config type when initializing config history: {config_type}'
                 )
+
+            if (config_type == ConfigHistoryType.SERVICE
+                    and self.service_auth_is_external and isinstance(data, dict)):
+                data = self.prepare_service_auth_history_data(data)
 
             insert_cmd = """
                 INSERT INTO config_history
@@ -2047,6 +2133,9 @@ class PostgresConnector:
             description: Description of what changed
             tags: Optional list of tags to associate with this change
         """
+        if (config_type == ConfigHistoryType.SERVICE
+                and self.service_auth_is_external and isinstance(data, dict)):
+            data = self.prepare_service_auth_history_data(data)
         # Insert the history entry with calculated revision
         insert_cmd = """
             WITH next_rev AS (
@@ -3150,8 +3239,16 @@ class DynamicConfig(ExtraArgBaseModel):
     model_config = pydantic.ConfigDict(validate_assignment=True)
 
     @classmethod
-    def deserialize(cls, config_dict: Dict, postgres: PostgresConnector):
+    def deserialize(
+        cls,
+        config_dict: Dict,
+        postgres: PostgresConnector,
+        *,
+        runtime_overrides: Dict[str, Any] | None = None,
+        persist_secret_updates: bool = True,
+    ):
         """ Decrypts all secrets in `config_dict` """
+        runtime_overrides = runtime_overrides or {}
         encrypt_keys = set()
 
         # Define function to pass into secret_manager.decrypt to update secrets
@@ -3205,25 +3302,32 @@ class DynamicConfig(ExtraArgBaseModel):
                 jwetoken = jwe.JWE()
                 try:
                     jwetoken.deserialize(secret)
-                    encrypted = Encrypted(secret)
-                    new_encrypted_list: List = []
-                    # If re-encryption is needed, top_level_key will be added to `encrypt_keys`.
-                    # New encrypted value will be added to `new_encrypted_list`.
-                    decrypted = postgres.secret_manager.decrypt(
-                        encrypted, '', re_encrypt(top_level_key, new_encrypted_list))
-                    new_encrypted = secret
-                    if new_encrypted_list:
-                        new_encrypted = new_encrypted_list[0]
-                    return decrypted.value, new_encrypted
-                except (JWException, osmo_errors.OSMONotFoundError):
+                except JWException:
                     # Encrypt the plain text secret
-                    encrypted = postgres.secret_manager.encrypt(secret, '')
-                    encrypt_keys.add(top_level_key)
-                    return secret, encrypted.value
+                    if persist_secret_updates:
+                        encrypted = postgres.secret_manager.encrypt(secret, '')
+                        encrypt_keys.add(top_level_key)
+                        return secret, encrypted.value
+                    return secret, None
+
+                encrypted = Encrypted(secret)
+                new_encrypted_list: List = []
+                # If re-encryption is needed, top_level_key will be added to `encrypt_keys`.
+                # New encrypted value will be added to `new_encrypted_list`.
+                update_callback = (
+                    re_encrypt(top_level_key, new_encrypted_list)
+                    if persist_secret_updates else lambda _value: None)
+                decrypted = postgres.secret_manager.decrypt(
+                    encrypted, '', update_callback)
+                new_encrypted = secret
+                if new_encrypted_list:
+                    new_encrypted = new_encrypted_list[0]
+                return decrypted.value, new_encrypted
             else:
                 return encrypted_data, None
 
-        dynamic_config = cls.from_db(config_dict)
+        construction_data = {**config_dict, **runtime_overrides}
+        dynamic_config = cls.from_db(construction_data)
         encrypted_dict = dynamic_config.model_dump(exclude_unset=True)
         decrypted_dict = dynamic_config.model_dump(exclude_unset=True)
 
@@ -3234,6 +3338,7 @@ class DynamicConfig(ExtraArgBaseModel):
             if new_encrypted is not None:
                 encrypted_dict[key] = new_encrypted
             decrypted_dict[key] = decrypted
+        decrypted_dict.update(runtime_overrides)
         dynamic_config = cls(**decrypted_dict)
 
         # Encrypt updated secrets

--- a/src/utils/connectors/tests/BUILD
+++ b/src/utils/connectors/tests/BUILD
@@ -136,6 +136,7 @@ py_test(
         requirement("jwcrypto"),
         requirement("psycopg2-binary"),
         "//src/lib/utils:osmo_errors",
+        "//src/utils:auth",
         "//src/utils/connectors:connectors",
         "//src/utils/secret_manager",
         "//src/utils/secret_manager:mek_lifecycle",
@@ -143,4 +144,17 @@ py_test(
     local = True,
     size = "medium",
     tags = ["exclusive", "integration"],
+)
+
+py_test(
+    name = "test_service_auth",
+    srcs = ["test_service_auth.py"],
+    deps = [
+        requirement("jwcrypto"),
+        "//src/lib/utils:osmo_errors",
+        "//src/utils:auth",
+        "//src/utils:configmap_state",
+        "//src/utils/connectors:connectors",
+    ],
+    size = "small",
 )

--- a/src/utils/connectors/tests/test_mek_reconciliation_postgres.py
+++ b/src/utils/connectors/tests/test_mek_reconciliation_postgres.py
@@ -17,7 +17,7 @@ import unittest
 from jwcrypto import jwk  # type: ignore
 import psycopg2  # type: ignore
 
-from src.utils import connectors
+from src.utils import auth, connectors
 from src.utils.secret_manager import SecretManager
 
 
@@ -197,6 +197,45 @@ class TestMekReconciliationPostgres(unittest.TestCase):
         # authenticated direct-MEK ciphertext even when no application read
         # performs the historical lazy-encryption step.
         self.assertGreaterEqual(counts["old"], 3)
+
+    def test_retained_legacy_service_auth_is_inventoried_and_rewrapped(self) -> None:
+        service_auth = auth.AuthenticationConfig.generate_default()
+        payload = service_auth.plaintext_dict()
+        active_key = payload["active_key"]
+        payload["keys"][active_key]["private_key"] = (
+            self.database.secret_manager.encrypt(
+                payload["keys"][active_key]["private_key"], "").value)
+        self.database.execute_commit_command(
+            "INSERT INTO configs(key, type, value) VALUES (%s, %s, %s);",
+            ("service_auth", "SERVICE", json.dumps(payload)),
+        )
+
+        counts, blockers = self.database._scan_mek_references()
+        self.assertEqual(blockers, [])
+        self.assertEqual(counts["old"], 2)
+
+        _write_keyring(
+            self.keyring_path, "new", {"old": self.old_mek, "new": self.new_mek})
+        self.database.secret_manager = SecretManager(
+            str(self.keyring_path), self.database.read_uek, self.database.write_uek,
+            self.database.read_current_kid, self.database.add_user)
+        snapshot = self.database.secret_manager.rewrap_snapshot()
+        self.database.rewrap_mek_references(
+            expected_generation=snapshot.generation,
+            expected_current_kid="new",
+            expected_registry_digest=(
+                self.database.secret_manager.rewrap_snapshot_digest(snapshot)),
+        )
+
+        row = self.database.execute_fetch_command(
+            "SELECT value FROM configs WHERE key = 'service_auth' AND type = 'SERVICE';",
+            (), return_raw=True)[0]
+        rewrapped = json.loads(row["value"])["keys"][active_key]["private_key"]
+        self.assertEqual(
+            self.database.secret_manager.authenticate_mek_encrypted(rewrapped), "new")
+        counts, blockers = self.database._scan_mek_references()
+        self.assertEqual(blockers, [])
+        self.assertEqual(counts, {"old": 0, "new": 2})
 
     def test_startup_inventory_rejects_a_missing_historical_key(self) -> None:
         _write_keyring(self.keyring_path, "new", {"new": self.new_mek})

--- a/src/utils/connectors/tests/test_service_auth.py
+++ b/src/utils/connectors/tests/test_service_auth.py
@@ -1,0 +1,218 @@
+"""
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import json
+import types
+from typing import Any
+import unittest
+from unittest import mock
+
+from jwcrypto import jwk
+
+from src.lib.utils import osmo_errors
+from src.utils import auth, configmap_state, connectors
+
+
+def _authentication_config() -> auth.AuthenticationConfig:
+    key_name = 'installation-key'
+    key = jwk.JWK.generate(kty='RSA', kid=key_name, size=2048)
+    return auth.AuthenticationConfig(
+        keys={
+            key_name: auth.AsymmetricKeyPair(
+                public_key=key.export_public(),
+                private_key=key.export_private(),
+            ),
+        },
+        active_key=key_name,
+        issuer='osmo',
+        audience='osmo',
+    )
+
+
+def _connector(
+    service_auth: auth.AuthenticationConfig | None,
+) -> connectors.PostgresConnector:
+    postgres = connectors.PostgresConnector.__new__(connectors.PostgresConnector)
+    untyped_postgres: Any = postgres
+    untyped_postgres.config = types.SimpleNamespace(
+        service_auth_file='mounted-secret.json' if service_auth else None,
+    )
+    untyped_postgres.secret_manager = mock.MagicMock()
+    untyped_postgres._service_auth = service_auth
+    untyped_postgres._runtime_service_auth_login_info = None
+    return postgres
+
+
+class ServiceAuthConnectorTest(unittest.TestCase):
+
+    def setUp(self):
+        configmap_state.set_parsed_configs(None)
+
+    def tearDown(self):
+        configmap_state.set_parsed_configs(None)
+
+    def test_missing_legacy_database_identity_fails(self):
+        postgres = _connector(None)
+        postgres.execute_fetch_command = mock.Mock(return_value=[])
+
+        with self.assertRaisesRegex(
+                osmo_errors.OSMODatabaseError, 'Service auth is not found'):
+            postgres.get_service_auth()
+
+        postgres.execute_fetch_command.assert_called_once()
+
+    def test_legacy_chart_identity_is_read_from_database(self):
+        service_auth = _authentication_config()
+        postgres = _connector(None)
+        postgres.execute_fetch_command = mock.Mock(return_value=[{
+            'value': service_auth.canonical_json(include_login_info=False),
+        }])
+
+        with mock.patch.object(
+            connectors.ServiceConfig, 'deserialize',
+            return_value=types.SimpleNamespace(service_auth=service_auth),
+        ) as deserialize:
+            loaded = postgres.get_service_auth()
+
+        self.assertEqual(
+            loaded.canonical_json(include_login_info=False),
+            service_auth.canonical_json(include_login_info=False))
+        deserialize.assert_called_once()
+
+    def test_secret_backed_service_read_excludes_legacy_database_row(self):
+        service_auth = _authentication_config()
+        postgres = _connector(service_auth)
+        postgres.execute_fetch_command = mock.Mock(return_value=[
+            types.SimpleNamespace(
+                key='service_base_url', value='https://osmo.example.com',
+                type='SERVICE'),
+        ])
+
+        with mock.patch.object(
+            auth.AuthenticationConfig,
+            'generate_default',
+            side_effect=AssertionError('must not generate a key'),
+        ) as generate_default:
+            service_config = postgres.get_service_configs()
+
+        generate_default.assert_not_called()
+        query = postgres.execute_fetch_command.call_args.args[0]
+        self.assertIn("key != 'service_auth'", query)
+        self.assertEqual(service_config.service_auth.active_key, service_auth.active_key)
+        self.assertEqual(service_config.service_base_url, 'https://osmo.example.com')
+
+    def test_login_info_is_overlaid_without_changing_stable_identity(self):
+        service_auth = _authentication_config()
+        postgres = _connector(service_auth)
+        login_info = auth.LoginInfo(
+            device_endpoint='https://login.example.com/device')
+
+        postgres.set_runtime_service_auth_login_info(login_info)
+        loaded = postgres.get_service_auth()
+
+        self.assertEqual(loaded.login_info, login_info)
+        self.assertEqual(
+            loaded.canonical_json(include_login_info=False),
+            service_auth.canonical_json(include_login_info=False),
+        )
+
+    def test_external_service_auth_database_write_is_rejected(self):
+        postgres = _connector(_authentication_config())
+        postgres.execute_commit_command = mock.Mock()
+
+        with self.assertRaisesRegex(
+                osmo_errors.OSMOUserError, 'managed outside PostgreSQL') as context:
+            postgres.set_config(
+                'service_auth', '{}', connectors.ConfigType.SERVICE)
+
+        self.assertEqual(context.exception.status_code, 409)
+        postgres.execute_commit_command.assert_not_called()
+
+    def test_legacy_chart_database_write_remains_available(self):
+        postgres = _connector(None)
+        postgres.execute_commit_command = mock.Mock(return_value=1)
+
+        self.assertEqual(postgres.set_config(
+            'service_auth', '{}', connectors.ConfigType.SERVICE), 1)
+
+        postgres.execute_commit_command.assert_called_once()
+
+    def test_service_history_always_omits_service_auth(self):
+        service_auth = _authentication_config()
+        postgres = _connector(service_auth)
+        postgres.execute_commit_command = mock.Mock()
+
+        postgres.create_config_history_entry(
+            config_type=connectors.ConfigHistoryType.SERVICE,
+            name='',
+            username='operator',
+            data={
+                'service_auth': service_auth.plaintext_dict(),
+                'service_base_url': 'https://osmo.example.com',
+            },
+            description='Secret-native snapshot',
+        )
+
+        parameters = postgres.execute_commit_command.call_args.args[1]
+        persisted_data = json.loads(parameters[6])
+        self.assertNotIn('service_auth', persisted_data)
+        self.assertEqual(
+            persisted_data['service_base_url'], 'https://osmo.example.com')
+
+    def test_initial_service_history_omits_service_auth(self):
+        service_auth = _authentication_config()
+        postgres = _connector(service_auth)
+        postgres.execute_fetch_command = mock.Mock(return_value=[])
+        postgres.execute_commit_command = mock.Mock()
+        service_configs = types.SimpleNamespace(
+            plaintext_dict=mock.Mock(return_value={
+                'service_auth': service_auth.plaintext_dict(),
+                'service_base_url': 'https://osmo.example.com',
+            }))
+        workflow_configs = types.SimpleNamespace(
+            plaintext_dict=mock.Mock(return_value={}))
+
+        with (
+            mock.patch.object(postgres, '_init_default_configs'),
+            mock.patch.object(postgres, 'create_default_roles'),
+            mock.patch.object(
+                postgres, 'get_service_configs', return_value=service_configs),
+            mock.patch.object(
+                postgres, 'get_workflow_configs', return_value=workflow_configs),
+            mock.patch.object(connectors.Backend, 'list_from_db', return_value=[]),
+            mock.patch.object(connectors.PodTemplate, 'list_from_db', return_value=[]),
+            mock.patch.object(connectors.GroupTemplate, 'list_from_db', return_value=[]),
+            mock.patch.object(connectors.ResourceValidation, 'list_from_db', return_value=[]),
+            mock.patch.object(connectors.BackendTests, 'list_from_db', return_value=[]),
+            mock.patch.object(connectors.Role, 'list_from_db', return_value=[]),
+            mock.patch(
+                'src.utils.connectors.postgres.fetch_editable_pool_config',
+                return_value=[],
+            ),
+        ):
+            postgres._init_configs()  # pylint: disable=protected-access
+
+        service_parameters = postgres.execute_commit_command.call_args_list[0].args[1]
+        persisted_data = json.loads(service_parameters[5])
+        self.assertNotIn('service_auth', persisted_data)
+        self.assertEqual(
+            persisted_data['service_base_url'], 'https://osmo.example.com')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/utils/connectors/tests/test_user_names_db.py
+++ b/src/utils/connectors/tests/test_user_names_db.py
@@ -17,6 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import unittest
+from typing import IO
 from unittest import mock
 
 from src.lib.utils import osmo_errors
@@ -40,9 +41,12 @@ class UserNamesDatabaseTest(
         fixtures.OsmoTestFixture):
     """Database coverage for current-user identity resolution."""
 
+    service_auth_file: IO[str]
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.service_auth_file = fixtures.create_service_auth_file()
         postgres.PostgresConnector(
             postgres.PostgresConfig(
                 postgres_host=cls.postgres_container.get_container_host_ip(),
@@ -51,6 +55,7 @@ class UserNamesDatabaseTest(
                 postgres_database_name=cls.postgres_container.dbname,
                 postgres_user=cls.postgres_container.username,
                 method='dev',
+                service_auth_file=cls.service_auth_file.name,
             ))
 
     @classmethod
@@ -60,6 +65,7 @@ class UserNamesDatabaseTest(
                 postgres.PostgresConnector._instance.close()  # pylint: disable=protected-access
                 postgres.PostgresConnector._instance = None  # pylint: disable=protected-access
         finally:
+            cls.service_auth_file.close()
             super().tearDownClass()
 
     @property

--- a/src/utils/job/tests/BUILD
+++ b/src/utils/job/tests/BUILD
@@ -29,6 +29,7 @@ osmo_py_library(
         requirement("redis"),
         requirement("pydantic"),
         "//src/service/core/workflow",
+        "//src/utils:auth",
         "//src/utils/connectors",
         "//src/utils/job",
         "//src/utils/job:backend_job",

--- a/src/utils/job/tests/test_harness.py
+++ b/src/utils/job/tests/test_harness.py
@@ -30,6 +30,7 @@ import kombu.mixins  # type: ignore
 import kombu.transport.redis  # type: ignore
 
 from src.utils import connectors
+from src.utils import auth
 from src.utils.connectors import postgres
 from src.utils.job import jobs, backend_jobs
 
@@ -69,10 +70,17 @@ class TestHarness:
     def __init__(self, postgres_port: int = 5555, redis_port: int = 5556):
         # pylint: disable=consider-using-with
         # Setup config
+        self.service_auth_file = tempfile.NamedTemporaryFile(
+            mode='w+', encoding='utf-8')
+        self.service_auth_file.write(
+            auth.AuthenticationConfig.generate_default().canonical_json(
+                include_login_info=False))
+        self.service_auth_file.flush()
         self.config = TestHarnessConfig(
             postgres_port=postgres_port,
             postgres_password='osmo',
             method='dev',
+            service_auth_file=self.service_auth_file.name,
             redis_port=redis_port)
 
         # Start redis using purely in-memory storage

--- a/src/utils/job/tests/test_task_db.py
+++ b/src/utils/job/tests/test_task_db.py
@@ -17,7 +17,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 import datetime
 import json
-from typing import Any, List
+from typing import Any, IO, List
 from unittest import mock
 
 from src.lib.utils import common, osmo_errors, priority as wf_priority
@@ -41,9 +41,12 @@ class TaskDbFixture(
 ):
     """Postgres-only fixture for testing Task/TaskGroup DB operations."""
 
+    service_auth_file: IO[str]
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.service_auth_file = fixtures.create_service_auth_file()
 
         # Initialize PostgresConnector singleton with the testcontainer
         postgres.PostgresConnector(
@@ -54,6 +57,7 @@ class TaskDbFixture(
                 postgres_database_name=cls.postgres_container.dbname,
                 postgres_user=cls.postgres_container.username,
                 method='dev',
+                service_auth_file=cls.service_auth_file.name,
             )
         )
 
@@ -64,6 +68,7 @@ class TaskDbFixture(
                 postgres.PostgresConnector._instance.close()  # pylint: disable=protected-access
                 postgres.PostgresConnector._instance = None  # pylint: disable=protected-access
         finally:
+            cls.service_auth_file.close()
             super().tearDownClass()
 
     def _get_db(self) -> postgres.PostgresConnector:

--- a/src/utils/tests/test_auth.py
+++ b/src/utils/tests/test_auth.py
@@ -18,10 +18,13 @@ SPDX-License-Identifier: Apache-2.0
 """
 import base64
 import json
+import os
+import tempfile
 import unittest
 
 from jwcrypto import jwk, jws, jwt
 
+from src.lib.utils import osmo_errors
 from src.utils import auth
 
 # Verify that the keys we use have a RSA modulus of at least 4096 bits
@@ -70,6 +73,48 @@ class TestAuth(unittest.TestCase):
             jwt1.validate(jwk.JWK.from_json(default_key_pair_2.get_current_key().public_key))
         with self.assertRaises(jws.InvalidJWSSignature):
             jwt2.validate(jwk.JWK.from_json(default_key_pair_1.get_current_key().public_key))
+
+    def test_canonical_secret_file_round_trip(self):
+        service_auth = auth.AuthenticationConfig.generate_default()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            auth_path = os.path.join(
+                temporary_directory, 'authentication-config.json')
+            with open(auth_path, 'w', encoding='utf-8') as auth_file:
+                auth_file.write(service_auth.canonical_json(include_login_info=False))
+
+            loaded = auth.load_authentication_config_file(auth_path)
+
+        self.assertEqual(
+            loaded.canonical_json(include_login_info=False),
+            service_auth.canonical_json(include_login_info=False),
+        )
+        token = loaded.create_idtoken_jwt(
+            expire_timestamp=2**31, username='test', roles=['osmo-user'])
+        parsed_token = jwt.JWT.from_jose_token(token)
+        parsed_token.validate(jwk.JWK.from_json(loaded.get_current_key().public_key))
+
+    def test_invalid_secret_file_error_is_sanitized(self):
+        sentinel = 'private-key-sentinel'
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            auth_path = os.path.join(
+                temporary_directory, 'authentication-config.json')
+            with open(auth_path, 'w', encoding='utf-8') as auth_file:
+                json.dump({
+                    'keys': {
+                        'bad': {
+                            'public_key': '{}',
+                            'private_key': sentinel,
+                        },
+                    },
+                    'active_key': 'bad',
+                    'issuer': 'osmo',
+                    'audience': 'osmo',
+                }, auth_file)
+
+            with self.assertRaises(osmo_errors.OSMOError) as context:
+                auth.load_authentication_config_file(auth_path)
+
+        self.assertNotIn(sentinel, str(context.exception))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

Move the installation-scoped JWT signing identity from mutable PostgreSQL configuration to an externally persisted Kubernetes Secret and establish the clean 6.4 cutover path.

- Fresh installations generate one canonical identity offline with `service-auth-bootstrap generate`, then create the Kubernetes Secret before Helm installation.
- Existing installations stop the old API writers, pre-provision a release-authorized empty Secret, and run a read-only pre-upgrade migration hook that decrypts, validates, copies, and rechecks the exact legacy identity.
- API, worker, agent, logger, router, delayed-job monitor, and database-backed MEK lifecycle operations consume the same read-only Secret file.
- Unified-chart workloads never fall back to the PostgreSQL `service_auth` row, and configuration API writes are rejected in file-backed mode. The legacy encrypted row remains only for rollback and MEK inventory/rewrap during the rollback window.
- The transitional `service_auth_database_write_lock` and phased runtime modes are removed.

The migration fails closed for missing, malformed, changing, unauthorized, or mismatched identity data. Its Kubernetes token is short-lived and its Role is restricted to `get` and `update` on the named Secret. Service-auth data is excluded from configuration API responses and configuration history.

The unmodified legacy `deployments/charts/service` chart temporarily retains its existing database-backed behavior when no service-auth file is configured. Removing that compatibility path must be coupled with retiring or migrating the legacy chart in the final 6.4 DB-mode removal.

Validation:

- `bazel test //src/service/core/tests:test_service_auth_bootstrap //src/utils/connectors/tests:test_service_auth //src/utils/connectors/tests:test_mek_reconciliation_postgres //src/service/core/config/tests:test_configmap_loader_unit --test_output=errors`
- `bazel test //src/service/core/config/tests:test_config_history_helpers --test_output=errors`
- build validation for the modified local launcher and database-backed integration fixtures
- `helm lint deployments/charts/osmo` with the split-plane control values
- `bash deployments/charts/osmo/tests/test_osmo_charts.sh osmo` in Linux

Internal tracking: OSMO-6648

Issue #None

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
