### PR TITLE
Umbrella chart: add generic single-plane profile

### DIFF
--- a/.github/workflows/helm-chart-lint.yaml
+++ b/.github/workflows/helm-chart-lint.yaml
@@ -72,12 +72,12 @@ jobs:
 
           if [ -z "$CHARTS" ]; then
             echo "No chart changes detected"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "charts=[]" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "charts=[]" >> "$GITHUB_OUTPUT"
           else
             echo "Changed charts: [$CHARTS]"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "charts=[$CHARTS]" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "charts=[$CHARTS]" >> "$GITHUB_OUTPUT"
           fi
 
   #######################
@@ -137,6 +137,14 @@ jobs:
               --kube-version 1.30.0 \
               -f deployments/charts/osmo/profiles/self-contained.yaml \
               -f deployments/charts/osmo/tests/self-contained-lint-values.yaml
+            helm lint deployments/charts/osmo \
+              --kube-version 1.30.0 \
+              -f deployments/charts/osmo/profiles/single-plane.yaml \
+              -f deployments/charts/osmo/tests/single-plane-azure-values.yaml
+            helm lint deployments/charts/osmo \
+              --kube-version 1.30.0 \
+              -f deployments/charts/osmo/profiles/single-plane.yaml \
+              -f deployments/charts/osmo/tests/single-plane-s3-values.yaml
           else
             helm lint "deployments/charts/$CHART"
           fi
@@ -166,6 +174,16 @@ jobs:
               --kube-version 1.30.0 \
               -f deployments/charts/osmo/profiles/split-plane-compute.yaml \
               --set-string compute.backendName=test-backend \
+              >/dev/null
+            helm template test-single-plane-azure deployments/charts/osmo \
+              --kube-version 1.30.0 \
+              -f deployments/charts/osmo/profiles/single-plane.yaml \
+              -f deployments/charts/osmo/tests/single-plane-azure-values.yaml \
+              >/dev/null
+            helm template test-single-plane-s3 deployments/charts/osmo \
+              --kube-version 1.30.0 \
+              -f deployments/charts/osmo/profiles/single-plane.yaml \
+              -f deployments/charts/osmo/tests/single-plane-s3-values.yaml \
               >/dev/null
             helm template test-self-contained deployments/charts/osmo \
               --kube-version 1.30.0 \

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -698,11 +698,8 @@ above.
   value when empty. Otherwise the chart uses `nvcr.io/nvidia/osmo` and the
   component name. The chart writes the resolved workflow images into the
   managed API configuration unless `configuration.workflow.backend_images`
-  overrides them. Set
-  `runtimeImage.pullSecret` to a Docker config Secret when those workflow
-  images are private; OSMO converts it into workflow-scoped pull credentials.
-  Configure dependency images and pull credentials in their native values
-  blocks; for example, Valkey uses `valkey.image` and
+  overrides them. Configure dependency images and pull credentials in their
+  native values blocks; for example, Valkey uses `valkey.image` and
   `valkey.imagePullSecrets`.
 - Configure replicas, autoscaling, resources, disruption budgets, scheduling,
   security contexts, probes, volumes, and ServiceAccounts under `services`,

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -158,6 +158,8 @@ osmo workflow query <workflow-id> --format-type json
 ```
 
 Repeat the query until the workflow status is `COMPLETED`.
+The workflow passes a marker between its two tasks through the configured
+object store, so completion validates both upload and download access.
 
 ### Troubleshooting and cleanup
 
@@ -205,6 +207,78 @@ identity through a NodePort. It is not a production security or availability
 configuration. Use a production profile with managed credentials, TLS,
 authorization, backups, suitable resource sizing, and HA dependencies for
 long-lived environments.
+
+## Single-plane external dependencies
+
+`profiles/single-plane.yaml` is a provider-neutral, converged base overlay for
+one cluster that runs both the control and compute planes. It disables embedded
+PostgreSQL, Valkey, and object storage, while retaining the gateway as a
+`ClusterIP` Service. Layer a site-specific values file after it for the public
+URL, external dependency connections, and backend name. Ingress is deliberately
+an external, later step; enable and configure it only when the site has its
+ingress controller and public DNS ready.
+
+The profile configures Envoy to validate supplied OSMO access tokens against the
+API service's in-cluster `https://osmo-api/api/auth/keys` endpoint. It requires
+JWTs and leaves all default identity headers empty, so site values must provide
+any deliberately permissive development identity. External identity providers
+remain site-specific gateway configuration.
+
+Object storage uses exact `locations` for workflow data, logs, and apps. All
+three locations must use the same URI scheme. The URI scheme selects the storage
+backend: Azure locations use `azure://<account>/<container>/<prefix>`, while S3
+locations use `s3://<bucket>/<prefix>`. Azure locations forbid the S3-only
+settings in `externalDependencies.objectStorage.s3`; set that block only for S3
+locations. Authentication is independent of the URI scheme:
+
+- `authentication.type: static` is the default. Store credentials for all
+  three locations in one pre-provisioned Kubernetes Secret selected by
+  `secrets.objectStorage.existingSecret`.
+- `authentication.type: sdkDefault` omits static credential mounts and lets the
+  provider SDK discover credentials, such as Azure DefaultAzureCredential, the
+  AWS default credential provider chain, or Google Application Default
+  Credentials. Leave `secrets.objectStorage.existingSecret` empty.
+
+Do not place credential material in values files or Helm command lines.
+
+For example, an Azure site overlay contains only its connection values and
+locations:
+
+```yaml
+externalDependencies:
+  objectStorage:
+    authentication:
+      type: sdkDefault
+    locations:
+      workflows: azure://osmoazure/osmo-workflows/workflows
+      logs: azure://osmoazure/osmo-workflows/logs
+      apps: azure://osmoazure/osmo-workflows/apps
+```
+
+An S3 site uses the S3 URI scheme and its S3-specific settings instead:
+
+```yaml
+externalDependencies:
+  objectStorage:
+    authentication:
+      type: static
+    locations:
+      workflows: s3://osmo-workflows/workflows
+      logs: s3://osmo-logs/logs
+      apps: s3://osmo-apps/apps
+    s3:
+      region: us-east-1
+      overrideUrl: https://s3.example.com
+```
+
+Install the generic profile first and the site overlay second:
+
+```bash
+helm upgrade --install osmo deployments/charts/osmo \
+  --namespace osmo \
+  --values deployments/charts/osmo/profiles/single-plane.yaml \
+  --values single-plane-azure.yaml
+```
 
 ## Self-contained production
 
@@ -430,12 +504,13 @@ externalDependencies:
     port: 6379
     database: 0
   objectStorage:
-    endpoint: https://s3.example.com
-    region: us-east-1
-    buckets:
-      workflows: osmo-workflows
-      logs: osmo-logs
-      apps: osmo-apps
+    locations:
+      workflows: s3://osmo-workflows/workflows
+      logs: s3://osmo-logs/logs
+      apps: s3://osmo-apps/apps
+    s3:
+      region: us-east-1
+      overrideUrl: https://s3.example.com
 
 secrets:
   postgresql:
@@ -566,11 +641,13 @@ embeddedDependencies:
 
 externalDependencies:
   objectStorage:
-    endpoint: ''
-    buckets:
+    locations:
       workflows: ''
       logs: ''
       apps: ''
+    s3:
+      region: ''
+      overrideUrl: ''
 
 secrets:
   objectStorage:
@@ -621,8 +698,11 @@ above.
   value when empty. Otherwise the chart uses `nvcr.io/nvidia/osmo` and the
   component name. The chart writes the resolved workflow images into the
   managed API configuration unless `configuration.workflow.backend_images`
-  overrides them. Configure dependency images and pull credentials in their
-  native values blocks; for example, Valkey uses `valkey.image` and
+  overrides them. Set
+  `runtimeImage.pullSecret` to a Docker config Secret when those workflow
+  images are private; OSMO converts it into workflow-scoped pull credentials.
+  Configure dependency images and pull credentials in their native values
+  blocks; for example, Valkey uses `valkey.image` and
   `valkey.imagePullSecrets`.
 - Configure replicas, autoscaling, resources, disruption budgets, scheduling,
   security contexts, probes, volumes, and ServiceAccounts under `services`,

--- a/deployments/charts/osmo/embedded-rustfs-ha-values.yaml
+++ b/deployments/charts/osmo/embedded-rustfs-ha-values.yaml
@@ -14,11 +14,13 @@ embeddedDependencies:
 
 externalDependencies:
   objectStorage:
-    endpoint: ''
-    buckets:
+    locations:
       workflows: ''
       logs: ''
       apps: ''
+    s3:
+      region: ''
+      overrideUrl: ''
 
 secrets:
   objectStorage:

--- a/deployments/charts/osmo/profiles/README.md
+++ b/deployments/charts/osmo/profiles/README.md
@@ -13,6 +13,7 @@ values after a base overlay so that the environment values take precedence.
 | --- | --- | --- |
 | Chart defaults (`values.yaml`) | Yes, on a development cluster | KAI Scheduler, the CloudNativePG operator, and a default dynamic StorageClass installed separately; `osmo-service-auth` generated and created as documented |
 | `self-contained.yaml` | Yes, with production inputs | KAI Scheduler, the CloudNativePG operator, a default dynamic StorageClass, at least four schedulable nodes, a NetworkPolicy-enforcing CNI, an OIDC client and Secret with role assignments, an `osmo-service-auth` Secret generated as documented, a TLS edge and public `externalUrl`, and IPv4 cluster CIDRs |
+| `single-plane.yaml` | Base overlay | Site-specific external PostgreSQL, Valkey, and object-storage locations; required Kubernetes Secrets for static authentication; `externalUrl`; and `compute.backendName` |
 | `split-plane-control.yaml` | Base overlay | PostgreSQL, Valkey, and object-storage endpoints; Kubernetes Secrets; and `externalUrl` |
 | `split-plane-compute.yaml` | Base overlay | A control-plane `externalUrl`, a compute authentication Secret, and `compute.backendName` set explicitly at install time |
 
@@ -40,6 +41,25 @@ role before exposing the service. The split profiles contain example names and
 endpoints; copy them into an environment values file before installation.
 Production operators must also provide and test backup and restore for the
 stateful volumes.
+
+`single-plane.yaml` enables both planes with externally managed dependencies.
+It is provider-neutral and is not directly installable: layer it before a
+site-specific values file that supplies the required dependency locations and
+connection details. Object storage defaults to static Secret authentication;
+sites using a cloud SDK identity can set
+`externalDependencies.objectStorage.authentication.type: sdkDefault` instead.
+The profile requires JWT authentication and configures the OSMO service's local
+JWKS endpoint as its provider. Its gateway is a ClusterIP and it creates no
+Ingress or HTTPRoute. Sites can replace or extend the local provider and enable
+authorization and TLS through their environment-specific authentication
+overlay before exposing the gateway.
+For example:
+
+```bash
+helm upgrade --install osmo deployments/charts/osmo \
+  --values deployments/charts/osmo/profiles/single-plane.yaml \
+  --values single-plane-azure.yaml
+```
 
 KAI Scheduler is a prerequisite for every profile that enables the compute
 plane. The unified chart does not install or manage KAI. CloudNativePG must also

--- a/deployments/charts/osmo/profiles/single-plane.yaml
+++ b/deployments/charts/osmo/profiles/single-plane.yaml
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Development-oriented converged profile. Layer a site-specific values file
+# after this profile to provide external service connections and a public URL.
+planes:
+  control:
+    enabled: true
+  compute:
+    enabled: true
+
+fullnameOverride: osmo
+
+imageTag: latest
+runtimeImage:
+  tag: latest
+
+embeddedDependencies:
+  postgresql:
+    enabled: false
+  valkey:
+    enabled: false
+  objectStorage:
+    enabled: false
+
+secrets:
+  postgresql:
+    existingSecret: osmo-postgresql
+  valkey:
+    generate: false
+    existingSecret: osmo-valkey
+  objectStorage:
+    generate: false
+    existingSecret: osmo-object-storage
+  backendApiTokens:
+    enabled: true
+    credentials:
+    - name: default
+      existingSecret:
+        name: osmo-backend-token
+  masterEncryptionKey:
+    managementMode: osmo
+    existingSecret:
+      name: osmo-master-encryption-key
+      key: mek.yaml
+    bootstrap:
+      enabled: false
+
+services:
+  ui:
+    enabled: true
+    replicas: 1
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
+  mcp:
+    enabled: false
+  api:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  worker:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  router:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
+  logger:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  agent:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  delayedJobMonitor:
+    replicas: 1
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
+  backendListener:
+    replicas: 1
+    image:
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  backendWorker:
+    replicas: 1
+    image:
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    pod:
+      topologySpreadConstraints: []
+  backendTestRunner:
+    enabled: false
+
+gateway:
+  envoy:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    image:
+      pullPolicy: IfNotPresent
+    podDisruptionBudget:
+      enabled: false
+    defaultIdentity:
+      # Keep the provider-neutral profile fail-closed. A trusted development
+      # overlay can set these headers when it also allows requests without JWTs.
+      user: ''
+      roles: ''
+      allowedPools: ''
+    jwt:
+      # Reject requests without a JWT. Sites can replace or extend the local
+      # OSMO provider below in their environment-specific authentication overlay.
+      allowMissing: false
+      providers:
+      - issuer: osmo
+        audience: osmo
+        jwks_uri: https://osmo-api/api/auth/keys
+        user_claim: unique_name
+        cluster: osmo-api-jwks
+    service:
+      type: ClusterIP
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 512Mi
+    pod:
+      topologySpreadConstraints: []
+  oauth2Proxy:
+    enabled: false
+  authz:
+    enabled: false
+  rateLimit:
+    enabled: false
+  tls:
+    enabled: false
+  upstreams:
+    ui:
+      enabled: true
+
+ingress:
+  enabled: false
+
+httproute:
+  enabled: false
+
+monitoring:
+  podMonitor:
+    control:
+      enabled: false
+    compute:
+      enabled: false
+
+configuration:
+  enabled: true
+  podTemplates:
+    # KAI treats even a zero-valued nvidia.com/gpu resource key as a GPU pod
+    # and injects the NVIDIA RuntimeClass. This CPU-only profile omits the key.
+    default_user:
+      spec:
+        containers:
+        - name: '{{USER_CONTAINER_NAME}}'
+          resources:
+            limits:
+              cpu: '{{USER_CPU}}'
+              memory: '{{USER_MEMORY}}'
+              ephemeral-storage: '{{USER_STORAGE}}'
+            requests:
+              cpu: '{{USER_CPU}}'
+              memory: '{{USER_MEMORY}}'
+              ephemeral-storage: '{{USER_STORAGE}}'
+  pools:
+    default:
+      common_pod_template:
+      - default_ctrl
+      - default_user
+
+compute:
+  workloadNamespace:
+    name: ''
+    create: false
+  backendTestNamespace: ''
+  authentication:
+    existingSecret: osmo-backend-token
+    tokenKey: token

--- a/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
@@ -771,7 +771,14 @@ data:
                   - match:
                       prefix: /
                     requires:
-                      {{- if eq (len $jwtProviders) 1 }}
+                      {{- if $envoy.jwt.allowMissing }}
+                      requires_any:
+                        requirements:
+                        {{- range $i, $provider := $jwtProviders }}
+                        - provider_name: provider_{{$i}}
+                        {{- end}}
+                        - allow_missing: {}
+                      {{- else if eq (len $jwtProviders) 1 }}
                       provider_name: provider_0
                       {{- else }}
                       requires_any:

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -386,11 +386,6 @@ data:
   mountPath: /etc/osmo/secrets/{{ . }}
   readOnly: true
 {{- end }}
-{{- with .Values.runtimeImage.pullSecret }}
-- name: runtime-image-pull-secret
-  mountPath: /etc/osmo/secrets/{{ . }}
-  readOnly: true
-{{- end }}
 {{- end }}
 {{- end -}}
 
@@ -406,11 +401,6 @@ data:
     items:
     - key: {{ $.Values.secrets.objectStorage.keys.credentials | quote }}
       path: {{ $.Values.secrets.objectStorage.keys.credentials | quote }}
-{{- end }}
-{{- with .Values.runtimeImage.pullSecret }}
-- name: runtime-image-pull-secret
-  secret:
-    secretName: {{ . }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -386,6 +386,11 @@ data:
   mountPath: /etc/osmo/secrets/{{ . }}
   readOnly: true
 {{- end }}
+{{- with .Values.runtimeImage.pullSecret }}
+- name: runtime-image-pull-secret
+  mountPath: /etc/osmo/secrets/{{ . }}
+  readOnly: true
+{{- end }}
 {{- end }}
 {{- end -}}
 
@@ -401,6 +406,11 @@ data:
     items:
     - key: {{ $.Values.secrets.objectStorage.keys.credentials | quote }}
       path: {{ $.Values.secrets.objectStorage.keys.credentials | quote }}
+{{- end }}
+{{- with .Values.runtimeImage.pullSecret }}
+- name: runtime-image-pull-secret
+  secret:
+    secretName: {{ . }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -508,8 +518,6 @@ osmo.nvidia.com/service-auth-rollout: {{ .Values.secrets.serviceAuth.rolloutNonc
 {{- define "osmo.objectStorage.endpoint" -}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
 {{- printf "http://%s-svc.%s.svc:9000" (include "osmo.rustfs.fullname" .) .Release.Namespace -}}
-{{- else -}}
-{{- .Values.externalDependencies.objectStorage.endpoint -}}
 {{- end -}}
 {{- end -}}
 
@@ -517,22 +525,36 @@ osmo.nvidia.com/service-auth-rollout: {{ .Values.secrets.serviceAuth.rolloutNonc
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
 {{- .Values.embeddedDependencies.objectStorage.region -}}
 {{- else -}}
-{{- .Values.externalDependencies.objectStorage.region -}}
+{{- .Values.externalDependencies.objectStorage.s3.region -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "osmo.objectStorage.bucket" -}}
 {{- if .root.Values.embeddedDependencies.objectStorage.enabled -}}
 {{- get .root.Values.embeddedDependencies.objectStorage.buckets .name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.location" -}}
+{{- if .root.Values.embeddedDependencies.objectStorage.enabled -}}
+{{- printf "s3://%s/%s" (get .root.Values.embeddedDependencies.objectStorage.buckets .name) .name -}}
 {{- else -}}
-{{- get .root.Values.externalDependencies.objectStorage.buckets .name -}}
+{{- get .root.Values.externalDependencies.objectStorage.locations .name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.objectStorage.overrideUrl" -}}
+{{- if .Values.embeddedDependencies.objectStorage.enabled -}}
+{{- include "osmo.objectStorage.endpoint" . -}}
+{{- else -}}
+{{- .Values.externalDependencies.objectStorage.s3.overrideUrl -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "osmo.objectStorage.secretName" -}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
 {{- .Values.rustfs.secret.existingSecret -}}
-{{- else -}}
+{{- else if eq .Values.externalDependencies.objectStorage.authentication.type "static" -}}
 {{- .Values.secrets.objectStorage.existingSecret -}}
 {{- end -}}
 {{- end -}}

--- a/deployments/charts/osmo/templates/configs.yaml
+++ b/deployments/charts/osmo/templates/configs.yaml
@@ -51,9 +51,6 @@ data:
       {{- if not (index $backendImages "client") }}
       {{- $_ := set $backendImages "client" (printf "%s/client:%s" $runtimeRepository $runtimeTag) }}
       {{- end }}
-      {{- with .Values.runtimeImage.pullSecret }}
-      {{- $_ := set $backendImages "credential" (dict "secretName" . "secretKey" ".dockerconfigjson") }}
-      {{- end }}
       {{- $_ := set $workflow "backend_images" $backendImages }}
       {{- $secret := .Values.secrets.objectStorage }}
       {{- $secretName := include "osmo.objectStorage.secretName" . }}

--- a/deployments/charts/osmo/templates/configs.yaml
+++ b/deployments/charts/osmo/templates/configs.yaml
@@ -51,17 +51,38 @@ data:
       {{- if not (index $backendImages "client") }}
       {{- $_ := set $backendImages "client" (printf "%s/client:%s" $runtimeRepository $runtimeTag) }}
       {{- end }}
+      {{- with .Values.runtimeImage.pullSecret }}
+      {{- $_ := set $backendImages "credential" (dict "secretName" . "secretKey" ".dockerconfigjson") }}
+      {{- end }}
       {{- $_ := set $workflow "backend_images" $backendImages }}
       {{- $secret := .Values.secrets.objectStorage }}
       {{- $secretName := include "osmo.objectStorage.secretName" . }}
-      {{- $endpoint := include "osmo.objectStorage.endpoint" . }}
+      {{- $overrideUrl := include "osmo.objectStorage.overrideUrl" . }}
       {{- $region := include "osmo.objectStorage.region" . }}
-      {{- $workflowBucket := include "osmo.objectStorage.bucket" (dict "root" . "name" "workflows") }}
-      {{- $logBucket := include "osmo.objectStorage.bucket" (dict "root" . "name" "logs") }}
-      {{- $appBucket := include "osmo.objectStorage.bucket" (dict "root" . "name" "apps") }}
-      {{- $_ := set $workflow "workflow_data" (dict "credential" (dict "secretName" $secretName "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/workflows" $workflowBucket) "override_url" $endpoint "region" $region)) }}
-      {{- $_ := set $workflow "workflow_log" (dict "credential" (dict "secretName" $secretName "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/logs" $logBucket) "override_url" $endpoint "region" $region)) }}
-      {{- $_ := set $workflow "workflow_app" (dict "credential" (dict "secretName" $secretName "secretKey" $secret.keys.credentials "endpoint" (printf "s3://%s/apps" $appBucket) "override_url" $endpoint "region" $region)) }}
+      {{- $workflowDataCredential := dict "endpoint" (include "osmo.objectStorage.location" (dict "root" . "name" "workflows")) }}
+      {{- if $secretName }}
+      {{- $_ := set $workflowDataCredential "secretName" $secretName }}
+      {{- $_ := set $workflowDataCredential "secretKey" $secret.keys.credentials }}
+      {{- end }}
+      {{- if $overrideUrl }}{{- $_ := set $workflowDataCredential "override_url" $overrideUrl }}{{- end }}
+      {{- if $region }}{{- $_ := set $workflowDataCredential "region" $region }}{{- end }}
+      {{- $_ := set $workflow "workflow_data" (dict "credential" $workflowDataCredential) }}
+      {{- $workflowLogCredential := dict "endpoint" (include "osmo.objectStorage.location" (dict "root" . "name" "logs")) }}
+      {{- if $secretName }}
+      {{- $_ := set $workflowLogCredential "secretName" $secretName }}
+      {{- $_ := set $workflowLogCredential "secretKey" $secret.keys.credentials }}
+      {{- end }}
+      {{- if $overrideUrl }}{{- $_ := set $workflowLogCredential "override_url" $overrideUrl }}{{- end }}
+      {{- if $region }}{{- $_ := set $workflowLogCredential "region" $region }}{{- end }}
+      {{- $_ := set $workflow "workflow_log" (dict "credential" $workflowLogCredential) }}
+      {{- $workflowAppCredential := dict "endpoint" (include "osmo.objectStorage.location" (dict "root" . "name" "apps")) }}
+      {{- if $secretName }}
+      {{- $_ := set $workflowAppCredential "secretName" $secretName }}
+      {{- $_ := set $workflowAppCredential "secretKey" $secret.keys.credentials }}
+      {{- end }}
+      {{- if $overrideUrl }}{{- $_ := set $workflowAppCredential "override_url" $overrideUrl }}{{- end }}
+      {{- if $region }}{{- $_ := set $workflowAppCredential "region" $region }}{{- end }}
+      {{- $_ := set $workflow "workflow_app" (dict "credential" $workflowAppCredential) }}
       {{- toYaml $workflow | nindent 6 }}
     {{- end }}
     {{- if $cfg.pools }}

--- a/deployments/charts/osmo/templates/validate-values.yaml
+++ b/deployments/charts/osmo/templates/validate-values.yaml
@@ -145,19 +145,26 @@
 {{- end -}}
 {{- end -}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled -}}
-{{- $externalBuckets := .Values.externalDependencies.objectStorage.buckets -}}
+{{- $externalLocations := .Values.externalDependencies.objectStorage.locations -}}
+{{- $externalS3 := .Values.externalDependencies.objectStorage.s3 -}}
 {{- $embeddedBuckets := .Values.embeddedDependencies.objectStorage.buckets -}}
-{{- if .Values.externalDependencies.objectStorage.endpoint -}}
-{{- fail "externalDependencies.objectStorage.endpoint must be empty when embedded object storage is enabled" -}}
+{{- if ne .Values.externalDependencies.objectStorage.authentication.type "static" -}}
+{{- fail "embedded object storage requires static authentication" -}}
 {{- end -}}
-{{- if $externalBuckets.workflows -}}
-{{- fail "externalDependencies.objectStorage.buckets.workflows must be empty when embedded object storage is enabled" -}}
+{{- if $externalLocations.workflows -}}
+{{- fail "externalDependencies.objectStorage.locations.workflows must be empty when embedded object storage is enabled" -}}
 {{- end -}}
-{{- if $externalBuckets.logs -}}
-{{- fail "externalDependencies.objectStorage.buckets.logs must be empty when embedded object storage is enabled" -}}
+{{- if $externalLocations.logs -}}
+{{- fail "externalDependencies.objectStorage.locations.logs must be empty when embedded object storage is enabled" -}}
 {{- end -}}
-{{- if $externalBuckets.apps -}}
-{{- fail "externalDependencies.objectStorage.buckets.apps must be empty when embedded object storage is enabled" -}}
+{{- if $externalLocations.apps -}}
+{{- fail "externalDependencies.objectStorage.locations.apps must be empty when embedded object storage is enabled" -}}
+{{- end -}}
+{{- if $externalS3.region -}}
+{{- fail "externalDependencies.objectStorage.s3.region must be empty when embedded object storage is enabled" -}}
+{{- end -}}
+{{- if $externalS3.overrideUrl -}}
+{{- fail "externalDependencies.objectStorage.s3.overrideUrl must be empty when embedded object storage is enabled" -}}
 {{- end -}}
 {{- if and .Values.secrets.objectStorage.generate .Values.secrets.objectStorage.existingSecret -}}
 {{- fail "secrets.objectStorage.generate and existingSecret are mutually exclusive" -}}
@@ -247,7 +254,9 @@
 {{- fail "embedded object-storage bucket names must use valid S3 syntax" -}}
 {{- end -}}
 {{- end -}}
-{{- else if .Values.secrets.objectStorage.generate -}}
+{{- else if and
+  .Values.secrets.objectStorage.generate
+  (eq .Values.externalDependencies.objectStorage.authentication.type "static") -}}
 {{- fail "secrets.objectStorage.generate is supported only when embedded object storage is enabled" -}}
 {{- end -}}
 {{- if .Values.embeddedDependencies.valkey.enabled -}}
@@ -398,17 +407,26 @@
 {{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.externalDependencies.valkey.host) -}}
 {{- fail "externalDependencies.valkey.host is required for the control plane" -}}
 {{- end -}}
-{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.endpoint) -}}
-{{- fail "externalDependencies.objectStorage.endpoint is required for the control plane" -}}
+{{- if not .Values.embeddedDependencies.objectStorage.enabled -}}
+{{- $externalLocations := .Values.externalDependencies.objectStorage.locations -}}
+{{- $externalS3 := .Values.externalDependencies.objectStorage.s3 -}}
+{{- if not $externalLocations.workflows -}}
+{{- fail "externalDependencies.objectStorage.locations.workflows is required for the control plane" -}}
 {{- end -}}
-{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.buckets.workflows) -}}
-{{- fail "externalDependencies.objectStorage.buckets.workflows is required for the control plane" -}}
+{{- if not $externalLocations.logs -}}
+{{- fail "externalDependencies.objectStorage.locations.logs is required for the control plane" -}}
 {{- end -}}
-{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.buckets.logs) -}}
-{{- fail "externalDependencies.objectStorage.buckets.logs is required for the control plane" -}}
+{{- if not $externalLocations.apps -}}
+{{- fail "externalDependencies.objectStorage.locations.apps is required for the control plane" -}}
 {{- end -}}
-{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.externalDependencies.objectStorage.buckets.apps) -}}
-{{- fail "externalDependencies.objectStorage.buckets.apps is required for the control plane" -}}
+{{- $azureLocations := and (hasPrefix "azure://" $externalLocations.workflows) (hasPrefix "azure://" $externalLocations.logs) (hasPrefix "azure://" $externalLocations.apps) -}}
+{{- $s3Locations := and (hasPrefix "s3://" $externalLocations.workflows) (hasPrefix "s3://" $externalLocations.logs) (hasPrefix "s3://" $externalLocations.apps) -}}
+{{- if not (or $azureLocations $s3Locations) -}}
+{{- fail "externalDependencies.objectStorage locations must use one storage URI scheme" -}}
+{{- end -}}
+{{- if and $azureLocations (or $externalS3.region $externalS3.overrideUrl) -}}
+{{- fail "externalDependencies.objectStorage.s3 must be empty for Azure locations" -}}
+{{- end -}}
 {{- end -}}
 {{- if and (not .Values.embeddedDependencies.postgresql.enabled) (not .Values.secrets.postgresql.existingSecret) -}}
 {{- fail "secrets.postgresql.existingSecret is required for the control plane" -}}
@@ -416,7 +434,16 @@
 {{- if and (not .Values.embeddedDependencies.valkey.enabled) (not .Values.secrets.valkey.existingSecret) -}}
 {{- fail "secrets.valkey.existingSecret is required for the control plane" -}}
 {{- end -}}
-{{- if and (not .Values.embeddedDependencies.objectStorage.enabled) (not .Values.secrets.objectStorage.existingSecret) -}}
+{{- if and
+  (not .Values.embeddedDependencies.objectStorage.enabled)
+  (eq .Values.externalDependencies.objectStorage.authentication.type "sdkDefault")
+  (or .Values.secrets.objectStorage.generate .Values.secrets.objectStorage.existingSecret) -}}
+{{- fail "sdkDefault authentication must not configure an object-storage Secret" -}}
+{{- end -}}
+{{- if and
+  (not .Values.embeddedDependencies.objectStorage.enabled)
+  (eq .Values.externalDependencies.objectStorage.authentication.type "static")
+  (not .Values.secrets.objectStorage.existingSecret) -}}
 {{- fail "secrets.objectStorage.existingSecret is required for the control plane" -}}
 {{- end -}}
 {{- if not .Values.secrets.masterEncryptionKey.existingSecret.name -}}

--- a/deployments/charts/osmo/templates/worker.yaml
+++ b/deployments/charts/osmo/templates/worker.yaml
@@ -129,6 +129,8 @@ spec:
         volumeMounts:
         - name: osmo-progress-files
           mountPath: /var/run/osmo
+        - name: osmo-runtime-tmp
+          mountPath: /tmp
         {{- if .Values.secrets.masterEncryptionKey.existingSecret.name }}
         - mountPath: {{ include "osmo.secrets.mekMountPath" . | quote }}
           name: mek-volume
@@ -161,6 +163,8 @@ spec:
       {{- include "osmo.pod.extraContainers" .Values.services.worker | nindent 6 }}
       volumes:
         - name: osmo-progress-files
+          emptyDir: {}
+        - name: osmo-runtime-tmp
           emptyDir: {}
         {{- include "osmo.pod.extraVolumes" .Values.services.worker | nindent 8 }}
         {{- include "osmo.secrets.mekVolume" . | nindent 8 }}

--- a/deployments/charts/osmo/tests/control-embedded-values.yaml
+++ b/deployments/charts/osmo/tests/control-embedded-values.yaml
@@ -27,12 +27,13 @@ externalDependencies:
     port: 6379
     database: 0
   objectStorage:
-    endpoint: https://s3.external.example.com
-    region: us-east-1
-    buckets:
-      workflows: osmo-workflows
-      logs: osmo-logs
-      apps: osmo-apps
+    locations:
+      workflows: s3://osmo-workflows/workflows
+      logs: s3://osmo-logs/logs
+      apps: s3://osmo-apps/apps
+    s3:
+      region: us-east-1
+      overrideUrl: https://s3.external.example.com
 
 postgresql:
   fullnameOverride: null

--- a/deployments/charts/osmo/tests/control-external-azure-values.yaml
+++ b/deployments/charts/osmo/tests/control-external-azure-values.yaml
@@ -1,22 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-planes:
-  control:
-    enabled: true
-  compute:
-    enabled: false
-
-fullnameOverride: ''
-
-embeddedDependencies:
-  postgresql:
-    enabled: false
-  valkey:
-    enabled: false
-  objectStorage:
-    enabled: false
-
 externalUrl: http://osmo-gateway
 
 externalDependencies:
@@ -31,12 +15,12 @@ externalDependencies:
     database: 0
   objectStorage:
     locations:
-      workflows: s3://osmo-workflows/workflows
-      logs: s3://osmo-logs/logs
-      apps: s3://osmo-apps/apps
+      workflows: azure://osmotest/osmo-workflows/workflows
+      logs: azure://osmotest/osmo-workflows/logs
+      apps: azure://osmotest/osmo-workflows/apps
     s3:
-      region: us-east-1
-      overrideUrl: https://s3.external.example.com
+      region: ""
+      overrideUrl: ""
 
 secrets:
   postgresql:
@@ -44,21 +28,13 @@ secrets:
     keys:
       password: external-db-password
   valkey:
-    generate: false
     existingSecret: external-valkey-secret
   objectStorage:
-    generate: false
     existingSecret: external-object-storage-secret
-  backendApiTokens:
-    enabled: false
-    credentials: []
   masterEncryptionKey:
-    managementMode: external
     existingSecret:
       name: external-master-encryption-key-secret
       key: keyring.yaml
-    bootstrap:
-      enabled: false
 
 services:
   api:

--- a/deployments/charts/osmo/tests/object-storage-lifecycle-values.yaml
+++ b/deployments/charts/osmo/tests/object-storage-lifecycle-values.yaml
@@ -38,11 +38,13 @@ embeddedDependencies:
 
 externalDependencies:
   objectStorage:
-    endpoint: ''
-    buckets:
+    locations:
       workflows: ''
       logs: ''
       apps: ''
+    s3:
+      region: ''
+      overrideUrl: ''
 
 secrets:
   objectStorage:

--- a/deployments/charts/osmo/tests/single-plane-azure-values.yaml
+++ b/deployments/charts/osmo/tests/single-plane-azure-values.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+externalUrl: http://osmo-gateway
+
+compute:
+  backendName: default
+
+services:
+  worker:
+    serviceAccount:
+      create: true
+      annotations:
+        azure.workload.identity/client-id: single-plane-test-client-id
+    pod:
+      labels:
+        azure.workload.identity/use: "true"
+
+externalDependencies:
+  postgresql:
+    host: azure-postgresql.internal
+    port: 5432
+    database: osmo
+    username: postgres
+    tls:
+      enabled: false
+  valkey:
+    host: azure-redis.internal
+    port: 10000
+    database: 0
+    tls:
+      enabled: true
+  objectStorage:
+    authentication:
+      type: sdkDefault
+    locations:
+      workflows: azure://osmoazure/osmo-workflows/workflows
+      logs: azure://osmoazure/osmo-workflows/logs
+      apps: azure://osmoazure/osmo-workflows/apps
+
+secrets:
+  objectStorage:
+    existingSecret: ''

--- a/deployments/charts/osmo/tests/single-plane-azure-values.yaml
+++ b/deployments/charts/osmo/tests/single-plane-azure-values.yaml
@@ -7,6 +7,16 @@ compute:
   backendName: default
 
 services:
+  api:
+    extraVolumeMounts:
+    - name: runtime-image-pull-secret
+      mountPath: /etc/osmo/secrets/osmo-runtime-pull
+      readOnly: true
+    pod:
+      extraVolumes:
+      - name: runtime-image-pull-secret
+        secret:
+          secretName: osmo-runtime-pull
   worker:
     serviceAccount:
       create: true
@@ -37,6 +47,13 @@ externalDependencies:
       workflows: azure://osmoazure/osmo-workflows/workflows
       logs: azure://osmoazure/osmo-workflows/logs
       apps: azure://osmoazure/osmo-workflows/apps
+
+configuration:
+  workflow:
+    backend_images:
+      credential:
+        secretName: osmo-runtime-pull
+        secretKey: .dockerconfigjson
 
 secrets:
   objectStorage:

--- a/deployments/charts/osmo/tests/single-plane-s3-values.yaml
+++ b/deployments/charts/osmo/tests/single-plane-s3-values.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+externalUrl: http://osmo-gateway
+
+compute:
+  backendName: default
+
+externalDependencies:
+  postgresql:
+    host: s3-postgresql.internal
+    port: 5432
+    database: osmo
+    username: postgres
+    tls:
+      enabled: false
+  valkey:
+    host: s3-redis.internal
+    port: 6379
+    database: 0
+    tls:
+      enabled: true
+  objectStorage:
+    locations:
+      workflows: s3://osmo-workflows/workflows
+      logs: s3://osmo-logs/logs
+      apps: s3://osmo-apps/apps
+    s3:
+      region: us-east-1
+      overrideUrl: https://s3.example.com

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -975,7 +975,6 @@ test_control_umbrella() {
         --api-versions postgresql.cnpg.io/v1 \
         -f "$charts_copy/osmo/profiles/single-plane.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/single-plane-azure-values.yaml" \
-        --set-string runtimeImage.pullSecret=osmo-runtime-pull \
         >"$TEST_DIRECTORY/single-plane-azure.yaml"
     require_deployment "$TEST_DIRECTORY/single-plane-azure.yaml" "osmo-api"
     require_deployment "$TEST_DIRECTORY/single-plane-azure.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -51,6 +51,22 @@ require_schema_path() {
     ' "$file" || fail "expected schema path '$expected' in $file"
 }
 
+require_additional_property_error() {
+    local file=$1
+    local property=$2
+    awk -v property="$property" '
+        {
+            line = tolower($0)
+            if (index(line, "additional propert") > 0 &&
+                    index(line, tolower(property)) > 0 &&
+                    index(line, "not allowed") > 0) {
+                found = 1
+            }
+        }
+        END { exit !found }
+    ' "$file" || fail "expected additional-property error for '$property' in $file"
+}
+
 require_not_contains() {
     local file=$1
     local unexpected=$2
@@ -67,6 +83,18 @@ require_occurrences() {
     actual=$(grep -Fc -- "$expected" "$file" || true)
     [[ "$actual" -eq "$count" ]] || \
         fail "expected '$expected' $count times in $file, found $actual"
+}
+
+require_empty_dir_volume() {
+    local file=$1
+    local volume_name=$2
+    awk -v volume_name="$volume_name" '
+        $0 == "        - name: " volume_name {
+            getline
+            if ($0 == "          emptyDir: {}") found = 1
+        }
+        END { exit !found }
+    ' "$file" || fail "expected emptyDir volume '$volume_name' in $file"
 }
 
 require_line_count() {
@@ -921,6 +949,182 @@ test_control_umbrella() {
         "object-storage-bootstrap"
     require_not_contains "$TEST_DIRECTORY/quickstart-api.yaml" \
         "imagePullSecrets:"
+
+    if helm_template single-plane-profile-only "$charts_copy/osmo" \
+            --api-versions postgresql.cnpg.io/v1 \
+            -f "$charts_copy/osmo/profiles/single-plane.yaml" \
+            >"$TEST_DIRECTORY/single-plane-profile-only.out" 2>&1; then
+        fail "expected the single-plane profile without site values to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/single-plane-profile-only.out" \
+        "externalDependencies.postgresql.host is required for the control plane"
+
+    if helm_template single-plane-partial "$charts_copy/osmo" \
+            --api-versions postgresql.cnpg.io/v1 \
+            -f "$charts_copy/osmo/profiles/single-plane.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/single-plane-azure-values.yaml" \
+            --set-string externalUrl= \
+            >"$TEST_DIRECTORY/single-plane-partial.out" 2>&1; then
+        fail "expected the single-plane profile with partial site values to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/single-plane-partial.out" \
+        "externalUrl is required for the control plane"
+
+    helm_template single-plane-azure "$charts_copy/osmo" \
+        --namespace osmo \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$charts_copy/osmo/profiles/single-plane.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/single-plane-azure-values.yaml" \
+        --set-string runtimeImage.pullSecret=osmo-runtime-pull \
+        >"$TEST_DIRECTORY/single-plane-azure.yaml"
+    require_deployment "$TEST_DIRECTORY/single-plane-azure.yaml" "osmo-api"
+    require_deployment "$TEST_DIRECTORY/single-plane-azure.yaml" \
+        "osmo-backend-listener"
+    require_deployment "$TEST_DIRECTORY/single-plane-azure.yaml" \
+        "osmo-backend-worker"
+    resource_document "$TEST_DIRECTORY/single-plane-azure.yaml" Service \
+        "osmo-gateway" >"$TEST_DIRECTORY/single-plane-azure-gateway.yaml"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-gateway.yaml" \
+        "type: ClusterIP"
+    require_no_resource "$TEST_DIRECTORY/single-plane-azure.yaml" Cluster "osmo-pg"
+    require_no_deployment "$TEST_DIRECTORY/single-plane-azure.yaml" "osmo-valkey"
+    require_no_deployment "$TEST_DIRECTORY/single-plane-azure.yaml" "osmo-rustfs"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure.yaml" \
+        "type: LoadBalancer"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure.yaml" "kind: Ingress"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure.yaml" "kind: HTTPRoute"
+    require_contains "$TEST_DIRECTORY/single-plane-azure.yaml" \
+        "secretName: osmo-backend-token"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure.yaml" \
+        "OSMO_LOGIN_DEV"
+    resource_document "$TEST_DIRECTORY/single-plane-azure.yaml" ConfigMap \
+        "osmo-gateway-envoy-config" \
+        >"$TEST_DIRECTORY/single-plane-azure-gateway-config.yaml"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-gateway-config.yaml" \
+        "issuer: osmo"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-gateway-config.yaml" \
+        "uri: https://osmo-api/api/auth/keys"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-gateway-config.yaml" \
+        "cluster: osmo-api-jwks"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-gateway-config.yaml" \
+        "allow_missing:"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-gateway-config.yaml" \
+        "key: x-osmo-user"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-gateway-config.yaml" \
+        "key: x-osmo-roles"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-gateway-config.yaml" \
+        "key: x-osmo-allowed-pools"
+    resource_document "$TEST_DIRECTORY/single-plane-azure.yaml" ConfigMap \
+        "osmo-api-config" >"$TEST_DIRECTORY/single-plane-azure-config.yaml"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "secretName: osmo-runtime-pull"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "secretKey: .dockerconfigjson"
+    resource_document "$TEST_DIRECTORY/single-plane-azure.yaml" Deployment \
+        "osmo-api" >"$TEST_DIRECTORY/single-plane-azure-api.yaml"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-api.yaml" \
+        "memory: 1Gi"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-api.yaml" \
+        "mountPath: /etc/osmo/secrets/osmo-runtime-pull"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-api.yaml" \
+        "secretName: osmo-runtime-pull"
+    resource_document "$TEST_DIRECTORY/single-plane-azure.yaml" Deployment \
+        "osmo-worker" >"$TEST_DIRECTORY/single-plane-azure-worker.yaml"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-worker.yaml" \
+        "memory: 1Gi"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-worker.yaml" \
+        "serviceAccountName: osmo-worker"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-worker.yaml" \
+        'azure.workload.identity/use: "true"'
+    resource_document "$TEST_DIRECTORY/single-plane-azure.yaml" ServiceAccount \
+        "osmo-worker" >"$TEST_DIRECTORY/single-plane-azure-worker-service-account.yaml"
+    require_contains \
+        "$TEST_DIRECTORY/single-plane-azure-worker-service-account.yaml" \
+        "azure.workload.identity/client-id: single-plane-test-client-id"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "cpu: '{{USER_CPU}}'"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "nvidia.com/gpu"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "azure://osmoazure/osmo-workflows/workflows"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "azure://osmoazure/osmo-workflows/logs"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "azure://osmoazure/osmo-workflows/apps"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "secretName: osmo-object-storage"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "secretKey: object-storage.yaml"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-api.yaml" \
+        "mountPath: /etc/osmo/secrets/osmo-object-storage"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-api.yaml" \
+        "secretName: osmo-object-storage"
+    require_not_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" "s3://"
+    require_no_resource "$TEST_DIRECTORY/single-plane-azure.yaml" Secret \
+        "osmo-postgresql"
+    require_no_resource "$TEST_DIRECTORY/single-plane-azure.yaml" Secret \
+        "osmo-valkey"
+    require_no_resource "$TEST_DIRECTORY/single-plane-azure.yaml" Secret \
+        "osmo-object-storage"
+    require_no_resource "$TEST_DIRECTORY/single-plane-azure.yaml" Secret \
+        "osmo-backend-token"
+
+    helm_template single-plane-s3 "$charts_copy/osmo" \
+        --namespace osmo \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$charts_copy/osmo/profiles/single-plane.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/single-plane-s3-values.yaml" \
+        >"$TEST_DIRECTORY/single-plane-s3.yaml"
+    require_deployment "$TEST_DIRECTORY/single-plane-s3.yaml" "osmo-api"
+    require_deployment "$TEST_DIRECTORY/single-plane-s3.yaml" \
+        "osmo-backend-listener"
+    require_deployment "$TEST_DIRECTORY/single-plane-s3.yaml" \
+        "osmo-backend-worker"
+    resource_document "$TEST_DIRECTORY/single-plane-s3.yaml" Service \
+        "osmo-gateway" >"$TEST_DIRECTORY/single-plane-s3-gateway.yaml"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-gateway.yaml" \
+        "type: ClusterIP"
+    require_no_resource "$TEST_DIRECTORY/single-plane-s3.yaml" Cluster "osmo-pg"
+    require_no_deployment "$TEST_DIRECTORY/single-plane-s3.yaml" "osmo-valkey"
+    require_no_deployment "$TEST_DIRECTORY/single-plane-s3.yaml" "osmo-rustfs"
+    require_not_contains "$TEST_DIRECTORY/single-plane-s3.yaml" \
+        "type: LoadBalancer"
+    require_not_contains "$TEST_DIRECTORY/single-plane-s3.yaml" "kind: Ingress"
+    require_not_contains "$TEST_DIRECTORY/single-plane-s3.yaml" "kind: HTTPRoute"
+    require_contains "$TEST_DIRECTORY/single-plane-s3.yaml" \
+        "secretName: osmo-backend-token"
+    require_not_contains "$TEST_DIRECTORY/single-plane-s3.yaml" \
+        "OSMO_LOGIN_DEV"
+    resource_document "$TEST_DIRECTORY/single-plane-s3.yaml" ConfigMap \
+        "osmo-api-config" >"$TEST_DIRECTORY/single-plane-s3-config.yaml"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "cpu: '{{USER_CPU}}'"
+    require_not_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "nvidia.com/gpu"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "s3://osmo-workflows/workflows"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "s3://osmo-logs/logs"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "s3://osmo-apps/apps"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "region: us-east-1"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "override_url: https://s3.example.com"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "secretName: osmo-object-storage"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "secretKey: object-storage.yaml"
+    require_not_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" "azure://"
+    require_no_resource "$TEST_DIRECTORY/single-plane-s3.yaml" Secret \
+        "osmo-postgresql"
+    require_no_resource "$TEST_DIRECTORY/single-plane-s3.yaml" Secret \
+        "osmo-valkey"
+    require_no_resource "$TEST_DIRECTORY/single-plane-s3.yaml" Secret \
+        "osmo-object-storage"
+    require_no_resource "$TEST_DIRECTORY/single-plane-s3.yaml" Secret \
+        "osmo-backend-token"
+
     resource_document "$TEST_DIRECTORY/quickstart.yaml" Service \
         "osmo-gateway" >"$TEST_DIRECTORY/quickstart-gateway-service.yaml"
     require_contains "$TEST_DIRECTORY/quickstart-gateway-service.yaml" \
@@ -1788,11 +1992,13 @@ EOF
         require_contains "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
             "readOnlyRootFilesystem: true"
     done
-    for hardened_component in api router logger agent; do
+    for hardened_component in api worker router logger agent; do
         require_contains "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
             "mountPath: /tmp"
         require_contains "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
             "name: osmo-runtime-tmp"
+        require_empty_dir_volume "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
+            "osmo-runtime-tmp"
     done
     for hardened_component in worker logger agent delayed-job-monitor; do
         require_contains "$TEST_DIRECTORY/osmo-$hardened_component.yaml" \
@@ -2174,6 +2380,87 @@ EOF
         "endpoint: s3://osmo-apps/apps"
     require_contains "$TEST_DIRECTORY/osmo-external-object-storage-config.yaml" \
         "secretKey: object-storage.yaml"
+
+    helm_template azure-storage "$charts_copy/osmo" \
+        -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-azure-values.yaml" \
+        >"$TEST_DIRECTORY/osmo-external-azure-object-storage.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-external-azure-object-storage.yaml" \
+        ConfigMap azure-storage-osmo-api-config \
+        >"$TEST_DIRECTORY/osmo-external-azure-object-storage-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-external-azure-object-storage-config.yaml" \
+        "endpoint: azure://osmotest/osmo-workflows/workflows"
+    require_contains "$TEST_DIRECTORY/osmo-external-azure-object-storage-config.yaml" \
+        "endpoint: azure://osmotest/osmo-workflows/logs"
+    require_contains "$TEST_DIRECTORY/osmo-external-azure-object-storage-config.yaml" \
+        "endpoint: azure://osmotest/osmo-workflows/apps"
+    require_not_contains "$TEST_DIRECTORY/osmo-external-azure-object-storage-config.yaml" \
+        "override_url"
+    require_not_contains "$TEST_DIRECTORY/osmo-external-azure-object-storage-config.yaml" \
+        "region:"
+    require_not_contains "$TEST_DIRECTORY/osmo-external-azure-object-storage-config.yaml" \
+        "s3://"
+
+    local invalid_external_object_storage_case
+    local invalid_external_object_storage_settings
+    local invalid_external_object_storage_error
+    while IFS='|' read -r invalid_external_object_storage_case \
+            invalid_external_object_storage_settings \
+            invalid_external_object_storage_error; do
+        if helm_template "invalid-external-object-storage-$invalid_external_object_storage_case" \
+                "$charts_copy/osmo" \
+                -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+                -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+                $invalid_external_object_storage_settings \
+                >"$TEST_DIRECTORY/invalid-external-object-storage-$invalid_external_object_storage_case.out" 2>&1; then
+            fail "expected invalid external object storage case $invalid_external_object_storage_case to fail"
+        fi
+        if [[ "$invalid_external_object_storage_case" == legacy-* ]]; then
+            require_additional_property_error \
+                "$TEST_DIRECTORY/invalid-external-object-storage-$invalid_external_object_storage_case.out" \
+                "${invalid_external_object_storage_case#legacy-}"
+        else
+            require_contains \
+                "$TEST_DIRECTORY/invalid-external-object-storage-$invalid_external_object_storage_case.out" \
+                "$invalid_external_object_storage_error"
+        fi
+    done <<'EOF'
+missing-location|--set-string externalDependencies.objectStorage.locations.workflows=|externalDependencies.objectStorage.locations.workflows is required
+mixed-schemes|--set-string externalDependencies.objectStorage.locations.logs=azure://osmotest/osmo-workflows/logs|externalDependencies.objectStorage locations must use one storage URI scheme
+azure-s3-settings|--set-string externalDependencies.objectStorage.locations.workflows=azure://osmotest/osmo-workflows/workflows --set-string externalDependencies.objectStorage.locations.logs=azure://osmotest/osmo-workflows/logs --set-string externalDependencies.objectStorage.locations.apps=azure://osmotest/osmo-workflows/apps|externalDependencies.objectStorage.s3 must be empty for Azure locations
+account-only-azure|--set-string externalDependencies.objectStorage.locations.workflows=azure://osmotest|match pattern
+legacy-endpoint|--set-string externalDependencies.objectStorage.endpoint=https://legacy.example.com|
+legacy-buckets|--set-string externalDependencies.objectStorage.buckets.workflows=legacy-workflows|
+EOF
+    if helm_template invalid-object-storage-authentication "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            --set-string externalDependencies.objectStorage.authentication.type=azureWorkloadIdentity \
+            >"$TEST_DIRECTORY/invalid-object-storage-authentication.out" 2>&1; then
+        fail "expected an invalid object-storage authentication type to fail"
+    fi
+    require_schema_path "$TEST_DIRECTORY/invalid-object-storage-authentication.out" \
+        "externalDependencies.objectStorage.authentication.type"
+
+    local invalid_sdk_default_case
+    local invalid_sdk_default_settings
+    while IFS='|' read -r invalid_sdk_default_case invalid_sdk_default_settings; do
+        if helm_template "invalid-sdk-default-$invalid_sdk_default_case" \
+                "$charts_copy/osmo" \
+                -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+                -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+                --set-string externalDependencies.objectStorage.authentication.type=sdkDefault \
+                $invalid_sdk_default_settings \
+                >"$TEST_DIRECTORY/invalid-sdk-default-$invalid_sdk_default_case.out" 2>&1; then
+            fail "expected sdkDefault with $invalid_sdk_default_case credentials to fail"
+        fi
+        require_contains \
+            "$TEST_DIRECTORY/invalid-sdk-default-$invalid_sdk_default_case.out" \
+            "sdkDefault authentication must not configure an object-storage Secret"
+    done <<'EOF'
+existing-secret|--set-string secrets.objectStorage.existingSecret=unexpected
+generated-secret|--set secrets.objectStorage.generate=true --set-string secrets.objectStorage.existingSecret=
+EOF
     require_contains "$rendered" "nvcr.io/nvidia/osmo/service:latest"
     resource_document "$rendered" ConfigMap osmo-api-config \
         >"$TEST_DIRECTORY/osmo-external-runtime-config.yaml"
@@ -2575,10 +2862,11 @@ EOF
 
     local embedded_object_storage_settings=(
         --set embeddedDependencies.objectStorage.enabled=true
-        --set-string externalDependencies.objectStorage.endpoint=
-        --set-string externalDependencies.objectStorage.buckets.workflows=
-        --set-string externalDependencies.objectStorage.buckets.logs=
-        --set-string externalDependencies.objectStorage.buckets.apps=
+        --set-string externalDependencies.objectStorage.locations.workflows=
+        --set-string externalDependencies.objectStorage.locations.logs=
+        --set-string externalDependencies.objectStorage.locations.apps=
+        --set-string externalDependencies.objectStorage.s3.region=
+        --set-string externalDependencies.objectStorage.s3.overrideUrl=
         --set secrets.objectStorage.generate=true
         --set-string secrets.objectStorage.existingSecret=
     )
@@ -2966,10 +3254,11 @@ EOF
         require_contains "$TEST_DIRECTORY/conflicting-object-storage.out" \
             "$conflicting_external_object_storage_message"
     done <<'EOF'
-externalDependencies.objectStorage.endpoint=https://unexpected.example.com|externalDependencies.objectStorage.endpoint must be empty
-externalDependencies.objectStorage.buckets.workflows=unexpected-workflows|externalDependencies.objectStorage.buckets.workflows must be empty
-externalDependencies.objectStorage.buckets.logs=unexpected-logs|externalDependencies.objectStorage.buckets.logs must be empty
-externalDependencies.objectStorage.buckets.apps=unexpected-apps|externalDependencies.objectStorage.buckets.apps must be empty
+externalDependencies.objectStorage.locations.workflows=s3://unexpected-workflows/workflows|externalDependencies.objectStorage.locations.workflows must be empty
+externalDependencies.objectStorage.locations.logs=s3://unexpected-logs/logs|externalDependencies.objectStorage.locations.logs must be empty
+externalDependencies.objectStorage.locations.apps=s3://unexpected-apps/apps|externalDependencies.objectStorage.locations.apps must be empty
+externalDependencies.objectStorage.s3.region=us-west-2|externalDependencies.objectStorage.s3.region must be empty
+externalDependencies.objectStorage.s3.overrideUrl=https://unexpected.example.com|externalDependencies.objectStorage.s3.overrideUrl must be empty
 EOF
 
     if helm_template duplicate-object-storage-credentials "$charts_copy/osmo" \
@@ -2996,6 +3285,17 @@ EOF
     require_schema_path \
         "$TEST_DIRECTORY/invalid-empty-object-storage-credentials-key.out" \
         "secrets.objectStorage.keys.credentials"
+
+    if helm_template embedded-sdk-default "$charts_copy/osmo" \
+            -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            "${embedded_object_storage_settings[@]}" \
+            --set-string externalDependencies.objectStorage.authentication.type=sdkDefault \
+            >"$TEST_DIRECTORY/embedded-sdk-default.out" 2>&1; then
+        fail "expected embedded object storage with sdkDefault authentication to fail"
+    fi
+    require_contains "$TEST_DIRECTORY/embedded-sdk-default.out" \
+        "embedded object storage requires static authentication"
 
     local invalid_object_storage_credentials_key
     local invalid_object_storage_credentials_key_message
@@ -4874,9 +5174,9 @@ EOF
         require_contains "$TEST_DIRECTORY/missing-required.out" "$expected_message"
     done <<'EOF'
 externalUrl|externalUrl is required
-externalDependencies.objectStorage.buckets.workflows|buckets.workflows is required
-externalDependencies.objectStorage.buckets.logs|buckets.logs is required
-externalDependencies.objectStorage.buckets.apps|buckets.apps is required
+externalDependencies.objectStorage.locations.workflows|externalDependencies.objectStorage.locations.workflows is required
+externalDependencies.objectStorage.locations.logs|externalDependencies.objectStorage.locations.logs is required
+externalDependencies.objectStorage.locations.apps|externalDependencies.objectStorage.locations.apps is required
 EOF
 
     cat >"$charts_copy/osmo/templates/test-notes.yaml" <<'EOF'

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -610,10 +610,9 @@
       "properties": {
         "registry": { "type": "string" },
         "repository": { "type": "string" },
-        "tag": { "type": "string" },
-        "pullSecret": { "type": "string" }
+        "tag": { "type": "string" }
       },
-      "required": ["registry", "repository", "tag", "pullSecret"]
+      "required": ["registry", "repository", "tag"]
     },
     "componentImage": {
       "type": "object",

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -610,9 +610,10 @@
       "properties": {
         "registry": { "type": "string" },
         "repository": { "type": "string" },
-        "tag": { "type": "string" }
+        "tag": { "type": "string" },
+        "pullSecret": { "type": "string" }
       },
-      "required": ["registry", "repository", "tag"]
+      "required": ["registry", "repository", "tag", "pullSecret"]
     },
     "componentImage": {
       "type": "object",
@@ -859,6 +860,7 @@
       "type": "object",
       "properties": {
         "userHeader": { "type": "string" },
+        "allowMissing": { "type": "boolean" },
         "providers": { "type": "array" },
         "additionalProviders": { "type": "array" }
       }
@@ -1202,15 +1204,40 @@
     },
     "objectStorageConnection": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "endpoint": { "type": "string" },
-        "region": { "type": "string" },
-        "buckets": {
+        "authentication": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "workflows": { "type": "string" },
-            "logs": { "type": "string" },
-            "apps": { "type": "string" }
+            "type": { "type": "string", "enum": ["static", "sdkDefault"] }
+          },
+          "required": ["type"]
+        },
+        "locations": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "workflows": {
+              "type": "string",
+              "pattern": "^$|^(s3://[^/\\s]+(?:/[^\\s]*)?|azure://[^/\\s]+/[^/\\s]+(?:/[^\\s]*)?)$"
+            },
+            "logs": {
+              "type": "string",
+              "pattern": "^$|^(s3://[^/\\s]+(?:/[^\\s]*)?|azure://[^/\\s]+/[^/\\s]+(?:/[^\\s]*)?)$"
+            },
+            "apps": {
+              "type": "string",
+              "pattern": "^$|^(s3://[^/\\s]+(?:/[^\\s]*)?|azure://[^/\\s]+/[^/\\s]+(?:/[^\\s]*)?)$"
+            }
+          }
+        },
+        "s3": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "region": { "type": "string" },
+            "overrideUrl": { "type": "string" }
           }
         }
       }

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -161,9 +161,6 @@ runtimeImage:
   registry: ''
   repository: ''
   tag: ''
-  # Docker config Secret used to pull workflow init/client images. OSMO config
-  # consumers read it to create short-lived, workflow-scoped pull credentials.
-  pullSecret: ''
 
 # Metadata and scheduling defaults shared by OSMO-owned workloads. Labels,
 # annotations, and node selectors merge with service-specific pod values;
@@ -1320,6 +1317,9 @@ gateway:
       port: ''
     jwt:
       userHeader: x-osmo-user
+      # WARNING: Enabling this permits requests without a JWT. Use it only for
+      # trusted, non-public development access with an intentional fallback
+      # identity; never expose such a gateway to untrusted networks.
       allowMissing: false
       providers: []
       additionalProviders: []

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -116,14 +116,21 @@ externalDependencies:
       enabled: false
       caExistingSecret: ''
       caKey: ca-bundle.crt
-  # S3-compatible storage for workflow data, logs, and application bundles.
+  # Object storage for workflow data, logs, and application bundles.
   objectStorage:
-    endpoint: ''
-    region: us-east-1
-    buckets:
+    authentication:
+      # static loads SDK credentials from secrets.objectStorage.existingSecret.
+      # sdkDefault delegates credential discovery to the provider SDK, such as
+      # Azure DefaultAzureCredential, the AWS default credential provider
+      # chain, or Google Application Default Credentials.
+      type: static
+    locations:
       workflows: ''
       logs: ''
       apps: ''
+    s3:
+      region: ''
+      overrideUrl: ''
 
 # Override the names Helm derives from the chart and release. Leave empty for
 # conventional names such as `osmo-api` and `osmo-gateway`.
@@ -154,6 +161,9 @@ runtimeImage:
   registry: ''
   repository: ''
   tag: ''
+  # Docker config Secret used to pull workflow init/client images. OSMO config
+  # consumers read it to create short-lived, workflow-scoped pull credentials.
+  pullSecret: ''
 
 # Metadata and scheduling defaults shared by OSMO-owned workloads. Labels,
 # annotations, and node selectors merge with service-specific pod values;
@@ -1310,6 +1320,7 @@ gateway:
       port: ''
     jwt:
       userHeader: x-osmo-user
+      allowMissing: false
       providers: []
       additionalProviders: []
     skipAuthPaths:

--- a/src/lib/data/storage/backends/tests/test_backends.py
+++ b/src/lib/data/storage/backends/tests/test_backends.py
@@ -18,6 +18,8 @@
 Unit tests for the storage backends module.
 """
 
+import pathlib
+import tempfile
 import unittest
 from typing import cast
 from unittest import mock
@@ -239,6 +241,58 @@ class TestBackends(unittest.TestCase):
 
                     self.assertIn('Data credential not found', str(context.exception))
                     self.assertIn(expected_profile, str(context.exception))
+
+    def test_endpoint_only_config_uses_environment_auth(self):
+        """An SDK-default config entry must not be parsed as static credentials."""
+        with tempfile.TemporaryDirectory() as config_directory:
+            pathlib.Path(config_directory, 'config.yaml').write_text(
+                'auth:\n'
+                '  data:\n'
+                '    azure://testaccount:\n'
+                '      endpoint: azure://testaccount\n',
+                encoding='utf-8',
+            )
+            with mock.patch(
+                'src.lib.data.storage.credentials.credentials.client_configs.'
+                'get_client_config_dir',
+                return_value=config_directory,
+            ):
+                backend = backends.construct_storage_backend(
+                    uri='azure://testaccount/testcontainer/testpath',
+                )
+
+                data_cred = backend.resolved_data_credential
+
+        self.assertIsInstance(data_cred, credentials.DefaultDataCredential)
+        self.assertEqual(data_cred.endpoint, 'azure://testaccount')
+
+    def test_partial_static_credentials_raise_user_error(self):
+        """Static credentials require both the access key ID and secret."""
+        partial_credentials = [
+            '      access_key_id: only-an-id\n',
+            '      access_key: only-a-secret\n',
+        ]
+
+        for partial_credential in partial_credentials:
+            with self.subTest(partial_credential=partial_credential.strip()), \
+                    tempfile.TemporaryDirectory() as config_directory:
+                config_file = pathlib.Path(config_directory, 'config.yaml')
+                config_file.write_text(
+                    'auth:\n'
+                    '  data:\n'
+                    '    s3://test-bucket:\n'
+                    f'{partial_credential}',
+                    encoding='utf-8',
+                )
+
+                with self.assertRaises(osmo_errors.OSMOUserError) as context:
+                    credentials.get_static_data_credential_from_config(
+                        's3://test-bucket', str(config_file))
+
+                self.assertIn(
+                    'access_key_id and access_key must be provided together',
+                    str(context.exception),
+                )
 
 
 class AzureDefaultDataCredentialTest(unittest.TestCase):

--- a/src/lib/data/storage/credentials/credentials.py
+++ b/src/lib/data/storage/credentials/credentials.py
@@ -195,6 +195,14 @@ def get_static_data_credential_from_config(
 
         if 'auth' in configs and 'data' in configs['auth'] and url in configs['auth']['data']:
             data_cred_dict = configs['auth']['data'][url]
+            has_access_key_id = 'access_key_id' in data_cred_dict
+            has_access_key = 'access_key' in data_cred_dict
+            if not has_access_key_id and not has_access_key:
+                return None
+            if has_access_key_id != has_access_key:
+                raise osmo_errors.OSMOUserError(
+                    'Static data credential access_key_id and access_key must be '
+                    'provided together.')
             data_cred = StaticDataCredential(
                 access_key_id=data_cred_dict['access_key_id'],
                 access_key=pydantic.SecretStr(data_cred_dict['access_key']),

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -1075,29 +1075,32 @@ def _resolve_platform_fields(
 SECRETS_ROOT = '/etc/osmo/secrets'
 
 
-def _decode_dockerconfig_auth(auth_b64: str, username: str) -> str:
-    """Recover the raw password from a `.dockerconfigjson` `auth` field.
+def _decode_dockerconfig_identity(
+    auth_b64: str, username: str,
+) -> tuple[str, str]:
+    """Recover the username and raw password from a Docker `auth` field.
 
-    The `auth` field is base64(`username:password`); strip the username
-    prefix and a single ':' to get the password back. Returns '' on any
-    decode failure — caller logs and proceeds with empty credentials.
+    The `auth` field is base64(`username:password`). Docker config files may
+    omit the redundant `username` field, so preserve an explicit username or
+    recover it from the decoded composite. Returns the supplied username and
+    an empty password on decode failure.
     """
     if not auth_b64:
-        return ''
+        return username, ''
     try:
         decoded = base64.b64decode(auth_b64).decode('utf-8')
     except (ValueError, UnicodeDecodeError):
         logging.warning(
             'Could not base64-decode dockerconfigjson auth field; '
             'returning empty password')
-        return ''
+        return username, ''
     prefix = f'{username}:'
     if username and decoded.startswith(prefix):
-        return decoded[len(prefix):]
-    # No username, or auth doesn't start with username: — just split on
-    # first ':' as a best effort.
-    _, sep, password = decoded.partition(':')
-    return password if sep else ''
+        return username, decoded[len(prefix):]
+    decoded_username, separator, password = decoded.partition(':')
+    if not separator:
+        return username, ''
+    return username or decoded_username, password
 
 
 def _resolve_secret_file_references(config_data: Dict[str, Any],
@@ -1204,14 +1207,14 @@ def _resolve_single_secret(parent_dict: Dict[str, Any], key: str,
             # base64(username:password)). Prefer password; fall back to
             # decoding auth and stripping the username prefix so we always
             # land in the model with a raw token.
-            password = registry_data.get('password')
-            if not password:
-                password = _decode_dockerconfig_auth(
-                    registry_data.get('auth', ''),
-                    registry_data.get('username', ''))
+            username = registry_data.get('username', '')
+            decoded_username, decoded_password = _decode_dockerconfig_identity(
+                registry_data.get('auth', ''), username)
+            username = username or decoded_username
+            password = registry_data.get('password') or decoded_password
             extracted = {
                 'registry': registry_url,
-                'username': registry_data.get('username', ''),
+                'username': username,
                 'auth': password,
             }
             current_value.pop('secret_file', None)

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -335,6 +335,35 @@ class TestResolveSecretFileReferences(unittest.TestCase):
         finally:
             os.unlink(secret_path)
 
+    def test_resolve_dockerconfigjson_recovers_auth_only_identity(self):
+        """Docker config auth-only entries recover username and password."""
+        secret_data = {
+            'auths': {
+                'nvcr.io': {
+                    'auth': base64.b64encode(
+                        b'$oauthtoken:auth-only-token').decode(),
+                },
+            },
+        }
+        with tempfile.NamedTemporaryFile(
+                mode='w', suffix='.json', delete=False) as secret_file:
+            json.dump(secret_data, secret_file)
+            secret_path = secret_file.name
+        try:
+            config_data: Dict[str, Any] = {
+                'backend_images': {
+                    'credential': {'secret_file': secret_path},
+                },
+            }
+            configmap_loader._resolve_secret_file_references(config_data)
+
+            credential = config_data['backend_images']['credential']
+            self.assertEqual(credential['registry'], 'nvcr.io')
+            self.assertEqual(credential['username'], '$oauthtoken')
+            self.assertEqual(credential['auth'], 'auth-only-token')
+        finally:
+            os.unlink(secret_path)
+
 
 class TestResolveSecretDirectory(unittest.TestCase):
     """Tests for per-field Secret mount support (--from-literal)."""

--- a/src/utils/job/jobs.py
+++ b/src/utils/job/jobs.py
@@ -1268,7 +1268,7 @@ class UpdateGroup(WorkflowJob):
             retry_ids = task.Task.batch_fetch_latest_retry_ids(
                 database, self.workflow_id, task_names)
 
-            pipe = redis_client.pipeline()
+            pipe = redis_client.pipeline(transaction=False)
             pipe.set(action_key, json.dumps(attributes))
             pipe.expire(action_key, total_timeout, nx=True)
 
@@ -1441,7 +1441,7 @@ class CleanupWorkflow(WorkflowJob):
 
         redis_client = redis.from_url(workflow_obj.logs)
 
-        redis_batch_pipeline = redis_client.pipeline()
+        redis_batch_pipeline = redis_client.pipeline(transaction=False)
 
         if workflow_obj.status.failed():
             start_delimiter = '\n' + '-' * 100 + '\n'

--- a/src/utils/job/tests/test_jobs_pure.py
+++ b/src/utils/job/tests/test_jobs_pure.py
@@ -372,6 +372,7 @@ class UpdateGroupNotifyBarrierTest(unittest.TestCase):
              mock.patch.object(task.Task, 'batch_fetch_latest_retry_ids',
                                return_value={'t1': 0, 't2': 0}):
             ug._notify_barrier(database, client, total_timeout=60)
+        client.pipeline.assert_called_once_with(transaction=False)
         pipe.execute.assert_called_once()
         # Two members should each lpush once.
         self.assertEqual(pipe.lpush.call_count, 2)
@@ -1923,6 +1924,7 @@ class CleanupWorkflowExecuteTest(unittest.TestCase):
                                new=mock.AsyncMock(return_value=mock.Mock())):
             result = cw.execute(ctx, progress_writer)
         self.assertIsInstance(result, jobs_base.JobResult)
+        redis_client.pipeline.assert_called_once_with(transaction=False)
         # Update logs called for both logs and events
         wf.update_log_to_db.assert_called_once()
         wf.update_events_to_db.assert_called_once()


### PR DESCRIPTION
## Description

Add provider-neutral single-plane support to the OSMO umbrella chart. The new converged profile runs the control and compute planes in one cluster while leaving infrastructure and ingress site-specific. The Azure deployment script and all Terraform changes are split into stacked PR #1356.

The chart now accepts provider-native object-storage locations (`s3://` and `azure://`) and supports either static credentials or the cloud SDK default credential chain. Exact URIs avoid reconstructing provider-specific locations from S3-shaped endpoint and bucket fields, while `sdkDefault` lets workload identity supply credentials without embedding access keys in Helm values.

The gateway can use the in-cluster OSMO JWKS endpoint for local token validation. The single-plane profile requires JWTs by default; `allowMissing` remains available for deliberately isolated development gateways and is now documented as security-sensitive.

Supporting code changes make the provider-neutral chart configuration work end to end:

- ConfigMap secret loading now accepts Docker config entries containing only the standard base64 `auth` field and decodes the username and password needed for workflow image pulls.
- Storage credential parsing treats endpoint-only configuration as SDK-default authentication, while rejecting incomplete static key pairs with a user-facing error.
- Redis command batches in barrier notification and workflow cleanup use `pipeline(transaction=False)`. These batches benefit from pipelining but do not require atomicity; disabling `MULTI/EXEC` avoids cross-slot transaction failures with clustered or proxied Redis deployments.

Issue - None

## Verification

- Full OSMO chart suite with Helm 3.14 and Helm 4.0
- Azure and S3 single-plane Helm lint renders
- Bazel tests for storage backends, ConfigMap loading, and workflow job cleanup

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
