### PR TITLE
Fix mounted credential refresh without reloading startup config

### DIFF
--- a/docs/deployment_guide/getting_started/deploy_service.rst
+++ b/docs/deployment_guide/getting_started/deploy_service.rst
@@ -215,6 +215,29 @@ Use the two Kubernetes Secrets you created in Step 2 (``osmo-workflow-log-cred``
 
 In Step 4, follow the ``# static credentials`` comments inline in the ``osmo_values.yaml`` sample to flip the sample from workload identity to static credentials.
 
+Rotating mounted credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each service process checks explicitly referenced credential files every 30 seconds.
+This applies to ``workflow_data``, ``workflow_log``, and ``workflow_app`` access keys,
+and ``backend_images`` registry login credentials. Use ``secretName`` / ``secretKey``
+or ``secret_file`` directly under the corresponding ``credential`` setting.
+Kubernetes must first project the updated Secret into the pod, so total propagation
+time includes the kubelet's projection delay. Mount Secret directories, not ``subPath``
+files, to receive Kubernetes updates.
+
+Valid replacements are published together for subsequent credential reads. Missing,
+invalid, or concurrently changing files leave the last accepted credentials active;
+the next check retries automatically. Already-created task pods and in-flight
+operations retain their captured credentials. Keep old credentials valid until
+those tasks finish and all service replicas have observed the replacement.
+
+The ConfigMap remains startup-only. Changing Secret references, storage endpoints,
+regions, addressing options, registry addresses, or authentication mode requires a
+restart. Generic Secret-backed configuration and other secrets (including database,
+signing, and encryption keys) are not refreshed by this mechanism. ConfigMap changes
+do not affect which credential files an already running process checks.
+
 
 .. _deploy_service_osmo_values:
 

--- a/docs/deployment_guide/getting_started/deploy_service.rst
+++ b/docs/deployment_guide/getting_started/deploy_service.rst
@@ -215,33 +215,7 @@ Use the two Kubernetes Secrets you created in Step 2 (``osmo-workflow-log-cred``
 
 In Step 4, follow the ``# static credentials`` comments inline in the ``osmo_values.yaml`` sample to flip the sample from workload identity to static credentials.
 
-Rotating mounted credentials
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Each service process checks explicitly referenced credential files every 30 seconds.
-This applies to ``workflow_data``, ``workflow_log``, and ``workflow_app`` access keys,
-and ``backend_images`` registry login credentials. Use ``secretName`` / ``secretKey``
-or ``secret_file`` directly under the corresponding ``credential`` setting.
-Kubernetes must first project the updated Secret into the pod, so total propagation
-time includes the kubelet's projection delay. Mount Secret directories, not ``subPath``
-files, to receive Kubernetes updates.
-
-Valid replacements are published together for subsequent credential reads. Missing,
-invalid, or concurrently changing files leave the last accepted credentials active;
-the next check retries automatically. Already-created task pods and in-flight
-operations retain their captured credentials. Keep old credentials valid until
-those tasks finish and all service replicas have observed the replacement.
-
-Kubernetes event notifications are best effort: their separate client uses one-second
-connection and read timeouts with automatic retries disabled. Notification failures
-do not prevent subsequent credential-refresh attempts. Durable startup reconciliation
-uses its existing client and is not affected by these event-delivery limits.
-
-The ConfigMap remains startup-only. Changing Secret references, storage endpoints,
-regions, addressing options, registry addresses, or authentication mode requires a
-restart. Generic Secret-backed configuration and other secrets (including database,
-signing, and encryption keys) are not refreshed by this mechanism. ConfigMap changes
-do not affect which credential files an already running process checks.
+For ongoing credential rotation, see :ref:`rotating_mounted_credentials`.
 
 
 .. _deploy_service_osmo_values:

--- a/docs/deployment_guide/getting_started/deploy_service.rst
+++ b/docs/deployment_guide/getting_started/deploy_service.rst
@@ -232,6 +232,11 @@ the next check retries automatically. Already-created task pods and in-flight
 operations retain their captured credentials. Keep old credentials valid until
 those tasks finish and all service replicas have observed the replacement.
 
+Kubernetes event notifications are best effort: their separate client uses one-second
+connection and read timeouts with automatic retries disabled. Notification failures
+do not prevent subsequent credential-refresh attempts. Durable startup reconciliation
+uses its existing client and is not affected by these event-delivery limits.
+
 The ConfigMap remains startup-only. Changing Secret references, storage endpoints,
 regions, addressing options, registry addresses, or authentication mode requires a
 restart. Generic Secret-backed configuration and other secrets (including database,

--- a/docs/deployment_guide/references/configs_definitions/workflow.rst
+++ b/docs/deployment_guide/references/configs_definitions/workflow.rst
@@ -225,6 +225,40 @@ Credential
      - Cloud storage region.
      - ``None``
 
+.. _rotating_mounted_credentials:
+
+Rotating mounted credentials
+----------------------------
+
+Each service process checks explicitly referenced credential files every 30 seconds.
+This applies to ``workflow_data``, ``workflow_log``, and ``workflow_app`` access keys,
+and ``backend_images`` registry login credentials. Use ``secretName`` / ``secretKey``
+or ``secret_file`` directly under the corresponding ``credential`` setting.
+Kubernetes must first project the updated Secret into the pod, so total propagation
+time includes the kubelet's projection delay. Mount Secret directories, not ``subPath``
+files, to receive Kubernetes updates.
+
+At startup, detected dependency changes during credential reads are retried within
+the existing 30-second startup retry window. Stable malformed, missing, or invalid
+credential references remain startup errors.
+
+Valid replacements are published together for subsequent credential reads. Missing,
+invalid, or concurrently changing files leave the last accepted credentials active;
+the next check retries automatically. Already-created task pods and in-flight
+operations retain their captured credentials. Keep old credentials valid until
+those tasks finish and all service replicas have observed the replacement.
+
+Kubernetes event notifications are best effort: their separate client uses one-second
+connection and read timeouts with automatic retries disabled. Notification failures
+do not prevent subsequent credential-refresh attempts. Durable startup reconciliation
+uses its existing client and is not affected by these event-delivery limits.
+
+The ConfigMap remains startup-only. Changing Secret references, storage endpoints,
+regions, addressing options, registry addresses, or authentication mode requires a
+restart. Generic Secret-backed configuration and other secrets (including database,
+signing, and encryption keys) are not refreshed by this mechanism. ConfigMap changes
+do not affect which credential files an already running process checks.
+
 Workflow Information
 =====================
 

--- a/src/service/agent/agent_service.py
+++ b/src/service/agent/agent_service.py
@@ -148,6 +148,7 @@ def main():
         try:
             await uvicorn_server.serve()
         finally:
+            app.state.config_watcher.stop()
             liveness_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await liveness_task

--- a/src/service/core/config/BUILD
+++ b/src/service/core/config/BUILD
@@ -26,6 +26,7 @@ osmo_py_library(
         "configmap_events.py",
         "configmap_guard.py",
         "configmap_loader.py",
+        "secret_snapshot.py",
     ],
     deps = [
         requirement("kubernetes"),

--- a/src/service/core/config/configmap_events.py
+++ b/src/service/core/config/configmap_events.py
@@ -44,6 +44,10 @@ RECONCILIATION_STATE_ANNOTATION = (
 # don't get rejected by the apiserver.
 _MAX_MESSAGE_LENGTH = 1000
 
+# Event delivery runs on the credential polling thread. Bound each connect/read
+# and disable retries on its dedicated client, including Retry-After sleeps.
+_EVENT_REQUEST_TIMEOUT_S = (1.0, 1.0)
+
 
 class EventRecorder(Protocol):
     """Structural interface so tests can substitute a fake recorder."""
@@ -137,8 +141,13 @@ class ConfigMapEventRecorder:
                     'ConfigMapEventRecorder: no kubeconfig available; '
                     'events will not be emitted')
                 self._core_v1 = None
+                self._event_api = None
                 return
         self._core_v1 = client.CoreV1Api()
+        event_configuration = client.Configuration.get_default_copy()
+        event_configuration.retries = 0
+        self._event_api = client.CoreV1Api(
+            api_client=client.ApiClient(configuration=event_configuration))
 
     def emit_reload_failed(self, message: str) -> None:
         self._emit('Warning', REASON_RELOAD_FAILED, message)
@@ -178,7 +187,7 @@ class ConfigMapEventRecorder:
         incremented count and refreshed message/timestamp. This matches
         the kubelet pattern and prevents event spam during crash-loops.
         """
-        if self._core_v1 is None:
+        if self._event_api is None:
             return
 
         if len(message) > _MAX_MESSAGE_LENGTH:
@@ -188,8 +197,8 @@ class ConfigMapEventRecorder:
         event_name = f'{self._configmap_name}.{reason.lower()}'
 
         try:
-            existing = self._core_v1.read_namespaced_event(
-                event_name, self._namespace)
+            existing = self._event_api.read_namespaced_event(
+                event_name, self._namespace, _request_timeout=_EVENT_REQUEST_TIMEOUT_S)
         except ApiException as error:
             if error.status != 404:
                 logging.warning(
@@ -213,11 +222,16 @@ class ConfigMapEventRecorder:
                 count=1,
             )
             try:
-                self._core_v1.create_namespaced_event(self._namespace, event)
+                self._event_api.create_namespaced_event(
+                    self._namespace, event, _request_timeout=_EVENT_REQUEST_TIMEOUT_S)
             except Exception as create_error:  # pylint: disable=broad-exception-caught
                 logging.warning(
                     'Failed to create K8s Event %s: %s',
                     event_name, create_error)
+            return
+
+        except Exception:  # pylint: disable=broad-exception-caught
+            logging.warning('Unable to read Kubernetes event; skipping notification')
             return
 
         # Existing event → patch with incremented count
@@ -227,8 +241,8 @@ class ConfigMapEventRecorder:
             'message': message,
         }
         try:
-            self._core_v1.patch_namespaced_event(
-                event_name, self._namespace, patch)
+            self._event_api.patch_namespaced_event(
+                event_name, self._namespace, patch, _request_timeout=_EVENT_REQUEST_TIMEOUT_S)
         except Exception as patch_error:  # pylint: disable=broad-exception-caught
             logging.warning(
                 'Failed to patch K8s Event %s: %s', event_name, patch_error)
@@ -252,11 +266,11 @@ class ConfigMapEventRecorder:
     def _get_configmap_uid(self) -> str | None:
         if self._configmap_uid is not None:
             return self._configmap_uid
-        if self._core_v1 is None:
+        if self._event_api is None:
             return None
         try:
-            configmap = self._core_v1.read_namespaced_config_map(
-                self._configmap_name, self._namespace)
+            configmap = self._event_api.read_namespaced_config_map(
+                self._configmap_name, self._namespace, _request_timeout=_EVENT_REQUEST_TIMEOUT_S)
             self._configmap_uid = configmap.metadata.uid
             return self._configmap_uid
         except Exception as error:  # pylint: disable=broad-exception-caught

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -18,12 +18,14 @@ SPDX-License-Identifier: Apache-2.0
 
 import base64
 import copy
+import dataclasses
 import datetime
 import enum
 import hashlib
 import json
 import logging
 import os
+import threading
 import time
 from typing import Any, Callable, Dict, List
 
@@ -32,7 +34,7 @@ import yaml
 
 from src.lib.utils import jinja_sandbox, osmo_errors
 from src.lib.utils.common import merge_lists_on_name, recursive_dict_update
-from src.service.core.config import configmap_events, configmap_guard
+from src.service.core.config import configmap_events, configmap_guard, secret_snapshot
 from src.utils import auth, connectors
 
 
@@ -40,6 +42,23 @@ from src.utils import auth, connectors
 # ConfigMap volume on a new pod, so we retry the initial load before giving up.
 _STARTUP_RETRY_DEADLINE_S = 30.0
 _STARTUP_RETRY_INTERVAL_S = 1.0
+_DEPENDENCY_CHECK_INTERVAL_S = 30.0
+_REFRESHABLE_CREDENTIALS = {
+    'workflow_data': frozenset({'access_key_id', 'access_key'}),
+    'workflow_log': frozenset({'access_key_id', 'access_key'}),
+    'workflow_app': frozenset({'access_key_id', 'access_key'}),
+    'backend_images': frozenset({'username', 'auth', 'password'}),
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class RefreshStatus:
+    """Process-local freshness, not an attestation of cluster-wide rotation."""
+
+    sequence: int
+    last_success_time: float | None
+    failures: int
+    stale: bool
 
 
 class LoadResult(enum.Enum):
@@ -78,7 +97,7 @@ class ConfigFileMixin(pydantic.BaseModel):
 
 
 class ConfigMapWatcher:
-    """Loads one immutable ConfigMap snapshot during process startup."""
+    """Load immutable configuration; refresh only referenced authentication material."""
 
     def __init__(
         self,
@@ -104,6 +123,15 @@ class ConfigMapWatcher:
         # Only emit "reload succeeded" events when recovering from a
         # previous failure — successful reloads on their own are noise.
         self._last_reload_failed = False
+        self._reload_lock = threading.RLock()
+        self._stop_event = threading.Event()
+        self._dependency_thread: threading.Thread | None = None
+        self._credential_sources: Dict[str, Dict[str, Any]] = {}
+        self._startup_snapshot: Dict[str, Any] | None = None
+        self._loaded_dependencies: secret_snapshot.DependencySnapshot | None = None
+        self._sequence = 0
+        self._last_success_time: float | None = None
+        self._refresh_failures = 0
 
     def start(self) -> None:
         """Load configs and activate immutable ConfigMap mode.
@@ -141,25 +169,106 @@ class ConfigMapWatcher:
         logging.info(
             'Immutable ConfigMap snapshot loaded from %s; changes require a pod restart',
             self._config_file_path)
+        if self._credential_sources and not self._stop_event.is_set():
+            self._dependency_thread = threading.Thread(
+                target=self._watch_dependencies, name='credential-dependencies', daemon=True)
+            self._dependency_thread.start()
 
     def stop(self) -> None:
-        """Compatibility no-op; immutable snapshots have no background watcher."""
+        """Stop polling and wait for any in-flight publication."""
+        self._stop_event.set()
+        if self._dependency_thread:
+            self._dependency_thread.join(timeout=5)
+        with self._reload_lock:
+            pass
+
+    @property
+    def refresh_status(self) -> RefreshStatus:
+        with self._reload_lock:
+            return RefreshStatus(
+                self._sequence, self._last_success_time, self._refresh_failures,
+                self._last_reload_failed or self._loaded_dependencies is None
+                or not self._loaded_dependencies.unchanged())
+
+    def _watch_dependencies(self) -> None:
+        while not self._stop_event.wait(_DEPENDENCY_CHECK_INTERVAL_S):
+            self._check_dependencies()
+
+    def _check_dependencies(self) -> None:
+        with self._reload_lock:
+            if (self._stop_event.is_set() or self._startup_snapshot is None
+                    or not self._credential_sources):
+                return
+            if (self._last_reload_failed or self._loaded_dependencies is None
+                    or not self._loaded_dependencies.unchanged()):
+                self._refresh_secrets()
+
+    def _refresh_secrets(self) -> None:
+        # Called under the reload lock. Never read config.yaml or re-run startup
+        # reconciliation: only fixed credential subtrees may change after startup.
+        try:
+            if self._startup_snapshot is None:
+                return
+            candidate = copy.deepcopy(self._startup_snapshot)
+            dependencies = secret_snapshot.DependencySnapshot()
+            _resolve_refreshable_credentials(candidate, self._credential_sources, dependencies)
+            for name, fields in _REFRESHABLE_CREDENTIALS.items():
+                if name not in self._credential_sources:
+                    continue
+                previous = self._startup_snapshot['workflow'][name]['credential']
+                current = candidate['workflow'][name]['credential']
+                if not isinstance(current, dict) or not isinstance(previous, dict):
+                    raise ValueError('Credential must remain a mapping')
+                # Forbid changes to storage/registry routing and auth mode. Only
+                # replace authentication fields that existed at startup.
+                if (current.keys() != previous.keys()
+                        or {key: value for key, value in current.items() if key not in fields}
+                        != {key: value for key, value in previous.items() if key not in fields}):
+                    raise ValueError('Credential configuration changed; restart required')
+            if validate_configmap_snapshot(candidate):
+                raise ValueError('Credential candidate failed validation')
+            if self._stop_event.is_set() or not dependencies.unchanged():
+                raise secret_snapshot.DependencyReadError('Credential changed during validation')
+            configmap_guard.set_parsed_configs(candidate)
+            self._loaded_dependencies = dependencies
+            self._sequence += 1
+            self._last_success_time = time.time()
+            logging.info('Credential snapshot refreshed (sequence %d)', self._sequence)
+            self._record_success()
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Parser/model exceptions can contain credential input. Keep both
+            # logging and event notifications value-free, and keep polling alive.
+            self._record_failure('Credential refresh failed; keeping previous snapshot')
 
     def _record_failure(self, message: str) -> None:
         """Log + emit a K8s Warning event for a reload failure."""
         logging.error(message)
-        if self._event_recorder is not None:
-            self._event_recorder.emit_reload_failed(message)
         self._last_reload_failed = True
+        self._refresh_failures += 1
+        if self._event_recorder is not None:
+            try:
+                self._event_recorder.emit_reload_failed(message)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.warning('Unable to emit configuration refresh event')
 
     def _record_success(self) -> None:
         """Emit a Normal event only if we just recovered from a failure."""
-        if self._last_reload_failed and self._event_recorder is not None:
-            self._event_recorder.emit_reload_succeeded(
-                'ConfigMap reload succeeded after previous failure')
+        recovered = self._last_reload_failed
         self._last_reload_failed = False
+        if recovered and self._event_recorder is not None:
+            try:
+                self._event_recorder.emit_reload_succeeded(
+                    'ConfigMap reload succeeded after previous failure')
+            except Exception:  # pylint: disable=broad-exception-caught
+                logging.warning('Unable to emit configuration refresh event')
 
     def _load_and_apply(self) -> LoadResult:
+        with self._reload_lock:
+            if self._stop_event.is_set():
+                return LoadResult.TRANSIENT_FAILURE
+            return self._load_startup_snapshot()
+
+    def _load_startup_snapshot(self) -> LoadResult:
         """Parse, resolve secrets, validate, and swap the in-memory config dict.
 
         TRANSIENT_FAILURE means retrying may succeed (file not yet
@@ -206,6 +315,11 @@ class ConfigMapWatcher:
         if isinstance(service_config, dict):
             service_config.pop('service_auth', None)
 
+        # Extract only direct, explicit credential references. Generic Secret-
+        # backed configuration still resolves once and is never watched.
+        credential_sources = _extract_refreshable_credentials(managed_configs)
+        dependencies = secret_snapshot.DependencySnapshot()
+
         # Resolve mounted Secret references. Any missing, malformed, or
         # out-of-root reference is a permanent startup error; serving with
         # partially resolved credentials is never safe.
@@ -213,6 +327,7 @@ class ConfigMapWatcher:
             for section in managed_configs.values():
                 if isinstance(section, dict):
                     _resolve_secret_file_references(section)
+            _resolve_refreshable_credentials(managed_configs, credential_sources, dependencies)
         except (TypeError, ValueError) as error:
             self._record_failure(f'ConfigMap Secret resolution failed: {error}')
             return LoadResult.PERMANENT_FAILURE
@@ -234,6 +349,10 @@ class ConfigMapWatcher:
         # YAML that only contains reference names, not expanded content.
         _resolve_backend_test_computed_fields(managed_configs)
         _resolve_pool_computed_fields(managed_configs)
+
+        if not dependencies.unchanged():
+            self._record_failure('Credential changed during startup validation')
+            return LoadResult.TRANSIENT_FAILURE
 
         if self._enable_reconciliation:
             try:
@@ -264,7 +383,15 @@ class ConfigMapWatcher:
 
         # Publish the validated snapshot only after every required backend side
         # effect is durably queued and its cleanup checkpoint is persisted.
+        if self._stop_event.is_set() or not dependencies.unchanged():
+            self._record_failure('Credential changed before startup publication')
+            return LoadResult.TRANSIENT_FAILURE
         configmap_guard.set_parsed_configs(managed_configs)
+        self._startup_snapshot = copy.deepcopy(managed_configs)
+        self._credential_sources = credential_sources
+        self._loaded_dependencies = dependencies
+        self._sequence += 1
+        self._last_success_time = time.time()
         if not configmap_guard.is_configmap_mode():
             configmap_guard.set_configmap_mode(True)
             logging.info(
@@ -1292,6 +1419,34 @@ def _resolve_platform_fields(
 SECRETS_ROOT = '/etc/osmo/secrets'
 
 
+def _extract_refreshable_credentials(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Temporarily remove explicit credential refs for a separate coherent read."""
+    references: Dict[str, Dict[str, Any]] = {}
+    workflow = config.get('workflow')
+    if not isinstance(workflow, dict):
+        return references
+    for name in _REFRESHABLE_CREDENTIALS:
+        value = workflow.get(name)
+        if not isinstance(value, dict):
+            continue
+        credential = value.get('credential')
+        if isinstance(credential, dict) and (
+                'secret_file' in credential
+                or ('secretName' in credential and 'secretKey' in credential)):
+            references[name] = copy.deepcopy(value.pop('credential'))
+    return references
+
+
+def _resolve_refreshable_credentials(
+    config: Dict[str, Any], sources: Dict[str, Dict[str, Any]],
+    dependencies: secret_snapshot.DependencySnapshot,
+) -> None:
+    for name, source in sources.items():
+        resolved = {'credential': copy.deepcopy(source)}
+        _resolve_secret_file_references(resolved, f'workflow.{name}', snapshot=dependencies)
+        config['workflow'][name]['credential'] = resolved['credential']
+
+
 def _decode_dockerconfig_identity(
     auth_b64: str, username: str,
 ) -> tuple[str, str]:
@@ -1321,7 +1476,9 @@ def _decode_dockerconfig_identity(
 
 
 def _resolve_secret_file_references(config_data: Dict[str, Any],
-                                     parent_key: str = '') -> None:
+                                     parent_key: str = '', *,
+                                     snapshot: secret_snapshot.DependencySnapshot | None = None,
+                                     ) -> None:
     """Resolve explicit OSMO config Secret references without touching pod specs.
 
     Walks the dict tree. A Kubernetes Secret reference is recognized only when
@@ -1357,7 +1514,7 @@ def _resolve_secret_file_references(config_data: Dict[str, Any],
                     f'{label}: secret_file must resolve below the mounted '
                     'Kubernetes Secret root')
             _resolve_single_secret(
-                config_data, key, value, secret_file_path, label)
+                config_data, key, value, secret_file_path, label, snapshot=snapshot)
             continue
 
         if 'secretName' in value and 'secretKey' in value:
@@ -1379,15 +1536,16 @@ def _resolve_secret_file_references(config_data: Dict[str, Any],
                     'Kubernetes Secret root')
             _resolve_single_secret(
                 config_data, key, value,
-                os.path.join(secret_dir, explicit_key), label)
+                os.path.join(secret_dir, explicit_key), label, snapshot=snapshot)
             continue
 
-        _resolve_secret_file_references(value, label)
+        _resolve_secret_file_references(value, label, snapshot=snapshot)
 
 
 def _resolve_single_secret(parent_dict: Dict[str, Any], key: str,
                            current_value: Dict[str, Any],
-                           secret_file_path: str, path_label: str) -> None:
+                           secret_file_path: str, path_label: str, *,
+                           snapshot: secret_snapshot.DependencySnapshot | None = None) -> None:
     """Read a secret file and replace the reference with actual values.
 
     Supports three formats:
@@ -1396,8 +1554,11 @@ def _resolve_single_secret(parent_dict: Dict[str, Any], key: str,
     3. YAML dict: merges all keys into the current dict
     """
     try:
-        with open(secret_file_path, encoding='utf-8') as secret_file:
-            content = secret_file.read()
+        if snapshot is not None:
+            content = snapshot.read_file(secret_file_path)
+        else:
+            with open(secret_file_path, encoding='utf-8') as secret_file:
+                content = secret_file.read()
     except OSError as error:
         raise ValueError(f'{path_label}: mounted Secret file is unreadable') from error
 
@@ -1453,8 +1614,7 @@ def _resolve_single_secret(parent_dict: Dict[str, Any], key: str,
             current_value.pop('secretName', None)
             current_value.pop('secretKey', None)
             current_value.update(extracted)
-            logging.info('Loaded Docker registry credentials for %s from %s',
-                         path_label, registry_url)
+            logging.info('Loaded Docker registry credentials for %s', path_label)
             return
 
     current_value.pop('secret_file', None)

--- a/src/service/core/config/configmap_loader.py
+++ b/src/service/core/config/configmap_loader.py
@@ -320,14 +320,17 @@ class ConfigMapWatcher:
         credential_sources = _extract_refreshable_credentials(managed_configs)
         dependencies = secret_snapshot.DependencySnapshot()
 
-        # Resolve mounted Secret references. Any missing, malformed, or
-        # out-of-root reference is a permanent startup error; serving with
-        # partially resolved credentials is never safe.
+        # Stable missing, malformed, or out-of-root references are permanent
+        # errors. Observed changes (including removal of an old pinned generation)
+        # are retryable; never publish partially resolved credentials.
         try:
             for section in managed_configs.values():
                 if isinstance(section, dict):
                     _resolve_secret_file_references(section)
             _resolve_refreshable_credentials(managed_configs, credential_sources, dependencies)
+        except secret_snapshot.DependencyChangedError as error:
+            self._record_failure(f'ConfigMap Secret resolution failed: {error}')
+            return LoadResult.TRANSIENT_FAILURE
         except (TypeError, ValueError) as error:
             self._record_failure(f'ConfigMap Secret resolution failed: {error}')
             return LoadResult.PERMANENT_FAILURE

--- a/src/service/core/config/secret_snapshot.py
+++ b/src/service/core/config/secret_snapshot.py
@@ -1,0 +1,92 @@
+"""Coherent reads and cheap change detection for mounted config dependencies.
+
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import dataclasses
+import os
+from pathlib import Path
+
+
+class DependencyReadError(ValueError):
+    """Safe to report: deliberately contains no file contents or exception text."""
+
+
+def _file_signature(path: Path) -> tuple:
+    info = path.stat()
+    return (info.st_dev, info.st_ino, info.st_mtime_ns, info.st_ctime_ns, info.st_size)
+
+
+def _signature(path: Path) -> tuple:
+    """Bounded metadata reads; never recursively scan a dependency tree."""
+    signature = _file_signature(path)
+    if path.is_dir():
+        return signature + (tuple(
+            (entry.name, _file_signature(entry))
+            for entry in sorted(path.iterdir()) if not entry.name.startswith('..')
+        ),)
+    return signature
+
+
+@dataclasses.dataclass
+class DependencySnapshot:
+    """Provenance only, never credential values; one instance per candidate."""
+
+    signatures: dict[Path, tuple] = dataclasses.field(default_factory=dict)
+    projections: dict[Path, Path] = dataclasses.field(default_factory=dict)
+
+    def _track(self, path: Path) -> None:
+        signature = _signature(path)
+        previous = self.signatures.setdefault(path, signature)
+        if previous != signature:
+            raise DependencyReadError('Configuration dependency changed during read')
+
+    def _pin(self, path: Path) -> Path:
+        # Find the mounted volume root even for an explicit key in a subdirectory.
+        for parent in (path, *path.parents):
+            link = parent / '..data'
+            if link.is_symlink():
+                self._track(link)
+                target = self.projections.setdefault(parent, link.resolve(strict=True))
+                if not target.is_relative_to(parent.resolve()):
+                    raise DependencyReadError('Invalid projected dependency path')
+                pinned = target / path.relative_to(parent)
+                if not pinned.resolve(strict=True).is_relative_to(target):
+                    raise DependencyReadError('Invalid projected dependency key')
+                return pinned
+        return path
+
+    def read_file(self, path: str) -> str:
+        try:
+            source = Path(os.path.abspath(path))
+            pinned = self._pin(source)
+            self._track(source)
+            content = pinned.read_text(encoding='utf-8')
+            self._track(source)
+            return content
+        except (OSError, UnicodeError, RuntimeError):
+            raise DependencyReadError('Unable to read configuration dependency') from None
+
+    def read_directory(self, path: str) -> dict[str, str]:
+        try:
+            source = Path(os.path.abspath(path))
+            pinned = self._pin(source)
+            self._track(source)
+            fields = {}
+            for entry in sorted(pinned.iterdir()):
+                if entry.name.startswith('..'):
+                    continue
+                if not entry.is_file() or not entry.resolve().is_relative_to(pinned.resolve()):
+                    raise DependencyReadError('Invalid credential field')
+                fields[entry.name] = entry.read_text(encoding='utf-8').rstrip('\n')
+            self._track(source)
+            return fields
+        except (OSError, UnicodeError, RuntimeError):
+            raise DependencyReadError('Unable to read credential dependency') from None
+
+    def unchanged(self) -> bool:
+        try:
+            return all(_signature(path) == value for path, value in self.signatures.items())
+        except (OSError, RuntimeError):
+            return False

--- a/src/service/core/config/secret_snapshot.py
+++ b/src/service/core/config/secret_snapshot.py
@@ -13,6 +13,10 @@ class DependencyReadError(ValueError):
     """Safe to report: deliberately contains no file contents or exception text."""
 
 
+class DependencyChangedError(DependencyReadError):
+    """A previously observed dependency changed; retry with a fresh snapshot."""
+
+
 def _file_signature(path: Path) -> tuple:
     info = path.stat()
     return (info.st_dev, info.st_ino, info.st_mtime_ns, info.st_ctime_ns, info.st_size)
@@ -40,7 +44,7 @@ class DependencySnapshot:
         signature = _signature(path)
         previous = self.signatures.setdefault(path, signature)
         if previous != signature:
-            raise DependencyReadError('Configuration dependency changed during read')
+            raise DependencyChangedError('Configuration dependency changed during read')
 
     def _pin(self, path: Path) -> Path:
         # Find the mounted volume root even for an explicit key in a subdirectory.
@@ -66,6 +70,9 @@ class DependencySnapshot:
             self._track(source)
             return content
         except (OSError, UnicodeError, RuntimeError):
+            if self.signatures and not self.unchanged():
+                raise DependencyChangedError(
+                    'Configuration dependency changed during read') from None
             raise DependencyReadError('Unable to read configuration dependency') from None
 
     def read_directory(self, path: str) -> dict[str, str]:
@@ -83,6 +90,9 @@ class DependencySnapshot:
             self._track(source)
             return fields
         except (OSError, UnicodeError, RuntimeError):
+            if self.signatures and not self.unchanged():
+                raise DependencyChangedError(
+                    'Configuration dependency changed during read') from None
             raise DependencyReadError('Unable to read credential dependency') from None
 
     def unchanged(self) -> bool:

--- a/src/service/core/config/tests/BUILD
+++ b/src/service/core/config/tests/BUILD
@@ -16,7 +16,7 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 
-load("//bzl:py.bzl", "osmo_py_test")
+load("//bzl:py.bzl", "osmo_py_binary", "osmo_py_test")
 load("@osmo_python_deps//:requirements.bzl", "requirement")
 
 osmo_py_test(
@@ -61,4 +61,26 @@ osmo_py_test(
     size = "large",
     tags = ["requires-network"],
     visibility = ["//visibility:public"],
+)
+
+osmo_py_test(
+    name = "test_secret_refresh",
+    srcs = ["test_secret_refresh.py"],
+    deps = [
+        requirement("pyyaml"),
+        "//src/service/core/config:configmap_loader_lib",
+        "//src/utils:auth",
+        "//src/utils:configmap_state",
+        "//src/utils/connectors",
+        "//src/utils/job:job",
+    ],
+)
+
+# Explicit opt-in: creates only uniquely named, synthetic-only Kubernetes probes.
+osmo_py_binary(
+    name = "verify_secret_refresh_kubernetes",
+    srcs = ["verify_secret_refresh_kubernetes.py"],
+    main = "verify_secret_refresh_kubernetes.py",
+    data = ["secret_refresh_probe.py"],
+    tags = ["manual"],
 )

--- a/src/service/core/config/tests/BUILD
+++ b/src/service/core/config/tests/BUILD
@@ -45,6 +45,7 @@ osmo_py_test(
     deps = [
         requirement("fastapi"),
         requirement("pyyaml"),
+        requirement("urllib3"),
         "//src/service/core/config:config",
     ],
 )
@@ -68,6 +69,7 @@ osmo_py_test(
     srcs = ["test_secret_refresh.py"],
     deps = [
         requirement("pyyaml"),
+        requirement("urllib3"),
         "//src/service/core/config:configmap_loader_lib",
         "//src/utils:auth",
         "//src/utils:configmap_state",

--- a/src/service/core/config/tests/secret_refresh_probe.py
+++ b/src/service/core/config/tests/secret_refresh_probe.py
@@ -1,0 +1,72 @@
+"""Isolated probe of packaged loader code, driven by the Kubernetes integration test.
+
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import dataclasses
+import hashlib
+import json
+import os
+from pathlib import Path
+import threading
+import time
+
+from src.service.core.config import configmap_loader
+from src.utils import auth, configmap_state, connectors
+from src.utils.job import task
+
+
+def main():
+    config_path = Path('/probe/config.yaml')
+    watcher = configmap_loader.ConfigMapWatcher(str(config_path))
+    # An isolated signing identity: no live database, service auth, or storage access.
+    watcher._stable_service_auth = auth.AuthenticationConfig.generate_default()
+    if os.environ.get('DISABLE_DEPENDENCY_POLLING') == '1':
+        # Negative control is confined to this disposable probe process.
+        watcher._check_dependencies = lambda: None
+    if configmap_loader._DEPENDENCY_CHECK_INTERVAL_S != 30:
+        raise RuntimeError('Probe requires the production 30-second interval')
+    watcher.start()
+    deadline = time.monotonic() + 900
+    try:
+        while time.monotonic() < deadline:
+            snapshot = configmap_state.get_snapshot()
+            workflow = connectors.WorkflowConfig(**snapshot['workflow'])
+            resolved = []
+            for name in ('workflow_data', 'workflow_log', 'workflow_app'):
+                credential = getattr(workflow, name).credential
+                serialized = task.create_config_dict({'s3://test-bucket': credential})
+                fields = serialized['auth']['data']['s3://test-bucket']
+                matches = [revision for revision in ('A', 'B', 'C')
+                           if fields['access_key_id'] == f'fake-id-{revision}'
+                           and fields['access_key'] == f'fake-key-{revision}']
+                resolved.append(matches[0] if matches else 'invalid')
+            projected_path = Path('/etc/osmo/secrets/probe-storage/cred.yaml')
+            try:
+                projected = json.loads(projected_path.read_text())
+                projected_revision = next((revision for revision in ('A', 'B', 'C')
+                                           if projected.get('access_key_id') ==
+                                           f'fake-id-{revision}'), 'invalid')
+            except (ValueError, OSError):
+                projected_revision = 'invalid'
+            status = {
+                'resolved': resolved,
+                'startup_setting': snapshot['service']['max_pod_restart_limit'],
+                'projected': projected_revision,
+                'refresh': dataclasses.asdict(watcher.refresh_status),
+                'config_hash': hashlib.sha256(config_path.read_bytes()).hexdigest(),
+                'loader_hash': hashlib.sha256(
+                    Path(configmap_loader.__file__).read_bytes()).hexdigest(),
+                'pid': os.getpid(),
+            }
+            temporary = Path('/tmp/status-next.json')
+            temporary.write_text(json.dumps(status))
+            temporary.replace('/tmp/status.json')
+            threading.Event().wait(1)
+    finally:
+        watcher.stop()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/service/core/config/tests/test_configmap_loader_unit.py
+++ b/src/service/core/config/tests/test_configmap_loader_unit.py
@@ -31,6 +31,7 @@ from typing import Any, Dict
 from unittest import mock
 
 from fastapi import responses
+import urllib3
 import yaml
 
 from src.lib.utils import osmo_errors
@@ -1087,6 +1088,62 @@ class TestConfigMapEventRecorder(unittest.TestCase):
         recorder.emit_reload_failed('second')
         recorder.emit_reload_failed('third')
         self.assertEqual(mock_api.read_namespaced_config_map.call_count, 1)
+
+    def test_every_event_operation_has_connect_and_read_timeouts(self):
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.side_effect = self._not_found_api_exception()
+        recorder = self._build_recorder(mock_api)
+        recorder.emit_reload_failed('first failure')
+        for operation in (mock_api.read_namespaced_event,
+                          mock_api.read_namespaced_config_map,
+                          mock_api.create_namespaced_event):
+            self.assertEqual(operation.call_args.kwargs['_request_timeout'], (1.0, 1.0))
+        mock_api.read_namespaced_event.side_effect = None
+        mock_api.read_namespaced_event.return_value.count = 1
+        recorder.emit_reload_succeeded('recovered')
+        self.assertEqual(mock_api.patch_namespaced_event.call_args.kwargs['_request_timeout'],
+                         (1.0, 1.0))
+
+    def test_event_client_does_not_retry_or_change_reconciliation_client(self):
+        default_retries = configmap_events.client.Configuration.get_default_copy().retries
+        with mock.patch.object(configmap_events.kube_config, 'load_incluster_config'):
+            recorder = configmap_events.ConfigMapEventRecorder('ns', 'synthetic-config')
+        assert recorder._event_api is not None
+        assert recorder._core_v1 is not None
+        try:
+            self.assertIsNot(recorder._event_api.api_client, recorder._core_v1.api_client)
+            self.assertEqual(recorder._core_v1.api_client.configuration.retries, default_retries)
+            self.assertEqual(configmap_events.client.Configuration.get_default_copy().retries,
+                             default_retries)
+            manager = recorder._event_api.api_client.rest_client.pool_manager
+            self.assertEqual(urllib3.util.Retry.from_int(
+                manager.connection_pool_kw['retries']).total, 0)
+            pool = manager.connection_from_url(
+                recorder._event_api.api_client.configuration.host)
+            self.assertEqual(pool.retries.total, 0)
+            # Exercise urllib3's real retry loop, not a mocked request() shortcut.
+            for status in (429, 503):
+                response = urllib3.HTTPResponse(
+                    status=status, headers={'Retry-After': '3600'}, body=b'busy')
+                with self.subTest(status=status), \
+                     mock.patch.object(pool, '_make_request', return_value=response) as request, \
+                     mock.patch('urllib3.util.retry.time.sleep') as sleep:
+                    recorder.emit_reload_failed('synthetic error')
+                    request.assert_called_once()
+                    sleep.assert_not_called()
+        finally:
+            recorder._event_api.api_client.close()
+            recorder._core_v1.api_client.close()
+
+    def test_event_read_transport_timeout_is_swallowed(self):
+        mock_api = mock.MagicMock()
+        mock_api.read_namespaced_event.side_effect = TimeoutError('sensitive transport details')
+        recorder = self._build_recorder(mock_api)
+        with self.assertLogs(level='WARNING') as logs:
+            recorder.emit_reload_failed('synthetic error')
+        self.assertNotIn('sensitive transport details', '\n'.join(logs.output))
+        mock_api.create_namespaced_event.assert_not_called()
+        mock_api.patch_namespaced_event.assert_not_called()
 
     def test_reconciliation_checkpoint_round_trip_uses_annotation(self):
         mock_api = mock.MagicMock()

--- a/src/service/core/config/tests/test_secret_refresh.py
+++ b/src/service/core/config/tests/test_secret_refresh.py
@@ -19,8 +19,9 @@ import unittest
 from unittest import mock
 
 import yaml
+from urllib3.exceptions import ReadTimeoutError
 
-from src.service.core.config import configmap_loader, secret_snapshot
+from src.service.core.config import configmap_events, configmap_loader, secret_snapshot
 from src.utils import auth, configmap_state, connectors
 from src.utils.job import task
 
@@ -359,6 +360,63 @@ class SecretRefreshTest(unittest.TestCase):
 
     def test_default_interval_is_thirty_seconds(self):
         self.assertEqual(configmap_loader._DEPENDENCY_CHECK_INTERVAL_S, 30)
+
+    def test_stalled_event_transport_allows_refresh_recovery_and_shutdown(self):
+        failed_request = threading.Event()
+        recovery_request = threading.Event()
+        release_request = threading.Event()
+        stopped = threading.Event()
+        timeouts = []
+
+        def stalled_request(*args, **kwargs):
+            del args
+            timeout = kwargs.get('timeout')
+            timeouts.append(timeout)
+            (failed_request if len(timeouts) == 1 else recovery_request).set()
+            # Model a server that accepts a request but never responds. The real
+            # Kubernetes client must propagate its read deadline to the transport.
+            release_request.wait(timeout.read_timeout if timeout is not None else None)
+            raise ReadTimeoutError(event_pool, '/synthetic-event', 'stalled response')
+
+        with mock.patch.object(configmap_events.kube_config, 'load_incluster_config'):
+            recorder = configmap_events.ConfigMapEventRecorder('ns', 'synthetic-config')
+        assert recorder._event_api is not None
+        assert recorder._core_v1 is not None
+        event_manager = recorder._event_api.api_client.rest_client.pool_manager
+        event_pool = event_manager.connection_from_url(
+            recorder._event_api.api_client.configuration.host)
+        self.watcher._event_recorder = recorder
+        stopping = None
+
+        def stop():
+            self.watcher.stop()
+            stopped.set()
+
+        try:
+            with mock.patch.object(configmap_loader, '_DEPENDENCY_CHECK_INTERVAL_S', 0.01), \
+                 mock.patch.object(event_manager, 'request', side_effect=stalled_request):
+                self.watcher.start()
+                self.project('invalid', payload={})
+                self.assertTrue(failed_request.wait(3), 'Failure event was never attempted')
+                self.assertEqual(self.credential()['access_key_id'], 'fake-id-A')
+                self.project('B')
+                self.assertTrue(recovery_request.wait(3), 'Stalled event prevented recovery')
+                self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+                stopping = threading.Thread(target=stop, daemon=True)
+                stopping.start()
+                self.assertTrue(stopped.wait(3), 'Stalled recovery event prevented shutdown')
+                self.assertFalse(self.watcher.refresh_status.stale)
+                self.assertEqual(len(timeouts), 2)
+                for timeout in timeouts:
+                    assert timeout is not None
+                    self.assertEqual((timeout.connect_timeout, timeout.read_timeout), (1.0, 1.0))
+        finally:
+            release_request.set()
+            if stopping is not None:
+                stopping.join(5)
+            self.watcher.stop()
+            recorder._event_api.api_client.close()
+            recorder._core_v1.api_client.close()
 
     def test_stop_prevents_future_publication(self):
         self.load()

--- a/src/service/core/config/tests/test_secret_refresh.py
+++ b/src/service/core/config/tests/test_secret_refresh.py
@@ -104,6 +104,112 @@ class SecretRefreshTest(unittest.TestCase):
     def credential(self):
         return self.snapshot()['workflow']['workflow_data']['credential']
 
+    def rotate_during_read(self, *, remove_old=False, repeat=False):
+        track = secret_snapshot.DependencySnapshot._track
+        rotated = False
+
+        def rotating_track(dependency, path):
+            nonlocal rotated
+            first_read = path not in dependency.signatures
+            track(dependency, path)
+            if (path == self.secret / 'cred.yaml' and first_read
+                    and (repeat or not rotated)):
+                old_key = path.resolve(strict=True)
+                self.project('B')
+                if remove_old:
+                    old_key.unlink()
+                rotated = True
+
+        return mock.patch.object(secret_snapshot.DependencySnapshot, '_track', rotating_track)
+
+    def test_startup_rotation_is_transient_without_publication_or_reconciliation(self):
+        self.watcher._enable_reconciliation = True
+        state = mock.Mock()
+        state.load_reconciliation_state.return_value = None
+        self.watcher._reconciliation_state_store = state
+        with mock.patch.object(configmap_loader, '_reconcile_backend_side_effects',
+                               return_value=True) as reconcile:
+            with self.rotate_during_read():
+                result = self.watcher._load_and_apply()
+            self.assertEqual(result, configmap_loader.LoadResult.TRANSIENT_FAILURE)
+            self.assertIsNone(configmap_state.get_snapshot())
+            self.assertEqual(self.watcher.refresh_status.sequence, 0)
+            reconcile.assert_not_called()
+            state.save_reconciliation_state.assert_not_called()
+            self.postgres.get_service_auth.assert_not_called()
+            self.load()
+            self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+            self.assertEqual(self.watcher.refresh_status.sequence, 1)
+            reconcile.assert_called_once()
+            state.save_reconciliation_state.assert_called_once()
+
+    def test_startup_retries_mid_read_rotation_and_old_generation_removal(self):
+        for remove_old in (False, True):
+            with self.subTest(remove_old=remove_old):
+                self.project('A')
+                watcher = configmap_loader.ConfigMapWatcher(str(self.config_path), self.postgres)
+                self.watcher = watcher
+                try:
+                    with self.rotate_during_read(remove_old=remove_old), \
+                         mock.patch.object(configmap_loader.time, 'sleep') as sleep, \
+                         mock.patch.object(watcher, '_load_and_apply',
+                                           wraps=watcher._load_and_apply) as attempts:
+                        watcher.start()
+                    self.assertEqual(attempts.call_count, 2)
+                    sleep.assert_called_once_with(1.0)
+                    self.assertEqual(watcher.refresh_status.sequence, 1)
+                    self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+                    self.assertEqual(self.snapshot()['service']['service_auth'],
+                                     self.service_auth.plaintext_dict())
+                finally:
+                    watcher.stop()
+                    configmap_state.set_parsed_configs(None)
+                    configmap_state.set_configmap_mode(False)
+
+    def test_startup_repeated_rotations_exhaust_existing_retry_deadline(self):
+        with self.rotate_during_read(repeat=True), \
+             mock.patch.object(configmap_loader.time, 'monotonic', side_effect=[0, 1, 31]), \
+             mock.patch.object(configmap_loader.time, 'sleep') as sleep, \
+             mock.patch.object(self.watcher, '_load_and_apply',
+                               wraps=self.watcher._load_and_apply) as attempts:
+            with self.assertRaisesRegex(RuntimeError, 'after 30s'):
+                self.watcher.start()
+        self.assertEqual(attempts.call_count, 2)
+        sleep.assert_called_once_with(1.0)
+        self.assertEqual(self.watcher.refresh_status.sequence, 0)
+        self.assertIsNone(configmap_state.get_snapshot())
+
+    def test_stable_invalid_startup_credentials_still_fail_fast(self):
+        for invalid in ('malformed', 'missing', 'incomplete', 'non-utf8'):
+            with self.subTest(invalid=invalid):
+                fields = {'cred.yaml': 'access_key: [invalid'}
+                if invalid == 'missing':
+                    fields = {}
+                elif invalid == 'incomplete':
+                    fields = {'cred.yaml': 'access_key_id: incomplete'}
+                self.project('invalid', fields=fields)
+                if invalid == 'non-utf8':
+                    (self.secret / 'cred.yaml').write_bytes(b'\xff')
+                with mock.patch.object(configmap_loader.time, 'sleep') as sleep, \
+                     mock.patch.object(self.watcher, '_load_and_apply',
+                                       wraps=self.watcher._load_and_apply) as attempts:
+                    with self.assertRaisesRegex(RuntimeError, 'malformed or invalid'):
+                        self.watcher.start()
+                attempts.assert_called_once()
+                sleep.assert_not_called()
+                self.assertIsNone(configmap_state.get_snapshot())
+
+    def test_invalid_projected_path_still_fails_startup_without_retry(self):
+        outside = self.root / 'outside-volume'
+        self.project('B', root=outside)
+        (self.secret / '..data').unlink()
+        (self.secret / '..data').symlink_to((outside / '..data').resolve())
+        with mock.patch.object(configmap_loader.time, 'sleep') as sleep:
+            with self.assertRaisesRegex(RuntimeError, 'malformed or invalid'):
+                self.watcher.start()
+        sleep.assert_not_called()
+        self.assertIsNone(configmap_state.get_snapshot())
+
     def test_rotation_updates_task_serialization_without_mutating_old_snapshot(self):
         self.load()
         previous = self.snapshot()
@@ -306,7 +412,7 @@ class SecretRefreshTest(unittest.TestCase):
         dependency = secret_snapshot.DependencySnapshot()
         dependency.read_file(str(self.secret / 'cred.yaml'))
         self.project('B')
-        with self.assertRaises(secret_snapshot.DependencyReadError):
+        with self.assertRaises(secret_snapshot.DependencyChangedError):
             dependency.read_file(str(self.secret / 'cred.yaml'))
 
     def test_rotation_during_validation_is_not_published(self):

--- a/src/service/core/config/tests/test_secret_refresh.py
+++ b/src/service/core/config/tests/test_secret_refresh.py
@@ -1,0 +1,398 @@
+"""Credential rotations must not reload immutable service configuration.
+
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+# Tests exercise private polling and publication boundaries directly.
+# pylint: disable=protected-access
+
+import base64
+import concurrent.futures
+import copy
+import os
+from pathlib import Path
+import tempfile
+import threading
+from typing import Any
+import unittest
+from unittest import mock
+
+import yaml
+
+from src.service.core.config import configmap_loader, secret_snapshot
+from src.utils import auth, configmap_state, connectors
+from src.utils.job import task
+
+
+class SecretRefreshTest(unittest.TestCase):
+    """Real loader and validators with Kubernetes-style projected file fixtures."""
+
+    service_auth: auth.AuthenticationConfig
+
+    @classmethod
+    def setUpClass(cls):
+        cls.service_auth = auth.AuthenticationConfig.generate_default()
+
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        self.secret = self.root / 'storage'
+        self.config_path = self.root / 'config.yaml'
+        self.generation = 0
+        self.project('A')
+        self.config: dict[str, Any] = {
+            name: {} for name in configmap_loader._EXPECTED_CONFIG_KEYS}
+        self.config['roles'] = {'osmo-default': {'description': 'Default role', 'policies': [{
+            'effect': 'Allow', 'actions': ['system:Health'], 'resources': ['*']}],
+            'external_roles': []}}
+        self.config['workflow'] = {'workflow_data': {'credential': {
+            'secretName': 'storage', 'secretKey': 'cred.yaml'}}}
+        self.config['service'] = {'max_pod_restart_limit': '30m'}
+        self.write_config()
+        root_patch = mock.patch.object(configmap_loader, 'SECRETS_ROOT', str(self.root))
+        root_patch.start()
+        self.addCleanup(root_patch.stop)
+        self.postgres = mock.Mock()
+        self.postgres.get_service_auth.return_value = self.service_auth
+        self.postgres.execute_fetch_command.return_value = []
+        self.watcher = configmap_loader.ConfigMapWatcher(str(self.config_path), self.postgres)
+        self.addCleanup(self.watcher.stop)
+        self.addCleanup(configmap_state.set_parsed_configs, None)
+        self.addCleanup(configmap_state.set_configmap_mode, False)
+
+    def payload(self, revision):
+        return {'endpoint': 's3://test-bucket', 'region': 'us-west-2',
+                'access_key_id': f'fake-id-{revision}', 'access_key': f'fake-key-{revision}'}
+
+    def project(self, revision, *, payload=None, fields=None, root=None):
+        root = root or self.secret
+        root.mkdir(exist_ok=True)
+        self.generation += 1
+        generation = root / f'..generation-{self.generation}'
+        generation.mkdir()
+        if fields is None:
+            fields = {'cred.yaml': yaml.safe_dump(
+                self.payload(revision) if payload is None else payload)}
+        for key, value in fields.items():
+            (generation / key).write_text(value, encoding='utf-8')
+            target = root / key
+            if not target.is_symlink():
+                target.symlink_to(f'..data/{key}')
+        temporary = root / '..data_tmp'
+        temporary.symlink_to(generation.name)
+        os.replace(temporary, root / '..data')
+        for entry in root.iterdir():
+            if entry.is_symlink() and not entry.name.startswith('..') and entry.name not in fields:
+                entry.unlink()
+
+    def write_config(self):
+        temporary = self.root / 'candidate.yaml'
+        temporary.write_text(yaml.safe_dump(self.config), encoding='utf-8')
+        os.replace(temporary, self.config_path)
+
+    def load(self):
+        self.assertEqual(self.watcher._load_and_apply(), configmap_loader.LoadResult.SUCCESS)
+
+    def snapshot(self):
+        snapshot = configmap_state.get_snapshot()
+        assert snapshot is not None
+        return snapshot
+
+    def credential(self):
+        return self.snapshot()['workflow']['workflow_data']['credential']
+
+    def test_rotation_updates_task_serialization_without_mutating_old_snapshot(self):
+        self.load()
+        previous = self.snapshot()
+        self.project('B')
+        self.assertTrue(self.watcher.refresh_status.stale)
+        self.watcher._check_dependencies()
+        self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+        self.assertEqual(previous['workflow']['workflow_data']['credential']['access_key_id'],
+                         'fake-id-A')
+        config = connectors.WorkflowConfig(**self.snapshot()['workflow'])
+        credential = config.workflow_data.credential
+        assert credential is not None
+        generated = task.create_config_dict({'s3://test-bucket': credential})
+        self.assertEqual(generated['auth']['data']['s3://test-bucket']['access_key'], 'fake-key-B')
+        self.assertEqual(self.watcher.refresh_status.sequence, 2)
+        self.assertFalse(self.watcher.refresh_status.stale)
+
+    def test_configmap_rewrite_and_deletion_do_not_change_startup_semantics(self):
+        self.load()
+        original = copy.deepcopy(self.snapshot())
+        self.config['service']['max_pod_restart_limit'] = '45m'
+        self.config['workflow']['workflow_data']['credential']['secretName'] = 'replacement'
+        self.config['roles']['osmo-default']['description'] = 'new config must require restart'
+        self.write_config()
+        self.project('C', root=self.root / 'replacement')
+        self.watcher._check_dependencies()
+        self.assertEqual(self.watcher.refresh_status.sequence, 1)
+        self.project('B')
+        self.watcher._check_dependencies()
+        self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+        self.config_path.unlink()
+        self.project('C')
+        self.watcher._check_dependencies()
+        expected = copy.deepcopy(original)
+        expected['workflow']['workflow_data']['credential'] = self.payload('C')
+        self.assertEqual(self.snapshot(), expected)
+
+    def test_generic_config_secret_is_never_reloaded(self):
+        self.project('A', payload={'value': '30m'}, root=self.root / 'generic')
+        self.config['service']['max_pod_restart_limit'] = {
+            'secretName': 'generic', 'secretKey': 'cred.yaml'}
+        self.write_config()
+        self.load()
+        self.project('B', payload={'value': '45m'}, root=self.root / 'generic')
+        with mock.patch.object(self.watcher, '_refresh_secrets') as refresh:
+            self.watcher._check_dependencies()
+            refresh.assert_not_called()
+        self.project('B')
+        self.watcher._check_dependencies()
+        self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+        self.assertEqual(self.snapshot()['service']['max_pod_restart_limit'], '30m')
+
+    def test_same_secret_cannot_change_roles_or_routing_configuration(self):
+        role = copy.deepcopy(self.config['roles']['osmo-default'])
+        self.config['roles']['osmo-default'] = {'secretName': 'storage', 'secretKey': 'role.yaml'}
+        self.write_config()
+        self.project('A', fields={'cred.yaml': yaml.safe_dump(self.payload('A')),
+                                  'role.yaml': yaml.safe_dump(role)})
+        self.load()
+        changed_role = {**role, 'description': 'ignored until restart'}
+        self.project('B', fields={'cred.yaml': yaml.safe_dump(self.payload('B')),
+                                  'role.yaml': yaml.safe_dump(changed_role)})
+        self.watcher._check_dependencies()
+        self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+        self.assertEqual(self.snapshot()['roles']['osmo-default'], role)
+
+    def test_storage_routing_and_auth_mode_changes_require_restart(self):
+        self.load()
+        original = self.snapshot()
+        for changes in ({'endpoint': 's3://other-bucket'}, {'region': 'eu-west-1'},
+                        {'override_url': 'https://storage.example.test'},
+                        {'addressing_style': 'path'}):
+            with self.subTest(changes=changes):
+                self.project('B', payload={**self.payload('B'), **changes})
+                self.watcher._check_dependencies()
+                self.assertIs(self.snapshot(), original)
+                self.assertTrue(self.watcher.refresh_status.stale)
+        self.project('default-auth', payload={
+            'endpoint': 's3://test-bucket', 'region': 'us-west-2'})
+        self.watcher._check_dependencies()
+        self.assertIs(self.snapshot(), original)
+        self.project('C')
+        self.watcher._check_dependencies()
+        self.assertEqual(self.credential()['access_key_id'], 'fake-id-C')
+
+    def test_default_auth_cannot_silently_switch_to_static(self):
+        self.project('default', payload={'endpoint': 's3://test-bucket', 'region': 'us-west-2'})
+        self.load()
+        original = self.snapshot()
+        self.project('B')
+        self.watcher._check_dependencies()
+        self.assertIs(self.snapshot(), original)
+
+    def test_invalid_missing_and_incomplete_rotation_keeps_last_good(self):
+        self.load()
+        original = self.snapshot()
+        invalid_payloads: tuple[dict[str, Any], ...] = (
+                            {}, {'endpoint': 's3://test-bucket', 'access_key_id': 'only-id'},
+                            {**self.payload('B'), 'access_key': ''},
+                            {**self.payload('B'), 'access_key': '  '}, {'value': 'invalid'})
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                self.project('invalid', payload=payload)
+                self.watcher._check_dependencies()
+                self.assertIs(self.snapshot(), original)
+        self.project('missing', fields={})
+        self.watcher._check_dependencies()
+        self.assertIs(self.snapshot(), original)
+        self.project('C')
+        self.watcher._check_dependencies()
+        self.assertEqual(self.credential()['access_key_id'], 'fake-id-C')
+
+    def test_shared_reference_updates_all_storage_credentials_atomically(self):
+        self.config['workflow'] = {name: {'credential': {
+            'secretName': 'storage', 'secretKey': 'cred.yaml'}}
+            for name in ('workflow_data', 'workflow_log', 'workflow_app')}
+        self.write_config()
+        self.load()
+        self.project('B')
+        self.watcher._check_dependencies()
+        for name in self.config['workflow']:
+            self.assertEqual(self.snapshot()['workflow'][name]['credential'], self.payload('B'))
+
+    def test_one_bad_secret_prevents_partial_multi_secret_publication(self):
+        self.project('A', root=self.root / 'logs')
+        self.config['workflow']['workflow_log'] = {'credential': {
+            'secretName': 'logs', 'secretKey': 'cred.yaml'}}
+        self.write_config()
+        self.load()
+        original = self.snapshot()
+        self.project('B')
+        self.project('invalid', payload={}, root=self.root / 'logs')
+        self.watcher._check_dependencies()
+        self.assertIs(self.snapshot(), original)
+        self.project('B', root=self.root / 'logs')
+        self.watcher._check_dependencies()
+        for name in ('workflow_data', 'workflow_log'):
+            self.assertEqual(self.snapshot()['workflow'][name]['credential'], self.payload('B'))
+
+    def test_refresh_has_no_database_or_reconciliation_side_effects(self):
+        self.watcher._enable_reconciliation = True
+        self.watcher._reconciliation_state_store = mock.Mock()
+        self.watcher._reconciliation_state_store.load_reconciliation_state.return_value = None
+        with mock.patch.object(configmap_loader, '_reconcile_backend_side_effects',
+                               return_value=True) as reconcile:
+            self.load()
+            self.assertEqual(reconcile.call_count, 1)
+            self.postgres.reset_mock()
+            self.watcher._reconciliation_state_store.reset_mock()
+            original_auth = copy.deepcopy(self.snapshot()['service']['service_auth'])
+            self.project('B')
+            self.watcher._check_dependencies()
+            self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+            self.assertEqual(reconcile.call_count, 1)
+            self.assertEqual(self.postgres.mock_calls, [])
+            self.assertEqual(self.watcher._reconciliation_state_store.mock_calls, [])
+            self.assertEqual(self.snapshot()['service']['service_auth'], original_auth)
+
+    def test_unchanged_dependencies_do_not_parse(self):
+        self.load()
+        with mock.patch.object(self.watcher, '_refresh_secrets') as refresh:
+            self.watcher._check_dependencies()
+            refresh.assert_not_called()
+
+    def test_plain_file_replacement_is_detected(self):
+        path = self.root / 'plain.yaml'
+        path.write_text(yaml.safe_dump(self.payload('A')))
+        self.config['workflow']['workflow_data']['credential'] = {'secret_file': str(path)}
+        self.write_config()
+        self.load()
+        replacement = self.root / 'next.yaml'
+        replacement.write_text(yaml.safe_dump(self.payload('B')))
+        replacement.replace(path)
+        self.watcher._check_dependencies()
+        self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+
+    def test_registry_rotation_preserves_image_and_registry_location(self):
+        self.config['workflow']['backend_images'] = {'client': 'example.test/client:fixed',
+            'credential': {'secretName': 'registry', 'secretKey': 'cred.yaml'}}
+        self.write_config()
+        for revision in ('A', 'B'):
+            encoded = base64.b64encode(f'user:fake-{revision}'.encode()).decode()
+            self.project(revision, payload={'auths': {'example.test': {'auth': encoded}}},
+                         root=self.root / 'registry')
+            if revision == 'A':
+                self.load()
+            else:
+                self.watcher._check_dependencies()
+            result = self.snapshot()['workflow']['backend_images']
+            self.assertEqual(result['client'], 'example.test/client:fixed')
+            self.assertEqual(result['credential']['username'], 'user')
+            self.assertEqual(result['credential']['auth'], f'fake-{revision}')
+        original = self.snapshot()
+        self.project('C', payload={'auths': {'other.test': {'auth': encoded}}},
+                     root=self.root / 'registry')
+        self.watcher._check_dependencies()
+        self.assertIs(self.snapshot(), original)
+
+    def test_projected_reads_cannot_mix_generations(self):
+        dependency = secret_snapshot.DependencySnapshot()
+        dependency.read_file(str(self.secret / 'cred.yaml'))
+        self.project('B')
+        with self.assertRaises(secret_snapshot.DependencyReadError):
+            dependency.read_file(str(self.secret / 'cred.yaml'))
+
+    def test_rotation_during_validation_is_not_published(self):
+        self.load()
+        original = self.snapshot()
+        self.project('B')
+        validate = configmap_loader.validate_configmap_snapshot
+
+        def rotating_validate(config):
+            self.project('C')
+            return validate(config)
+
+        with mock.patch.object(configmap_loader, 'validate_configmap_snapshot',
+                               side_effect=rotating_validate):
+            self.watcher._check_dependencies()
+        self.assertIs(self.snapshot(), original)
+        self.watcher._check_dependencies()
+        self.assertEqual(self.credential()['access_key_id'], 'fake-id-C')
+
+    def test_real_polling_loop_and_event_failure_recovery(self):
+        failed = threading.Event()
+        recovered = threading.Event()
+        recorder = mock.Mock()
+
+        def fail_notification(message):
+            del message
+            failed.set()
+            raise TimeoutError('TOP-SECRET-CANARY')
+
+        def recover_notification(message):
+            del message
+            recovered.set()
+            raise TimeoutError('TOP-SECRET-CANARY')
+
+        recorder.emit_reload_failed.side_effect = fail_notification
+        recorder.emit_reload_succeeded.side_effect = recover_notification
+        self.watcher._event_recorder = recorder
+        with mock.patch.object(configmap_loader, '_DEPENDENCY_CHECK_INTERVAL_S', 0.01), \
+             self.assertLogs(level='WARNING') as logs:
+            self.watcher.start()
+            self.project('invalid', fields={'cred.yaml': 'access_key: [TOP-SECRET-CANARY'})
+            self.assertTrue(failed.wait(5), 'Secret-only failure never detected')
+            self.assertEqual(self.credential()['access_key_id'], 'fake-id-A')
+            self.project('B')
+            self.assertTrue(recovered.wait(5), 'Secret-only rotation never refreshed the snapshot')
+            self.assertEqual(self.credential()['access_key_id'], 'fake-id-B')
+            self.watcher.stop()
+            assert self.watcher._dependency_thread is not None
+            self.assertFalse(self.watcher._dependency_thread.is_alive())
+        self.assertNotIn('TOP-SECRET-CANARY', '\n'.join(logs.output))
+
+    def test_default_interval_is_thirty_seconds(self):
+        self.assertEqual(configmap_loader._DEPENDENCY_CHECK_INTERVAL_S, 30)
+
+    def test_stop_prevents_future_publication(self):
+        self.load()
+        original = self.snapshot()
+        self.watcher.stop()
+        self.project('B')
+        self.watcher._check_dependencies()
+        self.watcher._load_and_apply()
+        self.assertIs(self.snapshot(), original)
+
+    def test_concurrent_callbacks_are_serialized(self):
+        self.load()
+        entered = threading.Event()
+        release = threading.Event()
+        validate = configmap_loader.validate_configmap_snapshot
+
+        def slow_validate(config):
+            entered.set()
+            self.assertTrue(release.wait(5))
+            return validate(config)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            with mock.patch.object(configmap_loader, 'validate_configmap_snapshot',
+                                   side_effect=slow_validate):
+                self.project('B')
+                first = executor.submit(self.watcher._check_dependencies)
+                self.assertTrue(entered.wait(5))
+                self.project('C')
+                second = executor.submit(self.watcher._check_dependencies)
+                release.set()
+                first.result(timeout=5)
+                second.result(timeout=5)
+        self.assertEqual(self.credential()['access_key_id'], 'fake-id-C')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/service/core/config/tests/verify_secret_refresh_kubernetes.py
+++ b/src/service/core/config/tests/verify_secret_refresh_kubernetes.py
@@ -1,0 +1,198 @@
+"""Opt-in live Kubernetes projection test; only creates uniquely named probe objects.
+
+No production Secrets are read or changed. Requires kubectl access to the specified
+namespace and a built agent image. Run with --help for mandatory explicit targets.
+
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+import threading
+import time
+import uuid
+
+
+class ProjectionProbe:
+    """Exercise a disposable pod using synthetic credentials and fixed object names."""
+
+    def __init__(self, args):
+        self.args = args
+        self.name = 'secret-refresh-probe-' + uuid.uuid4().hex[:10]
+        self.objects = []
+
+    def kubectl(self, *arguments, payload=None):
+        result = subprocess.run(
+            ['kubectl', '--context', self.args.context, '--namespace', self.args.namespace,
+             *arguments], input=json.dumps(payload) if payload is not None else None,
+            text=True, capture_output=True, timeout=45, check=False)
+        if result.returncode:
+            # Do not dump objects or command output: this is also safe for failed API responses.
+            raise RuntimeError(f'kubectl {arguments[0]} failed with exit {result.returncode}')
+        return result.stdout
+
+    def create(self, kind, **fields):
+        self.kubectl('create', '-f', '-', payload={
+            'apiVersion': 'v1', 'kind': kind, 'metadata': {'name': self.name}, **fields})
+        self.objects.append(kind.lower())
+
+    def rotate(self, revision):
+        payload = {} if revision == 'invalid' else {
+            'endpoint': 's3://test-bucket', 'access_key_id': f'fake-id-{revision}',
+            'access_key': f'fake-key-{revision}', 'region': 'us-west-2'}
+        return {'cred.yaml': json.dumps(payload)}
+
+    def status(self):
+        return json.loads(self.kubectl(
+            'exec', self.name, '--', '/usr/bin/python3', '-c',
+            "print(open('/tmp/status.json').read())"))
+
+    def wait(self, predicate, description, timeout=180):
+        deadline = time.monotonic() + timeout
+        latest = None
+        while time.monotonic() < deadline:
+            try:
+                latest = self.status()
+                if predicate(latest):
+                    print(json.dumps({'checkpoint': description, 'status': latest}), flush=True)
+                    return latest
+            except (RuntimeError, ValueError):
+                pass  # Pod scheduling/image pull/status-file creation can be pending.
+            threading.Event().wait(5)
+        raise AssertionError(f'{description} timed out; last safe probe status: {latest}')
+
+    def identity(self):
+        pod = json.loads(self.kubectl('get', 'pod', self.name, '-o', 'json'))
+        config = json.loads(self.kubectl('get', 'configmap', self.name, '-o', 'json'))
+        return (pod['metadata']['uid'], config['metadata']['resourceVersion'],
+                [entry['restartCount'] for entry in pod['status']['containerStatuses']])
+
+    def run(self):
+        code = Path(__file__).with_name('secret_refresh_probe.py').read_text(encoding='utf-8')
+        config = {'workflow': {name: {'credential': {
+            'secretName': 'probe-storage', 'secretKey': 'cred.yaml'}}
+            for name in ('workflow_data', 'workflow_log', 'workflow_app')}}
+        config.update({name: {} for name in (
+            'service', 'backends', 'backend_tests', 'pools', 'pod_templates',
+            'group_templates', 'resource_validations', 'roles')})
+        config['service'] = {'max_pod_restart_limit': '30m'}
+        config['roles'] = {'osmo-default': {
+            'description': 'Synthetic probe role', 'external_roles': [],
+            'policies': [{'effect': 'Allow', 'actions': ['system:Health'], 'resources': ['*']}]}}
+        bootstrap = (
+            'import glob,runpy,sys; '
+            "roots=glob.glob('/src/service/*/*.runfiles'); "
+            "sys.path[:0]=[r+'/_main' for r in roots]+"
+            "[p for r in roots for p in glob.glob(r+'/rules_python++pip+*/site-packages')]; "
+            "runpy.run_path('/probe/secret_refresh_probe.py',run_name='__main__')")
+        try:
+            self.create('Secret', stringData=self.rotate('A'))
+            self.create('ConfigMap', data={'config.yaml': json.dumps(config),
+                                           'secret_refresh_probe.py': code})
+            self.create('Pod', spec={
+                'restartPolicy': 'Never', 'activeDeadlineSeconds': 900,
+                'automountServiceAccountToken': False,
+                'nodeSelector': {'kubernetes.io/arch': 'amd64',
+                                 **dict(self.args.node_selector)},
+                'tolerations': [{'key': 'dedicated', 'operator': 'Equal',
+                                 'value': 'osmo-service', 'effect': 'NoSchedule'}],
+                'imagePullSecrets': [{'name': self.args.image_pull_secret}],
+                'containers': [{
+                    'name': 'probe', 'image': self.args.image,
+                    'command': ['/usr/bin/python3', '-c', bootstrap],
+                    'env': [{'name': 'DISABLE_DEPENDENCY_POLLING',
+                             'value': '1' if self.args.negative_control else '0'}],
+                    'resources': {'requests': {'cpu': '100m', 'memory': '256Mi'},
+                                  'limits': {'cpu': '1', 'memory': '768Mi'}},
+                    'volumeMounts': [{'name': 'probe', 'mountPath': '/probe', 'readOnly': True},
+                                     {'name': 'storage', 'readOnly': True,
+                                      'mountPath': '/etc/osmo/secrets/probe-storage'}],
+                }],
+                'volumes': [{'name': 'probe', 'configMap': {'name': self.name}},
+                            {'name': 'storage', 'secret': {'secretName': self.name}}],
+            })
+            initial = self.wait(lambda s: s['resolved'] == ['A'] * 3, 'initial A')
+            if initial['loader_hash'] != self.args.loader_sha256:
+                raise AssertionError('Packaged loader does not match the reviewed source hash')
+            identity = self.identity()
+            previous_failures = initial['refresh']['failures']
+            for revision in ('B', 'invalid', 'C'):
+                self.kubectl('patch', 'secret', self.name, '--type=merge',
+                             '--patch-file=/dev/stdin',
+                             payload={'stringData': self.rotate(revision)})
+                self.wait(lambda s, revision=revision: s['projected'] == revision,
+                          f'kubelet projected {revision}')
+                if revision == 'invalid':
+                    current = self.wait(lambda s: s['refresh']['failures'] > previous_failures
+                                        and s['refresh']['stale'],
+                                        'invalid replacement rejected', timeout=75)
+                    if current['resolved'] != ['B'] * 3 or current['refresh']['sequence'] != 2:
+                        raise AssertionError('Invalid Secret replaced the last-good snapshot')
+                else:
+                    current = self.wait(
+                        lambda s, revision=revision: s['resolved'] == [revision] * 3
+                        and not s['refresh']['stale'],
+                        f'Secret-only rotation refreshed three references to {revision}',
+                        timeout=75)
+                    expected_sequence = 2 if revision == 'B' else 3
+                    if current['refresh']['sequence'] != expected_sequence:
+                        raise AssertionError('Unexpected publication without a dependency change')
+                if (self.identity() != identity or current['config_hash'] != initial['config_hash']
+                        or current['pid'] != initial['pid']):
+                    raise AssertionError('Pod restarted or ConfigMap changed during rotation')
+                previous_failures = current['refresh']['failures']
+            config['service']['max_pod_restart_limit'] = '45m'
+            for settings in config['workflow'].values():
+                settings['credential']['secretName'] = 'ignored-configmap-replacement'
+            self.kubectl('patch', 'configmap', self.name, '--type=merge',
+                         '--patch-file=/dev/stdin',
+                         payload={'data': {'config.yaml': json.dumps(config)}})
+            self.wait(lambda s: s['config_hash'] != initial['config_hash'],
+                      'kubelet projected new startup-only ConfigMap')
+            self.kubectl('patch', 'secret', self.name, '--type=merge',
+                         '--patch-file=/dev/stdin', payload={'stringData': self.rotate('A')})
+            self.wait(lambda s: s['projected'] == 'A', 'original Secret projected A again')
+            final = self.wait(lambda s: s['resolved'] == ['A'] * 3 and not s['refresh']['stale'],
+                              'original references refresh after ConfigMap replacement', timeout=75)
+            final_identity = self.identity()
+            if (final['startup_setting'] != '30m' or final['refresh']['sequence'] != 4
+                    or final['pid'] != initial['pid'] or final_identity[0] != identity[0]
+                    or final_identity[2] != identity[2]):
+                raise AssertionError('ConfigMap replacement changed startup state or restarted pod')
+            print('PASS: live projection, refresh, last-good recovery, immutable startup config',
+                  flush=True)
+        finally:
+            # Delete only the exact names this invocation successfully created.
+            active_exception = sys.exc_info()[0] is not None
+            cleanup_failures = []
+            for kind in reversed(self.objects):
+                try:
+                    self.kubectl('delete', kind, self.name, '--wait=false', '--ignore-not-found')
+                except (RuntimeError, subprocess.TimeoutExpired):
+                    cleanup_failures.append(kind)
+            if cleanup_failures:
+                message = f'Cleanup incomplete for {self.name}: {cleanup_failures}'
+                print(message, file=sys.stderr, flush=True)
+                if not active_exception:
+                    raise RuntimeError(message)
+            else:
+                print(f'Deleted synthetic probe objects: {self.name}', flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in ('context', 'namespace', 'image', 'image-pull-secret', 'loader-sha256'):
+        parser.add_argument('--' + name, required=True)
+    parser.add_argument('--node-selector', action='append', type=lambda s: s.split('=', 1),
+                        default=[])
+    parser.add_argument('--negative-control', action='store_true',
+                        help='Disable polling only in the disposable probe; test MUST fail')
+    ProjectionProbe(parser.parse_args()).run()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/service/core/service.py
+++ b/src/service/core/service.py
@@ -418,6 +418,8 @@ def main():
         uvicorn.run(app, host=host, port=port, log_config=None, **config.uvicorn_ssl_kwargs())
     except KeyboardInterrupt:
         sys.exit(0)
+    finally:
+        app.state.config_watcher.stop()
 
 
 if __name__ == '__main__':

--- a/src/service/logger/logger.py
+++ b/src/service/logger/logger.py
@@ -99,6 +99,7 @@ def main():
         try:
             await uvicorn_server.serve()
         finally:
+            app.state.config_watcher.stop()
             liveness_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await liveness_task

--- a/src/service/worker/worker.py
+++ b/src/service/worker/worker.py
@@ -260,6 +260,8 @@ def main():
             worker.run()
         except KeyboardInterrupt:
             sys.exit(0)
+        finally:
+            _active_config_watcher.stop()
 
 
 if __name__ == '__main__':

--- a/test/workflow/serial_workflow.yaml
+++ b/test/workflow/serial_workflow.yaml
@@ -22,6 +22,7 @@ workflow:
     args: [/tmp/run.sh]
     files:
     - contents: |
+        set -eu
         echo "Hello from task1 $(hostname)"
         echo "Hello from task1 $(hostname)" > {{output}}/hello1.txt
         echo "Data from task 1" > {{output}}/test_read.txt
@@ -35,12 +36,14 @@ workflow:
       FILE_PATH: /tmp/run.sh
     files:
     - contents: |
+        set -eu
         echo "Hello from task2 {{output}}"
         if [ ! -f "{{input:0}}/test_read.txt" ]; then
             echo "Error: {{input:0}}/test_read.txt does not exist"
             exit 1
         fi
-        head -1 {{input:0}}/test_read.txt
+        printf 'Data from task 1\n' > /tmp/expected.txt
+        cmp /tmp/expected.txt "{{input:0}}/test_read.txt"
         echo "Data from task 2" > {{output}}/test_read.txt
       path: /tmp/run.sh
     resource: default
@@ -52,14 +55,16 @@ workflow:
     args: ['/tmp/run.sh']
     files:
     - contents: |
+        set -eu
         echo "Reading from task 2"
         if [ ! -f "{{input:1}}/test_read.txt" ]; then
             echo "Error: {{input:1}}/test_read.txt does not exist"
             exit 1
         fi
-        while IFS= read -r line; do
-          echo "a line: $line"
-        done < {{input:1}}/test_read.txt
+        printf 'Data from task 1\n' > /tmp/expected1.txt
+        printf 'Data from task 2\n' > /tmp/expected2.txt
+        cmp /tmp/expected1.txt "{{input:0}}/test_read.txt"
+        cmp /tmp/expected2.txt "{{input:1}}/test_read.txt"
         cp {{input:1}}/test_read.txt {{output}}/task2_hello.txt
         echo "Hello from task3 $(hostname)"
         mkdir {{output}}/out3


### PR DESCRIPTION
## Description

Issue #None

Follow-up to #1361. A mounted credential Secret can rotate while a service process
continues using the credentials resolved at startup. This leaves newly generated
task configurations using stale storage or registry credentials until a restart.

- Check fixed, directly referenced credential files every 30 seconds using file
  metadata and Kubernetes projected-volume generations.
- Refresh only authentication fields in workflow data/log/app and backend image
  credentials. Freeze the accepted startup configuration, including references,
  routing, authentication mode, roles, service auth, and derived configuration.
- Validate and publish a complete candidate atomically. Preserve the last-good
  snapshot when files are missing, invalid, or change during a read; retry without
  a ConfigMap update. Never rerun database reconciliation during credential refresh.
- Stop background polling with each service lifecycle and keep refresh failures
  and event-notification errors free of credential values.
- Retry detected credential-generation changes during startup, including removal
  of the old pinned file. Keep stable invalid inputs permanent and retain the
  existing retry window, publication, and reconciliation boundaries.
- Bound event reporting with a separate no-retry Kubernetes client and one-second
  connection/read deadlines on all event API calls; leave reconciliation unchanged.
- Add focused regression coverage and an opt-in, synthetic-only Kubernetes probe;
  strengthen serial workflow transfers to compare exact bytes.

ConfigMap changes remain startup-only. Only direct `credential` object references
using `secretName` + `secretKey` or `secret_file` participate in refresh; generic
Secret-backed configuration still requires a restart.

## Validation

- 160 tests passed: 25 Secret-refresh regressions, 113 loader tests,
  5 config-history tests, 14 history-helper tests, and 3 asyncio-startup tests;
  Bazel mypy aspects passed.
- Eight repository pylint targets passed for the loader, new tests, and service
  lifecycle changes.
- Built API, agent, worker, and logger Linux/amd64 images locally with Apple Container.
- The packaged-image Kubernetes probe passed at the production 30-second interval:
  three references rotated A → B; invalid replacement retained B; valid C recovered;
  after a ConfigMap replacement, the original Secret still refreshed to A while
  startup settings, pod identity, process ID, and restart count remained unchanged.
- The synthetic Kubernetes negative control correctly failed after Kubernetes
  projected credential B while the polling-disabled process retained A.
- Both probes cleaned up their uniquely named synthetic Secret, ConfigMap, and pod.

The earlier full-instance workflow suite exercised the pre-port implementation;
it is not counted as full-instance verification of this current-main port.

The event-delivery follow-up also passed a stalled-transport recovery/shutdown
regression and real urllib3 retry-loop checks for `429`/`503` responses with
`Retry-After: 3600`. Disabling deadlines in an isolated negative control reproduced
the recovery failure. The live projection results above preceded this follow-up;
no real credentials were rotated for these transport regressions.

The startup-race follow-up adds tests for mid-read rotation, removal of the old
projected key, successful retry publishing sequence 1, retry-window exhaustion,
and stable invalid inputs remaining fail-fast. An isolated old-classification
negative control reproduced the original permanent-failure bug. Rotation guidance
now lives in the workflow configuration reference, with a deployment-guide link.
This follow-up was verified locally; no new live credential rotation was performed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Mounted workflow, application, and registry credentials now refresh automatically when rotated.
  - Valid updates are applied atomically without service restarts; invalid or incomplete updates retain the last accepted credentials.
  - Existing task pods continue using their captured credentials.

- **Bug Fixes**
  - Configuration watchers now shut down cleanly when services or workers stop.
  - Credential refreshes continue when Kubernetes event notifications time out or fail.

- **Documentation**
  - Added guidance for rotating mounted credentials and settings that still require restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

