### PR TITLE
docs: refresh CPU quickstart

### DIFF
--- a/deployments/charts/README.md
+++ b/deployments/charts/README.md
@@ -30,9 +30,9 @@ For an existing development cluster with KAI Scheduler, the CloudNativePG
 operator, and a default dynamic StorageClass, install the complete browser,
 CLI, API, and CPU workflow experience with the chart defaults:
 
-Before running Helm, generate the shared service-auth identity and create the
-required `osmo-service-auth` Secret by following the
-[`osmo` installation steps](osmo/README.md#install-osmo).
+No service-auth Secret needs to be created before installation. The chart's
+enabled-by-default bootstrap Job generates the shared development identity and
+creates the retained `osmo-service-auth` Secret directly in Kubernetes.
 
 ```bash
 helm dependency build deployments/charts/osmo
@@ -44,14 +44,16 @@ helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \
   --timeout 20m
 ```
 
-After the first installation bootstraps the retained master-encryption-key
-Secret, disable its one-time bootstrap Job and Secret-creation permission:
+After the first installation bootstraps the retained master-encryption-key and
+service-auth Secrets, disable both one-time bootstrap Jobs and their
+Secret-creation permissions:
 
 ```bash
 helm --kube-context kind-osmo upgrade osmo deployments/charts/osmo \
   --namespace osmo \
   --reuse-values \
   --set secrets.masterEncryptionKey.bootstrap.enabled=false \
+  --set secrets.serviceAuth.bootstrap.enabled=false \
   --wait \
   --timeout 20m
 ```

--- a/deployments/charts/README.md
+++ b/deployments/charts/README.md
@@ -30,10 +30,6 @@ For an existing development cluster with KAI Scheduler, the CloudNativePG
 operator, and a default dynamic StorageClass, install the complete browser,
 CLI, API, and CPU workflow experience with the chart defaults:
 
-No service-auth Secret needs to be created before installation. The chart's
-enabled-by-default bootstrap Job generates the shared development identity and
-creates the retained `osmo-service-auth` Secret directly in Kubernetes.
-
 ```bash
 helm dependency build deployments/charts/osmo
 helm --kube-context kind-osmo upgrade --install osmo deployments/charts/osmo \

--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -145,8 +145,8 @@ osmo workflow query <workflow-id> --format-type json
 ```
 
 Repeat the query until the workflow status is `COMPLETED`.
-The workflow passes a marker between its two tasks through the configured
-object store, so completion validates both upload and download access.
+The workflow runs a small Alpine container, so completion validates CPU
+scheduling and backend status reporting.
 
 ### Troubleshooting and cleanup
 

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -62,7 +62,7 @@ Install the following tools on your workstation:
 * `Docker <https://docs.docker.com/get-started/get-docker/>`_ - Container runtime (>=28.3.2)
 * `KIND <https://kind.sigs.k8s.io/docs/user/quick-start/#installation>`_ - Kubernetes in Docker (>=0.29.0)
 * `kubectl <https://kubernetes.io/docs/tasks/tools/>`_ - Kubernetes command-line tool (>=1.32.2)
-* `helm <https://helm.sh/docs/intro/install/>`_ - Helm package manager (>=3.16.2)
+* `helm <https://helm.sh/docs/intro/install/>`_ - Helm 3 package manager (>=3.16.2)
 
 The resulting cluster requires Kubernetes 1.30 or newer and a default dynamic
 ``StorageClass``.
@@ -127,9 +127,6 @@ service worker maps gateway NodePort ``30080`` to host port ``80``.
           nodeRegistration:
             kubeletExtraArgs:
               node-labels: "node_group=data,nvidia.com/gpu.deploy.operands=false"
-        extraMounts:
-          - hostPath: /tmp/localstack-s3
-            containerPath: /var/lib/localstack
       - role: worker
         kubeadmConfigPatches:
         - |
@@ -228,9 +225,6 @@ If your workstation does not have a GPU, create a standard CPU-only cluster.
           nodeRegistration:
             kubeletExtraArgs:
               node-labels: "node_group=data"
-        extraMounts:
-          - hostPath: /tmp/localstack-s3
-            containerPath: /var/lib/localstack
       - role: worker
         kubeadmConfigPatches:
         - |
@@ -269,7 +263,8 @@ Install cluster dependencies
 
 Install KAI Scheduler v0.12.10 for OSMO workflow scheduling, then install the
 CloudNativePG operator chart version 0.29.0 for the embedded PostgreSQL
-cluster:
+cluster. Wait for KAI's pods directly because its ``SchedulingShard`` custom
+resource can remain in a reconciling state after the scheduler is ready:
 
 .. code-block:: bash
 
@@ -279,8 +274,9 @@ cluster:
      --create-namespace -n kai-scheduler \
      --set global.nodeSelector.node_group=kai-scheduler \
      --set "scheduler.additionalArgs[0]=--default-staleness-grace-period=-1s" \
-     --set "scheduler.additionalArgs[1]=--update-pod-eviction-condition=true" \
-     --wait
+     --set "scheduler.additionalArgs[1]=--update-pod-eviction-condition=true"
+   kubectl --namespace kai-scheduler wait \
+     --for=condition=Ready pods --all --timeout=10m
 
    helm repo add cnpg https://cloudnative-pg.github.io/charts
    helm repo update cnpg
@@ -299,25 +295,6 @@ default pool. CPU workflows use a pod template without a GPU resource key.
 GPU workflows select the GPU platform, which requests ``nvidia.com/gpu`` in
 both the user-container requests and limits. No values overlay is required.
 
-Generate the shared development service-auth identity with the published OSMO
-service image and create its Secret. The generator writes the private identity
-only to a permission-restricted temporary file and never prints it:
-
-.. code-block:: bash
-
-   OSMO_SERVICE_AUTH_DIRECTORY="$(mktemp -d)"
-   docker run --rm --user "$(id -u):$(id -g)" \
-     --entrypoint service-auth-bootstrap \
-     --volume "${OSMO_SERVICE_AUTH_DIRECTORY}:/output" \
-     nvcr.io/nvidia/osmo/service:latest \
-     generate --output /output/authentication-config.json
-   kubectl create namespace osmo \
-     --dry-run=client --output=yaml | kubectl apply -f -
-   kubectl --namespace osmo create secret generic \
-     osmo-service-auth \
-     --from-file="authentication-config.json=${OSMO_SERVICE_AUTH_DIRECTORY}/authentication-config.json"
-   rm -r "${OSMO_SERVICE_AUTH_DIRECTORY}"
-
 The chart defaults are the development Quickstart. Build its dependencies and
 install it without a profile or values overlay:
 
@@ -329,6 +306,26 @@ install it without a profile or values overlay:
      --create-namespace \
      --wait \
      --wait-for-jobs \
+     --timeout 20m
+
+The enabled-by-default service-auth bootstrap Job generates the shared
+development identity directly in Kubernetes and creates the retained
+``osmo-service-auth`` Secret without putting private key material in Helm
+values, rendered manifests, or release state. The ``--wait-for-jobs`` option
+waits for that initialization to succeed.
+
+After the first installation creates the retained master-encryption-key and
+service-auth Secrets, disable both one-time bootstrap Jobs and their temporary
+Secret-creation permissions while retaining the other release values:
+
+.. code-block:: bash
+
+   helm upgrade osmo deployments/charts/osmo \
+     --namespace osmo \
+     --reuse-values \
+     --set secrets.masterEncryptionKey.bootstrap.enabled=false \
+     --set secrets.serviceAuth.bootstrap.enabled=false \
+     --wait \
      --timeout 20m
 
 Log in and run a workflow

--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -62,7 +62,7 @@ Install the following tools on your workstation:
 * `Docker <https://docs.docker.com/get-started/get-docker/>`_ - Container runtime (>=28.3.2)
 * `KIND <https://kind.sigs.k8s.io/docs/user/quick-start/#installation>`_ - Kubernetes in Docker (>=0.29.0)
 * `kubectl <https://kubernetes.io/docs/tasks/tools/>`_ - Kubernetes command-line tool (>=1.32.2)
-* `helm <https://helm.sh/docs/intro/install/>`_ - Helm 3 package manager (>=3.16.2)
+* `helm <https://helm.sh/docs/intro/install/>`_ - Helm package manager (>=3.16.2)
 
 The resulting cluster requires Kubernetes 1.30 or newer and a default dynamic
 ``StorageClass``.
@@ -127,6 +127,9 @@ service worker maps gateway NodePort ``30080`` to host port ``80``.
           nodeRegistration:
             kubeletExtraArgs:
               node-labels: "node_group=data,nvidia.com/gpu.deploy.operands=false"
+        extraMounts:
+          - hostPath: /tmp/localstack-s3
+            containerPath: /var/lib/localstack
       - role: worker
         kubeadmConfigPatches:
         - |
@@ -225,6 +228,9 @@ If your workstation does not have a GPU, create a standard CPU-only cluster.
           nodeRegistration:
             kubeletExtraArgs:
               node-labels: "node_group=data"
+        extraMounts:
+          - hostPath: /tmp/localstack-s3
+            containerPath: /var/lib/localstack
       - role: worker
         kubeadmConfigPatches:
         - |
@@ -263,8 +269,7 @@ Install cluster dependencies
 
 Install KAI Scheduler v0.12.10 for OSMO workflow scheduling, then install the
 CloudNativePG operator chart version 0.29.0 for the embedded PostgreSQL
-cluster. Wait for KAI's pods directly because its ``SchedulingShard`` custom
-resource can remain in a reconciling state after the scheduler is ready:
+cluster:
 
 .. code-block:: bash
 
@@ -274,9 +279,8 @@ resource can remain in a reconciling state after the scheduler is ready:
      --create-namespace -n kai-scheduler \
      --set global.nodeSelector.node_group=kai-scheduler \
      --set "scheduler.additionalArgs[0]=--default-staleness-grace-period=-1s" \
-     --set "scheduler.additionalArgs[1]=--update-pod-eviction-condition=true"
-   kubectl --namespace kai-scheduler wait \
-     --for=condition=Ready pods --all --timeout=10m
+     --set "scheduler.additionalArgs[1]=--update-pod-eviction-condition=true" \
+     --wait
 
    helm repo add cnpg https://cloudnative-pg.github.io/charts
    helm repo update cnpg
@@ -306,26 +310,6 @@ install it without a profile or values overlay:
      --create-namespace \
      --wait \
      --wait-for-jobs \
-     --timeout 20m
-
-The enabled-by-default service-auth bootstrap Job generates the shared
-development identity directly in Kubernetes and creates the retained
-``osmo-service-auth`` Secret without putting private key material in Helm
-values, rendered manifests, or release state. The ``--wait-for-jobs`` option
-waits for that initialization to succeed.
-
-After the first installation creates the retained master-encryption-key and
-service-auth Secrets, disable both one-time bootstrap Jobs and their temporary
-Secret-creation permissions while retaining the other release values:
-
-.. code-block:: bash
-
-   helm upgrade osmo deployments/charts/osmo \
-     --namespace osmo \
-     --reuse-values \
-     --set secrets.masterEncryptionKey.bootstrap.enabled=false \
-     --set secrets.serviceAuth.bootstrap.enabled=false \
-     --wait \
      --timeout 20m
 
 Log in and run a workflow


### PR DESCRIPTION
## Description
Refresh quickstart docs to remove token minting

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated quick-start deployment guidance and post-install cleanup steps for bootstrap jobs and permissions.
  * Clarified that the Alpine workflow validates CPU scheduling and backend status reporting.
  * Updated local deployment guidance with generic Helm instructions and restored local object-store mounts for CPU and GPU KIND configurations.
  * Revised scheduler installation to use Helm’s `--wait` option instead of explicit pod-readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->