### PR TITLE
fix(cli): preserve workflow HTTP error status

### DIFF
--- a/src/cli/tests/BUILD
+++ b/src/cli/tests/BUILD
@@ -25,6 +25,7 @@ py_test(
         "test_cli.py"
     ],
     deps = [
+        "//src/cli:cli",
         "//src/cli:cli_lib",
     ]
 )

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -16,11 +16,73 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import argparse
+import contextlib
+import io
+import json
 import unittest
 from unittest import mock
 
+import src.cli.cli as cli
 from src.cli import main_parser, workflow
 from src.lib.rsync import rsync
+from src.lib.utils import osmo_errors
+
+
+class TestSubmissionErrorOutput(unittest.TestCase):
+    """The CLI reports HTTP status separately from its process exit code."""
+
+    def _run_cli(self, format_type: str, status_code: int | None) -> tuple[str, int]:
+        args = argparse.Namespace(
+            format_type=format_type,
+            func=mock.Mock(side_effect=osmo_errors.OSMOSubmissionError(
+                'Workflow submit failed.',
+                status_code=status_code,
+            )),
+            log_level=mock.sentinel.log_level,
+        )
+        parser = mock.Mock()
+        parser.parse_args.return_value = args
+        output = io.StringIO()
+
+        with mock.patch.object(
+                cli.main_parser, 'create_cli_parser', return_value=parser), \
+             mock.patch.object(cli, 'configure_logging'), \
+             mock.patch.object(cli.client, 'LoginManager'), \
+             mock.patch.object(cli.client, 'ServiceClient'), \
+             mock.patch.object(cli.sys, 'argv', ['osmo']), \
+             contextlib.redirect_stdout(output), \
+             self.assertRaises(SystemExit) as raised:
+            cli.main()
+
+        exit_code = raised.exception.code
+        if not isinstance(exit_code, int):
+            self.fail(f'Expected integer exit code, got {exit_code!r}.')
+        return output.getvalue(), exit_code
+
+    def test_text_output_uses_http_status_and_submission_exit_code(self):
+        output, exit_code = self._run_cli('text', 400)
+
+        self.assertEqual(
+            output,
+            'Error message: Workflow submit failed.\nError code: 400\n',
+        )
+        self.assertEqual(exit_code, 1)
+
+    def test_json_output_uses_http_status_and_submission_exit_code(self):
+        output, exit_code = self._run_cli('json', 400)
+
+        self.assertEqual(
+            json.loads(output),
+            {'message': 'Workflow submit failed.', 'code': 400},
+        )
+        self.assertEqual(exit_code, 1)
+
+    def test_missing_http_status_retains_error_code_fallback(self):
+        output, exit_code = self._run_cli('text', None)
+
+        self.assertIn('Error code: 1', output)
+        self.assertEqual(exit_code, 1)
+
 
 class TestPortParse(unittest.TestCase):
     def test_port_parse(self):

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -335,6 +335,105 @@ class TestWorkflowLabelOutput(unittest.TestCase):
         self.assertIn('Labels', table.draw())
 
 
+class TestWorkflowSubmissionErrors(unittest.TestCase):
+    """Workflow submission wrappers preserve server error metadata."""
+
+    def test_resubmit_by_id_preserves_credential_error_status(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        service_client.request.side_effect = osmo_errors.OSMOCredentialError(
+            'Credential is invalid.',
+            workflow_id='failed-workflow',
+            status_code=401,
+        )
+        args = argparse.Namespace(
+            pool='pool-1',
+            priority=None,
+            workflow_file='source-workflow',
+            set=[],
+            set_string=[],
+            labels=[],
+            dry=False,
+            format_type='text',
+            rsync=None,
+        )
+
+        with mock.patch.object(
+                workflow, '_load_wf_file', side_effect=FileNotFoundError), \
+             mock.patch.object(workflow, 'is_workflow_id', return_value=True), \
+             self.assertRaises(osmo_errors.OSMOSubmissionError) as raised:
+            workflow._submit_workflow(service_client, args)
+
+        self.assertEqual(raised.exception.status_code, 401)
+        self.assertEqual(raised.exception.workflow_id, 'failed-workflow')
+        self.assertEqual(
+            raised.exception.message,
+            'Workflow failed-workflow submit failed:\nCredential is invalid.',
+        )
+
+    def test_fresh_submit_preserves_submission_error_status(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        service_client.request.side_effect = osmo_errors.OSMOSubmissionError(
+            'Workflow label value is invalid.',
+            workflow_id='failed-workflow',
+            status_code=400,
+        )
+        template_data = workflow.TemplateData(
+            file=PLAIN_WORKFLOW_SPEC,
+            set_variables=[],
+            set_string_variables=[],
+            is_templated=False,
+        )
+        args = argparse.Namespace(
+            pool='pool-1',
+            dry=False,
+            set_env=None,
+            rsync=None,
+            format_type='text',
+            priority=None,
+        )
+
+        with mock.patch.object(workflow, 'load_local_files'), \
+             self.assertRaises(osmo_errors.OSMOSubmissionError) as raised:
+            workflow.submit_workflow_helper(
+                service_client,
+                args,
+                template_data,
+                'workflow.yaml',
+                {},
+            )
+
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertEqual(raised.exception.workflow_id, 'failed-workflow')
+        self.assertEqual(
+            raised.exception.message,
+            'Workflow failed-workflow submit failed:\n'
+            'Workflow label value is invalid.',
+        )
+
+    def test_restart_preserves_submission_error_status(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        service_client.request.side_effect = osmo_errors.OSMOSubmissionError(
+            'Resource limit exceeded.',
+            workflow_id='restarted-workflow',
+            status_code=409,
+        )
+        args = argparse.Namespace(
+            workflow_id='source-workflow',
+            pool='pool-1',
+            format_type='text',
+        )
+
+        with self.assertRaises(osmo_errors.OSMOSubmissionError) as raised:
+            workflow._restart_workflow(service_client, args)
+
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertEqual(raised.exception.workflow_id, 'restarted-workflow')
+        self.assertEqual(
+            raised.exception.message,
+            'Workflow restarted-workflow submit failed:\nResource limit exceeded.',
+        )
+
+
 class WorkflowTemplateDetectionTest(unittest.TestCase):
     """Test CLI workflow template detection."""
 

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -759,7 +759,8 @@ def _submit_workflow(service_client: client.ServiceClient, args: argparse.Namesp
                 f'{err.workflow_id} ' if err.workflow_id is not None else ''
             raise osmo_errors.OSMOSubmissionError(
                 f'Workflow {workflow_string}submit failed:\n'
-                f'{err}', workflow_id=err.workflow_id)
+                f'{err}', workflow_id=err.workflow_id,
+                status_code=err.status_code)
 
         print_submission_results(result, args)
 
@@ -818,7 +819,8 @@ def submit_workflow_helper(service_client: client.ServiceClient, args: argparse.
             f'{err.workflow_id} ' if err.workflow_id is not None else ''
         raise osmo_errors.OSMOSubmissionError(
             f'Workflow {workflow_string}submit failed:\n'
-            f'{err}', workflow_id=err.workflow_id)
+            f'{err}', workflow_id=err.workflow_id,
+            status_code=err.status_code)
 
     print_submission_results(result, args)
 
@@ -858,7 +860,8 @@ def _restart_workflow(service_client: client.ServiceClient, args: argparse.Names
             f'{err.workflow_id} ' if err.workflow_id is not None else ''
         raise osmo_errors.OSMOSubmissionError(
             f'Workflow {workflow_string}submit failed:\n'
-            f'{err}', workflow_id=err.workflow_id)
+            f'{err}', workflow_id=err.workflow_id,
+            status_code=err.status_code)
 
     print_submission_results(result, args, args.workflow_id)
 

--- a/src/lib/utils/tests/test_validation.py
+++ b/src/lib/utils/tests/test_validation.py
@@ -234,7 +234,12 @@ class TestSanitizedPath(unittest.TestCase):
 class TestWorkflowLabelValidation(unittest.TestCase):
     """Tests for the workflow label validation helpers."""
 
-    def test_accepts_kubernetes_label_key_and_nonempty_value(self):
+    def _assert_no_platform_implementation_details(self, message: str):
+        normalized_message = message.lower()
+        self.assertNotIn('kubernetes', normalized_message)
+        self.assertNotIn('pod', normalized_message)
+
+    def test_accepts_workflow_label_key_and_nonempty_value(self):
         self.assertEqual(validation.validate_workflow_label_key('PPP'), 'PPP')
         self.assertEqual(
             validation.validate_workflow_label_key('example.com/experiment'),
@@ -259,15 +264,43 @@ class TestWorkflowLabelValidation(unittest.TestCase):
             with self.subTest(key=key):
                 self.assertEqual(validation.validate_workflow_label_key(key), key)
 
-    def test_rejects_invalid_key_syntax(self):
-        for key in ('', '/name', 'UPPER.example.com/name', 'example.com/', '-name'):
-            with self.subTest(key=key), self.assertRaises(ValueError):
-                validation.validate_workflow_label_key(key)
+    def test_rejects_key_with_multiple_separators_with_actionable_error(self):
+        with self.assertRaises(ValueError) as raised:
+            validation.validate_workflow_label_key('bad/key/nested')
 
-    def test_rejects_empty_or_invalid_value(self):
-        for value in ('', '-value', 'value/', 'x' * 64):
-            with self.subTest(value=value), self.assertRaises(ValueError):
+        self.assertIn('at most one "/"', str(raised.exception))
+        self._assert_no_platform_implementation_details(str(raised.exception))
+
+    def test_rejects_invalid_key_prefix_with_actionable_error(self):
+        with self.assertRaises(ValueError) as raised:
+            validation.validate_workflow_label_key('UPPER.example.com/name')
+
+        message = str(raised.exception)
+        self.assertIn('invalid prefix', message)
+        self.assertIn('lowercase letters', message)
+        self._assert_no_platform_implementation_details(message)
+
+    def test_rejects_invalid_key_name_with_actionable_error(self):
+        with self.assertRaises(ValueError) as raised:
+            validation.validate_workflow_label_key('example.com/-name')
+
+        message = str(raised.exception)
+        self.assertIn('invalid name', message)
+        self.assertIn('1-63 characters', message)
+        self._assert_no_platform_implementation_details(message)
+
+    def test_rejects_empty_oversized_and_invalid_value_with_actionable_error(self):
+        for value in ('', 'x' * 64, 'value/'):
+            with self.subTest(value=value), self.assertRaises(ValueError) as raised:
                 validation.validate_workflow_label_value(value)
+
+            message = str(raised.exception)
+            self.assertIn('1-63 characters', message)
+            self.assertIn(
+                'letters, numbers, hyphens, underscores, or periods',
+                message,
+            )
+            self._assert_no_platform_implementation_details(message)
 
     def test_rejects_more_than_sixteen_labels(self):
         labels = {f'label-{index}': 'value' for index in range(17)}
@@ -499,6 +532,9 @@ class TestPodLabelPrefix(unittest.TestCase):
         message = str(raised.exception)
         self.assertIn('team.example.com/role', message)
         self.assertIn('example.com/', message)
+        self.assertIn('configured label prefix', message)
+        self.assertNotIn('kubernetes', message.lower())
+        self.assertNotIn('pod', message.lower())
 
 
 if __name__ == '__main__':

--- a/src/lib/utils/workflow_labels.py
+++ b/src/lib/utils/workflow_labels.py
@@ -64,15 +64,22 @@ def validate_workflow_label_key(key: str) -> str:
     elif len(parts) == 2:
         prefix, name = parts
     else:
-        raise ValueError(f'Workflow label key "{key}" is not a valid Kubernetes label key.')
+        raise ValueError(
+            f'Workflow label key "{key}" is invalid. Keys may contain at most '
+            'one "/" separating an optional prefix from the name.')
 
     if prefix is not None:
         if not _DNS_PREFIX_PATTERN.fullmatch(prefix):
             raise ValueError(
-                f'Workflow label key "{key}" has an invalid DNS prefix.')
+                f'Workflow label key "{key}" has an invalid prefix. Prefixes '
+                'must be at most 253 characters and contain dot-separated '
+                'segments of at most 63 lowercase letters, numbers, or hyphens; '
+                'each segment must start and end with a letter or number.')
     if not _LABEL_NAME_PATTERN.fullmatch(name):
         raise ValueError(
-            f'Workflow label key "{key}" has an invalid name segment.')
+            f'Workflow label key "{key}" has an invalid name. Names must be '
+            '1-63 characters, start and end with a letter or number, and contain '
+            'only letters, numbers, hyphens, underscores, or periods.')
     return key
 
 
@@ -82,7 +89,9 @@ def validate_workflow_label_value(value: str) -> str:
         raise ValueError('Workflow label values must be strings.')
     if not _LABEL_NAME_PATTERN.fullmatch(value):
         raise ValueError(
-            f'Workflow label value "{value}" is not a valid non-empty Kubernetes label value.')
+            f'Workflow label value "{value}" is invalid. Values must be 1-63 '
+            'characters, start and end with a letter or number, and contain only '
+            'letters, numbers, hyphens, underscores, or periods.')
     return value
 
 
@@ -130,9 +139,9 @@ def validate_prefixed_workflow_label_keys(
             validate_workflow_label_key(prefixed_key)
         except ValueError as error:
             raise ValueError(
-                f'Label key "{key}" with the configured pod label prefix '
-                f'"{pod_label_prefix}" forms an invalid Kubernetes label key '
-                f'"{prefixed_key}": {error}') from error
+                f'Workflow label key "{key}" is incompatible with the configured '
+                f'label prefix "{pod_label_prefix}", which produces the invalid '
+                f'key "{prefixed_key}": {error}') from error
 
 
 def parse_workflow_label_assignment(assignment: str) -> tuple[str, str]:

--- a/src/service/core/workflow/tests/test_workflow_labels.py
+++ b/src/service/core/workflow/tests/test_workflow_labels.py
@@ -181,9 +181,12 @@ workflow:
              mock.patch.object(
                  objects.WorkflowSubmitInfo,
                  'insert_failed_submission_to_db') as insert_failed:
-            with self.assertRaises(osmo_errors.OSMOUsageError):
+            with self.assertRaises(osmo_errors.OSMOUsageError) as raised:
                 submit_info.construct_workflow_dict(template_spec)
 
+        self.assertIn('at most one "/"', raised.exception.message)
+        self.assertNotIn('kubernetes', raised.exception.message.lower())
+        self.assertNotIn('pod', raised.exception.message.lower())
         insert_failed.assert_not_called()
 
     def test_nested_yaml_label_does_not_create_failed_submission(self):
@@ -525,6 +528,9 @@ class TestPodLabelPrefixGate(unittest.TestCase):
                 _rendered_spec({'team.example.com/role': 'lead'}))
         self.assertIn(
             'example.com/team.example.com/role', raised.exception.message)
+        self.assertIn('configured label prefix', raised.exception.message)
+        self.assertNotIn('kubernetes', raised.exception.message.lower())
+        self.assertNotIn('pod', raised.exception.message.lower())
 
 
 class TestWorkflowLabelResponses(unittest.TestCase):

--- a/test/scenarios/workflow_labels.py
+++ b/test/scenarios/workflow_labels.py
@@ -297,12 +297,12 @@ class WorkflowLabels(_LabelsScenario):
             lambda: self._submit(
                 self._workflow_name("badkey"), labels=["bad/key/nested=value"],
                 validation_only=True),
-            fragment="is not a valid Kubernetes label key")
+            fragment='may contain at most one "/"')
         self._expect_rejected(
             lambda: self._submit(
                 self._workflow_name("emptyval"), labels=["team="],
                 validation_only=True),
-            fragment="is not a valid non-empty Kubernetes label value")
+            fragment="Values must be 1-63 characters")
 
     # ── List filters: real rows, no scheduling needed; cancelled in tearDown ──
 


### PR DESCRIPTION
## Description

Preserve server HTTP status codes when workflow submit and restart operations wrap submission or credential errors. This keeps process exit behavior unchanged while reporting the actual HTTP status in text and JSON output.

Workflow-label validation errors now use actionable OSMO terminology without exposing orchestration implementation details. Regression coverage exercises wrapper metadata, CLI output, shared validation, and service submission paths.

### Updated CLI output

For a server-side workflow submission error, the CLI now preserves and displays the HTTP status code:

```text
Server responded with status code 400
{
  "message": "Restart can only be used on FAILED workflows: Workflow example-workflow has status WorkflowStatus.COMPLETED",
  "code": 400
}
```

Previously, the workflow wrapper discarded the HTTP status and JSON output reported the generic `"code": 1` instead.

Issue - None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Tests

- `bazel test //src/cli/tests:test_workflow //src/cli/tests:test_cli //src/lib/utils/tests:test_client //src/lib/utils/tests:test_validation //src/service/core/workflow/tests:test_workflow_labels`
- `bazel test //src/cli/tests:all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CLI submission errors now report the server’s HTTP status when available, while preserving appropriate fallback exit codes.
  - Workflow submission and restart failures now retain relevant server status information and workflow identifiers.
  - Workflow label validation messages are clearer, more actionable, and platform-neutral.
  - Invalid label keys and values now identify the specific formatting or length requirement that must be corrected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->