### PR TITLE
fix(cli): handle empty app files sections

### DIFF
--- a/src/cli/tests/test_app.py
+++ b/src/cli/tests/test_app.py
@@ -22,6 +22,8 @@ import json
 import unittest
 from unittest import mock
 
+import yaml
+
 from src.cli import app
 from src.lib.utils import client, osmo_errors
 
@@ -745,6 +747,35 @@ class TestSubmitApp(unittest.TestCase):
         first_call = service_client.request.call_args_list[0]
         self.assertEqual(first_call[1]['params']['version'], 5)
         self.assertEqual(first_call[1]['params']['limit'], 1)
+
+    def test_submit_app_with_empty_files_field_reaches_server_validation(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        service_client.request.side_effect = [
+            {'uuid': 'u', 'versions': [{'version': 1}]},
+            '''version: 2
+workflow:
+  name: no-files
+  tasks:
+  - name: main
+    image: ubuntu
+    command: [echo]
+    files:
+''',
+            osmo_errors.OSMOSubmissionError('Input should be a valid list'),
+        ]
+        args = self._make_args()
+
+        with self.assertRaisesRegex(
+                osmo_errors.OSMOSubmissionError, 'Input should be a valid list'):
+            with mock.patch('builtins.print'):
+                app._submit_app(service_client, args)
+
+        self.assertEqual(service_client.request.call_count, 3)
+        submission_request = service_client.request.call_args_list[2]
+        self.assertEqual(submission_request.args[:2], (
+            client.RequestMethod.POST, 'api/pool/pool-1/workflow'))
+        submitted_spec = yaml.safe_load(submission_request.kwargs['payload']['file'])
+        self.assertIsNone(submitted_spec['workflow']['tasks'][0]['files'])
 
 
 if __name__ == '__main__':

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -713,6 +713,22 @@ class LoadLocalFilesTest(unittest.TestCase):
 
         self.assertEqual(spec['workflow']['tasks'], [{'name': 'standalone'}])
 
+    def test_tasks_without_local_files_are_unchanged(self):
+        file_sections: tuple[Dict[str, Any], ...] = ({}, {'files': []}, {'files': None})
+
+        for file_section in file_sections:
+            with self.subTest(file_section=file_section):
+                task = {'name': 'main', **file_section}
+                spec = {'workflow': {'tasks': [task]}}
+
+                try:
+                    workflow.load_local_files('/workspace/workflow.yaml', spec)
+                except TypeError as error:
+                    self.fail(f'No local files should not raise TypeError: {error}')
+
+                self.assertEqual(
+                    spec['workflow']['tasks'][0], {'name': 'main', **file_section})
+
 
 class SubmitWorkflowTest(unittest.TestCase):
     """Test the 'workflow submit' command handler."""

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -1221,7 +1221,11 @@ def _load_workflow_text(workflow_file: str) -> str:
 
 
 def _load_local_files_helper(workflow_file: str, section_dict: Dict):
-    for each_file in section_dict.get('files', []):
+    files = section_dict.get('files')
+    if files is None:
+        return
+
+    for each_file in files:
         if 'localpath' in each_file and 'contents' in each_file:
             raise osmo_errors.OSMOSubmissionError(
                 'Files tag dont support contents and localpath together')


### PR DESCRIPTION
## Description

When an app task contains an empty YAML `files:` field, PyYAML loads it as `None`. The CLI tried to iterate that value while resolving local files, causing `osmo app submit` to fail with an internal `TypeError` before the workflow reached normal server validation.

Treat `None` as having no local files to inline while preserving the original value for server-side schema validation. Regression tests cover omitted, empty-list, and null file sections through both the loader and app-submit paths.

Issue - None

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
