### PR TITLE
Migrate the unified chart's MCP to the single authentication path

### DIFF
--- a/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
@@ -41,6 +41,7 @@ setting detects this rotation and triggers Envoy to reload.
 {{- $mcpPath := "/mcp" }}
 {{- $mcpMetadataPath := "/.well-known/oauth-protected-resource/mcp" }}
 {{- $mcpResourceUrl := "" }}
+{{- $mcpTokenIssuer := "" }}
 {{- $mcpMetadataUrl := "" }}
 {{- $mcpServiceName := include "osmo.component.fullname" (dict "root" . "suffix" "mcp") }}
 {{- $jwtProviders := concat (default (list) $envoy.jwt.providers) (default (list) $envoy.jwt.additionalProviders) }}
@@ -60,25 +61,29 @@ setting detects this rotation and triggers Envoy to reload.
 {{- fail "services.mcp.enabled requires at least one gateway Envoy JWT provider" }}
 {{- end }}
 {{- $mcpResourceUrl = include "osmo.mcp.resourceUrl" . }}
-{{- if not (kindIs "slice" $mcp.authorizationServers) }}
-{{- fail "services.mcp.authorizationServers must be a list" }}
+{{- /*
+FastMCP publishes its own protected-resource and authorization-server metadata,
+so the gateway no longer needs the issuer and scope lists it used to synthesise
+those documents from. The relayed token's audience is the MCP resource URL, and
+it comes from the identity provider already configured for this deployment's own
+clients, so that audience is appended to the provider whose issuer matches
+rather than requiring a second, near-identical entry.
+
+The issuer is derivable: OpenID Connect Discovery defines the configuration URL
+as the issuer plus /.well-known/openid-configuration. accessTokenIssuer
+overrides it for a provider that issues access tokens elsewhere, as an
+application configured for v1-format tokens does.
+*/ -}}
+{{- $mcpTokenIssuer = $mcp.oidcProxy.oidc.accessTokenIssuer | default (trimSuffix "/.well-known/openid-configuration" (required "services.mcp.oidcProxy.oidc.configUrl is required when MCP is enabled" $mcp.oidcProxy.oidc.configUrl)) }}
+{{- $mcpTokenIssuer = trimSuffix "/" $mcpTokenIssuer }}
+{{- $mcpIssuerProviders := 0 }}
+{{- range $provider := $jwtProviders }}
+{{- if eq (trimSuffix "/" $provider.issuer) $mcpTokenIssuer }}
+{{- $mcpIssuerProviders = add1 $mcpIssuerProviders }}
 {{- end }}
-{{- if eq (len $mcp.authorizationServers) 0 }}
-{{- fail "services.mcp.authorizationServers must contain at least one issuer when MCP is enabled" }}
 {{- end }}
-{{- if not (kindIs "slice" $mcp.scopes) }}
-{{- fail "services.mcp.scopes must be a list" }}
-{{- end }}
-{{- if eq (len $mcp.scopes) 0 }}
-{{- fail "services.mcp.scopes must contain at least one scope when MCP is enabled" }}
-{{- end }}
-{{- range $scope := $mcp.scopes }}
-{{- if not (kindIs "string" $scope) }}
-{{- fail "services.mcp.scopes entries must be strings" }}
-{{- end }}
-{{- if eq (trim $scope) "" }}
-{{- fail "services.mcp.scopes entries must not be empty" }}
-{{- end }}
+{{- if eq $mcpIssuerProviders 0 }}
+{{- fail (printf "services.mcp.enabled requires a gateway Envoy JWT provider with issuer %s, which is where MCP's relayed tokens come from" $mcpTokenIssuer) }}
 {{- end }}
 {{- if and (not $mcp.image.repository) (not $mcp.image.name) }}
 {{- fail "services.mcp.image.repository or image.name is required when MCP is enabled" }}
@@ -302,9 +307,8 @@ data:
                 {{- end }}
 
                 {{- if $mcpEnabled }}
-                # RFC 9728 metadata is the only public MCP route. Keep the
-                # method and path exact so no neighboring path or write method
-                # inherits the authentication bypass.
+                # FastMCP serves its own RFC 9728 document, so the gateway
+                # forwards this path instead of synthesising it.
                 - name: mcp-protected-resource-metadata
                   match:
                     path: {{ $mcpMetadataPath }}
@@ -312,21 +316,9 @@ data:
                     - name: ":method"
                       string_match:
                         exact: GET
-                  direct_response:
-                    status: 200
-                    body:
-                      inline_string: {{ dict "resource" $mcpResourceUrl "authorization_servers" $mcp.authorizationServers "bearer_methods_supported" (list "header") "scopes_supported" $mcp.scopes | toJson | quote }}
-                  response_headers_to_add:
-                  - header:
-                      key: content-type
-                      value: application/json
-                    append_action: OVERWRITE_IF_EXISTS_OR_ADD
-                  # Inspector completes OAuth in its browser UI and fetches
-                  # this public, non-secret discovery document from localhost.
-                  - header:
-                      key: access-control-allow-origin
-                      value: "*"
-                    append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                  route:
+                    cluster: osmo-mcp
+                    timeout: 15s
                   typed_per_filter_config:
                     envoy.filters.http.jwt_authn:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
@@ -335,15 +327,77 @@ data:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
                       disabled: true
 
-                # Streamable HTTP uses the same exact endpoint for its
-                # supported methods. Authentication and semantic authorization
-                # remain enabled on this route.
+                # RFC 8414 path-aware authorization-server metadata. FastMCP
+                # registers it at the root, so the prefix is rewritten off.
+                - name: mcp-authorization-server-metadata
+                  match:
+                    path: /.well-known/oauth-authorization-server/mcp
+                    headers:
+                    - name: ":method"
+                      string_match:
+                        exact: GET
+                  route:
+                    cluster: osmo-mcp
+                    prefix_rewrite: /.well-known/oauth-authorization-server
+                    timeout: 15s
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+
+                # The /mcp/ prefix below publishes the container's whole root
+                # namespace, so any new non-OAuth root route must be carved out
+                # here too. Auth filters are off so the 404 is this route's own
+                # answer, not jwt_authn's 401 that a later change could move.
+                - name: mcp-health-not-public
+                  match:
+                    prefix: /mcp/health
+                  direct_response:
+                    status: 404
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+
+                # The MCP SDK registers OAuth at fixed root paths, so the
+                # gateway publishes them under /mcp -- matching what FastMCP
+                # advertises -- and rewrites the prefix off before forwarding.
+                - name: mcp-oauth
+                  match:
+                    prefix: /mcp/
+                  route:
+                    cluster: osmo-mcp
+                    prefix_rewrite: /
+                    timeout: 15s
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
+
+                # FastMCP validates its own token and relays the verified
+                # upstream token to protected /api.
                 - name: osmo-mcp
                   match:
                     path: {{ $mcpPath }}
                   route:
                     cluster: osmo-mcp
                     timeout: 0s
+                  typed_per_filter_config:
+                    envoy.filters.http.jwt_authn:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                      disabled: true
+                    envoy.filters.http.ext_authz:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                      disabled: true
                 {{- end }}
 
                 {{- if $gw.upstreams.router.enabled }}
@@ -505,38 +559,6 @@ data:
                         return
                       end
                     end
-            {{- if $mcpEnabled }}
-            - name: envoy.filters.http.lua.mcp-origin
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                default_source_code:
-                  inline_string: |
-                    function envoy_on_request(request_handle)
-                      local raw_path = request_handle:headers():get(":path") or ""
-                      local request_path = string.match(raw_path, "^[^?]*") or raw_path
-                      if request_path ~= {{ $mcpPath | quote }} then
-                        return
-                      end
-
-                      -- Native MCP clients omit Origin. A present Origin must
-                      -- exactly match the deployment's explicit allowlist.
-                      local origin = request_handle:headers():get("origin")
-                      if origin == nil then
-                        return
-                      end
-
-                      local allowed_origins = {}
-                      {{ range $origin := $mcp.allowedOrigins }}
-                      allowed_origins[{{ $origin | quote }}] = true
-                      {{ end }}
-                      if not allowed_origins[origin] then
-                        request_handle:respond(
-                          {[":status"] = "403", ["content-type"] = "text/plain"},
-                          "Origin is not allowed"
-                        )
-                      end
-                    end
-            {{- end }}
             {{- if $authnSkipPaths }}
             {{- /* Authn skip paths bypass both authn and authz. */}}
             # set_metadata has no path matcher of its own, so wrap it and
@@ -727,6 +749,9 @@ data:
                     issuer: {{ $provider.issuer }}
                     audiences:
                     - {{ $provider.audience }}
+                    {{- if and $mcpEnabled (eq (trimSuffix "/" $provider.issuer) $mcpTokenIssuer) (ne $provider.audience $mcpResourceUrl) }}
+                    - {{ $mcpResourceUrl }}
+                    {{- end }}
                     forward: true
                     payload_in_metadata: verified_jwt
                     from_headers:

--- a/deployments/charts/osmo/templates/mcp-service.yaml
+++ b/deployments/charts/osmo/templates/mcp-service.yaml
@@ -21,7 +21,28 @@
 {{- $mcpResourceUrl := include "osmo.mcp.resourceUrl" . }}
 {{- $gatewayUrl := trimSuffix "/mcp" $mcpResourceUrl }}
 {{- $requestTimeoutSeconds := toString $mcp.requestTimeoutSeconds }}
-{{- $reservedEnvNames := list "OSMO_MCP_HOST" "OSMO_MCP_PORT" "OSMO_GATEWAY_URL" "OSMO_MCP_REQUEST_TIMEOUT_SECONDS" }}
+{{- $oidcProxy := $mcp.oidcProxy }}
+{{- $oidcConfigUrl := required "services.mcp.oidcProxy.oidc.configUrl is required when MCP is enabled" $oidcProxy.oidc.configUrl }}
+{{- $oidcClientId := required "services.mcp.oidcProxy.oidc.clientId is required when MCP is enabled" $oidcProxy.oidc.clientId }}
+{{- $secretName := $oidcProxy.existingSecret.name }}
+{{- $secretMountPath := trimSuffix "/" $oidcProxy.existingSecret.mountPath }}
+{{- $oidcClientSecretFile := $oidcProxy.oidc.clientSecretFile }}
+{{- $redisPasswordFile := "" }}
+{{- if $secretName }}
+{{- $oidcClientSecretFile = printf "%s/%s" $secretMountPath (required "services.mcp.oidcProxy.existingSecret.clientSecretKey is required" $oidcProxy.existingSecret.clientSecretKey) }}
+{{- if $oidcProxy.existingSecret.redisPasswordKey }}
+{{- $redisPasswordFile = printf "%s/%s" $secretMountPath $oidcProxy.existingSecret.redisPasswordKey }}
+{{- end }}
+{{- end }}
+{{- if not $oidcClientSecretFile }}
+{{- fail "services.mcp.oidcProxy needs existingSecret.name, or oidc.clientSecretFile when the secret arrives another way" }}
+{{- end }}
+{{- /* Redis host, port and TLS come from the same valkey the rest of the chart
+uses; only the logical database is chosen here, to isolate proxy state. */ -}}
+{{- $redisHost := required "a valkey host is required when MCP is enabled" (include "osmo.valkey.host" .) }}
+{{- $redisScheme := ternary "rediss" "redis" (eq (include "osmo.valkey.tlsEnabled" .) "true") }}
+{{- $redisUrl := printf "%s://%s:%v/%v" $redisScheme $redisHost (include "osmo.valkey.port" .) $oidcProxy.redis.dbNumber }}
+{{- $reservedEnvNames := list "OSMO_MCP_HOST" "OSMO_MCP_PORT" "OSMO_GATEWAY_URL" "OSMO_MCP_REQUEST_TIMEOUT_SECONDS" "OSMO_MCP_ALLOWED_ORIGINS" "OSMO_MCP_AUTH_RESOURCE_URL" "OSMO_MCP_AUTH_REDIS_URL" "OSMO_MCP_AUTH_REDIS_PASSWORD_FILE" "OSMO_MCP_AUTH_REDIS_KEY_PREFIX" "OSMO_MCP_AUTH_OIDC_CONFIG_URL" "OSMO_MCP_AUTH_OIDC_CLIENT_ID" "OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE" "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER" "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE" "OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS" "OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS" "OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS" "OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS" "OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS" }}
 {{- range $env := $mcp.extraEnv }}
 {{- if has (toString (default "" $env.name)) $reservedEnvNames }}
 {{- fail (printf "services.mcp.extraEnv must not override managed variable %s" $env.name) }}
@@ -99,14 +120,57 @@ spec:
           value: {{ $gatewayUrl | quote }}
         - name: OSMO_MCP_REQUEST_TIMEOUT_SECONDS
           value: {{ $requestTimeoutSeconds | quote }}
+        {{- with $mcp.allowedOrigins }}
+        - name: OSMO_MCP_ALLOWED_ORIGINS
+          value: {{ join "," . | quote }}
+        {{- end }}
+        - name: OSMO_MCP_AUTH_RESOURCE_URL
+          value: {{ $mcpResourceUrl | quote }}
+        - name: OSMO_MCP_AUTH_REDIS_URL
+          value: {{ $redisUrl | quote }}
+        {{- if $redisPasswordFile }}
+        - name: OSMO_MCP_AUTH_REDIS_PASSWORD_FILE
+          value: {{ $redisPasswordFile | quote }}
+        {{- end }}
+        - name: OSMO_MCP_AUTH_REDIS_KEY_PREFIX
+          value: {{ $oidcProxy.redis.keyPrefix | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_CONFIG_URL
+          value: {{ $oidcConfigUrl | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_CLIENT_ID
+          value: {{ $oidcClientId | quote }}
+        - name: OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE
+          value: {{ $oidcClientSecretFile | quote }}
+        {{- with $oidcProxy.oidc.accessTokenIssuer }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER
+          value: {{ . | quote }}
+        {{- end }}
+        - name: OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE
+          value: {{ $oidcProxy.oidc.accessTokenRequiredScope | quote }}
+        - name: OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS
+          value: {{ $oidcProxy.accessTokenTtlSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS
+          value: {{ $oidcProxy.refreshTokenTtlSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS
+          value: {{ $oidcProxy.upstreamTimeoutSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS
+          value: {{ $oidcProxy.redis.connectTimeoutSeconds | int | quote }}
+        - name: OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS
+          value: {{ $oidcProxy.redis.operationTimeoutSeconds | int | quote }}
         {{- with $mcp.extraEnv }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
         resources:
           {{- toYaml $mcp.resources | nindent 10 }}
-        {{- if .Values.gateway.tls.enabled }}
+        {{- if or .Values.gateway.tls.enabled $secretName }}
         volumeMounts:
+        {{- if .Values.gateway.tls.enabled }}
         {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "mcp"))) | nindent 8 }}
+        {{- end }}
+        {{- if $secretName }}
+        - name: mcp-oidc-proxy
+          mountPath: {{ $secretMountPath }}
+          readOnly: true
+        {{- end }}
         {{- end }}
         {{- with (include "osmo.gateway.upstreamProbeYaml" (dict "probe" $mcp.livenessProbe "context" .)) }}
         livenessProbe:
@@ -121,9 +185,21 @@ spec:
           {{- . | nindent 10 }}
         {{- end }}
       {{- include "osmo.pod.extraContainers" $mcp | nindent 6 }}
-      {{- if or .Values.gateway.tls.enabled $mcp.pod.extraVolumes }}
+      {{- if or .Values.gateway.tls.enabled $mcp.pod.extraVolumes $secretName }}
       volumes:
       {{- include "osmo.gateway.upstreamTlsVolume" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "mcp"))) | nindent 6 }}
+      {{- if $secretName }}
+      - name: mcp-oidc-proxy
+        secret:
+          secretName: {{ $secretName }}
+          items:
+          - key: {{ $oidcProxy.existingSecret.clientSecretKey }}
+            path: {{ $oidcProxy.existingSecret.clientSecretKey }}
+          {{- with $oidcProxy.existingSecret.redisPasswordKey }}
+          - key: {{ . }}
+            path: {{ . }}
+          {{- end }}
+      {{- end }}
       {{- include "osmo.pod.extraVolumes" $mcp | nindent 6 }}
       {{- end }}
 

--- a/deployments/charts/osmo/tests/control-mcp-values.yaml
+++ b/deployments/charts/osmo/tests/control-mcp-values.yaml
@@ -5,10 +5,12 @@ services:
   mcp:
     enabled: true
     resourceUrl: https://osmo.example.com/mcp
-    authorizationServers:
-      - https://issuer.example.com
-    scopes:
-      - mcp:Access
+    oidcProxy:
+      oidc:
+        configUrl: https://issuer.example.com/.well-known/openid-configuration
+        clientId: example-mcp-client
+      existingSecret:
+        name: mcp-oidc-proxy-secrets
 
 gateway:
   authz:

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -37,6 +37,12 @@ require_contains() {
     grep -Fq -- "$expected" "$file" || fail "expected '$expected' in $file"
 }
 
+require_matches() {
+    local file=$1
+    local pattern=$2
+    grep -Eq -- "$pattern" "$file" || fail "expected /$pattern/ in $file"
+}
+
 require_schema_path() {
     local file=$1
     local expected=$2
@@ -1674,8 +1680,9 @@ test_control_umbrella() {
         --set services.mcp.enabled=true \
         --set gateway.authz.enabled=true \
         --set-string services.mcp.resourceUrl=https://osmo.example.com/mcp \
-        --set-string 'services.mcp.authorizationServers[0]=https://login.example.com' \
-        --set-string 'services.mcp.scopes[0]=mcp.read' \
+        --set-string 'services.mcp.oidcProxy.oidc.configUrl=https://login.example.com/.well-known/openid-configuration' \
+        --set-string 'services.mcp.oidcProxy.oidc.clientId=example-client' \
+        --set-string 'services.mcp.oidcProxy.existingSecret.name=mcp-oidc' \
         --set-string 'gateway.envoy.jwt.providers[0].issuer=https://login.example.com' \
         --set-string 'gateway.envoy.jwt.providers[0].audience=https://osmo.example.com/mcp' \
         --set-string 'gateway.envoy.jwt.providers[0].jwks_uri=https://login.example.com/keys' \
@@ -4538,10 +4545,28 @@ EOF
     require_deployment "$TEST_DIRECTORY/osmo-mcp.yaml" "osmo-mcp"
     require_deployment "$TEST_DIRECTORY/osmo-mcp.yaml" "osmo-gateway-authz"
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "path: /mcp"
+    # FastMCP serves its own metadata now, so the gateway forwards these
+    # paths instead of synthesising a document, and publishes the OAuth
+    # endpoints under /mcp with the prefix rewritten off before forwarding.
+    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "name: mcp-oauth"
+    # Anchored: a fixed-string check for "prefix_rewrite: /" also matches the
+    # authorization-server rewrite below it, and would pass with this one gone.
+    require_matches "$TEST_DIRECTORY/osmo-mcp.yaml" "prefix_rewrite: /$"
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
-        '\"resource\":\"https://osmo.example.com/mcp\"'
+        "name: mcp-authorization-server-metadata"
+    # The /mcp/ prefix would otherwise publish the container's health routes.
+    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "name: mcp-health-not-public"
+    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "status: 404"
+    # The runtime cannot start without these.
+    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "name: OSMO_MCP_AUTH_RESOURCE_URL"
+    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "name: OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE"
+    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
+        "value: \"/etc/osmo/mcp-auth/client-secret\""
+    # The MCP audience joins the provider whose issuer it authenticates against.
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
         "issuer: https://issuer.example.com"
+    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
+        "- https://osmo.example.com/mcp"
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
         "uri: https://issuer.example.com/.well-known/jwks.json"
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -1159,8 +1159,42 @@
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "resourceUrl": { "type": "string" },
         "requestTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 60 },
-        "authorizationServers": { "type": "array" },
-        "scopes": { "type": "array" },
+        "oidcProxy": {
+          "type": "object",
+          "properties": {
+            "oidc": {
+              "type": "object",
+              "properties": {
+                "configUrl": { "type": "string" },
+                "clientId": { "type": "string" },
+                "clientSecretFile": { "type": "string" },
+                "accessTokenIssuer": { "type": "string" },
+                "accessTokenRequiredScope": { "type": "string" }
+              }
+            },
+            "accessTokenTtlSeconds": { "type": "integer", "minimum": 60, "maximum": 3600 },
+            "refreshTokenTtlSeconds": { "type": "integer", "minimum": 300, "maximum": 604800 },
+            "upstreamTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 60 },
+            "redis": {
+              "type": "object",
+              "properties": {
+                "dbNumber": { "type": "integer", "minimum": 0, "maximum": 15 },
+                "keyPrefix": { "type": "string" },
+                "connectTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 30 },
+                "operationTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 30 }
+              }
+            },
+            "existingSecret": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "mountPath": { "type": "string" },
+                "clientSecretKey": { "type": "string" },
+                "redisPasswordKey": { "type": "string" }
+              }
+            }
+          }
+        },
         "allowedOrigins": { "type": "array" },
         "service": { "$ref": "#/definitions/serviceMetadata" },
         "serviceAccount": { "$ref": "#/definitions/serviceAccount" },

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -636,9 +636,37 @@ services:
     port: 8000
     resourceUrl: ''
     requestTimeoutSeconds: 10
-    authorizationServers: []
-    scopes: []
     allowedOrigins: []
+    ## Built-in FastMCP OIDC proxy. MCP authenticates every caller itself and
+    ## relays the verified upstream token to the Gateway for normal RBAC.
+    ##
+    ## Only four values have no default: services.mcp.resourceUrl, oidc.configUrl,
+    ## oidc.clientId, and a Secret holding the client secret. Secret file paths
+    ## follow existingSecret.mountPath; Redis host, port and TLS come from
+    ## services.redis; accessTokenIssuer is needed only for a provider whose
+    ## access tokens are issued from somewhere its discovery document does not
+    ## advertise, as an application configured for v1-format tokens is.
+    ##
+    oidcProxy:
+      oidc:
+        configUrl: ''
+        clientId: ''
+        clientSecretFile: ''
+        accessTokenIssuer: ''
+        accessTokenRequiredScope: access_as_user
+      accessTokenTtlSeconds: 600
+      refreshTokenTtlSeconds: 28800
+      upstreamTimeoutSeconds: 10
+      redis:
+        dbNumber: 1
+        keyPrefix: osmo:mcp-fastmcp
+        connectTimeoutSeconds: 3
+        operationTimeoutSeconds: 5
+      existingSecret:
+        name: ''
+        mountPath: /etc/osmo/mcp-auth
+        clientSecretKey: client-secret
+        redisPasswordKey: ''
     service:
       labels: {}
       annotations: {}


### PR DESCRIPTION
Issue - None

Stacked on #1350.

The unified `deployments/charts/osmo` chart carries its own copy of the MCP gateway surface and workload, and #1350 does not touch it. It still rendered the direct-provider design while the runtime no longer implements it — enabling MCP there produced a pod that failed configuration validation at start.

MCP is disabled by default in this chart, so only deployments that explicitly enabled it were affected. For those it was broken, not degraded.

## Before / after

```
BEFORE (unified chart)                    AFTER
─────────────────────────                 ──────────────────────────────────
gateway synthesises the                   FastMCP serves it; the gateway
RFC 9728 document from                    forwards /.well-known/oauth-
authorizationServers + scopes             protected-resource/mcp

no authorization-server route             /.well-known/oauth-authorization-
                                          server/mcp, prefix rewritten off

mcp-origin Lua filter enforces            FastMCP's HostOriginGuardMiddleware,
the browser Origin allowlist              from services.mcp.allowedOrigins

/mcp only                                 /mcp + /mcp/ prefix (rewritten) with
                                          /mcp/health carved out ahead of it

container gets 0 OIDC/Redis               7 OSMO_MCP_AUTH_* variables and the
settings → fails at start                 client-secret mount
```

## Configuration

`authorizationServers` and `scopes` are gone. In their place is the same `oidcProxy` contract the service chart uses, with the same four values that have no default:

```yaml
services:
  mcp:
    enabled: true
    resourceUrl: https://osmo.example.com/mcp
    oidcProxy:
      oidc:
        configUrl: https://idp.example.com/.well-known/openid-configuration
        clientId: <application-id>
      existingSecret:
        name: mcp-oidc
```

Redis comes from the same valkey the rest of the chart uses, through the existing `osmo.valkey.host`/`port`/`tlsEnabled` helpers, rather than a second set of connection settings. Only the logical database is chosen locally, to isolate proxy state.

The relayed token's audience is the MCP resource URL, and it comes from the identity provider already configured for this deployment's own clients, so that audience is appended to the JWT provider whose issuer matches. The issuer is derived from the OIDC configuration URL.

## Tests

The chart fixture moves to the new contract, and the assertions that checked the synthesised metadata document are replaced by ones checking the routes that now carry it.

Two of those, written first as fixed-string checks, **did not hold**: `"prefix_rewrite: /"` also matches the authorization-server rewrite below it, so the assertion passed with the route it guards deleted. The suite's helpers are fixed-string only, so this adds `require_matches` for anchored patterns. Both new assertions were negative-tested by removing what they guard and confirming the suite fails.

## Verified end to end on a local kind cluster

The dev instance deploys `charts/service`, so it cannot exercise this chart. Instead this was installed into a kind cluster with a real OIDC provider (`mock-oauth2-server` behind an nginx TLS front, since the config URL must be HTTPS) and a real Redis.

The MCP pod reached Running with 0 restarts, meaning it completed OIDC discovery against a live issuer and read the mounted client secret. Then, against the running service:

```
Protected-resource + authorization-server metadata     served by FastMCP
Unauthenticated POST /mcp                              401 + resource_metadata pointer
Dynamic client registration                            issues a client_id
authorize -> consent                                   redirect + page renders
Origin guard      own origin 400 (CSRF)   foreign 403   no Origin 400
```

Through the gateway, with the chart's own Envoy config and 9/9 route checks passing:

```
/.well-known/oauth-protected-resource/mcp    200
/.well-known/oauth-authorization-server/mcp  200   (prefix rewritten to root)
/mcp/health, /health/live, /health/ready     404   (carve-out holds)
/mcp/register, /mcp/authorize                reach the app (prefix rewritten off)
POST /mcp                                    401 + metadata pointer
```

A full registration and authorize ran through `/mcp/register` and `/mcp/authorize`, ending on a consent page advertised at `https://osmo.example.com/mcp/consent`.

Redis held the registration under the chart's `redis.keyPrefix`, with the payload in `__encrypted_data__` and `client_secret`, `redirect_uris` and the client ID all unreadable.

## Verification

- `deployments/charts/osmo/tests/test_osmo_charts.sh` — PASS
- `helm lint deployments/charts/osmo` — 0 failed
- `render-tests.sh` (service chart) — still passes
- No `authorizationServers` reference remains anywhere in the tree
- Negative-tested: removing the `/mcp/` rewrite, and renaming the health carve-out, each fail the suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OIDC proxy authentication for MCP services, including discovery, client credentials, token issuer, session settings, and existing-secret support.
  * Added protected-resource and authorization-server metadata routing for MCP requests.
  * Added Redis-backed session configuration and secure MCP audience handling.

* **Bug Fixes**
  * Improved token issuer and JWT audience validation.
  * Blocked access to the MCP health route.

* **Configuration**
  * Replaced authorization-server and scope-list settings with OIDC proxy configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
