### PR TITLE
Ecolter/speed up quickstart

### DIFF
--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -340,7 +340,9 @@ endpoint and credential Secret into the control plane. It creates the retained
 backend-token Secret through its bootstrap hook and the retained
 master-encryption-key Secret through the explicit lifecycle Job. The generated
 values never appear in Helm values, rendered manifests, logs, or Helm release
-state.
+state. The backend-token hook and object-storage bootstrap Job retain a `50m`
+CPU request but intentionally have no CPU limit so their short-lived CLI
+processes can use otherwise-idle CPU and finish quickly.
 
 ## Embedded PostgreSQL
 
@@ -578,9 +580,11 @@ rustfs:
 ```
 
 The chart deploys a standalone RustFS instance with a retained 10 GiB
-`ReadWriteOnce` PVC. A post-install/post-upgrade Job creates the configured
-workflow, log, and app buckets when they are absent. OSMO is configured with
-the RustFS endpoint, buckets, and generated credentials automatically.
+`ReadWriteOnce` PVC. A regular Job waits for RustFS and creates the configured
+workflow, log, and app buckets when they are absent. Use `--wait-for-jobs` with
+Helm so an install or upgrade does not return before bucket bootstrap succeeds.
+OSMO is configured with the RustFS endpoint, buckets, and generated credentials
+automatically.
 
 The generated `osmo-rustfs-credentials` Secret is retained on uninstall and
 reused on upgrades. To provide an existing Secret, disable

--- a/deployments/charts/osmo/files/backend-token-bootstrap.sh
+++ b/deployments/charts/osmo/files/backend-token-bootstrap.sh
@@ -152,22 +152,26 @@ validate_secret() {
 
 create_secret() {
     secret_name="$1"
-    if head -c 32 /dev/urandom \
-            | base64 \
-            | tr '/+' '_-' \
-            | tr -d '=\n' \
-            | kubectl create secret generic "$secret_name" \
-                --namespace "$namespace" \
-                --from-file=token=/dev/stdin \
-                --dry-run=client \
-                -o yaml \
-            | kubectl label --local -f - \
-                app.kubernetes.io/managed-by=osmo-backend-token-bootstrap \
-                "app.kubernetes.io/instance=$release_name" \
-                -o yaml \
-            | kubectl annotate --local -f - \
-                osmo.nvidia.com/credential-source=osmo-chart-bootstrap \
-                -o yaml \
+    encoded_token=$(head -c 32 /dev/urandom \
+        | base64 \
+        | tr '/+' '_-' \
+        | tr -d '=\n' \
+        | base64 \
+        | tr -d '\n')
+    if printf '%s\n' \
+            'apiVersion: v1' \
+            'kind: Secret' \
+            'metadata:' \
+            "  name: $secret_name" \
+            "  namespace: $namespace" \
+            '  labels:' \
+            '    app.kubernetes.io/managed-by: osmo-backend-token-bootstrap' \
+            "    app.kubernetes.io/instance: $release_name" \
+            '  annotations:' \
+            '    osmo.nvidia.com/credential-source: osmo-chart-bootstrap' \
+            'type: Opaque' \
+            'data:' \
+            "  token: $encoded_token" \
             | kubectl create -f - >/dev/null; then
         printf 'INFO Created backend token Secret %s\n' "$secret_name"
         return

--- a/deployments/charts/osmo/templates/backend-api-token-bootstrap.yaml
+++ b/deployments/charts/osmo/templates/backend-api-token-bootstrap.yaml
@@ -146,10 +146,9 @@ spec:
           mountPath: /tmp
         resources:
           requests:
-            cpu: 10m
+            cpu: 50m
             memory: 32Mi
           limits:
-            cpu: 100m
             memory: 128Mi
       volumes:
       - name: bootstrap-tmp

--- a/deployments/charts/osmo/templates/object-storage-bootstrap.yaml
+++ b/deployments/charts/osmo/templates/object-storage-bootstrap.yaml
@@ -3,6 +3,8 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{- if .Values.embeddedDependencies.objectStorage.enabled }}
 {{- $bootstrapName := printf "%s-object-storage-bootstrap" (include "osmo.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $jobIdentity := printf "%s/%s/%d/object-storage" .Release.Namespace .Release.Name .Release.Revision | sha256sum | trunc 10 }}
+{{- $bootstrapJobName := printf "%s-object-storage-bootstrap-%s" ((include "osmo.fullname" .) | trunc 27 | trimSuffix "-") $jobIdentity }}
 {{- $secretName := include "osmo.objectStorage.secretName" . }}
 apiVersion: v1
 kind: ConfigMap
@@ -11,8 +13,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "object-storage-bootstrap") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
   annotations:
-    {{- include "osmo.metadata.annotations" (dict "root" .) | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
 data:
   object-storage-bootstrap.sh: |-
 {{ .Files.Get "files/object-storage-bootstrap.sh" | nindent 4 }}
@@ -20,14 +24,17 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $bootstrapName }}
+  name: {{ $bootstrapJobName }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "osmo.component.labels" (dict "root" . "component" "object-storage-bootstrap") | nindent 4 }}
+  {{- with (include "osmo.metadata.annotations" (dict "root" .)) }}
   annotations:
-    {{- include "osmo.metadata.annotations" (dict "root" . "protectedAnnotations" (dict "helm.sh/hook" "post-install,post-upgrade" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded")) | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
 spec:
   backoffLimit: {{ .Values.embeddedDependencies.objectStorage.bootstrap.backoffLimit }}
+  ttlSecondsAfterFinished: 300
   template:
     metadata:
       labels:

--- a/deployments/charts/osmo/tests/test_backend_token_bootstrap.sh
+++ b/deployments/charts/osmo/tests/test_backend_token_bootstrap.sh
@@ -75,32 +75,20 @@ if [ "$1" = get ]; then
     exit 0
 fi
 
-if [ "$1" = create ] && [ "$2" = secret ]; then
-    secret_name="$4"
-    cat >"$FAKE_STATE_DIRECTORY/pending-token"
-    printf '%s\n' \
-        'apiVersion: v1' \
-        'kind: Secret' \
-        'metadata:' \
-        "  name: $secret_name" \
-        'type: Opaque'
-    printf '%s' "$secret_name" >"$FAKE_STATE_DIRECTORY/pending-name"
-    exit 0
-fi
-
-if { [ "$1" = label ] || [ "$1" = annotate ]; } && [ "$2" = --local ]; then
-    cat
-    exit 0
-fi
-
 if [ "$1" = create ] && [ "$2" = -f ]; then
-    cat >/dev/null
-    secret_name=$(cat "$FAKE_STATE_DIRECTORY/pending-name")
+    manifest_file="$FAKE_STATE_DIRECTORY/created-secret.yaml"
+    cat >"$manifest_file"
+    secret_name=$(awk '$1 == "name:" { print $2; exit }' "$manifest_file")
+    encoded_token=$(awk '$1 == "token:" { print $2; exit }' "$manifest_file")
+    printf '%s' "$encoded_token" | base64 --decode \
+        >"$FAKE_STATE_DIRECTORY/pending-token"
     if [ "${FAKE_CREATE_FAILURE:-false}" = true ]; then
+        rm -f "$FAKE_STATE_DIRECTORY/pending-token"
         exit 1
     fi
     cp "$FAKE_STATE_DIRECTORY/pending-token" \
         "$FAKE_STATE_DIRECTORY/$secret_name.token"
+    rm -f "$FAKE_STATE_DIRECTORY/pending-token"
     if [ "${FAKE_CREATE_RACE:-false}" = true ]; then
         exit 1
     fi
@@ -124,6 +112,18 @@ run_bootstrap() {
         "$@"
 }
 
+require_command_count() {
+    local command=$1
+    local expected=$2
+    local actual
+    actual=$(grep -Fc -- "$command" "$FAKE_STATE_DIRECTORY/commands" || true)
+    if [[ "$actual" -ne "$expected" ]]; then
+        echo "Expected '$command' $expected times, found $actual" >&2
+        exit 1
+    fi
+}
+
+: >"$FAKE_STATE_DIRECTORY/commands"
 output=$(run_bootstrap --secret-name generated-token)
 generated_token=$(cat "$FAKE_STATE_DIRECTORY/generated-token.token")
 if [[ ${#generated_token} -ne 43 ]]; then
@@ -136,6 +136,17 @@ if [[ "$generated_token" == *[!A-Za-z0-9_-]* ]]; then
 fi
 if [[ "$output" == *"$generated_token"* ]]; then
     echo 'Bootstrap output exposed generated token material' >&2
+    exit 1
+fi
+require_command_count "get secret generated-token" 1
+require_command_count "create -f -" 1
+require_command_count "label --local" 0
+require_command_count "annotate --local" 0
+if ! grep -Fq 'app.kubernetes.io/managed-by: osmo-backend-token-bootstrap' \
+        "$FAKE_STATE_DIRECTORY/created-secret.yaml" || \
+        ! grep -Fq 'osmo.nvidia.com/credential-source: osmo-chart-bootstrap' \
+        "$FAKE_STATE_DIRECTORY/created-secret.yaml"; then
+    echo 'Created backend token Secret is missing managed metadata' >&2
     exit 1
 fi
 

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -177,6 +177,27 @@ resource_document() {
     ' "$file"
 }
 
+resource_name_with_hash_suffix() {
+    local file=$1
+    local kind=$2
+    local suffix=$3
+    local matches
+    matches=$(resource_names "$file" "$kind" | \
+        grep -E -- "-${suffix}-[0-9a-f]{10}$" || true)
+    [[ $(awk 'NF { count += 1 } END { print count + 0 }' <<<"$matches") -eq 1 ]] || \
+        fail "expected exactly one $kind ending in ${suffix}-<hash>"
+    printf '%s\n' "$matches"
+}
+
+resource_document_with_hash_suffix() {
+    local file=$1
+    local kind=$2
+    local suffix=$3
+    local name
+    name=$(resource_name_with_hash_suffix "$file" "$kind" "$suffix")
+    resource_document "$file" "$kind" "$name"
+}
+
 secret_data_value() {
     local file=$1
     local key=$2
@@ -338,6 +359,10 @@ require_resource() {
     [[ -s "$document" ]] || fail "expected $kind/$name"
 }
 
+require_resource_with_hash_suffix() {
+    resource_name_with_hash_suffix "$1" "$2" "$3" >/dev/null
+}
+
 require_no_resource() {
     local file=$1
     local kind=$2
@@ -345,6 +370,15 @@ require_no_resource() {
     local document=$TEST_DIRECTORY/resource.yaml
     if resource_document "$file" "$kind" "$name" >"$document" 2>/dev/null; then
         fail "did not expect $kind/$name"
+    fi
+}
+
+require_no_resource_with_hash_suffix() {
+    local file=$1
+    local kind=$2
+    local suffix=$3
+    if resource_names "$file" "$kind" | grep -Eq -- "-${suffix}-[0-9a-f]{10}$"; then
+        fail "did not expect $kind ending in ${suffix}-<hash>"
     fi
 }
 
@@ -752,8 +786,8 @@ test_control_umbrella() {
         "osmo-backend-token-bootstrap"
     require_contains "$TEST_DIRECTORY/self-contained.yaml" \
         'name: "osmo-mek-bootstrap-'
-    require_resource "$TEST_DIRECTORY/self-contained.yaml" Job \
-        "osmo-object-storage-bootstrap"
+    require_resource_with_hash_suffix "$TEST_DIRECTORY/self-contained.yaml" Job \
+        "object-storage-bootstrap"
     require_contains "$TEST_DIRECTORY/self-contained.yaml" \
         "secretName: osmo-backend-token"
     require_not_contains "$TEST_DIRECTORY/self-contained.yaml" \
@@ -884,8 +918,8 @@ test_control_umbrella() {
     require_contains "$TEST_DIRECTORY/quickstart.yaml" \
         'name: "osmo-mek-bootstrap-'
     require_contains "$TEST_DIRECTORY/quickstart.yaml" '- "bootstrap"'
-    require_resource "$TEST_DIRECTORY/quickstart.yaml" Job \
-        "osmo-object-storage-bootstrap"
+    require_resource_with_hash_suffix "$TEST_DIRECTORY/quickstart.yaml" Job \
+        "object-storage-bootstrap"
     require_not_contains "$TEST_DIRECTORY/quickstart-api.yaml" \
         "imagePullSecrets:"
     resource_document "$TEST_DIRECTORY/quickstart.yaml" Service \
@@ -941,6 +975,8 @@ test_control_umbrella() {
         "deployments/charts/osmo/profiles/quickstart.yaml"
     require_contains "$charts_copy/osmo/README.md" \
         "helm --kube-context kind-osmo upgrade --install osmo"
+    require_occurrences "$charts_copy/osmo/README.md" \
+        "--wait-for-jobs" 3
     require_contains "$charts_copy/osmo/README.md" \
         "kubectl --context kind-osmo"
     require_contains "$charts_copy/osmo/README.md" \
@@ -1210,8 +1246,8 @@ test_control_umbrella() {
     resource_document "$TEST_DIRECTORY/conventions.yaml" Job \
         osmo-backend-token-bootstrap \
         >"$TEST_DIRECTORY/conventions-backend-token-bootstrap.yaml"
-    resource_document "$TEST_DIRECTORY/conventions.yaml" Job \
-        osmo-object-storage-bootstrap \
+    resource_document_with_hash_suffix "$TEST_DIRECTORY/conventions.yaml" Job \
+        object-storage-bootstrap \
         >"$TEST_DIRECTORY/conventions-object-storage-bootstrap.yaml"
     resource_document "$TEST_DIRECTORY/conventions.yaml" ConfigMap \
         osmo-backend-test-runner-template \
@@ -1615,9 +1651,24 @@ test_control_umbrella() {
         "managed-backend-token-osmo-backend-token-bootstrap"
     require_resource "$TEST_DIRECTORY/managed-backend-token.yaml" ConfigMap \
         "managed-backend-token-osmo-backend-token-bootstrap-state"
+    resource_document "$TEST_DIRECTORY/managed-backend-token.yaml" ConfigMap \
+        managed-backend-token-osmo-backend-token-bootstrap-state \
+        >"$TEST_DIRECTORY/managed-backend-token-state.yaml"
+    require_contains "$TEST_DIRECTORY/managed-backend-token-state.yaml" \
+        "    osmo-backend-token"
     resource_document "$TEST_DIRECTORY/managed-backend-token.yaml" Job \
         managed-backend-token-osmo-backend-token-bootstrap \
         >"$TEST_DIRECTORY/managed-backend-token-job.yaml"
+    require_contains "$TEST_DIRECTORY/managed-backend-token-job.yaml" \
+        "helm.sh/hook: pre-install,pre-upgrade"
+    require_contains "$TEST_DIRECTORY/managed-backend-token-job.yaml" \
+        "helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded"
+    require_occurrences "$TEST_DIRECTORY/managed-backend-token-job.yaml" \
+        "cpu:" 1
+    require_contains "$TEST_DIRECTORY/managed-backend-token-job.yaml" \
+        "cpu: 50m"
+    require_contains "$TEST_DIRECTORY/managed-backend-token-job.yaml" \
+        "memory: 128Mi"
     require_contains "$TEST_DIRECTORY/managed-backend-token-job.yaml" \
         "--api-deployment-name"
     require_contains "$TEST_DIRECTORY/managed-backend-token-job.yaml" \
@@ -1646,7 +1697,7 @@ test_control_umbrella() {
         osmo-backend-token
     require_contains "$TEST_DIRECTORY/managed-backend-token.yaml" \
         'image: "alpine/k8s:1.30.14"'
-    require_contains "$TEST_DIRECTORY/managed-backend-token.yaml" \
+    require_not_contains "$TEST_DIRECTORY/managed-backend-token.yaml" \
         "--from-file=token=/dev/stdin"
 
     helm_template upgraded-backend-token "$charts_copy/osmo" \
@@ -1658,10 +1709,10 @@ test_control_umbrella() {
         --set secrets.backendApiTokens.credentials[0].name=default \
         --set secrets.backendApiTokens.credentials[0].managedSecret.name=osmo-backend-token \
         >"$TEST_DIRECTORY/upgraded-backend-token.yaml"
-    require_contains "$TEST_DIRECTORY/upgraded-backend-token.yaml" \
-        "--state-config-map"
     require_occurrences "$TEST_DIRECTORY/upgraded-backend-token.yaml" \
         "        - --is-upgrade" 1
+    require_contains "$TEST_DIRECTORY/upgraded-backend-token.yaml" \
+        "--state-config-map"
     resource_document "$TEST_DIRECTORY/upgraded-backend-token.yaml" Deployment \
         upgraded-backend-token-osmo-api \
         >"$TEST_DIRECTORY/upgraded-backend-token-api.yaml"
@@ -2524,7 +2575,7 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-ui.yaml" \
         "serviceAccountName: default"
     require_no_resource "$rendered" ConfigMap "osmo-object-storage-bootstrap"
-    require_no_resource "$rendered" Job "osmo-object-storage-bootstrap"
+    require_no_resource_with_hash_suffix "$rendered" Job "object-storage-bootstrap"
 
     local embedded_object_storage_settings=(
         --set embeddedDependencies.objectStorage.enabled=true
@@ -2552,8 +2603,8 @@ EOF
         osmo-rustfs-credentials
     require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" ConfigMap \
         embedded-object-storage-osmo-object-storage-bootstrap
-    require_resource "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" Job \
-        embedded-object-storage-osmo-object-storage-bootstrap
+    require_resource_with_hash_suffix "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" Job \
+        object-storage-bootstrap
     resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
         Secret osmo-rustfs-credentials \
         >"$TEST_DIRECTORY/osmo-rustfs-secret.yaml"
@@ -2594,15 +2645,15 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-configmap.yaml" \
         "object-storage-bootstrap.sh:"
 
-    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
-        Job embedded-object-storage-osmo-object-storage-bootstrap \
+    resource_document_with_hash_suffix "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
+        Job object-storage-bootstrap \
         >"$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml"
+    require_not_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "helm.sh/hook"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
-        "helm.sh/hook: post-install,post-upgrade"
+        "ttlSecondsAfterFinished: 300"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
-        "helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded"
-    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
-        "backoffLimit: 3"
+        "backoffLimit: 5"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "amazon/aws-cli@sha256:e14216fb361cce909ce199616711ad103182d5937f851cda9bebf25867d7180a"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
@@ -2652,11 +2703,11 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "resources:"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
-        "cpu: 10m"
+        "cpu: 50m"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "memory: 32Mi"
-    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
-        "cpu: 100m"
+    require_occurrences "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "cpu:" 1
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "memory: 128Mi"
 
@@ -2762,8 +2813,8 @@ EOF
         >"$TEST_DIRECTORY/osmo-non-default-region-config.yaml"
     require_contains "$TEST_DIRECTORY/osmo-non-default-region-config.yaml" \
         "region: us-west-2"
-    resource_document "$TEST_DIRECTORY/osmo-embedded-non-default-region.yaml" \
-        Job embedded-non-default-region-osmo-object-storage-bootstrap \
+    resource_document_with_hash_suffix "$TEST_DIRECTORY/osmo-embedded-non-default-region.yaml" \
+        Job object-storage-bootstrap \
         >"$TEST_DIRECTORY/osmo-non-default-region-bootstrap-job.yaml"
     require_contains \
         "$TEST_DIRECTORY/osmo-non-default-region-bootstrap-job.yaml" \
@@ -2877,8 +2928,8 @@ EOF
     require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-osmo-config.yaml" \
         "secretKey: object-storage.yaml"
 
-    resource_document "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
-        Job embedded-object-storage-ha-osmo-object-storage-bootstrap \
+    resource_document_with_hash_suffix "$TEST_DIRECTORY/osmo-embedded-object-storage-ha.yaml" \
+        Job object-storage-bootstrap \
         >"$TEST_DIRECTORY/osmo-rustfs-ha-bootstrap-job.yaml"
     require_contains "$TEST_DIRECTORY/osmo-rustfs-ha-bootstrap-job.yaml" \
         'value: "http://embedded-object-storage-ha-rustfs-svc.default.svc:9000"'

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -78,13 +78,12 @@ embeddedDependencies:
         digest: sha256:e14216fb361cce909ce199616711ad103182d5937f851cda9bebf25867d7180a
         pullPolicy: IfNotPresent
       attempts: 30
-      backoffLimit: 3
+      backoffLimit: 5
       resources:
         requests:
-          cpu: 10m
+          cpu: 50m
           memory: 32Mi
         limits:
-          cpu: 100m
           memory: 128Mi
 
 # Connection details for dependencies owned outside this release. Each


### PR DESCRIPTION
## Description
Speed up quickstart bootstrap work while keeping backend-token reconciliation as a pre-install/pre-upgrade hook. The token hook now requests 50m CPU with no CPU limit and creates each managed Secret with one kubectl manifest instead of a create/label/annotate pipeline.

Object-storage bootstrap is now a revision-scoped regular Job, allowing Helm to apply the rest of the release while it waits for RustFS. It also requests 50m CPU with no CPU limit and retries failed Jobs up to five times.

The measured cached quickstart run improved from roughly 228s to 94s (about 134s faster). Cache conditions differed, so this is a directional rather than apples-to-apples comparison.

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration for shared service authentication, OAuth credentials, gateway TLS, secret rotation, and workload namespace creation.
  * Added support for additional JWT providers and flexible OSMO image configuration.
  * Added self-contained production installation guidance.

* **Improvements**
  * Bootstrap jobs now have improved readiness handling, resource settings, retry behavior, hashed names, and automatic cleanup.
  * Updated image defaults and namespace-qualified object-storage endpoints.

* **Documentation**
  * Replaced legacy development instructions with production-profile guidance and expanded setup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->