### PR TITLE
Remove retired workflow tag commands from the 6.4 CLI

### DIFF
--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -238,7 +238,8 @@ Workflow Information
      - **Default Values**
    * - ``tags``
      - Array[String]
-     - The list contains the available tags the user can mark their workflow
+     - Available legacy tags for the tag API and older clients. The 6.4 CLI
+       uses :ref:`workflow_spec_labels` for new workflows instead.
      - ``[]``
    * - ``max_name_length``
      - Integer

--- a/docs/user_guide/appendix/cli/cli_workflow.rst
+++ b/docs/user_guide/appendix/cli/cli_workflow.rst
@@ -23,6 +23,13 @@
 osmo workflow
 ================================================
 
+.. note::
+
+   In 6.4, ``osmo workflow tag`` and ``osmo workflow list --tags`` are removed.
+   Use :ref:`workflow_spec_labels` to classify new workflows at submission with
+   ``--label KEY=VALUE`` and filter lists with ``--label KEY=SELECTOR`` or
+   ``--no-label KEY``. Labels cannot be changed on existing runs.
+
 .. argparse-with-postprocess::
    :module: src.cli.main_parser
    :func: create_cli_parser

--- a/docs/user_guide/appendix/cli/cli_workflow.rst
+++ b/docs/user_guide/appendix/cli/cli_workflow.rst
@@ -25,7 +25,8 @@ osmo workflow
 
 .. note::
 
-   In 6.4, ``osmo workflow tag`` and ``osmo workflow list --tags`` are removed.
+   In 6.4, ``osmo workflow tag``, ``osmo workflow list --tags``, and the former
+   ``--tag`` abbreviation are removed.
    Use :ref:`workflow_spec_labels` to classify new workflows at submission with
    ``--label KEY=VALUE`` and filter lists with ``--label KEY=SELECTOR`` or
    ``--no-label KEY``. Labels cannot be changed on existing runs.

--- a/skills/osmo-user/SKILL.md
+++ b/skills/osmo-user/SKILL.md
@@ -96,9 +96,14 @@ Workflow submit/list/query/log/event/spec subcommand and flag lookup.
 - "Validate this workflow", "Dry run it", "What flags does workflow list support?", "How do I fetch logs?", "Show the rendered spec"
 - Use for command syntax only; use `references/workflow-submit.md`, `references/workflow-status.md`, or `references/troubleshooting.md` for procedures.
 
+For requests to add workflow tags, explain that the tag CLI was removed in 6.4.
+Use the label guidance in `references/workflow-commands.md`: labels are set at
+submission and cannot be changed on existing runs. Do not resubmit without an
+explicit user request.
+
 ### `references/workflow-runtime-commands.md`
 Live workflow runtime operations.
-- "Cancel workflow X", "Exec into task Y", "Port-forward task Z", "Rsync files into this workflow", "Add a tag to this workflow"
+- "Cancel workflow X", "Exec into task Y", "Port-forward task Z", "Rsync files into this workflow"
 - Ask for confirmation before cancellation and other destructive operations. A
   bare request like "Cancel workflow X" is not confirmation.
 

--- a/skills/osmo-user/references/workflow-commands.md
+++ b/skills/osmo-user/references/workflow-commands.md
@@ -12,7 +12,7 @@ dedicated references named below.
 | Status, logs, links, monitoring | `references/workflow-status.md` |
 | Failed, stuck, sparse logs | `references/troubleshooting.md` |
 | Workflow YAML fields | `references/workflow-spec.md` |
-| Runtime access, rsync, cancel, tags | `references/workflow-runtime-commands.md` |
+| Runtime access, rsync, cancel | `references/workflow-runtime-commands.md` |
 | Apps | `references/workflow-apps.md` |
 | Workflow credentials | `references/workflow-credentials.md` |
 
@@ -29,6 +29,7 @@ Common flags:
 | `--pool`, `-p` | Target pool. Uses profile default if omitted. |
 | `--set key=value ...` | Override Jinja defaults; values may be cast to number. |
 | `--set-string key=value ...` | Override Jinja defaults as strings. |
+| `--label KEY=VALUE` | Override a submission label. Repeat for multiple keys. |
 | `--set-env key=value ...` | Override workflow environment variables. |
 | `--dry-run` | Render and print the workflow without submitting. |
 | `--priority HIGH|NORMAL|LOW` | Scheduler priority. LOW may be preempted. |
@@ -42,7 +43,7 @@ resubmission request. In that mode, `--dry-run` and `--set` are not supported.
 
 ```bash
 osmo workflow validate <workflow_file> [--pool <pool>] \
-  [--set key=value ...] [--set-string key=value ...]
+  [--set key=value ...] [--set-string key=value ...] [--label KEY=VALUE]
 ```
 
 Use validation when the user asks to check a workflow before submitting. It does
@@ -63,13 +64,29 @@ submitting a local YAML file.
 osmo workflow list [--count N] [--offset N] [--name <substring>] \
   [--status <status> ...] [--pool <pool> ...] [--user <user> ... | --all-users] \
   [--order asc|desc] [--submitted-after YYYY-MM-DD] \
-  [--submitted-before YYYY-MM-DD] [--tags <tag> ...] \
+  [--submitted-before YYYY-MM-DD] [--label KEY=SELECTOR] [--no-label KEY] \
   [--priority HIGH|NORMAL|LOW ...] [--app <app[:version]>] \
   [--format-type json|text]
 ```
 
 For recent workflow summaries, prefer `osmo workflow list --format-type json`
 and format the answer using `workflow-status.md`.
+
+## Labels
+
+In 6.4, the workflow tag command and list tag filter are removed. Use labels to
+classify new workflows: set `workflow.labels` in the spec or pass repeated
+`--label KEY=VALUE` overrides to submit or validate. Label keys and values must
+follow the workflow label rules; arbitrary legacy tags cannot be automatically
+converted to labels.
+
+List filters accept exact values, `*` wildcards, and `(VALUE|VALUE)` alternatives,
+for example `--label 'project=(sim_*|hil_*)'`. Repeat `--label` to require all
+selectors. Use `--no-label KEY` to find workflows without a key; repeat it to
+require every listed key to be absent.
+
+Labels cannot be changed on existing runs. Do not silently resubmit a workflow
+to add labels; submission needs an explicit user request.
 
 ## Query, Logs, Events, and Spec
 

--- a/skills/osmo-user/references/workflow-runtime-commands.md
+++ b/skills/osmo-user/references/workflow-runtime-commands.md
@@ -1,7 +1,7 @@
 # OSMO Workflow Runtime Commands
 
 Use this reference for live workflow operations: cancel, exec, port-forward,
-rsync, and tags. For submit/list/query/log syntax, read `workflow-commands.md`.
+and rsync. For submit/list/query/log syntax, read `workflow-commands.md`.
 
 ## Safety
 
@@ -66,12 +66,8 @@ osmo workflow rsync stop [workflow_id] [--task <task>]
 If task is omitted, upload/download target the lead task of the first group.
 `/osmo/run/workspace` is always available as a remote path.
 
-## Tags
+## Workflow classification
 
-```bash
-osmo workflow tag
-osmo workflow tag --workflow <workflow_id> ... --add <tag> ...
-osmo workflow tag --workflow <workflow_id> ... --remove <tag> ...
-```
-
-Use tags only when the user explicitly asks to list or update workflow tags.
+For classification requests, use the label guidance in `workflow-commands.md`.
+The workflow tag CLI was removed in 6.4. Labels are set at submission and cannot
+be changed on existing runs.

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -220,6 +220,38 @@ class TestAsyncioEntrypoints(unittest.TestCase):
 
 
 class TestRemovedCommands(unittest.TestCase):
+    def test_workflow_tags_reject_before_login_or_requests(self):
+        cases = (
+            ['workflow', 'tag'],
+            ['workflow', 'tag', '--help'],
+            ['workflow', 'tag', '--workflow', 'wf-1', '--add', 'nightly'],
+            ['workflow', 'tag', '--workflow', 'wf-1', '--remove', 'nightly'],
+            ['workflow', 'list', '--tags', 'nightly'],
+            ['workflow', 'list', '--tag', 'nightly'],
+        )
+        for arguments in cases:
+            with self.subTest(arguments=arguments):
+                output = io.StringIO()
+                errors = io.StringIO()
+                with mock.patch.object(cli.sys, 'argv', ['osmo', *arguments]), \
+                     mock.patch.object(cli, 'configure_logging') as configure_logging, \
+                     mock.patch.object(cli.client, 'LoginManager') as login_manager, \
+                     mock.patch.object(cli.client, 'ServiceClient') as service_client, \
+                     contextlib.redirect_stdout(output), contextlib.redirect_stderr(errors):
+                    service_client.return_value.request.return_value = {
+                        'tags': [], 'workflows': [], 'more_entries': False,
+                    }
+                    with self.assertRaises(SystemExit) as raised:
+                        cli.main()
+
+                self.assertEqual(raised.exception.code, 2)
+                diagnostic = 'invalid choice' if arguments[1] == 'tag' else 'unrecognized arguments'
+                self.assertIn(diagnostic, errors.getvalue())
+                configure_logging.assert_not_called()
+                login_manager.assert_not_called()
+                service_client.assert_not_called()
+                service_client.return_value.request.assert_not_called()
+
     def test_dataset_command_is_not_registered(self):
         parser = main_parser.create_cli_parser()
 

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -59,7 +59,6 @@ def _make_list_args(**overrides) -> argparse.Namespace:
         'name': None,
         'order': 'asc',
         'all_users': False,
-        'tags': None,
         'pool': [],
         'app': None,
         'priority': None,
@@ -226,7 +225,6 @@ class TestWorkflowLabelParser(unittest.TestCase):
             name=None,
             order='asc',
             all_users=False,
-            tags=None,
             pool=[],
             app=None,
             priority=None,
@@ -264,7 +262,6 @@ class TestWorkflowLabelParser(unittest.TestCase):
             name=None,
             order='asc',
             all_users=False,
-            tags=None,
             pool=[],
             app=None,
             priority=None,
@@ -1344,10 +1341,17 @@ class ListWorkflowsTest(unittest.TestCase):
 
         self.assertEqual(service_client.request.call_args.kwargs['params']['all_users'], True)
 
-    def test_tag_filter_sets_the_tags_param(self):
-        service_client = self._run_list(_make_list_args(tags=['nightly']))
+    def test_default_list_from_parser_omits_tags(self):
+        parser = argparse.ArgumentParser()
+        workflow.setup_parser(parser.add_subparsers())
+        args = parser.parse_args(['workflow', 'list'])
+        service_client = self._run_list(args)
 
-        self.assertEqual(service_client.request.call_args.kwargs['params']['tags'], ['nightly'])
+        service_client.request.assert_called_once()
+        params = service_client.request.call_args.kwargs['params']
+        self.assertNotIn('tags', params)
+        self.assertEqual(params['limit'], args.count)
+        self.assertTrue(params['all_pools'])
 
     def test_pool_filter_sets_the_pools_param_instead_of_all_pools(self):
         service_client = self._run_list(_make_list_args(pool=['pool-1']))
@@ -1420,66 +1424,34 @@ class ListWorkflowsTest(unittest.TestCase):
         self.assertIn('There are no workflows to view.', _joined_print_output(mock_print))
 
 
-class TagWorkflowsTest(unittest.TestCase):
-    """Test the 'workflow tag' command handler."""
+class WorkflowTagRetirementTest(unittest.TestCase):
+    """Help exposes label filters and no callable workflow tag interface."""
 
-    def test_tag_changes_without_a_workflow_raises_user_error(self):
-        service_client = mock.Mock(spec=client.ServiceClient)
-        args = argparse.Namespace(workflow=None, add=['nightly'], remove=[])
+    def test_workflow_help_omits_tag_choices(self):
+        parser = argparse.ArgumentParser()
+        workflow.setup_parser(parser.add_subparsers())
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            parser.parse_args(['workflow', '--help'])
 
-        with self.assertRaisesRegex(osmo_errors.OSMOUserError, 'No workflow specified'):
-            workflow._tag_workflows(service_client, args)
+        self.assertEqual(raised.exception.code, 0)
+        help_text = output.getvalue()
+        self.assertNotIn(',tag,', help_text)
+        self.assertNotRegex(help_text, r'(?m)^\s+tag\s')
+        self.assertIn('submit', help_text)
+        self.assertIn('list', help_text)
 
-    def test_workflow_without_tag_changes_raises_user_error(self):
-        service_client = mock.Mock(spec=client.ServiceClient)
-        args = argparse.Namespace(workflow=['wf-1'], add=[], remove=[])
+    def test_list_help_keeps_label_filters_and_omits_tags(self):
+        parser = argparse.ArgumentParser()
+        workflow.setup_parser(parser.add_subparsers())
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            parser.parse_args(['workflow', 'list', '--help'])
 
-        with self.assertRaisesRegex(osmo_errors.OSMOUserError, 'No tags specified'):
-            workflow._tag_workflows(service_client, args)
-
-    def test_added_and_removed_tags_are_forwarded_per_workflow(self):
-        service_client = mock.Mock(spec=client.ServiceClient)
-        args = argparse.Namespace(workflow=['wf-1'], add=['nightly'], remove=['draft'])
-
-        with mock.patch('builtins.print') as mock_print:
-            workflow._tag_workflows(service_client, args)
-
-        self.assertEqual(
-            service_client.request.call_args.kwargs['params'],
-            {'add': ['nightly'], 'remove': ['draft']})
-        self.assertIn('Workflow wf-1 updated.', _joined_print_output(mock_print))
-
-    def test_rejected_tag_update_prints_the_user_error(self):
-        service_client = mock.Mock(spec=client.ServiceClient)
-        service_client.request.side_effect = osmo_errors.OSMOUserError('unknown tag nightly')
-        args = argparse.Namespace(workflow=['wf-1'], add=['nightly'], remove=[])
-
-        with mock.patch('builtins.print') as mock_print:
-            workflow._tag_workflows(service_client, args)
-
-        self.assertIn('unknown tag nightly', _joined_print_output(mock_print))
-
-    def test_no_workflow_lists_the_available_tags(self):
-        service_client = mock.Mock(spec=client.ServiceClient)
-        service_client.request.return_value = {'tags': ['nightly', 'release']}
-        args = argparse.Namespace(workflow=None, add=[], remove=[])
-
-        with mock.patch('builtins.print') as mock_print:
-            workflow._tag_workflows(service_client, args)
-
-        output = _joined_print_output(mock_print)
-        self.assertIn('- nightly', output)
-        self.assertIn('- release', output)
-
-    def test_empty_tag_list_reports_that_admins_set_no_tags(self):
-        service_client = mock.Mock(spec=client.ServiceClient)
-        service_client.request.return_value = {'tags': []}
-        args = argparse.Namespace(workflow=None, add=[], remove=[])
-
-        with mock.patch('builtins.print') as mock_print:
-            workflow._tag_workflows(service_client, args)
-
-        self.assertIn('No tags have been set by admins.', _joined_print_output(mock_print))
+        self.assertEqual(raised.exception.code, 0)
+        self.assertNotIn('--tags', output.getvalue())
+        self.assertIn('--label KEY=SELECTOR', output.getvalue())
+        self.assertIn('--no-label KEY', output.getvalue())
 
 
 class GetWorkflowSpecTest(unittest.TestCase):

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -77,7 +77,10 @@ def setup_parser(parser: argparse._SubParsersAction):
         parser: The parser to be configured.
     '''
     workflow_parser = parser.add_parser('workflow',
-        help='Manage workflows submitted to the workflow service.')
+        help='Manage workflows submitted to the workflow service.',
+        epilog='In 6.4, workflow tags are removed from the CLI. Use submit --label KEY=VALUE '
+               'and list --label KEY=SELECTOR or --no-label KEY. '
+               'Labels cannot be changed on existing runs.')
     subparsers = workflow_parser.add_subparsers(dest='command')
     subparsers.required = True
 
@@ -331,9 +334,6 @@ def setup_parser(parser: argparse._SubParsersAction):
                                   'Example: --submitted-after 2023-05-02 --submitted-before '
                                   '2023-05-04 includes all workflows that were submitted any '
                                   'time on May 2nd and May 3rd only.')
-    list_parser.add_argument('--tags',
-                             nargs='+',
-                             help='Filter for workflows that contain the tag(s).')
     list_parser.add_argument('--priority',
                              type=lambda x: x.upper(),
                              nargs='+',
@@ -377,25 +377,6 @@ def setup_parser(parser: argparse._SubParsersAction):
                                  'For a specific app or app version, use the format '
                                  '<app>:<version>.')
     list_parser.set_defaults(func=_list_workflows)
-
-    # Handle 'tag' command
-    tag_parser = subparsers.add_parser('tag',
-                                       help='List or change tags from workflow(s) '
-                                            'if no workflow is specified. '
-                                            'Remove is applied before add')
-    tag_parser.add_argument('--workflow', '-w',
-                            nargs='+',
-                            help='List of workflows to update. If not set, the CLI will '
-                                 'return the list of available tags to assign.')
-    tag_parser.add_argument('--add', '-a',
-                            nargs='+',
-                            default=[],
-                            help='List of tags to add.')
-    tag_parser.add_argument('--remove', '-r',
-                            nargs='+',
-                            default=[],
-                            help='List of tags to remove.')
-    tag_parser.set_defaults(func=_tag_workflows)
 
     # Handle 'exec' command
     exec_parser = subparsers.add_parser('exec', help='Exec into a task of a workflow.')
@@ -1099,8 +1080,6 @@ def _list_workflows(service_client: client.ServiceClient, args: argparse.Namespa
         params['order'] = 'DESC'
     if args.all_users:
         params['all_users'] = True
-    if args.tags:
-        params['tags'] = args.tags
     if args.pool:
         params['pools'] = args.pool
     else:
@@ -1162,38 +1141,6 @@ def _list_workflows(service_client: client.ServiceClient, args: argparse.Namespa
             print(table.draw())
         else:
             print('There are no workflows to view.')
-
-
-def _tag_workflows(service_client: client.ServiceClient, args: argparse.Namespace):
-    if (args.add or args.remove) and not args.workflow:
-        raise osmo_errors.OSMOUserError('No workflow specified to add/remove tags from!')
-    if args.workflow and not (args.add or args.remove):
-        raise osmo_errors.OSMOUserError('No tags specified to add/remove!')
-
-    # Add/remove tags
-    if args.workflow:
-        params = {'add': args.add, 'remove': args.remove}
-        for workflow in args.workflow:
-            try:
-                service_client.request(
-                    client.RequestMethod.POST,
-                    f'api/workflow/{workflow}/tag',
-                    params=params)
-                print(f'Workflow {workflow} updated.')
-            except osmo_errors.OSMOUserError as err:
-                print(err)
-        return
-
-    # Get Tags
-    tags_response = service_client.request(
-        client.RequestMethod.GET,
-        'api/tag')
-    tags = tags_response.get('tags', [])
-    if not tags:
-        print('No tags have been set by admins.')
-    print('Tags:')
-    for tag in tags:
-        print(f'- {tag}')
 
 
 def _get_spec(service_client: client.ServiceClient, args: argparse.Namespace):

--- a/src/service/mcp/tests/test_cli_parity.py
+++ b/src/service/mcp/tests/test_cli_parity.py
@@ -97,8 +97,12 @@ _PARITY_CONTRACTS = {
         ),
     ),
     'osmo_list_workflows': _ParityContract(
-        _SEMANTIC_PROJECTION,
+        _INTENTIONAL_DIFFERENCE,
         'osmo workflow list --format-type json',
+        (
+            'MCP retains its optional legacy tags filter for compatibility; '
+            'the 6.4 CLI removes it. Both surfaces keep label selectors.'
+        ),
     ),
     'osmo_list_tasks': _ParityContract(
         _SEMANTIC_PROJECTION,

--- a/test/workflow/scripts/workflow_cli.sh
+++ b/test/workflow/scripts/workflow_cli.sh
@@ -33,20 +33,15 @@ if [ $? -ne 0 ]; then
 fi
 echo "[Workflow Query Done]"
 
-echo "[Workflow Tag Start] ------------------------------------------------"
-osmo workflow tag --workflow {{workflow_id}} --add test
-if [ $? -ne 0 ]; then
-    echo "[Workflow Tag Failed] Failed to add tag to workflow"
+echo "[Workflow Tag Removal Start] ----------------------------------------"
+tag_output=$(osmo workflow tag --help 2>&1)
+tag_status=$?
+if [ "$tag_status" -ne 2 ] || ! printf '%s\n' "$tag_output" | grep -Fq "invalid choice: 'tag'"; then
+    echo "[Workflow Tag Removal Failed] Expected argument-parser rejection"
+    printf '%s\n' "$tag_output"
     exit 1
 fi
-
-echo "[Workflow Tag] Remove 'test' tag from workflow"
-osmo workflow tag --workflow {{workflow_id}} --remove test
-if [ $? -ne 0 ]; then
-    echo "[Workflow Tag Failed] Failed to remove tag from workflow"
-    exit 1
-fi
-echo "[Workflow Tag Done]"
+echo "[Workflow Tag Removal Done]"
 
 echo "[Workflow Spec Start] ------------------------------------------------"
 osmo workflow spec {{workflow_id}}


### PR DESCRIPTION
## Description

The 6.4 CLI still advertises legacy workflow tags even though workflow labels replace that feature. Remove `osmo workflow tag` and `osmo workflow list --tags`; both now fail during argument parsing before login or service requests. The former `--tag` abbreviation is also rejected.

Use submission-time `--label KEY=VALUE` and list `--label KEY=SELECTOR` / `--no-label KEY` instead. Labels cannot be changed on existing runs. Update generated CLI help, documentation, user skill guidance, and the workflow smoke script. Retain backend tag APIs, data, and the MCP legacy tag filter for compatibility; record the MCP/CLI difference in its parity contract.

## Validation

- New CLI regression test fails on baseline main for all six obsolete invocations and passes on the candidate.
- `bazel test //src/cli/tests:test_workflow //src/cli/tests:test_cli //src/cli:cli_lib-pylint //src/cli/tests:test_workflow-pylint //src/service/mcp/tests:test_cli_parity` — pass, including normal mypy checks; 144 unit tests and two lint targets.
- `bazel build //src/cli:cli` — pass. Built CLI rejects all six obsolete invocations with exit 2 and creates no login or log files.
- Bash/Zsh completion generation and syntax checks — pass; retired command/filter absent, label flags preserved.
- Fresh full HTML and Markdown builds — pass with zero warnings. Optional spelling extension disabled locally because native Enchant is unavailable.
- Full existing workflow CLI smoke script against a 6.4 dev service — pass, including profile, list, query, spec, pool, resource, and task checks. Bounded default and label-filtered workflow reads also pass.
- Updated smoke rejection block fails on the old CLI and passes on the candidate; `bash -n` and `git diff --check` pass.

- Independent implementation review — GO on `0ae3909e8b6c1b269fca64d8adbfebc4cc01d78c`, with no blocking findings.

Issue #None

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed workflow tag commands, the `--tag` abbreviation, and tag-based filtering from the 6.4 CLI.
  * Unsupported tag commands and options now return clear parser errors before service interaction.
  * Workflow lists continue to support label selectors, priority, pagination, pool, and no-label filters.
  * Labels must be assigned at submission and cannot be changed on existing runs.

* **Documentation**
  * Updated workflow guidance to explain the transition from tags to labels and related usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->