### PR TITLE
Fix unified chart MCP routing and credential mounts

### DIFF
--- a/deployments/charts/osmo/README.md
+++ b/deployments/charts/osmo/README.md
@@ -200,6 +200,47 @@ configuration. Use a production profile with managed credentials, TLS,
 authorization, backups, suitable resource sizing, and HA dependencies for
 long-lived environments.
 
+## MCP
+
+MCP uses an in-process OIDC proxy. Enable Gateway JWT authentication and
+authorization, then provide the public resource URL, OIDC discovery URL,
+client ID and an existing client Secret:
+
+```yaml
+services:
+  mcp:
+    enabled: true
+    resourceUrl: https://osmo.example.com/mcp
+    oidcProxy:
+      oidc:
+        configUrl: https://issuer.example.com/.well-known/openid-configuration
+        clientId: example-mcp-client
+      existingSecret:
+        name: mcp-oidc
+```
+
+The Secret's default key is `client-secret`. MCP inherits the effective
+external or embedded Valkey connection and password Secret; set
+`existingSecret.redisPasswordKey` only for a combined OIDC/Valkey Secret.
+For a custom file mount, leave `existingSecret.name` empty and configure
+`oidc.clientSecretFile`, `services.mcp.extraVolumeMounts` and
+`services.mcp.pod.extraVolumes`. Never put credential contents in values.
+Multiple replicas must share the same OIDC Secret, Valkey DB and key prefix.
+
+Register the upstream callback as `https://osmo.example.com/mcp/auth/callback`
+and the resource scope as `https://osmo.example.com/mcp/access_as_user`.
+Use a JWT provider matching the upstream access-token issuer. Set
+`oidc.accessTokenIssuer` when that issuer differs from discovery.
+Pin a compatible published MCP image using the standard component image fields.
+
+After deployment, connect an OAuth-capable client to `/mcp` and complete browser
+login. Verify `osmo_health`, `osmo_get_profile`, denied access for a restricted
+user, and refresh after token expiry. Discovery is public at the exact paths
+`/.well-known/oauth-authorization-server/mcp` and
+`/.well-known/oauth-protected-resource/mcp`. OAuth routes allow only their
+supported methods; unknown `/mcp/` paths, including health, return 404.
+Tool calls still pass through normal Gateway API authorization.
+
 ## Single-plane external dependencies
 
 `profiles/single-plane.yaml` is a provider-neutral, converged base overlay for

--- a/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
+++ b/deployments/charts/osmo/templates/_gateway-envoy-config.tpl
@@ -95,6 +95,7 @@ application configured for v1-format tokens does.
 {{- fail "services.mcp.allowedOrigins must be a list" }}
 {{- end }}
 {{- range $origin := $mcp.allowedOrigins }}
+{{- include "osmo.mcp.validateUrl" (dict "name" "services.mcp.allowedOrigins" "url" $origin) }}
 {{- if not (regexMatch "^https?://[^/?#]+$" $origin) }}
 {{- fail (printf "services.mcp.allowedOrigins entry %q must be an exact HTTP(S) Origin without a path" $origin) }}
 {{- end }}
@@ -102,7 +103,9 @@ application configured for v1-format tokens does.
 {{- range $skipPath := $skipAuthPaths }}
 {{- $overlapsMcpPath := or (hasPrefix $skipPath $mcpPath) (hasPrefix $mcpPath $skipPath) }}
 {{- $overlapsMcpMetadataPath := or (hasPrefix $skipPath $mcpMetadataPath) (hasPrefix $mcpMetadataPath $skipPath) }}
-{{- if or $overlapsMcpPath $overlapsMcpMetadataPath }}
+{{- $authorizationMetadataPath := "/.well-known/oauth-authorization-server/mcp" }}
+{{- $overlapsAuthorizationMetadata := or (hasPrefix $skipPath $authorizationMetadataPath) (hasPrefix $authorizationMetadataPath $skipPath) }}
+{{- if or $overlapsMcpPath $overlapsMcpMetadataPath $overlapsAuthorizationMetadata }}
 {{- fail (printf "gateway auth bypass prefix %q overlaps a protected MCP path" $skipPath) }}
 {{- end }}
 {{- end }}
@@ -307,18 +310,29 @@ data:
                 {{- end }}
 
                 {{- if $mcpEnabled }}
-                # FastMCP serves its own RFC 9728 document, so the gateway
-                # forwards this path instead of synthesising it.
-                - name: mcp-protected-resource-metadata
+                {{- $oauthRoutes := list
+                    (dict "name" "protected-resource-metadata" "path" $mcpMetadataPath "target" $mcpMetadataPath "methods" "GET|HEAD|OPTIONS")
+                    (dict "name" "authorization-server-metadata" "path" "/.well-known/oauth-authorization-server/mcp" "target" "/.well-known/oauth-authorization-server" "methods" "GET|HEAD|OPTIONS")
+                    (dict "name" "authorize" "path" "/mcp/authorize" "target" "/authorize" "methods" "GET|HEAD|POST")
+                    (dict "name" "consent" "path" "/mcp/consent" "target" "/consent" "methods" "GET|HEAD|POST")
+                    (dict "name" "callback" "path" "/mcp/auth/callback" "target" "/auth/callback" "methods" "GET|HEAD")
+                    (dict "name" "token" "path" "/mcp/token" "target" "/token" "methods" "POST|OPTIONS")
+                    (dict "name" "register" "path" "/mcp/register" "target" "/register" "methods" "POST|OPTIONS")
+                    (dict "name" "revoke" "path" "/mcp/revoke" "target" "/revoke" "methods" "POST|OPTIONS") }}
+                {{- range $route := $oauthRoutes }}
+                - name: mcp-{{ $route.name }}
                   match:
-                    path: {{ $mcpMetadataPath }}
+                    path: {{ $route.path }}
                     headers:
                     - name: ":method"
                       string_match:
-                        exact: GET
+                        safe_regex:
+                          google_re2: {}
+                          regex: {{ $route.methods | quote }}
                   route:
                     cluster: osmo-mcp
-                    timeout: 15s
+                    prefix_rewrite: {{ $route.target }}
+                    timeout: 45s
                   typed_per_filter_config:
                     envoy.filters.http.jwt_authn:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
@@ -326,35 +340,12 @@ data:
                     envoy.filters.http.ext_authz:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
                       disabled: true
+                {{- end }}
 
-                # RFC 8414 path-aware authorization-server metadata. FastMCP
-                # registers it at the root, so the prefix is rewritten off.
-                - name: mcp-authorization-server-metadata
+                {{- range $index, $path := list "/mcp/" $mcpMetadataPath "/.well-known/oauth-authorization-server/mcp" }}
+                - name: mcp-reject-{{ $index }}
                   match:
-                    path: /.well-known/oauth-authorization-server/mcp
-                    headers:
-                    - name: ":method"
-                      string_match:
-                        exact: GET
-                  route:
-                    cluster: osmo-mcp
-                    prefix_rewrite: /.well-known/oauth-authorization-server
-                    timeout: 15s
-                  typed_per_filter_config:
-                    envoy.filters.http.jwt_authn:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                      disabled: true
-                    envoy.filters.http.ext_authz:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
-                      disabled: true
-
-                # The /mcp/ prefix below publishes the container's whole root
-                # namespace, so any new non-OAuth root route must be carved out
-                # here too. Auth filters are off so the 404 is this route's own
-                # answer, not jwt_authn's 401 that a later change could move.
-                - name: mcp-health-not-public
-                  match:
-                    prefix: /mcp/health
+                    prefix: {{ $path }}
                   direct_response:
                     status: 404
                   typed_per_filter_config:
@@ -364,24 +355,7 @@ data:
                     envoy.filters.http.ext_authz:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
                       disabled: true
-
-                # The MCP SDK registers OAuth at fixed root paths, so the
-                # gateway publishes them under /mcp -- matching what FastMCP
-                # advertises -- and rewrites the prefix off before forwarding.
-                - name: mcp-oauth
-                  match:
-                    prefix: /mcp/
-                  route:
-                    cluster: osmo-mcp
-                    prefix_rewrite: /
-                    timeout: 15s
-                  typed_per_filter_config:
-                    envoy.filters.http.jwt_authn:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
-                      disabled: true
-                    envoy.filters.http.ext_authz:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
-                      disabled: true
+                {{- end }}
 
                 # FastMCP validates its own token and relays the verified
                 # upstream token to protected /api.
@@ -654,10 +628,8 @@ data:
                               value_match:
                                 prefix: "Bearer "
                           {{- if $mcpEnabled }}
-                          # MCP clients authenticate with bearer JWTs and must
-                          # receive the jwt_authn challenge when the token is
-                          # missing or invalid. Bypass only OAuth2 Proxy here;
-                          # jwt_authn and semantic ext_authz stay enabled.
+                          # These namespaces are handled only by the exact
+                          # FastMCP routes or local rejection routes above.
                           - single_predicate:
                               input:
                                 name: request-headers
@@ -667,29 +639,7 @@ data:
                               value_match:
                                 safe_regex:
                                   google_re2: {}
-                                  regex: "^/mcp([?].*)?$"
-                          # The protected-resource document is public only for
-                          # the exact GET route configured above.
-                          - and_matcher:
-                              predicate:
-                              - single_predicate:
-                                  input:
-                                    name: request-headers
-                                    typed_config:
-                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
-                                      header_name: ":path"
-                                  value_match:
-                                    safe_regex:
-                                      google_re2: {}
-                                      regex: "^/[.]well-known/oauth-protected-resource/mcp([?].*)?$"
-                              - single_predicate:
-                                  input:
-                                    name: request-headers
-                                    typed_config:
-                                      "@type": type.googleapis.com/envoy.type.matcher.v3.HttpRequestHeaderMatchInput
-                                      header_name: ":method"
-                                  value_match:
-                                    exact: "GET"
+                                  regex: "^(/mcp([/?].*)?|/[.]well-known/oauth-(protected-resource|authorization-server)/mcp.*)$"
                           {{- end }}
                           {{- if $authnSkipPaths }}
                           - single_predicate:

--- a/deployments/charts/osmo/templates/_helpers.tpl
+++ b/deployments/charts/osmo/templates/_helpers.tpl
@@ -489,10 +489,30 @@ data:
 
 {{- define "osmo.mcp.resourceUrl" -}}
 {{- $resourceUrl := required "services.mcp.resourceUrl is required when MCP is enabled" .Values.services.mcp.resourceUrl -}}
+{{- include "osmo.mcp.validateUrl" (dict "name" "services.mcp.resourceUrl" "url" $resourceUrl) -}}
 {{- if not (regexMatch "^https://[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:[0-9]{1,5})?/mcp$" $resourceUrl) -}}
 {{- fail "services.mcp.resourceUrl must be a valid HTTPS origin followed by the exact /mcp path" -}}
 {{- end -}}
 {{- $resourceUrl -}}
+{{- end -}}
+
+{{- define "osmo.mcp.validateUrl" -}}
+{{- if not (regexMatch "^https?://([A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?|\\[[0-9A-Fa-f:.]+\\])(:[0-9]{1,5})?(/[A-Za-z0-9._~%!$&'()*+,;=:@/-]*)?$" .url) -}}
+{{- fail (printf "%s must be an absolute HTTP(S) URL without credentials, query or fragment" .name) -}}
+{{- end -}}
+{{- $port := regexFind ":[0-9]+$" (urlParse .url).host -}}
+{{- if $port -}}
+{{- $number := trimSuffix "/" (trimPrefix ":" $port) | int -}}
+{{- if or (lt $number 1) (gt $number 65535) -}}
+{{- fail (printf "%s port must be between 1 and 65535" .name) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "osmo.mcp.validatePath" -}}
+{{- if or (not (regexMatch "^/[A-Za-z0-9._/-]+$" .path)) (regexMatch "(^|/)[.]{1,2}(/|$)|//" .path) -}}
+{{- fail (printf "%s must be a safe absolute path without dot segments or empty components" .name) -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "osmo.secrets.mekVolume" -}}

--- a/deployments/charts/osmo/templates/mcp-service.yaml
+++ b/deployments/charts/osmo/templates/mcp-service.yaml
@@ -24,6 +24,17 @@
 {{- $oidcProxy := $mcp.oidcProxy }}
 {{- $oidcConfigUrl := required "services.mcp.oidcProxy.oidc.configUrl is required when MCP is enabled" $oidcProxy.oidc.configUrl }}
 {{- $oidcClientId := required "services.mcp.oidcProxy.oidc.clientId is required when MCP is enabled" $oidcProxy.oidc.clientId }}
+{{- if not (trim $oidcClientId) }}
+{{- fail "services.mcp.oidcProxy.oidc.clientId must not be blank" }}
+{{- end }}
+{{- range $field, $url := dict "configUrl" $oidcConfigUrl "accessTokenIssuer" $oidcProxy.oidc.accessTokenIssuer }}
+{{- if $url }}
+{{- include "osmo.mcp.validateUrl" (dict "name" (printf "services.mcp.oidcProxy.oidc.%s" $field) "url" $url) }}
+{{- if not (hasPrefix "https://" $url) }}
+{{- fail (printf "services.mcp.oidcProxy.oidc.%s must use HTTPS" $field) }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- $secretName := $oidcProxy.existingSecret.name }}
 {{- $secretMountPath := trimSuffix "/" $oidcProxy.existingSecret.mountPath }}
 {{- $oidcClientSecretFile := $oidcProxy.oidc.clientSecretFile }}
@@ -50,6 +61,46 @@ uses; only the logical database is chosen here, to isolate proxy state. */ -}}
 {{- $redisHost := required "a valkey host is required when MCP is enabled" (include "osmo.valkey.host" .) }}
 {{- $redisScheme := ternary "rediss" "redis" (eq (include "osmo.valkey.tlsEnabled" .) "true") }}
 {{- $redisUrl := printf "%s://%s:%v/%v" $redisScheme $redisHost (include "osmo.valkey.port" .) $oidcProxy.redis.dbNumber }}
+{{- include "osmo.mcp.validatePath" (dict "name" "MCP client secret file" "path" $oidcClientSecretFile) }}
+{{- include "osmo.mcp.validatePath" (dict "name" "MCP Redis password file" "path" $redisPasswordFile) }}
+{{- $volumeNames := dict }}
+{{- $mountPaths := list }}
+{{- if .Values.gateway.tls.enabled }}
+{{- $_ := set $volumeNames "tls" true }}
+{{- $mountPaths = append $mountPaths "/etc/osmo/tls" }}
+{{- end }}
+{{- if $secretName }}
+{{- $_ := set $volumeNames "mcp-oidc-proxy" true }}
+{{- $mountPaths = append $mountPaths $secretMountPath }}
+{{- end }}
+{{- if $redisPasswordSecretName }}
+{{- $_ := set $volumeNames "mcp-valkey" true }}
+{{- $mountPaths = append $mountPaths $redisPasswordMountPath }}
+{{- end }}
+{{- range $volume := $mcp.pod.extraVolumes }}
+{{- $volumeName := required "services.mcp.pod.extraVolumes requires a name" $volume.name }}
+{{- if hasKey $volumeNames $volumeName }}
+{{- fail (printf "duplicate MCP volume name %s" $volumeName) }}
+{{- end }}
+{{- $_ := set $volumeNames $volumeName true }}
+{{- end }}
+{{- range $mount := $mcp.extraVolumeMounts }}
+{{- if not (hasKey $volumeNames (required "MCP extraVolumeMounts requires a name" $mount.name)) }}
+{{- fail (printf "MCP mount references unknown volume %s" $mount.name) }}
+{{- end }}
+{{- $mountPaths = append $mountPaths (required "MCP extraVolumeMounts requires mountPath" $mount.mountPath) }}
+{{- end }}
+{{- $seenPaths := list }}
+{{- range $path := $mountPaths }}
+{{- include "osmo.mcp.validatePath" (dict "name" "MCP mountPath" "path" $path) }}
+{{- $path = trimSuffix "/" $path }}
+{{- range $other := $seenPaths }}
+{{- if or (eq $path $other) (hasPrefix (printf "%s/" $path) $other) (hasPrefix (printf "%s/" $other) $path) }}
+{{- fail (printf "MCP mount paths overlap: %s and %s" $path $other) }}
+{{- end }}
+{{- end }}
+{{- $seenPaths = append $seenPaths $path }}
+{{- end }}
 {{- $reservedEnvNames := list "OSMO_MCP_HOST" "OSMO_MCP_PORT" "OSMO_GATEWAY_URL" "OSMO_MCP_REQUEST_TIMEOUT_SECONDS" "OSMO_MCP_ALLOWED_ORIGINS" "OSMO_MCP_AUTH_RESOURCE_URL" "OSMO_MCP_AUTH_REDIS_URL" "OSMO_MCP_AUTH_REDIS_PASSWORD_FILE" "OSMO_MCP_AUTH_REDIS_KEY_PREFIX" "OSMO_MCP_AUTH_OIDC_CONFIG_URL" "OSMO_MCP_AUTH_OIDC_CLIENT_ID" "OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE" "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_ISSUER" "OSMO_MCP_AUTH_OIDC_ACCESS_TOKEN_REQUIRED_SCOPE" "OSMO_MCP_AUTH_ACCESS_TOKEN_TTL_SECONDS" "OSMO_MCP_AUTH_REFRESH_TOKEN_TTL_SECONDS" "OSMO_MCP_AUTH_UPSTREAM_TIMEOUT_SECONDS" "OSMO_MCP_AUTH_REDIS_CONNECT_TIMEOUT_SECONDS" "OSMO_MCP_AUTH_REDIS_OPERATION_TIMEOUT_SECONDS" }}
 {{- range $env := $mcp.extraEnv }}
 {{- if has (toString (default "" $env.name)) $reservedEnvNames }}
@@ -172,7 +223,7 @@ spec:
         {{- end }}
         resources:
           {{- toYaml $mcp.resources | nindent 10 }}
-        {{- if or .Values.gateway.tls.enabled $secretName $redisPasswordSecretName }}
+        {{- if or .Values.gateway.tls.enabled $secretName $redisPasswordSecretName $mcp.extraVolumeMounts }}
         volumeMounts:
         {{- if .Values.gateway.tls.enabled }}
         {{- include "osmo.gateway.upstreamTlsVolumeMount" (dict "context" . "secretName" (include "osmo.gateway.tlsLeafSecretName" (dict "root" . "component" "mcp"))) | nindent 8 }}
@@ -187,6 +238,7 @@ spec:
           mountPath: {{ $redisPasswordMountPath }}
           readOnly: true
         {{- end }}
+        {{- include "osmo.component.extraVolumeMounts" $mcp | nindent 8 }}
         {{- end }}
         {{- with (include "osmo.gateway.upstreamProbeYaml" (dict "probe" $mcp.livenessProbe "context" .)) }}
         livenessProbe:

--- a/deployments/charts/osmo/tests/test_osmo_charts.sh
+++ b/deployments/charts/osmo/tests/test_osmo_charts.sh
@@ -5552,18 +5552,49 @@ EOF
     require_deployment "$TEST_DIRECTORY/osmo-mcp.yaml" "osmo-mcp"
     require_deployment "$TEST_DIRECTORY/osmo-mcp.yaml" "osmo-gateway-authz"
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "path: /mcp"
-    # FastMCP serves its own metadata now, so the gateway forwards these
-    # paths instead of synthesising a document, and publishes the OAuth
-    # endpoints under /mcp with the prefix rewritten off before forwarding.
-    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "name: mcp-oauth"
-    # Anchored: a fixed-string check for "prefix_rewrite: /" also matches the
-    # authorization-server rewrite below it, and would pass with this one gone.
-    require_matches "$TEST_DIRECTORY/osmo-mcp.yaml" "prefix_rewrite: /$"
-    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" \
-        "name: mcp-authorization-server-metadata"
-    # The /mcp/ prefix would otherwise publish the container's health routes.
-    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "name: mcp-health-not-public"
-    require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "status: 404"
+    local route_name route_path route_target route_methods
+    while IFS=' ' read -r route_name route_path route_target route_methods; do
+        awk -v route="mcp-$route_name" '
+            /^                - name:/ { keep = ($3 == route) }
+            keep { print }
+        ' "$TEST_DIRECTORY/osmo-mcp.yaml" >"$TEST_DIRECTORY/mcp-route.yaml"
+        require_contains "$TEST_DIRECTORY/mcp-route.yaml" "path: $route_path"
+        require_contains "$TEST_DIRECTORY/mcp-route.yaml" 'name: ":method"'
+        require_contains "$TEST_DIRECTORY/mcp-route.yaml" "regex: \"$route_methods\""
+        require_contains "$TEST_DIRECTORY/mcp-route.yaml" "prefix_rewrite: $route_target"
+        require_contains "$TEST_DIRECTORY/mcp-route.yaml" 'cluster: osmo-mcp'
+        require_contains "$TEST_DIRECTORY/mcp-route.yaml" 'timeout: 45s'
+        require_occurrences "$TEST_DIRECTORY/mcp-route.yaml" 'disabled: true' 2
+    done <<'MCP_ROUTES'
+protected-resource-metadata /.well-known/oauth-protected-resource/mcp /.well-known/oauth-protected-resource/mcp GET|HEAD|OPTIONS
+authorization-server-metadata /.well-known/oauth-authorization-server/mcp /.well-known/oauth-authorization-server GET|HEAD|OPTIONS
+authorize /mcp/authorize /authorize GET|HEAD|POST
+consent /mcp/consent /consent GET|HEAD|POST
+callback /mcp/auth/callback /auth/callback GET|HEAD
+token /mcp/token /token POST|OPTIONS
+register /mcp/register /register POST|OPTIONS
+revoke /mcp/revoke /revoke POST|OPTIONS
+MCP_ROUTES
+    require_not_contains "$TEST_DIRECTORY/osmo-mcp.yaml" 'name: mcp-oauth'
+    awk '
+        /name: mcp-revoke$/ { allowed = NR }
+        /name: mcp-reject-0$/ { rejected = NR }
+        /prefix: \/api\/router$/ { api = NR }
+        END { exit !(allowed && rejected > allowed && api > rejected) }
+    ' "$TEST_DIRECTORY/osmo-mcp.yaml" || fail 'MCP routes must precede rejections and API routes'
+    local rejected_path rejected_index=0
+    for rejected_path in /mcp/ /.well-known/oauth-protected-resource/mcp \
+            /.well-known/oauth-authorization-server/mcp; do
+        awk -v route="mcp-reject-$rejected_index" '
+            /^                - name:/ { keep = ($3 == route) }
+            keep { print }
+        ' "$TEST_DIRECTORY/osmo-mcp.yaml" >"$TEST_DIRECTORY/mcp-reject.yaml"
+        require_contains "$TEST_DIRECTORY/mcp-reject.yaml" "prefix: $rejected_path"
+        require_contains "$TEST_DIRECTORY/mcp-reject.yaml" 'status: 404'
+        require_not_contains "$TEST_DIRECTORY/mcp-reject.yaml" 'cluster:'
+        require_occurrences "$TEST_DIRECTORY/mcp-reject.yaml" 'disabled: true' 2
+        rejected_index=$((rejected_index + 1))
+    done
     # The runtime cannot start without these.
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "name: OSMO_MCP_AUTH_RESOURCE_URL"
     require_contains "$TEST_DIRECTORY/osmo-mcp.yaml" "name: OSMO_MCP_AUTH_OIDC_CLIENT_SECRET_FILE"
@@ -5617,6 +5648,101 @@ EOF
         '/etc/osmo/mcp-valkey'
     require_not_contains "$TEST_DIRECTORY/mcp-combined-secret-deployment.yaml" \
         'secretName: "external-valkey-secret"'
+
+    helm_template mcp-mounted "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-mcp-values.yaml" \
+        --set services.mcp.replicas=2 \
+        --set-string services.mcp.oidcProxy.existingSecret.name= \
+        --set-string services.mcp.oidcProxy.oidc.clientSecretFile=/credentials/client-secret \
+        --set-json 'services.mcp.pod.extraVolumes=[{"name":"credentials","secret":{"secretName":"external-oidc"}}]' \
+        --set-json 'services.mcp.extraVolumeMounts=[{"name":"credentials","mountPath":"/credentials","readOnly":true}]' \
+        >"$TEST_DIRECTORY/mcp-mounted.yaml"
+    resource_document "$TEST_DIRECTORY/mcp-mounted.yaml" Deployment \
+        mcp-mounted-osmo-mcp >"$TEST_DIRECTORY/mcp-mounted-deployment.yaml"
+    require_contains "$TEST_DIRECTORY/mcp-mounted-deployment.yaml" 'replicas: 2'
+    require_contains "$TEST_DIRECTORY/mcp-mounted-deployment.yaml" 'mountPath: /credentials'
+    require_contains "$TEST_DIRECTORY/mcp-mounted-deployment.yaml" 'secretName: external-oidc'
+    require_contains "$TEST_DIRECTORY/mcp-mounted-deployment.yaml" 'value: "/credentials/client-secret"'
+    require_contains "$TEST_DIRECTORY/mcp-mounted-deployment.yaml" 'automountServiceAccountToken: false'
+
+    helm_template mcp-ui "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-mcp-values.yaml" \
+        --set gateway.oauth2Proxy.enabled=true \
+        --set secrets.oauthClientSecret.existingSecret=ui-client \
+        --set secrets.oauthCookieSecret.existingSecret=ui-cookie \
+        >"$TEST_DIRECTORY/mcp-ui.yaml"
+    awk '
+        /- name: ext-authz-oauth2-proxy$/ { keep = 1 }
+        keep { print }
+        keep && /extension_config:/ { exit }
+    ' "$TEST_DIRECTORY/mcp-ui.yaml" >"$TEST_DIRECTORY/mcp-ui-matcher.yaml"
+    require_contains "$TEST_DIRECTORY/mcp-ui-matcher.yaml" \
+        'regex: "^(/mcp([/?].*)?|/[.]well-known/oauth-(protected-resource|authorization-server)/mcp.*)$"'
+    require_contains "$TEST_DIRECTORY/mcp-ui-matcher.yaml" 'name: skip'
+
+    helm_template mcp-url-port "$charts_copy/osmo" \
+        -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+        -f "$CHARTS_ROOT/osmo/tests/control-mcp-values.yaml" \
+        --set-string services.mcp.resourceUrl=https://osmo.example.com:65535/mcp \
+        --set-string 'services.mcp.allowedOrigins[0]=http://[::1]:6274' \
+        --set-string services.mcp.oidcProxy.oidc.configUrl=https://issuer.example.com/tenant/:0/discovery \
+        --set-string services.mcp.oidcProxy.oidc.accessTokenIssuer=https://issuer.example.com \
+        >"$TEST_DIRECTORY/mcp-url-port.yaml"
+    require_contains "$TEST_DIRECTORY/mcp-url-port.yaml" 'https://osmo.example.com:65535/mcp'
+
+    local invalid_mcp_value
+    while IFS= read -r invalid_mcp_value; do
+        if helm_template mcp-invalid "$charts_copy/osmo" \
+            -f "$CHARTS_ROOT/osmo/tests/control-external-values.yaml" \
+            -f "$CHARTS_ROOT/osmo/tests/control-mcp-values.yaml" \
+            --set "$invalid_mcp_value" >"$TEST_DIRECTORY/mcp-invalid.out" 2>&1; then
+            fail "expected invalid MCP setting to fail: $invalid_mcp_value"
+        fi
+        require_contains "$TEST_DIRECTORY/mcp-invalid.out" 'Error:'
+    done <<'MCP_INVALID_VALUES'
+services.mcp.unknown=true
+services.mcp.oidcProxy.enabled=false
+services.mcp.oidcProxy.oidc.audience=old
+services.mcp.oidcProxy.redis.host=old
+services.mcp.oidcProxy.existingSecret.unknown=true
+services.mcp.resourceUrl=https://osmo.example.com:0/mcp
+services.mcp.resourceUrl=https://osmo.example.com:65536/mcp
+services.mcp.resourceUrl=https://user@osmo.example.com/mcp
+services.mcp.oidcProxy.oidc.configUrl=http://issuer.example.com/.well-known/openid-configuration
+services.mcp.oidcProxy.oidc.configUrl=https://issuer.example.com:99999/.well-known/openid-configuration
+services.mcp.oidcProxy.oidc.accessTokenIssuer=https://issuer.example.com:0
+services.mcp.oidcProxy.oidc.accessTokenRequiredScope=two scopes
+services.mcp.oidcProxy.redis.keyPrefix=two prefixes
+services.mcp.oidcProxy.redis.dbNumber=16
+services.mcp.oidcProxy.accessTokenTtlSeconds=59
+services.mcp.oidcProxy.refreshTokenTtlSeconds=604801
+services.mcp.oidcProxy.upstreamTimeoutSeconds=61
+services.mcp.oidcProxy.redis.connectTimeoutSeconds=31
+services.mcp.oidcProxy.redis.operationTimeoutSeconds=0
+services.mcp.requestTimeoutSeconds=61
+services.mcp.allowedOrigins[0]=https://host:65536
+services.mcp.allowedOrigins[0]=http://[::1]:0
+services.mcp.allowedOrigins[0]=http://[::1]:65536
+services.mcp.allowedOrigins[0]=https://user@host
+services.mcp.oidcProxy.existingSecret.mountPath=/etc/../credentials
+services.mcp.oidcProxy.existingSecret.mountPath=/etc/osmo/mcp-valkey
+services.mcp.oidcProxy.existingSecret.clientSecretKey=../secret
+services.mcp.oidcProxy.existingSecret.clientSecretKey=..
+services.mcp.pod.extraVolumes[0].name=mcp-valkey
+services.mcp.extraVolumeMounts[0].name=missing,services.mcp.extraVolumeMounts[0].mountPath=/credentials
+services.mcp.extraVolumeMounts[0].name=mcp-valkey,services.mcp.extraVolumeMounts[0].mountPath=/etc
+services.mcp.extraVolumeMounts[0].name=mcp-valkey,services.mcp.extraVolumeMounts[0].mountPath=/etc/osmo/mcp-valkey/child
+services.mcp.extraEnv[0].name=OSMO_MCP_AUTH_RESOURCE_URL,services.mcp.extraEnv[0].value=override
+gateway.envoy.extraSkipAuthPaths[0]=/.well-known/oauth-authorization-server/mcp
+gateway.envoy.extraSkipAuthPaths[0]=/.well-known/oauth-authorization-server/
+gateway.envoy.extraSkipAuthPaths[0]=/.well-known/oauth-authorization-server/mcp/child
+gateway.envoy.extraSkipAuthPaths[0]=/mcp
+gateway.envoy.extraSkipAuthPaths[0]=/.well-known/oauth-protected-resource/mcp
+gateway.authz.enabled=false
+gateway.envoy.enabled=false
+MCP_INVALID_VALUES
 
     helm_template osmo "$charts_copy/osmo" \
         -f "$charts_copy/osmo/profiles/split-plane-control.yaml" \

--- a/deployments/charts/osmo/values.schema.json
+++ b/deployments/charts/osmo/values.schema.json
@@ -1239,6 +1239,7 @@
     },
     "mcpComponent": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "enabled": { "type": "boolean" },
         "replicas": { "type": "integer", "minimum": 0 },
@@ -1248,15 +1249,17 @@
         "requestTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 60 },
         "oidcProxy": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "oidc": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "configUrl": { "type": "string" },
                 "clientId": { "type": "string" },
-                "clientSecretFile": { "type": "string" },
+                "clientSecretFile": { "type": "string", "pattern": "^$|^/[^\\s]+$" },
                 "accessTokenIssuer": { "type": "string" },
-                "accessTokenRequiredScope": { "type": "string" }
+                "accessTokenRequiredScope": { "type": "string", "pattern": "^[A-Za-z0-9:._~-]{1,128}$" }
               }
             },
             "accessTokenTtlSeconds": { "type": "integer", "minimum": 60, "maximum": 3600 },
@@ -1264,25 +1267,27 @@
             "upstreamTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 60 },
             "redis": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "dbNumber": { "type": "integer", "minimum": 0, "maximum": 15 },
-                "keyPrefix": { "type": "string" },
+                "keyPrefix": { "type": "string", "pattern": "^[A-Za-z0-9:._~-]{1,128}$" },
                 "connectTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 30 },
                 "operationTimeoutSeconds": { "type": "integer", "minimum": 1, "maximum": 30 }
               }
             },
             "existingSecret": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "name": { "type": "string" },
-                "mountPath": { "type": "string" },
-                "clientSecretKey": { "type": "string" },
-                "redisPasswordKey": { "type": "string" }
+                "mountPath": { "type": "string", "pattern": "^/[^\\s]+$" },
+                "clientSecretKey": { "type": "string", "pattern": "^[A-Za-z0-9._-]+$" },
+                "redisPasswordKey": { "type": "string", "pattern": "^[A-Za-z0-9._-]*$" }
               }
             }
           }
         },
-        "allowedOrigins": { "type": "array" },
+        "allowedOrigins": { "type": "array", "items": { "type": "string" }, "uniqueItems": true },
         "service": { "$ref": "#/definitions/serviceMetadata" },
         "serviceAccount": { "$ref": "#/definitions/serviceAccount" },
         "podDisruptionBudget": { "$ref": "#/definitions/podDisruptionBudget" },
@@ -1291,6 +1296,7 @@
         "readinessProbe": { "$ref": "#/definitions/probe" },
         "startupProbe": { "$ref": "#/definitions/probe" },
         "extraEnv": { "type": "array" },
+        "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
         "pod": { "$ref": "#/definitions/podSettingsSchedulingOnly" },
         "deploymentStrategy": { "type": "object" }
       }

--- a/deployments/charts/osmo/values.yaml
+++ b/deployments/charts/osmo/values.yaml
@@ -767,6 +767,7 @@ services:
         timeoutSeconds: 3
         failureThreshold: 24
     extraEnv: []
+    extraVolumeMounts: []
     pod:
       labels: {}
       annotations: {}

--- a/src/service/mcp/tests/test_auth.py
+++ b/src/service/mcp/tests/test_auth.py
@@ -270,6 +270,22 @@ class MCPAuthRuntimeTest(unittest.IsolatedAsyncioTestCase):
                     '/.well-known/oauth-authorization-server',
                     route_paths,
                 )
+                expected_methods = {
+                    '/authorize': {'GET', 'HEAD', 'POST'},
+                    '/consent': {'GET', 'HEAD', 'POST'},
+                    '/auth/callback': {'GET', 'HEAD'},
+                    '/token': {'POST', 'OPTIONS'},
+                    '/register': {'POST', 'OPTIONS'},
+                    '/.well-known/oauth-authorization-server': {'GET', 'HEAD', 'OPTIONS'},
+                    '/.well-known/oauth-protected-resource/mcp': {'GET', 'HEAD', 'OPTIONS'},
+                }
+                actual_methods = {
+                    route.path: set(route.methods)
+                    for route in application.routes
+                    if hasattr(route, 'path') and hasattr(route, 'methods')
+                    and route.path in expected_methods
+                }
+                self.assertEqual(actual_methods, expected_methods)
                 async with (
                     application.router.lifespan_context(application),
                     httpx.AsyncClient(


### PR DESCRIPTION
## Description
Issue #None

Close the remaining MCP configuration and routing gaps in the unified chart:

- Match OAuth paths and methods explicitly, reject unknown MCP subpaths, and preserve normal API authorization.
- Support custom credential mounts and reject managed-mount collisions, unsupported settings, and invalid URLs or ports.
- Preserve IPv6 browser origins and validate URL ports separately from path segments.
- Document configuration and extend chart and runtime route-contract tests.

Authentication remains the existing in-process OIDC proxy. No direct-provider mode or new permissions are introduced. Image defaults are unchanged pending publication verification.

## Validation
- Unified Helm suite passed, including an independent reviewer run.
- Service-chart render suite passed.
- All 72 MCP Bazel checks passed.
- Live OAuth and RBAC acceptance testing passed on vpan dev: browser login, authenticated MCP tools, MCP token expiry and refresh, cross-replica state, and refresh-state persistence across pod replacement.
- RBAC verified: allowed → genuine 403 denial → allowed after restoration; temporary test configuration removed.
- Independent implementation and full E2E acceptance reviews approved.

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring custom secret and file mounts for MCP deployments.
  - Added explicit MCP OAuth endpoints, including authorization, consent, callback, token, registration, and revocation flows.
  - Added support for OAuth metadata and protected-resource discovery routes.

- **Bug Fixes**
  - Improved MCP authentication routing and protection against unauthorized access.

- **Documentation**
  - Added setup guidance for MCP OIDC authentication, OAuth registration, token configuration, routing, and validation.

- **Validation**
  - Added stricter checks for URLs, paths, secrets, mounts, volumes, scopes, and related MCP configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->