### PR TITLE
Fix service chart startup for 6.4 ConfigMap deployments

### DIFF
--- a/deployments/charts/service/templates/configs.yaml
+++ b/deployments/charts/service/templates/configs.yaml
@@ -61,10 +61,8 @@ data:
       {{- end }}
       {{- toYaml $backends | nindent 6 }}
     {{- end }}
-    {{- if $cfg.backendTests }}
     backend_tests:
-      {{- toYaml $cfg.backendTests | nindent 6 }}
-    {{- end }}
+      {{- toYaml ($cfg.backendTests | default dict) | nindent 6 }}
     {{- if $cfg.groupTemplates }}
     group_templates:
       {{- toYaml $cfg.groupTemplates | nindent 6 }}

--- a/deployments/charts/service/templates/gateway.yaml
+++ b/deployments/charts/service/templates/gateway.yaml
@@ -465,7 +465,9 @@ spec:
           - "--grpc-port={{ $gw.authz.grpcPort }}"
           {{- if .Values.services.configs.enabled }}
           - "--roles-file=/etc/osmo/configs/config.yaml"
-          {{- else }}
+          {{- end }}
+          # Runtime authorization state still comes from PostgreSQL when roles
+          # and pools are loaded from the ConfigMap.
           - "--postgres-host={{ .Values.services.postgres.serviceName }}"
           - "--postgres-port={{ .Values.services.postgres.port }}"
           - "--postgres-database={{ .Values.services.postgres.db }}"
@@ -474,9 +476,6 @@ spec:
           - "--postgres-max-conns={{ $gw.authz.postgres.maxConns }}"
           - "--postgres-min-conns={{ $gw.authz.postgres.minConns }}"
           - "--postgres-max-conn-lifetime={{ $gw.authz.postgres.maxConnLifetimeMin }}"
-          {{- end }}
-          - "--cache-ttl={{ $gw.authz.cache.ttl }}"
-          - "--cache-max-size={{ $gw.authz.cache.maxSize }}"
           {{- with .Values.global.logs.logFormat }}
           - "--log-format={{ . }}"
           {{- end }}

--- a/deployments/charts/service/templates/rbac-configs.yaml
+++ b/deployments/charts/service/templates/rbac-configs.yaml
@@ -33,10 +33,12 @@ rules:
 # configmap` filters associated events by involvedObject.uid, so without
 # this the events wouldn't appear in that view (though they'd still be
 # visible in `kubectl get events --field-selector` and the ArgoCD UI).
+# Patch this ConfigMap's annotations to persist the API's backend
+# reconciliation checkpoint before accepting its startup snapshot.
 - apiGroups: [""]
   resources: ["configmaps"]
   resourceNames: ["{{ .Values.services.service.serviceName }}-configs"]
-  verbs: ["get"]
+  verbs: ["get", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deployments/charts/service/tests/render-tests.sh
+++ b/deployments/charts/service/tests/render-tests.sh
@@ -39,6 +39,22 @@ helm_args=(
     --set 'services.backendApiTokens.enabled=true'
 )
 
+# ConfigMap mode still needs PostgreSQL runtime state and a durable API checkpoint.
+startup_render=$(helm template startup-test "$CHART_DIR" --namespace osmo \
+    --set 'services.configs.enabled=true' \
+    --set 'services.postgres.serviceName=runtime-postgres.example.com')
+grep -q -- '--roles-file=/etc/osmo/configs/config.yaml' <<<"$startup_render"
+grep -q -- '--postgres-host=runtime-postgres.example.com' <<<"$startup_render"
+if grep -q -- '--cache-ttl\|--cache-max-size' <<<"$startup_render"; then
+    echo 'Authz still receives cache flags removed from the 6.4 binary' >&2
+    exit 1
+fi
+startup_config=$(resource_document "$startup_render" ConfigMap osmo-service-configs)
+grep -A1 '^    backend_tests:' <<<"$startup_config" | grep -q '{}'
+startup_role=$(resource_document "$startup_render" Role osmo-service-configmap-events)
+grep -q 'resourceNames: \["osmo-service-configs"\]' <<<"$startup_role"
+grep -q 'verbs: \["get", "patch"\]' <<<"$startup_role"
+
 managed_render=$(helm template managed-test "$CHART_DIR" "${helm_args[@]}" \
     --set 'services.backendApiTokens.credentials[0].name=default' \
     --set 'services.backendApiTokens.credentials[0].managedSecret.name=agent-token')

--- a/deployments/charts/service/values.yaml
+++ b/deployments/charts/service/values.yaml
@@ -2346,8 +2346,8 @@ gateway:
     serviceAccountName: ""
 
   ## -----------------------------------------------------------------------
-  ## Gateway Authz — gRPC authorization service evaluating semantic RBAC
-  ## policies against PostgreSQL. Uses the shared services.postgres config.
+  ## Gateway Authz — gRPC authorization service loading roles and pools from
+  ## the ConfigMap, with runtime state in the shared services.postgres database.
   ## -----------------------------------------------------------------------
   authz:
     enabled: true
@@ -2386,9 +2386,6 @@ gateway:
       maxConns: 10
       minConns: 2
       maxConnLifetimeMin: 5
-    cache:
-      ttl: 300
-      maxSize: 1000
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:


### PR DESCRIPTION
ConfigMap deployments of 6.4 can fail at startup because the chart does not match the runtime contract: authz receives removed cache flags and lacks PostgreSQL arguments, empty backend test configuration is omitted, and the API cannot persist its reconciliation checkpoint.

Remove the obsolete authz cache options, always provide its PostgreSQL runtime connection settings, render an empty `backend_tests` mapping, and allow checkpoint patches only on the named service ConfigMap. The runtime writes the checkpoint to annotations; Kubernetes RBAC scopes this permission to the object, not to individual fields.

Validation: the chart render suite passes, including regression coverage for these startup requirements. Helm lint and a rendered-to-live comparison passed. Applying the equivalent fixes to an existing 6.4 RC3 environment recovered every Deployment, including both API replicas and authz; the public version endpoint responds successfully. No database migration or image rebuild is required for these chart fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Backend test configuration is now consistently included in generated service configuration, even when no values are provided.
  - Service reconciliation can update configuration annotations automatically.
  - Gateway authorization roles and pools are loaded from the ConfigMap, with runtime state stored in PostgreSQL.

- **Changes**
  - Gateway startup configuration now uses the PostgreSQL roles file when configured.
  - Removed authorization cache TTL and maximum-size settings.
  - Removed obsolete authorization fallback template options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->