### PR TITLE
docs: compare deployment profiles

### DIFF
--- a/docs/deployment_guide/appendix/deploy_local.rst
+++ b/docs/deployment_guide/appendix/deploy_local.rst
@@ -18,9 +18,9 @@
 .. _deploy_local:
 .. _quickstart:
 
-==========
-Quickstart
-==========
+=====================
+Quickstart Deployment
+=====================
 
 Try OSMO on your local workstation — no cloud account, no infrastructure costs, no enterprise approval needed.
 

--- a/docs/deployment_guide/index.rst
+++ b/docs/deployment_guide/index.rst
@@ -164,7 +164,7 @@ An OSMO deployment consists of two main components:
   :hidden:
   :caption: Additional Resources
 
-  Quickstart <appendix/deploy_local>
+  Quickstart Deployment <appendix/deploy_local>
   Self-contained Deployment <appendix/deploy_self_contained>
   Single-plane Deployment <appendix/deploy_minimal>
   appendix/workflow_execution

--- a/docs/deployment_guide/introduction/whats_next.rst
+++ b/docs/deployment_guide/introduction/whats_next.rst
@@ -28,36 +28,6 @@ Ready to Begin?
 
 Select the deployment model that fits your needs and environment.
 
-.. list-table:: Deployment profile comparison
-   :header-rows: 1
-   :widths: 18 20 20 10 32
-
-   * - Deployment
-     - Dependencies
-     - Environment
-     - Backends
-     - Recommended for
-   * - Quickstart Deployment
-     - Included (non-production)
-     - Local workstation
-     - 1
-     - Evaluation and development
-   * - Self-contained Deployment
-     - Included
-     - Edge or on-premises
-     - 1
-     - Production when the complete stack must remain local
-   * - Single-plane Deployment
-     - External
-     - Edge, on-premises, or cloud
-     - 1
-     - Production with separately managed dependencies
-   * - Split-plane Deployment
-     - External
-     - Cloud, on-premises, or hybrid
-     - Many
-     - Production across multiple compute clusters
-
 .. only:: html
 
   .. grid:: 1 2 2 2
@@ -94,3 +64,39 @@ Select the deployment model that fits your needs and environment.
 
           Prepare infrastructure for control and compute planes deployed on
           separate clusters.
+
+Deployment Profile Comparison
+=============================
+
+Use the following table to compare dependencies, target environments, and
+backend scale.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 20 20 10 32
+
+   * - Deployment
+     - Dependencies
+     - Environment
+     - Backends
+     - Recommended for
+   * - Quickstart Deployment
+     - Included (non-production)
+     - Local workstation
+     - 1
+     - Evaluation and development
+   * - Self-contained Deployment
+     - Included
+     - Edge or on-premises
+     - 1
+     - Production when the complete stack must remain local
+   * - Single-plane Deployment
+     - External
+     - Edge, on-premises, or cloud
+     - 1
+     - Production with separately managed dependencies
+   * - Split-plane Deployment
+     - External
+     - Cloud, on-premises, or hybrid
+     - Many
+     - Production across multiple compute clusters

--- a/docs/deployment_guide/introduction/whats_next.rst
+++ b/docs/deployment_guide/introduction/whats_next.rst
@@ -1,5 +1,5 @@
 ..
-  SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -28,12 +28,42 @@ Ready to Begin?
 
 Select the deployment model that fits your needs and environment.
 
+.. list-table:: Deployment profile comparison
+   :header-rows: 1
+   :widths: 18 20 20 10 32
+
+   * - Deployment
+     - Dependencies
+     - Environment
+     - Backends
+     - Recommended for
+   * - Quickstart Deployment
+     - Included (non-production)
+     - Local workstation
+     - 1
+     - Evaluation and development
+   * - Self-contained Deployment
+     - Included
+     - Edge or on-premises
+     - 1
+     - Production when the complete stack must remain local
+   * - Single-plane Deployment
+     - External
+     - Edge, on-premises, or cloud
+     - 1
+     - Production with separately managed dependencies
+   * - Split-plane Deployment
+     - External
+     - Cloud, on-premises, or hybrid
+     - Many
+     - Production across multiple compute clusters
+
 .. only:: html
 
   .. grid:: 1 2 2 2
       :gutter: 3
 
-      .. grid-item-card:: :octicon:`rocket` Quickstart
+      .. grid-item-card:: :octicon:`rocket` Quickstart Deployment
           :link: ../appendix/deploy_local
           :link-type: doc
           :class-card: tool-card


### PR DESCRIPTION
## Description
Add a table to better compare the different deployment profiles
Change some wording around "Quickstart"

Issue - None

## Checklist
- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Renamed “Quickstart” references to “Quickstart Deployment” in the deployment guide.
  - Reorganized the deployment profile comparison table into its own section following the deployment option cards.
  - Added a heading and introductory text to clarify the comparison table’s purpose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->