### PR TITLE
fix(helm): restore quickstart secret contract

### DIFF
--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -75,6 +75,24 @@ helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
   --timeout 20m
 ```
 
+For prerelease OSMO images published below `nvcr.io/nvstaging/osmo`, set the
+registry and repository defaults separately. The runtime init and client images
+use the same location and tag:
+
+```bash
+helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
+  --namespace osmo \
+  --create-namespace \
+  --values deployments/charts/osmo/profiles/quickstart.yaml \
+  --set-string compute.backendName=default \
+  --set-string imageRegistry=nvcr.io \
+  --set-string imageRepository=nvstaging/osmo \
+  --set-string imageTag=2026.8.28.3b3d1b0a2.ecolter3910-amd64 \
+  --set-string 'imagePullSecrets[0].name=osmo-nvcr-pull' \
+  --wait \
+  --timeout 20m
+```
+
 Inspect the release without reading generated Secret values:
 
 ```bash
@@ -510,14 +528,19 @@ above.
 
 ## Optional configuration
 
-- Configure the OSMO image registry under `imageRegistry`, a shared
-  OSMO component tag under `imageTag`, pull credentials under
-  `imagePullSecrets`, and workflow init/client images under `runtimeImage`.
-  The chart writes those workflow images into the managed API configuration
-  unless `configuration.workflow.backend_images` overrides them. Configure
-  per-component image overrides in each component's `image` block. Configure
-  dependency images and pull credentials in their native values blocks; for
-  example, Valkey uses `valkey.image` and `valkey.imagePullSecrets`.
+- Configure the OSMO image registry and base repository under `imageRegistry`
+  and `imageRepository`, a shared OSMO component tag under `imageTag`, pull
+  credentials under `imagePullSecrets`, and workflow init/client image
+  overrides under `runtimeImage`. Top-level pull credentials are used as
+  defaults for workflow pod templates unless a template defines its own list.
+  A non-empty service-specific
+  `image.registry` or `image.repository` takes precedence over these
+  top-level defaults; otherwise the chart uses `nvcr.io/nvidia/osmo` and the
+  component name. The chart writes the resolved workflow images into the
+  managed API configuration unless `configuration.workflow.backend_images`
+  overrides them. Configure dependency images and pull credentials in their
+  native values blocks; for example, Valkey uses `valkey.image` and
+  `valkey.imagePullSecrets`.
 - Configure replicas, autoscaling, resources, disruption budgets, scheduling,
   security contexts, probes, volumes, and ServiceAccounts under `services`,
   `gateway`, and `podDefaults`. Directly owned workload extensions use

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -75,24 +75,6 @@ helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
   --timeout 20m
 ```
 
-For prerelease OSMO images published below `nvcr.io/nvstaging/osmo`, set the
-registry and repository defaults separately. The runtime init and client images
-use the same location and tag:
-
-```bash
-helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
-  --namespace osmo \
-  --create-namespace \
-  --values deployments/charts/osmo/profiles/quickstart.yaml \
-  --set-string compute.backendName=default \
-  --set-string imageRegistry=nvcr.io \
-  --set-string imageRepository=nvstaging/osmo \
-  --set-string imageTag=2026.8.28.3b3d1b0a2.ecolter3910-amd64 \
-  --set-string 'imagePullSecrets[0].name=osmo-nvcr-pull' \
-  --wait \
-  --timeout 20m
-```
-
 Inspect the release without reading generated Secret values:
 
 ```bash

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -528,14 +528,13 @@ above.
 
 ## Optional configuration
 
-- Configure the OSMO image registry and base repository under `imageRegistry`
-  and `imageRepository`, a shared OSMO component tag under `imageTag`, pull
-  credentials under `imagePullSecrets`, and workflow init/client image
-  overrides under `runtimeImage`. Top-level pull credentials are used as
-  defaults for workflow pod templates unless a template defines its own list.
-  A non-empty service-specific
-  `image.registry` or `image.repository` takes precedence over these
-  top-level defaults; otherwise the chart uses `nvcr.io/nvidia/osmo` and the
+- Configure the OSMO image registry, base repository, and tag under
+  `imageRegistry`, `imageRepository`, and `imageTag`; they default to
+  `nvcr.io`, `nvidia/osmo`, and `latest`. A non-empty service-specific
+  `image.registry`, `image.repository`, or `image.tag` takes precedence over
+  the corresponding top-level value. Runtime workflow image fields under
+  `runtimeImage` are optional overrides and inherit the matching top-level
+  value when empty. Otherwise the chart uses `nvcr.io/nvidia/osmo` and the
   component name. The chart writes the resolved workflow images into the
   managed API configuration unless `configuration.workflow.backend_images`
   overrides them. Configure dependency images and pull credentials in their

--- a/deployments/charts/osmo/profiles/README.md
+++ b/deployments/charts/osmo/profiles/README.md
@@ -11,7 +11,7 @@ values take precedence.
 
 | File | Directly installable | Required environment input |
 | --- | --- | --- |
-| `quickstart.yaml` | Yes, on a development cluster | KAI Scheduler, the CloudNativePG operator, and a default dynamic StorageClass installed separately; `compute.backendName` set explicitly at install time |
+| `quickstart.yaml` | Yes, on a development cluster | KAI Scheduler, the CloudNativePG operator, and a default dynamic StorageClass installed separately; the pre-created `osmo-nvcr-pull` Secret; `compute.backendName` set explicitly at install time |
 | `kind-self-contained.yaml` | Yes, on kind | KAI Scheduler and the CloudNativePG operator installed separately; `compute.backendName` set explicitly at install time |
 | `split-plane-control.yaml` | Base overlay | PostgreSQL, Valkey, and object-storage endpoints; Kubernetes Secrets; and `externalUrl` |
 | `split-plane-compute.yaml` | Base overlay | A control-plane `externalUrl`, a compute authentication Secret, and `compute.backendName` set explicitly at install time |
@@ -20,8 +20,11 @@ The quick-start profile is the smallest complete control-and-compute deployment
 for browser, CLI, and CPU hello-world verification. It exposes the UI and API
 through gateway NodePort `30080` while omitting other optional services. The kind
 profile retains a broader local-development surface. Both profiles are
-development-only and intentionally use `latest` OSMO images, one replica per
-component, generated credentials, and embedded stateful dependencies. The split
+development-only and intentionally use `latest` OSMO images by default, one
+replica per component, generated credentials, and embedded stateful dependencies.
+The quick-start profile also references `osmo-nvcr-pull` for OSMO and workflow
+images; override it through top-level `imagePullSecrets` when using another
+Secret. The split
 profiles contain example names and endpoints; copy them into an environment
 values file before installation.
 

--- a/deployments/charts/osmo/profiles/README.md
+++ b/deployments/charts/osmo/profiles/README.md
@@ -11,7 +11,7 @@ values take precedence.
 
 | File | Directly installable | Required environment input |
 | --- | --- | --- |
-| `quickstart.yaml` | Yes, on a development cluster | KAI Scheduler, the CloudNativePG operator, and a default dynamic StorageClass installed separately; the pre-created `osmo-nvcr-pull` Secret; `compute.backendName` set explicitly at install time |
+| `quickstart.yaml` | Yes, on a development cluster | KAI Scheduler, the CloudNativePG operator, and a default dynamic StorageClass installed separately; `compute.backendName` set explicitly at install time |
 | `kind-self-contained.yaml` | Yes, on kind | KAI Scheduler and the CloudNativePG operator installed separately; `compute.backendName` set explicitly at install time |
 | `split-plane-control.yaml` | Base overlay | PostgreSQL, Valkey, and object-storage endpoints; Kubernetes Secrets; and `externalUrl` |
 | `split-plane-compute.yaml` | Base overlay | A control-plane `externalUrl`, a compute authentication Secret, and `compute.backendName` set explicitly at install time |
@@ -22,9 +22,10 @@ through gateway NodePort `30080` while omitting other optional services. The kin
 profile retains a broader local-development surface. Both profiles are
 development-only and intentionally use `latest` OSMO images by default, one
 replica per component, generated credentials, and embedded stateful dependencies.
-The quick-start profile also references `osmo-nvcr-pull` for OSMO and workflow
-images; override it through top-level `imagePullSecrets` when using another
-Secret. The split
+The quick-start installation path uses the chart's default image settings and
+does not require application Secrets or an image-pull Secret to be created
+beforehand. Configure top-level `imagePullSecrets` only when using a registry
+that requires credentials. The split
 profiles contain example names and endpoints; copy them into an environment
 values file before installation.
 

--- a/deployments/charts/osmo/profiles/quickstart.yaml
+++ b/deployments/charts/osmo/profiles/quickstart.yaml
@@ -12,8 +12,8 @@ planes:
 fullnameOverride: osmo
 
 imageTag: latest
-runtimeImage:
-  tag: latest
+imagePullSecrets:
+- name: osmo-nvcr-pull
 
 externalUrl: http://osmo-gateway
 

--- a/deployments/charts/osmo/profiles/quickstart.yaml
+++ b/deployments/charts/osmo/profiles/quickstart.yaml
@@ -11,10 +11,6 @@ planes:
 
 fullnameOverride: osmo
 
-imageTag: latest
-imagePullSecrets:
-- name: osmo-nvcr-pull
-
 externalUrl: http://osmo-gateway
 
 embeddedDependencies:

--- a/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
@@ -79,7 +79,9 @@ setting detects this rotation and triggers Envoy to reload.
 {{- fail "services.mcp.scopes entries must not be empty" }}
 {{- end }}
 {{- end }}
-{{- $_ := required "services.mcp.image.repository is required when MCP is enabled" $mcp.image.repository }}
+{{- if and (not $mcp.image.repository) (not $mcp.image.name) }}
+{{- fail "services.mcp.image.repository or image.name is required when MCP is enabled" }}
+{{- end }}
 {{- if or (lt (int $mcp.port) 1) (gt (int $mcp.port) 65535) }}
 {{- fail "services.mcp.port must be between 1 and 65535" }}
 {{- end }}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -91,16 +91,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $image := .image -}}
 {{- $registry := $image.registry -}}
 {{- $repository := $image.repository -}}
+{{- if .useSharedRegistry -}}
+{{- $registry = $registry | default $root.Values.imageRegistry -}}
+{{- end -}}
 {{- if hasKey $image "name" -}}
-{{- $registry = $registry | default $root.Values.imageRegistry | default "nvcr.io" -}}
+{{- $registry = $registry | default "nvcr.io" -}}
 {{- $repository = $repository | default $root.Values.imageRepository | default "nvidia/osmo" -}}
 {{- if not $image.repository -}}
 {{- $repository = printf "%s/%s" (trimSuffix "/" $repository) $image.name -}}
 {{- end -}}
 {{- else -}}
-{{- if and .useSharedRegistry (not $root.Values.imageRepository) -}}
-{{- $registry = $root.Values.imageRegistry | default $registry -}}
-{{- end -}}
 {{- $repository = required "image.repository is required" $repository -}}
 {{- end -}}
 {{- $base := ternary (printf "%s/%s" $registry $repository) $repository (ne $registry "") -}}

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -90,10 +90,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $root := .root -}}
 {{- $image := .image -}}
 {{- $registry := $image.registry -}}
-{{- if .useSharedRegistry -}}
+{{- $repository := $image.repository -}}
+{{- if hasKey $image "name" -}}
+{{- $registry = $registry | default $root.Values.imageRegistry | default "nvcr.io" -}}
+{{- $repository = $repository | default $root.Values.imageRepository | default "nvidia/osmo" -}}
+{{- if not $image.repository -}}
+{{- $repository = printf "%s/%s" (trimSuffix "/" $repository) $image.name -}}
+{{- end -}}
+{{- else -}}
+{{- if and .useSharedRegistry (not $root.Values.imageRepository) -}}
 {{- $registry = $root.Values.imageRegistry | default $registry -}}
 {{- end -}}
-{{- $repository := required "image.repository is required" $image.repository -}}
+{{- $repository = required "image.repository is required" $repository -}}
+{{- end -}}
 {{- $base := ternary (printf "%s/%s" $registry $repository) $repository (ne $registry "") -}}
 {{- if $image.digest -}}
 {{- printf "%s@%s" $base $image.digest -}}
@@ -111,12 +120,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "osmo.component.imageRepository" -}}
-{{- $registry := .Values.imageRegistry | default .Values.runtimeImage.registry -}}
-{{- ternary (printf "%s/%s" $registry .Values.runtimeImage.repository) .Values.runtimeImage.repository (ne $registry "") -}}
+{{- $registry := .Values.runtimeImage.registry | default .Values.imageRegistry | default "nvcr.io" -}}
+{{- $repository := .Values.runtimeImage.repository | default .Values.imageRepository | default "nvidia/osmo" -}}
+{{- printf "%s/%s" (trimSuffix "/" $registry) (trimSuffix "/" $repository) -}}
 {{- end -}}
 
 {{- define "osmo.component.imageTag" -}}
-{{- .Values.runtimeImage.tag | default .Chart.AppVersion -}}
+{{- .Values.runtimeImage.tag | default .Values.imageTag | default .Chart.AppVersion -}}
 {{- end -}}
 
 {{- define "osmo.compute.agentNamespace" -}}

--- a/deployments/charts/osmo/templates/configs.yaml
+++ b/deployments/charts/osmo/templates/configs.yaml
@@ -69,8 +69,20 @@ data:
       {{- toYaml $cfg.pools | nindent 6 }}
     {{- end }}
     {{- if $cfg.podTemplates }}
+    {{- $podTemplates := deepCopy $cfg.podTemplates }}
+    {{- if gt (len .Values.imagePullSecrets) 0 }}
+    {{- range $_, $podTemplate := $podTemplates }}
+    {{- if kindIs "map" $podTemplate }}
+    {{- $spec := index $podTemplate "spec" | default dict }}
+    {{- if and (kindIs "map" $spec) (not (hasKey $spec "imagePullSecrets")) }}
+    {{- $_ := set $spec "imagePullSecrets" $.Values.imagePullSecrets }}
+    {{- $_ := set $podTemplate "spec" $spec }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
     pod_templates:
-      {{- toYaml $cfg.podTemplates | nindent 6 }}
+      {{- toYaml $podTemplates | nindent 6 }}
     {{- end }}
     {{- if $cfg.resourceValidations }}
     resource_validations:

--- a/deployments/charts/osmo/templates/configs.yaml
+++ b/deployments/charts/osmo/templates/configs.yaml
@@ -69,20 +69,8 @@ data:
       {{- toYaml $cfg.pools | nindent 6 }}
     {{- end }}
     {{- if $cfg.podTemplates }}
-    {{- $podTemplates := deepCopy $cfg.podTemplates }}
-    {{- if gt (len .Values.imagePullSecrets) 0 }}
-    {{- range $_, $podTemplate := $podTemplates }}
-    {{- if kindIs "map" $podTemplate }}
-    {{- $spec := index $podTemplate "spec" | default dict }}
-    {{- if and (kindIs "map" $spec) (not (hasKey $spec "imagePullSecrets")) }}
-    {{- $_ := set $spec "imagePullSecrets" $.Values.imagePullSecrets }}
-    {{- $_ := set $podTemplate "spec" $spec }}
-    {{- end }}
-    {{- end }}
-    {{- end }}
-    {{- end }}
     pod_templates:
-      {{- toYaml $podTemplates | nindent 6 }}
+      {{- toYaml $cfg.podTemplates | nindent 6 }}
     {{- end }}
     {{- if $cfg.resourceValidations }}
     resource_validations:

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -451,6 +451,11 @@ test_control_umbrella() {
         fail "expected chart defaults to pass helm lint"
     fi
 
+    helm show values "$charts_copy/osmo" >"$TEST_DIRECTORY/osmo-values.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-values.yaml" "imageRegistry: nvcr.io"
+    require_contains "$TEST_DIRECTORY/osmo-values.yaml" "imageRepository: nvidia/osmo"
+    require_contains "$TEST_DIRECTORY/osmo-values.yaml" "imageTag: latest"
+
     if helm_template missing-split-backend-name "$charts_copy/osmo" \
             -f "$charts_copy/osmo/profiles/split-plane-compute.yaml" \
             >"$TEST_DIRECTORY/missing-split-backend-name.out" 2>&1; then
@@ -1820,7 +1825,13 @@ EOF
         "endpoint: s3://osmo-apps/apps"
     require_contains "$TEST_DIRECTORY/osmo-external-object-storage-config.yaml" \
         "secretKey: object-storage.yaml"
-    require_contains "$rendered" "nvcr.io/nvidia/osmo/service:6.3.1"
+    require_contains "$rendered" "nvcr.io/nvidia/osmo/service:latest"
+    resource_document "$rendered" ConfigMap osmo-api-config \
+        >"$TEST_DIRECTORY/osmo-external-runtime-config.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-external-runtime-config.yaml" \
+        "init: nvcr.io/nvidia/osmo/init-container:latest"
+    require_contains "$TEST_DIRECTORY/osmo-external-runtime-config.yaml" \
+        "client: nvcr.io/nvidia/osmo/client:latest"
     require_contains "$rendered" "- INFO"
     require_contains "$rendered" "service_base_url: http://osmo-gateway"
     require_not_contains "$rendered" "service_base_url: http://osmo-gateway-envoy"
@@ -3722,7 +3733,7 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
         "uri: https://issuer.example.com/.well-known/jwks.json"
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
-        "image: nvcr.io/nvidia/osmo/mcp-self-hosted:6.3.1"
+        "image: nvcr.io/nvidia/osmo/mcp-self-hosted:latest"
     require_occurrences "$TEST_DIRECTORY/osmo-mcp.yaml" \
         "kubernetes.io/os: linux" 11
 
@@ -3971,21 +3982,21 @@ EOF
         --set secrets.oauthCookieSecret.existingSecret=oauth-cookie \
         >"$TEST_DIRECTORY/osmo-image-defaults.yaml"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
-        "image: nvcr.io/nvidia/osmo/service:6.3.1"
+        "image: nvcr.io/nvidia/osmo/service:latest"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
-        "image: nvcr.io/nvidia/osmo/web-ui:6.3.1"
+        "image: nvcr.io/nvidia/osmo/web-ui:latest"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
-        "image: nvcr.io/nvidia/osmo/worker:6.3.1"
+        "image: nvcr.io/nvidia/osmo/worker:latest"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
-        "image: nvcr.io/nvidia/osmo/router:6.3.1"
+        "image: nvcr.io/nvidia/osmo/router:latest"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
-        "image: nvcr.io/nvidia/osmo/logger:6.3.1"
+        "image: nvcr.io/nvidia/osmo/logger:latest"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
-        "image: nvcr.io/nvidia/osmo/agent:6.3.1"
+        "image: nvcr.io/nvidia/osmo/agent:latest"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
-        "image: nvcr.io/nvidia/osmo/delayed-job-monitor:6.3.1"
+        "image: nvcr.io/nvidia/osmo/delayed-job-monitor:latest"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
-        "image: nvcr.io/nvidia/osmo/authz-sidecar:6.3.1"
+        "image: nvcr.io/nvidia/osmo/authz-sidecar:latest"
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
         'image: "docker.io/envoyproxy/envoy:v1.38.1"'
     require_contains "$TEST_DIRECTORY/osmo-image-defaults.yaml" \
@@ -3999,11 +4010,11 @@ EOF
         --set imagePullSecrets[0].name=mirror-secret \
         >"$TEST_DIRECTORY/osmo-image-mirror.yaml"
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
-        "image: mirror.example.com/nvidia/osmo/service:6.3.1"
+        "image: mirror.example.com/nvidia/osmo/service:latest"
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
-        'image: "mirror.example.com/envoyproxy/envoy:v1.38.1"'
+        'image: "docker.io/envoyproxy/envoy:v1.38.1"'
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
-        'image: "mirror.example.com/oauth2-proxy/oauth2-proxy:v7.14.2"'
+        'image: "quay.io/oauth2-proxy/oauth2-proxy:v7.14.2"'
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
         "- mirror.example.com/nvidia/osmo"
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
@@ -4079,7 +4090,7 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
         "name: osmo-mirror-secret"
     require_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
-        "image: osmo-mirror.example.com/nvidia/osmo/service:6.3.1"
+        "image: osmo-mirror.example.com/nvidia/osmo/service:latest"
     require_not_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \
         "valkey-mirror.example.com"
     require_not_contains "$TEST_DIRECTORY/osmo-api-image-pull-secret.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -662,29 +662,18 @@ test_control_umbrella() {
         "init: nvcr.io/nvstaging/osmo/init-container:$quickstart_runtime_tag"
     require_contains "$TEST_DIRECTORY/quickstart-runtime-config.yaml" \
         "client: nvcr.io/nvstaging/osmo/client:$quickstart_runtime_tag"
-    require_contains "$TEST_DIRECTORY/quickstart-runtime-config.yaml" \
+    require_not_contains "$TEST_DIRECTORY/quickstart-runtime-config.yaml" \
         "imagePullSecrets:"
-    require_contains "$TEST_DIRECTORY/quickstart-runtime-config.yaml" \
-        "name: osmo-nvcr-pull"
     resource_document "$TEST_DIRECTORY/quickstart-runtime.yaml" Deployment \
         osmo-api >"$TEST_DIRECTORY/quickstart-runtime-api.yaml"
     require_contains "$TEST_DIRECTORY/quickstart-runtime-api.yaml" \
         "image: nvcr.io/nvstaging/osmo/service:$quickstart_runtime_tag"
+    require_contains "$TEST_DIRECTORY/quickstart-runtime-api.yaml" \
+        "imagePullSecrets:"
+    require_contains "$TEST_DIRECTORY/quickstart-runtime-api.yaml" \
+        "name: osmo-nvcr-pull"
     require_occurrences "$TEST_DIRECTORY/quickstart-runtime.yaml" \
         "image: nvcr.io/nvstaging/osmo/service:$quickstart_runtime_tag" 2
-
-    helm_template_with_backend quick-start-workflow-pull-secret "$charts_copy/osmo" \
-        --namespace osmo \
-        --api-versions postgresql.cnpg.io/v1 \
-        -f "$charts_copy/osmo/profiles/quickstart.yaml" \
-        --set-string 'imagePullSecrets[0].name=sentinel-pull-secret' \
-        >"$TEST_DIRECTORY/quickstart-workflow-pull-secret.yaml"
-    resource_document "$TEST_DIRECTORY/quickstart-workflow-pull-secret.yaml" ConfigMap \
-        osmo-api-config >"$TEST_DIRECTORY/quickstart-workflow-pull-secret-config.yaml"
-    require_contains "$TEST_DIRECTORY/quickstart-workflow-pull-secret-config.yaml" \
-        "name: sentinel-pull-secret"
-    require_not_contains "$TEST_DIRECTORY/quickstart-workflow-pull-secret-config.yaml" \
-        "name: osmo-nvcr-pull"
 
     helm_template_with_backend quick-start "$charts_copy/osmo" \
         --namespace osmo \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -646,7 +646,7 @@ test_control_umbrella() {
     require_not_contains "$TEST_DIRECTORY/kind-self-contained-ui.yaml" \
         "scheme: HTTPS"
 
-    local quickstart_runtime_tag=2026.8.28.3b3d1b0a2.ecolter3910-amd64
+    local quickstart_runtime_tag=quickstart-test
     helm_template_with_backend quick-start-runtime "$charts_copy/osmo" \
         --namespace osmo \
         --api-versions postgresql.cnpg.io/v1 \
@@ -4026,11 +4026,11 @@ EOF
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         --set-string imageRegistry=nvcr.io \
         --set-string imageRepository=nvstaging/osmo \
-        --set-string imageTag=2026.8.28.3b3d1b0a2.ecolter3910-amd64 \
+        --set-string imageTag=quickstart-test \
         --set imagePullSecrets[0].name=nvcr-pull-secret \
         >"$TEST_DIRECTORY/osmo-image-family-override.yaml"
     require_contains "$TEST_DIRECTORY/osmo-image-family-override.yaml" \
-        "image: nvcr.io/nvstaging/osmo/worker:2026.8.28.3b3d1b0a2.ecolter3910-amd64"
+        "image: nvcr.io/nvstaging/osmo/worker:quickstart-test"
     require_contains "$TEST_DIRECTORY/osmo-image-family-override.yaml" \
         'image: "docker.io/envoyproxy/envoy:v1.38.1"'
 

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -720,8 +720,6 @@ test_control_umbrella() {
         "osmo-object-storage-bootstrap"
     require_not_contains "$TEST_DIRECTORY/quickstart-api.yaml" \
         "imagePullSecrets:"
-    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" \
-        "name: osmo-nvcr-pull"
     resource_document "$TEST_DIRECTORY/quickstart.yaml" Service \
         "osmo-gateway" >"$TEST_DIRECTORY/quickstart-gateway-service.yaml"
     require_contains "$TEST_DIRECTORY/quickstart-gateway-service.yaml" \
@@ -770,8 +768,6 @@ test_control_umbrella() {
     require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "/home/"
     require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "currentMek:"
     require_contains "$charts_copy/osmo/profiles/README.md" "quickstart.yaml"
-    require_not_contains "$charts_copy/osmo/profiles/README.md" \
-        "osmo-nvcr-pull"
     require_contains "$charts_copy/osmo/README.md" \
         "deployments/charts/osmo/profiles/quickstart.yaml"
     require_contains "$charts_copy/osmo/README.md" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -690,7 +690,6 @@ test_control_umbrella() {
         --namespace osmo \
         --api-versions postgresql.cnpg.io/v1 \
         -f "$charts_copy/osmo/profiles/quickstart.yaml" \
-        --set-string 'imagePullSecrets[0].name=osmo-nvcr-pull' \
         >"$TEST_DIRECTORY/quickstart.yaml"
     local quickstart_deployment
     for quickstart_deployment in \
@@ -730,8 +729,9 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/quickstart.yaml" '- "bootstrap"'
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
         "osmo-object-storage-bootstrap"
-    require_contains "$TEST_DIRECTORY/quickstart-api.yaml" "imagePullSecrets:"
-    require_contains "$TEST_DIRECTORY/quickstart-api.yaml" \
+    require_not_contains "$TEST_DIRECTORY/quickstart-api.yaml" \
+        "imagePullSecrets:"
+    require_not_contains "$TEST_DIRECTORY/quickstart.yaml" \
         "name: osmo-nvcr-pull"
     resource_document "$TEST_DIRECTORY/quickstart.yaml" Service \
         "osmo-gateway" >"$TEST_DIRECTORY/quickstart-gateway-service.yaml"
@@ -781,6 +781,8 @@ test_control_umbrella() {
     require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "/home/"
     require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "currentMek:"
     require_contains "$charts_copy/osmo/profiles/README.md" "quickstart.yaml"
+    require_not_contains "$charts_copy/osmo/profiles/README.md" \
+        "osmo-nvcr-pull"
     require_contains "$charts_copy/osmo/README.md" \
         "deployments/charts/osmo/profiles/quickstart.yaml"
     require_contains "$charts_copy/osmo/README.md" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -645,6 +645,7 @@ test_control_umbrella() {
         --namespace osmo \
         --api-versions postgresql.cnpg.io/v1 \
         -f "$charts_copy/osmo/profiles/quickstart.yaml" \
+        --set-string 'imagePullSecrets[0].name=osmo-nvcr-pull' \
         >"$TEST_DIRECTORY/quickstart.yaml"
     local quickstart_deployment
     for quickstart_deployment in \
@@ -679,9 +680,14 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/quickstart-rustfs-pvc.yaml" "storage: 1Gi"
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
         "osmo-backend-token-bootstrap"
-    require_contains "$TEST_DIRECTORY/quickstart.yaml" 'name: "osmo-mek-bootstrap-'
+    require_contains "$TEST_DIRECTORY/quickstart.yaml" \
+        'name: "osmo-mek-bootstrap-'
+    require_contains "$TEST_DIRECTORY/quickstart.yaml" '- "bootstrap"'
     require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
         "osmo-object-storage-bootstrap"
+    require_contains "$TEST_DIRECTORY/quickstart-api.yaml" "imagePullSecrets:"
+    require_contains "$TEST_DIRECTORY/quickstart-api.yaml" \
+        "name: osmo-nvcr-pull"
     resource_document "$TEST_DIRECTORY/quickstart.yaml" Service \
         "osmo-gateway" >"$TEST_DIRECTORY/quickstart-gateway-service.yaml"
     require_contains "$TEST_DIRECTORY/quickstart-gateway-service.yaml" \

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -641,6 +641,46 @@ test_control_umbrella() {
     require_not_contains "$TEST_DIRECTORY/kind-self-contained-ui.yaml" \
         "scheme: HTTPS"
 
+    local quickstart_runtime_tag=2026.8.28.3b3d1b0a2.ecolter3910-amd64
+    helm_template_with_backend quick-start-runtime "$charts_copy/osmo" \
+        --namespace osmo \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$charts_copy/osmo/profiles/quickstart.yaml" \
+        --set-string imageRegistry=nvcr.io \
+        --set-string imageRepository=nvstaging/osmo \
+        --set-string imageTag="$quickstart_runtime_tag" \
+        --set-string 'imagePullSecrets[0].name=osmo-nvcr-pull' \
+        >"$TEST_DIRECTORY/quickstart-runtime.yaml"
+    resource_document "$TEST_DIRECTORY/quickstart-runtime.yaml" ConfigMap \
+        osmo-api-config >"$TEST_DIRECTORY/quickstart-runtime-config.yaml"
+    require_contains "$TEST_DIRECTORY/quickstart-runtime-config.yaml" \
+        "init: nvcr.io/nvstaging/osmo/init-container:$quickstart_runtime_tag"
+    require_contains "$TEST_DIRECTORY/quickstart-runtime-config.yaml" \
+        "client: nvcr.io/nvstaging/osmo/client:$quickstart_runtime_tag"
+    require_contains "$TEST_DIRECTORY/quickstart-runtime-config.yaml" \
+        "imagePullSecrets:"
+    require_contains "$TEST_DIRECTORY/quickstart-runtime-config.yaml" \
+        "name: osmo-nvcr-pull"
+    resource_document "$TEST_DIRECTORY/quickstart-runtime.yaml" Deployment \
+        osmo-api >"$TEST_DIRECTORY/quickstart-runtime-api.yaml"
+    require_contains "$TEST_DIRECTORY/quickstart-runtime-api.yaml" \
+        "image: nvcr.io/nvstaging/osmo/service:$quickstart_runtime_tag"
+    require_occurrences "$TEST_DIRECTORY/quickstart-runtime.yaml" \
+        "image: nvcr.io/nvstaging/osmo/service:$quickstart_runtime_tag" 2
+
+    helm_template_with_backend quick-start-workflow-pull-secret "$charts_copy/osmo" \
+        --namespace osmo \
+        --api-versions postgresql.cnpg.io/v1 \
+        -f "$charts_copy/osmo/profiles/quickstart.yaml" \
+        --set-string 'imagePullSecrets[0].name=sentinel-pull-secret' \
+        >"$TEST_DIRECTORY/quickstart-workflow-pull-secret.yaml"
+    resource_document "$TEST_DIRECTORY/quickstart-workflow-pull-secret.yaml" ConfigMap \
+        osmo-api-config >"$TEST_DIRECTORY/quickstart-workflow-pull-secret-config.yaml"
+    require_contains "$TEST_DIRECTORY/quickstart-workflow-pull-secret-config.yaml" \
+        "name: sentinel-pull-secret"
+    require_not_contains "$TEST_DIRECTORY/quickstart-workflow-pull-secret-config.yaml" \
+        "name: osmo-nvcr-pull"
+
     helm_template_with_backend quick-start "$charts_copy/osmo" \
         --namespace osmo \
         --api-versions postgresql.cnpg.io/v1 \
@@ -3968,6 +4008,58 @@ EOF
         "- mirror.example.com/nvidia/osmo"
     require_contains "$TEST_DIRECTORY/osmo-image-mirror.yaml" \
         "name: mirror-secret"
+
+    helm_template image-family-override "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string imageRegistry=nvcr.io \
+        --set-string imageRepository=nvstaging/osmo \
+        --set-string imageTag=2026.8.28.3b3d1b0a2.ecolter3910-amd64 \
+        --set imagePullSecrets[0].name=nvcr-pull-secret \
+        >"$TEST_DIRECTORY/osmo-image-family-override.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-image-family-override.yaml" \
+        "image: nvcr.io/nvstaging/osmo/worker:2026.8.28.3b3d1b0a2.ecolter3910-amd64"
+    require_contains "$TEST_DIRECTORY/osmo-image-family-override.yaml" \
+        'image: "docker.io/envoyproxy/envoy:v1.38.1"'
+
+    helm_template image-priority "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string imageRegistry=nvcr.io \
+        --set-string imageRepository=nvstaging/osmo \
+        --set-string services.worker.image.registry=registry.example.com \
+        --set-string services.worker.image.repository=custom/team/worker \
+        --set-string services.worker.image.tag=v2 \
+        >"$TEST_DIRECTORY/osmo-image-priority.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-image-priority.yaml" \
+        "image: registry.example.com/custom/team/worker:v2"
+
+    helm_template image-field-priority "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string imageRegistry=registry.example.com \
+        --set-string imageRepository=team/osmo \
+        --set-string imageTag=v1 \
+        --set-string services.worker.image.registry=service.example.com \
+        --set-string services.router.image.repository=service/router \
+        >"$TEST_DIRECTORY/osmo-image-field-priority.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-image-field-priority.yaml" \
+        "image: service.example.com/team/osmo/worker:v1"
+    require_contains "$TEST_DIRECTORY/osmo-image-field-priority.yaml" \
+        "image: registry.example.com/service/router:v1"
+
+    helm_template runtime-priority "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string imageRegistry=nvcr.io \
+        --set-string imageRepository=nvstaging/osmo \
+        --set-string runtimeImage.registry=registry.example.com \
+        --set-string runtimeImage.repository=custom/runtime \
+        --set-string runtimeImage.tag=v3 \
+        >"$TEST_DIRECTORY/osmo-runtime-priority.yaml"
+    resource_document "$TEST_DIRECTORY/osmo-runtime-priority.yaml" Deployment \
+        runtime-priority-osmo-api \
+        >"$TEST_DIRECTORY/osmo-runtime-priority-api.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-runtime-priority-api.yaml" \
+        "registry.example.com/custom/runtime"
+    require_contains "$TEST_DIRECTORY/osmo-runtime-priority-api.yaml" \
+        '"v3"'
 
     helm_template embedded-image-pull-secret "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -27,6 +27,7 @@
     "nameOverride": { "type": "string" },
     "fullnameOverride": { "type": "string" },
     "imageRegistry": { "type": "string" },
+    "imageRepository": { "type": "string" },
     "imageTag": { "type": "string" },
     "imagePullSecrets": { "$ref": "#/definitions/imagePullSecrets" },
     "runtimeImage": { "$ref": "#/definitions/runtimeImage" },
@@ -106,7 +107,7 @@
       }
     }
   },
-  "required": ["planes", "compute", "embeddedDependencies", "externalDependencies", "imageRegistry", "imageTag", "imagePullSecrets", "runtimeImage", "externalUrl", "ingress", "httproute", "monitoring", "secrets", "services", "gateway"],
+  "required": ["planes", "compute", "embeddedDependencies", "externalDependencies", "imageRegistry", "imageRepository", "imageTag", "imagePullSecrets", "runtimeImage", "externalUrl", "ingress", "httproute", "monitoring", "secrets", "services", "gateway"],
   "definitions": {
     "enabledBlock": {
       "type": "object",
@@ -598,7 +599,7 @@
       "type": "object",
       "properties": {
         "registry": { "type": "string" },
-        "repository": { "type": "string", "minLength": 1 },
+        "repository": { "type": "string" },
         "tag": { "type": "string" }
       },
       "required": ["registry", "repository", "tag"]
@@ -607,12 +608,17 @@
       "type": "object",
       "properties": {
         "registry": { "type": "string" },
-        "repository": { "type": "string", "minLength": 1 },
+        "repository": { "type": "string" },
+        "name": { "type": "string", "minLength": 1 },
         "tag": { "type": "string" },
         "digest": { "type": "string", "pattern": "^$|^sha256:[A-Fa-f0-9]{64}$" },
         "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
       },
-      "required": ["registry", "repository", "tag", "digest", "pullPolicy"]
+      "required": ["registry", "repository", "tag", "digest", "pullPolicy"],
+      "anyOf": [
+        { "required": ["name"] },
+        { "properties": { "repository": { "minLength": 1 } } }
+      ]
     },
     "probe": {
       "type": "object",

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -127,18 +127,17 @@ fullnameOverride: ''
 
 # Registry default for OSMO-owned component and runtime images. A non-empty
 # service-specific image.registry or runtimeImage.registry takes precedence.
-imageRegistry: ''
+imageRegistry: nvcr.io
 
 # Base repository default for OSMO-owned component and runtime images. A
 # non-empty service-specific image.repository or runtimeImage.repository takes
 # precedence; component names are added only when the service repository is
 # left at its default empty value.
-imageRepository: ''
+imageRepository: nvidia/osmo
 
-# A non-empty tag overrides the chart application version for every OSMO-owned
-# component image. Development profiles use latest until matching release
-# images are published; individual component tags still take precedence.
-imageTag: ''
+# Shared tag default for OSMO-owned component and runtime images. A non-empty
+# service-specific image.tag or runtimeImage.tag takes precedence.
+imageTag: latest
 
 # Pull credential Secret references for OSMO-owned pods. They are also used as
 # defaults for workflow pod templates that do not define their own list.
@@ -146,7 +145,8 @@ imageTag: ''
 # values block.
 imagePullSecrets: []
 
-# Runtime images referenced by submitted workflows.
+# Runtime image overrides for submitted workflows. Leave a field empty to
+# inherit the corresponding top-level image default.
 runtimeImage:
   registry: ''
   repository: ''

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -139,10 +139,8 @@ imageRepository: nvidia/osmo
 # service-specific image.tag or runtimeImage.tag takes precedence.
 imageTag: latest
 
-# Pull credential Secret references for OSMO-owned pods. They are also used as
-# defaults for workflow pod templates that do not define their own list.
-# Configure third-party dependency pull credentials in the dependency's native
-# values block.
+# Pull credential Secret references for OSMO-owned pods. Configure third-party
+# dependency pull credentials in the dependency's native values block.
 imagePullSecrets: []
 
 # Runtime image overrides for submitted workflows. Leave a field empty to

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -125,23 +125,31 @@ externalDependencies:
 nameOverride: ''
 fullnameOverride: ''
 
-# A non-empty registry overrides OSMO-owned component and runtime image
-# registries. Configure third-party dependency registries in their values blocks.
+# Registry default for OSMO-owned component and runtime images. A non-empty
+# service-specific image.registry or runtimeImage.registry takes precedence.
 imageRegistry: ''
+
+# Base repository default for OSMO-owned component and runtime images. A
+# non-empty service-specific image.repository or runtimeImage.repository takes
+# precedence; component names are added only when the service repository is
+# left at its default empty value.
+imageRepository: ''
 
 # A non-empty tag overrides the chart application version for every OSMO-owned
 # component image. Development profiles use latest until matching release
 # images are published; individual component tags still take precedence.
 imageTag: ''
 
-# Pull credential Secret references for OSMO-owned pods. Configure third-party
-# dependency pull credentials in the dependency's native values block.
+# Pull credential Secret references for OSMO-owned pods. They are also used as
+# defaults for workflow pod templates that do not define their own list.
+# Configure third-party dependency pull credentials in the dependency's native
+# values block.
 imagePullSecrets: []
 
 # Runtime images referenced by submitted workflows.
 runtimeImage:
-  registry: nvcr.io
-  repository: nvidia/osmo
+  registry: ''
+  repository: ''
   tag: ''
 
 # Metadata and scheduling defaults shared by OSMO-owned workloads. Labels,
@@ -342,8 +350,9 @@ services:
     enabled: true
     replicas: 1
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/backend-listener
+      registry: ''
+      repository: ''
+      name: backend-listener
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -406,8 +415,9 @@ services:
     enabled: true
     replicas: 1
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/backend-worker
+      registry: ''
+      repository: ''
+      name: backend-worker
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -475,8 +485,9 @@ services:
       annotations: {}
       automountServiceAccountToken: true
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/backend-test-runner
+      registry: ''
+      repository: ''
+      name: backend-test-runner
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -569,8 +580,9 @@ services:
     enabled: false
     replicas: 1
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/mcp-self-hosted
+      registry: ''
+      repository: ''
+      name: mcp-self-hosted
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -647,8 +659,9 @@ services:
     enabled: true
     replicas: 1
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/web-ui
+      registry: ''
+      repository: ''
+      name: web-ui
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -745,8 +758,9 @@ services:
     enabled: true
     replicas: 1
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/delayed-job-monitor
+      registry: ''
+      repository: ''
+      name: delayed-job-monitor
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -798,8 +812,9 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/worker
+      registry: ''
+      repository: ''
+      name: worker
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -859,8 +874,9 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/service
+      registry: ''
+      repository: ''
+      name: service
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -950,8 +966,9 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/router
+      registry: ''
+      repository: ''
+      name: router
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -1031,8 +1048,9 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/logger
+      registry: ''
+      repository: ''
+      name: logger
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -1100,8 +1118,9 @@ services:
       customMetrics: []
       behavior: {}
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/agent
+      registry: ''
+      repository: ''
+      name: agent
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent
@@ -1409,8 +1428,9 @@ gateway:
       customMetrics: []
       behavior: {}
     image:
-      registry: nvcr.io
-      repository: nvidia/osmo/authz-sidecar
+      registry: ''
+      repository: ''
+      name: authz-sidecar
       tag: ''
       digest: ''
       pullPolicy: IfNotPresent


### PR DESCRIPTION
Fix secrets broken in profiles/quickstart.yaml

Description

- Quickstart now bootstraps the application Secrets it needs automatically, so a new installation requires only the supplied image-pull Secret.
- Image configuration now has consistent defaults and override precedence across OSMO services and workflow runtime images, including bootstrap components.
Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quickstart deployments can bootstrap the master encryption key from an existing Kubernetes Secret.
  * Added flexible global and component-level image configuration with registry, repository, name, tag, and pull-secret overrides.
  * Workflow pod templates inherit configured image pull Secrets when none are specified.
  * OSMO images now default to `nvcr.io/nvidia/osmo:latest`.

* **Bug Fixes**
  * Improved image validation and precedence handling for runtime and MCP images.

* **Documentation**
  * Updated image configuration guidance and clarified that quickstart deployments do not require pre-created image-pull Secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->