### PR TITLE
build: deduplicate Python runtime layers

### DIFF
--- a/bzl/tests/BUILD
+++ b/bzl/tests/BUILD
@@ -74,6 +74,30 @@ py_test(
 )
 
 py_test(
+    name = "service_python_runfiles_dedup_test",
+    srcs = ["python_image_runfiles_dedup_test.py"],
+    args = [
+        "$(rootpath //src/service/core:service_image_x86_64)",
+        "src/service/core/service_binary.runfiles",
+        "usr/bin/mek-lifecycle",
+        "src/utils/secret_manager/mek_lifecycle.py",
+    ],
+    data = ["//src/service/core:service_image_x86_64"],
+    main = "python_image_runfiles_dedup_test.py",
+)
+
+py_test(
+    name = "mcp_python_runfiles_dedup_test",
+    srcs = ["python_image_runfiles_dedup_test.py"],
+    args = [
+        "$(rootpath //src/service/mcp:mcp_image_x86_64)",
+        "src/service/mcp/mcp_binary.runfiles",
+    ],
+    data = ["//src/service/mcp:mcp_image_x86_64"],
+    main = "python_image_runfiles_dedup_test.py",
+)
+
+py_test(
     name = "non_python_image_runtime_test",
     srcs = ["python_image_runtime_dedup_test.py"],
     args = [

--- a/bzl/tests/BUILD
+++ b/bzl/tests/BUILD
@@ -52,6 +52,28 @@ py_test(
 )
 
 py_test(
+    name = "service_python_runtime_dedup_test",
+    srcs = ["python_image_runtime_dedup_test.py"],
+    args = [
+        "$(rootpath //src/service/core:service_image_x86_64)",
+        "1",
+    ],
+    data = ["//src/service/core:service_image_x86_64"],
+    main = "python_image_runtime_dedup_test.py",
+)
+
+py_test(
+    name = "mcp_python_runtime_dedup_test",
+    srcs = ["python_image_runtime_dedup_test.py"],
+    args = [
+        "$(rootpath //src/service/mcp:mcp_image_x86_64)",
+        "1",
+    ],
+    data = ["//src/service/mcp:mcp_image_x86_64"],
+    main = "python_image_runtime_dedup_test.py",
+)
+
+py_test(
     name = "non_python_image_runtime_test",
     srcs = ["python_image_runtime_dedup_test.py"],
     args = [

--- a/bzl/tests/python_image_runfiles_dedup_test.py
+++ b/bzl/tests/python_image_runfiles_dedup_test.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# pylint: disable=line-too-long
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Checks that a Python image packages one application runfiles tree."""
+
+import json
+import pathlib
+import re
+import sys
+import tarfile
+import unittest
+from typing import Any
+
+
+def _read_json_blob(layout: pathlib.Path, digest: str) -> dict[str, Any]:
+    algorithm, value = digest.split(":", maxsplit=1)
+    return json.loads((layout / "blobs" / algorithm / value).read_text())
+
+
+def _read_image(
+    layout: pathlib.Path, wrapper_path: str | None
+) -> tuple[set[str], bytes | None]:
+    index = json.loads((layout / "index.json").read_text())
+    manifest = _read_json_blob(layout, index["manifests"][0]["digest"])
+    member_names: set[str] = set()
+    wrapper: bytes | None = None
+
+    for layer in manifest["layers"]:
+        algorithm, value = layer["digest"].split(":", maxsplit=1)
+        with tarfile.open(layout / "blobs" / algorithm / value, mode="r:*") as archive:
+            for member in archive.getmembers():
+                name = member.name.removeprefix("./").removeprefix("/")
+                member_names.add(name)
+                if name == wrapper_path and member.isfile():
+                    extracted = archive.extractfile(member)
+                    if extracted is None:
+                        raise ValueError(f"Could not read {member.name}")
+                    wrapper = extracted.read()
+
+    return member_names, wrapper
+
+
+class PythonImageRunfilesDedupTest(unittest.TestCase):
+    """Locks the single-runfiles-tree image contract."""
+
+    expected_runfiles: str
+    wrapper_path: str | None
+    main_path: str | None
+    member_names: set[str]
+    wrapper: bytes | None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.expected_runfiles = sys.argv[2].strip("/")
+        cls.wrapper_path = sys.argv[3].strip("/") if len(sys.argv) > 3 else None
+        cls.main_path = sys.argv[4].strip("/") if len(sys.argv) > 4 else None
+        cls.member_names, cls.wrapper = _read_image(
+            pathlib.Path(sys.argv[1]), cls.wrapper_path
+        )
+
+    def test_uses_single_application_runfiles_tree(self) -> None:
+        runfiles_pattern = re.compile(r"^(.+?\.runfiles)(?:/|$)")
+        runfiles = {
+            match.group(1)
+            for name in self.member_names
+            if (match := runfiles_pattern.match(name)) is not None
+        }
+
+        self.assertEqual(runfiles, {self.expected_runfiles})
+
+    def test_companion_entry_point_uses_application_runfiles(self) -> None:
+        if self.wrapper_path is None or self.main_path is None:
+            self.skipTest("Image has no companion entry point")
+
+        if self.wrapper is None:
+            self.fail(f"Image does not contain {self.wrapper_path}")
+        self.assertIn(
+            f"/{self.expected_runfiles}".encode(),
+            self.wrapper,
+        )
+        self.assertIn(
+            f"{self.expected_runfiles}/_main/{self.main_path}",
+            self.member_names,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0]])

--- a/src/service/core/BUILD
+++ b/src/service/core/BUILD
@@ -67,7 +67,10 @@ osmo_py_binary(
     name = "service_binary",
     main = "service.py",
     srcs = ["service.py"],
-    deps = [":service_lib"],
+    deps = [
+        ":service_lib",
+        "//src/utils/secret_manager:mek_lifecycle_lib",
+    ],
 )
 
 py_image_layer(
@@ -83,25 +86,11 @@ osmo_python_wrapper(
     include_progress_check = True,
 )
 
-py_image_layer(
-    name = "mek_lifecycle_layer",
-    binary = "//src/utils/secret_manager:mek_lifecycle",
-)
-
 osmo_python_wrapper(
     name = "mek_lifecycle_wrapper",
     bin_name = "mek-lifecycle",
     main = "/src/utils/secret_manager/mek_lifecycle.py",
-    runfiles_dir = "/src/utils/secret_manager/mek_lifecycle.runfiles",
-)
-
-filegroup(
-    name = "mek_lifecycle_image_layers",
-    srcs = [
-        ":mek_lifecycle_layer_default",
-        ":mek_lifecycle_layer_packages",
-        ":mek_lifecycle_wrapper",
-    ],
+    runfiles_dir = "/src/service/core/service_binary.runfiles",
 )
 
 filegroup(
@@ -110,6 +99,7 @@ filegroup(
         ":service_layer_default",
         ":service_layer_packages",
         ":service_wrapper",
+        ":mek_lifecycle_wrapper",
     ],
 )
 
@@ -120,10 +110,7 @@ filegroup(
 oci_image(
     name = "service_image_x86_64",
     base = "//src:osmo_docker_distroless_image_amd64",
-    tars = [
-        ":service_image_layers",
-        ":mek_lifecycle_image_layers",
-    ],
+    tars = [":service_image_layers"],
     visibility = ["//visibility:public"],
     target_compatible_with = [
         "@platforms//cpu:x86_64",
@@ -161,10 +148,7 @@ oci_push(
 oci_image(
     name = "service_image_arm64",
     base = "//src:osmo_docker_distroless_image_arm64",
-    tars = [
-        ":service_image_layers",
-        ":mek_lifecycle_image_layers",
-    ],
+    tars = [":service_image_layers"],
     visibility = ["//visibility:public"],
     target_compatible_with = [
         "@platforms//cpu:arm64",

--- a/src/service/core/BUILD
+++ b/src/service/core/BUILD
@@ -99,7 +99,6 @@ filegroup(
     name = "mek_lifecycle_image_layers",
     srcs = [
         ":mek_lifecycle_layer_default",
-        ":mek_lifecycle_layer_interpreter",
         ":mek_lifecycle_layer_packages",
         ":mek_lifecycle_wrapper",
     ],

--- a/src/service/mcp/BUILD
+++ b/src/service/mcp/BUILD
@@ -494,7 +494,6 @@ filegroup(
     name = "mcp_image_layers",
     srcs = [
         ":mcp_layer_default",
-        ":mcp_layer_interpreter",
         ":mcp_layer_packages",
         ":mcp_wrapper",
     ],

--- a/src/utils/secret_manager/BUILD
+++ b/src/utils/secret_manager/BUILD
@@ -36,10 +36,9 @@ osmo_py_library(
     visibility = ["//visibility:public"],
 )
 
-osmo_py_binary(
-    name = "mek_lifecycle",
+osmo_py_library(
+    name = "mek_lifecycle_lib",
     srcs = ["mek_lifecycle.py"],
-    main = "mek_lifecycle.py",
     deps = [
         requirement("jwcrypto"),
         requirement("kubernetes"),
@@ -51,5 +50,13 @@ osmo_py_binary(
         "//src/utils/connectors",
         ":secret_manager",
     ],
+    visibility = ["//visibility:public"],
+)
+
+osmo_py_binary(
+    name = "mek_lifecycle",
+    srcs = ["mek_lifecycle.py"],
+    main = "mek_lifecycle.py",
+    deps = [":mek_lifecycle_lib"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Description
Remove duplicate Python interpreter layers from the service and MCP images. Also package the MEK lifecycle entry point in the service binary's existing runfiles, following the `progress_check` strategy, instead of adding a second copy of 58 transitive Python dependency repositories to the service image.

Issue - None

### Compressed image size impact (amd64)

| Image | Before | After | Savings |
| --- | ---: | ---: | ---: |
| Service | 153.17 MiB | 68.52 MiB | **84.65 MiB (55.3%)** |
| MCP | 107.09 MiB | 51.99 MiB | **55.10 MiB (51.5%)** |

Sizes are the sum of compressed OCI layer descriptor sizes. “Before” was built from the PR parent (`8fb90cea5`); “after” was built from this branch (`06e6a114b`) with the same toolchain and base image. The runfiles change alone saves 29.55 MiB compressed and 89.72 MiB uncompressed from the service image.

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service core and MCP container packaging to prevent duplicate Python runtimes and runfiles.
  - Consolidated service lifecycle components into the main service image for more consistent deployment.
  - Reduced unnecessary image layers, helping keep runtime environments leaner.

- **Tests**
  - Added automated validation confirming that service core and MCP images contain a single Python runtime and correctly packaged application files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
