### PR TITLE
perf: increase Redis log read count

### DIFF
--- a/src/utils/connectors/redis.py
+++ b/src/utils/connectors/redis.py
@@ -223,11 +223,11 @@ async def redis_log_streamer(
             logs = None
             try:
                 logs = await redis_client.xread({name: start_id}, 10)
-                start_id, log = logs[0][-1][0]
-                log = LogStreamBody(**{k.decode(): v.decode() for k, v in log.items()})
-                if log.io_type == IOType.END_FLAG:
-                    break
-                yield log
+                for start_id, log in logs[0][-1]:
+                    log = LogStreamBody(**{k.decode(): v.decode() for k, v in log.items()})
+                    if log.io_type == IOType.END_FLAG:
+                        return
+                    yield log
             except IndexError:  # No new line
                 await asyncio.sleep(1)  # Otherwise the stream will hang
     finally:

--- a/src/utils/connectors/redis.py
+++ b/src/utils/connectors/redis.py
@@ -222,7 +222,7 @@ async def redis_log_streamer(
         while not skip_streaming:
             logs = None
             try:
-                logs = await redis_client.xread({name: start_id}, 1)
+                logs = await redis_client.xread({name: start_id}, 10)
                 start_id, log = logs[0][-1][0]
                 log = LogStreamBody(**{k.decode(): v.decode() for k, v in log.items()})
                 if log.io_type == IOType.END_FLAG:

--- a/src/utils/connectors/tests/test_redis.py
+++ b/src/utils/connectors/tests/test_redis.py
@@ -36,6 +36,21 @@ def _log_line(text: str) -> redis.LogStreamBody:
     )
 
 
+def _redis_log_entry(
+    stream_id: str,
+    text: str,
+    io_type: redis.IOType = redis.IOType.STDOUT,
+) -> tuple[bytes, dict[bytes, bytes]]:
+    """One encoded Redis stream entry returned by xread."""
+    return stream_id.encode(), {
+        b'source': b'task-1',
+        b'retry_id': b'0',
+        b'time': b'2026-08-19T00:00:00',
+        b'text': text.encode(),
+        b'io_type': io_type.value.encode(),
+    }
+
+
 class TestRedisLogFormatter(unittest.IsolatedAsyncioTestCase):
     """Covers closure propagation from the log formatter to the Redis reader."""
 
@@ -63,7 +78,67 @@ class TestRedisLogFormatter(unittest.IsolatedAsyncioTestCase):
 
 
 class TestRedisLogStreamer(unittest.IsolatedAsyncioTestCase):
-    """Covers release of the Redis client when the reader is cancelled."""
+    """Covers Redis log streaming and client cleanup."""
+
+    async def test_yields_every_entry_in_xread_batch(self):
+        xread_responses = [
+            [(b'logs', [
+                _redis_log_entry('1-0', 'first log line'),
+                _redis_log_entry('2-0', 'second log line'),
+            ])],
+            [(b'logs', [
+                _redis_log_entry('3-0', '', redis.IOType.END_FLAG),
+            ])],
+        ]
+
+        class _FakeClient:
+            async def xread(self, *args, **kwargs):  # pylint: disable=unused-argument
+                return xread_responses.pop(0)
+
+            async def aclose(self):
+                pass
+
+        with mock.patch.object(redis.redis.asyncio, 'from_url',
+                               return_value=_FakeClient()):
+            lines = [
+                line async for line in redis.redis_log_streamer(
+                    'redis://localhost', 'logs')
+            ]
+
+        self.assertEqual(
+            ['first log line', 'second log line'],
+            [line.text for line in lines],
+        )
+
+    async def test_stops_at_end_flag_within_xread_batch(self):
+        xread_calls = 0
+
+        class _FakeClient:
+            async def xread(self, *args, **kwargs):  # pylint: disable=unused-argument
+                nonlocal xread_calls
+                xread_calls += 1
+                if xread_calls == 1:
+                    return [(b'logs', [
+                        _redis_log_entry('1-0', 'first log line'),
+                        _redis_log_entry('2-0', '', redis.IOType.END_FLAG),
+                        _redis_log_entry('3-0', 'after end flag'),
+                    ])]
+                return [(b'logs', [
+                    _redis_log_entry('4-0', '', redis.IOType.END_FLAG),
+                ])]
+
+            async def aclose(self):
+                pass
+
+        with mock.patch.object(redis.redis.asyncio, 'from_url',
+                               return_value=_FakeClient()):
+            lines = [
+                line async for line in redis.redis_log_streamer(
+                    'redis://localhost', 'logs')
+            ]
+
+        self.assertEqual(['first log line'], [line.text for line in lines])
+        self.assertEqual(1, xread_calls)
 
     async def test_client_is_closed_even_when_the_reader_is_cancelled(self):
         """A disconnect cancels the task driving the reader, and cancellation


### PR DESCRIPTION
## Description

Increase the Redis live-log read count so each service instance can handle more concurrent readers.

Local single-worker testing used 1,000 256-byte log entries/second. A reader passed only if it received every entry in order without sustained latency growth.

| `XREAD COUNT` | Max concurrent readers | First failing readers | Event-loop p99 at max |
| ---: | ---: | ---: | ---: |
| 1 | 5 | 6 | 0.94 ms |
| 10 | 14 | 15 | 12.56 ms |
| 100 | 18 | 19 | 131.60 ms |

`COUNT 10` was selected as the best balance: 2.8x the reader capacity of `COUNT 1` with about 13 ms p99 event-loop lag. `COUNT 100` adds only 29% more capacity while increasing p99 lag to about 132 ms.

Issue - None

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Redis log streaming now processes all entries in each batch in order.
  - Streaming stops immediately when an end-of-stream marker is received, preventing later entries from being emitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->