### PR TITLE
Handle leading-hyphen label assignments consistently

### DIFF
--- a/docs/user_guide/workflows/submission.rst
+++ b/docs/user_guide/workflows/submission.rst
@@ -191,6 +191,10 @@ flags. A command-line value wins over the same key in the workflow YAML.
        --label team=robotics \
        --label experiment=run42
 
+Label keys must start with a letter or number. For example, use
+``--label key=val``, not ``--label -key=val``. A leading hyphen is invalid in a
+label key and can cause the CLI to mistake the label for another command option.
+
 The same flag works for app submission and resubmission by workflow ID
 (``osmo workflow submit <workflow-id>``). Restart does not accept label
 overrides because it reuses the stored specification; resubmit the workflow

--- a/docs/user_guide/workflows/submission.rst
+++ b/docs/user_guide/workflows/submission.rst
@@ -196,7 +196,8 @@ Label keys must start with a letter or number. Both ``--label -key=val`` and
 identifying ``-key`` as invalid. Recognized command options after ``--label``
 still indicate a missing label argument.
 
-The same flag works for app submission and resubmission by workflow ID
+The same flag and validation behavior apply to app submission
+(``osmo app submit <app-name>``) and resubmission by workflow ID
 (``osmo workflow submit <workflow-id>``). Restart does not accept label
 overrides because it reuses the stored specification; resubmit the workflow
 when a stored label must change.

--- a/docs/user_guide/workflows/submission.rst
+++ b/docs/user_guide/workflows/submission.rst
@@ -191,10 +191,16 @@ flags. A command-line value wins over the same key in the workflow YAML.
        --label team=robotics \
        --label experiment=run42
 
-Label keys must start with a letter or number. Both ``--label -key=val`` and
+Immediately after ``--label``, a token in ``KEY=VALUE`` form is treated as the
+label assignment even if it starts with a hyphen or resembles a command option.
+Label keys must start with a letter or number, so both ``--label -key=val`` and
 ``--label=-key=val`` reach label validation and are rejected with an error
-identifying ``-key`` as invalid. Recognized command options after ``--label``
-still indicate a missing label argument.
+identifying ``-key`` as invalid.
+
+For example, ``--label --pool=foo`` is rejected as an invalid label key
+``--pool``, while ``--label --pool foo`` reports a missing label argument.
+Use ``--label team=alpha --pool=foo`` to set both a label and a pool.
+The ``--`` argument terminator retains its usual meaning.
 
 The same flag and validation behavior apply to app submission
 (``osmo app submit <app-name>``) and resubmission by workflow ID

--- a/docs/user_guide/workflows/submission.rst
+++ b/docs/user_guide/workflows/submission.rst
@@ -191,9 +191,10 @@ flags. A command-line value wins over the same key in the workflow YAML.
        --label team=robotics \
        --label experiment=run42
 
-Label keys must start with a letter or number. For example, use
-``--label key=val``, not ``--label -key=val``. A leading hyphen is invalid in a
-label key and can cause the CLI to mistake the label for another command option.
+Label keys must start with a letter or number. Both ``--label -key=val`` and
+``--label=-key=val`` reach label validation and are rejected with an error
+identifying ``-key`` as invalid. Recognized command options after ``--label``
+still indicate a missing label argument.
 
 The same flag works for app submission and resubmission by workflow ID
 (``osmo workflow submit <workflow-id>``). Restart does not accept label

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -154,6 +154,7 @@ def setup_parser(parser: argparse._SubParsersAction):
 
     submit_parser = subparsers.add_parser(
         'submit',
+        normalize_labels=True,
         help='Submit a workflow app version you created.')
     submit_parser.add_argument('name',
                                help='Name of the app. Specify version to submit '

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -37,7 +37,8 @@ def setup_parser(parser: argparse._SubParsersAction):
     app_parser = parser.add_parser('app',
         help='Create and manage workflow apps.',
         description='Apps are reusable workflow files that can be shared with other users.')
-    subparsers = app_parser.add_subparsers(dest='command')
+    subparsers = app_parser.add_subparsers(
+        dest='command', parser_class=workflow.WorkflowArgumentParser)
     subparsers.required = True
 
     create_parser = subparsers.add_parser(
@@ -225,7 +226,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                                default=[],
                                metavar='KEY=VALUE',
                                help='Set a workflow label. Repeat to set multiple labels. '
-                                    'Values override labels declared by the app.')
+                                    'Values override labels declared by the app. '
+                                    'Label keys must start with a letter or number.')
     submit_parser.set_defaults(func=_submit_app)
 
 

--- a/src/cli/tests/test_app.py
+++ b/src/cli/tests/test_app.py
@@ -172,7 +172,9 @@ class TestSetupParser(unittest.TestCase):
         self.assertEqual(args.labels, ['team=alpha', 'run=42'])
 
     def test_submit_hyphen_labels_match_equals_form(self):
-        for label in ('-key=val', '--key=val', '-bad.example/key=val'):
+        for label in ('-key=val', '--key=val', '-bad.example/key=val', '-project=val',
+                      '-label=val', '--pool=foo', '--local-path=/tmp', '--local=/tmp',
+                      '-p=foo', '-l=/tmp', '-=val'):
             for before_name in (False, True):
                 with self.subTest(label=label, before_name=before_name):
                     labels = ['--label', label, '--label', 'team=alpha']
@@ -187,8 +189,8 @@ class TestSetupParser(unittest.TestCase):
                     self.assertEqual(arguments, original)
 
     def test_submit_missing_labels_do_not_consume_options(self):
-        for trailing in ([], ['--pool=pool-1'], ['-p=pool-1'], ['--local-path=/tmp'],
-                         ['--local=/tmp'], ['-l=/tmp'], ['-l/tmp'], ['--help'], ['-key']):
+        for trailing in ([], ['--pool', 'foo'], ['--local-path', '/tmp'],
+                         ['-l/tmp'], ['--help'], ['-key'], ['--']):
             with self.subTest(trailing=trailing):
                 output = io.StringIO()
                 with contextlib.redirect_stderr(output), self.assertRaises(SystemExit) as raised:
@@ -196,6 +198,12 @@ class TestSetupParser(unittest.TestCase):
                         'app', 'submit', 'my-app', '--label', *trailing])
                 self.assertEqual(raised.exception.code, 2)
                 self.assertIn('argument --label: expected one argument', output.getvalue())
+
+    def test_submit_valid_label_preserves_following_pool_option(self):
+        args = self._build_parser().parse_args([
+            'app', 'submit', 'my-app', '--label', 'team=alpha', '--pool=foo'])
+        self.assertEqual(args.labels, ['team=alpha'])
+        self.assertEqual(args.pool, 'foo')
 
     def test_submit_terminator_stops_label_normalization(self):
         output = io.StringIO()

--- a/src/cli/tests/test_app.py
+++ b/src/cli/tests/test_app.py
@@ -18,6 +18,8 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import argparse
+import contextlib
+import io
 import json
 import unittest
 from unittest import mock
@@ -168,6 +170,60 @@ class TestSetupParser(unittest.TestCase):
         ])
 
         self.assertEqual(args.labels, ['team=alpha', 'run=42'])
+
+    def test_submit_hyphen_labels_match_equals_form(self):
+        for label in ('-key=val', '--key=val', '-bad.example/key=val'):
+            for before_name in (False, True):
+                with self.subTest(label=label, before_name=before_name):
+                    labels = ['--label', label, '--label', 'team=alpha']
+                    arguments = ['app', 'submit'] + (
+                        labels + ['my-app:3'] if before_name else ['my-app:3'] + labels)
+                    original = list(arguments)
+                    args = self._build_parser().parse_args(arguments)
+                    expected = self._build_parser().parse_args([
+                        'app', 'submit', 'my-app:3', f'--label={label}', '--label', 'team=alpha'])
+                    self.assertEqual(vars(args), vars(expected))
+                    self.assertEqual(args.labels, [label, 'team=alpha'])
+                    self.assertEqual(arguments, original)
+
+    def test_submit_missing_labels_do_not_consume_options(self):
+        for trailing in ([], ['--pool=pool-1'], ['-p=pool-1'], ['--local-path=/tmp'],
+                         ['--local=/tmp'], ['-l=/tmp'], ['-l/tmp'], ['--help'], ['-key']):
+            with self.subTest(trailing=trailing):
+                output = io.StringIO()
+                with contextlib.redirect_stderr(output), self.assertRaises(SystemExit) as raised:
+                    self._build_parser().parse_args([
+                        'app', 'submit', 'my-app', '--label', *trailing])
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn('argument --label: expected one argument', output.getvalue())
+
+    def test_submit_terminator_stops_label_normalization(self):
+        output = io.StringIO()
+        with contextlib.redirect_stderr(output), self.assertRaises(SystemExit) as raised:
+            self._build_parser().parse_args(['app', 'submit', '--', '--label', '-key=val'])
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn('unrecognized arguments: -key=val', output.getvalue())
+
+    def test_other_app_commands_do_not_accept_label_flag(self):
+        for arguments in (
+            ['create', 'my-app', '-d', 'description'], ['update', 'my-app'],
+            ['info', 'my-app'], ['show', 'my-app'], ['spec', 'my-app'],
+            ['list'], ['delete', 'my-app'], ['rename', 'my-app', 'new-name'],
+        ):
+            with self.subTest(arguments=arguments):
+                output = io.StringIO()
+                with contextlib.redirect_stderr(output), self.assertRaises(SystemExit) as raised:
+                    self._build_parser().parse_args(['app', *arguments, '--label', '-key=val'])
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn('unrecognized arguments: --label -key=val', output.getvalue())
+
+    def test_submit_help_explains_label_key_rule(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            self._build_parser().parse_args(['app', 'submit', '--help'])
+        self.assertEqual(raised.exception.code, 0)
+        self.assertIn('Label keys must start with a letter or number.',
+                      ' '.join(output.getvalue().split()))
 
 
 class TestCreateApp(unittest.TestCase):

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -28,6 +28,25 @@ from src.lib.rsync import rsync
 from src.lib.utils import osmo_errors
 
 
+class TestInvalidLabelArgument(unittest.TestCase):
+    def test_leading_hyphen_label_fails_before_client_setup(self):
+        output = io.StringIO()
+        with mock.patch.object(cli.sys, 'argv', [
+                'osmo', 'workflow', 'submit', 'workflow.yaml', '--label', '-key=val']), \
+             mock.patch.object(cli, 'configure_logging') as configure_logging, \
+             mock.patch.object(cli.client, 'LoginManager') as login_manager, \
+             mock.patch.object(cli.client, 'ServiceClient') as service_client, \
+             contextlib.redirect_stderr(output), self.assertRaises(SystemExit) as raised:
+            cli.main()
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn('If your label key starts with "-", it is invalid', output.getvalue())
+        self.assertIn('--label key=val', output.getvalue())
+        configure_logging.assert_not_called()
+        login_manager.assert_not_called()
+        service_client.assert_not_called()
+
+
 class TestSubmissionErrorOutput(unittest.TestCase):
     """The CLI reports HTTP status separately from its process exit code."""
 

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -32,7 +32,15 @@ from src.lib.utils import client, osmo_errors, validation
 
 class TestInvalidLabelArgument(unittest.TestCase):
     def test_spaced_and_equals_labels_reach_submission_validation(self):
-        def reject_invalid_label(method, endpoint, *, payload, params):
+        def respond(method, endpoint, *, params, payload=None, mode=client.ResponseMode.JSON):
+            if method == client.RequestMethod.GET:
+                if endpoint == 'api/app/user/my-app':
+                    self.assertEqual(params, {'version': 3, 'limit': 1})
+                    return {'uuid': 'app-uuid', 'versions': [{'version': 3}]}
+                self.assertEqual(endpoint, 'api/app/user/my-app/spec')
+                self.assertEqual(params, {'version': 3})
+                self.assertEqual(mode, client.ResponseMode.PLAIN_TEXT)
+                return 'version: 2\nworkflow:\n  name: workflow\n'
             self.assertEqual(method, client.RequestMethod.POST)
             self.assertEqual(endpoint, 'api/pool/pool-1/workflow')
             self.assertIn('name: workflow', payload['file'])
@@ -50,17 +58,22 @@ class TestInvalidLabelArgument(unittest.TestCase):
             workflow_file = pathlib.Path(directory) / 'workflow.yaml'
             workflow_file.write_text(
                 'version: 2\nworkflow:\n  name: workflow\n', encoding='utf-8')
-            requests = []
-            outputs = []
-            for command in ('submit', 'validate'):
+            for module, command, target in (
+                ('workflow', 'submit', str(workflow_file)),
+                ('workflow', 'validate', str(workflow_file)),
+                ('app', 'submit', 'my-app:3'),
+            ):
+                requests = []
+                outputs = []
                 for label_arguments in (['--label', '-key=val'], ['--label=-key=val']):
-                    with self.subTest(command=command, label_arguments=label_arguments):
+                    with self.subTest(module=module, command=command,
+                                      label_arguments=label_arguments):
                         output = io.StringIO()
                         errors = io.StringIO()
                         service_client = mock.Mock(spec=client.ServiceClient)
-                        service_client.request.side_effect = reject_invalid_label
+                        service_client.request.side_effect = respond
                         with mock.patch.object(cli.sys, 'argv', [
-                                'osmo', 'workflow', command, str(workflow_file),
+                                'osmo', module, command, target,
                                 '--pool', 'pool-1', *label_arguments]), \
                              mock.patch.object(cli, 'configure_logging'), \
                              mock.patch.object(cli.client, 'LoginManager'), \
@@ -77,13 +90,17 @@ class TestInvalidLabelArgument(unittest.TestCase):
                         self.assertIn('Error code: 400', output.getvalue())
                         self.assertNotIn('expected one argument', errors.getvalue())
                         self.assertNotIn('successful', output.getvalue())
-                        service_client.request.assert_called_once()
-                        requests.append(service_client.request.call_args)
+                        self.assertEqual(service_client.request.call_count,
+                                         3 if module == 'app' else 1)
+                        if module == 'app':
+                            params = service_client.request.call_args.kwargs['params']
+                            self.assertEqual(params['app_uuid'], 'app-uuid')
+                            self.assertEqual(params['app_version'], 3)
+                        requests.append(service_client.request.call_args_list)
                         outputs.append(output.getvalue())
-            self.assertEqual(requests[0], requests[1])
-            self.assertEqual(requests[2], requests[3])
-            self.assertEqual(outputs[0], outputs[1])
-            self.assertEqual(outputs[2], outputs[3])
+                if len(requests) == 2:
+                    self.assertEqual(requests[0], requests[1])
+                    self.assertEqual(outputs[0], outputs[1])
 
 
 class TestSubmissionErrorOutput(unittest.TestCase):

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 import argparse
 import contextlib
 import io
+import itertools
 import json
 import pathlib
 import tempfile
@@ -44,7 +45,7 @@ class TestInvalidLabelArgument(unittest.TestCase):
             self.assertEqual(method, client.RequestMethod.POST)
             self.assertEqual(endpoint, 'api/pool/pool-1/workflow')
             self.assertIn('name: workflow', payload['file'])
-            self.assertEqual(params['label'], ['-key=val'])
+            self.assertEqual(params['label'], [label])
             try:
                 validation.parse_workflow_label_assignment(params['label'][0])
             except ValueError as error:
@@ -58,14 +59,16 @@ class TestInvalidLabelArgument(unittest.TestCase):
             workflow_file = pathlib.Path(directory) / 'workflow.yaml'
             workflow_file.write_text(
                 'version: 2\nworkflow:\n  name: workflow\n', encoding='utf-8')
-            for module, command, target in (
+            commands = (
                 ('workflow', 'submit', str(workflow_file)),
                 ('workflow', 'validate', str(workflow_file)),
                 ('app', 'submit', 'my-app:3'),
-            ):
+            )
+            labels = ('-key=val', '-project=val', '-label=val', '--pool=foo')
+            for (module, command, target), label in itertools.product(commands, labels):
                 requests = []
                 outputs = []
-                for label_arguments in (['--label', '-key=val'], ['--label=-key=val']):
+                for label_arguments in (['--label', label], [f'--label={label}']):
                     with self.subTest(module=module, command=command,
                                       label_arguments=label_arguments):
                         output = io.StringIO()
@@ -85,7 +88,8 @@ class TestInvalidLabelArgument(unittest.TestCase):
                             cli.main()
 
                         self.assertEqual(raised.exception.code, 1)
-                        self.assertIn('Workflow label key "-key" has an invalid name.',
+                        key = label.split('=', 1)[0]
+                        self.assertIn(f'Workflow label key "{key}" has an invalid name.',
                                       output.getvalue())
                         self.assertIn('Error code: 400', output.getvalue())
                         self.assertNotIn('expected one argument', errors.getvalue())

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -19,32 +19,71 @@ import argparse
 import contextlib
 import io
 import json
+import pathlib
+import tempfile
 import unittest
 from unittest import mock
 
 import src.cli.cli as cli
 from src.cli import main_parser, workflow
 from src.lib.rsync import rsync
-from src.lib.utils import osmo_errors
+from src.lib.utils import client, osmo_errors, validation
 
 
 class TestInvalidLabelArgument(unittest.TestCase):
-    def test_leading_hyphen_label_fails_before_client_setup(self):
-        output = io.StringIO()
-        with mock.patch.object(cli.sys, 'argv', [
-                'osmo', 'workflow', 'submit', 'workflow.yaml', '--label', '-key=val']), \
-             mock.patch.object(cli, 'configure_logging') as configure_logging, \
-             mock.patch.object(cli.client, 'LoginManager') as login_manager, \
-             mock.patch.object(cli.client, 'ServiceClient') as service_client, \
-             contextlib.redirect_stderr(output), self.assertRaises(SystemExit) as raised:
-            cli.main()
+    def test_spaced_and_equals_labels_reach_submission_validation(self):
+        def reject_invalid_label(method, endpoint, *, payload, params):
+            self.assertEqual(method, client.RequestMethod.POST)
+            self.assertEqual(endpoint, 'api/pool/pool-1/workflow')
+            self.assertIn('name: workflow', payload['file'])
+            self.assertEqual(params['label'], ['-key=val'])
+            try:
+                validation.parse_workflow_label_assignment(params['label'][0])
+            except ValueError as error:
+                response = mock.Mock(
+                    status_code=400, headers={},
+                    text=json.dumps({'message': str(error), 'error_code': 'USAGE'}))
+                return client.handle_response(response)
+            self.fail('The invalid label must be rejected by the shared validator.')
 
-        self.assertEqual(raised.exception.code, 2)
-        self.assertIn('If your label key starts with "-", it is invalid', output.getvalue())
-        self.assertIn('--label key=val', output.getvalue())
-        configure_logging.assert_not_called()
-        login_manager.assert_not_called()
-        service_client.assert_not_called()
+        with tempfile.TemporaryDirectory() as directory:
+            workflow_file = pathlib.Path(directory) / 'workflow.yaml'
+            workflow_file.write_text(
+                'version: 2\nworkflow:\n  name: workflow\n', encoding='utf-8')
+            requests = []
+            outputs = []
+            for command in ('submit', 'validate'):
+                for label_arguments in (['--label', '-key=val'], ['--label=-key=val']):
+                    with self.subTest(command=command, label_arguments=label_arguments):
+                        output = io.StringIO()
+                        errors = io.StringIO()
+                        service_client = mock.Mock(spec=client.ServiceClient)
+                        service_client.request.side_effect = reject_invalid_label
+                        with mock.patch.object(cli.sys, 'argv', [
+                                'osmo', 'workflow', command, str(workflow_file),
+                                '--pool', 'pool-1', *label_arguments]), \
+                             mock.patch.object(cli, 'configure_logging'), \
+                             mock.patch.object(cli.client, 'LoginManager'), \
+                             mock.patch.object(cli.client, 'ServiceClient',
+                                               return_value=service_client), \
+                             contextlib.redirect_stdout(output), \
+                             contextlib.redirect_stderr(errors), \
+                             self.assertRaises(SystemExit) as raised:
+                            cli.main()
+
+                        self.assertEqual(raised.exception.code, 1)
+                        self.assertIn('Workflow label key "-key" has an invalid name.',
+                                      output.getvalue())
+                        self.assertIn('Error code: 400', output.getvalue())
+                        self.assertNotIn('expected one argument', errors.getvalue())
+                        self.assertNotIn('successful', output.getvalue())
+                        service_client.request.assert_called_once()
+                        requests.append(service_client.request.call_args)
+                        outputs.append(output.getvalue())
+            self.assertEqual(requests[0], requests[1])
+            self.assertEqual(requests[2], requests[3])
+            self.assertEqual(outputs[0], outputs[1])
+            self.assertEqual(outputs[2], outputs[3])
 
 
 class TestSubmissionErrorOutput(unittest.TestCase):

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -123,6 +123,69 @@ class TestWorkflowLabelParser(unittest.TestCase):
 
         self.assertEqual(args.labels, ['team=alpha', 'run=42'])
 
+    def test_missing_label_value_explains_invalid_leading_hyphen(self):
+        for command in ('submit', 'validate', 'list'):
+            positional = [] if command == 'list' else ['workflow.yaml']
+            for trailing in (['-key=val'], ['--key=val'], [], ['--pool', 'pool-1']):
+                with self.subTest(command=command, trailing=trailing):
+                    output = io.StringIO()
+                    with contextlib.redirect_stderr(output), \
+                         self.assertRaises(SystemExit) as raised:
+                        self._build_parser().parse_args([
+                            'workflow', command, *positional, '--label', *trailing,
+                        ])
+
+                    self.assertEqual(raised.exception.code, 2)
+                    self.assertIn('argument --label: expected one argument', output.getvalue())
+                    self.assertIn('If your label key starts with "-", it is invalid',
+                                  output.getvalue())
+                    self.assertIn('label keys must start with a letter or number',
+                                  output.getvalue())
+                    self.assertIn('--label key=val', output.getvalue())
+
+    def test_equals_label_form_still_defers_validation(self):
+        for command in ('submit', 'validate', 'list'):
+            with self.subTest(command=command):
+                positional = [] if command == 'list' else ['workflow.yaml']
+                args = self._build_parser().parse_args([
+                    'workflow', command, *positional,
+                    '--label=-key=val', '--label', 'team=alpha',
+                ])
+
+                self.assertEqual(args.labels, ['-key=val', 'team=alpha'])
+
+    def test_unrelated_parser_errors_do_not_show_label_hint(self):
+        for arguments in (
+            ['workflow', 'submit', 'workflow.yaml', '--pool'],
+            ['workflow', 'submit', 'workflow.yaml', '--unknown'],
+            ['workflow', 'logs', 'workflow-1', '--task'],
+            ['workflow', 'list', '--no-label'],
+        ):
+            with self.subTest(arguments=arguments):
+                output = io.StringIO()
+                with contextlib.redirect_stderr(output), self.assertRaises(SystemExit) as raised:
+                    self._build_parser().parse_args(arguments)
+
+                self.assertEqual(raised.exception.code, 2)
+                self.assertNotIn('If your label key', output.getvalue())
+
+    def test_label_after_argument_terminator_is_a_filename(self):
+        args = self._build_parser().parse_args(['workflow', 'submit', '--', '--label'])
+
+        self.assertEqual(args.workflow_file, '--label')
+        self.assertEqual(args.labels, [])
+
+    def test_label_help_explains_leading_character_rule(self):
+        for command in ('submit', 'validate'):
+            with self.subTest(command=command):
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+                    self._build_parser().parse_args(['workflow', command, '--help'])
+
+                self.assertEqual(raised.exception.code, 0)
+                self.assertIn('Label keys must start with a letter or number.',
+                              ' '.join(output.getvalue().split()))
+
     def test_list_accepts_present_and_missing_label_filters(self):
         args = self._build_parser().parse_args([
             'workflow', 'list',

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -123,10 +123,30 @@ class TestWorkflowLabelParser(unittest.TestCase):
 
         self.assertEqual(args.labels, ['team=alpha', 'run=42'])
 
-    def test_missing_label_value_explains_invalid_leading_hyphen(self):
+    def test_hyphen_label_assignments_match_equals_form(self):
         for command in ('submit', 'validate', 'list'):
             positional = [] if command == 'list' else ['workflow.yaml']
-            for trailing in (['-key=val'], ['--key=val'], [], ['--pool', 'pool-1']):
+            for label in ('-key=val', '--key=val', '-bad.example/key=val', '-key=a=b'):
+                for before_file in (False, True):
+                    with self.subTest(command=command, label=label, before_file=before_file):
+                        spaced = ['--label', label, '--label', 'team=alpha']
+                        explicit = [f'--label={label}', '--label', 'team=alpha']
+                        arguments = ['workflow', command] + (
+                            spaced + positional if before_file else positional + spaced)
+                        original = list(arguments)
+                        args = self._build_parser().parse_args(arguments)
+                        expected = self._build_parser().parse_args(
+                            ['workflow', command, *positional, *explicit])
+
+                        self.assertEqual(vars(args), vars(expected))
+                        self.assertEqual(args.labels, [label, 'team=alpha'])
+                        self.assertEqual(arguments, original)
+
+    def test_missing_label_and_known_options_remain_parser_errors(self):
+        for command in ('submit', 'validate', 'list'):
+            positional = [] if command == 'list' else ['workflow.yaml']
+            for trailing in ([], ['--pool', 'pool-1'], ['--pool=pool-1'],
+                             ['--po=pool-1'], ['--help'], ['-key'], ['-=val']):
                 with self.subTest(command=command, trailing=trailing):
                     output = io.StringIO()
                     with contextlib.redirect_stderr(output), \
@@ -134,46 +154,58 @@ class TestWorkflowLabelParser(unittest.TestCase):
                         self._build_parser().parse_args([
                             'workflow', command, *positional, '--label', *trailing,
                         ])
+                    self.assertEqual(raised.exception.code, 2)
+                    self.assertNotIn('has an invalid name', output.getvalue())
+                    self.assertNotIn('If your label key', output.getvalue())
+                    if trailing != ['-=val']:
+                        self.assertIn('argument --label: expected one argument',
+                                      output.getvalue())
 
+    def test_label_does_not_consume_short_options(self):
+        for command in ('submit', 'validate'):
+            for option in ('-p=pool-1', '-ppool-1', '-ppool=1', '-prefix/name=val'):
+                with self.subTest(command=command, option=option):
+                    output = io.StringIO()
+                    with contextlib.redirect_stderr(output), \
+                         self.assertRaises(SystemExit) as raised:
+                        self._build_parser().parse_args([
+                            'workflow', command, 'workflow.yaml', '--label', option])
                     self.assertEqual(raised.exception.code, 2)
                     self.assertIn('argument --label: expected one argument', output.getvalue())
-                    self.assertIn('If your label key starts with "-", it is invalid',
-                                  output.getvalue())
-                    self.assertIn('label keys must start with a letter or number',
-                                  output.getvalue())
-                    self.assertIn('--label key=val', output.getvalue())
 
-    def test_equals_label_form_still_defers_validation(self):
-        for command in ('submit', 'validate', 'list'):
-            with self.subTest(command=command):
-                positional = [] if command == 'list' else ['workflow.yaml']
-                args = self._build_parser().parse_args([
-                    'workflow', command, *positional,
-                    '--label=-key=val', '--label', 'team=alpha',
-                ])
-
-                self.assertEqual(args.labels, ['-key=val', 'team=alpha'])
-
-    def test_unrelated_parser_errors_do_not_show_label_hint(self):
+    def test_unrelated_arguments_are_not_normalized(self):
         for arguments in (
-            ['workflow', 'submit', 'workflow.yaml', '--pool'],
-            ['workflow', 'submit', 'workflow.yaml', '--unknown'],
-            ['workflow', 'logs', 'workflow-1', '--task'],
-            ['workflow', 'list', '--no-label'],
+            ['workflow', 'submit', 'workflow.yaml', '--pool', '-key=val'],
+            ['workflow', 'submit', 'workflow.yaml', '--unknown=-key=val'],
+            ['workflow', 'logs', 'workflow-1', '--label', '-key=val'],
+            ['workflow', 'list', '--no-label', '-key=val'],
         ):
             with self.subTest(arguments=arguments):
-                output = io.StringIO()
-                with contextlib.redirect_stderr(output), self.assertRaises(SystemExit) as raised:
+                with contextlib.redirect_stderr(io.StringIO()), \
+                     self.assertRaises(SystemExit) as raised:
                     self._build_parser().parse_args(arguments)
-
                 self.assertEqual(raised.exception.code, 2)
-                self.assertNotIn('If your label key', output.getvalue())
 
     def test_label_after_argument_terminator_is_a_filename(self):
-        args = self._build_parser().parse_args(['workflow', 'submit', '--', '--label'])
+        for filename in ('--label', '--label=-key=val'):
+            with self.subTest(filename=filename):
+                args = self._build_parser().parse_args(['workflow', 'submit', '--', filename])
+                self.assertEqual(args.workflow_file, filename)
+                self.assertEqual(args.labels, [])
 
-        self.assertEqual(args.workflow_file, '--label')
-        self.assertEqual(args.labels, [])
+    def test_argument_terminator_stops_label_normalization(self):
+        output = io.StringIO()
+        with contextlib.redirect_stderr(output), self.assertRaises(SystemExit) as raised:
+            self._build_parser().parse_args(['workflow', 'submit', '--', '--label', '-key=val'])
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn('unrecognized arguments: -key=val', output.getvalue())
+
+    def test_list_hyphen_key_reaches_selector_validation(self):
+        service_client = mock.Mock(spec=client.ServiceClient)
+        args = self._build_parser().parse_args(['workflow', 'list', '--label', '-key=val'])
+        with self.assertRaisesRegex(osmo_errors.OSMOUserError, 'label key "-key".*invalid name'):
+            args.func(service_client, args)
+        service_client.request.assert_not_called()
 
     def test_label_help_explains_leading_character_rule(self):
         for command in ('submit', 'validate'):

--- a/src/cli/tests/test_workflow.py
+++ b/src/cli/tests/test_workflow.py
@@ -126,7 +126,9 @@ class TestWorkflowLabelParser(unittest.TestCase):
     def test_hyphen_label_assignments_match_equals_form(self):
         for command in ('submit', 'validate', 'list'):
             positional = [] if command == 'list' else ['workflow.yaml']
-            for label in ('-key=val', '--key=val', '-bad.example/key=val', '-key=a=b'):
+            for label in ('-key=val', '--key=val', '-bad.example/key=val', '-key=a=b',
+                          '-project=val', '-label=val', '--pool=foo', '--po=foo',
+                          '-p=foo', '-ppool=foo', '-prefix/name=val', '-=val'):
                 for before_file in (False, True):
                     with self.subTest(command=command, label=label, before_file=before_file):
                         spaced = ['--label', label, '--label', 'team=alpha']
@@ -142,11 +144,10 @@ class TestWorkflowLabelParser(unittest.TestCase):
                         self.assertEqual(args.labels, [label, 'team=alpha'])
                         self.assertEqual(arguments, original)
 
-    def test_missing_label_and_known_options_remain_parser_errors(self):
+    def test_missing_labels_and_non_assignment_options_remain_parser_errors(self):
         for command in ('submit', 'validate', 'list'):
             positional = [] if command == 'list' else ['workflow.yaml']
-            for trailing in ([], ['--pool', 'pool-1'], ['--pool=pool-1'],
-                             ['--po=pool-1'], ['--help'], ['-key'], ['-=val']):
+            for trailing in ([], ['--pool', 'pool-1'], ['--help'], ['-key'], ['--']):
                 with self.subTest(command=command, trailing=trailing):
                     output = io.StringIO()
                     with contextlib.redirect_stderr(output), \
@@ -157,13 +158,11 @@ class TestWorkflowLabelParser(unittest.TestCase):
                     self.assertEqual(raised.exception.code, 2)
                     self.assertNotIn('has an invalid name', output.getvalue())
                     self.assertNotIn('If your label key', output.getvalue())
-                    if trailing != ['-=val']:
-                        self.assertIn('argument --label: expected one argument',
-                                      output.getvalue())
+                    self.assertIn('argument --label: expected one argument', output.getvalue())
 
     def test_label_does_not_consume_short_options(self):
         for command in ('submit', 'validate'):
-            for option in ('-p=pool-1', '-ppool-1', '-ppool=1', '-prefix/name=val'):
+            for option in ('-p', '-ppool-1'):
                 with self.subTest(command=command, option=option):
                     output = io.StringIO()
                     with contextlib.redirect_stderr(output), \
@@ -172,6 +171,15 @@ class TestWorkflowLabelParser(unittest.TestCase):
                             'workflow', command, 'workflow.yaml', '--label', option])
                     self.assertEqual(raised.exception.code, 2)
                     self.assertIn('argument --label: expected one argument', output.getvalue())
+
+    def test_valid_label_preserves_following_pool_option(self):
+        for command in ('submit', 'validate', 'list'):
+            with self.subTest(command=command):
+                positional = [] if command == 'list' else ['workflow.yaml']
+                args = self._build_parser().parse_args([
+                    'workflow', command, *positional, '--label', 'team=alpha', '--pool=foo'])
+                self.assertEqual(args.labels, ['team=alpha'])
+                self.assertEqual(args.pool, ['foo'] if command == 'list' else 'foo')
 
     def test_unrelated_arguments_are_not_normalized(self):
         for arguments in (
@@ -201,11 +209,15 @@ class TestWorkflowLabelParser(unittest.TestCase):
         self.assertIn('unrecognized arguments: -key=val', output.getvalue())
 
     def test_list_hyphen_key_reaches_selector_validation(self):
-        service_client = mock.Mock(spec=client.ServiceClient)
-        args = self._build_parser().parse_args(['workflow', 'list', '--label', '-key=val'])
-        with self.assertRaisesRegex(osmo_errors.OSMOUserError, 'label key "-key".*invalid name'):
-            args.func(service_client, args)
-        service_client.request.assert_not_called()
+        for key in ('-key', '-project', '-label', '--pool'):
+            with self.subTest(key=key):
+                service_client = mock.Mock(spec=client.ServiceClient)
+                args = self._build_parser().parse_args([
+                    'workflow', 'list', '--label', f'{key}=val'])
+                with self.assertRaisesRegex(
+                        osmo_errors.OSMOUserError, f'label key "{key}".*invalid name'):
+                    args.func(service_client, args)
+                service_client.request.assert_not_called()
 
     def test_label_help_explains_leading_character_rule(self):
         for command in ('submit', 'validate'):

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -52,10 +52,14 @@ RESIZE_PREFIX = b'\x00RESIZE:'
 
 
 class WorkflowArgumentParser(argparse.ArgumentParser):
-    """Let unknown option-shaped label assignments reach label validation."""
+    """Bind leading-hyphen label assignments before argparse classifies options."""
+
+    def __init__(self, *args, normalize_labels: bool = False, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.normalize_labels = normalize_labels
 
     def parse_known_args(self, args: Sequence[str] | None = None, namespace=None):
-        if '--label' not in self._option_string_actions:
+        if not self.normalize_labels:
             return super().parse_known_args(args, namespace)
 
         arguments = list(sys.argv[1:] if args is None else args)
@@ -66,11 +70,7 @@ class WorkflowArgumentParser(argparse.ArgumentParser):
             if arguments[index] == '--label':
                 value = arguments[index + 1]
                 if value.startswith('-') and '=' in value:
-                    option = value.split('=', 1)[0]
-                    # Preserve real options, including abbreviations and attached short options.
-                    if option not in self._option_string_actions and \
-                            not self._get_option_tuples(value):
-                        arguments[index:index + 2] = [f'--label={value}']
+                    arguments[index:index + 2] = [f'--label={value}']
             index += 1
         return super().parse_known_args(arguments, namespace)
 
@@ -111,6 +111,7 @@ def setup_parser(parser: argparse._SubParsersAction):
 
     # Handle 'submit' command
     submit_parser = subparsers.add_parser('submit',
+                                          normalize_labels=True,
                                           help='Submit a workflow to the workflow service.')
     submit_parser.add_argument('workflow_file',
                                type=str,
@@ -201,6 +202,7 @@ def setup_parser(parser: argparse._SubParsersAction):
 
     # Handle 'validate' command
     validate_parser = subparsers.add_parser('validate',
+                                            normalize_labels=True,
                                             help='validate a workflow to the workflow server.')
     validate_parser.add_argument('workflow_file',
                                  type=lambda p: os.path.abspath(p),
@@ -304,8 +306,10 @@ def setup_parser(parser: argparse._SubParsersAction):
     query_parser.set_defaults(func=_query_workflow)
 
     # Handle 'list' command
-    list_parser = subparsers.add_parser('list', help='List workflows with different filters. ' + \
-        'Without the --pool flag, workflows from all pools will be listed.')
+    list_parser = subparsers.add_parser(
+        'list', normalize_labels=True,
+        help='List workflows with different filters. '
+             'Without the --pool flag, workflows from all pools will be listed.')
     list_parser.add_argument('--count', '-c',
                              default=20,
                              type=validation.positive_integer,

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -30,7 +30,7 @@ import sys
 import termios
 import time
 import tty
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, NoReturn, Tuple
 
 import pydantic
 import requests  # type: ignore
@@ -49,6 +49,17 @@ from src.lib.utils import (client, common, osmo_errors, paths, port_forward, pri
 
 INTERACTIVE_COMMANDS = ['bash', 'sh', 'zsh', 'fish', 'tcsh', 'csh', 'ksh']
 RESIZE_PREFIX = b'\x00RESIZE:'
+
+
+class WorkflowArgumentParser(argparse.ArgumentParser):
+    """Explain label values that argparse can mistake for command options."""
+
+    def error(self, message: str) -> NoReturn:
+        if message == 'argument --label: expected one argument':
+            message += ('\nIf your label key starts with "-", it is invalid; '
+                        'label keys must start with a letter or number '
+                        '(for example, --label key=val).')
+        super().error(message)
 
 
 class TemplateData(pydantic.BaseModel, extra='forbid'):
@@ -81,7 +92,8 @@ def setup_parser(parser: argparse._SubParsersAction):
         epilog='In 6.4, workflow tags are removed from the CLI. Use submit --label KEY=VALUE '
                'and list --label KEY=SELECTOR or --no-label KEY. '
                'Labels cannot be changed on existing runs.')
-    subparsers = workflow_parser.add_subparsers(dest='command')
+    subparsers = workflow_parser.add_subparsers(
+        dest='command', parser_class=WorkflowArgumentParser)
     subparsers.required = True
 
     # Handle 'submit' command
@@ -156,7 +168,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                                default=[],
                                metavar='KEY=VALUE',
                                help='Set a workflow label. Repeat to set multiple labels. '
-                                    'Values override labels declared in the workflow file.')
+                                    'Values override labels declared in the workflow file. '
+                                    'Label keys must start with a letter or number.')
     submit_parser.set_defaults(func=_submit_workflow)
 
     # Handle 'restart' command
@@ -210,7 +223,8 @@ def setup_parser(parser: argparse._SubParsersAction):
                                  metavar='KEY=VALUE',
                                  help='Set a workflow label for validation. Repeat to set '
                                       'multiple labels. Values override labels declared in '
-                                      'the workflow file.')
+                                      'the workflow file. Label keys must start with a letter '
+                                      'or number.')
     validate_parser.set_defaults(func=_validate_workflow)
 
     # Handle 'logs' command

--- a/src/cli/workflow.py
+++ b/src/cli/workflow.py
@@ -30,7 +30,7 @@ import sys
 import termios
 import time
 import tty
-from typing import Any, Dict, List, NoReturn, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 
 import pydantic
 import requests  # type: ignore
@@ -52,14 +52,27 @@ RESIZE_PREFIX = b'\x00RESIZE:'
 
 
 class WorkflowArgumentParser(argparse.ArgumentParser):
-    """Explain label values that argparse can mistake for command options."""
+    """Let unknown option-shaped label assignments reach label validation."""
 
-    def error(self, message: str) -> NoReturn:
-        if message == 'argument --label: expected one argument':
-            message += ('\nIf your label key starts with "-", it is invalid; '
-                        'label keys must start with a letter or number '
-                        '(for example, --label key=val).')
-        super().error(message)
+    def parse_known_args(self, args: Sequence[str] | None = None, namespace=None):
+        if '--label' not in self._option_string_actions:
+            return super().parse_known_args(args, namespace)
+
+        arguments = list(sys.argv[1:] if args is None else args)
+        index = 0
+        while index < len(arguments) - 1:
+            if arguments[index] == '--':
+                break
+            if arguments[index] == '--label':
+                value = arguments[index + 1]
+                if value.startswith('-') and '=' in value:
+                    option = value.split('=', 1)[0]
+                    # Preserve real options, including abbreviations and attached short options.
+                    if option not in self._option_string_actions and \
+                            not self._get_option_tuples(value):
+                        arguments[index:index + 2] = [f'--label={value}']
+            index += 1
+        return super().parse_known_args(arguments, namespace)
 
 
 class TemplateData(pydantic.BaseModel, extra='forbid'):

--- a/src/service/core/workflow/tests/test_workflow_labels.py
+++ b/src/service/core/workflow/tests/test_workflow_labels.py
@@ -180,13 +180,10 @@ workflow:
              mock.patch.object(
                  objects.WorkflowSubmitInfo,
                  'insert_failed_submission_to_db') as insert_failed:
-            with self.assertRaises(osmo_errors.OSMOUsageError):
-                submit_info.construct_workflow_dict(
-                    template_spec,
-                    label_overrides=['missing-separator'],
-                )
-
-        insert_failed.assert_not_called()
+            for label in ('missing-separator', '-key=val'):
+                with self.subTest(label=label), self.assertRaises(osmo_errors.OSMOUsageError):
+                    submit_info.construct_workflow_dict(template_spec, label_overrides=[label])
+                insert_failed.assert_not_called()
 
     def test_invalid_yaml_label_does_not_create_failed_submission(self):
         submit_info = _submit_info([])


### PR DESCRIPTION
## Description

Leading-hyphen label assignments such as `--label -key=val` and `--label -project=val` could fail in argparse instead of reaching label validation. Their handling also depended on which options a command registered.

Bind a hyphen-prefixed `KEY=VALUE` token immediately after explicit `--label` as its value, matching the equals form. Enable this rule only for workflow submit/validate/list and app submit, and remove private argparse option lookups. Submission commands report the existing invalid-key validation error with exit code 1; workflow list uses its existing selector validator. App UUID/version and repeated label order are preserved.

The rule deliberately treats `--label --pool=foo` as an invalid label key `--pool`. `--label --pool foo` still reports a missing label argument, while `--label team=alpha --pool=foo` sets the label and pool normally. Normalization stops at `--`. Help and documentation describe the behavior.

Issue #None

## Validation

- Expanded real-CLI regression failed on seven option-collision cases before the simplification; equals-form controls passed.
- Tests cover identical requests and concrete validation errors for both spellings across workflow submit/validate and app submit, including app metadata/spec retrieval and UUID/version. Transport is simulated; shared validation and HTTP-error conversion run normally.
- Server regression verifies an invalid label is rejected without inserting a failed submission.
- Passed 238 tests, both relevant pylint targets, and configured mypy checks:
  `bazel test //src/cli/tests:test_app //src/cli/tests:test_cli //src/cli/tests:test_workflow //src/cli:cli_lib-pylint //src/cli/tests:test_workflow-pylint //src/service/core/workflow/tests:test_workflow_labels`
- `git diff --check` passed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of `--label` assignments whose keys begin with a hyphen, including spaced and equals-form syntax.
  * Invalid labels now receive consistent validation errors across app submission and workflow commands.
  * Preserved standard handling for recognized options, missing values, hyphen-prefixed values, and arguments after `--`.

* **Documentation**
  * Clarified label parsing and validation for app submissions and workflow commands.
  * Documented label-key requirements, option-like values, pool options, and `--` terminator behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

