### PR TITLE
Update docs quickstart to be in line with osmo umbrella chart

### DIFF
--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -22,29 +22,31 @@ installations, but it is not a dependency of this chart.
 ## Quick start
 
 The default values are a development-only path to trying the complete OSMO
-browser, CLI, API, and CPU workflow experience in one converged release. They
-install:
+browser, CLI, API, CPU workflow, and GPU workflow experience in one converged
+release. They install:
 
 - the Envoy gateway and browser UI;
 - the API, worker, router, logger, agent, and delayed-job monitor;
 - the compute backend listener and worker;
 - persistent CloudNativePG, Valkey, and RustFS instances;
 - generated development credentials, object-storage buckets, configuration,
-  and a CPU-only default pool. Service auth is generated explicitly before
-  installation so every process uses the same identity.
+  and CPU and GPU platforms in the default pool. Service auth is generated
+  explicitly before installation so every process uses the same identity.
 
 ### Prerequisites
 
 Use Kubernetes 1.30 or newer with enough capacity for the resources described
 below. The cluster must have a default dynamic StorageClass. Install Helm,
-`kubectl`, KAI Scheduler, and the CloudNativePG operator before OSMO. The
-examples use the `kind-osmo` context; replace it if your development cluster has
-a different context.
+`kubectl`, KAI Scheduler, and the CloudNativePG operator before OSMO. Select the
+development cluster context once; replace `kind-osmo` if your cluster has a
+different context. A GPU workflow also requires GPU-capable nodes and the
+NVIDIA GPU Operator.
 
 ```bash
-kubectl --context kind-osmo get storageclass
+kubectl config use-context kind-osmo
+kubectl get storageclass
 
-helm --kube-context kind-osmo upgrade --install kai-scheduler \
+helm upgrade --install kai-scheduler \
   https://github.com/NVIDIA/KAI-Scheduler/releases/download/v0.14.0/kai-scheduler-v0.14.0.tgz \
   --namespace kai-scheduler \
   --create-namespace \
@@ -53,7 +55,7 @@ helm --kube-context kind-osmo upgrade --install kai-scheduler \
 
 helm repo add cnpg https://cloudnative-pg.github.io/charts
 helm repo update cnpg
-helm --kube-context kind-osmo upgrade --install cnpg cnpg/cloudnative-pg \
+helm upgrade --install cnpg cnpg/cloudnative-pg \
   --version 0.29.0 \
   --namespace cnpg-system \
   --create-namespace \
@@ -73,14 +75,14 @@ docker run --rm --user "$(id -u):$(id -g)" \
   --volume "${OSMO_SERVICE_AUTH_DIRECTORY}:/output" \
   nvcr.io/nvidia/osmo/service:latest \
   generate --output /output/authentication-config.json
-kubectl --context kind-osmo create namespace osmo \
-  --dry-run=client --output=yaml | kubectl --context kind-osmo apply -f -
-kubectl --context kind-osmo --namespace osmo create secret generic \
+kubectl create namespace osmo \
+  --dry-run=client --output=yaml | kubectl apply -f -
+kubectl --namespace osmo create secret generic \
   osmo-service-auth \
   --from-file="authentication-config.json=${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
 
 helm dependency build deployments/charts/osmo
-helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
+helm upgrade --install osmo deployments/charts/osmo \
   --namespace osmo \
   --create-namespace \
   --wait \
@@ -90,17 +92,13 @@ helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
 
 The first installation uses the MEK bootstrap lifecycle Job to create the
 retained `osmo-master-encryption-key` Secret without putting key material in
-Helm state. After that installation succeeds, remove the temporary Secret
-creation permission and retain the remaining release values:
+Helm state. Bootstrap can remain enabled for the Quickstart. It must be
+disabled before rotating the MEK, as described in
+[Master encryption key lifecycle](#master-encryption-key-lifecycle).
+
+Remove the temporary service-auth file:
 
 ```bash
-helm --kube-context kind-osmo upgrade osmo deployments/charts/osmo \
-  --namespace osmo \
-  --reuse-values \
-  --set secrets.masterEncryptionKey.bootstrap.enabled=false \
-  --wait \
-  --timeout 20m
-
 rm "${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
 rmdir "${OSMO_SERVICE_AUTH_DIRECTORY}"
 ```
@@ -108,8 +106,8 @@ rmdir "${OSMO_SERVICE_AUTH_DIRECTORY}"
 Inspect the release without reading generated Secret values:
 
 ```bash
-kubectl --context kind-osmo --namespace osmo get pods,pvc,services,jobs
-kubectl --context kind-osmo --namespace osmo get service osmo-gateway
+kubectl --namespace osmo get pods,pvc,services,jobs
+kubectl --namespace osmo get service osmo-gateway
 ```
 
 ### Open the UI and use the CLI
@@ -118,7 +116,7 @@ The gateway exposes the UI and API on NodePort `30080`. Set `OSMO_URL` from a
 reachable node address, then open the same URL in a browser:
 
 ```bash
-export OSMO_NODE_ADDRESS="$(kubectl --context kind-osmo get nodes \
+export OSMO_NODE_ADDRESS="$(kubectl get nodes \
   --output jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')"
 export OSMO_URL="http://${OSMO_NODE_ADDRESS}:30080"
 curl --fail "$OSMO_URL/api/version"
@@ -135,7 +133,7 @@ If the NodePort is not reachable from the workstation, run a port-forward in
 one terminal:
 
 ```bash
-kubectl --context kind-osmo --namespace osmo \
+kubectl --namespace osmo \
   port-forward service/osmo-gateway 8080:80
 ```
 
@@ -169,17 +167,17 @@ working default StorageClass. A `Pending` workflow commonly means KAI is not
 healthy or the cluster lacks the workflow capacity described below.
 
 ```bash
-kubectl --context kind-osmo --namespace osmo get pods,pvc,jobs
-kubectl --context kind-osmo --namespace osmo get events \
+kubectl --namespace osmo get pods,pvc,jobs
+kubectl --namespace osmo get events \
   --sort-by=.lastTimestamp
-kubectl --context kind-osmo --namespace osmo logs deployment/osmo-ui
+kubectl --namespace osmo logs deployment/osmo-ui
 ```
 
 Clean up only the quick-start release and namespace:
 
 ```bash
-helm --kube-context kind-osmo uninstall osmo --namespace osmo --wait
-kubectl --context kind-osmo delete namespace osmo \
+helm uninstall osmo --namespace osmo --wait
+kubectl delete namespace osmo \
   --wait=true \
   --timeout=10m
 ```
@@ -198,11 +196,11 @@ CloudNativePG operator overhead.
 The canonical hello-world pod additionally requests 1 CPU, 1 GiB of memory, and
 1 GiB of ephemeral storage for both its user container and its `osmo-ctrl`
 container. Ensure an eligible worker has at least 2 CPU, 2 GiB of memory, and
-2 GiB of ephemeral storage available for that workflow. The profile disables
+2 GiB of ephemeral storage available for that workflow. The Quickstart disables
 MCP, optional gateway authentication and rate limiting, TLS, ingress,
 monitoring, autoscaling, disruption budgets, backups, and HA behavior.
 
-This profile uses development authentication and exposes an administrator
+The Quickstart uses development authentication and exposes an administrator
 identity through a NodePort. It is not a production security or availability
 configuration. Use a production profile with managed credentials, TLS,
 authorization, backups, suitable resource sizing, and HA dependencies for
@@ -349,10 +347,10 @@ rmdir "${OSMO_SERVICE_AUTH_DIRECTORY}"
 ```
 
 The first installation bootstraps the retained
-`osmo-master-encryption-key` Secret without rendering key material. As soon as
-it succeeds, persist `secrets.masterEncryptionKey.bootstrap.enabled: false` in
-`self-contained-environment-values.yaml` and apply the mandatory cleanup
-transaction:
+`osmo-master-encryption-key` Secret without rendering key material. Before
+rotating the MEK, persist
+`secrets.masterEncryptionKey.bootstrap.enabled: false` in
+`self-contained-environment-values.yaml` and apply that change:
 
 ```yaml
 secrets:
@@ -938,10 +936,20 @@ by this installation and authenticates the retained database before succeeding;
 it never overwrites or deletes a Secret. Non-chart database writers must be
 stopped for initial bootstrap.
 
-After the bootstrap Job succeeds, commit and sync
-`secrets.masterEncryptionKey.bootstrap.enabled: false`. This mandatory second
-Helm/GitOps transaction removes bootstrap Secret-creation RBAC from desired
-state. The chart rejects a rotation phase while bootstrap remains enabled.
+Before rotating the MEK, commit and sync
+`secrets.masterEncryptionKey.bootstrap.enabled: false`. The chart rejects a
+rotation phase while bootstrap remains enabled. For Helm, disable bootstrap in
+a separate upgrade before setting `rotation.phase`:
+
+```bash
+helm upgrade osmo deployments/charts/osmo \
+  --namespace "${OSMO_NAMESPACE}" \
+  --reuse-values \
+  --set secrets.masterEncryptionKey.bootstrap.enabled=false \
+  --wait \
+  --timeout 20m
+```
+
 If bootstrap fails or its database credentials are corrected under Argo CD or
 Flux, increment the non-secret `bootstrap.attempt` before syncing again; this
 creates a new immutable retry Job without deriving public names from credential

--- a/deployments/charts/osmo/profiles/self-contained.yaml
+++ b/deployments/charts/osmo/profiles/self-contained.yaml
@@ -59,8 +59,7 @@ secrets:
     existingSecret:
       name: osmo-master-encryption-key
       key: mek.yaml
-    # Disable bootstrap after the first successful installation and before any
-    # rotation phase so the one-time Secret-creation permission is removed.
+    # Disable bootstrap before starting a master-encryption-key rotation.
     bootstrap:
       enabled: true
   serviceAuth:
@@ -229,22 +228,6 @@ gateway:
 
 configuration:
   enabled: true
-  podTemplates:
-    default_user:
-      spec:
-        containers:
-        - name: '{{USER_CONTAINER_NAME}}'
-          resources:
-            limits:
-              cpu: '{{USER_CPU}}'
-              memory: '{{USER_MEMORY}}'
-              nvidia.com/gpu: '{{USER_GPU}}'
-              ephemeral-storage: '{{USER_STORAGE}}'
-            requests:
-              cpu: '{{USER_CPU}}'
-              memory: '{{USER_MEMORY}}'
-              nvidia.com/gpu: '{{USER_GPU}}'
-              ephemeral-storage: '{{USER_STORAGE}}'
   pools:
     default:
       common_pod_template:

--- a/deployments/charts/osmo/profiles/single-plane.yaml
+++ b/deployments/charts/osmo/profiles/single-plane.yaml
@@ -249,7 +249,8 @@ configuration:
   enabled: true
   podTemplates:
     # KAI treats even a zero-valued nvidia.com/gpu resource key as a GPU pod
-    # and injects the NVIDIA RuntimeClass. This CPU-only profile omits the key.
+    # and injects the NVIDIA RuntimeClass. The default CPU platform omits the
+    # key; the built-in GPU platform adds it through default_gpu_user.
     default_user:
       spec:
         containers:

--- a/deployments/charts/osmo/profiles/split-plane-control.yaml
+++ b/deployments/charts/osmo/profiles/split-plane-control.yaml
@@ -23,22 +23,6 @@ configuration:
   workflow:
     # Omit an optional workflow label policy in this minimal external profile.
     labels_config: null
-  podTemplates:
-    default_user:
-      spec:
-        containers:
-        - name: '{{USER_CONTAINER_NAME}}'
-          resources:
-            limits:
-              cpu: '{{USER_CPU}}'
-              memory: '{{USER_MEMORY}}'
-              nvidia.com/gpu: '{{USER_GPU}}'
-              ephemeral-storage: '{{USER_STORAGE}}'
-            requests:
-              cpu: '{{USER_CPU}}'
-              memory: '{{USER_MEMORY}}'
-              nvidia.com/gpu: '{{USER_GPU}}'
-              ephemeral-storage: '{{USER_STORAGE}}'
   pools:
     default:
       common_pod_template:

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -1042,7 +1042,11 @@ test_control_umbrella() {
         "azure.workload.identity/client-id: single-plane-test-client-id"
     require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
         "cpu: '{{USER_CPU}}'"
-    require_not_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+    require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "default_platform: cpu"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
+        "- default_gpu_user"
+    require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
         "nvidia.com/gpu"
     require_contains "$TEST_DIRECTORY/single-plane-azure-config.yaml" \
         "azure://osmoazure/osmo-workflows/workflows"
@@ -1098,7 +1102,11 @@ test_control_umbrella() {
         "osmo-api-config" >"$TEST_DIRECTORY/single-plane-s3-config.yaml"
     require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
         "cpu: '{{USER_CPU}}'"
-    require_not_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "default_platform: cpu"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
+        "- default_gpu_user"
+    require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
         "nvidia.com/gpu"
     require_contains "$TEST_DIRECTORY/single-plane-s3-config.yaml" \
         "s3://osmo-workflows/workflows"
@@ -1159,7 +1167,15 @@ test_control_umbrella() {
         "osmo-api-config" >"$TEST_DIRECTORY/quickstart-config.yaml"
     require_contains "$TEST_DIRECTORY/quickstart-config.yaml" \
         "cpu: '{{USER_CPU}}'"
-    require_not_contains "$TEST_DIRECTORY/quickstart-config.yaml" \
+    require_contains "$TEST_DIRECTORY/quickstart-config.yaml" \
+        "default_platform: cpu"
+    require_contains "$TEST_DIRECTORY/quickstart-config.yaml" \
+        "description: CPU workloads"
+    require_contains "$TEST_DIRECTORY/quickstart-config.yaml" \
+        "description: GPU workloads"
+    require_contains "$TEST_DIRECTORY/quickstart-config.yaml" \
+        "- default_gpu_user"
+    require_contains "$TEST_DIRECTORY/quickstart-config.yaml" \
         "nvidia.com/gpu"
     local quickstart_osmo_image
     for quickstart_osmo_image in \
@@ -1173,11 +1189,11 @@ test_control_umbrella() {
     require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "/home/"
     require_not_contains "$TEST_DIRECTORY/quickstart.yaml" "currentMek:"
     require_contains "$charts_copy/osmo/README.md" \
-        "helm --kube-context kind-osmo upgrade --install osmo"
+        "helm upgrade --install osmo deployments/charts/osmo"
     require_occurrences "$charts_copy/osmo/README.md" \
         "--wait-for-jobs" 3
     require_contains "$charts_copy/osmo/README.md" \
-        "kubectl --context kind-osmo"
+        "kubectl config use-context kind-osmo"
     require_contains "$charts_copy/osmo/README.md" \
         "deployments/workflows/verify-hello.yaml"
     require_contains "$charts_copy/osmo/README.md" \

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -313,7 +313,7 @@ secrets:
       name: osmo-master-encryption-key
       key: mek.yaml
     bootstrap:
-      # Must be set back to false immediately after a successful bootstrap.
+      # Disable before starting a master-encryption-key rotation.
       enabled: true
       # Increment after a failed GitOps attempt or credential correction.
       attempt: "1"
@@ -1683,6 +1683,15 @@ configuration:
               cpu: '{{USER_CPU}}'
               memory: '{{USER_MEMORY}}'
               ephemeral-storage: '{{USER_STORAGE}}'
+    default_gpu_user:
+      spec:
+        containers:
+        - name: '{{USER_CONTAINER_NAME}}'
+          resources:
+            limits:
+              nvidia.com/gpu: '{{USER_GPU}}'
+            requests:
+              nvidia.com/gpu: '{{USER_GPU}}'
   resourceValidations:
     default_cpu:
     - operator: LE
@@ -1803,7 +1812,7 @@ configuration:
     default:
       description: Default pool
       backend: default
-      default_platform: default
+      default_platform: cpu
       common_pod_template:
       - default_ctrl
       - default_user
@@ -1818,7 +1827,14 @@ configuration:
         USER_MEMORY: 1Gi
         USER_STORAGE: 1Gi
       platforms:
-        default: {}
+        cpu:
+          description: CPU workloads
+        gpu:
+          description: GPU workloads
+          default_variables:
+            USER_GPU: 1
+          override_pod_template:
+          - default_gpu_user
   backendTests: {}
   groupTemplates: {}
 

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -876,7 +876,7 @@ services:
         cpu: 100m
         memory: 256Mi
       limits:
-        memory: 512Mi
+        memory: 1Gi
     extraArgs: []
     serviceAccount:
       name: ''

--- a/deployments/workflows/verify-gpu.yaml
+++ b/deployments/workflows/verify-gpu.yaml
@@ -15,6 +15,7 @@ workflow:
     queue_timeout: 10m
   resources:
     one_gpu:
+      platform: gpu
       cpu: 2
       gpu: 1
       memory: 4Gi

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -169,7 +169,6 @@ host GPU through:
    nvkind cluster create --config-template=kind-osmo-cluster-config.yaml
    nvkind cluster print-gpus
    kubectl config use-context kind-osmo
-   kubectl get storageclass
 
 .. note::
 
@@ -196,20 +195,6 @@ fix required by this quickstart.
      --set nfd.enabled=true \
      --wait \
      --timeout 10m
-
-Wait for the GPU Operator pods to become Ready and verify that the compute node
-advertises one or more allocatable GPUs before installing OSMO:
-
-.. code-block:: bash
-
-   kubectl --namespace gpu-operator wait \
-     --for=condition=Ready pod --all --timeout=10m
-   kubectl get nodes -l node_group=compute \
-     -o custom-columns=NAME:.metadata.name,ALLOCATABLE_GPUS:.status.allocatable.nvidia\.com/gpu
-
-The ``compute`` node must show a positive ``ALLOCATABLE_GPUS`` value. If it
-does not, resolve the NVIDIA driver, Container Toolkit, or GPU Operator problem
-before proceeding.
 
 Option B: CPU Workstations (with KIND)
 ---------------------------------------
@@ -278,23 +263,24 @@ If your workstation does not have a GPU, create a standard CPU-only cluster.
 
    kind create cluster --config kind-osmo-cluster-config.yaml
    kubectl config use-context kind-osmo
-   kubectl get storageclass
 
 Install cluster dependencies
 ============================
 
-Install KAI Scheduler v0.14.0 for OSMO workflow scheduling, then install the
+Install KAI Scheduler v0.12.10 for OSMO workflow scheduling, then install the
 CloudNativePG operator chart version 0.29.0 for the embedded PostgreSQL
 cluster:
 
 .. code-block:: bash
 
    helm upgrade --install kai-scheduler \
-     https://github.com/NVIDIA/KAI-Scheduler/releases/download/v0.14.0/kai-scheduler-v0.14.0.tgz \
-     --namespace kai-scheduler \
-     --create-namespace \
-     --wait \
-     --timeout 10m
+     oci://ghcr.io/nvidia/kai-scheduler/kai-scheduler \
+     --version v0.12.10 \
+     --create-namespace -n kai-scheduler \
+     --set global.nodeSelector.node_group=kai-scheduler \
+     --set "scheduler.additionalArgs[0]=--default-staleness-grace-period=-1s" \
+     --set "scheduler.additionalArgs[1]=--update-pod-eviction-condition=true" \
+     --wait
 
    helm repo add cnpg https://cloudnative-pg.github.io/charts
    helm repo update cnpg
@@ -344,21 +330,11 @@ install it without a profile or values overlay:
      --wait-for-jobs \
      --timeout 20m
 
-Remove the temporary service-auth file:
+Remove the temporary service-auth directory:
 
 .. code-block:: bash
 
-   rm "${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
-   rmdir "${OSMO_SERVICE_AUTH_DIRECTORY}"
-
-Confirm that the release, embedded dependencies, and gateway are Ready:
-
-.. code-block:: bash
-
-   kubectl --namespace osmo wait \
-     --for=condition=Ready cluster/osmo-pg --timeout=10m
-   kubectl --namespace osmo get pods,pvc,services,jobs
-   kubectl --namespace osmo get service osmo-gateway
+   rm -r "${OSMO_SERVICE_AUTH_DIRECTORY}"
 
 Log in and run a workflow
 =========================
@@ -379,6 +355,11 @@ pool, and submit the canonical CPU verification workflow:
 
 Query the returned workflow ID until its status is ``COMPLETED``. The workflow
 uses the default ``cpu`` platform.
+
+.. admonition:: Success!
+   :class: tip
+
+   You now have OSMO configured and running on your workstation. You're ready to start running robotics workflows!
 
 If you used Option A, submit the GPU verification workflow too:
 

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -22,18 +22,17 @@
 Quickstart
 ==========
 
-This development-only Quickstart is the fastest way to try the complete OSMO
-control plane, compute plane, and a GPU workflow on a workstation with an
-NVIDIA GPU. It creates a multi-node Kubernetes-in-Docker cluster with
-``nvkind``, installs the required NVIDIA operators, and deploys the unified
-``osmo`` Helm chart.
+Try OSMO on your local workstation — no cloud account, no infrastructure costs, no enterprise approval needed.
+
+This Quickstart is the fastest way to try the complete OSMO platform locally.
+It creates a multi-node Kubernetes-in-Docker cluster with KIND or ``nvkind``
+and deploys the unified ``osmo`` Helm chart.
+
+.. tip::
+   **Perfect for evaluation** – Test your workflows, explore the platform, and assess fit for your robotics development needs before cloud deployment of OSMO.
 
 .. warning::
-
-   This is not a production configuration. It exposes a development
-   administrator identity and intentionally disables production security and
-   availability features. See :ref:`Capacity and limitations <quickstart_limits>`
-   before using it.
+   Local deployment is **not** recommended for production use as it lacks authentication and has limited features.
 
 Why Deploy Locally?
 ===================
@@ -53,9 +52,7 @@ Local deployment provides the complete OSMO experience on your workstation:
 .. admonition:: Seamless Scale to Cloud
    :class: info
 
-   If OSMO works for your use case locally, it will scale to hundreds of GPUs
-   in the cloud. You can use the exact same workflows; no code changes are
-   required.
+   If OSMO works for your use case locally, it will scale to hundreds of GPUs in the cloud. You can use the **exact same workflows**; no code changes required.
 
 Prerequisites
 =============
@@ -67,12 +64,6 @@ Install the following tools on your workstation:
 * `kubectl <https://kubernetes.io/docs/tasks/tools/>`_ - Kubernetes command-line tool (>=1.32.2)
 * `helm <https://helm.sh/docs/intro/install/>`_ - Helm package manager (>=3.16.2)
 
-The workstation must also have a supported NVIDIA GPU, NVIDIA driver, and
-NVIDIA Container Toolkit installed and working with Docker. Install ``nvkind``
-by following its `prerequisites
-<https://github.com/NVIDIA/nvkind?tab=readme-ov-file#prerequisites>`_, `setup
-<https://github.com/NVIDIA/nvkind?tab=readme-ov-file#setup>`_, and `installation
-<https://github.com/NVIDIA/nvkind?tab=readme-ov-file#install-nvkind>`_ guides.
 The resulting cluster requires Kubernetes 1.30 or newer and a default dynamic
 ``StorageClass``.
 
@@ -90,14 +81,28 @@ Clone the repository and run the remaining commands from its root:
    git clone https://github.com/NVIDIA/OSMO.git
    cd OSMO
 
-Create an nvkind cluster
-========================
+Step 1: Create KIND Cluster
+===========================
+
+Choose the appropriate setup based on whether your workstation has a GPU.
+
+Option A: GPU Workstations (with nvkind)
+-----------------------------------------
+
+If your workstation has a supported NVIDIA GPU, install the NVIDIA driver and
+NVIDIA Container Toolkit and confirm that they work with Docker. Install
+``nvkind`` by following its `prerequisites
+<https://github.com/NVIDIA/nvkind?tab=readme-ov-file#prerequisites>`_, `setup
+<https://github.com/NVIDIA/nvkind?tab=readme-ov-file#setup>`_, and `installation
+<https://github.com/NVIDIA/nvkind?tab=readme-ov-file#install-nvkind>`_ guides.
+
+**Create Cluster Configuration**
 
 Create the following multi-node configuration. The compute worker receives the
 GPU from ``nvkind``. The other workers disable GPU Operator operands, and the
 service worker maps gateway NodePort ``30080`` to host port ``80``.
 
-.. dropdown:: ``kind-osmo-cluster-config.yaml``
+.. dropdown:: ``kind-osmo-cluster-config.yaml`` (GPU version)
   :color: info
   :icon: file
 
@@ -154,7 +159,10 @@ service worker maps gateway NodePort ``30080`` to host port ``80``.
             kubeletExtraArgs:
               node-labels: "node_group=compute"
 
-Create the cluster and confirm that ``nvkind`` passes the host GPU through:
+**Create the Cluster**
+
+Create the cluster, select its context, and confirm that ``nvkind`` passes the
+host GPU through:
 
 .. code-block:: bash
 
@@ -168,8 +176,7 @@ Create the cluster and confirm that ``nvkind`` passes the host GPU through:
    You can ignore ``umount`` errors from ``nvkind`` if ``nvkind cluster
    print-gpus`` lists the workstation GPUs.
 
-Install cluster dependencies
-============================
+**Install GPU Operator**
 
 Install GPU Operator v25.10.1. The host driver and NVIDIA Container Toolkit
 are already managed by the ``nvkind`` prerequisites, so disable their in-cluster
@@ -189,6 +196,92 @@ fix required by this quickstart.
      --set nfd.enabled=true \
      --wait \
      --timeout 10m
+
+Wait for the GPU Operator pods to become Ready and verify that the compute node
+advertises one or more allocatable GPUs before installing OSMO:
+
+.. code-block:: bash
+
+   kubectl --namespace gpu-operator wait \
+     --for=condition=Ready pod --all --timeout=10m
+   kubectl get nodes -l node_group=compute \
+     -o custom-columns=NAME:.metadata.name,ALLOCATABLE_GPUS:.status.allocatable.nvidia\.com/gpu
+
+The ``compute`` node must show a positive ``ALLOCATABLE_GPUS`` value. If it
+does not, resolve the NVIDIA driver, Container Toolkit, or GPU Operator problem
+before proceeding.
+
+Option B: CPU Workstations (with KIND)
+---------------------------------------
+
+If your workstation does not have a GPU, create a standard CPU-only cluster.
+
+**Create Cluster Configuration**
+
+.. dropdown:: ``kind-osmo-cluster-config.yaml`` (CPU-only version)
+  :color: info
+  :icon: file
+
+  .. code-block:: yaml
+
+    kind: Cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    name: osmo
+    nodes:
+      - role: control-plane
+      - role: worker
+        kubeadmConfigPatches:
+        - |
+          kind: JoinConfiguration
+          nodeRegistration:
+            kubeletExtraArgs:
+              node-labels: "node_group=kai-scheduler"
+      - role: worker
+        kubeadmConfigPatches:
+        - |
+          kind: JoinConfiguration
+          nodeRegistration:
+            kubeletExtraArgs:
+              node-labels: "node_group=data"
+        extraMounts:
+          - hostPath: /tmp/localstack-s3
+            containerPath: /var/lib/localstack
+      - role: worker
+        kubeadmConfigPatches:
+        - |
+          kind: JoinConfiguration
+          nodeRegistration:
+            kubeletExtraArgs:
+              node-labels: "node_group=service"
+        extraPortMappings:
+          - containerPort: 30080
+            hostPort: 80
+            protocol: TCP
+      - role: worker
+        kubeadmConfigPatches:
+        - |
+          kind: JoinConfiguration
+          nodeRegistration:
+            kubeletExtraArgs:
+              node-labels: "node_group=service"
+      - role: worker
+        kubeadmConfigPatches:
+        - |
+          kind: JoinConfiguration
+          nodeRegistration:
+            kubeletExtraArgs:
+              node-labels: "node_group=compute"
+
+**Create the Cluster**
+
+.. code-block:: bash
+
+   kind create cluster --config kind-osmo-cluster-config.yaml
+   kubectl config use-context kind-osmo
+   kubectl get storageclass
+
+Install cluster dependencies
+============================
 
 Install KAI Scheduler v0.14.0 for OSMO workflow scheduling, then install the
 CloudNativePG operator chart version 0.29.0 for the embedded PostgreSQL
@@ -211,20 +304,6 @@ cluster:
      --create-namespace \
      --wait \
      --timeout 10m
-
-Wait for the GPU Operator pods to become Ready and verify that the compute node
-advertises one or more allocatable GPUs before installing OSMO:
-
-.. code-block:: bash
-
-   kubectl --namespace gpu-operator wait \
-     --for=condition=Ready pod --all --timeout=10m
-   kubectl get nodes -l node_group=compute \
-     -o custom-columns=NAME:.metadata.name,ALLOCATABLE_GPUS:.status.allocatable.nvidia\.com/gpu
-
-The ``compute`` node must show a positive ``ALLOCATABLE_GPUS`` value. If it
-does not, resolve the NVIDIA driver, Container Toolkit, or GPU Operator problem
-before proceeding.
 
 Install OSMO
 ============
@@ -265,10 +344,7 @@ install it without a profile or values overlay:
      --wait-for-jobs \
      --timeout 20m
 
-The first installation creates the retained master-encryption-key Secret.
-Bootstrap can remain enabled for this Quickstart. Before a later MEK rotation,
-disable it as described in the chart's master-encryption-key lifecycle
-documentation. Remove the temporary service-auth file:
+Remove the temporary service-auth file:
 
 .. code-block:: bash
 
@@ -284,12 +360,12 @@ Confirm that the release, embedded dependencies, and gateway are Ready:
    kubectl --namespace osmo get pods,pvc,services,jobs
    kubectl --namespace osmo get service osmo-gateway
 
-Log in and run CPU and GPU workflows
-====================================
+Log in and run a workflow
+=========================
 
 The cluster configuration maps the gateway to ``http://127.0.0.1``. Install the
 CLI if necessary, log in as the development administrator, select the default
-pool, and submit the canonical CPU and GPU verification workflows:
+pool, and submit the canonical CPU verification workflow:
 
 .. code-block:: bash
 
@@ -299,16 +375,23 @@ pool, and submit the canonical CPU and GPU verification workflows:
    osmo workflow submit deployments/workflows/verify-hello.yaml \
      --pool default \
      --format-type json
+   osmo workflow query <workflow-id> --format-type json
+
+Query the returned workflow ID until its status is ``COMPLETED``. The workflow
+uses the default ``cpu`` platform.
+
+If you used Option A, submit the GPU verification workflow too:
+
+.. code-block:: bash
+
    osmo workflow submit deployments/workflows/verify-gpu.yaml \
      --pool default \
      --format-type json
    osmo workflow query <workflow-id> --format-type json
 
-Query each returned workflow ID until its status is ``COMPLETED``. The CPU
-workflow uses the default ``cpu`` platform. The GPU workflow explicitly uses
-the ``gpu`` platform and runs ``nvidia-smi`` in a CUDA container, proving that
-OSMO and KAI scheduled it onto the GPU node and that the NVIDIA driver and
-Container Toolkit are usable.
+The GPU workflow explicitly uses the ``gpu`` platform and runs ``nvidia-smi``
+in a CUDA container, proving that OSMO and KAI scheduled it onto the GPU node
+and that the NVIDIA driver and Container Toolkit are usable.
 
 Troubleshooting
 ===============
@@ -343,7 +426,7 @@ availability guarantees. The exposed development administrator identity and
 NodePort are suitable only for a disposable local environment.
 
 CloudNativePG, Valkey, and RustFS use persistent volumes supplied by the
-``nvkind`` cluster's default StorageClass. Those local volumes, generated
+cluster's default StorageClass. Those local volumes, generated
 credentials, workflow state, and all other quickstart data disappear when the
 cluster is deleted. Do not use this quickstart for production data or any
 long-lived environment.
@@ -351,12 +434,18 @@ long-lived environment.
 Clean up resources
 ==================
 
-Remove the OSMO release and the disposable ``nvkind`` cluster:
+Remove the OSMO release, then delete the disposable cluster using the command
+for the option you selected:
 
 .. code-block:: bash
 
    helm uninstall osmo --namespace osmo --wait
+
+   # Option A
    nvkind cluster delete --name osmo
+
+   # Option B
+   kind delete cluster --name osmo
 
 Deleting the cluster removes all quickstart data, including its local
 persistent volumes and generated credentials.

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -16,75 +16,56 @@
   SPDX-License-Identifier: Apache-2.0
 
 .. _deploy_local:
+.. _quickstart:
 
-============================
-Local Deployment
-============================
+==========
+Quickstart
+==========
 
-Try OSMO on your local workstation — no cloud account, no infrastructure costs, no enterprise approval needed.
-
-This guide walks you through deploying the complete OSMO platform locally using KIND (Kubernetes in Docker) in about 10 minutes.
-
-.. tip::
-   **Perfect for evaluation** – Test your workflows, explore the platform, and assess fit for your robotics development needs before cloud deployment of OSMO.
+Use this development-only quickstart to run the complete OSMO control plane,
+compute plane, and a GPU workflow on a workstation with an NVIDIA GPU. It
+creates a multi-node Kubernetes-in-Docker cluster with ``nvkind``, installs the
+required NVIDIA operators, and deploys the unified ``osmo`` Helm chart.
 
 .. warning::
-   Local deployment is **not** recommended for production use as it lacks authentication and has limited features.
 
-Why Deploy Locally?
-===================
-
-Local deployment provides the complete OSMO experience on your workstation:
-
-✓ **Full workflow orchestration** – Task dependencies, parallel execution, state management
-
-✓ **Real containerized execution** – Your Docker images running in local Kubernetes
-
-✓ **Complete data management** – Local object storage for workflow inputs, outputs, and artifacts
-
-✓ **The same YAML workflows** that scale to cloud environments
-
-✓ **Zero cloud costs** – Everything runs on your workstation
-
-.. admonition:: Seamless Scale to Cloud
-   :class: info
-
-   If OSMO works for your use case locally, it will scale to hundreds of GPUs in the cloud. You can use the **exact same workflows**; no code changes required.
+   This is not a production configuration. It exposes a development
+   administrator identity and intentionally disables production security and
+   availability features. See :ref:`Capacity and limitations <quickstart_limits>`
+   before using it.
 
 Prerequisites
 =============
 
-Install the following tools on your workstation:
+The workstation must have a supported NVIDIA GPU, NVIDIA driver, and NVIDIA
+Container Toolkit installed and working with Docker. Follow the ``nvkind``
+`prerequisites <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#prerequisites>`_,
+`setup <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#setup>`_, and
+`installation <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#install-nvkind>`_
+instructions before continuing.
 
-* `Docker <https://docs.docker.com/get-started/get-docker/>`_ - Container runtime (>=28.3.2)
-* `KIND <https://kind.sigs.k8s.io/docs/user/quick-start/#installation>`_ - Kubernetes in Docker (>=0.29.0)
-* `kubectl <https://kubernetes.io/docs/tasks/tools/>`_ - Kubernetes command-line tool (>=1.32.2)
-* `helm <https://helm.sh/docs/intro/install/>`_ - Helm package manager (>=3.16.2)
+Install Docker, ``nvkind``, ``kubectl``, Helm, and the OSMO CLI installer
+dependencies. The cluster requires Kubernetes 1.30 or newer and a default
+dynamic ``StorageClass``. If Docker reports permission errors, ensure that your
+user can access the Docker daemon. On Linux, also raise the
+`inotify limits <https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files>`_
+when creating many containers.
 
-.. important::
+Clone the repository and run the remaining commands from its root:
 
-   **System Configuration**:
+.. code-block:: bash
 
-   1. `Raise inotify limits <https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files>`_ to prevent "too many open files" errors
-   2. `Ensure your user has Docker permissions <https://kind.sigs.k8s.io/docs/user/known-issues/#docker-permission-denied>`_
+   git clone https://github.com/NVIDIA/OSMO.git
+   cd OSMO
 
-Step 1: Create KIND Cluster
-============================
+Create an nvkind cluster
+========================
 
-Choose the appropriate setup based on whether your workstation has a GPU.
+Create the following multi-node configuration. The compute worker receives the
+GPU from ``nvkind``. The other workers disable GPU Operator operands, and the
+service worker maps gateway NodePort ``30080`` to host port ``80``.
 
-Option A: GPU Workstations (with nvkind)
------------------------------------------
-
-If your workstation has a GPU, follow these steps to create a cluster with GPU support.
-
-**Prerequisites**
-
-Install `nvkind <https://github.com/NVIDIA/nvkind>`_ by following the `prerequisites <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#prerequisites>`_, `setup <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#setup>`_, and `installation <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#install-nvkind>`_ guides.
-
-**Create Cluster Configuration**
-
-.. dropdown:: ``kind-osmo-cluster-config.yaml`` (GPU version)
+.. dropdown:: ``kind-osmo-cluster-config.yaml``
   :color: info
   :icon: file
 
@@ -141,298 +122,201 @@ Install `nvkind <https://github.com/NVIDIA/nvkind>`_ by following the `prerequis
             kubeletExtraArgs:
               node-labels: "node_group=compute"
 
-**Create the Cluster**
+Create the cluster and confirm that ``nvkind`` passes the host GPU through:
 
 .. code-block:: bash
 
-   $ nvkind cluster create --config-template=kind-osmo-cluster-config.yaml
+   nvkind cluster create --config-template=kind-osmo-cluster-config.yaml
+   nvkind cluster print-gpus
+   kubectl --context kind-osmo get storageclass
 
 .. note::
-   You can safely ignore any ``umount`` errors as long as ``nvkind cluster print-gpus`` shows your GPUs.
 
-**Install GPU Operator**
+   You can ignore ``umount`` errors from ``nvkind`` if ``nvkind cluster
+   print-gpus`` lists the workstation GPUs.
 
-After creating the cluster, install the GPU Operator to manage GPU resources:
+Install cluster dependencies
+============================
+
+Install GPU Operator v25.10.1. The host driver and NVIDIA Container Toolkit
+are already managed by the ``nvkind`` prerequisites, so disable their in-cluster
+management. Version v25.10.1 includes the Kubernetes 1.33 schema-validation
+fix required by this quickstart.
 
 .. code-block:: bash
 
-   $ helm fetch https://helm.ngc.nvidia.com/nvidia/charts/gpu-operator-v25.10.0.tgz
-   $ helm upgrade --install gpu-operator gpu-operator-v25.10.0.tgz \
+   helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
+   helm repo update nvidia
+   helm --kube-context kind-osmo upgrade --install gpu-operator nvidia/gpu-operator \
+     --version v25.10.1 \
      --namespace gpu-operator \
      --create-namespace \
      --set driver.enabled=false \
      --set toolkit.enabled=false \
      --set nfd.enabled=true \
-     --wait
+     --wait \
+     --timeout 10m
 
-Option B: CPU Workstations (with KIND)
---------------------------------------------
+Install KAI Scheduler v0.14.0 for OSMO workflow scheduling, then install the
+CloudNativePG operator chart version 0.29.0 for the embedded PostgreSQL
+cluster:
 
-If your workstation does not have a GPU, follow these steps for a standard CPU-only cluster.
+.. code-block:: bash
 
-**Create Cluster Configuration**
+   helm --kube-context kind-osmo upgrade --install kai-scheduler \
+     https://github.com/NVIDIA/KAI-Scheduler/releases/download/v0.14.0/kai-scheduler-v0.14.0.tgz \
+     --namespace kai-scheduler \
+     --create-namespace \
+     --wait \
+     --timeout 10m
 
-.. dropdown:: ``kind-osmo-cluster-config.yaml`` (CPU-only version)
+   helm repo add cnpg https://cloudnative-pg.github.io/charts
+   helm repo update cnpg
+   helm --kube-context kind-osmo upgrade --install cnpg cnpg/cloudnative-pg \
+     --version 0.29.0 \
+     --namespace cnpg-system \
+     --create-namespace \
+     --wait \
+     --timeout 10m
+
+Wait for the GPU Operator pods to become Ready and verify that the compute node
+advertises one or more allocatable GPUs before installing OSMO:
+
+.. code-block:: bash
+
+   kubectl --context kind-osmo --namespace gpu-operator wait \
+     --for=condition=Ready pod --all --timeout=10m
+   kubectl --context kind-osmo get nodes -l node_group=compute \
+     -o custom-columns=NAME:.metadata.name,ALLOCATABLE_GPUS:.status.allocatable.nvidia\.com/gpu
+
+The ``compute`` node must show a positive ``ALLOCATABLE_GPUS`` value. If it
+does not, resolve the NVIDIA driver, Container Toolkit, or GPU Operator problem
+before proceeding.
+
+Install OSMO
+============
+
+The ``quickstart.yaml`` profile is CPU-only by default. Override its
+``default_user`` pod template so OSMO requests the GPU resource in both the
+user-container requests and limits. Helm replaces lists instead of merging
+them, so the override repeats the complete container resource configuration,
+including CPU, memory, GPU, and ephemeral-storage requests and limits.
+
+.. dropdown:: ``osmo-gpu-pod-template.yaml``
   :color: info
   :icon: file
 
   .. code-block:: yaml
 
-    kind: Cluster
-    apiVersion: kind.x-k8s.io/v1alpha4
-    name: osmo
-    nodes:
-      - role: control-plane
-      - role: worker
-        kubeadmConfigPatches:
-        - |
-          kind: JoinConfiguration
-          nodeRegistration:
-            kubeletExtraArgs:
-              node-labels: "node_group=kai-scheduler"
-      - role: worker
-        kubeadmConfigPatches:
-        - |
-          kind: JoinConfiguration
-          nodeRegistration:
-            kubeletExtraArgs:
-              node-labels: "node_group=data"
-        extraMounts:
-          - hostPath: /tmp/localstack-s3
-            containerPath: /var/lib/localstack
-      - role: worker
-        kubeadmConfigPatches:
-        - |
-          kind: JoinConfiguration
-          nodeRegistration:
-            kubeletExtraArgs:
-              node-labels: "node_group=service"
-        extraPortMappings:
-          - containerPort: 30080
-            hostPort: 80
-            protocol: TCP
-      - role: worker
-        kubeadmConfigPatches:
-        - |
-          kind: JoinConfiguration
-          nodeRegistration:
-            kubeletExtraArgs:
-              node-labels: "node_group=service"
-      - role: worker
-        kubeadmConfigPatches:
-        - |
-          kind: JoinConfiguration
-          nodeRegistration:
-            kubeletExtraArgs:
-              node-labels: "node_group=compute"
+    configuration:
+      podTemplates:
+        default_user:
+          spec:
+            containers:
+            - name: '{{USER_CONTAINER_NAME}}'
+              resources:
+                limits:
+                  cpu: '{{USER_CPU}}'
+                  memory: '{{USER_MEMORY}}'
+                  nvidia.com/gpu: '{{USER_GPU}}'
+                  ephemeral-storage: '{{USER_STORAGE}}'
+                requests:
+                  cpu: '{{USER_CPU}}'
+                  memory: '{{USER_MEMORY}}'
+                  nvidia.com/gpu: '{{USER_GPU}}'
+                  ephemeral-storage: '{{USER_STORAGE}}'
 
-**Create the Cluster**
+Save the overlay, build the chart dependencies, and install the unified chart:
 
 .. code-block:: bash
 
-   $ kind create cluster --config kind-osmo-cluster-config.yaml
-
-Cluster Architecture
---------------------
-
-Both commands create a Kubernetes cluster on your workstation with a control plane node and several worker nodes. The core OSMO components will be installed on those worker nodes:
-
-**Control Plane**
-
-* 2 worker nodes labeled ``node_group=service`` for API server, workflow engine, and gateway (Envoy)
-* 1 worker node labeled ``node_group=kai-scheduler`` for KAI scheduler
-
-**Compute Layer**
-
-* 1 worker node labeled ``node_group=compute``
-
-**Data Layer**
-
-* 1 worker node labeled ``node_group=data`` for PostgreSQL, Redis, LocalStack S3
-
-Step 2: Install KAI Scheduler
-==============================
-
-KAI scheduler provides co-scheduling, priority, and preemption for workflows:
-
-.. code-block:: bash
-
-   $ helm upgrade --install kai-scheduler \
-     oci://ghcr.io/nvidia/kai-scheduler/kai-scheduler \
-     --version v0.12.10 \
-     --create-namespace -n kai-scheduler \
-     --set global.nodeSelector.node_group=kai-scheduler \
-     --set "scheduler.additionalArgs[0]=--default-staleness-grace-period=-1s" \
-     --set "scheduler.additionalArgs[1]=--update-pod-eviction-condition=true" \
-     --wait
-
-Step 3: Install OSMO
-====================
-
-Deploy the OSMO service chart first, then the backend operator chart. The
-values files below preserve the former local quick-start settings while keeping
-the charts independently managed.
-
-.. code-block:: bash
-
-   mkdir -p osmo-values
-   curl -fsSL https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/deployments/charts/service/quick-start-values.yaml \
-     -o osmo-values/service.yaml
-   curl -fsSL https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/deployments/charts/backend-operator/quick-start-values.yaml \
-     -o osmo-values/backend-operator.yaml
-
-   kubectl create namespace osmo --dry-run=client -o yaml | kubectl apply -f -
-   kubectl create namespace osmo-test --dry-run=client -o yaml | kubectl apply -f -
-   LOCAL_ADMIN_PASSWORD=$(dd if=/dev/urandom bs=32 count=1 2>/dev/null | base64 | tr -d '\n=' | head -c 43)
-   kubectl create secret generic local-admin-password \
+   helm dependency build deployments/charts/osmo
+   helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
      --namespace osmo \
-     --from-literal=password="$LOCAL_ADMIN_PASSWORD" \
-     --dry-run=client -o yaml | kubectl apply -f -
-
-   helm repo add osmo https://helm.ngc.nvidia.com/nvidia/osmo
-   helm repo update osmo
-   helm upgrade --install osmo osmo/service \
-     --namespace osmo \
-     -f osmo-values/service.yaml \
+     --create-namespace \
+     --values deployments/charts/osmo/profiles/quickstart.yaml \
+     --values osmo-gpu-pod-template.yaml \
+     --set-string compute.backendName=default \
      --wait \
-     --timeout 25m
+     --timeout 20m
 
-The quick-start values enable the install-only MEK bootstrap hook. It creates
-the ``osmo-mek`` Secret for this disposable local installation without placing
-key material in Helm values or release state. Existing Secrets are preserved,
-and upgrades fail if the Secret is missing rather than generating a new key.
-
-   helm upgrade --install osmo-backend-operator osmo/backend-operator \
-     --namespace osmo \
-     -f osmo-values/backend-operator.yaml \
-     --wait \
-     --timeout 10m
-
-The service quick-start values generate ``backend-operator-token`` during the
-first Helm install. The backend operator consumes it directly from the same
-namespace.
-
-.. tip::
-   Installation takes about 5 minutes. Monitor progress with:
-
-   .. code-block:: bash
-
-      $ kubectl get pods --namespace osmo
-
-.. note::
-   The quick-start values use chart-managed LocalStack storage, so you do not
-   need to run ``deployments/scripts/configure-storage.sh`` for this local
-   flow. If your image registry requires credentials, create a Kubernetes image
-   pull Secret and pass ``--set global.imagePullSecret=<secret-name>`` to both
-   chart installs.
-
-Step 4: Configure Access
-=========================
-
-Add an entry to /etc/hosts so your browser and CLI can reach OSMO by hostname:
+Confirm that the release, embedded dependencies, and gateway are Ready:
 
 .. code-block:: bash
 
-   $ echo "127.0.0.1 quick-start.osmo" | sudo tee -a /etc/hosts
-   $ echo "127.0.0.1 localstack-s3.osmo" | sudo tee -a /etc/hosts
+   kubectl --context kind-osmo --namespace osmo wait \
+     --for=condition=Ready cluster/osmo-pg --timeout=10m
+   kubectl --context kind-osmo --namespace osmo get pods,pvc,services,jobs
+   kubectl --context kind-osmo --namespace osmo get service osmo-gateway
 
-The KIND cluster maps host port 80 to the gateway's NodePort, so OSMO is accessible at ``http://quick-start.osmo`` with no port-forward needed.
+Log in and run a GPU workflow
+=============================
 
-Step 5: Install OSMO CLI
-=========================
-
-Download and install the OSMO command-line interface:
-
-.. code-block:: bash
-
-   $ curl -fsSL https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/install.sh | bash
-
-Step 6: Log In and Configure Local Credentials
-==============================================
-
-Authenticate with your local OSMO instance, set the default pool, and register
-the LocalStack data credential used by the CLI for storage upload and download:
+The cluster configuration maps the gateway to ``http://127.0.0.1``. Install the
+CLI if necessary, log in as the development administrator, select the default
+pool, and submit the canonical GPU verification workflow:
 
 .. code-block:: bash
 
-   $ osmo login http://quick-start.osmo --method=dev --username=testuser
-   $ osmo profile set pool default
-   $ osmo credential set osmo --type DATA --payload \
-     access_key_id=test \
-     access_key=test \
-     endpoint=s3://osmo \
-     override_url=http://localstack-s3.osmo:4566 \
-     region=us-east-1
+   curl -fsSL https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/install.sh | bash
+   osmo login http://127.0.0.1 --method=dev --username=testuser
+   osmo profile set pool default
+   osmo workflow submit deployments/workflows/verify-gpu.yaml \
+     --pool default \
+     --format-type json
+   osmo workflow query <workflow-id> --format-type json
 
-.. admonition:: Success!
-   :class: tip
-
-   You now have OSMO configured and running on your workstation. You're ready to start running robotics workflows!
-
-Next Steps
-==========
-
-Now that you have OSMO running locally, explore the platform:
-
-1. **Run Your First Workflow**: Visit the :ref:`User Guide <getting_started_next_steps>` for tutorials on submitting workflows, interactive development, distributed training, and more.
-
-2. **Explore the Web UI**: Visit ``http://quick-start.osmo`` to access the OSMO dashboard.
-
-3. **Test Your Own Workflows**: Use your own Docker images and storage locations to validate OSMO for your use case.
-
-.. tip::
-   **Ready to Scale?**
-
-   Once you have validated OSMO locally, you can scale to cloud environments (EKS, AKS, GKE) or on-premise clusters without rewriting your workflows. Contact your cloud administrator to discuss production deployment options—see the :ref:`deploy_service` guide for full production deployment.
-
-Cleanup
-=======
-
-Delete the local cluster and all associated resources:
-
-.. code-block:: bash
-
-   $ kind delete cluster --name osmo
-
-This removes the entire Kubernetes cluster, including all persistent volumes and the PostgreSQL database.
+Repeat the query until the workflow status is ``COMPLETED``. The workflow runs
+``nvidia-smi`` in a CUDA container, proving that OSMO and KAI scheduled it onto
+the GPU node and that the NVIDIA driver and Container Toolkit are usable.
 
 Troubleshooting
 ===============
 
-Too Many Files Open
--------------------
-
-If you encounter "too many files open" errors or pods fail to start, increase the inotify limits:
+If the GPU workflow remains pending or fails, first verify GPU capacity and
+the GPU Operator:
 
 .. code-block:: bash
 
-   $ echo "fs.inotify.max_user_watches=1048576" | sudo tee -a /etc/sysctl.conf
-   $ echo "fs.inotify.max_user_instances=512" | sudo tee -a /etc/sysctl.conf
-   $ sudo sysctl -p
+   kubectl --context kind-osmo get nodes \
+     -o custom-columns=NAME:.metadata.name,ALLOCATABLE_GPUS:.status.allocatable.nvidia\.com/gpu
+   kubectl --context kind-osmo --namespace gpu-operator get pods
+   kubectl --context kind-osmo --namespace osmo get events --sort-by=.lastTimestamp
+   kubectl --context kind-osmo --namespace osmo get pods
 
-For more details, see: `Pod errors due to "too many open files" <https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files>`_
+An allocatable GPU count of zero means the host NVIDIA driver, Container
+Toolkit, ``nvkind`` pass-through, or GPU Operator is not ready. Do not run
+other GPU workloads until ``verify-gpu.yaml`` completes. For OSMO deployment
+problems, inspect the listed pods and events; a pending PostgreSQL, Valkey, or
+RustFS PVC usually means the cluster lacks a working default ``StorageClass``.
 
-Docker Permission Denied
-------------------------
+.. _quickstart_limits:
 
-If you see "permission denied" errors when running Docker or KIND commands, add your user to the docker group:
+Capacity and limitations
+========================
+
+This profile runs one replica of each required OSMO service and uses generated
+development credentials, including the ``testuser`` identity with the
+``osmo-admin`` role. It disables TLS, authorization, rate limiting, backups,
+monitoring, PodDisruptionBudgets, and autoscaling. It also has no high
+availability guarantees. The exposed development administrator identity and
+NodePort are suitable only for a disposable local environment.
+
+CloudNativePG, Valkey, and RustFS use persistent volumes supplied by the
+``nvkind`` cluster's default StorageClass. Those local volumes, generated
+credentials, workflow state, and all other quickstart data disappear when the
+cluster is deleted. Do not use this quickstart for production data or any
+long-lived environment.
+
+Clean up resources
+==================
+
+Remove the OSMO release and the disposable ``nvkind`` cluster:
 
 .. code-block:: bash
 
-   $ sudo usermod -aG docker $USER && newgrp docker
+   helm --kube-context kind-osmo uninstall osmo --namespace osmo --wait
+   nvkind cluster delete --name osmo
 
-.. note::
-   If permission errors persist, log out and log back in for the group membership changes to take effect.
-
-For more details, see: `Docker permission denied <https://kind.sigs.k8s.io/docs/user/known-issues/#docker-permission-denied>`_
-
-Pods Not Starting
-------------------
-
-Check resource availability and logs:
-
-.. code-block:: bash
-
-   $ kubectl get pods --namespace osmo
-   $ kubectl describe pod <pod-name> --namespace osmo
-   $ kubectl logs <pod-name> --namespace osmo
+Deleting the cluster removes all quickstart data, including its local
+persistent volumes and generated credentials.

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -47,10 +47,11 @@ instructions before continuing.
 
 Install Docker, ``kind``, ``nvkind``, ``kubectl``, Helm, `Bazelisk
 <https://github.com/bazelbuild/bazelisk>`_, and the OSMO CLI installer
-dependencies. Bazelisk uses the repository's ``.bazelversion`` to select the
-supported Bazel release. The cluster requires Kubernetes 1.30 or newer and a
-default dynamic ``StorageClass``. If Docker reports permission errors, ensure
-that your user can access the Docker daemon. On Linux, also raise the
+dependencies. Install Bazelisk with its ``bazel`` shim on ``PATH``; it uses the
+repository's ``.bazelversion`` to select the supported Bazel release. The
+cluster requires Kubernetes 1.30 or newer and a default dynamic
+``StorageClass``. If Docker reports permission errors, ensure that your user
+can access the Docker daemon. On Linux, also raise the
 `inotify limits <https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files>`_
 when creating many containers.
 

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -22,10 +22,11 @@
 Quickstart
 ==========
 
-Use this development-only quickstart to run the complete OSMO control plane,
-compute plane, and a GPU workflow on a workstation with an NVIDIA GPU. It
-creates a multi-node Kubernetes-in-Docker cluster with ``nvkind``, installs the
-required NVIDIA operators, and deploys the unified ``osmo`` Helm chart.
+This development-only Quickstart is the fastest way to try the complete OSMO
+control plane, compute plane, and a GPU workflow on a workstation with an
+NVIDIA GPU. It creates a multi-node Kubernetes-in-Docker cluster with
+``nvkind``, installs the required NVIDIA operators, and deploys the unified
+``osmo`` Helm chart.
 
 .. warning::
 
@@ -44,10 +45,12 @@ Container Toolkit installed and working with Docker. Follow the ``nvkind``
 `installation <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#install-nvkind>`_
 instructions before continuing.
 
-Install Docker, ``nvkind``, ``kubectl``, Helm, and the OSMO CLI installer
-dependencies. The cluster requires Kubernetes 1.30 or newer and a default
-dynamic ``StorageClass``. If Docker reports permission errors, ensure that your
-user can access the Docker daemon. On Linux, also raise the
+Install Docker, ``kind``, ``nvkind``, ``kubectl``, Helm, `Bazelisk
+<https://github.com/bazelbuild/bazelisk>`_, and the OSMO CLI installer
+dependencies. Bazelisk uses the repository's ``.bazelversion`` to select the
+supported Bazel release. The cluster requires Kubernetes 1.30 or newer and a
+default dynamic ``StorageClass``. If Docker reports permission errors, ensure
+that your user can access the Docker daemon. On Linux, also raise the
 `inotify limits <https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files>`_
 when creating many containers.
 
@@ -202,6 +205,11 @@ user-container requests and limits. Helm replaces lists instead of merging
 them, so the override repeats the complete container resource configuration,
 including CPU, memory, GPU, and ephemeral-storage requests and limits.
 
+The unified chart on ``main`` also requires the API image from the same source
+revision for master-encryption-key lifecycle operations. The overlay selects
+the repository-built image for both the API and its bootstrap Job instead of a
+mutable registry image.
+
 .. dropdown:: ``osmo-gpu-pod-template.yaml``
   :color: info
   :icon: file
@@ -225,11 +233,22 @@ including CPU, memory, GPU, and ephemeral-storage requests and limits.
                   memory: '{{USER_MEMORY}}'
                   nvidia.com/gpu: '{{USER_GPU}}'
                   ephemeral-storage: '{{USER_STORAGE}}'
+    services:
+      api:
+        image:
+          registry: osmo.local
+          repository: service
+          tag: latest-x86_64
 
-Save the overlay, build the chart dependencies, and install the unified chart:
+Save the overlay, build and load the current API image, build the chart
+dependencies, and install the unified chart. ``kind load`` copies the image to
+every cluster node, and the Quickstart's ``IfNotPresent`` pull policy uses that
+local image without contacting a registry:
 
 .. code-block:: bash
 
+   bazel run //src/service/core:service_image_load_x86_64
+   kind load docker-image --name osmo osmo.local/service:latest-x86_64
    helm dependency build deployments/charts/osmo
    helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
      --namespace osmo \

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -200,16 +200,17 @@ before proceeding.
 Install OSMO
 ============
 
-The ``quickstart.yaml`` profile is CPU-only by default. Override its
-``default_user`` pod template so OSMO requests the GPU resource in both the
-user-container requests and limits. Helm replaces lists instead of merging
-them, so the override repeats the complete container resource configuration,
-including CPU, memory, GPU, and ephemeral-storage requests and limits.
+The chart's Quickstart defaults are CPU-only. Override the ``default_user`` pod
+template so OSMO requests the GPU resource in both the user-container requests
+and limits. Helm replaces lists instead of merging them, so the override
+repeats the complete container resource configuration, including CPU, memory,
+GPU, and ephemeral-storage requests and limits.
 
-The unified chart on ``main`` also requires the API image from the same source
-revision for master-encryption-key lifecycle operations. The overlay selects
-the repository-built image for both the API and its bootstrap Job instead of a
-mutable registry image.
+The unified chart on ``main`` also requires control-plane images from the same
+source revision for service authentication. The overlay selects the
+repository-built images instead of mutable registry images. The API image is
+also used for service-auth generation and the master-encryption-key bootstrap
+Job.
 
 .. dropdown:: ``osmo-gpu-pod-template.yaml``
   :color: info
@@ -240,25 +241,102 @@ mutable registry image.
           registry: osmo.local
           repository: service
           tag: latest-x86_64
+      worker:
+        image:
+          registry: osmo.local
+          repository: worker
+          tag: latest-x86_64
+      agent:
+        image:
+          registry: osmo.local
+          repository: agent
+          tag: latest-x86_64
+      router:
+        image:
+          registry: osmo.local
+          repository: router
+          tag: latest-x86_64
+      logger:
+        image:
+          registry: osmo.local
+          repository: logger
+          tag: latest-x86_64
+      delayedJobMonitor:
+        image:
+          registry: osmo.local
+          repository: delayed-job-monitor
+          tag: latest-x86_64
 
-Save the overlay, build and load the current API image, build the chart
-dependencies, and install the unified chart. ``kind load`` copies the image to
-every cluster node, and the Quickstart's ``IfNotPresent`` pull policy uses that
-local image without contacting a registry:
+Save the overlay, then build the current control-plane images and load them
+into the cluster. ``kind load`` copies the images to every cluster node, and
+the Quickstart's ``IfNotPresent`` pull policy uses them without contacting a
+registry:
 
 .. code-block:: bash
 
    bazel run //src/service/core:service_image_load_x86_64
-   kind load docker-image --name osmo osmo.local/service:latest-x86_64
+   bazel run //src/service/worker:worker_image_load_x86_64
+   bazel run //src/service/agent:agent_service_image_load_x86_64
+   bazel run //src/service/router:router_image_load_x86_64
+   bazel run //src/service/logger:logger_image_load_x86_64
+   bazel run //src/service/delayed_job_monitor:delayed_job_monitor_image_load_x86_64
+
+   kind load docker-image --name osmo \
+     osmo.local/service:latest-x86_64 \
+     osmo.local/worker:latest-x86_64 \
+     osmo.local/agent:latest-x86_64 \
+     osmo.local/router:latest-x86_64 \
+     osmo.local/logger:latest-x86_64 \
+     osmo.local/delayed-job-monitor:latest-x86_64
+
+Generate the shared development service-auth identity with that image and
+create its Secret. The generator writes the private identity only to a
+permission-restricted temporary file and never prints it:
+
+.. code-block:: bash
+
+   OSMO_SERVICE_AUTH_DIRECTORY="$(mktemp -d)"
+   docker run --rm --user "$(id -u):$(id -g)" \
+     --entrypoint service-auth-bootstrap \
+     --volume "${OSMO_SERVICE_AUTH_DIRECTORY}:/output" \
+     osmo.local/service:latest-x86_64 \
+     generate --output /output/authentication-config.json
+   kubectl --context kind-osmo create namespace osmo \
+     --dry-run=client --output=yaml | kubectl --context kind-osmo apply -f -
+   kubectl --context kind-osmo --namespace osmo create secret generic \
+     osmo-service-auth \
+     --from-file="authentication-config.json=${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
+
+The chart defaults are the development Quickstart. Build its dependencies and
+install it with only the GPU and local control-plane image overlay:
+
+.. code-block:: bash
+
    helm dependency build deployments/charts/osmo
    helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
      --namespace osmo \
      --create-namespace \
-     --values deployments/charts/osmo/profiles/quickstart.yaml \
      --values osmo-gpu-pod-template.yaml \
-     --set-string compute.backendName=default \
      --wait \
+     --wait-for-jobs \
      --timeout 20m
+
+After the first install creates the retained master-encryption-key Secret,
+remove the one-time bootstrap permission while preserving the remaining
+release values. Then remove the temporary service-auth file:
+
+.. code-block:: bash
+
+   helm --kube-context kind-osmo upgrade osmo deployments/charts/osmo \
+     --namespace osmo \
+     --reuse-values \
+     --set secrets.masterEncryptionKey.bootstrap.enabled=false \
+     --wait \
+     --wait-for-jobs \
+     --timeout 20m
+
+   rm "${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
+   rmdir "${OSMO_SERVICE_AUTH_DIRECTORY}"
 
 Confirm that the release, embedded dependencies, and gateway are Ready:
 

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -35,25 +35,53 @@ NVIDIA GPU. It creates a multi-node Kubernetes-in-Docker cluster with
    availability features. See :ref:`Capacity and limitations <quickstart_limits>`
    before using it.
 
+Why Deploy Locally?
+===================
+
+Local deployment provides the complete OSMO experience on your workstation:
+
+✓ **Full workflow orchestration** – Task dependencies, parallel execution, state management
+
+✓ **Real containerized execution** – Your Docker images running in local Kubernetes
+
+✓ **Complete data management** – Local object storage for workflow inputs, outputs, and artifacts
+
+✓ **The same YAML workflows** that scale to cloud environments
+
+✓ **Zero cloud costs** – Everything runs on your workstation
+
+.. admonition:: Seamless Scale to Cloud
+   :class: info
+
+   If OSMO works for your use case locally, it will scale to hundreds of GPUs
+   in the cloud. You can use the exact same workflows; no code changes are
+   required.
+
 Prerequisites
 =============
 
-The workstation must have a supported NVIDIA GPU, NVIDIA driver, and NVIDIA
-Container Toolkit installed and working with Docker. Follow the ``nvkind``
-`prerequisites <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#prerequisites>`_,
-`setup <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#setup>`_, and
-`installation <https://github.com/NVIDIA/nvkind?tab=readme-ov-file#install-nvkind>`_
-instructions before continuing.
+Install the following tools on your workstation:
 
-Install Docker, ``kind``, ``nvkind``, ``kubectl``, Helm, `Bazelisk
-<https://github.com/bazelbuild/bazelisk>`_, and the OSMO CLI installer
-dependencies. Install Bazelisk with its ``bazel`` shim on ``PATH``; it uses the
-repository's ``.bazelversion`` to select the supported Bazel release. The
-cluster requires Kubernetes 1.30 or newer and a default dynamic
-``StorageClass``. If Docker reports permission errors, ensure that your user
-can access the Docker daemon. On Linux, also raise the
-`inotify limits <https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files>`_
-when creating many containers.
+* `Docker <https://docs.docker.com/get-started/get-docker/>`_ - Container runtime (>=28.3.2)
+* `KIND <https://kind.sigs.k8s.io/docs/user/quick-start/#installation>`_ - Kubernetes in Docker (>=0.29.0)
+* `kubectl <https://kubernetes.io/docs/tasks/tools/>`_ - Kubernetes command-line tool (>=1.32.2)
+* `helm <https://helm.sh/docs/intro/install/>`_ - Helm package manager (>=3.16.2)
+
+The workstation must also have a supported NVIDIA GPU, NVIDIA driver, and
+NVIDIA Container Toolkit installed and working with Docker. Install ``nvkind``
+by following its `prerequisites
+<https://github.com/NVIDIA/nvkind?tab=readme-ov-file#prerequisites>`_, `setup
+<https://github.com/NVIDIA/nvkind?tab=readme-ov-file#setup>`_, and `installation
+<https://github.com/NVIDIA/nvkind?tab=readme-ov-file#install-nvkind>`_ guides.
+The resulting cluster requires Kubernetes 1.30 or newer and a default dynamic
+``StorageClass``.
+
+.. important::
+
+   **System Configuration**:
+
+   1. `Raise inotify limits <https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files>`_ to prevent "too many open files" errors.
+   2. `Ensure your user has Docker permissions <https://kind.sigs.k8s.io/docs/user/known-issues/#docker-permission-denied>`_.
 
 Clone the repository and run the remaining commands from its root:
 
@@ -132,7 +160,8 @@ Create the cluster and confirm that ``nvkind`` passes the host GPU through:
 
    nvkind cluster create --config-template=kind-osmo-cluster-config.yaml
    nvkind cluster print-gpus
-   kubectl --context kind-osmo get storageclass
+   kubectl config use-context kind-osmo
+   kubectl get storageclass
 
 .. note::
 
@@ -151,7 +180,7 @@ fix required by this quickstart.
 
    helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
    helm repo update nvidia
-   helm --kube-context kind-osmo upgrade --install gpu-operator nvidia/gpu-operator \
+   helm upgrade --install gpu-operator nvidia/gpu-operator \
      --version v25.10.1 \
      --namespace gpu-operator \
      --create-namespace \
@@ -167,7 +196,7 @@ cluster:
 
 .. code-block:: bash
 
-   helm --kube-context kind-osmo upgrade --install kai-scheduler \
+   helm upgrade --install kai-scheduler \
      https://github.com/NVIDIA/KAI-Scheduler/releases/download/v0.14.0/kai-scheduler-v0.14.0.tgz \
      --namespace kai-scheduler \
      --create-namespace \
@@ -176,7 +205,7 @@ cluster:
 
    helm repo add cnpg https://cloudnative-pg.github.io/charts
    helm repo update cnpg
-   helm --kube-context kind-osmo upgrade --install cnpg cnpg/cloudnative-pg \
+   helm upgrade --install cnpg cnpg/cloudnative-pg \
      --version 0.29.0 \
      --namespace cnpg-system \
      --create-namespace \
@@ -188,9 +217,9 @@ advertises one or more allocatable GPUs before installing OSMO:
 
 .. code-block:: bash
 
-   kubectl --context kind-osmo --namespace gpu-operator wait \
+   kubectl --namespace gpu-operator wait \
      --for=condition=Ready pod --all --timeout=10m
-   kubectl --context kind-osmo get nodes -l node_group=compute \
+   kubectl get nodes -l node_group=compute \
      -o custom-columns=NAME:.metadata.name,ALLOCATABLE_GPUS:.status.allocatable.nvidia\.com/gpu
 
 The ``compute`` node must show a positive ``ALLOCATABLE_GPUS`` value. If it
@@ -200,98 +229,14 @@ before proceeding.
 Install OSMO
 ============
 
-The chart's Quickstart defaults are CPU-only. Override the ``default_user`` pod
-template so OSMO requests the GPU resource in both the user-container requests
-and limits. Helm replaces lists instead of merging them, so the override
-repeats the complete container resource configuration, including CPU, memory,
-GPU, and ephemeral-storage requests and limits.
+The chart defaults define a ``cpu`` platform and a ``gpu`` platform in the
+default pool. CPU workflows use a pod template without a GPU resource key.
+GPU workflows select the GPU platform, which requests ``nvidia.com/gpu`` in
+both the user-container requests and limits. No values overlay is required.
 
-The unified chart on ``main`` also requires control-plane images from the same
-source revision for service authentication. The overlay selects the
-repository-built images instead of mutable registry images. The API image is
-also used for service-auth generation and the master-encryption-key bootstrap
-Job.
-
-.. dropdown:: ``osmo-gpu-pod-template.yaml``
-  :color: info
-  :icon: file
-
-  .. code-block:: yaml
-
-    configuration:
-      podTemplates:
-        default_user:
-          spec:
-            containers:
-            - name: '{{USER_CONTAINER_NAME}}'
-              resources:
-                limits:
-                  cpu: '{{USER_CPU}}'
-                  memory: '{{USER_MEMORY}}'
-                  nvidia.com/gpu: '{{USER_GPU}}'
-                  ephemeral-storage: '{{USER_STORAGE}}'
-                requests:
-                  cpu: '{{USER_CPU}}'
-                  memory: '{{USER_MEMORY}}'
-                  nvidia.com/gpu: '{{USER_GPU}}'
-                  ephemeral-storage: '{{USER_STORAGE}}'
-    services:
-      api:
-        image:
-          registry: osmo.local
-          repository: service
-          tag: latest-x86_64
-      worker:
-        image:
-          registry: osmo.local
-          repository: worker
-          tag: latest-x86_64
-      agent:
-        image:
-          registry: osmo.local
-          repository: agent
-          tag: latest-x86_64
-      router:
-        image:
-          registry: osmo.local
-          repository: router
-          tag: latest-x86_64
-      logger:
-        image:
-          registry: osmo.local
-          repository: logger
-          tag: latest-x86_64
-      delayedJobMonitor:
-        image:
-          registry: osmo.local
-          repository: delayed-job-monitor
-          tag: latest-x86_64
-
-Save the overlay, then build the current control-plane images and load them
-into the cluster. ``kind load`` copies the images to every cluster node, and
-the Quickstart's ``IfNotPresent`` pull policy uses them without contacting a
-registry:
-
-.. code-block:: bash
-
-   bazel run //src/service/core:service_image_load_x86_64
-   bazel run //src/service/worker:worker_image_load_x86_64
-   bazel run //src/service/agent:agent_service_image_load_x86_64
-   bazel run //src/service/router:router_image_load_x86_64
-   bazel run //src/service/logger:logger_image_load_x86_64
-   bazel run //src/service/delayed_job_monitor:delayed_job_monitor_image_load_x86_64
-
-   kind load docker-image --name osmo \
-     osmo.local/service:latest-x86_64 \
-     osmo.local/worker:latest-x86_64 \
-     osmo.local/agent:latest-x86_64 \
-     osmo.local/router:latest-x86_64 \
-     osmo.local/logger:latest-x86_64 \
-     osmo.local/delayed-job-monitor:latest-x86_64
-
-Generate the shared development service-auth identity with that image and
-create its Secret. The generator writes the private identity only to a
-permission-restricted temporary file and never prints it:
+Generate the shared development service-auth identity with the published OSMO
+service image and create its Secret. The generator writes the private identity
+only to a permission-restricted temporary file and never prints it:
 
 .. code-block:: bash
 
@@ -299,41 +244,33 @@ permission-restricted temporary file and never prints it:
    docker run --rm --user "$(id -u):$(id -g)" \
      --entrypoint service-auth-bootstrap \
      --volume "${OSMO_SERVICE_AUTH_DIRECTORY}:/output" \
-     osmo.local/service:latest-x86_64 \
+     nvcr.io/nvidia/osmo/service:latest \
      generate --output /output/authentication-config.json
-   kubectl --context kind-osmo create namespace osmo \
-     --dry-run=client --output=yaml | kubectl --context kind-osmo apply -f -
-   kubectl --context kind-osmo --namespace osmo create secret generic \
+   kubectl create namespace osmo \
+     --dry-run=client --output=yaml | kubectl apply -f -
+   kubectl --namespace osmo create secret generic \
      osmo-service-auth \
      --from-file="authentication-config.json=${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
 
 The chart defaults are the development Quickstart. Build its dependencies and
-install it with only the GPU and local control-plane image overlay:
+install it without a profile or values overlay:
 
 .. code-block:: bash
 
    helm dependency build deployments/charts/osmo
-   helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
+   helm upgrade --install osmo deployments/charts/osmo \
      --namespace osmo \
      --create-namespace \
-     --values osmo-gpu-pod-template.yaml \
      --wait \
      --wait-for-jobs \
      --timeout 20m
 
-After the first install creates the retained master-encryption-key Secret,
-remove the one-time bootstrap permission while preserving the remaining
-release values. Then remove the temporary service-auth file:
+The first installation creates the retained master-encryption-key Secret.
+Bootstrap can remain enabled for this Quickstart. Before a later MEK rotation,
+disable it as described in the chart's master-encryption-key lifecycle
+documentation. Remove the temporary service-auth file:
 
 .. code-block:: bash
-
-   helm --kube-context kind-osmo upgrade osmo deployments/charts/osmo \
-     --namespace osmo \
-     --reuse-values \
-     --set secrets.masterEncryptionKey.bootstrap.enabled=false \
-     --wait \
-     --wait-for-jobs \
-     --timeout 20m
 
    rm "${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
    rmdir "${OSMO_SERVICE_AUTH_DIRECTORY}"
@@ -342,31 +279,36 @@ Confirm that the release, embedded dependencies, and gateway are Ready:
 
 .. code-block:: bash
 
-   kubectl --context kind-osmo --namespace osmo wait \
+   kubectl --namespace osmo wait \
      --for=condition=Ready cluster/osmo-pg --timeout=10m
-   kubectl --context kind-osmo --namespace osmo get pods,pvc,services,jobs
-   kubectl --context kind-osmo --namespace osmo get service osmo-gateway
+   kubectl --namespace osmo get pods,pvc,services,jobs
+   kubectl --namespace osmo get service osmo-gateway
 
-Log in and run a GPU workflow
-=============================
+Log in and run CPU and GPU workflows
+====================================
 
 The cluster configuration maps the gateway to ``http://127.0.0.1``. Install the
 CLI if necessary, log in as the development administrator, select the default
-pool, and submit the canonical GPU verification workflow:
+pool, and submit the canonical CPU and GPU verification workflows:
 
 .. code-block:: bash
 
    curl -fsSL https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/install.sh | bash
    osmo login http://127.0.0.1 --method=dev --username=testuser
    osmo profile set pool default
+   osmo workflow submit deployments/workflows/verify-hello.yaml \
+     --pool default \
+     --format-type json
    osmo workflow submit deployments/workflows/verify-gpu.yaml \
      --pool default \
      --format-type json
    osmo workflow query <workflow-id> --format-type json
 
-Repeat the query until the workflow status is ``COMPLETED``. The workflow runs
-``nvidia-smi`` in a CUDA container, proving that OSMO and KAI scheduled it onto
-the GPU node and that the NVIDIA driver and Container Toolkit are usable.
+Query each returned workflow ID until its status is ``COMPLETED``. The CPU
+workflow uses the default ``cpu`` platform. The GPU workflow explicitly uses
+the ``gpu`` platform and runs ``nvidia-smi`` in a CUDA container, proving that
+OSMO and KAI scheduled it onto the GPU node and that the NVIDIA driver and
+Container Toolkit are usable.
 
 Troubleshooting
 ===============
@@ -376,11 +318,11 @@ the GPU Operator:
 
 .. code-block:: bash
 
-   kubectl --context kind-osmo get nodes \
+   kubectl get nodes \
      -o custom-columns=NAME:.metadata.name,ALLOCATABLE_GPUS:.status.allocatable.nvidia\.com/gpu
-   kubectl --context kind-osmo --namespace gpu-operator get pods
-   kubectl --context kind-osmo --namespace osmo get events --sort-by=.lastTimestamp
-   kubectl --context kind-osmo --namespace osmo get pods
+   kubectl --namespace gpu-operator get pods
+   kubectl --namespace osmo get events --sort-by=.lastTimestamp
+   kubectl --namespace osmo get pods
 
 An allocatable GPU count of zero means the host NVIDIA driver, Container
 Toolkit, ``nvkind`` pass-through, or GPU Operator is not ready. Do not run
@@ -393,7 +335,7 @@ RustFS PVC usually means the cluster lacks a working default ``StorageClass``.
 Capacity and limitations
 ========================
 
-This profile runs one replica of each required OSMO service and uses generated
+This Quickstart runs one replica of each required OSMO service and uses generated
 development credentials, including the ``testuser`` identity with the
 ``osmo-admin`` role. It disables TLS, authorization, rate limiting, backups,
 monitoring, PodDisruptionBudgets, and autoscaling. It also has no high
@@ -413,7 +355,7 @@ Remove the OSMO release and the disposable ``nvkind`` cluster:
 
 .. code-block:: bash
 
-   helm --kube-context kind-osmo uninstall osmo --namespace osmo --wait
+   helm uninstall osmo --namespace osmo --wait
    nvkind cluster delete --name osmo
 
 Deleting the cluster removes all quickstart data, including its local

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -316,6 +316,7 @@ only to a permission-restricted temporary file and never prints it:
    kubectl --namespace osmo create secret generic \
      osmo-service-auth \
      --from-file="authentication-config.json=${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
+   rm -r "${OSMO_SERVICE_AUTH_DIRECTORY}"
 
 The chart defaults are the development Quickstart. Build its dependencies and
 install it without a profile or values overlay:
@@ -330,12 +331,6 @@ install it without a profile or values overlay:
      --wait-for-jobs \
      --timeout 20m
 
-Remove the temporary service-auth directory:
-
-.. code-block:: bash
-
-   rm -r "${OSMO_SERVICE_AUTH_DIRECTORY}"
-
 Log in and run a workflow
 =========================
 
@@ -348,10 +343,8 @@ pool, and submit the canonical CPU verification workflow:
    curl -fsSL https://raw.githubusercontent.com/NVIDIA/OSMO/refs/heads/main/install.sh | bash
    osmo login http://127.0.0.1 --method=dev --username=testuser
    osmo profile set pool default
-   osmo workflow submit deployments/workflows/verify-hello.yaml \
-     --pool default \
-     --format-type json
-   osmo workflow query <workflow-id> --format-type json
+   osmo workflow submit deployments/workflows/verify-hello.yaml
+   osmo workflow query <workflow-id>
 
 Query the returned workflow ID until its status is ``COMPLETED``. The workflow
 uses the default ``cpu`` platform.
@@ -365,10 +358,8 @@ If you used Option A, submit the GPU verification workflow too:
 
 .. code-block:: bash
 
-   osmo workflow submit deployments/workflows/verify-gpu.yaml \
-     --pool default \
-     --format-type json
-   osmo workflow query <workflow-id> --format-type json
+   osmo workflow submit deployments/workflows/verify-gpu.yaml
+   osmo workflow query <workflow-id>
 
 The GPU workflow explicitly uses the ``gpu`` platform and runs ``nvidia-smi``
 in a CUDA container, proving that OSMO and KAI scheduled it onto the GPU node

--- a/docs/deployment_guide/index.rst
+++ b/docs/deployment_guide/index.rst
@@ -123,7 +123,7 @@ An OSMO deployment consists of two main components:
   :hidden:
   :caption: Getting Started
 
-  getting_started/infrastructure_setup
+  Split-plane Infrastructure <getting_started/infrastructure_setup>
   getting_started/create_storage/index
   getting_started/deploy_service
 
@@ -164,8 +164,8 @@ An OSMO deployment consists of two main components:
   :hidden:
   :caption: Additional Resources
 
-  appendix/deploy_local
-  appendix/deploy_minimal
+  Quickstart <appendix/deploy_local>
+  Single-plane Deployment <appendix/deploy_minimal>
   appendix/workflow_execution
   appendix/keycloak_setup
   appendix/authentication/index

--- a/docs/deployment_guide/introduction/architecture.rst
+++ b/docs/deployment_guide/introduction/architecture.rst
@@ -21,7 +21,13 @@
 Architecture
 ================================================
 
-OSMO is a distributed platform that separates control plane functionality (workflow management, API, UI) from compute plane functionality (where workflows actually execute). This separation allows you to manage multiple compute clusters from a single control point and scale compute resources independently.
+OSMO is a distributed platform that separates control plane functionality
+(workflow management, API, UI) from compute plane functionality (where
+workflows actually execute). The control and compute planes are logical
+planes: deploy them on separate clusters for a split-plane deployment, or run
+them together in one supported converged deployment. This separation allows
+you to manage multiple compute clusters from a single control point and scale
+compute resources independently.
 
 
 

--- a/docs/deployment_guide/introduction/whats_next.rst
+++ b/docs/deployment_guide/introduction/whats_next.rst
@@ -26,9 +26,36 @@ Now that you understand the OSMO deployment architecture, you're ready to begin 
 Ready to Begin?
 ===============
 
-Select one of the deployment options below depending on your needs and deployment environment to get started.
+Select the deployment model that fits your needs and environment.
 
 .. only:: html
 
-  .. raw:: html
-     :file: ../../deployment_options.svg
+  .. grid:: 1 2 2 2
+      :gutter: 3
+
+      .. grid-item-card:: :octicon:`rocket` Quickstart
+          :link: ../appendix/deploy_local
+          :class-card: tool-card
+
+          Run the complete OSMO control plane, compute plane, and a GPU
+          workflow on a local NVIDIA GPU workstation.
+
+      .. grid-item-card:: :octicon:`package` Self-contained Deployment
+          :class-card: tool-card
+
+          Run the control and compute planes together in a self-contained
+          environment when you need a converged deployment model.
+
+      .. grid-item-card:: :octicon:`server` Single-plane Deployment
+          :link: ../appendix/deploy_minimal
+          :class-card: tool-card
+
+          Deploy the service and backend operator in the same Kubernetes
+          cluster for testing, development, or evaluation.
+
+      .. grid-item-card:: :octicon:`workflow` Split-plane Infrastructure
+          :link: ../getting_started/infrastructure_setup
+          :class-card: tool-card
+
+          Prepare infrastructure for control and compute planes deployed on
+          separate clusters.

--- a/docs/deployment_guide/introduction/whats_next.rst
+++ b/docs/deployment_guide/introduction/whats_next.rst
@@ -35,19 +35,15 @@ Select the deployment model that fits your needs and environment.
 
       .. grid-item-card:: :octicon:`rocket` Quickstart
           :link: ../appendix/deploy_local
+          :link-type: doc
           :class-card: tool-card
 
           Run the complete OSMO control plane, compute plane, and a GPU
           workflow on a local NVIDIA GPU workstation.
 
-      .. grid-item-card:: :octicon:`package` Self-contained Deployment
-          :class-card: tool-card
-
-          Run the control and compute planes together in a self-contained
-          environment when you need a converged deployment model.
-
       .. grid-item-card:: :octicon:`server` Single-plane Deployment
           :link: ../appendix/deploy_minimal
+          :link-type: doc
           :class-card: tool-card
 
           Deploy the service and backend operator in the same Kubernetes
@@ -55,6 +51,7 @@ Select the deployment model that fits your needs and environment.
 
       .. grid-item-card:: :octicon:`workflow` Split-plane Infrastructure
           :link: ../getting_started/infrastructure_setup
+          :link-type: doc
           :class-card: tool-card
 
           Prepare infrastructure for control and compute planes deployed on

--- a/docs/deployment_guide/requirements/prereqs.rst
+++ b/docs/deployment_guide/requirements/prereqs.rst
@@ -33,7 +33,7 @@ Before deploying OSMO, ensure you have the following cloud components:
       .. grid-item-card:: :octicon:`stack` Kubernetes Cluster
           :class-card: tool-card
 
-          **Version**: 1.27 or higher
+          **Version**: 1.30 or higher
 
           Container orchestration platform for deploying and managing OSMO services.
 
@@ -44,17 +44,24 @@ Before deploying OSMO, ensure you have the following cloud components:
 
           Primary database for storing OSMO application data and metadata.
 
-      .. grid-item-card:: :octicon:`zap` Redis Instance
+      .. grid-item-card:: :octicon:`zap` Redis or Valkey Instance
           :class-card: tool-card
 
           **Version**: 7.0 or higher
 
           In-memory data store for caching and session management.
 
-      .. grid-item-card:: :octicon:`lock` Virtual Private Network (VPC)
+      .. grid-item-card:: :octicon:`database` Object Storage
           :class-card: tool-card
 
-          Network with subnets for the Kubernetes cluster, PostgreSQL database, and Redis instance.
+          **Type**: S3-compatible or Azure Blob Storage
+
+          Object storage for workflow inputs, outputs, logs, and applications.
+
+      .. grid-item-card:: :octicon:`lock` Virtual Network
+          :class-card: tool-card
+
+          Network with subnets for the Kubernetes cluster, PostgreSQL database, and Redis or Valkey instance.
 
           **Required for**: Secure communication between components
 

--- a/docs/deployment_guide/requirements/system_reqs.rst
+++ b/docs/deployment_guide/requirements/system_reqs.rst
@@ -48,7 +48,7 @@ Minimum system instance requirements to deploy OSMO and its related cloud compon
           - **Memory**: 4 GB
           - **Storage**: 32 GB
 
-      .. grid-item-card:: :octicon:`cache` Redis
+      .. grid-item-card:: :octicon:`cache` Redis or Valkey
           :class-card: requirement-card
 
           **Cache Configuration:**

--- a/docs/deployment_guide/requirements/tools.rst
+++ b/docs/deployment_guide/requirements/tools.rst
@@ -40,14 +40,6 @@ Tools
 
           Required for managing and inspecting cluster resources.
 
-      .. grid-item-card:: :octicon:`database` psql
-          :link: https://www.postgresql.org/docs/current/app-psql.html
-          :class-card: tool-card
-
-          PostgreSQL client.
-
-          Required for database initialization and management tasks.
-
       .. grid-item-card:: :octicon:`file-code` OSMO Client
           :link: ../../user_guide/getting_started/install/index
           :link-type: doc

--- a/docs/deployment_options.svg
+++ b/docs/deployment_options.svg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b0e8551dc29e62653b6edfe920e170bb840e1d36598c37b7e6a830ac6b42a28
-size 8935

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -257,6 +257,7 @@ py
 Pydantic
 Pytorch
 Quickstart
+quickstart
 ReadTimeoutError
 realtime
 rearchitected

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -28,8 +28,6 @@ autoscaling
 aws
 backend
 backends
-Bazel
-Bazelisk
 balancer
 balancers
 basename

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -347,6 +347,7 @@ validator
 validators
 verifier
 vCPUs
+Valkey
 VNet
 Volce
 volumeMounts

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -28,6 +28,8 @@ autoscaling
 aws
 backend
 backends
+Bazel
+Bazelisk
 balancer
 balancers
 basename


### PR DESCRIPTION
## Description
Update the docs to be inline with the new chart

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded GPU and CPU local-deployment quickstarts with setup, prerequisites, verification, authentication, and cleanup guidance.
  * Clarified split-plane and converged architectures, including independently scalable compute resources.
  * Replaced the deployment-options diagram with navigation cards for Quickstart, self-contained, single-plane, and split-plane deployments.
  * Updated prerequisites for Kubernetes 1.30+, Redis or Valkey, and S3-compatible or Azure Blob storage.
  * Removed the `psql` entry from documented deployment tools.
  * Updated deployment profiles with CPU defaults, GPU resource configuration, revised encryption-key rotation guidance, and KAI Scheduler setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->