### PR TITLE
#None - Test log stream cleanup after real HTTP disconnects

### DIFF
--- a/src/service/core/responses.py
+++ b/src/service/core/responses.py
@@ -32,9 +32,9 @@ class ClosingStreamingResponse(fastapi.responses.StreamingResponse):
     workflow -- is never told the client is gone, and the request runs forever.
 
     This restores the listener unconditionally and closes the body afterwards,
-    so whatever the body holds open is released with the response. Use it for a
-    body that can stay idle; a body that always has a next chunk does not need
-    it, because its next send will fail and end the request anyway.
+    so whatever the body holds open is released with the response. Active log
+    streams need the listener too: some servers silently discard sends after
+    a disconnect, so a successful send does not prove the client is present.
     """
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:

--- a/src/service/core/tests/BUILD
+++ b/src/service/core/tests/BUILD
@@ -76,6 +76,7 @@ osmo_py_test(
     deps = [
         "//src/service/core:responses",
         osmo_requirement("starlette"),
+        osmo_requirement("uvicorn"),
     ],
     size = "small",
     visibility = ["//visibility:public"],

--- a/src/service/core/tests/test_responses.py
+++ b/src/service/core/tests/test_responses.py
@@ -16,7 +16,11 @@ limitations under the License.
 SPDX-License-Identifier: Apache-2.0
 """
 import asyncio
+import socket
 import unittest
+from typing import Literal
+
+import uvicorn
 
 from starlette.applications import Starlette
 from starlette.background import BackgroundTask
@@ -132,6 +136,73 @@ class TestClosingStreamingResponse(unittest.IsolatedAsyncioTestCase):
             response(_scope(), _idle_receive, _discard_send), timeout=1)
 
         self.assertEqual(order, ['body closed', 'background'])
+
+    async def test_socket_disconnect_closes_idle_and_active_streams(self):
+        """Exercise real HTTP disconnects, including servers that discard sends."""
+        for protocol in ('h11', 'httptools'):
+            for active in (False, True):
+                with self.subTest(protocol=protocol, active=active):
+                    await self._check_socket_disconnect(protocol, active)
+
+    async def _check_socket_disconnect(
+        self, protocol: Literal['h11', 'httptools'], active: bool,
+    ):
+        closed = asyncio.Event()
+
+        async def body():
+            try:
+                yield 'first line\n'
+                while True:
+                    if active:
+                        await asyncio.sleep(0.01)
+                        yield 'next line\n'
+                    else:
+                        await asyncio.Future()
+            finally:
+                closed.set()
+
+        async def endpoint(request):  # pylint: disable=unused-argument
+            return responses.ClosingStreamingResponse(body())
+
+        async def pass_through(request, call_next):
+            return await call_next(request)
+
+        app = Starlette(routes=[Route('/logs', endpoint)])
+        app.add_middleware(BaseHTTPMiddleware, dispatch=pass_through)
+        with socket.socket() as listener:
+            listener.bind(('127.0.0.1', 0))
+            server = uvicorn.Server(uvicorn.Config(
+                app, http=protocol, lifespan='off', log_level='critical',
+                timeout_graceful_shutdown=1))
+            serving = asyncio.create_task(server.serve(sockets=[listener]))
+            try:
+                async def wait_started():
+                    while not server.started:
+                        if serving.done():
+                            serving.result()
+                        await asyncio.sleep(0.01)
+
+                await asyncio.wait_for(wait_started(), timeout=5)
+                reader, writer = await asyncio.open_connection(
+                    '127.0.0.1', listener.getsockname()[1])
+                try:
+                    writer.write(b'GET /logs HTTP/1.1\r\nHost: localhost\r\n\r\n')
+                    await writer.drain()
+                    await asyncio.wait_for(reader.readuntil(b'first line\n'), timeout=2)
+                finally:
+                    writer.close()
+                    await writer.wait_closed()
+
+                await asyncio.wait_for(closed.wait(), timeout=2)
+
+                async def wait_requests_finished():
+                    while server.server_state.tasks:
+                        await asyncio.sleep(0.01)
+
+                await asyncio.wait_for(wait_requests_finished(), timeout=2)
+            finally:
+                server.should_exit = True
+                await asyncio.wait_for(serving, timeout=5)
 
     async def test_quiet_body_is_closed_behind_http_middleware(self):
         """The core service wraps requests in BaseHTTPMiddleware; it must not


### PR DESCRIPTION
## Description

Issue #None

Redis-backed log responses must release their generators after clients close the HTTP connection, including when logs are actively streaming. PR #1317 adds explicit disconnect handling, but its tests call ASGI directly and its documentation assumes an active stream's next send always fails after disconnect.

Add real TCP disconnect coverage through BaseHTTPMiddleware using both Uvicorn h11 and httptools, for idle and active streams. Assert that the generator closes and the server releases the request task. Correct the response documentation to account for servers that silently discard post-disconnect sends. This validates the existing fix for 6.4 without changing storage-backed response behavior.

Validation:

- Bazel response and Redis cleanup tests, response/test lint, and associated type checks pass.
- Negative control: replacing the disconnect-aware response with ordinary StreamingResponse makes all four new socket cases fail waiting for generator closure.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/OSMO/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that active streaming responses must listen for client disconnects to ensure proper cleanup, especially when servers silently discard sends after a disconnect.

- **Tests**
  - Added coverage for cleanup after client disconnects during idle and active streaming.
  - Verified behavior across supported HTTP protocol implementations and when middleware is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->