### PR TITLE
fix(skills): remove unsupported profile bucket command

### DIFF
--- a/skills/osmo-user/references/cli-commands.md
+++ b/skills/osmo-user/references/cli-commands.md
@@ -38,11 +38,11 @@ or tokens into chat.
 ```bash
 osmo profile list [--format-type json|text]
 osmo profile set pool <pool_name>
-osmo profile set bucket <bucket_name>
+osmo profile set notifications <email|slack> [true|false]
 ```
 
-Use `profile list` to discover default pool/bucket. Change settings only when
-the user explicitly asks.
+Use `profile list` to discover the default pool and notification preferences.
+Change settings only when the user explicitly asks.
 
 ## Pools and Resources
 


### PR DESCRIPTION
<!-- Title should be "#<issue number> - <commit title>"-->

## Description
Correct the osmo-user CLI reference to list the supported notifications setting in place of the unsupported bucket setting. Align profile guidance with the actual CLI settings.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Profile command reference to describe notification preference management.
  * Added guidance for configuring email and Slack notifications.
  * Clarified information about default pools and notification preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->