### PR TITLE
Add the MCP audience to the gateway provider instead of asking for a second one

### DIFF
--- a/deployments/charts/service/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/service/templates/_gateway-envoy-config.tpl
@@ -35,6 +35,7 @@ setting detects this rotation and triggers Envoy to reload.
 {{- $mcpPath := "/mcp" }}
 {{- $mcpMetadataPath := "/.well-known/oauth-protected-resource/mcp" }}
 {{- $mcpResourceUrl := "" }}
+{{- $mcpTokenIssuer := "" }}
 {{- $mcpMetadataUrl := "" }}
 {{- $skipAuthPaths := concat (default (list) $envoy.skipAuthPaths) (default (list) $envoy.extraSkipAuthPaths) }}
 {{- $authnSkipPaths := $skipAuthPaths }}
@@ -49,8 +50,28 @@ setting detects this rotation and triggers Envoy to reload.
 {{- fail "services.mcp.enabled requires gateway.authz.enabled=true" }}
 {{- end }}
 {{- $mcpResourceUrl = include "osmo.mcp-resource-url" . }}
-{{- if not $envoy.jwt.providers }}
-{{- fail "services.mcp.enabled requires at least one gateway.envoy.jwt.providers entry" }}
+{{- /*
+The relayed upstream token carries the MCP resource URL as its audience, so the
+Gateway has to accept that audience from the identity provider MCP authenticates
+against. That provider is already configured for this deployment's own clients,
+and differs only in audience -- so the audience is appended to it rather than
+asking for a second, near-identical entry.
+
+OpenID Connect Discovery defines the configuration URL as the issuer followed by
+/.well-known/openid-configuration, so the issuer is derivable. accessTokenIssuer
+overrides it for providers whose access tokens are issued elsewhere, as an
+application configured for v1-format tokens does.
+*/ -}}
+{{- $mcpTokenIssuer = $mcpOidcProxy.oidc.accessTokenIssuer | default (trimSuffix "/.well-known/openid-configuration" (required "services.mcp.oidcProxy.oidc.configUrl is required when MCP is enabled" $mcpOidcProxy.oidc.configUrl)) }}
+{{- $mcpTokenIssuer = trimSuffix "/" $mcpTokenIssuer }}
+{{- $mcpIssuerProviders := 0 }}
+{{- range $provider := $envoy.jwt.providers }}
+{{- if eq (trimSuffix "/" $provider.issuer) $mcpTokenIssuer }}
+{{- $mcpIssuerProviders = add1 $mcpIssuerProviders }}
+{{- end }}
+{{- end }}
+{{- if eq $mcpIssuerProviders 0 }}
+{{- fail (printf "services.mcp.enabled requires a gateway.envoy.jwt.providers entry with issuer %s, which is where MCP's relayed tokens come from" $mcpTokenIssuer) }}
 {{- end }}
 {{- $mcpServiceName := required "services.mcp.serviceName is required when MCP is enabled" $mcp.serviceName }}
 {{- $mcpImageName := required "services.mcp.imageName is required when MCP is enabled" $mcp.imageName }}
@@ -675,6 +696,9 @@ data:
                     issuer: {{ $provider.issuer }}
                     audiences:
                     - {{ $provider.audience }}
+                    {{- if and $mcpEnabled (eq (trimSuffix "/" $provider.issuer) $mcpTokenIssuer) (ne $provider.audience $mcpResourceUrl) }}
+                    - {{ $mcpResourceUrl }}
+                    {{- end }}
                     forward: true
                     payload_in_metadata: verified_jwt
                     from_headers:

--- a/deployments/charts/service/tests/render-tests.sh
+++ b/deployments/charts/service/tests/render-tests.sh
@@ -157,10 +157,13 @@ for derived in OSMO_MCP_AUTH_ISSUER_URL OSMO_MCP_AUTH_SCOPE \
     fi
 done
 
-# Only an Entra v1 resource application needs the access-token issuer stated;
-# without it the service uses the issuer the discovery document advertises.
-helm template mcp-no-issuer "$CHART_DIR" --values "$mcp_values" \
-    --set 'services.mcp.oidcProxy.oidc.accessTokenIssuer=' >/dev/null
+# Only a provider issuing v1-format access tokens needs the issuer stated. With
+# it unset the issuer comes from the configuration URL, and the gateway provider
+# for that issuer is the one the MCP audience is added to.
+no_issuer=$(helm template mcp-no-issuer "$CHART_DIR" --values "$mcp_values" \
+    --set 'services.mcp.oidcProxy.oidc.accessTokenIssuer=' \
+    --set 'gateway.envoy.jwt.providers[0].issuer=https://login.example.com/example-tenant/v2.0')
+grep -q 'issuer: https://login.example.com/example-tenant/v2.0' <<<"$no_issuer"
 
 # The secret file paths follow the mount, so a deployer states neither of them.
 mount_render=$(helm template mcp-mount "$CHART_DIR" --values "$mcp_values" \
@@ -168,6 +171,20 @@ mount_render=$(helm template mcp-mount "$CHART_DIR" --values "$mcp_values" \
 grep -q 'value: "/var/run/mcp/client-secret"' <<<"$mount_render"
 grep -q 'value: "/var/run/mcp/redis-password"' <<<"$mount_render"
 grep -q 'mountPath: /var/run/mcp' <<<"$mount_render"
+
+# The MCP audience is added to the provider for its issuer, so no deployment
+# writes a second provider differing only in audience.
+aud_render=$(helm template mcp-aud "$CHART_DIR" --values "$mcp_values" \
+    --set 'gateway.envoy.jwt.providers[0].audience=some-client-id')
+grep -q -- '- some-client-id' <<<"$aud_render"
+grep -q -- '- https://osmo.example.com/mcp' <<<"$aud_render"
+
+# A provider already carrying that audience must not have it added twice.
+dupes=$(grep -c -- '- https://osmo.example.com/mcp' <<<"$mcp_render" || true)
+if [ "$dupes" -ne 1 ]; then
+    echo "MCP audience appears $dupes times on the gateway provider, want 1" >&2
+    exit 1
+fi
 
 # The proxy keeps its state in Redis, so scaling out must render.
 helm template mcp-scale "$CHART_DIR" --values "$mcp_values" \

--- a/docs/deployment_guide/advanced_config/mcp.rst
+++ b/docs/deployment_guide/advanced_config/mcp.rst
@@ -53,12 +53,14 @@ cannot elevate the user. See :ref:`mcp_identity_permissions` and
 Shared Prerequisites
 ====================
 
-Before enabling either mode:
+Before enabling MCP:
 
 * Keep ``gateway.envoy.enabled`` and ``gateway.authz.enabled`` set to ``true``.
 * Configure a ``gateway.envoy.jwt.providers`` entry that validates the bearer
   token used for downstream ``/api`` requests and resolves its identity and
-  roles to the intended OSMO user.
+  roles to the intended OSMO user. The chart adds the MCP resource URL to the
+  audiences of the entry whose issuer matches the one MCP authenticates
+  against, so no second entry is needed for MCP itself.
 * Publish the release Gateway on one HTTPS hostname. Set
   ``services.mcp.resourceUrl`` to that origin plus the exact ``/mcp`` path.
 * Ensure that the MCP pod can resolve and reach the public Gateway origin.


### PR DESCRIPTION
Stacked on #1344. Removes the last piece of MCP boilerplate a deployer has to write by hand.

Issue #None

## The problem

Enabling MCP required a `gateway.envoy.jwt.providers` entry carrying the MCP resource URL as its audience. In every deployment that entry was a copy of one already present — same issuer, same JWKS URI, same claim, same cluster — differing only in audience, because the relayed upstream token comes from the identity provider already configured for this deployment's own clients.

A minimal values file failed with:

```
Error: services.mcp.enabled requires at least one gateway.envoy.jwt.providers entry
```

and the deployer then had to work out five fields, four of which the chart already knew.

## The change

Envoy accepts several audiences per provider, so the resource URL is appended to the entry whose issuer matches the one MCP authenticates against. No deployment writes the second entry.

The issuer is derivable: OpenID Connect Discovery defines the configuration URL as the issuer followed by `/.well-known/openid-configuration`. `accessTokenIssuer` still overrides it for providers whose access tokens are issued elsewhere, as an application configured for v1-format tokens does.

Two details worth reviewer attention:

- The issuer comparison ignores a trailing slash, since a v1-style issuer carries one and a discovery-derived issuer does not.
- An entry already carrying that audience does not get it twice, so existing values files render unchanged until they drop the duplicate.

Failing to find a provider for that issuer now names the issuer, rather than saying an entry is required — which was the error a deployer hit *after* supplying one.

## What a deployment writes now

```yaml
services:
  redis:
    serviceName: redis
  mcp:
    enabled: true
    resourceUrl: https://osmo.example.com/mcp
    oidcProxy:
      oidc:
        configUrl: https://idp.example.com/.well-known/openid-configuration
        clientId: <application-id>
      existingSecret:
        name: mcp-oidc          # key: client-secret
```

The gateway provider it already needs for its own clients now covers MCP too.

## Verification

- `bazel test //src/service/mcp/... //test/smoke/...` passes 76/76
- `render-tests.sh` passes, with assertions that the audience is appended to the matching provider, that a provider already carrying it does not get it twice, and that an unset issuer resolves through the configuration URL
- Negative-tested by removing the append and confirming the harness fails
- An existing values file renders with its duplicate provider deleted, the audience landing on the entry that remains

Also corrects a stale "either mode" in the deployment guide, left from the direct-mode removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)