### PR TITLE
Update docs to add self-contained deployment

### DIFF
--- a/deployments/charts/osmo/examples/self-contained-environment-values.yaml
+++ b/deployments/charts/osmo/examples/self-contained-environment-values.yaml
@@ -4,8 +4,32 @@
 # Non-secret, environment-specific values for the self-contained profile.
 externalUrl: https://osmo.example.com
 
+podDefaults:
+  nodeSelector:
+    osmo.nvidia.com/node-pool: control-plane
+
+secrets:
+  serviceAuth:
+    bootstrap:
+      nodeSelector:
+        osmo.nvidia.com/node-pool: control-plane
+
+configuration:
+  podTemplates:
+    default_ctrl:
+      spec:
+        nodeSelector:
+          osmo.nvidia.com/node-pool: compute
+    default_user:
+      spec:
+        nodeSelector:
+          osmo.nvidia.com/node-pool: compute
+    default_gpu_user:
+      spec:
+        nodeSelector:
+          osmo.nvidia.com/node-pool: compute
+
 compute:
-  backendName: default
   workflowNetworkPolicy:
     clusterCIDRs:
     - 10.0.0.0/8
@@ -24,3 +48,28 @@ gateway:
         jwks_uri: https://idp.example.com/.well-known/jwks.json
         cluster: idp
         user_claim: preferred_username
+
+services:
+  api:
+    auth:
+      enabled: true
+      deviceEndpoint: https://idp.example.com/realms/osmo/protocol/openid-connect/auth/device
+      deviceClientId: osmo-cli
+      browserEndpoint: https://idp.example.com/realms/osmo/protocol/openid-connect/auth
+      browserClientId: osmo
+      tokenEndpoint: https://idp.example.com/realms/osmo/protocol/openid-connect/token
+      logoutEndpoint: https://idp.example.com/realms/osmo/protocol/openid-connect/logout
+
+postgresql:
+  cluster:
+    affinity:
+      nodeSelector:
+        osmo.nvidia.com/node-pool: control-plane
+
+valkey:
+  nodeSelector:
+    osmo.nvidia.com/node-pool: control-plane
+
+rustfs:
+  nodeSelector:
+    osmo.nvidia.com/node-pool: control-plane

--- a/deployments/charts/osmo/examples/self-contained-environment-values.yaml
+++ b/deployments/charts/osmo/examples/self-contained-environment-values.yaml
@@ -2,18 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Non-secret, environment-specific values for the self-contained profile.
+
+# Replace with the public HTTPS URL where users and the OSMO CLI reach OSMO.
 externalUrl: https://osmo.example.com
 
+# Place OSMO services and chart-owned bootstrap Jobs on platform nodes. Keep
+# this label in sync with the labels applied to your Kubernetes nodes.
 podDefaults:
   nodeSelector:
     osmo.nvidia.com/node-pool: control-plane
 
+# The service-auth bootstrap Job has its own scheduling settings and therefore
+# repeats the platform-node selector.
 secrets:
   serviceAuth:
     bootstrap:
       nodeSelector:
         osmo.nvidia.com/node-pool: control-plane
 
+# Place the built-in workflow Pod templates on compute nodes. Apply the same
+# selector to any additional workflow Pod templates you create.
 configuration:
   podTemplates:
     default_ctrl:
@@ -31,18 +39,24 @@ configuration:
 
 compute:
   workflowNetworkPolicy:
+    # Replace with every IPv4 Pod and Service CIDR used by your cluster.
     clusterCIDRs:
     - 10.0.0.0/8
 
 gateway:
   oauth2Proxy:
+    # Replace with the exact issuer in your identity provider's tokens and the
+    # confidential browser client whose Secret is stored in osmo-oauth2-proxy.
     oidcIssuerUrl: https://idp.example.com
     clientId: osmo
   envoy:
     idp:
+      # Replace with the identity-provider DNS host, without a URL scheme.
       host: idp.example.com
     jwt:
       additionalProviders:
+      # Replace issuer, audience, JWKS URL, and user claim to match issued
+      # tokens. Keep cluster set to idp so Envoy uses the host configured above.
       - issuer: https://idp.example.com
         audience: osmo
         jwks_uri: https://idp.example.com/.well-known/jwks.json
@@ -53,6 +67,8 @@ services:
   api:
     auth:
       enabled: true
+      # Replace these endpoints and client IDs with the public device-flow CLI
+      # client and confidential browser client registered with your provider.
       deviceEndpoint: https://idp.example.com/realms/osmo/protocol/openid-connect/auth/device
       deviceClientId: osmo-cli
       browserEndpoint: https://idp.example.com/realms/osmo/protocol/openid-connect/auth
@@ -63,13 +79,16 @@ services:
 postgresql:
   cluster:
     affinity:
+      # Keep embedded PostgreSQL on platform nodes.
       nodeSelector:
         osmo.nvidia.com/node-pool: control-plane
 
 valkey:
+  # Keep embedded Valkey on platform nodes.
   nodeSelector:
     osmo.nvidia.com/node-pool: control-plane
 
 rustfs:
+  # Keep embedded RustFS on platform nodes.
   nodeSelector:
     osmo.nvidia.com/node-pool: control-plane

--- a/deployments/charts/osmo/templates/mek-bootstrap.yaml
+++ b/deployments/charts/osmo/templates/mek-bootstrap.yaml
@@ -144,6 +144,10 @@ spec:
       serviceAccountName: {{ $name | quote }}
       automountServiceAccountToken: false
       {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.podDefaults.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: mek-lifecycle
         image: {{ include "osmo.component.image" (dict "root" . "component" .Values.services.api) }}

--- a/deployments/charts/osmo/templates/object-storage-bootstrap.yaml
+++ b/deployments/charts/osmo/templates/object-storage-bootstrap.yaml
@@ -42,6 +42,10 @@ spec:
     spec:
       automountServiceAccountToken: false
       {{- include "osmo.component.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.podDefaults.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -162,6 +162,9 @@ resource_names() {
         document_kind == kind && in_metadata && /^  name: / {
             name = $0
             sub(/^  name: /, "", name)
+            if (substr(name, 1, 1) == "\"") {
+                name = substr(name, 2, length(name) - 2)
+            }
             print name
             document_kind = ""
             in_metadata = 0
@@ -713,6 +716,10 @@ test_control_umbrella() {
     require_deployment "$TEST_DIRECTORY/self-contained.yaml" \
         "osmo-gateway-authz"
     resource_document "$TEST_DIRECTORY/self-contained.yaml" Deployment \
+        "osmo-api" >"$TEST_DIRECTORY/self-contained-api.yaml"
+    require_contains "$TEST_DIRECTORY/self-contained-api.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
+    resource_document "$TEST_DIRECTORY/self-contained.yaml" Deployment \
         "osmo-gateway-oauth2-proxy" \
         >"$TEST_DIRECTORY/self-contained-oauth2-proxy.yaml"
     require_occurrences "$TEST_DIRECTORY/self-contained-oauth2-proxy.yaml" \
@@ -756,6 +763,9 @@ test_control_umbrella() {
     require_contains \
         "$TEST_DIRECTORY/self-contained-backend-token-bootstrap.yaml" \
         'image: "alpine/k8s@sha256:3c6d1e613d94f03d63a6213b8687c7d4e5b9154903327aa8f0b5d628d7ab010b"'
+    require_contains \
+        "$TEST_DIRECTORY/self-contained-backend-token-bootstrap.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
     require_contains \
         "$TEST_DIRECTORY/self-contained-workflow-network-policy.yaml" \
         "kubernetes.io/metadata.name: osmo"
@@ -807,11 +817,15 @@ test_control_umbrella() {
         "number: 1"
     require_contains "$TEST_DIRECTORY/self-contained-postgresql.yaml" \
         "dataDurability: required"
+    require_contains "$TEST_DIRECTORY/self-contained-postgresql.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
     require_resource "$TEST_DIRECTORY/self-contained.yaml" StatefulSet \
         "osmo-valkey"
     resource_document "$TEST_DIRECTORY/self-contained.yaml" StatefulSet \
         "osmo-valkey" >"$TEST_DIRECTORY/self-contained-valkey.yaml"
     require_contains "$TEST_DIRECTORY/self-contained-valkey.yaml" "replicas: 3"
+    require_contains "$TEST_DIRECTORY/self-contained-valkey.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
     resource_document "$TEST_DIRECTORY/self-contained.yaml" ConfigMap \
         "osmo-valkey-init-scripts" \
         >"$TEST_DIRECTORY/self-contained-valkey-init.yaml"
@@ -836,6 +850,8 @@ test_control_umbrella() {
         "topologyKey: kubernetes.io/hostname"
     require_contains "$TEST_DIRECTORY/self-contained-rustfs.yaml" \
         "storage: 100Gi"
+    require_contains "$TEST_DIRECTORY/self-contained-rustfs.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
     resource_document "$TEST_DIRECTORY/self-contained.yaml" ConfigMap \
         "osmo-rustfs-config" >"$TEST_DIRECTORY/self-contained-rustfs-config.yaml"
     require_contains "$TEST_DIRECTORY/self-contained-rustfs-config.yaml" \
@@ -853,10 +869,26 @@ test_control_umbrella() {
         "osmo-backend-token-bootstrap"
     require_contains "$TEST_DIRECTORY/self-contained.yaml" \
         'name: "osmo-mek-bootstrap-'
+    resource_document_with_hash_suffix "$TEST_DIRECTORY/self-contained.yaml" \
+        Job mek-bootstrap >"$TEST_DIRECTORY/self-contained-mek-bootstrap.yaml"
+    require_contains "$TEST_DIRECTORY/self-contained-mek-bootstrap.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
     require_resource_with_hash_suffix "$TEST_DIRECTORY/self-contained.yaml" Job \
         "service-auth-bootstrap"
+    resource_document_with_hash_suffix "$TEST_DIRECTORY/self-contained.yaml" \
+        Job service-auth-bootstrap \
+        >"$TEST_DIRECTORY/self-contained-service-auth-bootstrap.yaml"
+    require_contains \
+        "$TEST_DIRECTORY/self-contained-service-auth-bootstrap.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
     require_resource_with_hash_suffix "$TEST_DIRECTORY/self-contained.yaml" Job \
         "object-storage-bootstrap"
+    resource_document_with_hash_suffix "$TEST_DIRECTORY/self-contained.yaml" \
+        Job object-storage-bootstrap \
+        >"$TEST_DIRECTORY/self-contained-object-storage-bootstrap.yaml"
+    require_contains \
+        "$TEST_DIRECTORY/self-contained-object-storage-bootstrap.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
     require_contains "$TEST_DIRECTORY/self-contained.yaml" \
         "secretName: osmo-backend-token"
     require_not_contains "$TEST_DIRECTORY/self-contained.yaml" \
@@ -896,6 +928,8 @@ test_control_umbrella() {
         "init: nvcr.io/nvidia/osmo/init-container:6.3.1"
     require_contains "$TEST_DIRECTORY/self-contained-config.yaml" \
         "client: nvcr.io/nvidia/osmo/client:6.3.1"
+    require_occurrences "$TEST_DIRECTORY/self-contained-config.yaml" \
+        "osmo.nvidia.com/node-pool: compute" 3
     require_not_contains "$TEST_DIRECTORY/self-contained-config.yaml" \
         "development_auth"
     require_contains "$TEST_DIRECTORY/self-contained.yaml" \
@@ -2484,7 +2518,12 @@ EOF
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
         --set secrets.masterEncryptionKey.managementMode=osmo \
         --set secrets.masterEncryptionKey.bootstrap.enabled=true \
+        --set-string 'podDefaults.nodeSelector.osmo\.nvidia\.com/node-pool=control-plane' \
         >"$TEST_DIRECTORY/mek-bootstrap.yaml"
+    resource_document_with_hash_suffix "$TEST_DIRECTORY/mek-bootstrap.yaml" \
+        Job mek-bootstrap >"$TEST_DIRECTORY/mek-bootstrap-job.yaml"
+    require_contains "$TEST_DIRECTORY/mek-bootstrap-job.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
     require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" 'command: ["mek-lifecycle"]'
     require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" '- "bootstrap"'
     require_contains "$TEST_DIRECTORY/mek-bootstrap.yaml" '--service_auth_file'
@@ -3493,6 +3532,7 @@ EOF
     helm_template embedded-object-storage "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \
         -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        --set-string 'podDefaults.nodeSelector.osmo\.nvidia\.com/node-pool=control-plane' \
         "${embedded_object_storage_settings[@]}" \
         >"$TEST_DIRECTORY/osmo-embedded-object-storage.yaml"
 
@@ -3551,6 +3591,8 @@ EOF
     resource_document_with_hash_suffix "$TEST_DIRECTORY/osmo-embedded-object-storage.yaml" \
         Job object-storage-bootstrap \
         >"$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml"
+    require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
+        "osmo.nvidia.com/node-pool: control-plane"
     require_not_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \
         "helm.sh/hook"
     require_contains "$TEST_DIRECTORY/osmo-object-storage-bootstrap-job.yaml" \

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -384,6 +384,12 @@ credentials, workflow state, and all other quickstart data disappear when the
 cluster is deleted. Do not use this quickstart for production data or any
 long-lived environment.
 
+.. seealso::
+
+   For a persistent, highly available local or edge installation, use the
+   :ref:`Self-contained Deployment
+   <deploy_self_contained>` guide.
+
 Clean up resources
 ==================
 

--- a/docs/deployment_guide/appendix/deploy_self_contained.rst
+++ b/docs/deployment_guide/appendix/deploy_self_contained.rst
@@ -1,0 +1,331 @@
+..
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+
+.. _deploy_self_contained:
+
+===========================
+Self-contained Deployment
+===========================
+
+A self-contained deployment runs the OSMO control plane, compute plane, and
+stateful dependencies in one non-cloud Kubernetes cluster. It is intended for
+edge sites, labs, and other environments that must keep the complete OSMO stack
+local while retaining data and service availability across Pod or node
+failures.
+
+Choose this deployment model when you need more durability and availability
+than the :ref:`Quickstart <quickstart>` can provide and the independently
+managed dependencies of a single-plane or split-plane deployment are not
+appropriate. The ``self-contained.yaml`` profile installs the control and
+compute planes together and provides multiple replicas for critical OSMO
+services, a synchronously replicated PostgreSQL cluster, persistent Valkey
+replicas, distributed RustFS with erasure coding, PodDisruptionBudgets,
+topology rules, OIDC authentication, authorization, internal TLS, and network
+isolation.
+
+.. important::
+
+   A highly available deployment still requires highly available nodes,
+   networking, and persistent storage. The Kubernetes cluster, storage system,
+   network, and site remain shared failure domains. Replication does not replace
+   tested backups and recovery procedures.
+
+Prerequisites
+=============
+
+Run the commands in this guide from the root of an OSMO repository clone. Set
+your current kubectl context to the Kubernetes cluster where you want to
+install OSMO before continuing.
+
+The cluster must provide:
+
+* Kubernetes 1.30 or newer;
+* at least four nodes labeled
+  ``osmo.nvidia.com/node-pool=control-plane``, with enough failure-domain
+  capacity for three PostgreSQL Pods, three Valkey Pods, and four RustFS Pods;
+* at least one node labeled ``osmo.nvidia.com/node-pool=compute`` for workflow
+  Pods;
+* a default dynamic ``StorageClass`` backed by durable storage;
+* a CNI that enforces Kubernetes ``NetworkPolicy`` resources;
+* the IPv4 Pod and Service CIDRs used by the cluster network;
+* network access to the OSMO and dependency image registries; and
+* DNS and time synchronization across the nodes.
+
+Install ``kubectl``, Helm, Docker, and the OSMO CLI. Confirm cluster access,
+node capacity, and the default ``StorageClass``:
+
+.. code-block:: bash
+
+   kubectl version
+   kubectl get nodes
+   kubectl get storageclass
+
+Label the nodes that will host the OSMO platform and the nodes that will run
+workflows. The ``control-plane`` value identifies OSMO platform nodes; these do
+not need to be Kubernetes control-plane nodes.
+
+.. code-block:: bash
+
+   kubectl label node \
+     <platform-node-1> <platform-node-2> <platform-node-3> <platform-node-4> \
+     osmo.nvidia.com/node-pool=control-plane
+   kubectl label node <compute-node-1> \
+     osmo.nvidia.com/node-pool=compute
+   kubectl get nodes --label-columns=osmo.nvidia.com/node-pool
+
+The profile creates three 20 GiB PostgreSQL volumes and four 100 GiB RustFS
+volumes in addition to persistent Valkey storage. Account for storage-provider
+overhead, backups, and the resources requested by concurrent workflows.
+
+Identity and edge requirements
+------------------------------
+
+Register a confidential browser client and a public device-flow CLI client with
+an identity provider reachable by users and the OSMO gateway. The provider can
+run inside or outside the cluster. Its tokens must contain an array-valued
+``roles`` claim and the audience expected by OSMO. Assign trusted operators the
+``osmo-admin`` role and workflow users the ``osmo-user`` role.
+
+Prepare these non-secret OIDC values before installation:
+
+* the issuer URL, browser client ID, browser authorization and logout
+  endpoints, audience, and JWKS URL;
+* the CLI client ID, device authorization endpoint, and token endpoint;
+* the identity-provider host reachable from the gateway;
+* the token claim that contains the user name; and
+* the public HTTPS URL for OSMO.
+
+The profile creates a ``ClusterIP`` gateway. Configure an operator-managed edge
+to terminate public TLS and route the public URL to the ``osmo-gateway`` Service
+on port 80. Validate the edge and the CNI's NetworkPolicy enforcement before
+exposing OSMO to users.
+
+Install cluster dependencies
+============================
+
+Install KAI Scheduler v0.12.10 for OSMO workflow scheduling:
+
+.. code-block:: bash
+
+   helm upgrade --install kai-scheduler \
+     oci://ghcr.io/nvidia/kai-scheduler/kai-scheduler \
+     --version v0.12.10 \
+     --create-namespace -n kai-scheduler \
+     --set-string 'global.nodeSelector.osmo\.nvidia\.com/node-pool=control-plane' \
+     --set "scheduler.additionalArgs[0]=--default-staleness-grace-period=-1s" \
+     --set "scheduler.additionalArgs[1]=--update-pod-eviction-condition=true" \
+     --wait
+
+Install CloudNativePG chart 0.29.0. The operator manages the PostgreSQL cluster
+created by the OSMO release:
+
+.. code-block:: bash
+
+   helm repo add cnpg https://cloudnative-pg.github.io/charts
+   helm repo update cnpg
+   helm upgrade --install cnpg cnpg/cloudnative-pg \
+     --version 0.29.0 \
+     --namespace cnpg-system \
+     --create-namespace \
+     --set-string 'nodeSelector.osmo\.nvidia\.com/node-pool=control-plane' \
+     --wait \
+     --timeout 10m
+
+Create the OAuth Secret
+=======================
+
+Create the release namespace. Prepare files that contain the OIDC client Secret
+and a 32-byte random cookie Secret without trailing newlines, then create the
+OAuth Secret without putting either value in Helm values or shell arguments:
+
+.. code-block:: bash
+
+   kubectl create namespace osmo
+   kubectl --namespace osmo create secret generic osmo-oauth2-proxy \
+     --from-file=client_secret=/secure/path/oidc-client-secret \
+     --from-file=cookie_secret=/secure/path/oauth-cookie-secret
+
+Install OSMO
+============
+
+Helm profiles are values overlays, not a ``profile`` setting. Copy the provided
+self-contained environment example and replace every example identity,
+network, and URL value for the target environment. Keep this environment file
+separate from the production profile so that upgrades can reuse it.
+
+The ``clusterCIDRs`` list must cover every IPv4 Pod and Service CIDR used by the
+cluster. Add entries when the cluster uses more than one CIDR.
+
+The dependency commands place KAI Scheduler and the PostgreSQL operator on
+nodes with the ``control-plane`` label. The example environment overlay applies
+the same selector to OSMO services and bootstrap Jobs, PostgreSQL, Valkey, and
+RustFS. It also adds the ``compute`` selector to the default workflow Pod
+templates. If you add pool-specific Pod templates or replace the default
+templates, retain the compute-node selector so workflows do not run on OSMO
+platform nodes.
+
+.. code-block:: bash
+
+   cp deployments/charts/osmo/examples/self-contained-environment-values.yaml \
+     self-contained-environment-values.yaml
+   # Edit self-contained-environment-values.yaml for the target environment.
+
+   helm dependency build deployments/charts/osmo
+   helm upgrade --install osmo deployments/charts/osmo \
+     --namespace osmo \
+     --values deployments/charts/osmo/profiles/self-contained.yaml \
+     --values self-contained-environment-values.yaml \
+     --wait \
+     --wait-for-jobs \
+     --timeout 30m
+
+The chart uses its application version for OSMO images and the cluster's
+default ``StorageClass``. The self-contained profile enables the service-auth
+bootstrap Job, which creates the shared service identity during installation.
+The chart also creates the local database, cache, object storage, required
+buckets, workflow namespace, configuration, backend bootstrap credential, and
+retained master encryption key.
+
+Validate the deployment
+=======================
+
+Verify the public edge and log in through the configured identity provider:
+
+.. code-block:: bash
+
+   curl --fail https://osmo.edge.example.com/api/version
+   osmo login https://osmo.edge.example.com --method=code
+   osmo profile set pool default
+   osmo workflow submit deployments/workflows/verify-hello.yaml \
+     --pool default \
+     --format-type json
+   osmo workflow query <workflow-id> --format-type json
+
+Repeat the query until the workflow status is ``COMPLETED``. A ``FAILED``,
+``CANCELLED``, or timed-out workflow is a validation failure. Inspect its logs
+and Kubernetes events before retrying.
+
+Troubleshooting
+===============
+
+Start with release status, workloads, PVCs, and recent events:
+
+.. code-block:: bash
+
+   helm status osmo --namespace osmo
+   kubectl --namespace osmo get pods,statefulsets,pvc,jobs
+   kubectl --namespace osmo get events --sort-by=.lastTimestamp
+   kubectl --namespace osmo-workflows get pods,networkpolicy
+
+Common causes include:
+
+* A ``Pending`` PostgreSQL, Valkey, or RustFS PVC means the default
+  ``StorageClass`` is absent, lacks capacity, or cannot bind on an eligible
+  node.
+* Unschedulable PostgreSQL or RustFS Pods usually mean fewer than four eligible
+  nodes are available or required hostname anti-affinity cannot be satisfied.
+* A workflow that remains queued usually means KAI Scheduler is not Ready or no
+  eligible node has the requested CPU, memory, GPU, or ephemeral storage.
+* An OAuth redirect loop or rejected token usually means the public URL, issuer,
+  audience, JWKS URL, client Secret, redirect URI, or role claim is inconsistent
+  between OSMO and the identity provider.
+* ``ImagePullBackOff`` means the image registry, tag, credentials, proxy, or
+  mirror configuration is incorrect.
+* A missing retained backend token, master encryption key, or stateful-service
+  credential blocks safe recovery. Restore the original Secret instead of
+  generating a replacement against retained data.
+
+Durability and availability
+===========================
+
+Quickstart is designed for a disposable workstation cluster with small
+single-node dependencies and one replica for each OSMO component. The
+self-contained profile instead supplies persistent, replicated dependencies and
+multiple replicas for critical stateless services:
+
+* PostgreSQL runs three instances and requires synchronous acknowledgment from
+  one standby;
+* Valkey runs one persistent primary and two persistent replicas with
+  write-safety checks; and
+* RustFS runs four instances with erasure coding and required hostname
+  anti-affinity.
+
+Valkey replication adds data redundancy, but the embedded chart has a fixed
+primary and no automatic promotion. Use an external Valkey service when
+automatic primary promotion or managed multi-zone recovery is required.
+
+The profile improves availability within one cluster. Use split-plane
+infrastructure and externally managed stateful services when control-plane
+isolation, multi-site recovery, or independent scaling is required.
+
+Upgrade and recovery
+====================
+
+Before an upgrade, back up PostgreSQL, RustFS, Valkey, and all retained
+credential Secrets. Keep the master encryption key with the database backup.
+Review the rendered change, then reuse the installed profile and environment
+values:
+
+.. code-block:: bash
+
+   helm upgrade osmo deployments/charts/osmo \
+     --namespace osmo \
+     --values deployments/charts/osmo/profiles/self-contained.yaml \
+     --values self-contained-environment-values.yaml \
+     --wait \
+     --wait-for-jobs \
+     --timeout 30m
+
+Do not replace ``osmo-master-encryption-key``, ``osmo-backend-token``, or the
+stateful-service credentials while retaining their data. Embedded backup and
+restore are not managed by the OSMO chart. Follow CloudNativePG and storage
+provider procedures, and test full recovery on a separate cluster.
+
+Clean up resources
+==================
+
+Uninstall the OSMO release when you want to remove its active workloads:
+
+.. code-block:: bash
+
+   helm uninstall osmo --namespace osmo --wait
+   kubectl --namespace osmo get pvc,secrets
+   kubectl get namespace osmo-workflows
+
+Generated credentials, stateful PVCs, the ``osmo-workflows`` namespace, and its
+NetworkPolicy can be retained. CloudNativePG data retention follows the
+operator and ``Cluster`` settings. Back up and inspect retained resources before
+deleting them.
+
+For a disposable installation, delete both namespaces and all remaining local
+data only after confirming that recovery is not required:
+
+.. code-block:: bash
+
+   kubectl delete namespace osmo osmo-workflows \
+     --wait=true \
+     --timeout=10m
+
+Remove the prerequisite operators only when no other workloads use them and no
+CloudNativePG ``Cluster`` resources remain:
+
+.. code-block:: bash
+
+   helm uninstall kai-scheduler --namespace kai-scheduler --wait
+   helm uninstall cnpg --namespace cnpg-system --wait
+
+Remove the operator-managed public edge separately when it is no longer used.

--- a/docs/deployment_guide/appendix/deploy_self_contained.rst
+++ b/docs/deployment_guide/appendix/deploy_self_contained.rst
@@ -278,9 +278,7 @@ Common causes include:
 Durability and availability
 ===========================
 
-Quickstart is designed for a disposable workstation cluster with small
-single-node dependencies and one replica for each OSMO component. The
-self-contained profile instead supplies persistent, replicated dependencies and
+The self-contained profile supplies persistent, replicated dependencies and
 multiple replicas for critical stateless services:
 
 * PostgreSQL runs three instances and requires synchronous acknowledgment from

--- a/docs/deployment_guide/appendix/deploy_self_contained.rst
+++ b/docs/deployment_guide/appendix/deploy_self_contained.rst
@@ -44,6 +44,8 @@ isolation.
    network, and site remain shared failure domains. Replication does not replace
    tested backups and recovery procedures.
 
+.. _self_contained_prerequisites:
+
 Prerequisites
 =============
 
@@ -148,24 +150,37 @@ created by the OSMO release:
 Create the OAuth Secret
 =======================
 
-Create the release namespace. Prepare files that contain the OIDC client Secret
-and a 32-byte random cookie Secret without trailing newlines, then create the
-OAuth Secret without putting either value in Helm values or shell arguments:
+Create the release namespace. Prepare a file that contains the OIDC client
+Secret, then generate an exact 32-byte cookie Secret and create the OAuth
+Secret. Using files keeps both values out of Helm values and shell arguments.
+``head`` writes the requested number of random bytes without adding a trailing
+newline:
 
 .. code-block:: bash
 
    kubectl create namespace osmo
+   OAUTH_COOKIE_SECRET_FILE="$(mktemp)"
+   head -c 32 /dev/urandom > "${OAUTH_COOKIE_SECRET_FILE}"
    kubectl --namespace osmo create secret generic osmo-oauth2-proxy \
      --from-file=client_secret=/secure/path/oidc-client-secret \
-     --from-file=cookie_secret=/secure/path/oauth-cookie-secret
+     --from-file="cookie_secret=${OAUTH_COOKIE_SECRET_FILE}"
+   rm "${OAUTH_COOKIE_SECRET_FILE}"
 
 Install OSMO
 ============
 
-Helm profiles are values overlays, not a ``profile`` setting. Copy the provided
-self-contained environment example and replace every example identity,
-network, and URL value for the target environment. Keep this environment file
-separate from the production profile so that upgrades can reuse it.
+Helm profiles are values overlays, not a ``profile`` setting. The environment
+overlay below is the file supplied with the chart. Before installing, replace:
+
+* ``externalUrl`` with the public HTTPS URL for OSMO;
+* every example identity-provider URL, host, client ID, audience, and claim;
+* ``clusterCIDRs`` with every IPv4 Pod and Service CIDR used by the cluster; and
+* node-selector keys or values only if you used labels other than those shown
+  in :ref:`the prerequisites <self_contained_prerequisites>`.
+
+Keep the ``cluster: idp`` value unless you also define a different Envoy cluster
+for the identity provider. Keep all environment-specific values separate from
+the production profile so that upgrades can reuse them.
 
 The ``clusterCIDRs`` list must cover every IPv4 Pod and Service CIDR used by the
 cluster. Add entries when the cluster uses more than one CIDR.
@@ -178,11 +193,17 @@ templates. If you add pool-specific Pod templates or replace the default
 templates, retain the compute-node selector so workflows do not run on OSMO
 platform nodes.
 
+Review the complete environment overlay before copying it:
+
+.. literalinclude:: ../../../deployments/charts/osmo/examples/self-contained-environment-values.yaml
+   :language: yaml
+   :start-after: SPDX-License-Identifier: Apache-2.0
+
 .. code-block:: bash
 
    cp deployments/charts/osmo/examples/self-contained-environment-values.yaml \
      self-contained-environment-values.yaml
-   # Edit self-contained-environment-values.yaml for the target environment.
+   # Replace the example values described above.
 
    helm dependency build deployments/charts/osmo
    helm upgrade --install osmo deployments/charts/osmo \
@@ -233,6 +254,11 @@ Start with release status, workloads, PVCs, and recent events:
 
 Common causes include:
 
+* During initial startup, the backend worker and listener Pods may briefly enter
+  ``CrashLoopBackOff`` while they wait for the API Pods to become Ready. They
+  should recover automatically after the API is available. If the restarts
+  continue, inspect their logs and confirm that the API Pods and Service are
+  healthy.
 * A ``Pending`` PostgreSQL, Valkey, or RustFS PVC means the default
   ``StorageClass`` is absent, lacks capacity, or cannot bind on an eligible
   node.
@@ -295,8 +321,8 @@ stateful-service credentials while retaining their data. Embedded backup and
 restore are not managed by the OSMO chart. Follow CloudNativePG and storage
 provider procedures, and test full recovery on a separate cluster.
 
-Clean up resources
-==================
+Uninstall OSMO and Clean up Resources
+=====================================
 
 Uninstall the OSMO release when you want to remove its active workloads:
 

--- a/docs/deployment_guide/index.rst
+++ b/docs/deployment_guide/index.rst
@@ -165,6 +165,7 @@ An OSMO deployment consists of two main components:
   :caption: Additional Resources
 
   Quickstart <appendix/deploy_local>
+  Self-contained Deployment <appendix/deploy_self_contained>
   Single-plane Deployment <appendix/deploy_minimal>
   appendix/workflow_execution
   appendix/keycloak_setup

--- a/docs/deployment_guide/introduction/whats_next.rst
+++ b/docs/deployment_guide/introduction/whats_next.rst
@@ -41,6 +41,14 @@ Select the deployment model that fits your needs and environment.
           Run the complete OSMO control plane, compute plane, and a GPU
           workflow on a local NVIDIA GPU workstation.
 
+      .. grid-item-card:: :octicon:`package` Self-contained Deployment
+          :link: ../appendix/deploy_self_contained
+          :link-type: doc
+          :class-card: tool-card
+
+          Run the control plane, compute plane, and required dependencies in
+          one non-cloud Kubernetes cluster for edge and local environments.
+
       .. grid-item-card:: :octicon:`server` Single-plane Deployment
           :link: ../appendix/deploy_minimal
           :link-type: doc


### PR DESCRIPTION
## Description
Add self-contained deployment guide

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-contained Kubernetes deployment guide with GPU/CPU setup, authentication, validation, troubleshooting, upgrades, and recovery guidance.
  * Added node-placement configuration for control-plane workloads, bootstrap jobs, object storage, databases, caching, and compute workloads.
  * Added service-auth bootstrap configuration for supported deployment scenarios.
  * Enabled OIDC authentication settings in the self-contained deployment example.

* **Documentation**
  * Updated deployment navigation with dedicated Quickstart, Self-contained, Single-plane, and Split-plane Infrastructure guides.
  * Added deployment-option cards linking to the relevant guides.
  * Updated the Quickstart guide with GPU-focused setup, workflow verification, limitations, and cleanup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->